### PR TITLE
[RFC] Set color/brightness for turned off lights

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -42,6 +42,7 @@ SUPPORT_RGB_COLOR = 16
 SUPPORT_TRANSITION = 32
 SUPPORT_XY_COLOR = 64
 SUPPORT_WHITE_VALUE = 128
+SUPPORT_OFF_STATE = 256
 
 # Integer that represents transition time in seconds to make change.
 ATTR_TRANSITION = "transition"
@@ -77,6 +78,8 @@ EFFECT_WHITE = "white"
 
 LIGHT_PROFILES_FILE = "light_profiles.csv"
 
+ATTR_POWER_ON = "power_on"
+
 PROP_TO_ATTR = {
     'brightness': ATTR_BRIGHTNESS,
     'color_temp': ATTR_COLOR_TEMP,
@@ -107,6 +110,7 @@ LIGHT_TURN_ON_SCHEMA = vol.Schema({
     ATTR_WHITE_VALUE: vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
     ATTR_FLASH: vol.In([FLASH_SHORT, FLASH_LONG]),
     ATTR_EFFECT: cv.string,
+    vol.Optional(ATTR_POWER_ON, default=True): cv.boolean,
 })
 
 LIGHT_TURN_OFF_SCHEMA = vol.Schema({
@@ -143,19 +147,20 @@ def is_on(hass, entity_id=None):
 
 def turn_on(hass, entity_id=None, transition=None, brightness=None,
             rgb_color=None, xy_color=None, color_temp=None, white_value=None,
-            profile=None, flash=None, effect=None, color_name=None):
+            profile=None, flash=None, effect=None, color_name=None,
+            power_on=None):
     """Turn all or specified light on."""
     hass.add_job(
         async_turn_on, hass, entity_id, transition, brightness,
         rgb_color, xy_color, color_temp, white_value,
-        profile, flash, effect, color_name)
+        profile, flash, effect, color_name, power_on)
 
 
 @callback
 def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
                   rgb_color=None, xy_color=None, color_temp=None,
                   white_value=None, profile=None, flash=None, effect=None,
-                  color_name=None):
+                  color_name=None, power_on=None):
     """Turn all or specified light on."""
     data = {
         key: value for key, value in [
@@ -170,6 +175,7 @@ def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
             (ATTR_FLASH, flash),
             (ATTR_EFFECT, effect),
             (ATTR_COLOR_NAME, color_name),
+            (ATTR_POWER_ON, power_on),
         ] if value is not None
     }
 

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -59,24 +59,27 @@ PLATFORM_SCHEMA = vol.Schema({
 })
 
 
-def set_lights_xy(hass, lights, x_val, y_val, brightness):
+def set_lights(hass, lights, **kwargs):
     """Set color of array of lights."""
     for light in lights:
         if is_on(hass, light):
-            turn_on(hass, light,
-                    xy_color=[x_val, y_val],
-                    brightness=brightness,
-                    transition=30)
+            turn_on(hass, light, **kwargs)
+
+
+def set_lights_xy(hass, lights, x_val, y_val, brightness):
+    """Set color of array of lights."""
+    set_lights(hass, lights,
+               xy_color=[x_val, y_val],
+               brightness=brightness,
+               transition=30)
 
 
 def set_lights_temp(hass, lights, mired, brightness):
     """Set color of array of lights."""
-    for light in lights:
-        if is_on(hass, light):
-            turn_on(hass, light,
-                    color_temp=int(mired),
-                    brightness=brightness,
-                    transition=30)
+    set_lights(hass, lights,
+               color_temp=int(mired),
+               brightness=brightness,
+               transition=30)
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
## Description:

### Background

The LIFX light API has a very handy feature: setting the color/brightness without actually turning the light on. Philips Hue apparently does not support this functionality natively though it is frequently requested, like here: https://developers.meethue.com/content/changing-color-while-onfalse

This PR is a proposal to add that feature to Home Assistant.

Setting the color of a light that is turned off might sound odd at first and I have seen it rejected as absurd elsewhere. However, this functionality is very useful for decoupling color and power changes. If the above link is not convincing, I can give several other examples.

The easiest way to see that it is _not_ absurd is probably to compare to media players where the volume can be set even with nothing playing.


### Implementation

A new `power_on` attribute is added to the `light.turn_on` call. Setting this to `False` will send just the color change, not the power on command. Thus, the light stays at its current power state.

As this is not supported by all lights, a `SUPPORT_OFF_STATE` flag is also added. This is used by the Flux switch to fix long-standing issues like #4005 (but only for supporting lights).

Using `power_on: False` without `SUPPORT_OFF_STATE` can be handled in a couple of ways. I think the best alternative is probably to leave it undefined, for the platform to handle.


### Alternatives

I think `light.turn_on` is already too busy and this change makes it even worse. Also, to `turn_on` a light without powering it on sounds a bit weird.

It would IMHO be better to split the current functionality into `light.turn_on`, `light.set_color`, `light.effect_start` etc. The proposal would then be to add optional power control to `set_color`. I would be happy to work on such a split but it would be quite disruptive so I did not go down that path yet.

Because I actually don’t think this proposal is the best solution in an absolute sense I have marked the PR with [RFC]. If you feel like shooting down the implementation, please indicate whether you at least agree that the fundamental feature itself is useful.


### Further work

Personally, I think that this feature is so useful that partial `SUPPORT_OFF_STATE` could be considered for `hue` and other platforms as well. This would involve a platform cache that adds the last set color to the `turn_on` call that eventually turns a light on.

It would only be a partial solution because the cache would not be applied if an external switch toggles a light without going through HA. It could, however, fix #4005 for Hue as well.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  # Reset all lights from our evening fun, but do not light up the whole house.
  - alias: Bright morning light
    trigger:
      platform: time
      after: '06:00'
    action:
      - service: light.turn_on
        data:
          color_temp: 200
          brightness: 200
          transition: 180
          power_on: false
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54