### PR TITLE
Only install tox in dev mode

### DIFF
--- a/script/bootstrap_frontend
+++ b/script/bootstrap_frontend
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Resolve all frontend dependencies that the application requires to run.
+# Resolve all frontend dependencies that the application requires to develop.
 
 # Stop on errors
 set -e

--- a/script/bootstrap_server
+++ b/script/bootstrap_server
@@ -1,26 +1,10 @@
 #!/bin/sh
-# Resolve all server dependencies that the application requires to run.
+# Resolve all server dependencies that the application requires to develop.
 
 # Stop on errors
 set -e
 
 cd "$(dirname "$0")/.."
 
-# Some requirements use parameter --only-binary only available
-# in pip 7+. Upgrade if necessary.
-if ! python3 -c 'import pkg_resources ; pkg_resources.require(["pip>=7.0.0"])' 2>/dev/null ; then
-  echo "Upgrading pip..."
-  python3 -m pip install -U pip
-fi
-
 echo "Installing test dependencies..."
-python3 -m pip install -r requirements_test_all.txt
-
-REQ_DEV_STATUS=$?
-
-if [ $REQ_DEV_STATUS -eq 0 ]
-then
-  exit $REQ_STATUS
-else
-  exit $REQ_DEV_STATUS
-fi
+python3 -m pip install tox


### PR DESCRIPTION
## Description:
Ha, after merging the last PR where we didn't all all requirements but only the ones for testing I realized that we can make it even simpler. All we need is to install `tox`. All other testing is done in a VM when the user is ready for it.

I will update the testing part of the docs to say that if you want to run the tests outside of tox that you have to `pip3 install -r requirements_test_all.txt`

CC @MartinHjelmare because he was involved in last PR.