### PR TITLE
sensor.envirophat: add missing requirement

### DIFF
--- a/homeassistant/components/sensor/envirophat.py
+++ b/homeassistant/components/sensor/envirophat.py
@@ -15,7 +15,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['envirophat==0.0.6']
+REQUIREMENTS = ['envirophat==0.0.6',
+                'smbus-cffi==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -767,6 +767,9 @@ sleekxmpp==1.3.2
 # homeassistant.components.sleepiq
 sleepyq==0.6
 
+# homeassistant.components.sensor.envirophat
+smbus-cffi==0.5.1
+
 # homeassistant.components.media_player.snapcast
 snapcast==1.2.2
 


### PR DESCRIPTION
## Description:

Adding a requirement that is for some reason not explicitly pulled in by the library that manages the Enviro pHAT.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
