### PR TITLE
Update pywebpush 1.0.0

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -25,8 +25,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.frontend import add_manifest_json_key
 from homeassistant.helpers import config_validation as cv
 
-# pyelliptic is dependency of pywebpush and 1.5.8 contains a breaking change
-REQUIREMENTS = ['pywebpush==0.6.1', 'PyJWT==1.4.2', 'pyelliptic==1.5.7']
+REQUIREMENTS = ['pywebpush==1.0.0', 'PyJWT==1.4.2']
 
 DEPENDENCIES = ['frontend']
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -526,9 +526,6 @@ pyebox==0.1.0
 # homeassistant.components.eight_sleep
 pyeight==0.0.4
 
-# homeassistant.components.notify.html5
-pyelliptic==1.5.7
-
 # homeassistant.components.media_player.emby
 pyemby==1.2
 
@@ -711,7 +708,7 @@ pyunifi==2.12
 pyvera==0.2.30
 
 # homeassistant.components.notify.html5
-pywebpush==0.6.1
+pywebpush==1.0.0
 
 # homeassistant.components.wemo
 pywemo==0.4.19

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -106,9 +106,6 @@ pycmus==0.1.0
 # homeassistant.components.zwave
 pydispatcher==2.0.5
 
-# homeassistant.components.notify.html5
-pyelliptic==1.5.7
-
 # homeassistant.components.litejet
 pylitejet==0.1
 
@@ -126,7 +123,7 @@ python-forecastio==1.3.5
 pyunifi==2.12
 
 # homeassistant.components.notify.html5
-pywebpush==0.6.1
+pywebpush==1.0.0
 
 # homeassistant.components.rflink
 rflink==0.0.34


### PR DESCRIPTION
## Description:
update pywebpush to 1.0.0. this removes the dependency to unmaintained 'pyelliptic'.
also works on systems using openssl 1.1

**Related issue (if applicable):** fixes #
https://github.com/web-push-libs/pywebpush/issues/48
https://github.com/web-push-libs/pywebpush/issues/49


## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
