### PR TITLE
Hide proximity updates in logbook

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -50,6 +50,8 @@ CONFIG_SCHEMA = vol.Schema({
 
 GROUP_BY_MINUTES = 15
 
+CONTINUOUS_DOMAINS = ['proximity', 'sensor']
+
 ATTR_NAME = 'name'
 ATTR_MESSAGE = 'message'
 ATTR_DOMAIN = 'domain'
@@ -190,7 +192,8 @@ def humanify(events):
                 if entity_id is None:
                     continue
 
-                if entity_id.startswith('sensor.'):
+                if entity_id.startswith(tuple('{}.'.format(
+                        domain) for domain in CONTINUOUS_DOMAINS)):
                     last_sensor_event[entity_id] = event
 
             elif event.event_type == EVENT_HOMEASSISTANT_STOP:
@@ -222,12 +225,12 @@ def humanify(events):
                 domain = to_state.domain
 
                 # Skip all but the last sensor state
-                if domain == 'sensor' and \
+                if domain in CONTINUOUS_DOMAINS and \
                    event != last_sensor_event[to_state.entity_id]:
                     continue
 
                 # Don't show continuous sensor value changes in the logbook
-                if domain == 'sensor' and \
+                if domain in CONTINUOUS_DOMAINS and \
                    to_state.attributes.get('unit_of_measurement'):
                     continue
 


### PR DESCRIPTION
## Description:
This PR updates logbook to treat proximity events the same as sensor events. Like sensors, the proximity is a continuous value and better viewed in the history panel.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
