### PR TITLE
File sensor

### DIFF
--- a/homeassistant/components/sensor/file.py
+++ b/homeassistant/components/sensor/file.py
@@ -85,7 +85,8 @@ class FileSensor(Entity):
                 for line in file_data:
                     data = line
                 data = data.strip()
-        except (IndexError, FileNotFoundError, IsADirectoryError):
+        except (IndexError, FileNotFoundError, IsADirectoryError,
+                UnboundLocalError):
             _LOGGER.warning("File or data not present at the moment: %s",
                             os.path.basename(self._file_path))
             return

--- a/homeassistant/components/sensor/file.py
+++ b/homeassistant/components/sensor/file.py
@@ -82,7 +82,9 @@ class FileSensor(Entity):
         """Get the latest entry from a file and updates the state."""
         try:
             with open(self._file_path, 'r', encoding='utf-8') as file_data:
-                data = file_data.readlines()[-1].strip()
+                for line in file_data:
+                    data = line
+                data = data.strip()
         except (IndexError, FileNotFoundError, IsADirectoryError):
             _LOGGER.warning("File or data not present at the moment: %s",
                             os.path.basename(self._file_path))

--- a/homeassistant/components/sensor/file.py
+++ b/homeassistant/components/sensor/file.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_VALUE_TEMPLATE, CONF_NAME, CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN)
+    CONF_VALUE_TEMPLATE, CONF_NAME, CONF_UNIT_OF_MEASUREMENT)
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
@@ -78,19 +78,18 @@ class FileSensor(Entity):
         """Return the state of the sensor."""
         return self._state
 
-    @asyncio.coroutine
-    def async_update(self):
+    def update(self):
         """Get the latest entry from a file and updates the state."""
         try:
             with open(self._file_path, 'r', encoding='utf-8') as file_data:
                 data = file_data.readlines()[-1].strip()
         except (IndexError, FileNotFoundError, IsADirectoryError):
-            data = STATE_UNKNOWN
             _LOGGER.warning("File or data not present at the moment: %s",
                             os.path.basename(self._file_path))
+            return
 
         if self._val_tpl is not None:
             self._state = self._val_tpl.async_render_with_possible_json_value(
-                data, STATE_UNKNOWN)
+                data, None)
         else:
             self._state = data

--- a/homeassistant/components/sensor/file.py
+++ b/homeassistant/components/sensor/file.py
@@ -1,0 +1,96 @@
+"""
+Support for sensor value(s) stored in local files.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.file/
+"""
+import os
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_VALUE_TEMPLATE, CONF_NAME, CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN)
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_FILE_PATH = 'file_path'
+
+DEFAULT_NAME = 'File'
+
+ICON = 'mdi:file'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_FILE_PATH): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the file sensor."""
+    file_path = config.get(CONF_FILE_PATH)
+    name = config.get(CONF_NAME)
+    unit = config.get(CONF_UNIT_OF_MEASUREMENT)
+    value_template = config.get(CONF_VALUE_TEMPLATE)
+
+    if value_template is not None:
+        value_template.hass = hass
+
+    async_add_devices(
+        [FileSensor(name, file_path, unit, value_template)], True)
+
+
+class FileSensor(Entity):
+    """Implementation of a file sensor."""
+
+    def __init__(self, name, file_path, unit_of_measurement, value_template):
+        """Initialize the file sensor."""
+        self._name = name
+        self._file_path = file_path
+        self._unit_of_measurement = unit_of_measurement
+        self._val_tpl = value_template
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit_of_measurement
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return ICON
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Get the latest entry from a file and updates the state."""
+        try:
+            with open(self._file_path, 'r', encoding='utf-8') as file_data:
+                data = file_data.readlines()[-1].strip()
+        except (IndexError, FileNotFoundError, IsADirectoryError):
+            data = STATE_UNKNOWN
+            _LOGGER.warning("File or data not present at the moment: %s",
+                            os.path.basename(self._file_path))
+
+        if self._val_tpl is not None:
+            self._state = self._val_tpl.async_render_with_possible_json_value(
+                data, STATE_UNKNOWN)
+        else:
+            self._state = data

--- a/tests/components/sensor/test_file.py
+++ b/tests/components/sensor/test_file.py
@@ -1,0 +1,115 @@
+"""The tests for local file sensor platform."""
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+# Using third party package because of a bug reading binary data in Python 3.4
+# https://bugs.python.org/issue23004
+from mock_open import MockOpen
+
+from homeassistant.setup import setup_component
+from homeassistant.const import STATE_UNKNOWN
+
+from tests.common import get_test_home_assistant
+
+
+def create_file(path, data):
+    """Create a sensor file."""
+    with open(path, 'w') as test_file:
+        test_file.write(data)
+
+
+class TestFileSensor(unittest.TestCase):
+    """Test the File sensor."""
+
+    def setup_method(self, method):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @patch('os.path.isfile', Mock(return_value=True))
+    @patch('os.access', Mock(return_value=True))
+    def test_file_value(self):
+        """Test the File sensor."""
+        config = {
+            'sensor': {
+                'platform': 'file',
+                'name': 'file1',
+                'file_path': 'mock.file1',
+            }
+        }
+
+        assert setup_component(self.hass, 'sensor', config)
+
+        create_file('mock.file1', '43\n45\n21')
+
+        m_open = MockOpen()
+        with patch('homeassistant.components.sensor.file.open', m_open,
+                   create=True):
+            content = open('mock.file1')
+            result = content.readlines()[-1].strip()
+
+        self.assertEqual(result, '21')
+
+        state = self.hass.states.get('sensor.file1')
+        self.assertEqual(state.state, '21')
+
+    @patch('os.path.isfile', Mock(return_value=True))
+    @patch('os.access', Mock(return_value=True))
+    def test_file_value_template(self):
+        """Test the File sensor with JSON entries."""
+        config = {
+            'sensor': {
+                'platform': 'file',
+                'name': 'file2',
+                'file_path': 'mock.file2',
+                'value_template': '{{ value_json.temperature }}',
+            }
+        }
+
+        assert setup_component(self.hass, 'sensor', config)
+
+        create_file('mock.file2',
+                    '{"temperature": 29, "humidity": 31}\n'
+                    '{"temperature": 26, "humidity": 36}')
+
+        m_open = MockOpen()
+        with patch('homeassistant.components.sensor.file.open', m_open,
+                   create=True):
+            content = open('mock.file2')
+            result = content.readlines()[-1].strip()
+
+        self.assertEqual(result, '{"temperature": 26, "humidity": 36}')
+
+        state = self.hass.states.get('sensor.file2')
+        self.assertEqual(state.state, str(json.loads(result)['temperature']))
+
+    @patch('os.path.isfile', Mock(return_value=True))
+    @patch('os.access', Mock(return_value=True))
+    def test_file_empty(self):
+        """Test the File sensor with an empty file."""
+        config = {
+            'sensor': {
+                'platform': 'file',
+                'name': 'file3',
+                'file_path': 'mock.file',
+            }
+        }
+
+        assert setup_component(self.hass, 'sensor', config)
+
+        create_file('mock.file', '')
+
+        m_open = MockOpen()
+        with patch('homeassistant.components.sensor.file.open', m_open,
+                   create=True):
+            content = open('mock.file')
+            result = content.read()
+
+        self.assertEqual(result, '')
+
+        state = self.hass.states.get('sensor.file3')
+        self.assertEqual(state.state, STATE_UNKNOWN)


### PR DESCRIPTION
## Description:
The `file` sensor reads the last entry of a plain text file. The entries can be simple values or JSON with is handled by our templating feature

**Related issue (if applicable):** fixes [File sensors](https://community.home-assistant.io/t/file-sensors/3721)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2625

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: file
    file_path: /home/fab/.homeassistant/test/sensor-test.txt
    value_template: '{{ value_json.temperature }}'
    unit_of_measurement: '°C'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
