### PR TITLE
Abort tests when instances leaked

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from homeassistant import util, setup
 from homeassistant.util import location
 from homeassistant.components import mqtt
 
-from tests.common import async_test_home_assistant, mock_coro
+from tests.common import async_test_home_assistant, mock_coro, INSTANCES
 from tests.test_util.aiohttp import mock_aiohttp_client
 from tests.mock.zwave import MockNetwork, MockOption
 
@@ -50,8 +50,12 @@ def verify_cleanup():
     """Verify that the test has cleaned up resources correctly."""
     yield
 
-    from tests import common
-    assert common.INST_COUNT < 2
+    if len(INSTANCES) >= 2:
+        count = len(INSTANCES)
+        for inst in INSTANCES:
+            inst.stop()
+        pytest.exit("Detected non stopped instances "
+                    "({}), aborting test run".format(count))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description:
This will abort the test run when instances are leaked instead of raising an asserting error for this and every subsequent error (which pretty much ruins the logs).

Most of the times these errors are because our detection for calling a threaded helper from inside async is accidentally triggered. Not sure yet how to get around these false positives.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
