### PR TITLE
Pin requests

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,4 +1,4 @@
-requests>=2,<3
+requests==2.13
 pyyaml>=3.11,<4
 pytz>=2017.02
 pip>=7.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,5 +1,5 @@
 # Home Assistant core
-requests>=2,<3
+requests==2.13
 pyyaml>=3.11,<4
 pytz>=2017.02
 pip>=7.1.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ DOWNLOAD_URL = ('{}/archive/'
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
 REQUIRES = [
-    'requests>=2,<3',
+    # Don't upgrade Requests
+    # https://github.com/kennethreitz/requests/issues/4006
+    'requests==2.13',
     'pyyaml>=3.11,<4',
     'pytz>=2017.02',
     'pip>=7.1.0',


### PR DESCRIPTION
## Description:
Requests only supports pip versions released in the last year. Although we depend on upgrading pip in our dependencies, requests is installed in the same "pip install", and thus is still run in the old pip environment, causing it to crash.

https://github.com/kennethreitz/requests/issues/4006
