### PR TITLE
Fix plant MIN_TEMPERATURE, MAX_TEMPERATURE validation

### DIFF
--- a/homeassistant/components/plant.py
+++ b/homeassistant/components/plant.py
@@ -58,8 +58,8 @@ SCHEMA_SENSORS = vol.Schema({
 PLANT_SCHEMA = vol.Schema({
     vol.Required(CONF_SENSORS): vol.Schema(SCHEMA_SENSORS),
     vol.Optional(CONF_MIN_BATTERY_LEVEL): cv.positive_int,
-    vol.Optional(CONF_MIN_TEMPERATURE): vol.All(vol.Coerce(float)),
-    vol.Optional(CONF_MAX_TEMPERATURE): vol.All(vol.Coerce(float)),
+    vol.Optional(CONF_MIN_TEMPERATURE): vol.Coerce(float),
+    vol.Optional(CONF_MAX_TEMPERATURE): vol.Coerce(float),
     vol.Optional(CONF_MIN_MOISTURE): cv.positive_int,
     vol.Optional(CONF_MAX_MOISTURE): cv.positive_int,
     vol.Optional(CONF_MIN_CONDUCTIVITY): cv.positive_int,

--- a/homeassistant/components/plant.py
+++ b/homeassistant/components/plant.py
@@ -58,8 +58,8 @@ SCHEMA_SENSORS = vol.Schema({
 PLANT_SCHEMA = vol.Schema({
     vol.Required(CONF_SENSORS): vol.Schema(SCHEMA_SENSORS),
     vol.Optional(CONF_MIN_BATTERY_LEVEL): cv.positive_int,
-    vol.Optional(CONF_MIN_TEMPERATURE): cv.small_float,
-    vol.Optional(CONF_MAX_TEMPERATURE): cv.small_float,
+    vol.Optional(CONF_MIN_TEMPERATURE): vol.All(vol.Coerce(float)),
+    vol.Optional(CONF_MAX_TEMPERATURE): vol.All(vol.Coerce(float)),
     vol.Optional(CONF_MIN_MOISTURE): cv.positive_int,
     vol.Optional(CONF_MAX_MOISTURE): cv.positive_int,
     vol.Optional(CONF_MIN_CONDUCTIVITY): cv.positive_int,


### PR DESCRIPTION
small_float only allows values from 0 to 1 so we should use float instead

## Description:

the plant component uses small_float validation for temperature. Small float only covers floats from 0 to 1.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
