### PR TITLE
Allow negative chat ID for Telegram

### DIFF
--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -27,7 +27,7 @@ ATTR_DOCUMENT = 'document'
 CONF_CHAT_ID = 'chat_id'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_CHAT_ID): cv.positive_int,
+    vol.Required(CONF_CHAT_ID): vol.Coerce(int),
 })
 
 

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -8,7 +8,6 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
     ATTR_MESSAGE, ATTR_TITLE, ATTR_DATA, ATTR_TARGET,
     PLATFORM_SCHEMA, BaseNotificationService)

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -113,19 +113,19 @@ SERVICE_SCHEMA_SEND_LOCATION = BASE_SERVICE_SCHEMA.extend({
 SERVICE_EDIT_MESSAGE = 'edit_message'
 SERVICE_SCHEMA_EDIT_MESSAGE = SERVICE_SCHEMA_SEND_MESSAGE.extend({
     vol.Required(ATTR_MESSAGEID): vol.Any(cv.positive_int, cv.string),
-    vol.Required(ATTR_CHAT_ID): cv.positive_int,
+    vol.Required(ATTR_CHAT_ID): vol.Coerce(int),
 })
 SERVICE_EDIT_CAPTION = 'edit_caption'
 SERVICE_SCHEMA_EDIT_CAPTION = vol.Schema({
     vol.Required(ATTR_MESSAGEID): vol.Any(cv.positive_int, cv.string),
-    vol.Required(ATTR_CHAT_ID): cv.positive_int,
+    vol.Required(ATTR_CHAT_ID): vol.Coerce(int),
     vol.Required(ATTR_CAPTION): cv.string,
     vol.Optional(ATTR_KEYBOARD_INLINE): cv.ensure_list,
 }, extra=vol.ALLOW_EXTRA)
 SERVICE_EDIT_REPLYMARKUP = 'edit_replymarkup'
 SERVICE_SCHEMA_EDIT_REPLYMARKUP = vol.Schema({
     vol.Required(ATTR_MESSAGEID): vol.Any(cv.positive_int, cv.string),
-    vol.Required(ATTR_CHAT_ID): cv.positive_int,
+    vol.Required(ATTR_CHAT_ID): vol.Coerce(int),
     vol.Required(ATTR_KEYBOARD_INLINE): cv.ensure_list,
 }, extra=vol.ALLOW_EXTRA)
 SERVICE_ANSWER_CALLBACK_QUERY = 'answer_callback_query'


### PR DESCRIPTION
## Description:

The latest version of HASS requires a positive integer for `CHAT_ID` in Telegram:

```
Invalid config for [notify.telegram]: value must be at least 0 for dictionary
value @ data['chat_id']. Got '-12345678'. (See ?, line ?). Please check the
docs at https://home-assistant.io/components/notify.telegram/
```

However, this breaks group chats within Telegram: if the chat is a group, the chat id is negative. If it is a single person, the chat id is positive. This PR allows for group chats again.