### PR TITLE
Upgrade Openhome library

### DIFF
--- a/homeassistant/components/media_player/openhome.py
+++ b/homeassistant/components/media_player/openhome.py
@@ -14,7 +14,7 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (
     STATE_IDLE, STATE_PAUSED, STATE_PLAYING, STATE_OFF)
 
-REQUIREMENTS = ['openhomedevice==0.2.1']
+REQUIREMENTS = ['openhomedevice==0.4.0']
 
 SUPPORT_OPENHOME = SUPPORT_SELECT_SOURCE | \
     SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET | \
@@ -92,7 +92,7 @@ class OpenhomeDevice(MediaPlayerDevice):
 
         if self._source["type"] == "Radio":
             self._supported_features |= SUPPORT_STOP | SUPPORT_PLAY
-        if self._source["type"] == "Playlist":
+        if self._source["type"] == "Playlist" || self._source["type"] == "Cloud":
             self._supported_features |= SUPPORT_PREVIOUS_TRACK | \
                 SUPPORT_NEXT_TRACK | SUPPORT_PAUSE | SUPPORT_PLAY
 
@@ -173,17 +173,17 @@ class OpenhomeDevice(MediaPlayerDevice):
     @property
     def media_image_url(self):
         """Image url of current playing media."""
-        return self._track_information["albumArt"]
+        return self._track_information["albumArtwork"]
 
     @property
     def media_artist(self):
         """Artist of current playing media, music track only."""
-        return self._track_information["artist"]
+        return self._track_information["artist"][0]
 
     @property
     def media_album_name(self):
         """Album name of current playing media, music track only."""
-        return self._track_information["album"]
+        return self._track_information["albumTitle"]
 
     @property
     def media_title(self):

--- a/homeassistant/components/media_player/openhome.py
+++ b/homeassistant/components/media_player/openhome.py
@@ -92,7 +92,7 @@ class OpenhomeDevice(MediaPlayerDevice):
 
         if self._source["type"] == "Radio":
             self._supported_features |= SUPPORT_STOP | SUPPORT_PLAY
-        if self._source["type"] == "Playlist" || self._source["type"] == "Cloud":
+        if self._source["type"] in ("Playlist", "Cloud"):
             self._supported_features |= SUPPORT_PREVIOUS_TRACK | \
                 SUPPORT_NEXT_TRACK | SUPPORT_PAUSE | SUPPORT_PLAY
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -409,7 +409,7 @@ onkyo-eiscp==1.1
 openevsewifi==0.4
 
 # homeassistant.components.media_player.openhome
-openhomedevice==0.2.1
+openhomedevice==0.4.0
 
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1


### PR DESCRIPTION
## Description:

This increases the version of the openhomedevice library to 0.4.0 for openhome compliant media players and introduces support for a new service available on these device. 

**Related issue (if applicable):** None

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** No documentation changes required

## Example entry for `configuration.yaml` (if applicable): 
No configuration changes required

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.