### PR TITLE
Update join

### DIFF
--- a/homeassistant/components/joaoapps_join.py
+++ b/homeassistant/components/joaoapps_join.py
@@ -11,52 +11,65 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_NAME, CONF_API_KEY
 
-REQUIREMENTS = ['python-join-api==0.0.1']
+REQUIREMENTS = ['python-join-api==0.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'joaoapps_join'
 CONF_DEVICE_ID = 'device_id'
+CONF_DEVICE_IDS = 'device_ids'
+CONF_DEVICE_NAMES = 'device_names'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.All(cv.ensure_list, [{
-        vol.Required(CONF_DEVICE_ID): cv.string,
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_API_KEY): cv.string
+        vol.Required(CONF_API_KEY): cv.string,
+        vol.Optional(CONF_DEVICE_ID): cv.string,
+        vol.Optional(CONF_DEVICE_IDS): cv.string,
+        vol.Optional(CONF_DEVICE_NAMES): cv.string,
+        vol.Optional(CONF_NAME): cv.string
     }])
 }, extra=vol.ALLOW_EXTRA)
 
 
-def register_device(hass, device_id, api_key, name):
+def register_device(hass, api_key, name, device_id, device_ids, device_names):
     """Register services for each join device listed."""
     from pyjoin import (ring_device, set_wallpaper, send_sms,
                         send_file, send_url, send_notification)
 
     def ring_service(service):
         """Service to ring devices."""
-        ring_device(device_id, api_key=api_key)
+        ring_device(api_key=api_key, device_id=device_id,
+                    device_ids=device_ids, device_names=device_names)
 
     def set_wallpaper_service(service):
         """Service to set wallpaper on devices."""
-        set_wallpaper(device_id, url=service.data.get('url'), api_key=api_key)
+        set_wallpaper(api_key=api_key, device_id=device_id,
+                      device_ids=device_ids, device_names=device_names,
+                      url=service.data.get('url'))
 
     def send_file_service(service):
         """Service to send files to devices."""
-        send_file(device_id, url=service.data.get('url'), api_key=api_key)
+        send_file(api_key=api_key, device_id=device_id,
+                  device_ids=device_ids, device_names=device_names,
+                  url=service.data.get('url'))
 
     def send_url_service(service):
         """Service to open url on devices."""
-        send_url(device_id, url=service.data.get('url'), api_key=api_key)
+        send_url(api_key=api_key, device_id=device_id,
+                 device_ids=device_ids, device_names=device_names,
+                 url=service.data.get('url'))
 
     def send_tasker_service(service):
         """Service to open url on devices."""
-        send_notification(device_id=device_id,
-                          text=service.data.get('command'),
-                          api_key=api_key)
+        send_notification(api_key=api_key, device_id=device_id,
+                          device_ids=device_ids, device_names=device_names,
+                          text=service.data.get('command'))
 
     def send_sms_service(service):
         """Service to send sms from devices."""
         send_sms(device_id=device_id,
+                 device_ids=device_ids,
+                 device_names=device_names,
                  sms_number=service.data.get('number'),
                  sms_text=service.data.get('message'),
                  api_key=api_key)
@@ -74,13 +87,21 @@ def setup(hass, config):
     """Set up the Join services."""
     from pyjoin import get_devices
     for device in config[DOMAIN]:
-        device_id = device.get(CONF_DEVICE_ID)
         api_key = device.get(CONF_API_KEY)
+        device_id = device.get(CONF_DEVICE_ID)
+        device_ids = device.get(CONF_DEVICE_IDS)
+        device_names = device.get(CONF_DEVICE_NAMES)
         name = device.get(CONF_NAME)
         name = name.lower().replace(" ", "_") + "_" if name else ""
         if api_key:
             if not get_devices(api_key):
                 _LOGGER.error("Error connecting to Join, check API key")
                 return False
-        register_device(hass, device_id, api_key, name)
+        if device_id is None and device_ids is None and device_names is None:
+            _LOGGER.error("No device was provided. Please specify device_id"
+                          ", device_ids, or device_names")
+            return False
+
+        register_device(hass, api_key, name,
+                        device_id, device_ids, device_names)
     return True

--- a/homeassistant/components/notify/joaoapps_join.py
+++ b/homeassistant/components/notify/joaoapps_join.py
@@ -12,38 +12,51 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-join-api==0.0.1']
+REQUIREMENTS = ['python-join-api==0.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_DEVICE_ID = 'device_id'
+CONF_DEVICE_IDS = 'device_ids'
+CONF_DEVICE_NAMES = 'device_names'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_DEVICE_ID): cv.string,
-    vol.Optional(CONF_API_KEY): cv.string
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_DEVICE_ID): cv.string,
+    vol.Optional(CONF_DEVICE_IDS): cv.string,
+    vol.Optional(CONF_DEVICE_NAMES): cv.string,
 })
 
 
 # pylint: disable=unused-variable
 def get_service(hass, config, discovery_info=None):
     """Get the Join notification service."""
-    device_id = config.get(CONF_DEVICE_ID)
     api_key = config.get(CONF_API_KEY)
+    device_id = config.get(CONF_DEVICE_ID)
+    device_ids = config.get(CONF_DEVICE_IDS)
+    device_names = config.get(CONF_DEVICE_NAMES)
     if api_key:
         from pyjoin import get_devices
         if not get_devices(api_key):
-            _LOGGER.error("Error connecting to Join. Check  theAPI key")
+            _LOGGER.error("Error connecting to Join. Check the API key")
             return False
-    return JoinNotificationService(device_id, api_key)
+    if device_id is None and device_ids is None and device_names is None:
+        _LOGGER.error("No device was provided. Please specify device_id"
+                      ", device_ids, or device_names")
+        return False
+    return JoinNotificationService(api_key, device_id,
+                                   device_ids, device_names)
 
 
 class JoinNotificationService(BaseNotificationService):
     """Implement the notification service for Join."""
 
-    def __init__(self, device_id, api_key=None):
+    def __init__(self, api_key, device_id, device_ids, device_names):
         """Initialize the service."""
-        self._device_id = device_id
         self._api_key = api_key
+        self._device_id = device_id
+        self._device_ids = device_ids
+        self._device_names = device_names
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
@@ -51,6 +64,7 @@ class JoinNotificationService(BaseNotificationService):
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
         data = kwargs.get(ATTR_DATA) or {}
         send_notification(
-            device_id=self._device_id, text=message, title=title,
+            device_id=self._device_id, device_ids=self._device_ids,
+            device_names=self._device_names, text=message, title=title,
             icon=data.get('icon'), smallicon=data.get('smallicon'),
-            api_key=self._api_key)
+            vibration=data.get('vibration'), api_key=self._api_key)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -653,7 +653,7 @@ python-hpilo==3.9
 
 # homeassistant.components.joaoapps_join
 # homeassistant.components.notify.joaoapps_join
-python-join-api==0.0.1
+python-join-api==0.0.2
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3


### PR DESCRIPTION
## Description:
Update python-join-api to 0.0.2.  This update now uses api key for all commands.  Also add device_ids, device_names, and vibration

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2564

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: joaoapps_join
    name: join
    device_names: Pixel
    api_key: asdfasdfaadsfasdf

joaoapps_join:
  - name: Pixel 
    api_key: asdfasdfaadsfasdf
    device_names: Pixel
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.


