### PR TITLE
Sort entities in default groups by name

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -229,15 +229,17 @@ class EntityComponent(object):
 
         This method must be run in the event loop.
         """
+        def sorted_ids():
+            """Return our entity ids sorted by entity name."""
+            return sorted((ent_id for ent_id in self.entities.keys()),
+                          key=lambda x: self.entities[x].name)
+
         if self.group is None and self.group_name is not None:
             group = get_component('group')
             self.group = yield from group.Group.async_create_group(
-                self.hass, self.group_name, self.entities.keys(),
-                user_defined=False
-            )
+                self.hass, self.group_name, sorted_ids(), user_defined=False)
         elif self.group is not None:
-            yield from self.group.async_update_tracked_entity_ids(
-                self.entities.keys())
+            yield from self.group.async_update_tracked_entity_ids(sorted_ids())
 
     def reset(self):
         """Remove entities and reset the entity component to initial values."""

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -229,17 +229,15 @@ class EntityComponent(object):
 
         This method must be run in the event loop.
         """
-        def sorted_ids():
-            """Return our entity ids sorted by entity name."""
-            return sorted((ent_id for ent_id in self.entities.keys()),
-                          key=lambda x: self.entities[x].name)
-
         if self.group is None and self.group_name is not None:
             group = get_component('group')
             self.group = yield from group.Group.async_create_group(
-                self.hass, self.group_name, sorted_ids(), user_defined=False)
+                self.hass, self.group_name,
+                sorted(self.entities, key=lambda x: self.entities[x].name),
+                user_defined=False)
         elif self.group is not None:
-            yield from self.group.async_update_tracked_entity_ids(sorted_ids())
+            yield from self.group.async_update_tracked_entity_ids(
+                sorted(self.entities, key=lambda x: self.entities[x].name))
 
     def reset(self):
         """Remove entities and reset the entity component to initial values."""

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -92,13 +92,14 @@ class TestHelpersEntityComponent(unittest.TestCase):
         assert group.attributes.get('entity_id') == ('test_domain.hello',)
 
         # group extended
-        component.add_entities([EntityTest(name='hello2')])
+        component.add_entities([EntityTest(name='goodbye')])
 
         assert len(self.hass.states.entity_ids()) == 3
         group = self.hass.states.get('group.everyone')
 
-        assert sorted(group.attributes.get('entity_id')) == \
-            ['test_domain.hello', 'test_domain.hello2']
+        # Sorted order
+        assert group.attributes.get('entity_id') == \
+            ('test_domain.goodbye', 'test_domain.hello')
 
     def test_polling_only_updates_entities_it_should_poll(self):
         """Test the polling of only updated entities."""


### PR DESCRIPTION
## Description:

When used in a frontend view, having things like `group.all_scripts` assume a new random order on each restart is annoying. This sorts them by name instead.

**Related issue (if applicable):** fixes #6557

## Example entry for `configuration.yaml` (if applicable):
```yaml
group:
  default_view:
    name: Admin
    view: yes
    entities:
      - group.all_automations
      - group.all_scripts
```

## Checklist:

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [X] Tests have been added to verify that the new code works.
