### PR TITLE
Upgrade python-telegram-bot to 6.0.1

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -22,47 +22,51 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.setup import async_prepare_setup_platform
 
-DOMAIN = 'telegram_bot'
-REQUIREMENTS = ['python-telegram-bot==5.3.1']
+REQUIREMENTS = ['python-telegram-bot==6.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 
-EVENT_TELEGRAM_COMMAND = 'telegram_command'
-EVENT_TELEGRAM_TEXT = 'telegram_text'
-EVENT_TELEGRAM_CALLBACK = 'telegram_callback'
-
-PARSER_MD = 'markdown'
-PARSER_HTML = 'html'
-ATTR_TEXT = 'text'
-ATTR_COMMAND = 'command'
-ATTR_USER_ID = 'user_id'
 ATTR_ARGS = 'args'
-ATTR_MSG = 'message'
-ATTR_EDITED_MSG = 'edited_message'
-ATTR_CHAT_INSTANCE = 'chat_instance'
-ATTR_CHAT_ID = 'chat_id'
-ATTR_MSGID = 'id'
-ATTR_FROM_FIRST = 'from_first'
-ATTR_FROM_LAST = 'from_last'
-ATTR_SHOW_ALERT = 'show_alert'
-ATTR_MESSAGEID = 'message_id'
-ATTR_PARSER = 'parse_mode'
-ATTR_DISABLE_NOTIF = 'disable_notification'
-ATTR_DISABLE_WEB_PREV = 'disable_web_page_preview'
-ATTR_REPLY_TO_MSGID = 'reply_to_message_id'
-ATTR_REPLYMARKUP = 'reply_markup'
 ATTR_CALLBACK_QUERY = 'callback_query'
 ATTR_CALLBACK_QUERY_ID = 'callback_query_id'
-ATTR_TARGET = 'target'
+ATTR_CAPTION = 'caption'
+ATTR_CHAT_ID = 'chat_id'
+ATTR_CHAT_INSTANCE = 'chat_instance'
+ATTR_COMMAND = 'command'
+ATTR_DISABLE_NOTIF = 'disable_notification'
+ATTR_DISABLE_WEB_PREV = 'disable_web_page_preview'
+ATTR_EDITED_MSG = 'edited_message'
+ATTR_FILE = 'file'
+ATTR_FROM_FIRST = 'from_first'
+ATTR_FROM_LAST = 'from_last'
 ATTR_KEYBOARD = 'keyboard'
 ATTR_KEYBOARD_INLINE = 'inline_keyboard'
-ATTR_URL = 'url'
-ATTR_FILE = 'file'
-ATTR_CAPTION = 'caption'
-ATTR_USERNAME = 'username'
+ATTR_MESSAGEID = 'message_id'
+ATTR_MSG = 'message'
+ATTR_MSGID = 'id'
+ATTR_PARSER = 'parse_mode'
 ATTR_PASSWORD = 'password'
+ATTR_REPLY_TO_MSGID = 'reply_to_message_id'
+ATTR_REPLYMARKUP = 'reply_markup'
+ATTR_SHOW_ALERT = 'show_alert'
+ATTR_TARGET = 'target'
+ATTR_TEXT = 'text'
+ATTR_URL = 'url'
+ATTR_USER_ID = 'user_id'
+ATTR_USERNAME = 'username'
+
 CONF_ALLOWED_CHAT_IDS = 'allowed_chat_ids'
 CONF_TRUSTED_NETWORKS = 'trusted_networks'
+
+DOMAIN = 'telegram_bot'
+
+EVENT_TELEGRAM_CALLBACK = 'telegram_callback'
+EVENT_TELEGRAM_COMMAND = 'telegram_command'
+EVENT_TELEGRAM_TEXT = 'telegram_text'
+
+PARSER_HTML = 'html'
+PARSER_MD = 'markdown'
+
 DEFAULT_TRUSTED_NETWORKS = [
     ip_network('149.154.167.197/32'),
     ip_network('149.154.167.198/31'),
@@ -81,7 +85,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(ATTR_PARSER, default=PARSER_MD): cv.string,
         vol.Optional(CONF_TRUSTED_NETWORKS, default=DEFAULT_TRUSTED_NETWORKS):
             vol.All(cv.ensure_list, [ip_network])
-    })
+    }),
 }, extra=vol.ALLOW_EXTRA)
 
 BASE_SERVICE_SCHEMA = vol.Schema({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -684,7 +684,7 @@ python-roku==3.1.3
 python-synology==0.1.0
 
 # homeassistant.components.telegram_bot
-python-telegram-bot==5.3.1
+python-telegram-bot==6.0.1
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0


### PR DESCRIPTION
## 6.0.1
- Add support for ``User.language_code``
- Fix ``Message.text_html`` and ``Message.text_markdown`` for messages with emoji

## 6.0.0

- Add support for Bot API 2.3.1
- Add support for ``deleteMessage`` API method
- New, simpler API for ``JobQueue`` - https://github.com/python-telegram-bot/python-telegram-bot/pull/484
- Download files into file-like objects - https://github.com/python-telegram-bot/python-telegram-bot/pull/459
- Use vendor ``urllib3`` to address issues with timeouts
  - The default timeout for messages is now 5 seconds. For sending media, the default timeout is now 20 seconds.
- String attributes that are not set are now ``None`` by default, instead of empty strings
- Add ``text_markdown`` and ``text_html`` properties to ``Message`` - https://github.com/python-telegram-bot/python-telegram-bot/pull/507
- Add support for Socks5 proxy - https://github.com/python-telegram-bot/python-telegram-bot/pull/518
- Add support for filters in ``CommandHandler`` - https://github.com/python-telegram-bot/python-telegram-bot/pull/536
- Add the ability to invert (not) filters - https://github.com/python-telegram-bot/python-telegram-bot/pull/552
- Add ``Filters.group`` and ``Filters.private``
- Compatibility with GAE via ``urllib3.contrib`` package - https://github.com/python-telegram-bot/python-telegram-bot/pull/583
- Add equality rich comparision operators to telegram objects - https://github.com/python-telegram-bot/python-telegram-bot/pull/604
- Several bugfixes and other improvements
- Remove some deprecated code

Tested with the following configuration:

``` yaml
telegram_bot:
  platform: polling
  api_key: !secret telegram_api
  allowed_chat_ids:
    - !secret telegram_client

notify:
  - platform: telegram
    name: telegram
    chat_id: !secret telegram_client
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```