### PR TITLE
Regression fix: camera.zoneminder: Fix camera status checks while also supporting old ZM

### DIFF
--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -107,12 +107,7 @@ class ZoneMinderCamera(MjpegCamera):
                             self._monitor_id)
             return
 
-        if not status_response.get("success", False):
-            _LOGGER.warning("Alarm status API call failed for monitor %i",
-                            self._monitor_id)
-            return
-
-        self._is_recording = status_response['status'] == ZM_STATE_ALARM
+        self._is_recording = status_response.get('status') == ZM_STATE_ALARM
 
     @property
     def is_recording(self):


### PR DESCRIPTION
## Description:
Checks added in #7181 and #7340 were considering the wrong property name since there is never a "success" key. This meant that users running modern ZoneMinder lost the functionality that the method provided.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/pull/7340#issuecomment-299294899 and https://github.com/home-assistant/home-assistant/commit/2f4b2ddc0a175871ae0c11e8628ccd0d11a2ed3c#commitcomment-21878798

