### PR TITLE
Upgrade dweepy to 0.3.0

### DIFF
--- a/homeassistant/components/dweet.py
+++ b/homeassistant/components/dweet.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import state as state_helper
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['dweepy==0.2.0']
+REQUIREMENTS = ['dweepy==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -67,4 +67,4 @@ def send_data(name, msg):
     try:
         dweepy.dweet_for(name, msg)
     except dweepy.DweepyError:
-        _LOGGER.error("Error saving data '%s' to Dweet.io", msg)
+        _LOGGER.error("Error saving data to Dweet.io: %s", msg)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -160,7 +160,7 @@ dsmr_parser==0.8
 
 # homeassistant.components.dweet
 # homeassistant.components.sensor.dweet
-dweepy==0.2.0
+dweepy==0.3.0
 
 # homeassistant.components.sensor.eliqonline
 eliqonline==1.0.13


### PR DESCRIPTION
## 0.3.0

Changelog: https://github.com/paddycarey/dweepy/commits/master

This PR fixes also the `RuntimeError: Cannot be called from within the event loop` caused by the template rendering.

Tested with the following  configuration:

```yaml
dweet:
  name: ha-sensor
  whitelist:
    - sensor.random
    - sensor.cpu

sensor:
  - platform: dweet
    name: Dweet.io CPU
    device: ha
    value_template: '{{ value_json.CPU }}'
    unit_of_measurement: 'GHz'
```