### PR TITLE
Kodi specific services to call Kodi API methods

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.kodi/
 """
 import asyncio
-from collections import OrderedDict
 from functools import wraps
 import logging
 import urllib

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -290,17 +290,6 @@ kodi_add_to_playlist:
       description: Optional artist name for filtering media.
       example: 'AC/DC'
 
-kodi_execute_addon:
-  description: 'Execute a Kodi addon with optional parameters. Results of the Kodi API call, if any, will be redirected in a Home Assistant event: `kodi_execute_addon_result`.'
-
-  fields:
-    entity_id:
-      description: Name(s) of the Kodi entities where to execute the (pre-installed) Kodi Addon.
-      example: 'media_player.living_room_kodi'
-    addonid:
-      description: Name of the Kodi addon.
-      example: 'script.json-cec'
-
 kodi_run_method:
   description: 'Run a Kodi JSONRPC API method with optional parameters. Results of the Kodi API call will be redirected in a Home Assistant event: `kodi_run_method_result`.'
 

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -289,3 +289,25 @@ kodi_add_to_playlist:
     artist_name:
       description: Optional artist name for filtering media.
       example: 'AC/DC'
+
+kodi_execute_addon:
+  description: 'Execute a Kodi addon with optional parameters. Results of the Kodi API call, if any, will be redirected in a Home Assistant event: `kodi_execute_addon_result`.'
+
+  fields:
+    entity_id:
+      description: Name(s) of the Kodi entities where to execute the (pre-installed) Kodi Addon.
+      example: 'media_player.living_room_kodi'
+    addonid:
+      description: Name of the Kodi addon.
+      example: 'script.json-cec'
+
+kodi_run_method:
+  description: 'Run a Kodi JSONRPC API method with optional parameters. Results of the Kodi API call will be redirected in a Home Assistant event: `kodi_run_method_result`.'
+
+  fields:
+    entity_id:
+      description: Name(s) of the Kodi entities where to run the API method.
+      example: 'media_player.living_room_kodi'
+    method:
+      description: Name of the Kodi JSONRPC API method to be called.
+      example: 'VideoLibrary.GetRecentlyAddedEpisodes'

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -290,8 +290,8 @@ kodi_add_to_playlist:
       description: Optional artist name for filtering media.
       example: 'AC/DC'
 
-kodi_run_method:
-  description: 'Run a Kodi JSONRPC API method with optional parameters. Results of the Kodi API call will be redirected in a Home Assistant event: `kodi_run_method_result`.'
+kodi_call_method:
+  description: 'Call a Kodi JSONRPC API method with optional parameters. Results of the Kodi API call will be redirected in a Home Assistant event: `kodi_call_method_result`.'
 
   fields:
     entity_id:


### PR DESCRIPTION
## Description:

New Kodi-specific services for accessing the **Kodi JSONRPC API** through Home Assistant, in order to simply (and asynchronously) access the full potential of the Kodi API.

Calls to the Kodi API that return results are redirected by triggering events with the information of the call parameters and the results obtained:
 ```
 event_data = {
   'result': api_call_results,
   'result_ok': boolean,
   'input': api_call_parameters,
   'entity_id': 'media_player.kodi'}
```

The new services are:
 - ~**`kodi_execute_addon`** to run a Kodi Addon with optional parameters. Results of the Kodi API call, if any, are redirected in a Home Assistant event: **`kodi_execute_addon_result`**.~
 - **`kodi_call_method`** to run a Kodi JSONRPC API method with optional parameters. Results of the Kodi API call are redirected in a Home Assistant event: **`kodi_call_method_result`**.

Also, expose the `timeout` parameter in the Kodi platform yaml config, to be able to make slow queries to the JSONRPC API (default timeout is set to 5s).

The documentation PR includes two examples of using these new services, including a simple example of using a Kodi Addon to turn on the TV, and a more complex one with scripts and a small AppDaemon App to form a dynamic `input_select` with choices of media playback in Kodi.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2635

## Checklist:
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)