### PR TITLE
Add enable_output service to Yamaha platform

### DIFF
--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -269,3 +269,17 @@ soundtouch_remove_zone_slave:
     slaves:
       description: Name of slaves entities to remove from the existing zone
       example: 'media_player.soundtouch_bedroom'
+
+yamaha_enable_output:
+  description: Enable or disable an output port
+
+  fields:
+    entity_id:
+      description: Name(s) of entites to enable/disable port on.
+      example: 'media_player.yamaha'
+    port:
+      description: Name of port to enable/disable.
+      example: 'hdmi1'
+    enabled:
+      description: Boolean indicating if port should be enabled or not.
+      example: true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -737,7 +737,7 @@ ring_doorbell==0.1.4
 russound==0.1.7
 
 # homeassistant.components.media_player.yamaha
-rxv==0.4.0
+rxv==0.5.0
 
 # homeassistant.components.media_player.samsungtv
 samsungctl==0.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -135,7 +135,7 @@ rflink==0.0.34
 ring_doorbell==0.1.4
 
 # homeassistant.components.media_player.yamaha
-rxv==0.4.0
+rxv==0.5.0
 
 # homeassistant.components.sleepiq
 sleepyq==0.6


### PR DESCRIPTION
## Description:
This PR adds the service ``yamaha_enable_output`` that makes it possible to enable or disable an output (usually HDMI).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2602

## Example service call:
```yaml
service: media_player.yamaha_enable_output
data:
  entity_id: media_player.yamaha
  port: hdmi1
  enabled: true
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
 
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
