### PR TITLE
Coerce color_temp to int even when passed in as kelvin

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -229,7 +229,7 @@ def preprocess_turn_on_alternatives(params):
     kelvin = params.pop(ATTR_KELVIN, None)
     if kelvin is not None:
         mired = color_util.color_temperature_kelvin_to_mired(kelvin)
-        params[ATTR_COLOR_TEMP] = mired
+        params[ATTR_COLOR_TEMP] = int(mired)
 
     brightness_pct = params.pop(ATTR_BRIGHTNESS_PCT, None)
     if brightness_pct is not None:

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -56,10 +56,10 @@ class TestDemoLight(unittest.TestCase):
         self.assertEqual(154, state.attributes.get(light.ATTR_MIN_MIREDS))
         self.assertEqual(500, state.attributes.get(light.ATTR_MAX_MIREDS))
         self.assertEqual('none', state.attributes.get(light.ATTR_EFFECT))
-        light.turn_on(self.hass, ENTITY_LIGHT, kelvin=4000, brightness_pct=50)
+        light.turn_on(self.hass, ENTITY_LIGHT, kelvin=3000, brightness_pct=50)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_LIGHT)
-        self.assertEqual(250, state.attributes.get(light.ATTR_COLOR_TEMP))
+        self.assertEqual(333, state.attributes.get(light.ATTR_COLOR_TEMP))
         self.assertEqual(127, state.attributes.get(light.ATTR_BRIGHTNESS))
 
     def test_turn_off(self):


### PR DESCRIPTION
## Description:

Small fix for #7596.

My own lights want Kelvin so they don't mind. However,  I expect _some_ platform will break with `color_temp` being a float.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
