### PR TITLE
LIFX: avoid out-of-bounds hue aborting the colorloop effect

### DIFF
--- a/homeassistant/components/light/lifx/effects.py
+++ b/homeassistant/components/light/lifx/effects.py
@@ -292,7 +292,7 @@ class LIFXEffectColorloop(LIFXEffect):
         direction = 1 if random.randint(0, 1) else -1
 
         # Random start
-        hue = random.randint(0, 359)
+        hue = random.uniform(0, 360) % 360
 
         while self.lights:
             hue = (hue + direction*change) % 360
@@ -312,7 +312,7 @@ class LIFXEffectColorloop(LIFXEffect):
                     brightness = light.effect_data.color[2]
 
                 hsbk = [
-                    int(65535/359*lhue),
+                    int(65535/360*lhue),
                     int(random.uniform(0.8, 1.0)*65535),
                     brightness,
                     NEUTRAL_WHITE,


### PR DESCRIPTION
## Description:

The hue is now a float but the hsbk conversion still believed it to be
an integer that could not be larger than 359. The float can in fact be,
for example, 359.9 and this would cause an out-of-bounds error in the
set_color call.

For completeness, the initial hue is also changed to a float.

Reported by @arsaboo - thanks!

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
