### PR TITLE
Spotify: changing source only forces "play" if the current state is "playing"

### DIFF
--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -213,7 +213,8 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
 
     def select_source(self, source):
         """Select playback device."""
-        self._player.transfer_playback(self._devices[source])
+        self._player.transfer_playback(self._devices[source],
+                                       self._state == STATE_PLAYING)
 
     def play_media(self, media_type, media_id, **kwargs):
         """Play media."""


### PR DESCRIPTION
## Description:
With the previous implementation, changing the spotify "source" (which changes the device which is playing music) would make the music start even if it was paused. This PR prevents the music from starting if it is not playing. 

This allows more control, for example:
- set the device volume before starting playing music (great at night)
- change to another device without starting music (when going to work, set the work computer as source, without playing).

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
