### PR TITLE
Add kelvin/brightness_pct alternatives to light.turn_on

### DIFF
--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -18,10 +18,11 @@ import voluptuous as vol
 
 from homeassistant.components.light import (
     Light, DOMAIN, PLATFORM_SCHEMA, LIGHT_TURN_ON_SCHEMA,
-    ATTR_BRIGHTNESS, ATTR_COLOR_NAME, ATTR_RGB_COLOR,
+    ATTR_BRIGHTNESS, ATTR_RGB_COLOR,
     ATTR_XY_COLOR, ATTR_COLOR_TEMP, ATTR_TRANSITION, ATTR_EFFECT,
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR,
-    SUPPORT_XY_COLOR, SUPPORT_TRANSITION, SUPPORT_EFFECT)
+    SUPPORT_XY_COLOR, SUPPORT_TRANSITION, SUPPORT_EFFECT,
+    preprocess_turn_on_alternatives)
 from homeassistant.config import load_yaml_config_file
 from homeassistant.util.color import (
     color_temperature_mired_to_kelvin, color_temperature_kelvin_to_mired)
@@ -434,9 +435,7 @@ class LIFXLight(Light):
         if hsbk is not None:
             return [hsbk, True]
 
-        color_name = kwargs.pop(ATTR_COLOR_NAME, None)
-        if color_name is not None:
-            kwargs[ATTR_RGB_COLOR] = color_util.color_name_to_rgb(color_name)
+        preprocess_turn_on_alternatives(kwargs)
 
         if ATTR_RGB_COLOR in kwargs:
             hue, saturation, brightness = \

--- a/homeassistant/components/light/lifx/effects.py
+++ b/homeassistant/components/light/lifx/effects.py
@@ -6,8 +6,9 @@ import random
 import voluptuous as vol
 
 from homeassistant.components.light import (
-    DOMAIN, ATTR_BRIGHTNESS, ATTR_COLOR_NAME, ATTR_RGB_COLOR, ATTR_EFFECT,
-    ATTR_TRANSITION)
+    DOMAIN, ATTR_BRIGHTNESS, ATTR_BRIGHTNESS_PCT, ATTR_COLOR_NAME,
+    ATTR_RGB_COLOR, ATTR_EFFECT, ATTR_TRANSITION,
+    VALID_BRIGHTNESS, VALID_BRIGHTNESS_PCT)
 from homeassistant.const import (ATTR_ENTITY_ID)
 import homeassistant.helpers.config_validation as cv
 
@@ -36,7 +37,8 @@ LIFX_EFFECT_SCHEMA = vol.Schema({
 })
 
 LIFX_EFFECT_BREATHE_SCHEMA = LIFX_EFFECT_SCHEMA.extend({
-    ATTR_BRIGHTNESS: vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255)),
+    ATTR_BRIGHTNESS: VALID_BRIGHTNESS,
+    ATTR_BRIGHTNESS_PCT: VALID_BRIGHTNESS_PCT,
     ATTR_COLOR_NAME: cv.string,
     ATTR_RGB_COLOR: vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
                             vol.Coerce(tuple)),
@@ -49,7 +51,8 @@ LIFX_EFFECT_BREATHE_SCHEMA = LIFX_EFFECT_SCHEMA.extend({
 LIFX_EFFECT_PULSE_SCHEMA = LIFX_EFFECT_BREATHE_SCHEMA
 
 LIFX_EFFECT_COLORLOOP_SCHEMA = LIFX_EFFECT_SCHEMA.extend({
-    ATTR_BRIGHTNESS: vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255)),
+    ATTR_BRIGHTNESS: VALID_BRIGHTNESS,
+    ATTR_BRIGHTNESS_PCT: VALID_BRIGHTNESS_PCT,
     vol.Optional(ATTR_PERIOD, default=60):
         vol.All(vol.Coerce(float), vol.Clamp(min=0.05)),
     vol.Optional(ATTR_CHANGE, default=20):

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -26,7 +26,11 @@ turn_on:
 
     color_temp:
       description: Color temperature for the light in mireds
-      example: '250'
+      example: 250
+
+    kelvin:
+      description: Color temperature for the light in Kelvin
+      example: 4000
 
     white_value:
       description: Number between 0..255 indicating level of white

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -40,6 +40,10 @@ turn_on:
       description: Number between 0..255 indicating brightness
       example: 120
 
+    brightness_pct:
+      description: Number between 0..100 indicating percentage of full brightness
+      example: 47
+
     profile:
       description: Name of a light profile to use
       example: relax

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -56,6 +56,11 @@ class TestDemoLight(unittest.TestCase):
         self.assertEqual(154, state.attributes.get(light.ATTR_MIN_MIREDS))
         self.assertEqual(500, state.attributes.get(light.ATTR_MAX_MIREDS))
         self.assertEqual('none', state.attributes.get(light.ATTR_EFFECT))
+        light.turn_on(self.hass, ENTITY_LIGHT, kelvin=4000, brightness_pct=50)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_LIGHT)
+        self.assertEqual(250, state.attributes.get(light.ATTR_COLOR_TEMP))
+        self.assertEqual(127, state.attributes.get(light.ATTR_BRIGHTNESS))
 
     def test_turn_off(self):
         """Test light turn off method."""


### PR DESCRIPTION
## Description:

The existing `color_temp` (in mired) and `brightness` (arbitrary 8-bit scale) parameters to `light.turn_on` usually require calculations that most people cannot do in their head.

This PR adds alternative and well-known ways to specify white temperature (`kelvin`) and brightness (`brightness_pct`).

I guess the best way to express brightness would be with a calibrated unit like lumen but I do not see any way to provide that.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
[...]
      service: light.turn_on
      entity_id: group.basement
      data:
        kelvin: 3000
        brightness_pct: 40
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [X] Tests have been added to verify that the new code works.
