### PR TITLE
Blinkpy version bump to 0.6.0

### DIFF
--- a/homeassistant/components/blink.py
+++ b/homeassistant/components/blink.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD, ATTR_FRIENDLY_NAME, ATTR_ARMED)
 from homeassistant.helpers import discovery
 
-REQUIREMENTS = ['blinkpy==0.5.2']
+REQUIREMENTS = ['blinkpy==0.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/blink.py
+++ b/homeassistant/components/sensor/blink.py
@@ -77,7 +77,7 @@ class BlinkSensor(Entity):
         if self._type == 'temperature':
             self._state = camera.temperature
         elif self._type == 'battery':
-            self._state = camera.battery
+            self._state = camera.battery_string
         elif self._type == 'notifications':
             self._state = camera.notifications
         else:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -90,7 +90,7 @@ beautifulsoup4==4.6.0
 bellows==0.2.7
 
 # homeassistant.components.blink
-blinkpy==0.5.2
+blinkpy==0.6.0
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.8


### PR DESCRIPTION
## Description:
Bumped blink version to support automatic re-authorization when tokens expire. Changed the battery sensor call to a string version so that the battery reports back "Low" or "OK".  Previously the raw integer that Blink reports (0-3) was used, but clearly caused some confusion (see below issue)

**Related issue (if applicable):** fixes #7097

## Checklist:

If user exposed functionality or configuration variables are added/changed:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.