### PR TITLE
Add password parameter to uvc component

### DIFF
--- a/homeassistant/components/camera/uvc.py
+++ b/homeassistant/components/camera/uvc.py
@@ -20,12 +20,15 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_NVR = 'nvr'
 CONF_KEY = 'key'
+CONF_PASSWORD = 'password'
 
+DEFAULT_PASSWORD = 'ubnt'
 DEFAULT_PORT = 7080
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_NVR): cv.string,
     vol.Required(CONF_KEY): cv.string,
+    vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
 })
 
@@ -34,6 +37,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Discover cameras on a Unifi NVR."""
     addr = config[CONF_NVR]
     key = config[CONF_KEY]
+    password = config[CONF_PASSWORD]
     port = config[CONF_PORT]
 
     from uvcclient import nvr
@@ -59,7 +63,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     add_devices([UnifiVideoCamera(nvrconn,
                                   camera[identifier],
-                                  camera['name'])
+                                  camera['name'],
+                                  password)
                  for camera in cameras])
     return True
 
@@ -67,12 +72,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class UnifiVideoCamera(Camera):
     """A Ubiquiti Unifi Video Camera."""
 
-    def __init__(self, nvr, uuid, name):
+    def __init__(self, nvr, uuid, name, password):
         """Initialize an Unifi camera."""
         super(UnifiVideoCamera, self).__init__()
         self._nvr = nvr
         self._uuid = uuid
         self._name = name
+        self._password = password
         self.is_streaming = False
         self._connect_addr = None
         self._camera = None
@@ -102,20 +108,12 @@ class UnifiVideoCamera(Camera):
     def _login(self):
         """Login to the camera."""
         from uvcclient import camera as uvc_camera
-        from uvcclient import store as uvc_store
 
         caminfo = self._nvr.get_camera(self._uuid)
         if self._connect_addr:
             addrs = [self._connect_addr]
         else:
             addrs = [caminfo['host'], caminfo['internalHost']]
-
-        store = uvc_store.get_info_store()
-        password = store.get_camera_password(self._uuid)
-        if password is None:
-            _LOGGER.debug("Logging into camera %(name)s with default password",
-                          dict(name=self._name))
-            password = 'ubnt'
 
         if self._nvr.server_version >= (3, 2, 0):
             client_cls = uvc_camera.UVCCameraClientV320
@@ -126,7 +124,7 @@ class UnifiVideoCamera(Camera):
         for addr in addrs:
             try:
                 camera = client_cls(
-                    addr, caminfo['username'], password)
+                    addr, caminfo['username'], self._password)
                 camera.login()
                 _LOGGER.debug("Logged into UVC camera %(name)s via %(addr)s",
                               dict(name=self._name, addr=addr))


### PR DESCRIPTION
## Description:
Fixes an issue where the UVC component would not properly authenticate.

The _uvcclient_ requires that the camera password [is stored](https://github.com/kk7ds/uvcclient/blob/master/uvcclient/store.py#L15-L19) in a JSON file in `~/.uvcclient` by default.

The current integration Home Assistant is [defaulting](https://github.com/home-assistant/home-assistant/blob/3ee4d1060fdbe067c19f7d4ce4777a7eb9dbb412/homeassistant/components/camera/uvc.py#L118) to the `ubnt` password but does not work for users that are using another password.

I really don't see how this ever worked for users that changed the default `ubnt` password. It probably never did which is why so many users are reporting problems.

This PR removes the "store" [codepath](https://github.com/home-assistant/home-assistant/blob/3ee4d1060fdbe067c19f7d4ce4777a7eb9dbb412/homeassistant/components/camera/uvc.py#L113-L114) and simply allows a `password` argument to be passed for the component.

**Related issues:**

Fixes #2979.
Fixes #7151.
Fixes #3810. (in my opinion)

**Related community issues:**

* https://community.home-assistant.io/t/unifi-video-compatibility/4339
* https://community.home-assistant.io/t/unifi-camera-component-not-working/6679
* https://community.home-assistant.io/t/unifi-nvr-issue/14473
* https://community.home-assistant.io/t/unifi-nvr-issue-2nd-post/14723

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#2600

## Example entry for `configuration.yaml`:
```yaml
camera:
  - platform: uvc
    nvr: IP_ADDRESS
    key: API_KEY
    password: PASSWORD
```

## Checklist:

  - [x] Documentation updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [ ] Local tests with `tox` run successfully.
