### PR TITLE
Update netdisco

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==1.0.0rc3']
+REQUIREMENTS = ['netdisco==1.0.0']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -382,7 +382,7 @@ mutagen==1.37.0
 myusps==1.0.5
 
 # homeassistant.components.discovery
-netdisco==1.0.0rc3
+netdisco==1.0.0
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -78,9 +78,6 @@ mficlient==0.3.0
 # homeassistant.components.tts
 mutagen==1.37.0
 
-# homeassistant.components.discovery
-netdisco==1.0.0rc3
-
 # homeassistant.components.mqtt
 paho-mqtt==1.2.3
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -48,7 +48,6 @@ TEST_REQUIREMENTS = (
     'pilight',
     'fuzzywuzzy',
     'datadog',
-    'netdisco',
     'rflink',
     'ring_doorbell',
     'sleepyq',

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -1,8 +1,9 @@
 """The tests for the discovery component."""
 import asyncio
 import os
+from unittest.mock import patch, MagicMock
 
-from unittest.mock import patch
+import pytest
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import discovery
@@ -32,6 +33,15 @@ IGNORE_CONFIG = {
         'ignore': [SERVICE_NO_PLATFORM]
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def netdisco_mock():
+    """Mock netdisco."""
+    with patch.dict('sys.modules', {
+        'netdisco.discovery': MagicMock(),
+    }):
+        yield
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:
This updates the netdisco dependency to 1.0

I also realized that our current test requirements can be trimmed down a lot more. Most things are only imported but not used in tests because they are mocked out.

## Example entry for `configuration.yaml` (if applicable):
```yaml
discovery:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
