### PR TITLE
Fix object type for default KNX port

### DIFF
--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -18,7 +18,7 @@ REQUIREMENTS = ['knxip==0.3.3']
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_HOST = '0.0.0.0'
-DEFAULT_PORT = '3671'
+DEFAULT_PORT = 3671
 DOMAIN = 'knx'
 
 EVENT_KNX_FRAME_RECEIVED = 'knx_frame_received'


### PR DESCRIPTION
#7429 describes a TypeError that is raised if the port is omitted in the config for the KNX component (integer is required (got type str)). This commit changes the default port from a string to an integer. I expect this will resolve that issue...

**Related issue (if applicable):** fixes #7429 (probably...)

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
