### PR TITLE
Pin requests to 2.13.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,3 +1,4 @@
+requests==2.13.0
 requests>=2,<3
 pyyaml>=3.11,<4
 pytz>=2017.02

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,4 +1,5 @@
 # Home Assistant core
+requests==2.13.0
 requests>=2,<3
 pyyaml>=3.11,<4
 pytz>=2017.02

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ DOWNLOAD_URL = ('{}/archive/'
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
 REQUIRES = [
-    'requests>=2,<3',
+    'requests==2.13.0',  # Pin it for now instead of 'requests>=2,<3'
     'pyyaml>=3.11,<4',
     'pytz>=2017.02',
     'pip>=7.1.0',


### PR DESCRIPTION
## Description:
Travis is failing because they are using an old release of `pip`.

See: https://github.com/kennethreitz/requests/issues/4006

This would be the alternative but it's unknown what release of `pip` people are [using](https://gitter.im/home-assistant/home-assistant/devs?at=5911fce6c89bb14b5ae7628a).

```yaml
install:
  - pip install --upgrade pip
  - pip install -U tox coveralls
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
