### PR TITLE
Upgrade async_timeout to 1.2.1

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,5 +6,5 @@ jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.0.7
-async_timeout==1.2.0
+async_timeout==1.2.1
 chardet==3.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -7,7 +7,7 @@ jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.0.7
-async_timeout==1.2.0
+async_timeout==1.2.1
 chardet==3.0.2
 
 # homeassistant.components.nuimo_controller

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ REQUIRES = [
     'voluptuous==0.10.5',
     'typing>=3,<4',
     'aiohttp==2.0.7',
-    'async_timeout==1.2.0',
+    'async_timeout==1.2.1',
     'chardet==3.0.2'
 ]
 


### PR DESCRIPTION
## 1.2.1

- Support unpublished event loop's "current_task" api.

Tested with the following configuration:

``` yaml
http:
```