### PR TITLE
Add support for face recognition with dlib

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -237,6 +237,8 @@ omit =
     homeassistant/components/foursquare.py
     homeassistant/components/hdmi_cec.py
     homeassistant/components/ifttt.py
+    homeassistant/components/image_processing/dlib_face_detect.py
+    homeassistant/components/image_processing/dlib_face_identify.py
     homeassistant/components/joaoapps_join.py
     homeassistant/components/keyboard.py
     homeassistant/components/keyboard_remote.py

--- a/homeassistant/components/image_processing/dlib_face_detect.py
+++ b/homeassistant/components/image_processing/dlib_face_detect.py
@@ -13,7 +13,7 @@ from homeassistant.components.image_processing import (  # noqa
 from homeassistant.components.image_processing.microsoft_face_identify import (
     ImageProcessingFaceEntity)
 
-REQUIREMENTS = ['face_recognition==0.1.12']
+REQUIREMENTS = ['face_recognition==0.1.14']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/image_processing/dlib_face_detect.py
+++ b/homeassistant/components/image_processing/dlib_face_detect.py
@@ -8,6 +8,7 @@ import logging
 import io
 
 from homeassistant.core import split_entity_id
+# pylint: disable=unused-import
 from homeassistant.components.image_processing import PLATFORM_SCHEMA  # noqa
 from homeassistant.components.image_processing import (
     CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)

--- a/homeassistant/components/image_processing/dlib_face_detect.py
+++ b/homeassistant/components/image_processing/dlib_face_detect.py
@@ -1,0 +1,74 @@
+"""
+Component that will help set the dlib face detect processing.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/image_processing.dlib_face_detect/
+"""
+import logging
+import io
+
+import voluptuous as vol
+
+from homeassistant.core import split_entity_id
+from homeassistant.components.image_processing import (
+    PLATFORM_SCHEMA, CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)  # noqa
+from homeassistant.components.image_processing.microsoft_face_identify import (
+    ImageProcessingFaceEntity)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['face_recognition==0.1.12']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Microsoft Face detection platform."""
+    entities = []
+    for camera in config[CONF_SOURCE]:
+        entities.append(DlibFaceDetectEntity(
+            camera[CONF_ENTITY_ID], camera.get(CONF_NAME)
+        ))
+
+    add_devices(entities)
+
+
+class DlibFaceDetectEntity(ImageProcessingFaceEntity):
+    """Dlib Face API entity for identify."""
+
+    def __init__(self, camera_entity, name=None):
+        """Initialize Dlib."""
+        super().__init__()
+
+        self._api = api
+        self._camera = camera_entity
+        self._attributes = attributes
+
+        if name:
+            self._name = name
+        else:
+            self._name = "Dlib Face {0}".format(
+                split_entity_id(camera_entity)[1])
+
+    @property
+    def camera_entity(self):
+        """Return camera entity id from process pictures."""
+        return self._camera
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
+
+    def process_image(self, image):
+        """Process image."""
+        import face_recognition
+
+        fak_file = io.BytesIO(image)
+        fak_file.name = "snapshot.jpg"
+        fak_file.seek(0)
+
+        image = face_recognition.load_image_file(fak_file)
+        face_locations = face_recognition.face_locations(image)
+
+        self.process_faces(face_locations, len(face_locations))

--- a/homeassistant/components/image_processing/dlib_face_detect.py
+++ b/homeassistant/components/image_processing/dlib_face_detect.py
@@ -8,8 +8,8 @@ import logging
 import io
 
 from homeassistant.core import split_entity_id
-from homeassistant.components.image_processing import (
-    PLATFORM_SCHEMA, CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)  # noqa
+from homeassistant.components.image_processing import (  # noqa
+    PLATFORM_SCHEMA, CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)
 from homeassistant.components.image_processing.microsoft_face_identify import (
     ImageProcessingFaceEntity)
 

--- a/homeassistant/components/image_processing/dlib_face_detect.py
+++ b/homeassistant/components/image_processing/dlib_face_detect.py
@@ -56,6 +56,7 @@ class DlibFaceDetectEntity(ImageProcessingFaceEntity):
 
     def process_image(self, image):
         """Process image."""
+        # pylint: disable=import-error
         import face_recognition
 
         fak_file = io.BytesIO(image)

--- a/homeassistant/components/image_processing/dlib_face_detect.py
+++ b/homeassistant/components/image_processing/dlib_face_detect.py
@@ -7,19 +7,15 @@ https://home-assistant.io/components/image_processing.dlib_face_detect/
 import logging
 import io
 
-import voluptuous as vol
-
 from homeassistant.core import split_entity_id
 from homeassistant.components.image_processing import (
     PLATFORM_SCHEMA, CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)  # noqa
 from homeassistant.components.image_processing.microsoft_face_identify import (
     ImageProcessingFaceEntity)
-import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['face_recognition==0.1.12']
 
 _LOGGER = logging.getLogger(__name__)
-
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -40,9 +36,7 @@ class DlibFaceDetectEntity(ImageProcessingFaceEntity):
         """Initialize Dlib."""
         super().__init__()
 
-        self._api = api
         self._camera = camera_entity
-        self._attributes = attributes
 
         if name:
             self._name = name

--- a/homeassistant/components/image_processing/dlib_face_detect.py
+++ b/homeassistant/components/image_processing/dlib_face_detect.py
@@ -8,8 +8,9 @@ import logging
 import io
 
 from homeassistant.core import split_entity_id
-from homeassistant.components.image_processing import (  # noqa
-    PLATFORM_SCHEMA, CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)
+from homeassistant.components.image_processing import PLATFORM_SCHEMA  # noqa
+from homeassistant.components.image_processing import (
+    CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)
 from homeassistant.components.image_processing.microsoft_face_identify import (
     ImageProcessingFaceEntity)
 

--- a/homeassistant/components/image_processing/dlib_face_detect.py
+++ b/homeassistant/components/image_processing/dlib_face_detect.py
@@ -8,8 +8,8 @@ import logging
 import io
 
 from homeassistant.core import split_entity_id
-from homeassistant.components.image_processing import (  # noqa
-    PLATFORM_SCHEMA, CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)
+from homeassistant.components.image_processing import (
+    PLATFORM_SCHEMA, CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)  # noqa
 from homeassistant.components.image_processing.microsoft_face_identify import (
     ImageProcessingFaceEntity)
 

--- a/homeassistant/components/image_processing/dlib_face_identify.py
+++ b/homeassistant/components/image_processing/dlib_face_identify.py
@@ -4,7 +4,6 @@ Component that will help set the dlib face detect processing.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/image_processing.dlib_face_identify/
 """
-import asyncio
 import logging
 import io
 
@@ -21,6 +20,7 @@ REQUIREMENTS = ['face_recognition==0.1.12']
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_NAME = 'name'
 CONF_FACES = 'faces'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -58,7 +58,7 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
         self._faces = {}
         for name, face_file in faces.items():
             image = face_recognition.load_image_file(face_file)
-            self._faces[name] = face_recognition.face_encodings(face_file)[0]
+            self._faces[name] = face_recognition.face_encodings(image)[0]
 
     @property
     def camera_entity(self):
@@ -82,7 +82,7 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
         unknowns = face_recognition.face_encodings(image)
 
         found = []
-        for unknown_face in unkowns:
+        for unknown_face in unknowns:
             for name, face in self._faces.items():
                 result = face_recognition.compare_faces([face], unknown_face)
                 if result[0]:

--- a/homeassistant/components/image_processing/dlib_face_identify.py
+++ b/homeassistant/components/image_processing/dlib_face_identify.py
@@ -86,11 +86,10 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
         found = []
         for unknown_face in unknowns:
             for name, face in self._faces.items():
-                # pylint: disable=undefined-loop-variable
                 result = face_recognition.compare_faces([face], unknown_face)
                 if result[0]:
                     found.append({
                         ATTR_NAME: name
                     })
 
-        self.process_faces(found, len(unknown_face))
+        self.process_faces(found, len(unknowns))

--- a/homeassistant/components/image_processing/dlib_face_identify.py
+++ b/homeassistant/components/image_processing/dlib_face_identify.py
@@ -16,7 +16,7 @@ from homeassistant.components.image_processing.microsoft_face_identify import (
     ImageProcessingFaceEntity)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['face_recognition==0.1.12']
+REQUIREMENTS = ['face_recognition==0.1.14']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/image_processing/dlib_face_identify.py
+++ b/homeassistant/components/image_processing/dlib_face_identify.py
@@ -1,0 +1,95 @@
+"""
+Component that will help set the dlib face detect processing.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/image_processing.dlib_face_identify/
+"""
+import asyncio
+import logging
+import io
+
+import voluptuous as vol
+
+from homeassistant.core import split_entity_id
+from homeassistant.components.image_processing import (
+    PLATFORM_SCHEMA, CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)
+from homeassistant.components.image_processing.microsoft_face_identify import (
+    ImageProcessingFaceEntity)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['face_recognition==0.1.12']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_FACES = 'faces'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_FACES): {cv.string: cv.isfile},
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Microsoft Face detection platform."""
+    entities = []
+    for camera in config[CONF_SOURCE]:
+        entities.append(DlibFaceIdentifyEntity(
+            camera[CONF_ENTITY_ID], config[CONF_FACES], camera.get(CONF_NAME)
+        ))
+
+    add_devices(entities)
+
+
+class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
+    """Dlib Face API entity for identify."""
+
+    def __init__(self, camera_entity, faces, name=None):
+        """Initialize Dlib."""
+        import face_recognition
+        super().__init__()
+
+        self._api = api
+        self._camera = camera_entity
+        self._attributes = attributes
+
+        if name:
+            self._name = name
+        else:
+            self._name = "Dlib Face {0}".format(
+                split_entity_id(camera_entity)[1])
+
+        self._faces = {}
+        for name, face_file in faces.items()
+            image = face_recognition.load_image_file(face_file)
+            self._faces[name] = face_recognition.face_encodings(face_file)[0]
+
+    @property
+    def camera_entity(self):
+        """Return camera entity id from process pictures."""
+        return self._camera
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
+
+    def process_image(self, image):
+        """Process image."""
+        import face_recognition
+
+        fak_file = io.BytesIO(image)
+        fak_file.name = "snapshot.jpg"
+        fak_file.seek(0)
+
+        image = face_recognition.load_image_file(fak_file)
+        unknowns = face_recognition.face_encodings(image)
+
+        found = []
+        for unknown_face in unkowns:
+            for name, face in self._faces.items():
+                result = face_recognition.compare_faces([face], unknown_face)
+                if result[0]:
+                    found.append({
+                        ATTR_NAME: name
+                    })
+
+        self.process_faces(found, len(unknown_face))

--- a/homeassistant/components/image_processing/dlib_face_identify.py
+++ b/homeassistant/components/image_processing/dlib_face_identify.py
@@ -44,6 +44,7 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
 
     def __init__(self, camera_entity, faces, name=None):
         """Initialize Dlib."""
+        # pylint: disable=import-error
         import face_recognition
         super().__init__()
 
@@ -72,6 +73,7 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
 
     def process_image(self, image):
         """Process image."""
+        # pylint: disable=import-error
         import face_recognition
 
         fak_file = io.BytesIO(image)

--- a/homeassistant/components/image_processing/dlib_face_identify.py
+++ b/homeassistant/components/image_processing/dlib_face_identify.py
@@ -47,9 +47,7 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
         import face_recognition
         super().__init__()
 
-        self._api = api
         self._camera = camera_entity
-        self._attributes = attributes
 
         if name:
             self._name = name
@@ -58,7 +56,7 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
                 split_entity_id(camera_entity)[1])
 
         self._faces = {}
-        for name, face_file in faces.items()
+        for name, face_file in faces.items():
             image = face_recognition.load_image_file(face_file)
             self._faces[name] = face_recognition.face_encodings(face_file)[0]
 

--- a/homeassistant/components/image_processing/dlib_face_identify.py
+++ b/homeassistant/components/image_processing/dlib_face_identify.py
@@ -86,6 +86,7 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
         found = []
         for unknown_face in unknowns:
             for name, face in self._faces.items():
+                # pylint: disable=undefined-loop-variable
                 result = face_recognition.compare_faces([face], unknown_face)
                 if result[0]:
                     found.append({

--- a/homeassistant/components/image_processing/microsoft_face_detect.py
+++ b/homeassistant/components/image_processing/microsoft_face_detect.py
@@ -22,8 +22,6 @@ DEPENDENCIES = ['microsoft_face']
 
 _LOGGER = logging.getLogger(__name__)
 
-EVENT_IDENTIFY_FACE = 'detect_face'
-
 SUPPORTED_ATTRIBUTES = [
     ATTR_AGE,
     ATTR_GENDER,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,7 +173,7 @@ evohomeclient==0.2.5
 
 # homeassistant.components.image_processing.dlib_face_detect
 # homeassistant.components.image_processing.dlib_face_identify
-face_recognition==0.1.12
+face_recognition==0.1.14
 
 # homeassistant.components.sensor.fastdotcom
 fastdotcom==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -171,6 +171,10 @@ enocean==0.31
 # homeassistant.components.climate.honeywell
 evohomeclient==0.2.5
 
+# homeassistant.components.image_processing.dlib_face_detect
+# homeassistant.components.image_processing.dlib_face_identify
+face_recognition==0.1.12
+
 # homeassistant.components.sensor.fastdotcom
 fastdotcom==0.0.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,7 +173,7 @@ evohomeclient==0.2.5
 
 # homeassistant.components.image_processing.dlib_face_detect
 # homeassistant.components.image_processing.dlib_face_identify
-face_recognition==0.1.14
+# face_recognition==0.1.14
 
 # homeassistant.components.sensor.fastdotcom
 fastdotcom==0.0.1

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -22,7 +22,8 @@ COMMENT_REQUIREMENTS = (
     'pycups',
     'python-eq3bt',
     'avion',
-    'decora'
+    'decora',
+    'face_recognition'
 )
 
 IGNORE_PACKAGES = (


### PR DESCRIPTION
## Description:

Add Support for dlib face identify and detection:
https://github.com/ageitgey/face_recognition/blob/master/docs/index.rst

I ignore the library while travis have follow error:
```
CMake 2.8.12 or higher is required.  You are running version 2.8.7
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

image_processing:
  platform: dlib_face_detect
  source:
     entity_id: camera.door
  platform: dlib_face_identify
  source:
     entity_id: camera.door
  faces:
    Papa: /tmp/papa.jpg
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
