### PR TITLE
Added buienradar sensor and weather

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -358,6 +358,7 @@ omit =
     homeassistant/components/sensor/bitcoin.py
     homeassistant/components/sensor/bom.py
     homeassistant/components/sensor/broadlink.py
+    homeassistant/components/sensor/buienradar.py
     homeassistant/components/sensor/dublin_bus_transport.py
     homeassistant/components/sensor/coinmarketcap.py
     homeassistant/components/sensor/cert_expiry.py
@@ -478,6 +479,7 @@ omit =
     homeassistant/components/tts/picotts.py
     homeassistant/components/upnp.py
     homeassistant/components/weather/bom.py
+    homeassistant/components/weather/buienradar.py
     homeassistant/components/weather/metoffice.py
     homeassistant/components/weather/openweathermap.py
     homeassistant/components/weather/zamg.py

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.event import (
     async_track_point_in_utc_time)
 from homeassistant.util import dt as dt_util
 
-REQUIREMENTS = ['buienradar==0.3', 'xmltodict==0.11.0']
+REQUIREMENTS = ['buienradar==0.4', 'xmltodict==0.11.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -24,7 +24,6 @@ REQUIREMENTS = ['buienradar==0.4', 'xmltodict==0.11.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-
 # Sensor types are defined like so:
 # SENSOR_TYPES = { 'key': ['Display name',
 #                          'unit of measurement',
@@ -46,22 +45,6 @@ SENSOR_TYPES = {
     'precipitation': ['Precipitation', 'mm/h', 'mdi:weather-pouring'],
     'irradiance': ['Irradiance', 'W/m2', 'mdi:sunglasses'],
 }
-
-"""
-SENSOR_ICONS = {
-    br.HUMIDITY: ,
-    br.TEMPERATURE: ,
-    br.GROUNDTEMP: ,
-    br.WINDSPEED: ,
-    br.WINDFORCE: ,
-    br.WINDDIRECTION: ,
-    br.WINDAZIMUTH: ,
-    br.PRESSURE: ,
-    br.WINDGUST: ,
-    br.IRRADIANCE: ,
-    br.PRECIPITATION: ,
-}
-"""
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MONITORED_CONDITIONS,
@@ -219,12 +202,12 @@ class BrData(object):
                                            DATA, MESSAGE, STATUS_CODE, SUCCESS)
 
         result = get_data()
-        if result[SUCCESS]:
-            result = parse_data(result[CONTENT],
+        if result.get(SUCCESS):
+            result = parse_data(result.get(CONTENT),
                                 latitude=self.coordinates[CONF_LATITUDE],
                                 longitude=self.coordinates[CONF_LONGITUDE])
-            if result[SUCCESS]:
-                self.data = result[DATA]
+            if result.get(SUCCESS):
+                self.data = result.get(DATA)
 
                 yield from self.update_devices()
 

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -1,0 +1,471 @@
+"""
+Support for Buienradar.nl weather service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.buienradar/
+"""
+import asyncio
+import logging
+from datetime import datetime, time, timedelta
+import time as tm
+from xml.parsers.expat import ExpatError
+
+import async_timeout
+import aiohttp
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_LATITUDE, CONF_LONGITUDE, CONF_MONITORED_CONDITIONS,
+    ATTR_ATTRIBUTION, ATTR_TEMPERATURE)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import (
+    async_track_point_in_utc_time, async_track_time_interval)
+from homeassistant.util import dt as dt_util
+from homeassistant.util.location import distance
+
+REQUIREMENTS = ['xmltodict==0.11.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ATTRIBUTION = "Data provided by buienradar.nl"
+CONF_DATETIME = 'datetime'
+CONF_STATIONNAME = 'stationname'
+CONF_SYMBOL = 'symbol'
+CONF_HUMIDITY = 'humidity'
+CONF_GROUNDTEMP = 'groundtemperature'
+CONF_WINDSPEED = 'windspeed'
+CONF_WINDFORCE = 'windforce'
+CONF_WINDDIRECTION = 'winddirection'
+CONF_WINDAZIMUTH = 'windazimuth'
+CONF_PRESSURE = 'pressure'
+CONF_VISIBILITY = 'visibility'
+CONF_WINDGUST = 'windgust'
+CONF_PRECIPITATION = 'precipitation'
+CONF_IRRADIANCE = 'irradiance'
+CONF_FORECAST = 'forecast'
+
+# key names in buienradar xml:
+CONF_BR_ROOT = 'buienradarnl'
+CONF_BR_WEERGEGEVENS = 'weergegevens'
+CONF_BR_ACTUEELWEER = 'actueel_weer'
+CONF_BR_WEERSTATIONS = 'weerstations'
+CONF_BR_WEERSTATION = 'weerstation'
+CONF_BR_LAT = 'lat'
+CONF_BR_LON = 'lon'
+CONF_BR_STATIONCODE = 'stationcode'
+CONF_BR_STATIONNAME = 'stationnaam'
+CONF_BR_TEXT = '#text'
+CONF_BR_ZIN = '@zin'
+CONF_BR_IMG = '_img'
+CONF_BR_FORECAST = 'verwachting_meerdaags'
+CONF_BR_DAYFC = "dag-plus%d"
+CONF_BR_MINTEMP = 'maxtemp'
+CONF_BR_MAXTEMP = 'maxtempmax'
+
+# Sensor types are defined like so:
+# SENSOR_TYPES = { 'key': ['Display name',
+#                          'unit of measurement',
+#                          'key in buienradar xml'],}
+SENSOR_TYPES = {
+    CONF_STATIONNAME: ['Stationname', None, 'stationnaam'],
+    CONF_SYMBOL: ['Symbol', None, 'icoonactueel'],
+    CONF_HUMIDITY: ['Humidity', '%', 'luchtvochtigheid'],
+    ATTR_TEMPERATURE: ['Temperature', '°C', 'temperatuurGC'],
+    CONF_GROUNDTEMP: ['Ground Temperature', '°C', 'temperatuur10cm'],
+    CONF_WINDSPEED: ['Wind speed', 'm/s', 'windsnelheidMS'],
+    CONF_WINDFORCE: ['Wind force', 'Bft', 'windsnelheidBF'],
+    CONF_WINDDIRECTION: ['Wind direction', '°', 'windrichtingGR'],
+    CONF_WINDAZIMUTH: ['Wind direction azimuth', None, 'windrichting'],
+    CONF_PRESSURE: ['Pressure', 'hPa', 'luchtdruk'],
+    CONF_VISIBILITY: ['Visibility', 'm', 'zichtmeters'],
+    CONF_WINDGUST: ['Wind gust', 'm/s', 'windstotenMS'],
+    CONF_PRECIPITATION: ['Precipitation', 'mm/h', 'regenMMPU'],
+    CONF_IRRADIANCE: ['Irradiance', 'W/m2', 'zonintensiteitWM2'],
+}
+
+SENSOR_ICONS = {
+    CONF_HUMIDITY: 'mdi:water-percent',
+    ATTR_TEMPERATURE: 'mdi:thermometer',
+    CONF_GROUNDTEMP: 'mdi:thermometer',
+    CONF_WINDSPEED: 'mdi:weather-windy',
+    CONF_WINDFORCE: 'mdi:weather-windy',
+    CONF_WINDDIRECTION: 'mdi:compass-outline',
+    CONF_WINDAZIMUTH: 'mdi:compass-outline',
+    CONF_PRESSURE: 'mdi:gauge',
+    CONF_WINDGUST: 'mdi:weather-windy',
+    CONF_IRRADIANCE: 'mdi:sunglasses',
+    CONF_PRECIPITATION: 'mdi:weather-pouring',
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_MONITORED_CONDITIONS,
+                 default=[CONF_SYMBOL, ATTR_TEMPERATURE]): vol.All(
+                     cv.ensure_list, vol.Length(min=1),
+                     [vol.In(SENSOR_TYPES.keys())]),
+    vol.Optional(CONF_LATITUDE): cv.latitude,
+    vol.Optional(CONF_LONGITUDE): cv.longitude,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Setup the buienradar_nl sensor."""
+    latitude = config.get(CONF_LATITUDE, hass.config.latitude)
+    longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
+
+    if None in (latitude, longitude):
+        _LOGGER.error("Latitude or longitude not set in HomeAssistant config")
+        return False
+
+    coordinates = {CONF_LATITUDE: float(latitude),
+                   CONF_LONGITUDE: float(longitude)}
+
+    dev = []
+    for sensor_type in config[CONF_MONITORED_CONDITIONS]:
+        dev.append(BrSensor(sensor_type))
+    async_add_devices(dev)
+
+    weather = BrData(hass, coordinates, dev)
+    # Update weather every 10 minutes, since
+    # the data gets updated every 10 minutes
+    async_track_time_interval(hass, weather.async_update,
+                              timedelta(minutes=10))
+    yield from weather.async_update()
+
+
+class BrSensor(Entity):
+    """Representation of an Buienradar sensor."""
+
+    def __init__(self, sensor_type):
+        """Initialize the sensor."""
+        self.client_name = 'br'
+        self._name = SENSOR_TYPES[sensor_type][0]
+        self.type = sensor_type
+        self._state = None
+        self._unit_of_measurement = SENSOR_TYPES[self.type][1]
+        self._entity_picture = None
+
+    def load_data(self, data):
+        """Load the sensor with relevant data."""
+        # Find sensor
+        if self.type == CONF_SYMBOL:
+            # update weather symbol & status text
+            new_state = data[self.type]
+            img = data[self.type + CONF_BR_IMG]
+
+            # pylint: disable=protected-access
+            if new_state != self._state or img != self._entity_picture:
+                self._state = new_state
+                self._entity_picture = img
+                return True
+        else:
+            # update all other sensors
+            new_state = data[self.type]
+            # pylint: disable=protected-access
+            if new_state != self._state:
+                self._state = new_state
+                return True
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} {}'.format(self.client_name, self._name)
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def should_poll(self):  # pylint: disable=no-self-use
+        """No polling needed."""
+        return False
+
+    @property
+    def entity_picture(self):
+        """Weather symbol if type is symbol."""
+        if self.type != 'symbol':
+            return None
+        else:
+            return self._entity_picture
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+        }
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit_of_measurement
+
+    @property
+    def icon(self):
+        """Return possible sensor specific icon."""
+        if self.type in SENSOR_ICONS:
+            return SENSOR_ICONS[self.type]
+
+
+class BrData(object):
+    """Get the latest data and updates the states."""
+
+    def __init__(self, hass, coordinates, devices):
+        """Initialize the data object."""
+        self._url = 'https://xml.buienradar.nl/'
+        self.devices = devices
+        self.data = {}
+        self.hass = hass
+        self.coordinates = coordinates
+        self.weatherstation = None
+
+    @asyncio.coroutine
+    def update_devices(self):
+        """Update all devices/sensors."""
+        if self.devices:
+            tasks = []
+            # Update all devices
+            for dev in self.devices:
+                if dev.load_data(self.data):
+                    tasks.append(dev.async_update_ha_state())
+
+            if tasks:
+                yield from asyncio.wait(tasks, loop=self.hass.loop)
+
+    @asyncio.coroutine
+    def async_update(self, *_):
+        """Update the data from buienradar."""
+        def get_temp(section):
+            """Get the forecasted temp from xml section."""
+            try:
+                return (float(section[CONF_BR_MINTEMP]) +
+                        float(section[CONF_BR_MAXTEMP])) / 2
+            except (ValueError, TypeError, KeyError):
+                return None
+
+        def select_nearest_ws(xmldata):
+            """Select the nearest weatherstation."""
+            dist = 0
+            loc_data = None
+
+            xmldata_tmp = xmldata
+            if CONF_BR_WEERGEGEVENS not in xmldata_tmp:
+                # no section with weatherdata
+                _LOGGER.warning("Missing section in Buienradar xmldata (%s)."
+                                "Can happen 00:00-01:00 CE(S)T",
+                                CONF_BR_WEERGEGEVENS)
+                return None
+
+            xmldata_tmp = xmldata_tmp[CONF_BR_WEERGEGEVENS]
+            if CONF_BR_ACTUEELWEER not in xmldata_tmp:
+                # no section current weather
+                _LOGGER.warning("Missing section in Buienradar xmldata (%s)."
+                                "Can happen 00:00-01:00 CE(S)T",
+                                CONF_BR_ACTUEELWEER)
+                return None
+
+            xmldata_tmp = xmldata_tmp[CONF_BR_ACTUEELWEER]
+            if CONF_BR_WEERSTATIONS not in xmldata_tmp:
+                # no section with weather stations
+                _LOGGER.warning("Missing section in Buienradar xmldata (%s)."
+                                "Can happen 00:00-01:00 CE(S)T",
+                                CONF_BR_WEERSTATIONS)
+                return None
+
+            xmldata_tmp = xmldata_tmp[CONF_BR_WEERSTATIONS]
+            if CONF_BR_WEERSTATION not in xmldata_tmp:
+                # no weatherstation section(s)
+                _LOGGER.warning("Missing section in Buienradar xmldata (%s)."
+                                "Can happen 00:00-01:00 CE(S)T",
+                                CONF_BR_WEERSTATION)
+                return None
+
+            xmldata_tmp = xmldata_tmp[CONF_BR_WEERSTATION]
+            for wstation in xmldata_tmp:
+                wslat = float(wstation[CONF_BR_LAT])
+                wslon = float(wstation[CONF_BR_LON])
+
+                if ((loc_data is None) or (
+                        distance(self.coordinates[CONF_LATITUDE],
+                                 self.coordinates[CONF_LONGITUDE],
+                                 wslat,
+                                 wslon) < dist)):
+                    dist = distance(self.coordinates[CONF_LATITUDE],
+                                    self.coordinates[CONF_LONGITUDE],
+                                    wslat, wslon)
+                    self.weatherstation = wstation[CONF_BR_STATIONCODE]
+                    loc_data = wstation
+
+            if loc_data is None:
+                _LOGGER.warning("No weatherstation selected; aborting update.")
+                return None
+            else:
+                _LOGGER.debug("Selected station: code='%s', "
+                              "name='%s', lat='%s', lon='%s'.",
+                              loc_data[CONF_BR_STATIONCODE],
+                              loc_data[CONF_BR_STATIONNAME][CONF_BR_TEXT],
+                              loc_data[CONF_BR_LAT],
+                              loc_data[CONF_BR_LON])
+                return loc_data
+
+        def try_again(err: str):
+            """Retry in 2 minutes."""
+            _LOGGER.warning('Retrying in 2 minutes: %s', err)
+            nxt = dt_util.utcnow() + timedelta(minutes=2)
+            async_track_point_in_utc_time(self.hass, self.async_update,
+                                          nxt)
+
+        def local_time_offset(convt=None):
+            """Return offset of local zone from UTC."""
+            # python2.3 localtime() can't take None
+            if convt is None:
+                convt = tm.time()
+
+            if tm.localtime(convt).tm_isdst and tm.daylight:
+                _LOGGER.debug('local_time_offset: %s', -tm.altzone)
+                return -tm.altzone
+            else:
+                _LOGGER.debug('local_time_offset: %s', -tm.timezone)
+                return -tm.timezone
+
+        # get weather data
+        resp = None
+        try:
+            websession = async_get_clientsession(self.hass)
+            with async_timeout.timeout(10, loop=self.hass.loop):
+                resp = yield from websession.get(self._url)
+            if resp.status != 200:
+                try_again('{} returned {}'.format(resp.url, resp.status))
+                return
+            text = yield from resp.text()
+        except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+            try_again(err)
+            return
+        finally:
+            if resp is not None:
+                yield from resp.release()
+
+        # convert to to dictionary
+        try:
+            import xmltodict
+            xmldata = xmltodict.parse(text)[CONF_BR_ROOT]
+        except (ExpatError, IndexError) as err:
+            try_again(err)
+            return
+
+        # select the nearest ws from the data
+        loc_data = select_nearest_ws(xmldata)
+        if loc_data:
+            # update the data
+            # pylint: disable=unused-variable
+            for key, value in SENSOR_TYPES.items():
+                self.data[key] = None
+                try:
+                    sens_data = loc_data[SENSOR_TYPES[key][2]]
+                    if key == CONF_SYMBOL:
+                        # update weather symbol & status text
+                        self.data[key] = sens_data[CONF_BR_ZIN]
+                        self.data[key + CONF_BR_IMG] = sens_data[CONF_BR_TEXT]
+                    else:
+                        # update all other data
+                        if key == CONF_STATIONNAME:
+                            self.data[key] = sens_data[CONF_BR_TEXT]
+                        else:
+                            self.data[key] = sens_data
+                except KeyError:
+                    _LOGGER.warning("Data element with key='%s' "
+                                    "not loaded from br data!", key)
+            _LOGGER.debug("BR cached data: %s", self.data)
+
+        # forecast data
+        self.data[CONF_FORECAST] = []
+
+        if CONF_BR_WEERGEGEVENS in xmldata:
+            section = xmldata[CONF_BR_WEERGEGEVENS]
+            if CONF_BR_FORECAST in section:
+                section = section[CONF_BR_FORECAST]
+                for daycnt in range(1, 6):
+                    daysection = CONF_BR_DAYFC % daycnt
+                    if daysection in section:
+                        tmpsect = section[daysection]
+                        # tomorrow, mid day:
+                        fcdatetime = datetime.combine(datetime.today(),
+                                                      time(12))
+                        # add daycnt days
+                        fcdatetime += timedelta(days=daycnt)
+                        # add timezoneoffset, to show OK in HA gui
+                        fcdatetime -= timedelta(seconds=local_time_offset())
+
+                        fcdata = {ATTR_TEMPERATURE: get_temp(tmpsect),
+                                  CONF_DATETIME: fcdatetime}
+                        self.data[CONF_FORECAST].append(fcdata)
+        _LOGGER.debug('BR Forecast data: %s', self.forecast)
+
+        yield from self.update_devices()
+
+    @property
+    def stationname(self):
+        """Return the name of the selected weatherstation."""
+        if CONF_STATIONNAME in self.data:
+            return self.data[CONF_STATIONNAME]
+
+    @property
+    def condition(self):
+        """Return the condition."""
+        if CONF_SYMBOL in self.data:
+            return self.data[CONF_SYMBOL]
+
+    @property
+    def temperature(self):
+        """Return the temperature, or None."""
+        if ATTR_TEMPERATURE in self.data:
+            try:
+                return float(self.data[ATTR_TEMPERATURE])
+            except (ValueError, TypeError):
+                return None
+
+    @property
+    def pressure(self):
+        """Return the pressure, or None."""
+        if CONF_PRESSURE in self.data:
+            try:
+                return float(self.data[CONF_PRESSURE])
+            except (ValueError, TypeError):
+                return None
+
+    @property
+    def humidity(self):
+        """Return the humidity, or None."""
+        if CONF_HUMIDITY in self.data:
+            try:
+                return int(self.data[CONF_HUMIDITY])
+            except (ValueError, TypeError):
+                return None
+
+    @property
+    def wind_speed(self):
+        """Return the windspeed, or None."""
+        if CONF_WINDSPEED in self.data:
+            try:
+                return float(self.data[CONF_WINDSPEED])
+            except (ValueError, TypeError):
+                return None
+
+    @property
+    def wind_bearing(self):
+        """Return the wind bearing, or None."""
+        if CONF_WINDDIRECTION in self.data:
+            try:
+                return int(self.data[CONF_WINDDIRECTION])
+            except (ValueError, TypeError):
+                return None
+
+    @property
+    def forecast(self):
+        """Return the forecast data."""
+        if CONF_FORECAST in self.data:
+            return self.data[CONF_FORECAST]

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -5,104 +5,67 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.buienradar/
 """
 import asyncio
+from datetime import timedelta
 import logging
-from datetime import datetime, time, timedelta
-import time as tm
-from xml.parsers.expat import ExpatError
 
-import async_timeout
-import aiohttp
+from buienradar import buienradar as br
+
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_MONITORED_CONDITIONS,
-    ATTR_ATTRIBUTION, ATTR_TEMPERATURE)
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+    ATTR_ATTRIBUTION)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
-    async_track_point_in_utc_time, async_track_time_interval)
+    async_track_point_in_utc_time)
 from homeassistant.util import dt as dt_util
-from homeassistant.util.location import distance
+# from homeassistant.util.location import distance
 
-REQUIREMENTS = ['xmltodict==0.11.0']
+REQUIREMENTS = ['buienradar==0.3', 'xmltodict==0.11.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ATTRIBUTION = "Data provided by buienradar.nl"
-CONF_DATETIME = 'datetime'
-CONF_STATIONNAME = 'stationname'
-CONF_SYMBOL = 'symbol'
-CONF_HUMIDITY = 'humidity'
-CONF_GROUNDTEMP = 'groundtemperature'
-CONF_WINDSPEED = 'windspeed'
-CONF_WINDFORCE = 'windforce'
-CONF_WINDDIRECTION = 'winddirection'
-CONF_WINDAZIMUTH = 'windazimuth'
-CONF_PRESSURE = 'pressure'
-CONF_VISIBILITY = 'visibility'
-CONF_WINDGUST = 'windgust'
-CONF_PRECIPITATION = 'precipitation'
-CONF_IRRADIANCE = 'irradiance'
-CONF_FORECAST = 'forecast'
-
-# key names in buienradar xml:
-CONF_BR_ROOT = 'buienradarnl'
-CONF_BR_WEERGEGEVENS = 'weergegevens'
-CONF_BR_ACTUEELWEER = 'actueel_weer'
-CONF_BR_WEERSTATIONS = 'weerstations'
-CONF_BR_WEERSTATION = 'weerstation'
-CONF_BR_LAT = 'lat'
-CONF_BR_LON = 'lon'
-CONF_BR_STATIONCODE = 'stationcode'
-CONF_BR_STATIONNAME = 'stationnaam'
-CONF_BR_TEXT = '#text'
-CONF_BR_ZIN = '@zin'
-CONF_BR_IMG = '_img'
-CONF_BR_FORECAST = 'verwachting_meerdaags'
-CONF_BR_DAYFC = "dag-plus%d"
-CONF_BR_MINTEMP = 'maxtemp'
-CONF_BR_MAXTEMP = 'maxtempmax'
 
 # Sensor types are defined like so:
 # SENSOR_TYPES = { 'key': ['Display name',
 #                          'unit of measurement',
-#                          'key in buienradar xml'],}
+#                }
 SENSOR_TYPES = {
-    CONF_STATIONNAME: ['Stationname', None, 'stationnaam'],
-    CONF_SYMBOL: ['Symbol', None, 'icoonactueel'],
-    CONF_HUMIDITY: ['Humidity', '%', 'luchtvochtigheid'],
-    ATTR_TEMPERATURE: ['Temperature', '°C', 'temperatuurGC'],
-    CONF_GROUNDTEMP: ['Ground Temperature', '°C', 'temperatuur10cm'],
-    CONF_WINDSPEED: ['Wind speed', 'm/s', 'windsnelheidMS'],
-    CONF_WINDFORCE: ['Wind force', 'Bft', 'windsnelheidBF'],
-    CONF_WINDDIRECTION: ['Wind direction', '°', 'windrichtingGR'],
-    CONF_WINDAZIMUTH: ['Wind direction azimuth', None, 'windrichting'],
-    CONF_PRESSURE: ['Pressure', 'hPa', 'luchtdruk'],
-    CONF_VISIBILITY: ['Visibility', 'm', 'zichtmeters'],
-    CONF_WINDGUST: ['Wind gust', 'm/s', 'windstotenMS'],
-    CONF_PRECIPITATION: ['Precipitation', 'mm/h', 'regenMMPU'],
-    CONF_IRRADIANCE: ['Irradiance', 'W/m2', 'zonintensiteitWM2'],
+    br.STATIONNAME: ['Stationname', None],
+    br.SYMBOL: ['Symbol', None],
+    br.HUMIDITY: ['Humidity', '%'],
+    br.TEMPERATURE: ['Temperature', '°C'],
+    br.GROUNDTEMP: ['Ground Temperature', '°C'],
+    br.WINDSPEED: ['Wind speed', 'm/s'],
+    br.WINDFORCE: ['Wind force', 'Bft'],
+    br.WINDDIRECTION: ['Wind direction', '°'],
+    br.WINDAZIMUTH: ['Wind direction azimuth', None],
+    br.PRESSURE: ['Pressure', 'hPa'],
+    br.VISIBILITY: ['Visibility', 'm'],
+    br.WINDGUST: ['Wind gust', 'm/s'],
+    br.PRECIPITATION: ['Precipitation', 'mm/h'],
+    br.IRRADIANCE: ['Irradiance', 'W/m2'],
 }
 
 SENSOR_ICONS = {
-    CONF_HUMIDITY: 'mdi:water-percent',
-    ATTR_TEMPERATURE: 'mdi:thermometer',
-    CONF_GROUNDTEMP: 'mdi:thermometer',
-    CONF_WINDSPEED: 'mdi:weather-windy',
-    CONF_WINDFORCE: 'mdi:weather-windy',
-    CONF_WINDDIRECTION: 'mdi:compass-outline',
-    CONF_WINDAZIMUTH: 'mdi:compass-outline',
-    CONF_PRESSURE: 'mdi:gauge',
-    CONF_WINDGUST: 'mdi:weather-windy',
-    CONF_IRRADIANCE: 'mdi:sunglasses',
-    CONF_PRECIPITATION: 'mdi:weather-pouring',
+    br.HUMIDITY: 'mdi:water-percent',
+    br.TEMPERATURE: 'mdi:thermometer',
+    br.GROUNDTEMP: 'mdi:thermometer',
+    br.WINDSPEED: 'mdi:weather-windy',
+    br.WINDFORCE: 'mdi:weather-windy',
+    br.WINDDIRECTION: 'mdi:compass-outline',
+    br.WINDAZIMUTH: 'mdi:compass-outline',
+    br.PRESSURE: 'mdi:gauge',
+    br.WINDGUST: 'mdi:weather-windy',
+    br.IRRADIANCE: 'mdi:sunglasses',
+    br.PRECIPITATION: 'mdi:weather-pouring',
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MONITORED_CONDITIONS,
-                 default=[CONF_SYMBOL, ATTR_TEMPERATURE]): vol.All(
+                 default=[br.SYMBOL, br.TEMPERATURE]): vol.All(
                      cv.ensure_list, vol.Length(min=1),
                      [vol.In(SENSOR_TYPES.keys())]),
     vol.Optional(CONF_LATITUDE): cv.latitude,
@@ -129,10 +92,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     async_add_devices(dev)
 
     weather = BrData(hass, coordinates, dev)
-    # Update weather every 10 minutes, since
-    # the data gets updated every 10 minutes
-    async_track_time_interval(hass, weather.async_update,
-                              timedelta(minutes=10))
     yield from weather.async_update()
 
 
@@ -147,14 +106,16 @@ class BrSensor(Entity):
         self._state = None
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
         self._entity_picture = None
+        self._attribution = None
 
     def load_data(self, data):
         """Load the sensor with relevant data."""
         # Find sensor
-        if self.type == CONF_SYMBOL:
+        self._attribution = data.get(br.ATTRIBUTION)
+        if self.type == br.SYMBOL:
             # update weather symbol & status text
-            new_state = data[self.type]
-            img = data[self.type + CONF_BR_IMG]
+            new_state = data.get(self.type)
+            img = data.get(br.IMAGE)
 
             # pylint: disable=protected-access
             if new_state != self._state or img != self._entity_picture:
@@ -163,11 +124,16 @@ class BrSensor(Entity):
                 return True
         else:
             # update all other sensors
-            new_state = data[self.type]
+            new_state = data.get(self.type)
             # pylint: disable=protected-access
             if new_state != self._state:
                 self._state = new_state
                 return True
+
+    @property
+    def attribution(self):
+        """Return the attribution."""
+        return self._attribution
 
     @property
     def name(self):
@@ -196,7 +162,7 @@ class BrSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return {
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+            ATTR_ATTRIBUTION: self._attribution,
         }
 
     @property
@@ -216,12 +182,10 @@ class BrData(object):
 
     def __init__(self, hass, coordinates, devices):
         """Initialize the data object."""
-        self._url = 'https://xml.buienradar.nl/'
         self.devices = devices
         self.data = {}
         self.hass = hass
         self.coordinates = coordinates
-        self.weatherstation = None
 
     @asyncio.coroutine
     def update_devices(self):
@@ -236,236 +200,95 @@ class BrData(object):
             if tasks:
                 yield from asyncio.wait(tasks, loop=self.hass.loop)
 
+    def schedule_update(self, minute=1):
+        """Schedule an update after minutes minutes."""
+        # schedule new call
+        _LOGGER.debug("Scheduling next update in %s minutes.", minute)
+        nxt = dt_util.utcnow() + timedelta(minutes=minute)
+        async_track_point_in_utc_time(self.hass, self.async_update,
+                                      nxt)
+
     @asyncio.coroutine
     def async_update(self, *_):
         """Update the data from buienradar."""
-        def get_temp(section):
-            """Get the forecasted temp from xml section."""
-            try:
-                return (float(section[CONF_BR_MINTEMP]) +
-                        float(section[CONF_BR_MAXTEMP])) / 2
-            except (ValueError, TypeError, KeyError):
-                return None
+        result = br.get_data()
+        if result[br.SUCCESS]:
+            result = br.parse_data(result[br.CONTENT],
+                                   latitude=self.coordinates[CONF_LATITUDE],
+                                   longitude=self.coordinates[CONF_LONGITUDE])
+            if result[br.SUCCESS]:
+                self.data = result[br.DATA]
 
-        def select_nearest_ws(xmldata):
-            """Select the nearest weatherstation."""
-            dist = 0
-            loc_data = None
+                yield from self.update_devices()
 
-            xmldata_tmp = xmldata
-            if CONF_BR_WEERGEGEVENS not in xmldata_tmp:
-                # no section with weatherdata
-                _LOGGER.warning("Missing section in Buienradar xmldata (%s)."
-                                "Can happen 00:00-01:00 CE(S)T",
-                                CONF_BR_WEERGEGEVENS)
-                return None
-
-            xmldata_tmp = xmldata_tmp[CONF_BR_WEERGEGEVENS]
-            if CONF_BR_ACTUEELWEER not in xmldata_tmp:
-                # no section current weather
-                _LOGGER.warning("Missing section in Buienradar xmldata (%s)."
-                                "Can happen 00:00-01:00 CE(S)T",
-                                CONF_BR_ACTUEELWEER)
-                return None
-
-            xmldata_tmp = xmldata_tmp[CONF_BR_ACTUEELWEER]
-            if CONF_BR_WEERSTATIONS not in xmldata_tmp:
-                # no section with weather stations
-                _LOGGER.warning("Missing section in Buienradar xmldata (%s)."
-                                "Can happen 00:00-01:00 CE(S)T",
-                                CONF_BR_WEERSTATIONS)
-                return None
-
-            xmldata_tmp = xmldata_tmp[CONF_BR_WEERSTATIONS]
-            if CONF_BR_WEERSTATION not in xmldata_tmp:
-                # no weatherstation section(s)
-                _LOGGER.warning("Missing section in Buienradar xmldata (%s)."
-                                "Can happen 00:00-01:00 CE(S)T",
-                                CONF_BR_WEERSTATION)
-                return None
-
-            xmldata_tmp = xmldata_tmp[CONF_BR_WEERSTATION]
-            for wstation in xmldata_tmp:
-                wslat = float(wstation[CONF_BR_LAT])
-                wslon = float(wstation[CONF_BR_LON])
-
-                if ((loc_data is None) or (
-                        distance(self.coordinates[CONF_LATITUDE],
-                                 self.coordinates[CONF_LONGITUDE],
-                                 wslat,
-                                 wslon) < dist)):
-                    dist = distance(self.coordinates[CONF_LATITUDE],
-                                    self.coordinates[CONF_LONGITUDE],
-                                    wslat, wslon)
-                    self.weatherstation = wstation[CONF_BR_STATIONCODE]
-                    loc_data = wstation
-
-            if loc_data is None:
-                _LOGGER.warning("No weatherstation selected; aborting update.")
-                return None
+                self.schedule_update(10)
             else:
-                _LOGGER.debug("Selected station: code='%s', "
-                              "name='%s', lat='%s', lon='%s'.",
-                              loc_data[CONF_BR_STATIONCODE],
-                              loc_data[CONF_BR_STATIONNAME][CONF_BR_TEXT],
-                              loc_data[CONF_BR_LAT],
-                              loc_data[CONF_BR_LON])
-                return loc_data
+                self.schedule_update(2)
+        else:
+            # unable to get the data
+            _LOGGER.warning("Unable to retrieve data from Buienradar."
+                            "(Msg: %s, status: %s,)",
+                            result.get(br.MESSAGE),
+                            result.get(br.STATUS_CODE),)
+            # schedule new call
+            self.schedule_update(2)
 
-        def try_again(err: str):
-            """Retry in 2 minutes."""
-            _LOGGER.warning('Retrying in 2 minutes: %s', err)
-            nxt = dt_util.utcnow() + timedelta(minutes=2)
-            async_track_point_in_utc_time(self.hass, self.async_update,
-                                          nxt)
-
-        def local_time_offset(convt=None):
-            """Return offset of local zone from UTC."""
-            # python2.3 localtime() can't take None
-            if convt is None:
-                convt = tm.time()
-
-            if tm.localtime(convt).tm_isdst and tm.daylight:
-                _LOGGER.debug('local_time_offset: %s', -tm.altzone)
-                return -tm.altzone
-            else:
-                _LOGGER.debug('local_time_offset: %s', -tm.timezone)
-                return -tm.timezone
-
-        # get weather data
-        resp = None
-        try:
-            websession = async_get_clientsession(self.hass)
-            with async_timeout.timeout(10, loop=self.hass.loop):
-                resp = yield from websession.get(self._url)
-            if resp.status != 200:
-                try_again('{} returned {}'.format(resp.url, resp.status))
-                return
-            text = yield from resp.text()
-        except (asyncio.TimeoutError, aiohttp.ClientError) as err:
-            try_again(err)
-            return
-        finally:
-            if resp is not None:
-                yield from resp.release()
-
-        # convert to to dictionary
-        try:
-            import xmltodict
-            xmldata = xmltodict.parse(text)[CONF_BR_ROOT]
-        except (ExpatError, IndexError) as err:
-            try_again(err)
-            return
-
-        # select the nearest ws from the data
-        loc_data = select_nearest_ws(xmldata)
-        if loc_data:
-            # update the data
-            # pylint: disable=unused-variable
-            for key, value in SENSOR_TYPES.items():
-                self.data[key] = None
-                try:
-                    sens_data = loc_data[SENSOR_TYPES[key][2]]
-                    if key == CONF_SYMBOL:
-                        # update weather symbol & status text
-                        self.data[key] = sens_data[CONF_BR_ZIN]
-                        self.data[key + CONF_BR_IMG] = sens_data[CONF_BR_TEXT]
-                    else:
-                        # update all other data
-                        if key == CONF_STATIONNAME:
-                            self.data[key] = sens_data[CONF_BR_TEXT]
-                        else:
-                            self.data[key] = sens_data
-                except KeyError:
-                    _LOGGER.warning("Data element with key='%s' "
-                                    "not loaded from br data!", key)
-            _LOGGER.debug("BR cached data: %s", self.data)
-
-        # forecast data
-        self.data[CONF_FORECAST] = []
-
-        if CONF_BR_WEERGEGEVENS in xmldata:
-            section = xmldata[CONF_BR_WEERGEGEVENS]
-            if CONF_BR_FORECAST in section:
-                section = section[CONF_BR_FORECAST]
-                for daycnt in range(1, 6):
-                    daysection = CONF_BR_DAYFC % daycnt
-                    if daysection in section:
-                        tmpsect = section[daysection]
-                        # tomorrow, mid day:
-                        fcdatetime = datetime.combine(datetime.today(),
-                                                      time(12))
-                        # add daycnt days
-                        fcdatetime += timedelta(days=daycnt)
-                        # add timezoneoffset, to show OK in HA gui
-                        fcdatetime -= timedelta(seconds=local_time_offset())
-
-                        fcdata = {ATTR_TEMPERATURE: get_temp(tmpsect),
-                                  CONF_DATETIME: fcdatetime}
-                        self.data[CONF_FORECAST].append(fcdata)
-        _LOGGER.debug('BR Forecast data: %s', self.forecast)
-
-        yield from self.update_devices()
+    @property
+    def attribution(self):
+        """Return the attribution."""
+        return self.data.get(br.ATTRIBUTION)
 
     @property
     def stationname(self):
         """Return the name of the selected weatherstation."""
-        if CONF_STATIONNAME in self.data:
-            return self.data[CONF_STATIONNAME]
+        return self.data.get(br.STATIONNAME)
 
     @property
     def condition(self):
         """Return the condition."""
-        if CONF_SYMBOL in self.data:
-            return self.data[CONF_SYMBOL]
+        return self.data.get(br.SYMBOL)
 
     @property
     def temperature(self):
         """Return the temperature, or None."""
-        if ATTR_TEMPERATURE in self.data:
-            try:
-                return float(self.data[ATTR_TEMPERATURE])
-            except (ValueError, TypeError):
-                return None
+        try:
+            return float(self.data.get(br.TEMPERATURE))
+        except (ValueError, TypeError):
+            return None
 
     @property
     def pressure(self):
         """Return the pressure, or None."""
-        if CONF_PRESSURE in self.data:
-            try:
-                return float(self.data[CONF_PRESSURE])
-            except (ValueError, TypeError):
-                return None
+        try:
+            return float(self.data.get(br.PRESSURE))
+        except (ValueError, TypeError):
+            return None
 
     @property
     def humidity(self):
         """Return the humidity, or None."""
-        if CONF_HUMIDITY in self.data:
-            try:
-                return int(self.data[CONF_HUMIDITY])
-            except (ValueError, TypeError):
-                return None
+        try:
+            return int(self.data.get(br.HUMIDITY))
+        except (ValueError, TypeError):
+            return None
 
     @property
     def wind_speed(self):
         """Return the windspeed, or None."""
-        if CONF_WINDSPEED in self.data:
-            try:
-                return float(self.data[CONF_WINDSPEED])
-            except (ValueError, TypeError):
-                return None
+        try:
+            return float(self.data.get(br.WINDSPEED))
+        except (ValueError, TypeError):
+            return None
 
     @property
     def wind_bearing(self):
         """Return the wind bearing, or None."""
-        if CONF_WINDDIRECTION in self.data:
-            try:
-                return int(self.data[CONF_WINDDIRECTION])
-            except (ValueError, TypeError):
-                return None
+        try:
+            return int(self.data.get(br.WINDDIRECTION))
+        except (ValueError, TypeError):
+            return None
 
     @property
     def forecast(self):
         """Return the forecast data."""
-        if CONF_FORECAST in self.data:
-            return self.data[CONF_FORECAST]
+        return self.data.get(br.FORECAST)

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -21,7 +21,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time)
 from homeassistant.util import dt as dt_util
-# from homeassistant.util.location import distance
 
 REQUIREMENTS = ['buienradar==0.3', 'xmltodict==0.11.0']
 

--- a/homeassistant/components/weather/buienradar.py
+++ b/homeassistant/components/weather/buienradar.py
@@ -56,6 +56,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     # schedule the first update in 1 minute from now:
     data.schedule_update(1)
 
+
 class BrWeather(WeatherEntity):
     """Representation of a weather condition."""
 

--- a/homeassistant/components/weather/buienradar.py
+++ b/homeassistant/components/weather/buienradar.py
@@ -1,0 +1,116 @@
+"""
+Support for Buienradar.nl weather service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/weather.buienradar/
+"""
+import logging
+import asyncio
+from datetime import timedelta
+from homeassistant.components.weather import (
+    WeatherEntity, PLATFORM_SCHEMA)
+from homeassistant.const import \
+    CONF_NAME, TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.helpers import config_validation as cv
+# Reuse data and API logic from the sensor implementation
+from homeassistant.components.sensor.buienradar import (
+    BrData, CONF_ATTRIBUTION, CONF_FORECAST)
+from homeassistant.helpers.event import (
+    async_track_time_interval)
+import voluptuous as vol
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_LATITUDE): cv.latitude,
+    vol.Optional(CONF_LONGITUDE): cv.longitude,
+    vol.Optional(CONF_FORECAST, default=True): cv.boolean,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the buienradar platform."""
+    latitude = config.get(CONF_LATITUDE, hass.config.latitude)
+    longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
+
+    if None in (latitude, longitude):
+        _LOGGER.error("Latitude or longitude not set in Home Assistant config")
+        return False
+
+    coordinates = {CONF_LATITUDE:  float(latitude),
+                   CONF_LONGITUDE: float(longitude)}
+
+    # create weather data:
+    data = BrData(hass, coordinates, None)
+    # create weather device:
+    async_add_devices([BrWeather(data, config.get(CONF_FORECAST, True),
+                                 config.get(CONF_NAME, None))])
+
+    # Update weather every 10 minutes, since
+    # the data gets updated every 10 minutes
+    async_track_time_interval(hass, data.async_update, timedelta(minutes=10))
+    yield from data.async_update()
+
+
+class BrWeather(WeatherEntity):
+    """Representation of a weather condition."""
+
+    def __init__(self, data, forecast, stationname=None):
+        """Initialise the platform with a data instance and station name."""
+        self._stationname = stationname
+        self._forecast = forecast
+        self._data = data
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._stationname or 'BR {}'.format(self._data.stationname
+                                                   or '(unknown station)')
+
+    @property
+    def condition(self):
+        """Return the name of the sensor."""
+        return self._data.condition
+
+    @property
+    def temperature(self):
+        """Return the name of the sensor."""
+        return self._data.temperature
+
+    @property
+    def pressure(self):
+        """Return the name of the sensor."""
+        return self._data.pressure
+
+    @property
+    def humidity(self):
+        """Return the name of the sensor."""
+        return self._data.humidity
+
+    @property
+    def wind_speed(self):
+        """Return the name of the sensor."""
+        return self._data.wind_speed
+
+    @property
+    def wind_bearing(self):
+        """Return the name of the sensor."""
+        return self._data.wind_bearing
+
+    @property
+    def attribution(self):
+        """Return the attribution."""
+        return CONF_ATTRIBUTION
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
+
+    @property
+    def forecast(self):
+        """Return the forecast."""
+        if self._forecast:
+            return self._data.forecast

--- a/homeassistant/components/weather/buienradar.py
+++ b/homeassistant/components/weather/buienradar.py
@@ -14,12 +14,14 @@ from homeassistant.const import \
 from homeassistant.helpers import config_validation as cv
 # Reuse data and API logic from the sensor implementation
 from homeassistant.components.sensor.buienradar import (
-    BrData, CONF_ATTRIBUTION, CONF_FORECAST)
+    BrData)
 from homeassistant.helpers.event import (
     async_track_time_interval)
 import voluptuous as vol
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_FORECAST = 'forecast'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
@@ -64,6 +66,11 @@ class BrWeather(WeatherEntity):
         self._data = data
 
     @property
+    def attribution(self):
+        """Return the attribution."""
+        return self._data.attribution
+
+    @property
     def name(self):
         """Return the name of the sensor."""
         return self._stationname or 'BR {}'.format(self._data.stationname
@@ -98,11 +105,6 @@ class BrWeather(WeatherEntity):
     def wind_bearing(self):
         """Return the name of the sensor."""
         return self._data.wind_bearing
-
-    @property
-    def attribution(self):
-        """Return the attribution."""
-        return CONF_ATTRIBUTION
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/weather/buienradar.py
+++ b/homeassistant/components/weather/buienradar.py
@@ -53,8 +53,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     # Update weather every 10 minutes, since
     # the data gets updated every 10 minutes
     async_track_time_interval(hass, data.async_update, timedelta(minutes=10))
-    yield from data.async_update()
-
+    # schedule the first update in 1 minute from now:
+    data.schedule_update(1)
 
 class BrWeather(WeatherEntity):
     """Representation of a weather condition."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -861,7 +861,6 @@ xbee-helper==0.0.7
 # homeassistant.components.sensor.xbox_live
 xboxapi==0.1.1
 
-# homeassistant.components.sensor.buienradar
 # homeassistant.components.sensor.swiss_hydrological_data
 # homeassistant.components.sensor.ted5000
 # homeassistant.components.sensor.yr

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -109,7 +109,7 @@ boto3==1.4.3
 broadlink==0.3
 
 # homeassistant.components.sensor.buienradar
-buienradar==0.3
+buienradar==0.4
 
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -108,6 +108,9 @@ boto3==1.4.3
 # homeassistant.components.switch.broadlink
 broadlink==0.3
 
+# homeassistant.components.sensor.buienradar
+buienradar==0.3
+
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -858,6 +858,7 @@ xbee-helper==0.0.7
 # homeassistant.components.sensor.xbox_live
 xboxapi==0.1.1
 
+# homeassistant.components.sensor.buienradar
 # homeassistant.components.sensor.swiss_hydrological_data
 # homeassistant.components.sensor.ted5000
 # homeassistant.components.sensor.yr


### PR DESCRIPTION
## Description:
These components add weather information from [buienradar.nl](url); a webservice that provides detailed weather information for HA users in The Netherlands. The relevant weather station used will be automatically be selected based on the location specified in the HA config (or in the buienradar weather/sensor component).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2638

## Example entry for `configuration.yaml`:
**To add the buienradar weather component:**
```yaml
weather:
  - platform: buienradar
    name: buienradar
    latitude: 51.65
    longitude: 5.70
    forecast: True
```
- platform: buienradar (required)
- name: a logical name (required)
- latitude: latitude to use for selection of data source location (optional). Longitude & latitude will be taken from HA configuration, but can be overridden/changed in this component to select a different location for buienradar.
- longitude: latitude to use for selection of data source location (optional).Longitude & latitude will be taken from HA configuration, but can be overridden/changed in this component to select a different location for buienradar.
- forecast: True/False (enable or disable the output of the temperature forecast

**To add the buienradar sensor component:**
```yaml
 - platform: buienradar
    latitude: 51.65
    longitude: 5.70
    monitored_conditions:
      - stationname
      - symbol
      - humidity
      - temperature
      - groundtemperature
      - windspeed
      - windforce
      - winddirection
      - windazimuth
      - pressure
      - visibility
      - windgust
      - precipitation
      - irradiance
```
- platform: buienradar (required)
- latitude: latitude to use for selection of data source location (optional). Longitude & latitude will be taken from HA configuration, but can be overridden/changed in this component to select a different location for buienradar.
- longitude: latitude to use for selection of data source location (optional).Longitude & latitude will be taken from HA configuration, but can be overridden/changed in this component to select a different location for buienradar.
- monitored_conditions: sensor types that can be selected:
      - stationname: name of the selected weatherstation (for example: 'Meetstation Volkel')
      - symbol: icon of current weather condition
      - humidity: humidity in %
      - temperature: current temperature in °C
      - groundtemperature: temp on ground level (°C)
      - windspeed: windspeed in m/s
      - windforce: windspeed in Bft
      - winddirection: in °
      - windazimuth: direction if wind using compass direction (N, NE, etc.)
      - pressure: in hPa
      - visibility: in meters (m)
      - windgust: in m/s
      - precipitation: in milimeters per hour (mm/h)
      - irradiance: sun radiation


## Checklist:
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/pull/2638)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
