### PR TITLE
HomeMatic: Fix for broken virtual switches

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -577,6 +577,8 @@ def _device_from_servicecall(hass, service):
     """Extract homematic device from service call."""
     address = service.data.get(ATTR_ADDRESS)
     proxy = service.data.get(ATTR_PROXY)
+    if address == 'BIDCOS-RF':
+        address = 'BidCoS-RF'
 
     if proxy:
         return hass.data[DATA_HOMEMATIC].devices[proxy].get(address)


### PR DESCRIPTION
## Description:
In the past it was possible to trigger virtual switches on the HomeMatic hub using a service. This doesn't work anymore because the payload data is being capitalized, whereas the device IDs for HomeMatic are case sensitive, which is relevant for this one particular device type.
This change reverts the `upper()`'d device ID to how it should be.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
