### PR TITLE
Osram lightify Removed wrong assignment

### DIFF
--- a/homeassistant/components/light/osramlightify.py
+++ b/homeassistant/components/light/osramlightify.py
@@ -195,7 +195,7 @@ class Luminary(Light):
             self._brightness = kwargs[ATTR_BRIGHTNESS]
             _LOGGER.debug("turn_on requested brightness for light: %s is: %s ",
                           self._name, self._brightness)
-            self._brightness = self._luminary.set_luminance(
+            self._luminary.set_luminance(
                 int(self._brightness / 2.55),
                 transition)
 


### PR DESCRIPTION
self._brightness was assigned with the returned value of the
set_luminance() function, which is always equal to None. I found this bug using a sensor to control a lightify light. I tested the correction with my setup and it works as expected.