### PR TITLE
Add support for disabling tradfri groups

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -11,7 +11,7 @@ from homeassistant.components.light import (
     SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR, Light)
 from homeassistant.components.light import \
     PLATFORM_SCHEMA as LIGHT_PLATFORM_SCHEMA
-from homeassistant.components.tradfri import KEY_GATEWAY
+from homeassistant.components.tradfri import KEY_GATEWAY, KEY_TRADFRI_GROUPS
 from homeassistant.util import color as color_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,6 @@ IKEA = 'IKEA of Sweden'
 ALLOWED_TEMPERATURES = {
     IKEA: {2200: 'efd275', 2700: 'f1e0b5', 4000: 'f5faf6'}
 }
-
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the IKEA Tradfri Light platform."""
@@ -35,8 +34,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     lights = [dev for dev in devices if dev.has_light_control]
     add_devices(Tradfri(light) for light in lights)
 
-    groups = gateway.get_groups()
-    add_devices(TradfriGroup(group) for group in groups)
+    allow_tradfri_groups = hass.data[KEY_TRADFRI_GROUPS][gateway_id]
+    if allow_tradfri_groups:
+        groups = gateway.get_groups()
+        add_devices(TradfriGroup(group) for group in groups)
 
 
 class TradfriGroup(Light):

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -23,6 +23,7 @@ ALLOWED_TEMPERATURES = {
     IKEA: {2200: 'efd275', 2700: 'f1e0b5', 4000: 'f5faf6'}
 }
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the IKEA Tradfri Light platform."""
     if discovery_info is None:

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -17,16 +17,22 @@ from homeassistant.const import CONF_HOST, CONF_API_KEY
 from homeassistant.loader import get_component
 from homeassistant.components.discovery import SERVICE_IKEA_TRADFRI
 
+REQUIREMENTS = ['pytradfri==1.1']
+
 DOMAIN = 'tradfri'
 CONFIG_FILE = 'tradfri.conf'
 KEY_CONFIG = 'tradfri_configuring'
 KEY_GATEWAY = 'tradfri_gateway'
-REQUIREMENTS = ['pytradfri==1.1']
+KEY_TRADFRI_GROUPS = 'tradfri_allow_tradfri_groups'
+CONF_ALLOW_TRADFRI_GROUPS = 'allow_tradfri_groups'
+DEFAULT_ALLOW_TRADFRI_GROUPS = True
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Inclusive(CONF_HOST, 'gateway'): cv.string,
         vol.Inclusive(CONF_API_KEY, 'gateway'): cv.string,
+        vol.Optional(CONF_ALLOW_TRADFRI_GROUPS,
+                 default=DEFAULT_ALLOW_TRADFRI_GROUPS): cv.boolean,
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -77,6 +83,7 @@ def async_setup(hass, config):
     conf = config.get(DOMAIN, {})
     host = conf.get(CONF_HOST)
     key = conf.get(CONF_API_KEY)
+    allow_tradfri_groups = conf.get(CONF_ALLOW_TRADFRI_GROUPS)
 
     @asyncio.coroutine
     def gateway_discovered(service, info):
@@ -85,7 +92,7 @@ def async_setup(hass, config):
         host = info['host']
 
         if host in keys:
-            yield from _setup_gateway(hass, config, host, keys[host]['key'])
+            yield from _setup_gateway(hass, config, host, keys[host]['key'], allow_tradfri_groups)
         else:
             hass.async_add_job(request_configuration, hass, config, host)
 
@@ -94,11 +101,11 @@ def async_setup(hass, config):
     if host is None:
         return True
 
-    return (yield from _setup_gateway(hass, config, host, key))
+    return (yield from _setup_gateway(hass, config, host, key, allow_tradfri_groups))
 
 
 @asyncio.coroutine
-def _setup_gateway(hass, hass_config, host, key):
+def _setup_gateway(hass, hass_config, host, key, allow_tradfri_groups):
     """Create a gateway."""
     from pytradfri import cli_api_factory, Gateway, RequestError, retry_timeout
 
@@ -111,6 +118,10 @@ def _setup_gateway(hass, hass_config, host, key):
     gateway_id = gateway.get_gateway_info().id
     hass.data.setdefault(KEY_GATEWAY, {})
     gateways = hass.data[KEY_GATEWAY]
+
+    hass.data.setdefault(KEY_TRADFRI_GROUPS, {})
+    tradfri_groups = hass.data[KEY_TRADFRI_GROUPS]
+    tradfri_groups[gateway_id] = allow_tradfri_groups
 
     # Check if already set up
     if gateway_id in gateways:

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Inclusive(CONF_HOST, 'gateway'): cv.string,
         vol.Inclusive(CONF_API_KEY, 'gateway'): cv.string,
         vol.Optional(CONF_ALLOW_TRADFRI_GROUPS,
-                 default=DEFAULT_ALLOW_TRADFRI_GROUPS): cv.boolean,
+                     default=DEFAULT_ALLOW_TRADFRI_GROUPS): cv.boolean,
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -92,7 +92,8 @@ def async_setup(hass, config):
         host = info['host']
 
         if host in keys:
-            yield from _setup_gateway(hass, config, host, keys[host]['key'], allow_tradfri_groups)
+            yield from _setup_gateway(hass, config, host, keys[host]['key'],
+                                      allow_tradfri_groups)
         else:
             hass.async_add_job(request_configuration, hass, config, host)
 
@@ -101,7 +102,8 @@ def async_setup(hass, config):
     if host is None:
         return True
 
-    return (yield from _setup_gateway(hass, config, host, key, allow_tradfri_groups))
+    return (yield from _setup_gateway(hass, config, host, key,
+                                      allow_tradfri_groups))
 
 
 @asyncio.coroutine

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -53,7 +53,8 @@ def request_configuration(hass, config, host):
     def configuration_callback(callback_data):
         """Handle the submitted configuration."""
         res = yield from _setup_gateway(hass, config, host,
-                                        callback_data.get('key'))
+                                        callback_data.get('key'),
+                                        DEFAULT_ALLOW_TRADFRI_GROUPS)
         if not res:
             hass.async_add_job(configurator.notify_errors, instance,
                                "Unable to connect.")


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2632

## Example entry for `configuration.yaml` (if applicable):
```yaml
tradfri:
  allow_tradfri_groups: False
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
