### PR TITLE
Force automation ids to always be a string

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -82,7 +82,8 @@ _TRIGGER_SCHEMA = vol.All(
 _CONDITION_SCHEMA = vol.All(cv.ensure_list, [cv.CONDITION_SCHEMA])
 
 PLATFORM_SCHEMA = vol.Schema({
-    CONF_ID: cv.string,
+    # str on purpose
+    CONF_ID: str,
     CONF_ALIAS: cv.string,
     vol.Optional(CONF_INITIAL_STATE): cv.boolean,
     vol.Optional(CONF_HIDE_ENTITY, default=DEFAULT_HIDE_ENTITY): cv.boolean,


### PR DESCRIPTION
## Description:
It is important that the ID of an automation is always a string or else the automation editor can't find the correct entry.
