### PR TITLE
Eight Sleep - Fix handling of single user

### DIFF
--- a/homeassistant/components/eight_sleep.py
+++ b/homeassistant/components/eight_sleep.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
 
-REQUIREMENTS = ['pyeight==0.0.4']
+REQUIREMENTS = ['pyeight==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -145,6 +145,9 @@ def async_setup(hass, config):
                 sensors.append('{}_{}'.format(obj.side, sensor))
             binary_sensors.append('{}_presence'.format(obj.side))
         sensors.append('room_temp')
+    else:
+        # No users, cannot continue
+        return False
 
     hass.async_add_job(discovery.async_load_platform(
         hass, 'sensor', DOMAIN, {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -527,7 +527,7 @@ pydroid-ipcam==0.8
 pyebox==0.1.0
 
 # homeassistant.components.eight_sleep
-pyeight==0.0.4
+pyeight==0.0.5
 
 # homeassistant.components.media_player.emby
 pyemby==1.2


### PR DESCRIPTION
## Description:
This fixes a setup error when using the eight_sleep component with ```Partner: False``` (single bed user) when that user is on the right side of the bed.

It would be great if this could be included in the next hotfix release, 0.44.3?

**Related issue (if applicable):** fixes Reported on forum.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
