### PR TITLE
LIFX: add lifx_set_state service call

### DIFF
--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -45,7 +45,7 @@ BULB_LATENCY = 500
 
 CONF_SERVER = 'server'
 
-SERVICE_LIFX_SET_COLOR = 'lifx_set_color'
+SERVICE_LIFX_SET_STATE = 'lifx_set_state'
 
 ATTR_HSBK = 'hsbk'
 ATTR_POWER_ON = 'power_on'
@@ -60,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SERVER, default='0.0.0.0'): cv.string,
 })
 
-LIFX_SET_COLOR_SCHEMA = LIGHT_TURN_ON_SCHEMA.extend({
+LIFX_SET_STATE_SCHEMA = LIGHT_TURN_ON_SCHEMA.extend({
     vol.Optional(ATTR_POWER_ON, default=False): cv.boolean,
 })
 
@@ -103,8 +103,8 @@ class LIFXManager(object):
             """Apply a service."""
             tasks = []
             for light in self.service_to_entities(service):
-                if service.service == SERVICE_LIFX_SET_COLOR:
-                    task = light.async_set_color(**service.data)
+                if service.service == SERVICE_LIFX_SET_STATE:
+                    task = light.async_set_state(**service.data)
                 tasks.append(hass.async_add_job(task))
             if tasks:
                 yield from asyncio.wait(tasks, loop=hass.loop)
@@ -112,9 +112,9 @@ class LIFXManager(object):
         descriptions = self.get_descriptions()
 
         hass.services.async_register(
-            DOMAIN, SERVICE_LIFX_SET_COLOR, async_service_handle,
-            descriptions.get(SERVICE_LIFX_SET_COLOR),
-            schema=LIFX_SET_COLOR_SCHEMA)
+            DOMAIN, SERVICE_LIFX_SET_STATE, async_service_handle,
+            descriptions.get(SERVICE_LIFX_SET_STATE),
+            schema=LIFX_SET_STATE_SCHEMA)
 
     @staticmethod
     def get_descriptions():
@@ -345,10 +345,10 @@ class LIFXLight(Light):
     def async_turn_on(self, **kwargs):
         """Turn the device on."""
         kwargs[ATTR_POWER_ON] = True
-        yield from self.async_set_color(**kwargs)
+        yield from self.async_set_state(**kwargs)
 
     @asyncio.coroutine
-    def async_set_color(self, **kwargs):
+    def async_set_state(self, **kwargs):
         """Set a color on the light."""
         yield from self.stop_effect()
 

--- a/homeassistant/components/light/lifx/effects.py
+++ b/homeassistant/components/light/lifx/effects.py
@@ -2,16 +2,13 @@
 import logging
 import asyncio
 import random
-from os import path
 
 import voluptuous as vol
 
 from homeassistant.components.light import (
     DOMAIN, ATTR_BRIGHTNESS, ATTR_COLOR_NAME, ATTR_RGB_COLOR, ATTR_EFFECT,
     ATTR_TRANSITION)
-from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (ATTR_ENTITY_ID)
-from homeassistant.helpers.service import extract_entity_ids
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -73,19 +70,12 @@ def setup(hass, lifx_manager):
     @asyncio.coroutine
     def async_service_handle(service):
         """Apply a service."""
-        entity_ids = extract_entity_ids(hass, service)
-        if entity_ids:
-            devices = [entity for entity in lifx_manager.entities.values()
-                       if entity.entity_id in entity_ids]
-        else:
-            devices = list(lifx_manager.entities.values())
-
-        if devices:
-            yield from start_effect(hass, devices,
+        entities = lifx_manager.service_to_entities(service)
+        if entities:
+            yield from start_effect(hass, entities,
                                     service.service, **service.data)
 
-    descriptions = load_yaml_config_file(
-        path.join(path.dirname(__file__), 'services.yaml'))
+    descriptions = lifx_manager.get_descriptions()
 
     hass.services.async_register(
         DOMAIN, SERVICE_EFFECT_BREATHE, async_service_handle,

--- a/homeassistant/components/light/lifx/services.yaml
+++ b/homeassistant/components/light/lifx/services.yaml
@@ -1,16 +1,16 @@
-lifx_set_color:
-  description: Set a color just like light.turn_on, but only turn on if power_on is True
+lifx_set_state:
+  description: Set a color/brightness just like light.turn_on, but only turn on if power_on is True
 
   fields:
     entity_id:
-      description: Name(s) of entities to set a color on
+      description: Name(s) of entities to set a state on
       example: 'light.garage'
 
     '...':
       description: All turn_on parameters can be used to specify a color
 
     transition:
-      description: Duration in seconds it takes to get to final state
+      description: Duration in seconds it takes to get to the final state
       example: 10
 
     power_on:

--- a/homeassistant/components/light/lifx/services.yaml
+++ b/homeassistant/components/light/lifx/services.yaml
@@ -1,5 +1,5 @@
 lifx_set_state:
-  description: Set a color/brightness just like light.turn_on, but only turn on if power_on is True
+  description: Set a color/brightness and possibliy turn the light on/off
 
   fields:
     entity_id:
@@ -13,8 +13,8 @@ lifx_set_state:
       description: Duration in seconds it takes to get to the final state
       example: 10
 
-    power_on:
-      description: Turn on the light if it is currently off (default False)
+    power:
+      description: Turn the light on (True) or off (False). Leave out to keep the power as it is.
       example: True
 
 

--- a/homeassistant/components/light/lifx/services.yaml
+++ b/homeassistant/components/light/lifx/services.yaml
@@ -1,3 +1,23 @@
+lifx_set_color:
+  description: Set a color just like light.turn_on, but only turn on if power_on is True
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to set a color on
+      example: 'light.garage'
+
+    '...':
+      description: All turn_on parameters can be used to specify a color
+
+    transition:
+      description: Duration in seconds it takes to get to final state
+      example: 10
+
+    power_on:
+      description: Turn on the light if it is currently off (default False)
+      example: True
+
+
 lifx_effect_breathe:
   description: Run a breathe effect by fading to a color and back.
 


### PR DESCRIPTION
## Description:

As suggested in #7477, this is a LIFX-specific service that is just like `light.turn_on` except it does not actually turn on the light (unless asked to).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2620

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  # Reset all lights from our evening fun (but do not light up the whole house).
  - alias: Bright morning light
    trigger:
      platform: time
      after: '06:00'
    action:
      - service: light.lifx_set_state
        data:
          color_temp: 200
          brightness: 200
          transition: 180
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.