### PR TITLE
Fail gracefully when commands have incorrect padding

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -158,8 +158,18 @@ class BroadlinkRMSwitch(SwitchDevice):
         """Initialize the switch."""
         self._name = friendly_name
         self._state = False
-        self._command_on = b64decode(command_on) if command_on else None
-        self._command_off = b64decode(command_off) if command_off else None
+        if len(command_on) % 4 == 0:
+            self._command_on = b64decode(command_on) if command_on else None
+        else:
+            _LOGGER.error("""Failed to set command_on for %(friendly_name)s because the padding seems to be incorrect. 
+            Please ensure that the base64 encoded string is padded with '=' characters to a length divisible by 4."""
+                          % locals())
+        if len(command_off) % 4 == 0:
+            self._command_off = b64decode(command_off) if command_off else None
+        else:
+            _LOGGER.error("""Failed to set command_off for %(friendly_name)s because the padding seems to be incorrect. 
+            Please ensure that the base64 encoded string is padded with '=' characters to a length divisible by 4."""
+                          % locals())
         self._device = device
 
     @property


### PR DESCRIPTION
## Description:
Base64 strings need to be padded to a length divisible by 4. Read [this lengthy answer on Stack Overflow ](http://stackoverflow.com/a/26632221) for details. The padding character '=' is not always selected when copying and pasting command strings from browser, so this can easily cause configuration errors that are hard to spot.
This PR ensures that sensible errors are shown in the logs whenever the command strings have incorrect lengths.

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: broadlink
    host: 192.168.1.42
    mac: 'CA:FE:BA:BE:13:37'
    switches:
      valid_switch:
        friendly_name: "Valid switch"
        command_on:    'sgccAAoWCgoW='
        command_off:   'sggcAAoVC'
      invalid_switch:
        friendly_name: "Invalid switch"
        command_on:    'sgccAAoWCgoW' # This one lacks a = on the end
        command_off:   'sggcAAo=' # ..and so does this.
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
