### PR TITLE
Automation State Change For Timer Fix for Attribute Changes

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -79,6 +79,10 @@ def async_trigger(hass, config, action):
             call_action()
             return
 
+        # If only state attributes changed, ignore this event
+        if from_s.last_changed == to_s.last_changed:
+            return
+
         @callback
         def state_for_listener(now):
             """Fire on state changes after a delay and calls action."""


### PR DESCRIPTION
## Description:
This PR is a small change to the automation state change trigger. Currently, when a state change trigger is waiting on its "for" timer, any attribute change will restart the timer. The expectation is that only actual state changes will change the timer. The state condition actually already has this behavior, since it's based on the `last_changed` property already.

I chose to compare the `last_changed` properties instead of `state` since that makes it equivalent to the condition logic, and also rolls in the `force_update` edge case.

## Use Case:
Currently I have a device tracker that updates with a new GPS location every 60 seconds. I want to create an automation that triggers when the device has been away for 2 minutes, but it currently never triggers.