### PR TITLE
Switch pymodbus to pypi

### DIFF
--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -16,8 +16,7 @@ from homeassistant.const import (
 
 DOMAIN = 'modbus'
 
-REQUIREMENTS = ['https://github.com/bashwork/pymodbus/archive/'
-                'd7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0']
+REQUIREMENTS = ['pymodbus==1.3.0rc1']
 
 # Type of network
 CONF_BAUDRATE = 'baudrate'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -270,9 +270,6 @@ https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
 # homeassistant.components.cover.myq
 https://github.com/arraylabs/pymyq/archive/v0.0.8.zip#pymyq==0.0.8
 
-# homeassistant.components.modbus
-https://github.com/bashwork/pymodbus/archive/d7fc4f1cc975631e0a9011390e8017f64b612661.zip#pymodbus==1.2.0
-
 # homeassistant.components.media_player.spotify
 https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f86c90aa26b2.zip#spotipy==2.4.4
 
@@ -592,6 +589,9 @@ pymailgunner==1.4
 
 # homeassistant.components.mochad
 pymochad==0.1.1
+
+# homeassistant.components.modbus
+pymodbus==1.3.0rc1
 
 # homeassistant.components.mysensors
 pymysensors==0.10.0


### PR DESCRIPTION
## Description:

Switch pymodbus to pypi
**Related issue (if applicable):** #7069 
Following https://github.com/riptideio/pymodbus/issues/155 

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
