### PR TITLE
Add SSL support to NZBGet sensor

### DIFF
--- a/homeassistant/components/sensor/nzbget.py
+++ b/homeassistant/components/sensor/nzbget.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_NAME, CONF_PORT,
-    CONTENT_TYPE_JSON, CONF_MONITORED_VARIABLES)
+    CONF_SSL, CONTENT_TYPE_JSON, CONF_MONITORED_VARIABLES)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -44,6 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_SSL, default=False): cv.boolean,
     vol.Optional(CONF_USERNAME): cv.string,
 })
 
@@ -53,12 +54,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the NZBGet sensors."""
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
+    ssl = 's' if config.get(CONF_SSL) else ''
     name = config.get(CONF_NAME)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     monitored_types = config.get(CONF_MONITORED_VARIABLES)
 
-    url = "http://{}:{}/jsonrpc".format(host, port)
+    url = "http{}://{}:{}/jsonrpc".format(ssl, host, port)
 
     try:
         nzbgetapi = NZBGetAPI(


### PR DESCRIPTION
## Description:
Adds support for SSL hosts to the NZBGet sensor.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2616

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: nzbget
  host: nzbget.domain.com
  port: 443
  ssl: true
  monitored_variables:
    - download_rate
    - download_size
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
