### PR TITLE
Initialize sun with unknown values.

### DIFF
--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from homeassistant.const import CONF_ELEVATION, STATE_UNKNOWN
+from homeassistant.const import CONF_ELEVATION
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
@@ -59,10 +59,10 @@ class Sun(Entity):
         """Initialize the sun."""
         self.hass = hass
         self.location = location
-        self._state = self.next_rising = self.next_setting = STATE_UNKNOWN
-        self.next_dawn = self.next_dusk = STATE_UNKNOWN
-        self.next_midnight = self.next_noon = STATE_UNKNOWN
-        self.solar_elevation = self.solar_azimuth = STATE_UNKNOWN
+        self._state = self.next_rising = self.next_setting = None
+        self.next_dawn = self.next_dusk = None
+        self.next_midnight = self.next_noon = None
+        self.solar_elevation = self.solar_azimuth = None
 
         async_track_utc_time_change(hass, self.timer_update, second=30)
 
@@ -124,8 +124,7 @@ class Sun(Entity):
     @callback
     def point_in_time_listener(self, now):
         """Run when the state of the sun has changed."""
-        if self.solar_elevation == STATE_UNKNOWN:
-            self.update_sun_position(dt_util.utcnow())
+        self.update_sun_position(dt_util.utcnow())
         self.update_as_of(now)
         self.hass.async_add_job(self.async_update_ha_state())
 

--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -124,6 +124,8 @@ class Sun(Entity):
     @callback
     def point_in_time_listener(self, now):
         """Run when the state of the sun has changed."""
+        if self.solar_elevation == STATE_UNKNOWN:
+            self.update_sun_position(dt_util.utcnow())
         self.update_as_of(now)
         self.hass.async_add_job(self.async_update_ha_state())
 

--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -124,7 +124,7 @@ class Sun(Entity):
     @callback
     def point_in_time_listener(self, now):
         """Run when the state of the sun has changed."""
-        self.update_sun_position(dt_util.utcnow())
+        self.update_sun_position(now)
         self.update_as_of(now)
         self.hass.async_add_job(self.async_update_ha_state())
 

--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from homeassistant.const import CONF_ELEVATION
+from homeassistant.const import CONF_ELEVATION, STATE_UNKNOWN
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
@@ -59,10 +59,10 @@ class Sun(Entity):
         """Initialize the sun."""
         self.hass = hass
         self.location = location
-        self._state = self.next_rising = self.next_setting = None
-        self.next_dawn = self.next_dusk = None
-        self.next_midnight = self.next_noon = None
-        self.solar_elevation = self.solar_azimuth = 0
+        self._state = self.next_rising = self.next_setting = STATE_UNKNOWN
+        self.next_dawn = self.next_dusk = STATE_UNKNOWN
+        self.next_midnight = self.next_noon = STATE_UNKNOWN
+        self.solar_elevation = self.solar_azimuth = STATE_UNKNOWN
 
         async_track_utc_time_change(hass, self.timer_update, second=30)
 


### PR DESCRIPTION
## Description:
Initial values should be `unknown` instead of `0`. Otherwise on HA restart the value of `0` is pushed to metrics databases (graphite/influx/recorder).

