### PR TITLE
Correct retrieval of spotify shuffle state

### DIFF
--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -176,6 +176,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         self._state = STATE_PAUSED
         if current.get('is_playing'):
             self._state = STATE_PLAYING
+        self._shuffle = current.get('shuffle_state')
         device = current.get('device')
         if device is None:
             self._state = STATE_IDLE
@@ -184,8 +185,6 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
                 self._volume = device.get('volume_percent') / 100
             if device.get('name'):
                 self._current_device = device.get('name')
-            if device.get('shuffle_state'):
-                self._shuffle = device.get('shuffle_state')
 
     def set_volume_level(self, volume):
         """Set the volume level."""


### PR DESCRIPTION
## Description:

The wrong key path is being used for shuffle state, meaning it always stays false, even when shuffle is on.
Shuffle state is not at `device.shuffle_state` but just `shuffle_state` on the root response (https://developer.spotify.com/web-api/get-information-about-the-users-current-playback/)


## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.