### PR TITLE
update usps

### DIFF
--- a/homeassistant/components/sensor/usps.py
+++ b/homeassistant/components/sensor/usps.py
@@ -15,31 +15,28 @@ from homeassistant.const import (CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
                                  ATTR_ATTRIBUTION)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
-from homeassistant.util import Throttle
 from homeassistant.util.dt import now, parse_datetime
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['myusps==1.0.5']
+REQUIREMENTS = ['myusps==1.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 
+DOMAIN = 'usps'
+SCAN_INTERVAL = timedelta(minutes=30)
 COOKIE = 'usps_cookies.pickle'
-CONF_UPDATE_INTERVAL = 'update_interval'
-ICON = 'mdi:package-variant-closed'
 STATUS_DELIVERED = 'delivered'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=1800)): (
-        vol.All(cv.time_period, cv.positive_timedelta)),
+    vol.Optional(CONF_NAME): cv.string
 })
 
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the USPS platform."""
+    """Setup the USPS platform."""
     import myusps
     try:
         cookie = hass.config.path(COOKIE)
@@ -47,38 +44,34 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             config.get(CONF_USERNAME), config.get(CONF_PASSWORD),
             cookie_path=cookie)
     except myusps.USPSError:
-        _LOGGER.exception("Could not connect to My USPS")
+        _LOGGER.exception('Could not connect to My USPS')
         return False
 
-    add_devices([USPSSensor(session, config.get(CONF_NAME),
-                            config.get(CONF_UPDATE_INTERVAL))])
+    add_devices([USPSPackageSensor(session, config.get(CONF_NAME)),
+                 USPSMailSensor(session, config.get(CONF_NAME))], True)
 
 
-class USPSSensor(Entity):
-    """USPS Sensor."""
+class USPSPackageSensor(Entity):
+    """USPS Package Sensor."""
 
-    def __init__(self, session, name, interval):
+    def __init__(self, session, name):
         """Initialize the sensor."""
-        import myusps
         self._session = session
         self._name = name
-        self._profile = myusps.get_profile(session)
         self._attributes = None
         self._state = None
-        self.update = Throttle(interval)(self._update)
-        self.update()
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return self._name or self._profile.get('address')
+        return '{} packages'.format(self._name or DOMAIN)
 
     @property
     def state(self):
         """Return the state of the sensor."""
         return self._state
 
-    def _update(self):
+    def update(self):
         """Update device state."""
         import myusps
         status_counts = defaultdict(int)
@@ -102,4 +95,43 @@ class USPSSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return ICON
+        return 'mdi:package-variant-closed'
+
+
+class USPSMailSensor(Entity):
+    "USPS Mail Sensor."""
+
+    def __init__(self, session, name):
+        """Initialize the sensor."""
+        self._session = session
+        self._name = name
+        self._attributes = None
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} mail'.format(self._name or DOMAIN)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    def update(self):
+        """Update device state."""
+        import myusps
+        self._state = len(myusps.get_mail(self._session))
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        import myusps
+        return {
+            ATTR_ATTRIBUTION: myusps.ATTRIBUTION
+        }
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return 'mdi:mailbox'

--- a/homeassistant/components/sensor/usps.py
+++ b/homeassistant/components/sensor/usps.py
@@ -99,7 +99,7 @@ class USPSPackageSensor(Entity):
 
 
 class USPSMailSensor(Entity):
-    "USPS Mail Sensor."""
+    """USPS Mail Sensor."""
 
     def __init__(self, session, name):
         """Initialize the sensor."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -382,7 +382,7 @@ miflora==0.1.16
 mutagen==1.37.0
 
 # homeassistant.components.sensor.usps
-myusps==1.0.5
+myusps==1.1.1
 
 # homeassistant.components.discovery
 netdisco==1.0.0


### PR DESCRIPTION
## Description:

Bumps usps version:
- fixes various login/parsing issues
- adds [informed delivery](https://informeddelivery.usps.com/box/pages/intro/start.action) support

Breaking changes:
- entity naming changed since we now add two entities. Uses the `name` suffixed with `_packages` or `_mail`.
- now uses `scan_interval` instead of `update_interval` in config

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/2662

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
