### PR TITLE
Spotify aliases

### DIFF
--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -54,7 +54,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_CLIENT_SECRET): cv.string,
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_CACHE_PATH): cv.string,
-    vol.Optional(CONF_ALIASES, {}): {cv.string: cv.string}
+    vol.Optional(CONF_ALIASES, default={}): {cv.string: cv.string}
 })
 
 SCAN_INTERVAL = timedelta(seconds=30)

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -120,7 +120,7 @@ class SpotifyAuthCallbackView(HomeAssistantView):
 class SpotifyMediaPlayer(MediaPlayerDevice):
     """Representation of a Spotify controller."""
 
-    def __init__(self, oauth, name, aliases={}):
+    def __init__(self, oauth, name, aliases):
         """Initialize."""
         self._name = name
         self._oauth = oauth

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -40,6 +40,7 @@ AUTH_CALLBACK_NAME = 'api:spotify'
 ICON = 'mdi:spotify'
 DEFAULT_NAME = 'Spotify'
 DOMAIN = 'spotify'
+CONF_ALIASES = 'aliases'
 CONF_CLIENT_ID = 'client_id'
 CONF_CLIENT_SECRET = 'client_secret'
 CONF_CACHE_PATH = 'cache_path'
@@ -52,7 +53,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_CLIENT_ID): cv.string,
     vol.Required(CONF_CLIENT_SECRET): cv.string,
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_CACHE_PATH): cv.string
+    vol.Optional(CONF_CACHE_PATH): cv.string,
+    vol.Optional(CONF_ALIASES, {}): { cv.string: cv.string }
 })
 
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -89,7 +91,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         configurator = get_component('configurator')
         configurator.request_done(hass.data.get(DOMAIN))
         del hass.data[DOMAIN]
-    player = SpotifyMediaPlayer(oauth, config.get(CONF_NAME, DEFAULT_NAME))
+    player = SpotifyMediaPlayer(oauth, config.get(CONF_NAME, DEFAULT_NAME),
+                                config[CONF_ALIASES])
     add_devices([player], True)
 
 
@@ -117,7 +120,7 @@ class SpotifyAuthCallbackView(HomeAssistantView):
 class SpotifyMediaPlayer(MediaPlayerDevice):
     """Representation of a Spotify controller."""
 
-    def __init__(self, oauth, name):
+    def __init__(self, oauth, name, aliases={}):
         """Initialize."""
         self._name = name
         self._oauth = oauth
@@ -128,10 +131,11 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         self._image_url = None
         self._state = STATE_UNKNOWN
         self._current_device = None
-        self._devices = None
+        self._devices = {}
         self._volume = None
         self._shuffle = False
         self._player = None
+        self._aliases = aliases
         self._token_info = self._oauth.get_cached_token()
 
     def refresh_spotify_instance(self):
@@ -156,8 +160,15 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         # Available devices
         devices = self._player.devices().get('devices')
         if devices is not None:
-            self._devices = {device.get('name'): device.get('id')
+            current_device_keys = self._devices.keys()
+            self._devices = {self._aliases.get(device.get('id'),
+                                               device.get('name')):
+                                    device.get('id')
                              for device in devices}
+            shared_items = \
+                set(current_device_keys) & set(self._devices.keys())
+            if len(shared_items) != len(current_device_keys):
+                _LOGGER.info('Devices: %s', str(self._devices))
         # Current playback state
         current = self._player.current_playback()
         if current is None:

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -158,7 +158,9 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         """Update state and attributes."""
         self.refresh_spotify_instance()
         # Available devices
-        devices = self._player.devices().get('devices')
+        player_devices = self._player.devices()
+        if player_devices is not None:
+            devices = player_devices.get('devices')
         if devices is not None:
             old_devices = self._devices
             self._devices = {self._aliases.get(device.get('id'),

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -54,7 +54,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_CLIENT_SECRET): cv.string,
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_CACHE_PATH): cv.string,
-    vol.Optional(CONF_ALIASES, {}): { cv.string: cv.string }
+    vol.Optional(CONF_ALIASES, {}): {cv.string: cv.string}
 })
 
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -160,15 +160,15 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         # Available devices
         devices = self._player.devices().get('devices')
         if devices is not None:
-            current_device_keys = self._devices.keys()
+            old_devices = self._devices
             self._devices = {self._aliases.get(device.get('id'),
                                                device.get('name')):
-                                    device.get('id')
+                             device.get('id')
                              for device in devices}
-            device_diff = {name:id for name, id in self._devices.items()
+            device_diff = {name: id for name, id in self._devices.items()
                            if old_devices.get(name, None) is None}
             if len(device_diff) > 0:
-              _LOGGER.info("New Devices: %s", str(device_diff))
+                _LOGGER.info("New Devices: %s", str(device_diff))
         # Current playback state
         current = self._player.current_playback()
         if current is None:

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -165,10 +165,10 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
                                                device.get('name')):
                                     device.get('id')
                              for device in devices}
-            shared_items = \
-                set(current_device_keys) & set(self._devices.keys())
-            if len(shared_items) != len(current_device_keys):
-                _LOGGER.info('Devices: %s', str(self._devices))
+            device_diff = {name:id for name, id in self._devices.items()
+                           if old_devices.get(name, None) is None}
+            if len(device_diff) > 0:
+              _LOGGER.info("New Devices: %s", str(device_diff))
         # Current playback state
         current = self._player.current_playback()
         if current is None:


### PR DESCRIPTION
## Description:
Spotify some times doesn't respect device names, or just names them terribly. This adds ability to alias the media player instances and logs out new devices to `info` for ease of aliasing.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2684

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: spotify
    client_id: <your client id>
    client_secret: <your client secret>
    aliases:
        abc123def456: 'Living Room'
        9183abas000: 'Bed Room'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
