### PR TITLE
Fix automation failing to setup if no automations specified

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -156,10 +156,7 @@ def async_setup(hass, config):
     component = EntityComponent(_LOGGER, DOMAIN, hass,
                                 group_name=GROUP_NAME_ALL_AUTOMATIONS)
 
-    success = yield from _async_process_config(hass, config, component)
-
-    if not success:
-        return False
+    yield from _async_process_config(hass, config, component)
 
     descriptions = yield from hass.loop.run_in_executor(
         None, conf_util.load_yaml_config_file, os.path.join(
@@ -417,8 +414,6 @@ def _async_process_config(hass, config, component):
 
     if entities:
         yield from component.async_add_entities(entities)
-
-    return len(entities) > 0
 
 
 def _async_get_action(hass, config, name):

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -33,7 +33,7 @@ class TestAutomation(unittest.TestCase):
     def test_service_data_not_a_dict(self):
         """Test service data not dict."""
         with assert_setup_component(0):
-            assert not setup_component(self.hass, automation.DOMAIN, {
+            assert setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'event',

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -245,7 +245,7 @@ class TestAutomationState(unittest.TestCase):
     def test_if_fails_setup_if_to_boolean_value(self):
         """Test for setup failure for boolean to."""
         with assert_setup_component(0):
-            assert not setup_component(self.hass, automation.DOMAIN, {
+            assert setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'state',
@@ -260,7 +260,7 @@ class TestAutomationState(unittest.TestCase):
     def test_if_fails_setup_if_from_boolean_value(self):
         """Test for setup failure for boolean from."""
         with assert_setup_component(0):
-            assert not setup_component(self.hass, automation.DOMAIN, {
+            assert setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'state',
@@ -275,7 +275,7 @@ class TestAutomationState(unittest.TestCase):
     def test_if_fails_setup_bad_for(self):
         """Test for setup failure for bad for."""
         with assert_setup_component(0):
-            assert not setup_component(self.hass, automation.DOMAIN, {
+            assert setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'state',
@@ -293,7 +293,7 @@ class TestAutomationState(unittest.TestCase):
     def test_if_fails_setup_for_without_to(self):
         """Test for setup failures for missing to."""
         with assert_setup_component(0):
-            assert not setup_component(self.hass, automation.DOMAIN, {
+            assert setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'state',
@@ -475,7 +475,7 @@ class TestAutomationState(unittest.TestCase):
     def test_if_fails_setup_for_without_time(self):
         """Test for setup failure if no time is provided."""
         with assert_setup_component(0):
-            assert not setup_component(self.hass, automation.DOMAIN, {
+            assert setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'event',
@@ -493,7 +493,7 @@ class TestAutomationState(unittest.TestCase):
     def test_if_fails_setup_for_without_entity(self):
         """Test for setup failure if no entity is provided."""
         with assert_setup_component(0):
-            assert not setup_component(self.hass, automation.DOMAIN, {
+            assert setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {'event_type': 'bla'},
                     'condition': {

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -370,7 +370,7 @@ class TestAutomationTemplate(unittest.TestCase):
     def test_if_fires_on_change_with_bad_template(self):
         """Test for firing on change with bad template."""
         with assert_setup_component(0):
-            assert not setup_component(self.hass, automation.DOMAIN, {
+            assert setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'template',

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -207,7 +207,7 @@ class TestAutomationTime(unittest.TestCase):
     def test_if_not_working_if_no_values_in_conf_provided(self):
         """Test for failure if no configuration."""
         with assert_setup_component(0):
-            assert not setup_component(self.hass, automation.DOMAIN, {
+            assert setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'time',
@@ -230,7 +230,7 @@ class TestAutomationTime(unittest.TestCase):
         This should break the before rule.
         """
         with assert_setup_component(0):
-            assert not setup_component(self.hass, automation.DOMAIN, {
+            assert setup_component(self.hass, automation.DOMAIN, {
                 automation.DOMAIN: {
                     'trigger': {
                         'platform': 'time',


### PR DESCRIPTION
## Description:
The automation component would fail to setup if no automations specified. Since the introduction of the automation editor we enable the automation editor in the default config, causing that to break out of the box. This fixes it by allowing the automation editor to setup correctly when there are no automations.

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
