### PR TITLE
device_tracker.ubus: Handle empty results

### DIFF
--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -144,7 +144,10 @@ def _req_json_rpc(url, session_id, rpcmethod, subsystem, method, **params):
         response = res.json()
 
         if rpcmethod == "call":
-            return response["result"][1]
+            try:
+                return response["result"][1]
+            except IndexError:
+                return
         else:
             return response["result"]
 


### PR DESCRIPTION
## Description:

If OpenWRT isn't running the DHCP server then some OpenWRT hardware,
such as TP-Link TL-WDR3600 v1, can't determine the host
corresponding to an associated wifi client. This change handles that
by returning None when the request has no data in the result.

**Related issue (if applicable):** fixes #7672

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** No documentation changes required

## Example entry for `configuration.yaml` (if applicable):

No configuration changes required

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

