### PR TITLE
Test only dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ matrix:
   fast_finish: true
   include:
     - python: "3.4.2"
-      env: TOXENV=py34
-    - python: "3.4.2"
-      env: TOXENV=requirements
-    - python: "3.4.2"
       env: TOXENV=lint
+    - python: "3.4.2"
+      env: TOXENV=py34
     # - python: "3.5"
     #   env: TOXENV=typing
     - python: "3.5"
@@ -20,6 +18,8 @@ matrix:
       env: TOXENV=py36
     - python: "3.6-dev"
       env: TOXENV=py36
+    - python: "3.4.2"
+      env: TOXENV=requirements
   # allow_failures:
   #   - python: "3.5"
   #     env: TOXENV=typing

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1,0 +1,158 @@
+# Home Assistant test
+# linters such as flake8 and pylint should be pinned, as new releases
+# make new things fail. Manually update these pins when pulling in a
+# new version
+flake8==3.3
+pylint==1.6.5
+mypy==0.501
+pydocstyle==1.1.1
+coveralls>=1.1
+pytest>=2.9.2
+pytest-aiohttp>=0.1.3
+pytest-asyncio>=0.5.0
+pytest-cov>=2.3.1
+pytest-timeout>=1.2.0
+pytest-catchlog>=1.2.2
+pytest-sugar>=0.7.1
+requests_mock>=1.0
+mock-open>=1.3.1
+flake8-docstrings==1.0.2
+asynctest>=0.8.0
+freezegun>=0.3.8
+
+
+# homeassistant.components.notify.html5
+PyJWT==1.4.2
+
+# homeassistant.components.media_player.sonos
+SoCo==0.12
+
+# homeassistant.components.device_tracker.automatic
+aioautomatic==0.3.1
+
+# homeassistant.components.emulated_hue
+# homeassistant.components.http
+aiohttp_cors==0.5.3
+
+# homeassistant.components.notify.apns
+apns2==0.1.1
+
+# homeassistant.components.sun
+# homeassistant.components.sensor.moon
+astral==1.4
+
+# homeassistant.components.datadog
+datadog==0.15.0
+
+# homeassistant.components.sensor.dsmr
+dsmr_parser==0.8
+
+# homeassistant.components.climate.honeywell
+evohomeclient==0.2.5
+
+# homeassistant.components.media_player.frontier_silicon
+fsapi==0.0.7
+
+# homeassistant.components.conversation
+fuzzywuzzy==0.15.0
+
+# homeassistant.components.tts.google
+gTTS-token==1.1.1
+
+# homeassistant.components.ffmpeg
+ha-ffmpeg==1.5
+
+# homeassistant.components.mqtt.server
+hbmqtt==0.8
+
+# homeassistant.components.binary_sensor.workday
+holidays==0.8.1
+
+# homeassistant.components.influxdb
+# homeassistant.components.sensor.influxdb
+influxdb==3.0.0
+
+# homeassistant.components.media_player.soundtouch
+libsoundtouch==0.3.0
+
+# homeassistant.components.sensor.mfi
+# homeassistant.components.switch.mfi
+mficlient==0.3.0
+
+# homeassistant.components.tts
+mutagen==1.37.0
+
+# homeassistant.components.discovery
+netdisco==1.0.0rc3
+
+# homeassistant.components.mqtt
+paho-mqtt==1.2.3
+
+# homeassistant.components.device_tracker.aruba
+# homeassistant.components.device_tracker.asuswrt
+# homeassistant.components.device_tracker.cisco_ios
+# homeassistant.components.media_player.pandora
+pexpect==4.0.1
+
+# homeassistant.components.pilight
+pilight==0.1.1
+
+# homeassistant.components.sensor.mhz19
+# homeassistant.components.sensor.serial_pm
+pmsensor==0.4
+
+# homeassistant.components.media_player.cast
+pychromecast==0.8.1
+
+# homeassistant.components.media_player.cmus
+pycmus==0.1.0
+
+# homeassistant.components.zwave
+pydispatcher==2.0.5
+
+# homeassistant.components.litejet
+pylitejet==0.1
+
+# homeassistant.components.mochad
+pymochad==0.1.1
+
+# homeassistant.components.alarm_control_panel.nx584
+# homeassistant.components.binary_sensor.nx584
+pynx584==0.4
+
+# homeassistant.components.sensor.darksky
+python-forecastio==1.3.5
+
+# homeassistant.components.device_tracker.unifi
+pyunifi==2.0
+
+# homeassistant.components.notify.html5
+pywebpush==0.6.1
+
+# homeassistant.components.rflink
+rflink==0.0.31
+
+# homeassistant.components.ring
+ring_doorbell==0.1.4
+
+# homeassistant.components.media_player.yamaha
+rxv==0.4.0
+
+# homeassistant.components.sleepiq
+sleepyq==0.6
+
+# homeassistant.components.climate.honeywell
+somecomfort==0.4.1
+
+# homeassistant.components.recorder
+# homeassistant.scripts.db_migrator
+sqlalchemy==1.1.9
+
+# homeassistant.components.statsd
+statsd==3.2.1
+
+# homeassistant.components.camera.uvc
+uvcclient==0.10.0
+
+# homeassistant.components.sensor.yahoo_finance
+yahoo-finance==1.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -110,6 +110,9 @@ pycmus==0.1.0
 # homeassistant.components.zwave
 pydispatcher==2.0.5
 
+# homeassistant.components.notify.html5
+pyelliptic==1.5.7
+
 # homeassistant.components.litejet
 pylitejet==0.1
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -235,6 +235,12 @@ def validate_requirements_file(data):
         return data == ''.join(req_file)
 
 
+def validate_requirements_test_file(data):
+    """Validate if requirements_all.txt is up to date."""
+    with open('requirements_test_all.txt', 'r') as req_file:
+        return data == ''.join(req_file)
+
+
 def validate_constraints_file(data):
     """Validate if constraints is up to date."""
     with open(CONSTRAINT_PATH, 'r') as req_file:
@@ -254,23 +260,31 @@ def main():
 
     constraints = gather_constraints()
 
+    reqs_file = requirements_all_output(data)
+    reqs_test_file = requirements_test_output(data)
+
     if sys.argv[-1] == 'validate':
-        if not validate_requirements_file(data):
-            print("******* ERROR")
-            print("requirements_all.txt is not up to date")
-            print("Please run script/gen_requirements_all.py")
-            sys.exit(1)
+        errors = []
+        if not validate_requirements_file(reqs_file):
+            errors.append("requirements_all.txt is not up to date")
+
+        if not validate_requirements_test_file(reqs_test_file):
+            errors.append("requirements_test_all.txt is not up to date")
 
         if not validate_constraints_file(constraints):
+            errors.append(
+                "home-assistant/package_constraints.txt is not up to date")
+
+        if errors:
             print("******* ERROR")
-            print("home-assistant/package_constraints.txt is not up to date")
+            print('\n'.join(errors))
             print("Please run script/gen_requirements_all.py")
             sys.exit(1)
 
         sys.exit(0)
 
-    write_requirements_file(requirements_all_output(data))
-    write_test_requirements_file(requirements_test_output(data))
+    write_requirements_file(reqs_file)
+    write_test_requirements_file(reqs_test_file)
     write_constraints_file(constraints)
 
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -180,7 +180,7 @@ def generate_requirements_list(reqs):
 
 
 def requirements_all_output(reqs):
-    """Generate output for requirements_all"""
+    """Generate output for requirements_all."""
     output = []
     output.append('# Home Assistant core')
     output.append('\n')

--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,14 @@ install_command = /usr/bin/env LANG=C.UTF-8 pip install {opts} {packages}
 commands =
      py.test --timeout=30 --duration=10 --cov --cov-report= {posargs}
 deps =
-     -r{toxinidir}/requirements_all.txt
-     -r{toxinidir}/requirements_test.txt
+     -r{toxinidir}/requirements_test_all.txt
 
 [testenv:lint]
 basepython = python3
 ignore_errors = True
+deps =
+     -r{toxinidir}/requirements_all.txt
+     -r{toxinidir}/requirements_test.txt
 commands =
      flake8
      pylint homeassistant


### PR DESCRIPTION
## Description:
Only install the minimum set of dependencies needed to run tests.

Fixes #7458 

We only have to install `libudev-dev` now for the linting task. We might want to see if we can download libudev-dev as a tox prep task for that env ? 🤔 

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
