### PR TITLE
Switch basicmodem and python-roku to pypi

### DIFF
--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -17,9 +17,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 import homeassistant.loader as loader
 
-REQUIREMENTS = [
-    'https://github.com/bah2830/python-roku/archive/3.1.3.zip'
-    '#roku==3.1.3']
+REQUIREMENTS = ['python-roku==3.1.3']
 
 KNOWN_HOSTS = []
 DEFAULT_PORT = 8060

--- a/homeassistant/components/sensor/modem_callerid.py
+++ b/homeassistant/components/sensor/modem_callerid.py
@@ -14,9 +14,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/vroomfonde1/basicmodem'
-                '/archive/0.7.zip'
-                '#basicmodem==0.7']
+REQUIREMENTS = ['basicmodem==0.7']
 
 _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = 'Modem CallerID'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -70,6 +70,9 @@ apns2==0.1.1
 # homeassistant.components.light.avion
 # avion==0.6
 
+# homeassistant.components.sensor.modem_callerid
+basicmodem==0.7
+
 # homeassistant.components.sensor.linux_battery
 batinfo==0.4.2
 
@@ -264,9 +267,6 @@ https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
 # homeassistant.components.cover.myq
 https://github.com/arraylabs/pymyq/archive/v0.0.8.zip#pymyq==0.0.8
 
-# homeassistant.components.media_player.roku
-https://github.com/bah2830/python-roku/archive/3.1.3.zip#roku==3.1.3
-
 # homeassistant.components.modbus
 https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0
 
@@ -305,9 +305,6 @@ https://github.com/tfriedel/python-lightify/archive/1bb1db0e7bd5b14304d7bb267e23
 
 # homeassistant.components.lutron
 https://github.com/thecynic/pylutron/archive/v0.1.0.zip#pylutron==0.1.0
-
-# homeassistant.components.sensor.modem_callerid
-https://github.com/vroomfonde1/basicmodem/archive/0.7.zip#basicmodem==0.7
 
 # homeassistant.components.tado
 https://github.com/wmalgadey/PyTado/archive/0.1.10.zip#PyTado==0.1.10
@@ -670,6 +667,9 @@ python-nmap==0.6.1
 
 # homeassistant.components.notify.pushover
 python-pushover==0.2
+
+# homeassistant.components.media_player.roku
+python-roku==3.1.3
 
 # homeassistant.components.sensor.synologydsm
 python-synology==0.1.0


### PR DESCRIPTION
## Description:

Switch basicmodem and python-roku to pypi

Following https://github.com/vroomfonde1/basicmodem/issues/1 and https://github.com/bah2830/python-roku/pull/8

**Related issue (if applicable):** #7069

  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
