### PR TITLE
Support lutron serena shades

### DIFF
--- a/homeassistant/components/cover/lutron_caseta.py
+++ b/homeassistant/components/cover/lutron_caseta.py
@@ -1,8 +1,8 @@
 """
-Support for Lutron Caseta lights.
+Support for Lutron Caseta SerenaRollerShade.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/light.lutron_caseta/
+https://home-assistant.io/components/cover.lutron_caseta/
 """
 import logging
 
@@ -24,8 +24,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
     cover_devices = bridge.get_devices_by_types(["SerenaRollerShade"])
-    for light_device in cover_devices:
-        dev = LutronCasetaCover(light_device, bridge)
+    for cover_device in cover_devices:
+        dev = LutronCasetaCover(cover_device, bridge)
         devs.append(dev)
 
     add_devices(devs, True)

--- a/homeassistant/components/cover/lutron_caseta.py
+++ b/homeassistant/components/cover/lutron_caseta.py
@@ -1,0 +1,62 @@
+"""
+Support for Lutron Caseta lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.lutron_caseta/
+"""
+import logging
+
+
+from homeassistant.components.cover import (
+    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE)
+from homeassistant.components.lutron_caseta import (
+    LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice)
+
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['lutron_caseta']
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Lutron Caseta Serena shades as a cover device."""
+    devs = []
+    bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
+    cover_devices = bridge.get_devices_by_types(["SerenaRollerShade"])
+    for light_device in cover_devices:
+        dev = LutronCasetaCover(light_device, bridge)
+        devs.append(dev)
+
+    add_devices(devs, True)
+
+
+class LutronCasetaCover(LutronCasetaDevice, CoverDevice):
+    """Representation of a Lutron Serena shade."""
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_OPEN | SUPPORT_CLOSE
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return self._state["current_state"] < 1
+
+    def close_cover(self):
+        """Close the cover."""
+        self._smartbridge.set_value(self._device_id, 0)
+
+    def open_cover(self):
+        """Open the cover."""
+        self._smartbridge.set_value(self._device_id, 100)
+
+    def set_cover_position(self, position, **kwargs):
+        """Move the roller shutter to a specific position."""
+        self._smartbridge.set_value(self._device_id, position)
+
+    def update(self):
+        """Call when forcing a refresh of the device."""
+        self._state = self._smartbridge.get_device_by_id(self._device_id)
+        _LOGGER.debug(self._state)

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -44,7 +44,7 @@ def setup(hass, base_config):
 
     _LOGGER.info("Connected to Lutron smartbridge at %s", config[CONF_HOST])
 
-    for component in ('light', 'switch'):
+    for component in ('light', 'switch', 'cover'):
         discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     return True


### PR DESCRIPTION
## Description:

This PR will add support for the Caseta Serena Shades hardware as a home assistant cover device.  
There are no breaking changes.
There is no change to the configuration.  

**Related issue (if applicable):** fixes #na

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2622

## Example entry for `configuration.yaml` (if applicable): 
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
