### PR TITLE
Remove listening to homeassistant_start with event automation

### DIFF
--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -9,8 +9,8 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback, CoreState
-from homeassistant.const import CONF_PLATFORM, EVENT_HOMEASSISTANT_START
+from homeassistant.core import callback
+from homeassistant.const import CONF_PLATFORM
 from homeassistant.helpers import config_validation as cv
 
 CONF_EVENT_TYPE = 'event_type'
@@ -30,19 +30,6 @@ def async_trigger(hass, config, action):
     """Listen for events based on configuration."""
     event_type = config.get(CONF_EVENT_TYPE)
     event_data = config.get(CONF_EVENT_DATA)
-
-    if (event_type == EVENT_HOMEASSISTANT_START and
-            hass.state == CoreState.starting):
-        _LOGGER.warning('Deprecation: Automations should not listen to event '
-                        "'homeassistant_start'. Use platform 'homeassistant' "
-                        'instead. Feature will be removed in 0.45')
-        hass.async_run_job(action, {
-            'trigger': {
-                'platform': 'event',
-                'event': None,
-            },
-        })
-        return lambda: None
 
     @callback
     def handle_event(event):

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -1,13 +1,11 @@
 """The tests for the Event automation."""
-import asyncio
 import unittest
 
-from homeassistant.const import EVENT_HOMEASSISTANT_START
-from homeassistant.core import callback, CoreState
-from homeassistant.setup import setup_component, async_setup_component
+from homeassistant.core import callback
+from homeassistant.setup import setup_component
 import homeassistant.components.automation as automation
 
-from tests.common import get_test_home_assistant, mock_component, mock_service
+from tests.common import get_test_home_assistant, mock_component
 
 
 # pylint: disable=invalid-name
@@ -94,30 +92,3 @@ class TestAutomationEvent(unittest.TestCase):
         self.hass.bus.fire('test_event', {'some_attr': 'some_other_value'})
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
-
-
-@asyncio.coroutine
-def test_if_fires_on_event_with_data(hass):
-    """Test the firing of events with data."""
-    calls = mock_service(hass, 'test', 'automation')
-    hass.state = CoreState.not_running
-
-    res = yield from async_setup_component(hass, automation.DOMAIN, {
-        automation.DOMAIN: {
-            'alias': 'hello',
-            'trigger': {
-                'platform': 'event',
-                'event_type': EVENT_HOMEASSISTANT_START,
-            },
-            'action': {
-                'service': 'test.automation',
-            }
-        }
-    })
-    assert res
-    assert not automation.is_on(hass, 'automation.hello')
-    assert len(calls) == 0
-
-    yield from hass.async_start()
-    assert automation.is_on(hass, 'automation.hello')
-    assert len(calls) == 1


### PR DESCRIPTION
## Description:
This removes listening to event "homeassistant_start" in the event automation. Removal was announced a couple of releases ago.

