### PR TITLE
Additional Wink lock features

### DIFF
--- a/homeassistant/components/alarm_control_panel/wink.py
+++ b/homeassistant/components/alarm_control_panel/wink.py
@@ -41,6 +41,7 @@ class WinkCameraDevice(WinkDevice, alarm.AlarmControlPanel):
     def __init__(self, wink, hass):
         """Initialize the Wink alarm."""
         super().__init__(wink, hass)
+        hass.data[DOMAIN]['entities']['alarm_control_panel'].append(self)
 
     @property
     def state(self):

--- a/homeassistant/components/alarm_control_panel/wink.py
+++ b/homeassistant/components/alarm_control_panel/wink.py
@@ -4,6 +4,7 @@ Interfaces with Wink Cameras.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/alarm_control_panel.wink/
 """
+import asyncio
 import logging
 
 import homeassistant.components.alarm_control_panel as alarm
@@ -41,7 +42,11 @@ class WinkCameraDevice(WinkDevice, alarm.AlarmControlPanel):
     def __init__(self, wink, hass):
         """Initialize the Wink alarm."""
         super().__init__(wink, hass)
-        hass.data[DOMAIN]['entities']['alarm_control_panel'].append(self)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        self.hass.data[DOMAIN]['entities']['alarm_control_panel'].append(self)
 
     @property
     def state(self):

--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -92,6 +92,7 @@ class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
     def __init__(self, wink, hass):
         """Initialize the Wink binary sensor."""
         super().__init__(wink, hass)
+        hass.data[DOMAIN]['entities']['binary_sensor'].append(self)
         if hasattr(self.wink, 'unit'):
             self._unit_of_measurement = self.wink.unit()
         else:

--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -4,6 +4,7 @@ Support for Wink binary sensors.
 For more details about this platform, please refer to the documentation at
 at https://home-assistant.io/components/binary_sensor.wink/
 """
+import asyncio
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
@@ -92,7 +93,6 @@ class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
     def __init__(self, wink, hass):
         """Initialize the Wink binary sensor."""
         super().__init__(wink, hass)
-        hass.data[DOMAIN]['entities']['binary_sensor'].append(self)
         if hasattr(self.wink, 'unit'):
             self._unit_of_measurement = self.wink.unit()
         else:
@@ -101,6 +101,11 @@ class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
             self.capability = self.wink.capability()
         else:
             self.capability = None
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        self.hass.data[DOMAIN]['entities']['binary_sensor'].append(self)
 
     @property
     def is_on(self):

--- a/homeassistant/components/climate/wink.py
+++ b/homeassistant/components/climate/wink.py
@@ -4,6 +4,8 @@ Support for Wink thermostats.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.wink/
 """
+import asyncio
+
 from homeassistant.components.wink import WinkDevice, DOMAIN
 from homeassistant.components.climate import (
     STATE_AUTO, STATE_COOL, STATE_HEAT, ClimateDevice,
@@ -50,8 +52,12 @@ class WinkThermostat(WinkDevice, ClimateDevice):
     def __init__(self, wink, hass, temp_unit):
         """Initialize the Wink device."""
         super().__init__(wink, hass)
-        hass.data[DOMAIN]['entities']['climate'].append(self)
         self._config_temp_unit = temp_unit
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        self.hass.data[DOMAIN]['entities']['climate'].append(self)
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/climate/wink.py
+++ b/homeassistant/components/climate/wink.py
@@ -50,6 +50,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
     def __init__(self, wink, hass, temp_unit):
         """Initialize the Wink device."""
         super().__init__(wink, hass)
+        hass.data[DOMAIN]['entities']['climate'].append(self)
         self._config_temp_unit = temp_unit
 
     @property

--- a/homeassistant/components/cover/wink.py
+++ b/homeassistant/components/cover/wink.py
@@ -4,6 +4,8 @@ Support for Wink Covers.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.wink/
 """
+import asyncio
+
 from homeassistant.components.cover import CoverDevice
 from homeassistant.components.wink import WinkDevice, DOMAIN
 
@@ -30,7 +32,11 @@ class WinkCoverDevice(WinkDevice, CoverDevice):
     def __init__(self, wink, hass):
         """Initialize the cover."""
         super().__init__(wink, hass)
-        hass.data[DOMAIN]['entities']['cover'].append(self)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        self.hass.data[DOMAIN]['entities']['cover'].append(self)
 
     def close_cover(self):
         """Close the shade."""

--- a/homeassistant/components/cover/wink.py
+++ b/homeassistant/components/cover/wink.py
@@ -30,6 +30,7 @@ class WinkCoverDevice(WinkDevice, CoverDevice):
     def __init__(self, wink, hass):
         """Initialize the cover."""
         super().__init__(wink, hass)
+        hass.data[DOMAIN]['entities']['cover'].append(self)
 
     def close_cover(self):
         """Close the shade."""

--- a/homeassistant/components/fan/wink.py
+++ b/homeassistant/components/fan/wink.py
@@ -4,6 +4,7 @@ Support for Wink fans.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/fan.wink/
 """
+import asyncio
 import logging
 
 from homeassistant.components.fan import (FanEntity, SPEED_HIGH,
@@ -35,7 +36,11 @@ class WinkFanDevice(WinkDevice, FanEntity):
     def __init__(self, wink, hass):
         """Initialize the fan."""
         super().__init__(wink, hass)
-        hass.data[DOMAIN]['entities']['fan'].append(self)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        self.hass.data[DOMAIN]['entities']['fan'].append(self)
 
     def set_direction(self: ToggleEntity, direction: str) -> None:
         """Set the direction of the fan."""

--- a/homeassistant/components/fan/wink.py
+++ b/homeassistant/components/fan/wink.py
@@ -12,6 +12,8 @@ from homeassistant.components.fan import (FanEntity, SPEED_HIGH,
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.components.wink import WinkDevice, DOMAIN
 
+DEPENDENCIES = ['wink']
+
 _LOGGER = logging.getLogger(__name__)
 
 SPEED_LOWEST = 'lowest'
@@ -33,6 +35,7 @@ class WinkFanDevice(WinkDevice, FanEntity):
     def __init__(self, wink, hass):
         """Initialize the fan."""
         super().__init__(wink, hass)
+        hass.data[DOMAIN]['entities']['fan'].append(self)
 
     def set_direction(self: ToggleEntity, direction: str) -> None:
         """Set the direction of the fan."""

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -4,6 +4,7 @@ Support for Wink lights.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.wink/
 """
+import asyncio
 import colorsys
 
 from homeassistant.components.light import (
@@ -37,7 +38,11 @@ class WinkLight(WinkDevice, Light):
     def __init__(self, wink, hass):
         """Initialize the Wink device."""
         super().__init__(wink, hass)
-        hass.data[DOMAIN]['entities']['light'].append(self)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        self.hass.data[DOMAIN]['entities']['light'].append(self)
 
     @property
     def is_on(self):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -37,6 +37,7 @@ class WinkLight(WinkDevice, Light):
     def __init__(self, wink, hass):
         """Initialize the Wink device."""
         super().__init__(wink, hass)
+        hass.data[DOMAIN]['entities']['light'].append(self)
 
     @property
     def is_on(self):

--- a/homeassistant/components/lock/services.yaml
+++ b/homeassistant/components/lock/services.yaml
@@ -55,3 +55,59 @@ unlock:
     code:
       description: An optional code to unlock the lock with
       example: 1234
+
+wink_set_lock_vacation_mode:
+  description: Set vacation mode for all or specified locks. Disables all user codes.
+
+  fields:
+    entity_id:
+      description: Name of lock to unlock
+      example: 'lock.front_door'
+    enabled:
+      description: enable or disable. true or false. 
+      example: true
+
+wink_set_lock_alarm_mode:
+  description: Set alarm mode for all or specified locks.
+
+  fields:
+    entity_id:
+      description: Name of lock to unlock
+      example: 'lock.front_door'
+    mode:
+      description: One of tamper, activity, or forced_entry 
+      example: tamper
+
+wink_set_lock_alarm_sensitivity:
+  description: Set alarm sensitivity for all or specified locks.
+
+  fields:
+    entity_id:
+      description: Name of lock to unlock
+      example: 'lock.front_door'
+    sensitivity:
+      description: One of low, medium_low, medium, medium_high, high 
+      example: medium
+
+wink_set_lock_alarm_state:
+  description: Set alarm state.
+
+  fields:
+    entity_id:
+      description: Name of lock to unlock
+      example: 'lock.front_door'
+    enabled:
+      description: enable or disable. true or false. 
+      example: true
+
+wink_set_lock_beeper_state:
+  description: Set beeper state.
+
+  fields:
+    entity_id:
+      description: Name of lock to unlock
+      example: 'lock.front_door'
+    enabled:
+      description: enable or disable. true or false. 
+      example: true
+

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -4,10 +4,53 @@ Support for Wink locks.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/lock.wink/
 """
+import logging
+from os import path
+
+import voluptuous as vol
+
 from homeassistant.components.lock import LockDevice
 from homeassistant.components.wink import WinkDevice, DOMAIN
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.config import load_yaml_config_file
 
 DEPENDENCIES = ['wink']
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_SET_VACATION_MODE = 'wink_set_lock_vacation_mode'
+SERVICE_SET_ALARM_MODE = 'wink_set_lock_alarm_mode'
+SERVICE_SET_ALARM_SENSITIVITY = 'wink_set_lock_alarm_sensitivity'
+SERVICE_SET_ALARM_STATE = 'wink_set_lock_alarm_state'
+SERVICE_SET_BEEPER_STATE = 'wink_set_lock_beeper_state'
+
+ATTR_ENABLED = 'enabled'
+ATTR_SENSITIVITY = 'sensitivity'
+ATTR_MODE = 'mode'
+
+ALARM_SENSITIVITY_MAP = {"low": 0.2, "medium_low": 0.4,
+                         "medium": 0.6, "medium_high": 0.8,
+                         "high": 1.0}
+
+ALARM_MODES_MAP = {"tamper": "tamper",
+                   "activity": "alert",
+                   "forced_entry": "forced_entry"}
+
+SET_ENABLED_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_ENABLED): cv.string,
+})
+
+SET_SENSITIVITY_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_SENSITIVITY): vol.In(ALARM_SENSITIVITY_MAP)
+})
+
+SET_ALARM_MODES_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_MODE): vol.In(ALARM_MODES_MAP)
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -19,6 +62,58 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if _id not in hass.data[DOMAIN]['unique_ids']:
             add_devices([WinkLockDevice(lock, hass)])
 
+    def service_handle(service):
+        """Handler for services."""
+        entity_ids = service.data.get('entity_id')
+        all_locks = hass.data[DOMAIN]['entities']['lock']
+        locks_to_set = []
+        if entity_ids is None:
+            locks_to_set = all_locks
+        else:
+            for lock in all_locks:
+                if lock.entity_id in entity_ids:
+                    locks_to_set.append(lock)
+
+        for lock in locks_to_set:
+            if service.service == SERVICE_SET_VACATION_MODE:
+                lock.set_vacation_mode(service.data.get(ATTR_ENABLED))
+            elif service.service == SERVICE_SET_ALARM_STATE:
+                lock.set_alarm_state(service.data.get(ATTR_ENABLED))
+            elif service.service == SERVICE_SET_BEEPER_STATE:
+                lock.set_beeper_state(service.data.get(ATTR_ENABLED))
+            elif service.service == SERVICE_SET_ALARM_MODE:
+                lock.set_alarm_mode(service.data.get(ATTR_MODE))
+            elif service.service == SERVICE_SET_ALARM_SENSITIVITY:
+                lock.set_alarm_sensitivity(service.data.get(ATTR_SENSITIVITY))
+
+    descriptions = load_yaml_config_file(
+        path.join(path.dirname(__file__), 'services.yaml'))
+
+    hass.services.register(DOMAIN, SERVICE_SET_VACATION_MODE,
+                           service_handle,
+                           descriptions.get(SERVICE_SET_VACATION_MODE),
+                           schema=SET_ENABLED_SCHEMA)
+
+    hass.services.register(DOMAIN, SERVICE_SET_ALARM_STATE,
+                           service_handle,
+                           descriptions.get(SERVICE_SET_ALARM_STATE),
+                           schema=SET_ENABLED_SCHEMA)
+
+    hass.services.register(DOMAIN, SERVICE_SET_BEEPER_STATE,
+                           service_handle,
+                           descriptions.get(SERVICE_SET_BEEPER_STATE),
+                           schema=SET_ENABLED_SCHEMA)
+
+    hass.services.register(DOMAIN, SERVICE_SET_ALARM_MODE,
+                           service_handle,
+                           descriptions.get(SERVICE_SET_ALARM_MODE),
+                           schema=SET_ALARM_MODES_SCHEMA)
+
+    hass.services.register(DOMAIN, SERVICE_SET_ALARM_SENSITIVITY,
+                           service_handle,
+                           descriptions.get(SERVICE_SET_ALARM_SENSITIVITY),
+                           schema=SET_SENSITIVITY_SCHEMA)
+
 
 class WinkLockDevice(WinkDevice, LockDevice):
     """Representation of a Wink lock."""
@@ -26,6 +121,7 @@ class WinkLockDevice(WinkDevice, LockDevice):
     def __init__(self, wink, hass):
         """Initialize the lock."""
         super().__init__(wink, hass)
+        hass.data[DOMAIN]['entities']['lock'].append(self)
 
     @property
     def is_locked(self):
@@ -39,3 +135,62 @@ class WinkLockDevice(WinkDevice, LockDevice):
     def unlock(self, **kwargs):
         """Unlock the device."""
         self.wink.set_state(False)
+
+    def set_alarm_state(self, enabled):
+        """Set lock's alarm state."""
+        self.wink.set_alarm_state(enabled)
+
+    def set_vacation_mode(self, enabled):
+        """Set lock's vacation mode."""
+        self.wink.set_vacation_mode(enabled)
+
+    def set_beeper_state(self, enabled):
+        """Set lock's beeper mode."""
+        self.wink.set_beeper_mode(enabled)
+
+    def set_alarm_sensitivity(self, sensitivity):
+        """
+        Set lock's alarm sensitivity.
+
+        Valid sensitivities:
+            0.2, 0.4, 0.6, 0.8, 1.0
+        """
+        self.wink.set_alarm_sensitivity(sensitivity)
+
+    def set_alarm_mode(self, mode):
+        """
+        Set lock's alarm mode.
+
+        Valid modes:
+            alert - Beep when lock is locked or unlocked
+            tamper - 15 sec alarm when lock is disturbed when locked
+            forced_entry - 3 min alarm when significant force applied
+                           to door when locked.
+        """
+        self.wink.set_alarm_mode(mode)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        super_attrs = super().device_state_attributes
+        sensitivity = dict_value_to_key(ALARM_SENSITIVITY_MAP,
+                                        self.wink.alarm_sensitivity())
+        super_attrs['alarm sensitivity'] = sensitivity
+        super_attrs['vacation mode'] = self.wink.vacation_mode_enabled()
+        super_attrs['beeper mode'] = self.wink.beeper_enabled()
+        super_attrs['auto lock'] = self.wink.auto_lock_enabled()
+        alarm_mode = dict_value_to_key(ALARM_MODES_MAP,
+                                       self.wink.alarm_mode())
+        super_attrs['alarm mode'] = alarm_mode
+        super_attrs['alarm enabled'] = self.wink.alarm_enabled()
+        return super_attrs
+
+
+def dict_value_to_key(dict_map, comp_value):
+    """
+    Return the key that has the provided value.
+    """
+    for key, value in dict_map.items():
+        if value == comp_value:
+            return key
+    return STATE_UNKNOWN

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -187,9 +187,7 @@ class WinkLockDevice(WinkDevice, LockDevice):
 
 
 def dict_value_to_key(dict_map, comp_value):
-    """
-    Return the key that has the provided value.
-    """
+    """Return the key that has the provided value."""
     for key, value in dict_map.items():
         if value == comp_value:
             return key

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -4,6 +4,7 @@ Support for Wink locks.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/lock.wink/
 """
+import asyncio
 import logging
 from os import path
 
@@ -121,7 +122,11 @@ class WinkLockDevice(WinkDevice, LockDevice):
     def __init__(self, wink, hass):
         """Initialize the lock."""
         super().__init__(wink, hass)
-        hass.data[DOMAIN]['entities']['lock'].append(self)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        self.hass.data[DOMAIN]['entities']['lock'].append(self)
 
     @property
     def is_locked(self):

--- a/homeassistant/components/scene/wink.py
+++ b/homeassistant/components/scene/wink.py
@@ -4,6 +4,7 @@ Support for Wink scenes.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/scene.wink/
 """
+import asyncio
 import logging
 
 from homeassistant.components.scene import Scene
@@ -30,6 +31,11 @@ class WinkScene(WinkDevice, Scene):
         """Initialize the Wink device."""
         super().__init__(wink, hass)
         hass.data[DOMAIN]['entities']['scene'].append(self)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        self.hass.data[DOMAIN]['entities']['scene'].append(self)
 
     @property
     def is_on(self):

--- a/homeassistant/components/scene/wink.py
+++ b/homeassistant/components/scene/wink.py
@@ -29,6 +29,7 @@ class WinkScene(WinkDevice, Scene):
     def __init__(self, wink, hass):
         """Initialize the Wink device."""
         super().__init__(wink, hass)
+        hass.data[DOMAIN]['entities']['scene'].append(self)
 
     @property
     def is_on(self):

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -52,6 +52,7 @@ class WinkSensorDevice(WinkDevice, Entity):
     def __init__(self, wink, hass):
         """Initialize the Wink device."""
         super().__init__(wink, hass)
+        hass.data[DOMAIN]['entities']['sensor'].append(self)
         self.capability = self.wink.capability()
         if self.wink.unit() == '°':
             self._unit_of_measurement = TEMP_CELSIUS

--- a/homeassistant/components/sensor/wink.py
+++ b/homeassistant/components/sensor/wink.py
@@ -4,6 +4,7 @@ Support for Wink sensors.
 For more details about this platform, please refer to the documentation at
 at https://home-assistant.io/components/sensor.wink/
 """
+import asyncio
 import logging
 
 from homeassistant.const import TEMP_CELSIUS
@@ -52,12 +53,16 @@ class WinkSensorDevice(WinkDevice, Entity):
     def __init__(self, wink, hass):
         """Initialize the Wink device."""
         super().__init__(wink, hass)
-        hass.data[DOMAIN]['entities']['sensor'].append(self)
         self.capability = self.wink.capability()
         if self.wink.unit() == '°':
             self._unit_of_measurement = TEMP_CELSIUS
         else:
             self._unit_of_measurement = self.wink.unit()
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        self.hass.data[DOMAIN]['entities']['sensor'].append(self)
 
     @property
     def state(self):

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -4,6 +4,7 @@ Support for Wink switches.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.wink/
 """
+import asyncio
 
 from homeassistant.components.wink import WinkDevice, DOMAIN
 from homeassistant.helpers.entity import ToggleEntity
@@ -39,7 +40,11 @@ class WinkToggleDevice(WinkDevice, ToggleEntity):
     def __init__(self, wink, hass):
         """Initialize the Wink device."""
         super().__init__(wink, hass)
-        hass.data[DOMAIN]['entities']['switch'].append(self)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        self.hass.data[DOMAIN]['entities']['switch'].append(self)
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -39,6 +39,7 @@ class WinkToggleDevice(WinkDevice, ToggleEntity):
     def __init__(self, wink, hass):
         """Initialize the Wink device."""
         super().__init__(wink, hass)
+        hass.data[DOMAIN]['entities']['switch'].append(self)
 
     @property
     def is_on(self):


### PR DESCRIPTION
## Description:

This adds support for changing the additional features supported by Wink locks.

This adds services to
- Enabled/disable lock vacation mode (disables all user codes)
- Enabled/disable the beeper
- Enable/disable the alarm
- Set the alarm mode to one of
  - activity="beep any time the lock is activated (locked/unlocked)"
  - tamper="beep if force is applied to door 3 minutes"
  - forced_entry="continuous alarm if lock is forced open"
- Set the alarm sensitivity to one of the following
  - low, medium_low, medium, medium_high, high

~~Since this is unique to Wink should the service descriptions got in the services.yaml?~~

~~Is there a better way to handle the service calls one entity vs multiple?~~

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/2609

## Example entry for `configuration.yaml` (if applicable):
See doc for examples.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
