### PR TITLE
Add juicenet platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -62,6 +62,9 @@ omit =
     homeassistant/components/isy994.py
     homeassistant/components/*/isy994.py
 
+    homeassistant/components/juicenet.py
+    homeassistant/components/*/juicenet.py
+
     homeassistant/components/kira.py
     homeassistant/components/*/kira.py
 

--- a/homeassistant/components/juicenet.py
+++ b/homeassistant/components/juicenet.py
@@ -32,16 +32,11 @@ def setup(hass, config):
     import pyjuicenet
 
     hass.data[DOMAIN] = {}
-    hass.data[DOMAIN]['unique_ids'] = []
-    hass.data[DOMAIN]['entities'] = {}
 
     access_token = config[DOMAIN].get(CONF_ACCESS_TOKEN)
-
     hass.data[DOMAIN]['api'] = pyjuicenet.Api(access_token)
 
-    hass.data[DOMAIN]['entities']['sensor'] = []
     discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
-
     return True
 
 
@@ -62,16 +57,6 @@ class JuicenetDevice(Entity):
     def update(self):
         """Update state of the device."""
         self.device.update_state()
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        attributes = {}
-        if self.type == 'status':
-            man_dev_id = self._manufacturer_device_id
-            if man_dev_id:
-                attributes["manufacturer_device_id"] = man_dev_id
-        return attributes
 
     @property
     def _manufacturer_device_id(self):

--- a/homeassistant/components/juicenet.py
+++ b/homeassistant/components/juicenet.py
@@ -68,6 +68,7 @@ class JuicenetDevice(Entity):
     """Represent a base Juicenet device."""
 
     def __init__(self, device, sensor_type, hass):
+        """Initialise the sensor."""
         self.hass = hass
         self.device = device
         self.type = sensor_type

--- a/homeassistant/components/juicenet.py
+++ b/homeassistant/components/juicenet.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/juicenet
 """
 
 import logging
-import time
 
 import voluptuous as vol
 
@@ -86,4 +85,5 @@ class JuicenetDevice(Entity):
 
     @property
     def unique_id(self):
+        """Return an unique ID."""
         return "{}-{}".format(self.device.id(), self.type)

--- a/homeassistant/components/juicenet.py
+++ b/homeassistant/components/juicenet.py
@@ -30,6 +30,7 @@ CONFIG_SCHEMA = vol.Schema({
     })
 }, extra=vol.ALLOW_EXTRA)
 
+
 def setup(hass, config):
     """Set up the Juicenet component."""
     import pyjuicenet
@@ -61,6 +62,7 @@ def setup(hass, config):
     discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
 
     return True
+
 
 class JuicenetDevice(Entity):
     """Represent a base Juicenet device."""

--- a/homeassistant/components/juicenet.py
+++ b/homeassistant/components/juicenet.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-juicenet==0.0.4']
+REQUIREMENTS = ['python-juicenet==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/juicenet.py
+++ b/homeassistant/components/juicenet.py
@@ -1,0 +1,106 @@
+"""
+Support for Juicenet cloud.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/juicenet
+"""
+
+import logging
+import time
+
+import voluptuous as vol
+
+from homeassistant.helpers import discovery
+from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['python-juicenet==0.0.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'juicenet'
+
+SERVICE_ADD_NEW_DEVICES = 'add_new_devices'
+SERVICE_REFRESH_STATES = 'refresh_state_from_juicenet'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_ACCESS_TOKEN): cv.string
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+def setup(hass, config):
+    """Set up the Juicenet component."""
+    import pyjuicenet
+
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN]['unique_ids'] = []
+    hass.data[DOMAIN]['entities'] = {}
+
+    access_token = config[DOMAIN].get(CONF_ACCESS_TOKEN)
+
+    hass.data[DOMAIN]['api'] = pyjuicenet.Api(access_token)
+
+    def force_update(call):
+        """Force all devices to poll the Juicenet API."""
+        _LOGGER.info("Refreshing Juicenet states from API")
+        for entity_list in hass[DOMAIN]['entities'].values():
+            for entity in entity_list:
+                time.sleep(1)
+                entity.schedule_update_ha_state(True)
+    hass.services.register(DOMAIN, SERVICE_REFRESH_STATES, force_update)
+
+    def pull_new_devices(call):
+        """Pull new devices added to users Juicenet account since startup."""
+        _LOGGER.info("Getting new devices from Juicenet API")
+        discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
+    hass.services.register(DOMAIN, SERVICE_ADD_NEW_DEVICES, pull_new_devices)
+
+    hass.data[DOMAIN]['entities']['sensor'] = []
+    discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
+
+    return True
+
+class JuicenetDevice(Entity):
+    """Represent a base Juicenet device."""
+
+    def __init__(self, device, sensor_type, hass):
+        self.hass = hass
+        self.device = device
+        self.type = sensor_type
+        hass.data[DOMAIN]['unique_ids'].append(self.device.id())
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self.device.name()
+
+    def update(self):
+        """Update state of the device."""
+        self.device.update_state()
+
+    @property
+    def should_poll(self):
+        """Always poll."""
+        return True
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attributes = {}
+        if self.type == 'status':
+            man_dev_id = self._manufacturer_device_id
+            if man_dev_id:
+                attributes["manufacturer_device_id"] = man_dev_id
+        return attributes
+
+    @property
+    def _manufacturer_device_id(self):
+        """Return the manufacturer device id."""
+        return self.device.id()
+
+    @property
+    def _token(self):
+        """Return the device API token."""
+        return self.device.token()

--- a/homeassistant/components/juicenet.py
+++ b/homeassistant/components/juicenet.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-juicenet==0.0.3']
+REQUIREMENTS = ['python-juicenet==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/juicenet.py
+++ b/homeassistant/components/juicenet.py
@@ -83,11 +83,6 @@ class JuicenetDevice(Entity):
         self.device.update_state()
 
     @property
-    def should_poll(self):
-        """Always poll."""
-        return True
-
-    @property
     def device_state_attributes(self):
         """Return the state attributes."""
         attributes = {}

--- a/homeassistant/components/sensor/juicenet.py
+++ b/homeassistant/components/sensor/juicenet.py
@@ -107,7 +107,7 @@ class JuicenetSensorDevice(JuicenetDevice, Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attributes = super().device_state_attributes
+        attributes = {}
         if self.type == 'status':
             man_dev_id = self.device.id()
             if man_dev_id:

--- a/homeassistant/components/sensor/juicenet.py
+++ b/homeassistant/components/sensor/juicenet.py
@@ -33,9 +33,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     dev = []
     for device in api.get_devices():
         for variable in SENSOR_TYPES:
-            _id = "{}-{}".format(device.id(), variable)
-            if _id not in hass.data[DOMAIN]['unique_ids']:
-                dev.append(JuicenetSensorDevice(device, variable, hass))
+            dev.append(JuicenetSensorDevice(device, variable, hass))
 
     add_devices(dev)
 
@@ -48,11 +46,6 @@ class JuicenetSensorDevice(JuicenetDevice, Entity):
         super().__init__(device, sensor_type, hass)
         self._name = SENSOR_TYPES[sensor_type][0]
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
-
-    @asyncio.coroutine
-    def async_added_to_hass(self):
-        """Callback when entity is added to hass."""
-        self.hass.data[DOMAIN]['entities']['sensor'].append(self)
 
     @property
     def name(self):
@@ -83,8 +76,6 @@ class JuicenetSensorDevice(JuicenetDevice, Entity):
             icon = 'mdi:timer'
         elif self.type == 'energy_added':
             icon = 'mdi:flash'
-        else:
-            icon = 'mdi:eye'
         return icon
 
     @property

--- a/homeassistant/components/sensor/juicenet.py
+++ b/homeassistant/components/sensor/juicenet.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 at https://home-assistant.io/components/sensor.juicenet/
 """
 
-import asyncio
 import logging
 
 from homeassistant.const import TEMP_CELSIUS

--- a/homeassistant/components/sensor/juicenet.py
+++ b/homeassistant/components/sensor/juicenet.py
@@ -1,0 +1,123 @@
+"""
+Support for monitoring juicenet/juicepoint/juicebox based EVSE sensors.
+
+For more details about this platform, please refer to the documentation at
+at https://home-assistant.io/components/sensor.juicenet/
+"""
+
+import asyncio
+import logging
+
+from homeassistant.const import TEMP_CELSIUS
+from homeassistant.helpers.entity import Entity
+from homeassistant.components.juicenet import JuicenetDevice, DOMAIN
+
+DEPENDENCIES = ['juicenet']
+_LOGGER = logging.getLogger(__name__)
+
+SENSOR_TYPES = {
+    'status': ['Charging Status', None],
+    'temperature': ['Temperature', TEMP_CELSIUS],
+    'voltage': ['Voltage', 'V'],
+    'amps': ['Amps', 'A'],
+    'watts': ['Watts', 'W'],
+    'charge_time': ['Charge time', 's'],
+    'energy_added': ['Energy added', 'Wh']
+}
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Juicenet sensor"""
+
+    api = hass.data[DOMAIN]['api']
+
+    dev = []
+    for device in api.get_devices():
+        _id = device.id()
+        if _id not in hass.data[DOMAIN]['unique_ids']:
+            for variable in SENSOR_TYPES:
+                dev.append(JuicenetSensorDevice(device, variable, hass))
+
+    add_devices(dev)
+
+
+class JuicenetSensorDevice(JuicenetDevice, Entity):
+    """Implementation of a Juicenet sensor."""
+
+    def __init__(self, device, sensor_type, hass):
+        """Initialise the sensor"""
+        super().__init__(device, sensor_type, hass)
+        self._name = SENSOR_TYPES[sensor_type][0]
+        self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        self.hass.data[DOMAIN]['entities']['sensor'].append(self)
+
+    @property
+    def name(self):
+        return '{} {}'.format(self.device.name(), self._name)
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        icon = None
+        if self.type == 'status':
+            status = self.device.getStatus()
+            if status == 'standby':
+                icon = 'mdi:power-plug-off'
+            elif status == 'plugged':
+                icon = 'mdi:power-plug'
+            elif status == 'charging':
+                icon = 'mdi:battery-positive'
+        elif self.type == 'temperature':
+            icon = 'mdi:thermometer'
+        elif self.type == 'voltage':
+            icon = 'mdi:flash'
+        elif self.type == 'amps':
+            icon = 'mdi:flash'
+        elif self.type == 'watts':
+            icon = 'mdi:flash'
+        elif self.type == 'charge_time':
+            icon = 'mdi:timer'
+        elif self.type == 'energy_added':
+            icon = 'mdi:flash'
+        else:
+            icon = 'mdi:eye'
+        return icon
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit_of_measurement
+
+    @property
+    def state(self):
+        """Return the state"""
+        state = None
+        if self.type == 'status':
+            state = self.device.getStatus()
+        elif self.type == 'temperature':
+            state = self.device.getTemperature()
+        elif self.type == 'voltage':
+            state = self.device.getVoltage()
+        elif self.type == 'amps':
+            state = self.device.getAmps()
+        elif self.type == 'watts':
+            state = self.device.getWatts()
+        elif self.type == 'charge_time':
+            state = self.device.getChargeTime()
+        elif self.type == 'energy_added':
+            state = self.device.getEnergyAdded()
+        else:
+            state = 'Unknown'
+        return state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attributes = super().device_state_attributes
+        if self.type == 'status':
+            if man_dev_id:
+                attributes["manufacturer_device_id"] = man_dev_id
+        return attributes

--- a/homeassistant/components/sensor/juicenet.py
+++ b/homeassistant/components/sensor/juicenet.py
@@ -42,7 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 class JuicenetSensorDevice(JuicenetDevice, Entity):
     """Implementation of a Juicenet sensor."""
-    
+
     def __init__(self, device, sensor_type, hass):
         """Initialise the sensor."""
         super().__init__(device, sensor_type, hass)

--- a/homeassistant/components/sensor/juicenet.py
+++ b/homeassistant/components/sensor/juicenet.py
@@ -25,6 +25,7 @@ SENSOR_TYPES = {
     'energy_added': ['Energy added', 'Wh']
 }
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Juicenet sensor"""
 
@@ -118,6 +119,7 @@ class JuicenetSensorDevice(JuicenetDevice, Entity):
         """Return the state attributes."""
         attributes = super().device_state_attributes
         if self.type == 'status':
+            man_dev_id = self.device.id()
             if man_dev_id:
                 attributes["manufacturer_device_id"] = man_dev_id
         return attributes

--- a/homeassistant/components/sensor/juicenet.py
+++ b/homeassistant/components/sensor/juicenet.py
@@ -32,9 +32,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     dev = []
     for device in api.get_devices():
-        _id = device.id()
         for variable in SENSOR_TYPES:
-            if "{}-{}".format(_id, variable) not in hass.data[DOMAIN]['unique_ids']:
+            _id = "{}-{}".format(device.id(), variable)
+            if _id not in hass.data[DOMAIN]['unique_ids']:
                 dev.append(JuicenetSensorDevice(device, variable, hass))
 
     add_devices(dev)

--- a/homeassistant/components/sensor/juicenet.py
+++ b/homeassistant/components/sensor/juicenet.py
@@ -27,8 +27,7 @@ SENSOR_TYPES = {
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the Juicenet sensor"""
-
+    """Set up the Juicenet sensor."""
     api = hass.data[DOMAIN]['api']
 
     dev = []
@@ -43,9 +42,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 class JuicenetSensorDevice(JuicenetDevice, Entity):
     """Implementation of a Juicenet sensor."""
-
+    
     def __init__(self, device, sensor_type, hass):
-        """Initialise the sensor"""
+        """Initialise the sensor."""
         super().__init__(device, sensor_type, hass)
         self._name = SENSOR_TYPES[sensor_type][0]
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
@@ -57,6 +56,7 @@ class JuicenetSensorDevice(JuicenetDevice, Entity):
 
     @property
     def name(self):
+        """Return the name of the device."""
         return '{} {}'.format(self.device.name(), self._name)
 
     @property
@@ -94,7 +94,7 @@ class JuicenetSensorDevice(JuicenetDevice, Entity):
 
     @property
     def state(self):
-        """Return the state"""
+        """Return the state."""
         state = None
         if self.type == 'status':
             state = self.device.getStatus()

--- a/homeassistant/components/sensor/juicenet.py
+++ b/homeassistant/components/sensor/juicenet.py
@@ -33,8 +33,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     dev = []
     for device in api.get_devices():
         _id = device.id()
-        if _id not in hass.data[DOMAIN]['unique_ids']:
-            for variable in SENSOR_TYPES:
+        for variable in SENSOR_TYPES:
+            if "{}-{}".format(_id, variable) not in hass.data[DOMAIN]['unique_ids']:
                 dev.append(JuicenetSensorDevice(device, variable, hass))
 
     add_devices(dev)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -659,7 +659,7 @@ python-hpilo==3.9
 python-join-api==0.0.2
 
 # homeassistant.components.juicenet
-python-juicenet==0.0.3
+python-juicenet==0.0.4
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -659,7 +659,7 @@ python-hpilo==3.9
 python-join-api==0.0.2
 
 # homeassistant.components.juicenet
-python-juicenet==0.0.4
+python-juicenet==0.0.5
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -658,6 +658,9 @@ python-hpilo==3.9
 # homeassistant.components.notify.joaoapps_join
 python-join-api==0.0.2
 
+# homeassistant.components.juicenet
+python-juicenet==0.0.3
+
 # homeassistant.components.lirc
 # python-lirc==1.2.3
 


### PR DESCRIPTION
## Description:
The `juicenet` sensor platform pulls data from a [JuiceNet](https://emotorwerks.com/products/juicenet/) Charging station equipped with a wifi connection.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2670

## Example entry for `configuration.yaml` (if applicable):
```yaml
juicenet:
    access_token: ACCESS_TOKEN

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
