### PR TITLE
Added persistent error message if cover.myq fails to load

### DIFF
--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -59,8 +59,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             hass, 'Error: {}<br />'
             'You will need to restart hass after fixing.'
             ''.format(ex),
-             title=NOTIFICATION_TITLE,
-             notification_id=NOTIFICATION_ID)
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID)
         return False
 
 

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -20,7 +20,6 @@ REQUIREMENTS = [
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_ENTITY_NAMESPACE = 'myq'
 DEFAULT_NAME = 'myq'
 
 NOTIFICATION_ID = 'myq_notification'

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -12,18 +12,25 @@ from homeassistant.components.cover import CoverDevice
 from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD, CONF_TYPE, STATE_CLOSED)
 import homeassistant.helpers.config_validation as cv
+import homeassistant.loader as loader
 
 REQUIREMENTS = [
     'https://github.com/arraylabs/pymyq/archive/v0.0.8.zip'
     '#pymyq==0.0.8']
+
+_LOGGER = logging.get_LOGGER(__name__)
+
+DEFAULT_ENTITY_NAMESPACE = 'myq'
+DEFAULT_NAME = 'myq'
+
+NOTIFICATION_ID = 'myq_notification'
+NOTIFICATION_TITLE = 'MyQ Cover Setup'
 
 COVER_SCHEMA = vol.Schema({
     vol.Required(CONF_TYPE): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string
 })
-
-DEFAULT_NAME = 'myq'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -33,23 +40,28 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     brand = config.get(CONF_TYPE)
-
-    logger = logging.getLogger(__name__)
-
+    persistent_notification = loader.get_component('persistent_notification')
     myq = pymyq(username, password, brand)
 
-    if not myq.is_supported_brand():
-        logger.error("Unsupported type. See documentation")
-        return
-
-    if not myq.is_login_valid():
-        logger.error("Username or Password is incorrect")
-        return
-
     try:
+        if not myq.is_supported_brand():
+            raise ValueError("Unsupported type. See documentation")
+
+        if not myq.is_login_valid():
+            raise ValueError("Username or Password is incorrect")
+
         add_devices(MyQDevice(myq, door) for door in myq.get_garage_doors())
+        return True
+
     except (TypeError, KeyError, NameError) as ex:
-        logger.error("%s", ex)
+        _LOGGER.error("%s", ex)
+        persistent_notification.create(
+            hass, 'Error: {}<br />'
+            'You will need to restart hass after fixing.'
+            ''.format(ex),
+             title=NOTIFICATION_TITLE,
+             notification_id=NOTIFICATION_ID)
+        return False
 
 
 class MyQDevice(CoverDevice):

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -53,7 +53,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         add_devices(MyQDevice(myq, door) for door in myq.get_garage_doors())
         return True
 
-    except (TypeError, KeyError, NameError) as ex:
+    except (TypeError, KeyError, NameError, ValueError) as ex:
         _LOGGER.error("%s", ex)
         persistent_notification.create(
             hass, 'Error: {}<br />'

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -18,7 +18,7 @@ REQUIREMENTS = [
     'https://github.com/arraylabs/pymyq/archive/v0.0.8.zip'
     '#pymyq==0.0.8']
 
-_LOGGER = logging.get_LOGGER(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 DEFAULT_ENTITY_NAMESPACE = 'myq'
 DEFAULT_NAME = 'myq'


### PR DESCRIPTION
## Description:
* Added persistent error message if cover.myq fails to load. 

## Example entry for `configuration.yaml` (if applicable):
```yaml
#cover.yaml
- platform: myq
  username: !secret myq_username
  password: !secret myq_password
  type: chamberlain
```
## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.