### PR TITLE
Ignore attribute changes in automation trigger from/to

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -12,6 +12,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.const import MATCH_ALL, CONF_PLATFORM
 from homeassistant.helpers.event import (
     async_track_state_change, async_track_point_in_utc_time)
+from homeassistant.helpers.deprecation import get_deprecated
 import homeassistant.helpers.config_validation as cv
 
 CONF_ENTITY_ID = 'entity_id'
@@ -40,7 +41,7 @@ def async_trigger(hass, config, action):
     """Listen for state changes based on configuration."""
     entity_id = config.get(CONF_ENTITY_ID)
     from_state = config.get(CONF_FROM, MATCH_ALL)
-    to_state = config.get(CONF_TO) or config.get(CONF_STATE) or MATCH_ALL
+    to_state = get_deprecated(config, CONF_TO, CONF_STATE, MATCH_ALL)
     time_delta = config.get(CONF_FOR)
     async_remove_state_for_cancel = None
     async_remove_state_for_listener = None
@@ -75,12 +76,13 @@ def async_trigger(hass, config, action):
                 }
             })
 
-        if time_delta is None:
-            call_action()
+        # Ignore changes to state attributes if from/to is in use
+        match_all = (from_state == MATCH_ALL and to_state == MATCH_ALL)
+        if not match_all and from_s.last_changed == to_s.last_changed:
             return
 
-        # If only state attributes changed, ignore this event
-        if from_s.last_changed == to_s.last_changed:
+        if time_delta is None:
+            call_action()
             return
 
         @callback

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -23,8 +23,8 @@ def deprecated_substitute(substitute_name):
                 if not warnings.get(module_name):
                     logger = logging.getLogger(module_name)
                     logger.warning(
-                        "%s is deprecated. Please rename %s to "
-                        "%s in '%s' to ensure future support.",
+                        "'%s' is deprecated. Please rename '%s' to "
+                        "'%s' in '%s' to ensure future support.",
                         substitute_name, substitute_name, func.__name__,
                         inspect.getfile(self.__class__))
                     warnings[module_name] = True
@@ -49,7 +49,7 @@ def get_deprecated(config, new_name, old_name, default=None):
         module_name = inspect.getmodule(inspect.stack()[1][0]).__name__
         logger = logging.getLogger(module_name)
         logger.warning(
-            "%s is deprecated. Please rename %s to %s in your "
+            "'%s' is deprecated. Please rename '%s' to '%s' in your "
             "configuration file.", old_name, old_name, new_name)
         return config.get(old_name)
     return config.get(new_name, default)

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -110,6 +110,26 @@ class TestAutomationState(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
 
+    def test_if_fires_on_attribute_change_with_to_filter(self):
+        """Test for not firing on attribute change."""
+        assert setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'state',
+                    'entity_id': 'test.entity',
+                    'to': 'world'
+                },
+                'action': {
+                    'service': 'test.automation'
+                }
+            }
+        })
+
+        self.hass.states.set('test.entity', 'world', {'test_attribute': 11})
+        self.hass.states.set('test.entity', 'world', {'test_attribute': 12})
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
     def test_if_fires_on_entity_change_with_state_filter(self):
         """Test for firing on entity change with state filter."""
         assert setup_component(self.hass, automation.DOMAIN, {


### PR DESCRIPTION
## Description:

This changes `from`/`to` filters on automation triggers to only consider actual state changes, not attribute updates. The change only makes a difference if just one of `from`/`to` is specified.

Using `state` as an alias of `to` is deprecated because it is ambiguous.

These changes were agreed upon in #7556.

**Related issue (if applicable):** fixes #6299 #7556

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2665

**Breaking change note 1:** An automation state trigger that had only `from` or `to` (but not both) used to be triggered whenever state attributes changed, even if the actual `from`/`to` state remained the same. This has been changed so that `from` and `to` will only match when the state actually changes from or to the specified state.

**Breaking change note 2:** The automation state trigger used to allow `state` as an alias for `to`. This naming was a bit confusing and `state` has now been deprecated.

## Example entry for `configuration.yaml` (if applicable):

This example no longer arms the alarm when GPS coordinates are updated while the device is home:

```yaml
automation:
  - alias: ‘Arm alarm when leaving home'
    trigger:
      - platform: state
        entity_id: device_tracker.amelchio
        from: ‘home’
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [X] Tests have been added to verify that the new code works.
