### PR TITLE
Add sonos alarm clock update service

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -104,6 +104,7 @@ SONOS_UPDATE_ALARM_SCHEMA = SONOS_SCHEMA.extend({
     vol.Optional(ATTR_INCLUDE_LINKED_ZONES): cv.boolean,
 })
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Sonos platform."""
     import soco
@@ -1061,10 +1062,10 @@ class SonosDevice(MediaPlayerDevice):
         from soco import alarms
         a = None
         for alarm in alarms.get_alarms(self.soco):
-            if alarm._alarm_id == str(data[ATTR_ALARM_ID]):
-                _LOGGER.warning("found alarm %s" % alarm)
+            if alarm._alarm_id == str(data[ATTR_ALARM_ID]):  # pylint: disable=W0212
                 a = alarm
         if a is None:
+            _LOGGER.warning("did not find alarm with id %s", data[ATTR_ALARM_ID])
             return
         if ATTR_TIME in data:
             a.start_time = data[ATTR_TIME]

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -51,6 +51,7 @@ SERVICE_SNAPSHOT = 'sonos_snapshot'
 SERVICE_RESTORE = 'sonos_restore'
 SERVICE_SET_TIMER = 'sonos_set_sleep_timer'
 SERVICE_CLEAR_TIMER = 'sonos_clear_sleep_timer'
+SERVICE_UPDATE_ALARM_CLOCK = 'sonos_update_alarm_clock'
 
 DATA_SONOS = 'sonos'
 
@@ -62,6 +63,11 @@ CONF_INTERFACE_ADDR = 'interface_addr'
 
 # Service call validation schemas
 ATTR_SLEEP_TIME = 'sleep_time'
+ATTR_ALARM_CLOCK_ID = 'alarm_clock_id'
+ATTR_VOLUME = 'volume'
+ATTR_ENABLED = 'enabled'
+ATTR_INCLUDE_LINKED_ZONES = 'include_linked_zones'
+ATTR_TIME = 'time'
 ATTR_MASTER = 'master'
 ATTR_WITH_GROUP = 'with_group'
 
@@ -90,6 +96,13 @@ SONOS_SET_TIMER_SCHEMA = SONOS_SCHEMA.extend({
         vol.All(vol.Coerce(int), vol.Range(min=0, max=86399))
 })
 
+SONOS_UPDATE_ALARM_CLOCK_SCHEMA = SONOS_SCHEMA.extend({
+    vol.Required(ATTR_ALARM_CLOCK_ID): cv.positive_int,
+    vol.Optional(ATTR_TIME): cv.time,
+    vol.Optional(ATTR_VOLUME): cv.small_float,
+    vol.Optional(ATTR_ENABLED): cv.boolean,
+    vol.Optional(ATTR_INCLUDE_LINKED_ZONES): cv.boolean,
+})
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Sonos platform."""
@@ -166,6 +179,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 device.set_sleep_timer(service.data[ATTR_SLEEP_TIME])
             elif service.service == SERVICE_CLEAR_TIMER:
                 device.clear_sleep_timer()
+            elif service.service == SERVICE_UPDATE_ALARM_CLOCK:
+                device.update_alarm_clock(**service.data)
 
             device.schedule_update_ha_state(True)
 
@@ -192,6 +207,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     hass.services.register(
         DOMAIN, SERVICE_CLEAR_TIMER, service_handle,
         descriptions.get(SERVICE_CLEAR_TIMER), schema=SONOS_SCHEMA)
+
+    hass.services.register(
+        DOMAIN, SERVICE_UPDATE_ALARM_CLOCK, service_handle,
+        descriptions.get(SERVICE_UPDATE_ALARM_CLOCK), schema=SONOS_UPDATE_ALARM_CLOCK_SCHEMA)
 
 
 def _parse_timespan(timespan):
@@ -1027,6 +1046,32 @@ class SonosDevice(MediaPlayerDevice):
     def set_sleep_timer(self, sleep_time):
         """Set the timer on the player."""
         self._player.set_sleep_timer(sleep_time)
+
+    @soco_error
+    @soco_coordinator
+    def update_alarm_clock(self, **data):
+        """Set the alarm clock on the player."""
+        from soco import alarms
+        a = None
+        for alarm in alarms.get_alarms():
+            if alarm._alarm_id == str(data[ATTR_ALARM_CLOCK_ID]):
+                _LOGGER.warning("found alarm %s" % alarm)
+                a = alarm
+        if a is None:
+            return
+        if ATTR_TIME in data:
+            _LOGGER.warning("found time updating %s" % data[ATTR_TIME])
+            a.start_time = data[ATTR_TIME]
+        if ATTR_VOLUME in data:
+            _LOGGER.warning("found volume updating %s" % data[ATTR_VOLUME])
+            a.volume = int(data[ATTR_VOLUME] * 100)
+        if ATTR_ENABLED in data:
+            _LOGGER.warning("found enabled updating %s" % data[ATTR_ENABLED])
+            a.enabled = data[ATTR_ENABLED]
+        if ATTR_INCLUDE_LINKED_ZONES in data:
+            _LOGGER.warning("found include_linked_zones updating %s" % data[ATTR_INCLUDE_LINKED_ZONES])
+            a.include_linked_zones = data[ATTR_INCLUDE_LINKED_ZONES]
+        a.save()
 
     @soco_error
     @soco_coordinator

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -1062,10 +1062,12 @@ class SonosDevice(MediaPlayerDevice):
         from soco import alarms
         a = None
         for alarm in alarms.get_alarms(self.soco):
-            if alarm._alarm_id == str(data[ATTR_ALARM_ID]):  # pylint: disable=W0212
+            # pylint: disable=protected-access
+            if alarm._alarm_id == str(data[ATTR_ALARM_ID]):
                 a = alarm
         if a is None:
-            _LOGGER.warning("did not find alarm with id %s", data[ATTR_ALARM_ID])
+            _LOGGER.warning("did not find alarm with id %s",
+                            data[ATTR_ALARM_ID])
             return
         if ATTR_TIME in data:
             a.start_time = data[ATTR_TIME]

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -211,7 +211,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     hass.services.register(
         DOMAIN, SERVICE_UPDATE_ALARM, service_handle,
         descriptions.get(SERVICE_UPDATE_ALARM),
-                         schema=SONOS_UPDATE_ALARM_SCHEMA)
+        schema=SONOS_UPDATE_ALARM_SCHEMA)
 
 
 def _parse_timespan(timespan):

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -337,7 +337,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
             self.assertEqual(alarm1.include_linked_zones,
                              attrs['include_linked_zones'])
             self.assertEqual(alarm1.volume, 30)
-            alarm1.save.assert_called_once()
+            alarm1.save.assert_called_once_with()
 
     @mock.patch('soco.SoCo', new=SoCoMock)
     @mock.patch('socket.create_connection', side_effect=socket.error())

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -1,9 +1,11 @@
 """The tests for the Demo Media player platform."""
+import datetime
 import socket
 import unittest
 import soco.snapshot
 from unittest import mock
 import soco
+from soco import alarms
 
 from homeassistant.setup import setup_component
 from homeassistant.components.media_player import sonos, DOMAIN
@@ -306,6 +308,37 @@ class TestSonosMediaPlayer(unittest.TestCase):
 
         device.set_sleep_timer(None)
         set_sleep_timerMock.assert_called_once_with(None)
+
+    @mock.patch('soco.SoCo', new=SoCoMock)
+    @mock.patch('soco.alarms.Alarm')
+    @mock.patch('socket.create_connection', side_effect=socket.error())
+    def test_update_alarm(self, soco_mock, alarm_mock, *args):
+        """Ensuring soco methods called for sonos_set_sleep_timer service."""
+        sonos.setup_platform(self.hass, {}, fake_add_device, {
+            'host': '192.0.2.1'
+        })
+        device = self.hass.data[sonos.DATA_SONOS][-1]
+        device.hass = self.hass
+        spec = ['time', 'enabled', 'include_linked_zones', 'volume']
+        alarm1 = alarms.Alarm(soco_mock)
+        alarm1.configure_mock(_alarm_id="1", start_time=None, enabled=False,
+                              include_linked_zones=False, volume=100)
+        with mock.patch('soco.alarms.get_alarms', return_value=[alarm1]):
+            attrs = {
+                'time': datetime.time(12,00),
+                'enabled': True,
+                'include_linked_zones': True,
+                'volume': 0.30,
+            }
+            device.update_alarm(alarm_id=2)
+            alarm1.save.assert_not_called()
+            device.update_alarm(alarm_id=1, **attrs)
+            self.assertEqual(alarm1.enabled, attrs['enabled'])
+            self.assertEqual(alarm1.start_time, attrs['time'])
+            self.assertEqual(alarm1.include_linked_zones,
+                             attrs['include_linked_zones'])
+            self.assertEqual(alarm1.volume, 30)
+            alarm1.save.assert_called_once()
 
     @mock.patch('soco.SoCo', new=SoCoMock)
     @mock.patch('socket.create_connection', side_effect=socket.error())

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -319,13 +319,12 @@ class TestSonosMediaPlayer(unittest.TestCase):
         })
         device = self.hass.data[sonos.DATA_SONOS][-1]
         device.hass = self.hass
-        spec = ['time', 'enabled', 'include_linked_zones', 'volume']
         alarm1 = alarms.Alarm(soco_mock)
         alarm1.configure_mock(_alarm_id="1", start_time=None, enabled=False,
                               include_linked_zones=False, volume=100)
         with mock.patch('soco.alarms.get_alarms', return_value=[alarm1]):
             attrs = {
-                'time': datetime.time(12,00),
+                'time': datetime.time(12, 00),
                 'enabled': True,
                 'include_linked_zones': True,
                 'volume': 0.30,


### PR DESCRIPTION
## Description:
Initial attempt on getting support for sonos alarm clock. This first service is to update an existing alarm. I would like to get some feedback since sonos uses the alarm_clock_id to identify existing alarms. The idea is to be able to activate/deactivate or change the time of an existing alarm. Is using this ID that is only available through SoCo a good way of doing that? It seems the only reliable way to repeatedly update a single alarm (wake up alarm in my case).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation :** home-assistant/home-assistant.github.io#2631
## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
