### PR TITLE
HomeMatic: Minor fixes + device support

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['pyhomematic==0.1.25']
+REQUIREMENTS = ['pyhomematic==0.1.26']
 
 DOMAIN = 'homematic'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -551,7 +551,7 @@ pyharmony==1.0.12
 pyhik==0.1.2
 
 # homeassistant.components.homematic
-pyhomematic==0.1.25
+pyhomematic==0.1.26
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==1.1.0


### PR DESCRIPTION
## Description:
Updated the pyhomematic module. Result: Minor fixes + better support for KeyMatic, added BC-TC-C-WM-2 wall thermostat.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
