### PR TITLE
Fix for #7459

### DIFF
--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -17,7 +17,6 @@ from homeassistant.core import callback
 from homeassistant.const import HTTP_BAD_REQUEST
 from homeassistant.helpers import template, script, config_validation as cv
 from homeassistant.components.http import HomeAssistantView
-import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +35,6 @@ CONF_TEXT = 'text'
 
 CONF_FLASH_BRIEFINGS = 'flash_briefings'
 CONF_UID = 'uid'
-CONF_DATE = 'date'
 CONF_TITLE = 'title'
 CONF_AUDIO = 'audio'
 CONF_TEXT = 'text'
@@ -88,7 +86,6 @@ CONFIG_SCHEMA = vol.Schema({
         CONF_FLASH_BRIEFINGS: {
             cv.string: vol.All(cv.ensure_list, [{
                 vol.Required(CONF_UID, default=str(uuid.uuid4())): cv.string,
-                vol.Optional(CONF_DATE, default=datetime.utcnow()): cv.string,
                 vol.Required(CONF_TITLE): cv.template,
                 vol.Optional(CONF_AUDIO): cv.template,
                 vol.Required(CONF_TEXT, default=""): cv.template,
@@ -331,10 +328,7 @@ class AlexaFlashBriefingView(HomeAssistantView):
                 else:
                     output[ATTR_REDIRECTION_URL] = item.get(CONF_DISPLAY_URL)
 
-            if isinstance(item[CONF_DATE], str):
-                item[CONF_DATE] = dt_util.parse_datetime(item[CONF_DATE])
-
-            output[ATTR_UPDATE_DATE] = item[CONF_DATE].strftime(DATE_FORMAT)
+            output[ATTR_UPDATE_DATE] = datetime.now().strftime(DATE_FORMAT)
 
             briefing.append(output)
 

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -19,9 +19,6 @@ calls = []
 
 NPR_NEWS_MP3_URL = "https://pd.npr.org/anon.npr-mp3/npr/news/newscast.mp3"
 
-# 2016-10-10T19:51:42+00:00
-STATIC_TIME = datetime.datetime.utcfromtimestamp(1476129102)
-
 
 @pytest.fixture
 def alexa_client(loop, hass, test_client):
@@ -39,17 +36,16 @@ def alexa_client(loop, hass, test_client):
             "flash_briefings": {
                 "weather": [
                     {"title": "Weekly forecast",
-                     "text": "This week it will be sunny.",
-                     "date": "2016-10-09T19:51:42.0Z"},
+                     "text": "This week it will be sunny."
+                    },
                     {"title": "Current conditions",
-                     "text": "Currently it is 80 degrees fahrenheit.",
-                     "date": STATIC_TIME}
+                     "text": "Currently it is 80 degrees fahrenheit."
+                    }
                 ],
                 "news_audio": {
                     "title": "NPR",
                     "audio": NPR_NEWS_MP3_URL,
                     "display_url": "https://npr.org",
-                    "date": STATIC_TIME,
                     "uid": "uuid"
                 }
             },
@@ -436,16 +432,8 @@ def test_flash_briefing_date_from_str(alexa_client):
     req = yield from _flash_briefing_req(alexa_client, "weather")
     assert req.status == 200
     data = yield from req.json()
-    assert data[0].get(alexa.ATTR_UPDATE_DATE) == "2016-10-09T19:51:42.0Z"
-
-
-@asyncio.coroutine
-def test_flash_briefing_date_from_datetime(alexa_client):
-    """Test the response has a valid date from a datetime object."""
-    req = yield from _flash_briefing_req(alexa_client, "weather")
-    assert req.status == 200
-    data = yield from req.json()
-    assert data[1].get(alexa.ATTR_UPDATE_DATE) == '2016-10-10T19:51:42.0Z'
+    assert isinstance(datetime.datetime.strptime(data[0].get(
+        alexa.ATTR_UPDATE_DATE), alexa.DATE_FORMAT), datetime.datetime)
 
 
 @asyncio.coroutine
@@ -463,4 +451,8 @@ def test_flash_briefing_valid(alexa_client):
     req = yield from _flash_briefing_req(alexa_client, "news_audio")
     assert req.status == 200
     json = yield from req.json()
+    assert isinstance(datetime.datetime.strptime(json[0].get(
+        alexa.ATTR_UPDATE_DATE), alexa.DATE_FORMAT), datetime.datetime)
+    json[0].pop(alexa.ATTR_UPDATE_DATE)
+    data[0].pop(alexa.ATTR_UPDATE_DATE)
     assert json == data

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -36,11 +36,9 @@ def alexa_client(loop, hass, test_client):
             "flash_briefings": {
                 "weather": [
                     {"title": "Weekly forecast",
-                     "text": "This week it will be sunny."
-                    },
+                     "text": "This week it will be sunny."},
                     {"title": "Current conditions",
-                     "text": "Currently it is 80 degrees fahrenheit."
-                    }
+                     "text": "Currently it is 80 degrees fahrenheit."}
                 ],
                 "news_audio": {
                     "title": "NPR",


### PR DESCRIPTION
## Description:
When HA starts a date value is cached in Alexa's updateDate field for flash briefings.  This value is never updated, after a few weeks of uptime, Amazon regards the content as being stale and reports "\<HA flash briefing\> does not contain any recent content at the moment.".  This occurs regardless of the freshness of the payload, which is generated with each call.

These commits address that issue by causing updateDate to be generated along with the other content each time flash briefing is invoked.

**Related issue (if applicable):** fixes #7459 