### PR TITLE
Add image processing feature to store images

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -252,6 +252,7 @@ omit =
     homeassistant/components/ifttt.py
     homeassistant/components/image_processing/dlib_face_detect.py
     homeassistant/components/image_processing/dlib_face_identify.py
+    homeassistant/components/image_processing/file.py
     homeassistant/components/joaoapps_join.py
     homeassistant/components/keyboard.py
     homeassistant/components/keyboard_remote.py

--- a/homeassistant/components/image_processing/file.py
+++ b/homeassistant/components/image_processing/file.py
@@ -1,0 +1,112 @@
+"""
+Storing images to file from a given source.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/image_processing.file/
+"""
+import io
+import logging
+import os
+
+import voluptuous as vol
+
+import homeassistant.util.dt as dt_util
+import homeassistant.helpers.config_validation as cv
+from homeassistant.core import split_entity_id
+from homeassistant.components.image_processing import (
+    ImageProcessingEntity, PLATFORM_SCHEMA)
+from homeassistant.components.image_processing import (
+    CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)
+
+REQUIREMENTS = ['Pillow==4.1.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_FILE_PATH = 'file_path'
+CONF_IMAGE_TYPE = 'image_type'
+CONF_TIMESTAMP = 'timestamp'
+
+DEFAULT_IMAGE_TYPE = 'png'
+DEFAULT_TIMESTAMP = False
+
+SUPPORTED_IMAGE_TYPES = ['png', 'jpg']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_FILE_PATH): cv.string,
+    vol.Optional(CONF_IMAGE_TYPE, default=DEFAULT_IMAGE_TYPE):
+        vol.In(SUPPORTED_IMAGE_TYPES),
+    vol.Optional(CONF_TIMESTAMP, default=DEFAULT_TIMESTAMP): cv.boolean,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the File storage platform."""
+    file_path = config.get(CONF_FILE_PATH)
+    image_type = config.get(CONF_IMAGE_TYPE)
+    timestamp = config.get(CONF_TIMESTAMP)
+
+    entities = []
+    for camera in config[CONF_SOURCE]:
+        entities.append(FileStorage(
+            camera[CONF_ENTITY_ID], file_path, image_type, timestamp,
+            camera.get(CONF_NAME)))
+
+    add_devices(entities)
+
+
+class FileStorage(ImageProcessingEntity):
+    """Representation of a File Storage entity."""
+
+    def __init__(
+            self, camera_entity, file_path, image_type, timestamp, name=None):
+        """Initialize the File Storage entity."""
+        self._camera = camera_entity
+        self._file_path = file_path
+        self._image_type = image_type
+        self._timestamp = timestamp
+        self._files = 0
+        if name:
+            self._name = name
+        else:
+            self._name = "File storage Camera {0}".format(
+                split_entity_id(camera_entity)[1])
+
+        self._file_name = self._name.lower().replace(' ', '-')
+
+    @property
+    def camera_entity(self):
+        """Return camera entity id from process pictures."""
+        return self._camera
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self._files
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
+
+    def process_image(self, image):
+        """Process image."""
+        from PIL import Image, ImageFont, ImageDraw
+
+        current_timestamp = dt_util.utcnow().isoformat()
+        file_name = '{}-{}.{}'.format(
+            self._file_name, current_timestamp, self._image_type)
+
+        self._files = self._files + 1
+        stream = io.BytesIO(image)
+        img = Image.open(stream)
+
+        if self._timestamp:
+            font = ImageFont.load_default()
+            draw = ImageDraw.Draw(img)
+            draw.text((10, 10), current_timestamp, font=font)
+
+        filepath = os.path.join(self._file_path, file_name)
+        try:
+            img.save(filepath, self._image_type)
+        except FileNotFoundError:
+            _LOGGER.warning("Path does not exist: %s", self._file_path)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -17,6 +17,9 @@ astral==1.4
 # homeassistant.components.bbb_gpio
 # Adafruit_BBIO==1.0.0
 
+# homeassistant.components.image_processing.file
+Pillow==4.1.1
+
 # homeassistant.components.isy994
 PyISY==1.0.7
 


### PR DESCRIPTION
## Description:
This image processing platform stores data from a given `camera` platform to disk. This is a MVP because perhaps there are more efficient ways to add timestamps, crop, or other manipulation before saving.

The interval is given by the entity which provide the data.

![file-storage-camera-test-2017-05-17t09 29 34 839729 00 00](https://cloud.githubusercontent.com/assets/116184/26148165/0c49bf30-3af6-11e7-8ec0-2a5b1d67eda5.png)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: ffmpeg
    name: test
    input: /dev/video1
image_processing:
  - platform: file
    file_path: /home/user/.homeassistant/test/
    timestamp: True
    source:
      - entity_id: camera.test
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
