### PR TITLE
Added support to Amcrest camera to feed using RTSP via ffmpeg

### DIFF
--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -16,9 +16,9 @@ from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_PORT)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import (
-    async_get_clientsession, async_aiohttp_proxy_web)
+    async_get_clientsession, async_aiohttp_proxy_web, async_aiohttp_proxy_stream)
 
-REQUIREMENTS = ['amcrest==1.1.9']
+REQUIREMENTS = ['amcrest==1.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,8 @@ RESOLUTION_LIST = {
 
 STREAM_SOURCE_LIST = {
     'mjpeg': 0,
-    'snapshot': 1
+    'snapshot': 1,
+    'rtsp': 2,
 }
 
 CONTENT_TYPE_HEADER = 'Content-Type'
@@ -117,15 +118,29 @@ class AmcrestCam(Camera):
             yield from super().handle_async_mjpeg_stream(request)
             return
 
-        # Otherwise, stream an MJPEG image stream directly from the camera
-        websession = async_get_clientsession(self.hass)
-        streaming_url = '{0}mjpg/video.cgi?channel=0&subtype={1}'.format(
-            self._base_url, self._resolution)
+        elif self._stream_source == STREAM_SOURCE_LIST['mjpeg']:
+            # stream an MJPEG image stream directly from the camera
+            websession = async_get_clientsession(self.hass)
+            streaming_url = self._camera.mjpeg_url(typeno=self._resolution)
+            stream_coro = websession.get(
+                streaming_url, auth=self._token, timeout=TIMEOUT)
 
-        stream_coro = websession.get(
-            streaming_url, auth=self._token, timeout=TIMEOUT)
+            yield from async_aiohttp_proxy_web(self.hass, request, stream_coro)
 
-        yield from async_aiohttp_proxy_web(self.hass, request, stream_coro)
+        else:
+            # streaming via fmpeg
+            from haffmpeg import CameraMjpeg
+
+            streaming_url = self._camera.rtsp_url(typeno=self._resolution)
+            stream =  CameraMjpeg('ffmpeg', loop=self.hass.loop)
+            yield from stream.open_camera(
+                streaming_url, extra_cmd='')
+
+            yield from async_aiohttp_proxy_stream(
+                self.hass, request, stream,
+                'multipart/x-mixed-replace;boundary=ffserver')
+            yield from stream.close()
+
 
     @property
     def name(self):

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -16,7 +16,8 @@ from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_PORT)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import (
-    async_get_clientsession, async_aiohttp_proxy_web, async_aiohttp_proxy_stream)
+    async_get_clientsession, async_aiohttp_proxy_web,
+    async_aiohttp_proxy_stream)
 
 REQUIREMENTS = ['amcrest==1.2.0']
 DEPENDENCIES = ['ffmpeg']
@@ -142,7 +143,7 @@ class AmcrestCam(Camera):
             from haffmpeg import CameraMjpeg
 
             streaming_url = self._camera.rtsp_url(typeno=self._resolution)
-            stream =  CameraMjpeg(self._ffmpeg_binary, loop=self.hass.loop)
+            stream = CameraMjpeg(self._ffmpeg_binary, loop=self.hass.loop)
             yield from stream.open_camera(
                 streaming_url, extra_cmd=self._ffmpeg_arguments)
 
@@ -150,7 +151,6 @@ class AmcrestCam(Camera):
                 self.hass, request, stream,
                 'multipart/x-mixed-replace;boundary=ffserver')
             yield from stream.close()
-
 
     @property
     def name(self):

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -61,8 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_STREAM_SOURCE, default=DEFAULT_STREAM_SOURCE):
         vol.All(vol.In(STREAM_SOURCE_LIST)),
-    vol.Optional(CONF_FFMPEG_ARGUMENTS, default=''):
-        cv.string,
+    vol.Optional(CONF_FFMPEG_ARGUMENTS): cv.string,
 })
 
 

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.aiohttp_client import (
     async_get_clientsession, async_aiohttp_proxy_web, async_aiohttp_proxy_stream)
 
 REQUIREMENTS = ['amcrest==1.2.0']
+DEPENDENCIES = ['ffmpeg']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -19,7 +19,7 @@ import homeassistant.loader as loader
 
 from requests.exceptions import HTTPError, ConnectTimeout
 
-REQUIREMENTS = ['amcrest==1.1.9']
+REQUIREMENTS = ['amcrest==1.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -56,7 +56,7 @@ alarmdecoder==0.12.1.0
 
 # homeassistant.components.camera.amcrest
 # homeassistant.components.sensor.amcrest
-amcrest==1.1.9
+amcrest==1.2.0
 
 # homeassistant.components.media_player.anthemav
 anthemav==1.1.8


### PR DESCRIPTION
## Description:
Added support to Amcrest camera to feed using RTSP via ffmpeg.
This patch is also an alternative to `aiohttp` not supporting `HTTPDigest` authentication. 

Of course is expected the `ffmpeg` to be installed on the system. Documentation will be updated pointing to https://home-assistant.io/components/ffmpeg/ install as pre-requisite.

**Related issue (if applicable):** fixes #6884 #7398

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2654
## Example entry for `configuration.yaml` (if applicable):
```yaml
#cameras.yaml
- platform: amcrest
  name: "Amcrest Backyard"
  host: !secret amcrest_backyard_host
  username: !secret amcrest_backyard_username
  password: !secret amcrest_backyard_password
  port: 80
  resolution: low
  stream_source: rtsp

- platform: amcrest
  name: "Amcrest Driveway"
  host: !secret amcrest_driveway_host
  username: !secret amcrest_driveway_username
  password: !secret amcrest_driveway_password
  port: 80
  resolution: high
  stream_source: rtsp
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

Many thanks to @pvizeli  on explaining how `ha-ffmpeg` works.
