### PR TITLE
ZWave: Add reset service to meters

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -179,10 +179,6 @@ def setup(hass, config):
 
     register_built_in_panel(hass, 'map', 'Map', 'mdi:account-location')
 
-    zwave = config.get('zwave')
-    if zwave:
-        register_built_in_panel(hass, 'zwave', 'Z-Wave', 'mdi:nfc')
-
     for panel in ('dev-event', 'dev-info', 'dev-service', 'dev-state',
                   'dev-template'):
         register_built_in_panel(hass, panel)

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -179,6 +179,10 @@ def setup(hass, config):
 
     register_built_in_panel(hass, 'map', 'Map', 'mdi:account-location')
 
+    zwave = config.get('zwave')
+    if zwave:
+        register_built_in_panel(hass, 'zwave', 'Z-Wave', 'mdi:nfc')
+
     for panel in ('dev-event', 'dev-info', 'dev-service', 'dev-state',
                   'dev-template'):
         register_built_in_panel(hass, panel)

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -512,7 +512,7 @@ def setup(hass, config):
         for value in (
                 node.get_values(class_id=const.COMMAND_CLASS_METER)
                 .values()):
-            if value.index != 33:
+            if value.index != const.METER_RESET_INDEX:
                 continue
             if value.instance != instance:
                 continue

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -95,6 +95,11 @@ REFRESH_ENTITY_SCHEMA = vol.Schema({
     vol.Required(ATTR_ENTITY_ID): cv.entity_id,
 })
 
+RESET_NODE_METERS_SCHEMA = vol.Schema({
+    vol.Required(const.ATTR_NODE_ID): vol.Coerce(int),
+    vol.Optional(const.ATTR_INSTANCE, default=1): vol.Coerce(int)
+})
+
 CHANGE_ASSOCIATION_SCHEMA = vol.Schema({
     vol.Required(const.ATTR_ASSOCIATION): cv.string,
     vol.Required(const.ATTR_NODE_ID): vol.Coerce(int),
@@ -499,6 +504,26 @@ def setup(hass, config):
         node = network.nodes[node_id]
         node.refresh_info()
 
+    def reset_node_meters(service):
+        """Reset meter counters of a node."""
+        node_id = service.data.get(const.ATTR_NODE_ID)
+        instance = service.data.get(const.ATTR_INSTANCE)
+        node = network.nodes[node_id]
+        for value in (
+                node.get_values(class_id=const.COMMAND_CLASS_METER)
+                .values()):
+            if value.index != 33:
+                continue
+            if value.instance != instance:
+                continue
+            network.manager.pressButton(value.value_id)
+            network.manager.releaseButton(value.value_id)
+            _LOGGER.info("Resetting meters on node %s instance %s....",
+                         node_id, instance)
+            return
+        _LOGGER.info("Node %s on instance %s does not have resettable "
+                     "meters.", node_id, instance)
+
     def start_zwave(_service_or_event):
         """Startup Z-Wave network."""
         _LOGGER.info("Starting Z-Wave network...")
@@ -606,6 +631,11 @@ def setup(hass, config):
                                descriptions[
                                    const.SERVICE_REFRESH_NODE],
                                schema=NODE_SERVICE_SCHEMA)
+        hass.services.register(DOMAIN, const.SERVICE_RESET_NODE_METERS,
+                               reset_node_meters,
+                               descriptions[
+                                   const.SERVICE_RESET_NODE_METERS],
+                               schema=RESET_NODE_METERS_SCHEMA)
 
     # Setup autoheal
     if autoheal:

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -37,6 +37,7 @@ SERVICE_START_NETWORK = "start_network"
 SERVICE_RENAME_NODE = "rename_node"
 SERVICE_REFRESH_ENTITY = "refresh_entity"
 SERVICE_REFRESH_NODE = "refresh_node"
+SERVICE_RESET_NODE_METERS = "reset_node_meters"
 
 EVENT_SCENE_ACTIVATED = "zwave.scene_activated"
 EVENT_NODE_EVENT = "zwave.node_event"

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -330,3 +330,5 @@ DISC_SPECIFIC_DEVICE_CLASS = "specific_device_class"
 DISC_TYPE = "type"
 DISC_VALUES = "values"
 DISC_WRITEONLY = "writeonly"
+
+METER_RESET_INDEX = 33

--- a/homeassistant/components/zwave/services.yaml
+++ b/homeassistant/components/zwave/services.yaml
@@ -108,3 +108,11 @@ rename_node:
     name:
       description: New Name
       example: 'kitchen'
+
+reset_node_meters:
+  description: Resets the meter counters of a node.
+  fields:
+    node_id:
+      description: Node id of the device to reset meters for. (integer)
+    instance:
+      description: (Optional) Instance of association. Defaults to instance 1.


### PR DESCRIPTION
## Description:
This adds a reset_node_meters service to zwave that can let the user reset values in the command_class_meter class. (I.e. kWh meter) This "button" will be present at index 33 of the values if the node supports it.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2674

