### PR TITLE
Suppress logs when octorpint goes offline

### DIFF
--- a/homeassistant/components/octoprint.py
+++ b/homeassistant/components/octoprint.py
@@ -85,7 +85,8 @@ class OctoPrintAPI(object):
                 self.printer_last_reading[0] = response.json()
                 self.printer_last_reading[1] = time.time()
             return response.json()
-        except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError) as conn_exc:
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.HTTPError) as conn_exc:
             _LOGGER.error("Failed to update OctoPrint status.  Error: %s",
                           conn_exc)
 

--- a/homeassistant/components/octoprint.py
+++ b/homeassistant/components/octoprint.py
@@ -85,18 +85,15 @@ class OctoPrintAPI(object):
                 self.printer_last_reading[0] = response.json()
                 self.printer_last_reading[1] = time.time()
             return response.json()
-        except requests.exceptions.ConnectionError as conn_exc:
+        except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError) as conn_exc:
             _LOGGER.error("Failed to update OctoPrint status.  Error: %s",
                           conn_exc)
-            raise
 
     def update(self, sensor_type, end_point, group, tool=None):
         """Return the value for sensor_type from the provided endpoint."""
-        try:
-            return get_value_from_json(
-                self.get(end_point), sensor_type, group, tool)
-        except requests.exceptions.ConnectionError:
-            raise
+        response = self.get(end_point)
+        if response is not None:
+            return get_value_from_json(response, sensor_type, group, tool)
 
 
 # pylint: disable=unused-variable


### PR DESCRIPTION
## Description:
If the users OctoPrint server is taken offline or they power off their printer, currently a Trackback is written to the logs. This logs an error message to the logs still, but doesn't raise the caught exception. 

This won't fix the issue were a config error is created if the printer isn't connected at HA startup. 

Fixes one of the issues reported in the thread below. 

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/octoprint-persistent-notification-invalid-config-when-3d-printer-is-not-turned-on

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
