### PR TITLE
Zwave: Apply refresh_node workaround on 1st instance only

### DIFF
--- a/homeassistant/components/zwave/workaround.py
+++ b/homeassistant/components/zwave/workaround.py
@@ -24,7 +24,7 @@ SOMFY_ZRTSI = 0x5a52
 PHILIO_SLIM_SENSOR_MOTION_MTII = (PHILIO, PHILIO_SENSOR, PHILIO_SLIM_SENSOR, 0)
 PHILIO_3_IN_1_SENSOR_GEN_4_MOTION_MTII = (
     PHILIO, PHILIO_SENSOR, PHILIO_3_IN_1_SENSOR_GEN_4, 0)
-PHILIO_PAN07_MTII = (PHILIO, PHILIO_SWITCH, PHILIO_PAN07, 0)
+PHILIO_PAN07_MTI_INSTANCE = (PHILIO, PHILIO_SWITCH, PHILIO_PAN07, 1)
 WENZHOU_SLIM_SENSOR_MOTION_MTII = (
     WENZHOU, PHILIO_SENSOR, PHILIO_SLIM_SENSOR, 0)
 
@@ -39,7 +39,11 @@ DEVICE_MAPPINGS_MTII = {
     PHILIO_SLIM_SENSOR_MOTION_MTII: WORKAROUND_NO_OFF_EVENT,
     PHILIO_3_IN_1_SENSOR_GEN_4_MOTION_MTII: WORKAROUND_NO_OFF_EVENT,
     WENZHOU_SLIM_SENSOR_MOTION_MTII: WORKAROUND_NO_OFF_EVENT,
-    PHILIO_PAN07_MTII: WORKAROUND_REFRESH_NODE_ON_UPDATE,
+}
+
+# List of workarounds by (manufacturer_id, product_type, product_id, instance)
+DEVICE_MAPPINGS_MTI_INSTANCE = {
+    PHILIO_PAN07_MTI_INSTANCE: WORKAROUND_REFRESH_NODE_ON_UPDATE,
 }
 
 SOMFY_ZRTSI_CONTROLLER_MT = (SOMFY, SOMFY_ZRTSI)
@@ -91,6 +95,12 @@ def get_device_mapping(value):
             (manufacturer_id, product_type, product_id, value.index))
         if result:
             return result
+
+        result = DEVICE_MAPPINGS_MTI_INSTANCE.get(
+            (manufacturer_id, product_type, product_id, value.instance))
+        if result:
+            return result
+
         return DEVICE_MAPPINGS_MT.get((manufacturer_id, product_type))
 
     return None

--- a/tests/components/switch/test_zwave.py
+++ b/tests/components/switch/test_zwave.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from homeassistant.components.switch import zwave
 
 from tests.mock.zwave import (
-   MockNode, MockValue, MockEntityValues, value_changed)
+    MockNode, MockValue, MockEntityValues, value_changed)
 
 
 def test_get_device_detects_switch(mock_openzwave):
@@ -61,7 +61,7 @@ def test_switch_refresh_on_update(mock_counter, mock_openzwave):
     mock_counter.return_value = 10
     node = MockNode(manufacturer_id='013c', product_type='0001',
                     product_id='0005')
-    value = MockValue(data=False, node=node)
+    value = MockValue(data=False, node=node, instance=1)
     values = MockEntityValues(primary=value)
     device = zwave.get_device(node=node, values=values, node_config={})
 

--- a/tests/components/zwave/test_workaround.py
+++ b/tests/components/zwave/test_workaround.py
@@ -46,3 +46,6 @@ def test_get_device_mapping_mti_instance():
                     product_id='0005')
     value = MockValue(data=0, node=node, instance=1)
     assert workaround.get_device_mapping(value) == 'refresh_node_on_update'
+
+    value = MockValue(data=0, node=node, instance=2)
+    assert workaround.get_device_mapping(value) is None

--- a/tests/components/zwave/test_workaround.py
+++ b/tests/components/zwave/test_workaround.py
@@ -38,3 +38,11 @@ def test_get_device_mapping_mtii():
                     product_id='0002')
     value = MockValue(data=0, node=node, index=0)
     assert workaround.get_device_mapping(value) == 'trigger_no_off_event'
+
+
+def test_get_device_mapping_mti_instance():
+    """Test that device mapping mti_instance is returned."""
+    node = MockNode(manufacturer_id='013c', product_type='0001',
+                    product_id='0005')
+    value = MockValue(data=0, node=node, instance=1)
+    assert workaround.get_device_mapping(value) == 'refresh_node_on_update'


### PR DESCRIPTION
## Description:

Apply refresh_node workaround on 1st instance only.
The buggy device behavior is sending update on main instance (1) when another instance changed.
Thus it is enough to apply workaround on instance 1 only.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
