### PR TITLE
bump ups version

### DIFF
--- a/homeassistant/components/sensor/ups.py
+++ b/homeassistant/components/sensor/ups.py
@@ -19,7 +19,7 @@ from homeassistant.util import Throttle
 from homeassistant.util.dt import now, parse_date
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['upsmychoice==1.0.2']
+REQUIREMENTS = ['upsmychoice==1.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -829,7 +829,7 @@ twilio==5.7.0
 uber_rides==0.4.1
 
 # homeassistant.components.sensor.ups
-upsmychoice==1.0.2
+upsmychoice==1.0.4
 
 # homeassistant.components.camera.uvc
 uvcclient==0.10.0


### PR DESCRIPTION
## Description:

Bump ups version:
- fixes py 3.5 dependency: https://github.com/home-assistant/home-assistant/issues/6251
- fixes login issue (ups website changed)

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
