### PR TITLE
Update to pyunifi 2.12

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -15,7 +15,7 @@ from homeassistant.components.device_tracker import (
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.const import CONF_VERIFY_SSL
 
-REQUIREMENTS = ['pyunifi==2.0']
+REQUIREMENTS = ['pyunifi==2.12']
 
 _LOGGER = logging.getLogger(__name__)
 CONF_PORT = 'port'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -698,7 +698,7 @@ pytrackr==0.0.5
 pytradfri==1.1
 
 # homeassistant.components.device_tracker.unifi
-pyunifi==2.0
+pyunifi==2.12
 
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11


### PR DESCRIPTION
## Description:
Attempted to add improved exception handling within pyunifi.  The pyunifi package will now attempt to log in if an access error is encountered.  Additionally, the package will try 5 times for the unifi server to be brought back up in 1 minute intervals prior to giving up.

If the end user decides to not use a verified ssl certificate, the pyunifi package will now spit out warnings every time it sends a request as was requested by @balloob.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
No changes

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
