### PR TITLE
Do not install all dependencies in dev mode

### DIFF
--- a/homeassistant/components/light/blinkt.py
+++ b/homeassistant/components/light/blinkt.py
@@ -29,6 +29,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Blinkt Light platform."""
+    # pylint: disable=import-error
     import blinkt
 
     # ensure that the lights are off when exiting

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -90,7 +90,7 @@ blinkpy==0.5.2
 blinkstick==1.1.8
 
 # homeassistant.components.light.blinkt
-blinkt==0.1.0
+# blinkt==0.1.0
 
 # homeassistant.components.sensor.bitcoin
 blockchain==1.3.3

--- a/script/bootstrap_server
+++ b/script/bootstrap_server
@@ -6,8 +6,9 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-# parameter --only-binary doesn't work with pip < 7.0.0. Causing
-# python3 -m pip install -r requirements_all.txt to fail unless pip upgraded.
+# We upgrade pip as part of installing Home Assistant. However,
+# some requirements use parameter --only-binary only available
+# in pip 7+. Upgrade if necessary.
 if ! python3 -c 'import pkg_resources ; pkg_resources.require(["pip>=7.0.0"])' 2>/dev/null ; then
   echo "Upgrading pip..."
   python3 -m pip install -U pip

--- a/script/bootstrap_server
+++ b/script/bootstrap_server
@@ -6,10 +6,12 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-echo "Installing Home Assistant in development mode..."
-python3 setup.py develop
-
-REQ_STATUS=$?
+# parameter --only-binary doesn't work with pip < 7.0.0. Causing
+# python3 -m pip install -r requirements_all.txt to fail unless pip upgraded.
+if ! python3 -c 'import pkg_resources ; pkg_resources.require(["pip>=7.0.0"])' 2>/dev/null ; then
+  echo "Upgrading pip..."
+  python3 -m pip install -U pip
+fi
 
 echo "Installing test dependencies..."
 python3 -m pip install -r requirements_test_all.txt

--- a/script/bootstrap_server
+++ b/script/bootstrap_server
@@ -6,21 +6,13 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-echo "Installing dependencies..."
-# Requirements_all.txt states minimum pip version as 7.0.0 however,
-# parameter --only-binary doesn't work with pip < 7.0.0. Causing
-# python3 -m pip install -r requirements_all.txt to fail unless pip upgraded.
-
-if ! python3 -c 'import pkg_resources ; pkg_resources.require(["pip>=7.0.0"])' 2>/dev/null ; then
-  echo "Upgrading pip..."
-  python3 -m pip install -U pip
-fi
-python3 -m pip install -r requirements_all.txt
+echo "Installing Home Assistant in development mode..."
+python3 setup.py develop
 
 REQ_STATUS=$?
 
-echo  "Installing development dependencies..."
-python3 -m pip install -r requirements_test.txt
+echo "Installing test dependencies..."
+python3 -m pip install -r requirements_test_all.txt
 
 REQ_DEV_STATUS=$?
 

--- a/script/bootstrap_server
+++ b/script/bootstrap_server
@@ -6,8 +6,7 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-# We upgrade pip as part of installing Home Assistant. However,
-# some requirements use parameter --only-binary only available
+# Some requirements use parameter --only-binary only available
 # in pip 7+. Upgrade if necessary.
 if ! python3 -c 'import pkg_resources ; pkg_resources.require(["pip>=7.0.0"])' 2>/dev/null ; then
   echo "Upgrading pip..."

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -25,7 +25,8 @@ COMMENT_REQUIREMENTS = (
     'python-eq3bt',
     'avion',
     'decora',
-    'face_recognition'
+    'face_recognition',
+    'blinkt',
 )
 
 TEST_REQUIREMENTS = (


### PR DESCRIPTION
## Description:
Our instructions on the website recommend running `script/bootstrap` which would install all dependencies of Home Assistant. This is however not necessary at all for development.

Instead, we need to install Home Assistant in development mode and install only the dependencies necessary for running the tests.

This PR does just that.
