### PR TITLE
Upgrade rflink to 0.0.34

### DIFF
--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -20,7 +20,7 @@ from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['rflink==0.0.31']
+REQUIREMENTS = ['rflink==0.0.34']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -728,7 +728,7 @@ radiotherm==1.2
 # raspihats==2.2.1
 
 # homeassistant.components.rflink
-rflink==0.0.31
+rflink==0.0.34
 
 # homeassistant.components.ring
 ring_doorbell==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -133,7 +133,7 @@ pyunifi==2.12
 pywebpush==0.6.1
 
 # homeassistant.components.rflink
-rflink==0.0.31
+rflink==0.0.34
 
 # homeassistant.components.ring
 ring_doorbell==0.1.4


### PR DESCRIPTION
A small bug in the python-rflink library caused incoming packets to be printed to stdout. This update prevents this from happening.
