### PR TITLE
zoneminder: fix incorrect use of logging.exception.

### DIFF
--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -109,7 +109,7 @@ def _zm_request(method, api_url, data=None):
             break
 
     else:
-        _LOGGER.exception("Unable to get API response from ZoneMinder")
+        _LOGGER.error("Unable to get API response from ZoneMinder")
 
     try:
         return req.json()


### PR DESCRIPTION
## Description:

Prior to this change the zoneminder component was attempting to
use logging.exception outside of exception handling code. This
would lead to the traceback module throwing an exception when
trying to work out the traceback for the exception.

This fixes the issue by changing the exception call into a
plain error logging call.

**Related issue (if applicable):** fixes #7674

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** No documentation change needed.

## Example entry for `configuration.yaml` (if applicable):
No configuration change needed.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
