### PR TITLE
Don't initialize mqtt components which have already been discovered

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -28,7 +28,8 @@ ALLOWED_PLATFORMS = {
     'switch': ['mqtt'],
 }
 
-already_discovered = set()
+ALREADY_DISCOVERED = set()
+
 
 @asyncio.coroutine
 def async_start(hass, discovery_topic, hass_config):
@@ -67,12 +68,12 @@ def async_start(hass, discovery_topic, hass_config):
                 discovery_topic, component, object_id)
 
         discovery_hash = json.dumps([component, object_id], sort_keys=True)
-        if discovery_hash in already_discovered:
+        if discovery_hash in ALREADY_DISCOVERED:
             _LOGGER.info("Component is already discovered: %s %s",
                          component, object_id)
             return
 
-        already_discovered.add(discovery_hash)
+        ALREADY_DISCOVERED.add(discovery_hash)
 
         _LOGGER.info("Found new component: %s %s", component, object_id)
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -72,7 +72,7 @@ def async_start(hass, discovery_topic, hass_config):
 
         discovery_hash = (component, object_id)
         if discovery_hash in hass.data[ALREADY_DISCOVERED]:
-            _LOGGER.info("Component is already discovered: %s %s",
+            _LOGGER.info("Component has already been discovered: %s %s",
                          component, object_id)
             return
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -28,6 +28,7 @@ ALLOWED_PLATFORMS = {
     'switch': ['mqtt'],
 }
 
+already_discovered = set()
 
 @asyncio.coroutine
 def async_start(hass, discovery_topic, hass_config):
@@ -64,6 +65,15 @@ def async_start(hass, discovery_topic, hass_config):
         if CONF_STATE_TOPIC not in payload:
             payload[CONF_STATE_TOPIC] = '{}/{}/{}/state'.format(
                 discovery_topic, component, object_id)
+
+        discovery_hash = json.dumps([component, object_id], sort_keys=True)
+        if discovery_hash in already_discovered:
+            _LOGGER.info("Component is already discovered: %s %s", component, object_id)
+            return
+
+        already_discovered.add(discovery_hash)
+
+        _LOGGER.info("Found new component: %s %s", component, object_id)
 
         yield from async_load_platform(
             hass, component, platform, payload, hass_config)

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -17,7 +17,7 @@ from homeassistant.components.mqtt import CONF_STATE_TOPIC
 _LOGGER = logging.getLogger(__name__)
 
 TOPIC_MATCHER = re.compile(
-    r'(?P<prefix_topic>\w+)/(?P<component>\w+)/(?P<object_id>\w+)/config')
+    r'(?P<prefix_topic>\w+)/(?P<component>\w+)/(?P<object_id>[a-zA-Z0-9_-]+)/config')
 
 SUPPORTED_COMPONENTS = ['binary_sensor', 'light', 'sensor', 'switch']
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -17,7 +17,8 @@ from homeassistant.components.mqtt import CONF_STATE_TOPIC
 _LOGGER = logging.getLogger(__name__)
 
 TOPIC_MATCHER = re.compile(
-    r'(?P<prefix_topic>\w+)/(?P<component>\w+)/(?P<object_id>[a-zA-Z0-9_-]+)/config')
+    r'(?P<prefix_topic>\w+)/(?P<component>\w+)/(?P<object_id>[a-zA-Z0-9_-]+)'
+    '/config')
 
 SUPPORTED_COMPONENTS = ['binary_sensor', 'light', 'sensor', 'switch']
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -28,7 +28,7 @@ ALLOWED_PLATFORMS = {
     'switch': ['mqtt'],
 }
 
-ALREADY_DISCOVERED = set()
+ALREADY_DISCOVERED = 'mqtt_discovered_components'
 
 
 @asyncio.coroutine
@@ -67,13 +67,16 @@ def async_start(hass, discovery_topic, hass_config):
             payload[CONF_STATE_TOPIC] = '{}/{}/{}/state'.format(
                 discovery_topic, component, object_id)
 
-        discovery_hash = json.dumps([component, object_id], sort_keys=True)
-        if discovery_hash in ALREADY_DISCOVERED:
+        if ALREADY_DISCOVERED not in hass.data:
+            hass.data[ALREADY_DISCOVERED] = set()
+
+        discovery_hash = (component, object_id)
+        if discovery_hash in hass.data[ALREADY_DISCOVERED]:
             _LOGGER.info("Component is already discovered: %s %s",
                          component, object_id)
             return
 
-        ALREADY_DISCOVERED.add(discovery_hash)
+        hass.data[ALREADY_DISCOVERED].add(discovery_hash)
 
         _LOGGER.info("Found new component: %s %s", component, object_id)
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -68,7 +68,8 @@ def async_start(hass, discovery_topic, hass_config):
 
         discovery_hash = json.dumps([component, object_id], sort_keys=True)
         if discovery_hash in already_discovered:
-            _LOGGER.info("Component is already discovered: %s %s", component, object_id)
+            _LOGGER.info("Component is already discovered: %s %s",
+                         component, object_id)
             return
 
         already_discovered.add(discovery_hash)

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -93,4 +93,4 @@ def test_non_duplicate_discovery(hass, mqtt_mock, caplog):
     assert state.name == 'Beer'
     assert state_duplicate is None
     assert 'Component has already been discovered: ' \
-                            'binary_sensor bla' in caplog.text
+           'binary_sensor bla' in caplog.text

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -73,3 +73,24 @@ def test_correct_config_discovery(hass, mqtt_mock, caplog):
 
     assert state is not None
     assert state.name == 'Beer'
+
+
+@asyncio.coroutine
+def test_non_duplicate_discovery(hass, mqtt_mock, caplog):
+    """Test for a non duplicate component."""
+    yield from async_start(hass, 'homeassistant', {})
+
+    async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
+                            '{ "name": "Beer" }')
+    async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
+                            '{ "name": "Beer" }')
+    yield from hass.async_block_till_done()
+
+    state = hass.states.get('binary_sensor.beer')
+    state_duplicate = hass.states.get('binary_sensor.beer1')
+
+    assert state is not None
+    assert state.name == 'Beer'
+    assert state_duplicate is None
+    assert 'Component has already been discovered: ' \
+                            'binary_sensor bla' in caplog.text


### PR DESCRIPTION
## Description:
Like https://github.com/home-assistant/home-assistant/pull/6381 in dicovery component. The same for mqtt discovery, otherwise the entities are duplicated when rediscovered. Unfortunately, I do not know how to write a test.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
