### PR TITLE
Guard against new and removed state change events

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -45,6 +45,7 @@ def async_trigger(hass, config, action):
     time_delta = config.get(CONF_FOR)
     async_remove_state_for_cancel = None
     async_remove_state_for_listener = None
+    match_all = (from_state == MATCH_ALL and to_state == MATCH_ALL)
 
     @callback
     def clear_listener():
@@ -77,8 +78,8 @@ def async_trigger(hass, config, action):
             })
 
         # Ignore changes to state attributes if from/to is in use
-        match_all = (from_state == MATCH_ALL and to_state == MATCH_ALL)
-        if not match_all and from_s.last_changed == to_s.last_changed:
+        if (not match_all and from_s is not None and to_s is not None and
+                from_s.last_changed == to_s.last_changed):
             return
 
         if time_delta is None:


### PR DESCRIPTION
## Description:
Guard for new events and for when we remove events (and thus `to_s` or `from_s` is None)

**Related issue (if applicable):** fixes #7691

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
