### PR TITLE
Add support for variable dictionaries as `template_data`

### DIFF
--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -134,7 +134,12 @@ class BinarySensorTemplate(BinarySensorDevice):
     def async_update(self):
         """Update the state from the template."""
         try:
-            self._state = self._template.async_render().lower() == 'true'
+            render = self._template.async_render()
+            if not isinstance(render, bool):
+                _LOGGER.warning('Could not render template %s, '
+                                'result value is not binary.', self._name)
+                return
+            self._state = render
         except TemplateError as ex:
             if ex.args and ex.args[0].startswith(
                     "UndefinedError: 'None' has no attribute"):

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -438,8 +438,12 @@ def request_handler_factory(view, handler):
         elif result is None:
             result = b''
         elif not isinstance(result, bytes):
-            assert False, ('Result should be None, string, bytes or Response. '
-                           'Got: {}').format(result)
+            try:
+                # Try to cast result to string
+                result = str(result).encode('utf-8')
+            except ValueError:
+                assert False, ('Result should be None, string, bytes '
+                               'or Response. Got: {}').format(result)
 
         return web.Response(body=result, status=status_code)
 

--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -233,7 +233,7 @@ class HistoryStatsSensor(Entity):
             except (TemplateError, TypeError) as ex:
                 HistoryStatsHelper.handle_template_exception(ex, 'start')
                 return
-            start = dt_util.parse_datetime(start_rendered)
+            start = dt_util.parse_datetime(str(start_rendered))
             if start is None:
                 try:
                     start = dt_util.as_local(dt_util.utc_from_timestamp(
@@ -250,7 +250,7 @@ class HistoryStatsSensor(Entity):
             except (TemplateError, TypeError) as ex:
                 HistoryStatsHelper.handle_template_exception(ex, 'end')
                 return
-            end = dt_util.parse_datetime(end_rendered)
+            end = dt_util.parse_datetime(str(end_rendered))
             if end is None:
                 try:
                     end = dt_util.as_local(dt_util.utc_from_timestamp(

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.restore_state import async_get_last_state
 from homeassistant.helpers.script import Script
 
 _LOGGER = logging.getLogger(__name__)
-_VALID_STATES = [STATE_ON, STATE_OFF, 'true', 'false']
+_VALID_STATES = [STATE_ON, STATE_OFF, True, False]
 
 ON_ACTION = 'turn_on'
 OFF_ACTION = 'turn_off'
@@ -146,14 +146,14 @@ class SwitchTemplate(SwitchDevice):
     def async_update(self):
         """Update the state from the template."""
         try:
-            state = self._template.async_render().lower()
+            state = self._template.async_render()
 
             if state in _VALID_STATES:
-                self._state = state in ('true', STATE_ON)
+                self._state = state in (True, STATE_ON)
             else:
                 _LOGGER.error(
                     'Received invalid switch is_on state: %s. Expected: %s',
-                    state, ', '.join(_VALID_STATES))
+                    state, ', '.join(str(vst) for vst in _VALID_STATES))
                 self._state = None
 
         except TemplateError as ex:

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -288,7 +288,12 @@ def async_template(hass, value_template, variables=None):
         _LOGGER.error('Error during template condition: %s', ex)
         return False
 
-    return value.lower() == 'true'
+    if not isinstance(value, bool):
+        _LOGGER.error('Could not render condition template, '
+                      'result value is not binary.')
+        return False
+
+    return value
 
 
 def async_template_from_config(config, config_validation=True):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -437,7 +437,7 @@ SERVICE_SCHEMA = vol.All(vol.Schema({
     vol.Exclusive('service', 'service name'): service,
     vol.Exclusive('service_template', 'service name'): template,
     vol.Optional('data'): dict,
-    vol.Optional('data_template'): {match_all: template_complex},
+    vol.Optional('data_template'): template_complex,
     vol.Optional(CONF_ENTITY_ID): entity_ids,
 }), has_at_least_one_key('service', 'service_template'))
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1,4 +1,5 @@
 """Template helper methods for rendering strings with Home Assistant data."""
+import ast
 from datetime import datetime
 import json
 import logging
@@ -96,9 +97,16 @@ class Template(object):
             kwargs.update(variables)
 
         try:
-            return self._compiled.render(kwargs).strip()
+            rendered = self._compiled.render(kwargs).strip()
+            return ast.literal_eval(rendered)
         except jinja2.TemplateError as err:
             raise TemplateError(err)
+        except (ValueError, SyntaxError) as err:
+            # Even if Ast gives us an error,
+            # the rendered template is actually still a valid string
+            if rendered.lower() == 'true' or rendered.lower() == 'false':
+                return rendered.lower() == 'true'
+            return rendered
 
     def render_with_possible_json_value(self, value, error_value=_SENTINEL):
         """Render template with value exposed.

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -99,7 +99,7 @@ class TestMQTT(unittest.TestCase):
         self.hass.block_till_done()
         self.assertTrue(self.hass.data['mqtt'].async_publish.called)
         self.assertEqual(
-            self.hass.data['mqtt'].async_publish.call_args[0][1], "2")
+            self.hass.data['mqtt'].async_publish.call_args[0][1], 2)
 
     def test_service_call_with_payload_doesnt_render_template(self):
         """Test the service call with unrendered template.

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -92,7 +92,7 @@ class TestNotifyDemo(unittest.TestCase):
         self.hass.block_till_done()
         last_event = self.events[-1]
         self.assertEqual(last_event.data[notify.ATTR_TITLE], 'temperature')
-        self.assertEqual(last_event.data[notify.ATTR_MESSAGE], '10')
+        self.assertEqual(last_event.data[notify.ATTR_MESSAGE], 10)
 
     def test_method_forwards_correct_data(self):
         """Test that all data from the service gets forwarded to service."""

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -71,13 +71,13 @@ class TestHelpersTemplate(unittest.TestCase):
         self.hass.states.set('sensor.temperature', '12')
 
         self.assertEqual(
-            '12.0',
+            12.0,
             template.Template(
                 '{{ float(states.sensor.temperature.state) }}',
                 self.hass).render())
 
         self.assertEqual(
-            'True',
+            True,
             template.Template(
                 '{{ float(states.sensor.temperature.state) > 11 }}',
                 self.hass).render())
@@ -87,13 +87,13 @@ class TestHelpersTemplate(unittest.TestCase):
         self.hass.states.set('sensor.temperature', 12.78)
 
         self.assertEqual(
-            '12.8',
+            12.8,
             template.Template(
                 '{{ states.sensor.temperature.state | round(1) }}',
                 self.hass).render())
 
         self.assertEqual(
-            '128',
+            128,
             template.Template(
                 '{{ states.sensor.temperature.state | multiply(10) | round }}',
                 self.hass).render())
@@ -101,7 +101,7 @@ class TestHelpersTemplate(unittest.TestCase):
     def test_rounding_value_get_original_value_on_error(self):
         """Test rounding value get original value on error."""
         self.assertEqual(
-            'None',
+            None,
             template.Template('{{ None | round }}', self.hass).render())
 
         self.assertEqual(
@@ -112,8 +112,8 @@ class TestHelpersTemplate(unittest.TestCase):
     def test_multiply(self):
         """Test multiply."""
         tests = {
-            None: 'None',
-            10: '100',
+            None: None,
+            10: 100,
             '"abcd"': 'abcd'
         }
 
@@ -135,27 +135,27 @@ class TestHelpersTemplate(unittest.TestCase):
             ('2016-10-19', '%Y-%m-%d', None),
             ('2016', '%Y', None),
             ('15:22:05', '%H:%M:%S', None),
-            ('1469119144', '%Y', '1469119144'),
+            ('1469119144', '%Y', 1469119144),
             ('invalid', '%Y', 'invalid')
         ]
 
         for inp, fmt, expected in tests:
             if expected is None:
-                expected = datetime.strptime(inp, fmt)
+                expected = str(datetime.strptime(inp, fmt))
 
             temp = '{{ strptime(\'%s\', \'%s\') }}' % (inp, fmt)
 
             self.assertEqual(
-                str(expected),
+                expected,
                 template.Template(temp, self.hass).render())
 
     def test_timestamp_custom(self):
         """Test the timestamps to custom filter."""
         now = dt_util.utcnow()
         tests = [
-            (None, None, None, 'None'),
+            (None, None, None, None),
             (1469119144, None, True, '2016-07-21 16:39:04'),
-            (1469119144, '%Y', True, '2016'),
+            (1469119144, '%Y', True, 2016),
             (1469119144, 'invalid', True, 'invalid'),
             (dt_util.as_timestamp(now), None, False,
                 now.strftime('%Y-%m-%d %H:%M:%S'))
@@ -177,7 +177,7 @@ class TestHelpersTemplate(unittest.TestCase):
     def test_timestamp_local(self):
         """Test the timestamps to local filter."""
         tests = {
-            None: 'None',
+            None: None,
             1469119144: '2016-07-21 16:39:04',
         }
 
@@ -190,14 +190,14 @@ class TestHelpersTemplate(unittest.TestCase):
     def test_min(self):
         """Test the min filter."""
         self.assertEqual(
-            '1',
+            1,
             template.Template('{{ [1, 2, 3] | min }}',
                               self.hass).render())
 
     def test_max(self):
         """Test the max filter."""
         self.assertEqual(
-            '3',
+            3,
             template.Template('{{ [1, 2, 3] | max }}',
                               self.hass).render())
 
@@ -205,7 +205,7 @@ class TestHelpersTemplate(unittest.TestCase):
         """Test the timestamps to local filter."""
         now = dt_util.utcnow()
         tests = {
-            None: 'None',
+            None: None,
             1469119144: '2016-07-21 16:39:04',
             dt_util.as_timestamp(now):
                 now.strftime('%Y-%m-%d %H:%M:%S')
@@ -219,29 +219,29 @@ class TestHelpersTemplate(unittest.TestCase):
 
     def test_as_timestamp(self):
         """Test the as_timestamp function."""
-        self.assertEqual("None",
+        self.assertEqual(None,
                          template.Template('{{ as_timestamp("invalid") }}',
                                            self.hass).render())
         self.hass.mock = None
-        self.assertEqual("None",
+        self.assertEqual(None,
                          template.Template('{{ as_timestamp(states.mock) }}',
                                            self.hass).render())
 
         tpl = '{{ as_timestamp(strptime("2024-02-03T09:10:24+0000", ' \
             '"%Y-%m-%dT%H:%M:%S%z")) }}'
-        self.assertEqual("1706951424.0",
+        self.assertEqual(1706951424.0,
                          template.Template(tpl, self.hass).render())
 
     def test_passing_vars_as_keywords(self):
         """Test passing variables as keywords."""
         self.assertEqual(
-            '127',
+            127,
             template.Template('{{ hello }}', self.hass).render(hello=127))
 
     def test_passing_vars_as_vars(self):
         """Test passing variables as variables."""
         self.assertEqual(
-            '127',
+            127,
             template.Template('{{ hello }}', self.hass).render({'hello': 127}))
 
     def test_render_with_possible_json_value_with_valid_json(self):
@@ -317,7 +317,7 @@ class TestHelpersTemplate(unittest.TestCase):
         tpl = template.Template("""
 {{ is_state("test.noobject", "available") }}
             """, self.hass)
-        self.assertEqual('False', tpl.render())
+        self.assertEqual(False, tpl.render())
 
     def test_is_state_attr(self):
         """Test is_state_attr method."""
@@ -330,7 +330,7 @@ class TestHelpersTemplate(unittest.TestCase):
         tpl = template.Template("""
 {{ is_state_attr("test.noobject", "mode", "on") }}
                 """, self.hass)
-        self.assertEqual('False', tpl.render())
+        self.assertEqual(False, tpl.render())
 
     def test_states_function(self):
         """Test using states as a function."""
@@ -371,7 +371,7 @@ class TestHelpersTemplate(unittest.TestCase):
         })
         tpl = template.Template('{{ distance(states.test.object) | round }}',
                                 self.hass)
-        self.assertEqual('187', tpl.render())
+        self.assertEqual(187, tpl.render())
 
     def test_distance_function_with_2_states(self):
         """Test distance function with 2 states."""
@@ -386,20 +386,20 @@ class TestHelpersTemplate(unittest.TestCase):
         tpl = template.Template(
             '{{ distance(states.test.object, states.test.object_2) | round }}',
             self.hass)
-        self.assertEqual('187', tpl.render())
+        self.assertEqual(187, tpl.render())
 
     def test_distance_function_with_1_coord(self):
         """Test distance function with 1 coord."""
         tpl = template.Template(
             '{{ distance("32.87336", "-117.22943") | round }}', self.hass)
         self.assertEqual(
-            '187',
+            187,
             tpl.render())
 
     def test_distance_function_with_2_coords(self):
         """Test distance function with 2 coords."""
         self.assertEqual(
-            '187',
+            187,
             template.Template(
                 '{{ distance("32.87336", "-117.22943", %s, %s) | round }}'
                 % (self.hass.config.latitude, self.hass.config.longitude),
@@ -414,12 +414,12 @@ class TestHelpersTemplate(unittest.TestCase):
         tpl = template.Template(
             '{{ distance("32.87336", "-117.22943", states.test.object_2) '
             '| round }}', self.hass)
-        self.assertEqual('187', tpl.render())
+        self.assertEqual(187, tpl.render())
 
         tpl2 = template.Template(
             '{{ distance(states.test.object_2, "32.87336", "-117.22943") '
             '| round }}', self.hass)
-        self.assertEqual('187', tpl2.render())
+        self.assertEqual(187, tpl2.render())
 
     def test_distance_function_return_None_if_invalid_state(self):
         """Test distance function return None if invalid state."""
@@ -429,18 +429,18 @@ class TestHelpersTemplate(unittest.TestCase):
         tpl = template.Template('{{ distance(states.test.object_2) | round }}',
                                 self.hass)
         self.assertEqual(
-            'None',
+            None,
             tpl.render())
 
     def test_distance_function_return_None_if_invalid_coord(self):
         """Test distance function return None if invalid coord."""
         self.assertEqual(
-            'None',
+            None,
             template.Template(
                 '{{ distance("123", "abc") }}', self.hass).render())
 
         self.assertEqual(
-            'None',
+            None,
             template.Template('{{ distance("123") }}', self.hass).render())
 
         self.hass.states.set('test.object_2', 'happy', {
@@ -450,7 +450,7 @@ class TestHelpersTemplate(unittest.TestCase):
         tpl = template.Template('{{ distance("123", states.test_object_2) }}',
                                 self.hass)
         self.assertEqual(
-            'None',
+            None,
             tpl.render())
 
     def test_closest_function_home_vs_domain(self):
@@ -610,7 +610,7 @@ class TestHelpersTemplate(unittest.TestCase):
 
         for state in ('states.zone.non_existing', '"zone.non_existing"'):
             self.assertEqual(
-                'None',
+                None,
                 template.Template('{{ closest(%s, states) }}' % state,
                                   self.hass).render())
 
@@ -622,7 +622,7 @@ class TestHelpersTemplate(unittest.TestCase):
         })
 
         self.assertEqual(
-            'None',
+            None,
             template.Template(
                 '{{ closest(states.test_domain.closest_home, '
                 'states) }}', self.hass).render())
@@ -635,14 +635,14 @@ class TestHelpersTemplate(unittest.TestCase):
         })
 
         self.assertEqual(
-            'None',
+            None,
             template.Template('{{ closest("invalid", "coord", states) }}',
                               self.hass).render())
 
     def test_closest_function_no_location_states(self):
         """Test closest function without location states."""
         self.assertEqual(
-            'None',
+            None,
             template.Template('{{ closest(states) }}', self.hass).render())
 
     def test_extract_entities_none_exclude_stuff(self):


### PR DESCRIPTION
## Description:
Currently the `template_data` expects a dictionary of separate keys. When multiple of these keys need a value based on the same variable, the configuration gets redundant very quickly.
In my quest to make the `template_data` less redundant I had to make some changes that affect the template output.

First of all I changed the config validation to accept a template for `template_data` without it being wrapped in a YAML dict (nothing fancy here).
Second, since Jinja will always output a string, **all** template output is now `eval`ed using `ast.literal_eval()`. The `ast` eval only accepts `strings`, `bytes`, `numbers`, `tuples`, `lists`, `dicts`, `sets`, `booleans`, and `None`, so is safe to use.
This also means everything is outputted as the correct type already, resulting in more "natural" variables as well! (and probably less filters to cast these variables)
And third, I had to make some changes to the existing tests to accept the "natural" variables instead of expecting strings everywhere.

It passes the tests, but I still feel it would be better if tested on several real world configurations to make sure nothing still expects to receive a string instead of an int/float/etc...

*Known issues*: Both Jinja and the `eval` strip off quotes. So something like `'"a string"'` will result in `a string` instead of `"a string"`. This can probably be solved by checking if `ast` returns a string, and when it does use the template-rendered string instead of the `ast` output.

**Related issue:** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:**
Will have to review the docs if anything changes. Might want to add the dictionary example.

## Example entry for `configuration.yaml`:
```yaml
automation:
  - alias: Example configuration
    action:
      service: light.turn_on
      data_template: >
        {% set some_var_to_reuse = range(1, 255) | random %}
        {% set our_dict = { "brightness": some_var_to_reuse, "transition": some_var_to_reuse * 2 } %}
        {{ our_dict }}
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) *(Will have to review this)*

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
