### PR TITLE
Pass additional arguments to tox in test_docker

### DIFF
--- a/script/test_docker
+++ b/script/test_docker
@@ -1,5 +1,8 @@
 #!/bin/sh
 # Executes the tests with tox in a docker container.
+# Every argment is passed to tox to allow running only a subset of tests.
+# The following example will only run media_player tests:
+# ./test_docker -- tests/components/media_player/
 
 # Stop on errors
 set -e
@@ -10,4 +13,4 @@ docker build -t home-assistant-test -f virtualization/Docker/Dockerfile.dev .
 docker run --rm \
     -v `pwd`/.tox/:/usr/src/app/.tox/ \
     -t -i home-assistant-test \
-    tox -e py36
+    tox -e py36 ${@:2}


### PR DESCRIPTION
## Description:
Pass arguments to test_docker to tox. This allows only running specific tests.

Example:

./test_docker -- tests/components/media_player/

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
