### PR TITLE
Uses pypi for the pulutron_caseta dependency

### DIFF
--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -14,9 +14,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['https://github.com/gurumitts/'
-                'pylutron-caseta/archive/v0.2.6.zip#'
-                'pylutron-caseta==v0.2.6']
+REQUIREMENTS = ['pylutron-caseta==0.2.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -273,9 +273,6 @@ https://github.com/bah2830/python-roku/archive/3.1.3.zip#roku==3.1.3
 # homeassistant.components.modbus
 https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0
 
-# homeassistant.components.lutron_caseta
-https://github.com/gurumitts/pylutron-caseta/archive/v0.2.6.zip#pylutron-caseta==v0.2.6
-
 # homeassistant.components.media_player.spotify
 https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f86c90aa26b2.zip#spotipy==2.4.4
 
@@ -583,6 +580,9 @@ pylitejet==0.1
 
 # homeassistant.components.sensor.loopenergy
 pyloopenergy==0.0.17
+
+# homeassistant.components.lutron_caseta
+pylutron-caseta==0.2.6
 
 # homeassistant.components.notify.mailgun
 pymailgunner==1.4


### PR DESCRIPTION
## Description:
The pylutron_caseta dependency has been migrated to pypi as sugested here:  home-assistant/home-assistant#7069

**Related issue (if applicable):** fixes:  Does not fix but help the goal of:  home-assistant/home-assistant#7069

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** NA


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
