### PR TITLE
Upgrade temperusb to 1.5.3

### DIFF
--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['temperusb==1.5.1']
+REQUIREMENTS = ['temperusb==1.5.3']
 
 CONF_SCALE = 'scale'
 CONF_OFFSET = 'offset'
@@ -35,7 +35,7 @@ def get_temper_devices():
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setu p the Temper sensors."""
+    """Set up the Temper sensors."""
     temp_unit = hass.config.units.temperature_unit
     name = config.get(CONF_NAME)
     scaling = {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -784,7 +784,7 @@ tellcore-py==1.1.2
 tellduslive==0.3.4
 
 # homeassistant.components.sensor.temper
-temperusb==1.5.1
+temperusb==1.5.3
 
 # homeassistant.components.thingspeak
 thingspeak==0.4.1


### PR DESCRIPTION
1.5.3
----

### Added
- Support for 0c45:7402 (RDing TEMPer1F_H1_V1.4) including humidity
- Hints for local development
- Add release documentation to `DEVELOPMENT.md`.

### Fixed
- Negative temperature readings incorrectly wrapped around to very high temperatures
- Fixed format string error in the munin plugin

Tested with the following configuration:

``` yaml
sensor:
  - platform: temper
    name: TemperUSB
```

```bash
[33613.334949] usb 1-1: USB disconnect, device number 29
[33616.514292] usb 1-1: new low-speed USB device number 30 using xhci_hcd
[33616.690502] usb 1-1: New USB device found, idVendor=0c45, idProduct=7401
[33616.690510] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[33616.690514] usb 1-1: Product: TEMPer1V1.4
[33616.690518] usb 1-1: Manufacturer: RDing
[33616.698727] input: RDing TEMPer1V1.4 as /devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1:1.0/0003:0C45:7401.000B/input/input24
[33616.752479] hid-generic 0003:0C45:7401.000B: input,hidraw0: USB HID v1.10 Keyboard [RDing TEMPer1V1.4] on usb-0000:00:14.0-1/input0
[33616.756364] hid-generic 0003:0C45:7401.000C: hiddev0,hidraw1: USB HID v1.10 Device [RDing TEMPer1V1.4] on usb-0000:00:14.0-1/input1
```