### PR TITLE
Update Docker base image to python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
 
 # Uncomment any of the following lines to disable the installation.


### PR DESCRIPTION
## Description:

This updates the base image for Docker to Python 3.6.

@balloob mentioned on Gitter that when 3.6.1 is out we could/should update.