### PR TITLE
Fix telegram chats

### DIFF
--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -27,7 +27,7 @@ ATTR_DOCUMENT = 'document'
 CONF_CHAT_ID = 'chat_id'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_CHAT_ID): cv.positive_int,
+    vol.Required(CONF_CHAT_ID): vol.Coerce(int),
 })
 
 

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -8,7 +8,6 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
     ATTR_MESSAGE, ATTR_TITLE, ATTR_DATA, ATTR_TARGET,
     PLATFORM_SCHEMA, BaseNotificationService)

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -38,6 +38,7 @@ ATTR_COMMAND = 'command'
 ATTR_USER_ID = 'user_id'
 ATTR_ARGS = 'args'
 ATTR_MSG = 'message'
+ATTR_EDITED_MSG = 'edited_message'
 ATTR_CHAT_INSTANCE = 'chat_instance'
 ATTR_CHAT_ID = 'chat_id'
 ATTR_MSGID = 'id'
@@ -505,9 +506,12 @@ class BaseTelegramBotEntity:
 
     def process_message(self, data):
         """Check for basic message rules and fire an event if message is ok."""
-        if ATTR_MSG in data:
+        if ATTR_MSG in data or ATTR_EDITED_MSG in data:
             event = EVENT_TELEGRAM_COMMAND
-            data = data.get(ATTR_MSG)
+            if ATTR_MSG in data:
+                data = data.get(ATTR_MSG)
+            else:
+                data = data.get(ATTR_EDITED_MSG)
             message_ok, event_data = self._get_message_data(data)
             if event_data is None:
                 return message_ok

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -483,9 +483,8 @@ class BaseTelegramBotEntity:
             return None
         bad_fields = (not hasattr(msg_data, 'text') and
                       not hasattr(msg_data, 'data') and
-                      not hasattr(msg_data, 'from') and
                       not hasattr(msg_data, 'chat'))
-        if (bad_fields or
+        if (bad_fields or not hasattr(msg_data, 'from') or
                 msg_data['from'].get('id') not in self.allowed_chat_ids):
             # Message is not correct.
             _LOGGER.error("Incoming message does not have required data (%s)",


### PR DESCRIPTION
## Description:

Related issue (if applicable): fixes #7694 

Fix negative `chat_id`s used in Telegram groups:
- Negative `chat_id`s for groups.
- Include `chat_id` in event data.
- Handle KeyError when receiving other types of messages, as `new_chat_member` ones, and send them as text.

I know this is like a duplicate of #7688, but this has more changes to allow **receiving** messages from a group, not only sending them.

It's tested and intended to be included in 0.45.1