### PR TITLE
Fix systematic warning in influxdb sensor

### DIFF
--- a/homeassistant/components/sensor/influxdb.py
+++ b/homeassistant/components/sensor/influxdb.py
@@ -174,7 +174,7 @@ class InfluxSensorData(object):
                             "to UNKNOWN: %s", self.query)
             self.value = None
         else:
-            if points:
+            if len(points) > 1:
                 _LOGGER.warning("Query returned multiple points, only first "
                                 "one shown: %s", self.query)
             self.value = points[0].get('value')


### PR DESCRIPTION
## Description:
Influxdb sensor is giving a warning for each query. The test need to be on the length of the list since we want to check if there is more than one value.