### PR TITLE
WIP: Automation timer

### DIFF
--- a/homeassistant/components/automation/timer.py
+++ b/homeassistant/components/automation/timer.py
@@ -1,0 +1,161 @@
+import asyncio
+import logging
+import voluptuous as vol
+from datetime import timedelta
+
+from homeassistant.const import (ATTR_ENTITY_ID, CONF_ICON, CONF_NAME, CONF_DURATION, STATE_RUNNING, STATE_STOPPED, SERVICE_TIMER_START, SERVICE_TIMER_RESTART, SERVICE_TIMER_CANCEL)
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+
+DOMAIN = 'timer'
+SCAN_INTERVAL = timedelta(seconds=30)
+
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+})
+
+SERVICE_START_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(CONF_DURATION): cv.time_period,
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        cv.slug: vol.Any({
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Required(CONF_DURATION): cv.time_period,
+            vol.Optional(CONF_ICON): cv.icon,
+        }, None)
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Track states and offer events for binary sensors."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
+
+    entities = []
+
+    for object_id, cfg in config[DOMAIN].items():
+        if not cfg:
+            cfg = {}
+
+        name = cfg.get(CONF_NAME)
+        duration = cfg.get(CONF_DURATION)
+        icon = cfg.get(CONF_ICON)
+
+        entities.append(Timer(object_id, name, duration, icon))
+
+    if not entities:
+        return False
+
+    @asyncio.coroutine
+    def async_timer_start_service(call):
+        """Handle a calls to the input select option service."""
+        target_inputs = component.async_extract_from_service(call)
+
+        tasks = [timer.async_start(call.data[CONF_DURATION])
+                 for timer in target_inputs]
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_TIMER_START, async_timer_start_service, schema=SERVICE_START_SCHEMA)
+
+    @asyncio.coroutine
+    def async_handler_service(call):
+        """Handle a calls to the input boolean services."""
+        target_inputs = component.async_extract_from_service(call)
+
+        if call.service == SERVICE_TIMER_RESTART:
+            attr = 'async_restart'
+        elif call.service == SERVICE_TIMER_CANCEL:
+            attr = 'async_cancel'
+
+        tasks = [getattr(input_b, attr)() for input_b in target_inputs]
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_TIMER_RESTART, async_handler_service, schema=SERVICE_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_TIMER_CANCEL, async_handler_service, schema=SERVICE_SCHEMA)
+
+    yield from component.async_setup(config)
+    return True
+
+class Timer(Entity):
+    """Represent a countdown timer."""
+
+    def __init__(self, object_id, name, duration, icon):
+        """Initialize a boolean input."""
+        self.entity_id = ENTITY_ID_FORMAT.format(object_id)
+        self._name = name
+        self._duration = duration
+        self._is_running = False
+        self._icon = icon
+
+    @property
+    def should_poll(self):
+        """If entity should be polled."""
+        return False
+
+    @property
+    def is_running(self):
+        """Whether the timer is currently running."""
+        return self._is_running
+
+    @property
+    def state(self):
+        """Return the state of the timer."""
+        return STATE_RUNNING if self.is_running else STATE_STOPPED
+
+    @asyncio.coroutine
+    def async_start(self, duration=None):
+        """Turn the entity on."""
+
+        if self._is_running:
+            return
+
+        if duration:
+            # TODO: Override the duration
+
+
+
+        # TODO: Start the timer
+
+        # TODO: Fire start event
+
+        self._is_running = True
+
+        yield from self.async_update_ha_state()
+
+    @asyncio.coroutine
+    def async_restart(self):
+        if not self._is_running:
+            return
+
+        # TODO: Fire a restart event
+        # TODO: Cancel previous timer
+        # TODO: Start new timer
+
+
+    @asyncio.coroutine
+    def async_cancel(self):
+        if not self._is_running:
+            return
+
+        # TODO: Cancel previous timer
+        # TODO: Fire cancellation event
+
+        self._is_running = False
+
+        yield from self.async_update_ha_state()
+

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -88,6 +88,7 @@ CONF_DISCOVERY = 'discovery'
 CONF_DISPLAY_OPTIONS = 'display_options'
 CONF_DOMAIN = 'domain'
 CONF_DOMAINS = 'domains'
+CONF_DURATION = 'duration'
 CONF_EFFECT = 'effect'
 CONF_ELEVATION = 'elevation'
 CONF_EMAIL = 'email'
@@ -194,6 +195,8 @@ STATE_ALARM_TRIGGERED = 'triggered'
 STATE_LOCKED = 'locked'
 STATE_UNLOCKED = 'unlocked'
 STATE_UNAVAILABLE = 'unavailable'
+STATE_RUNNING = 'running'
+STATE_STOPPED = 'stopped'
 
 # #### STATE AND EVENT ATTRIBUTES ####
 # Attribution
@@ -348,6 +351,10 @@ SERVICE_STOP_COVER = 'stop_cover'
 SERVICE_STOP_COVER_TILT = 'stop_cover_tilt'
 
 SERVICE_SELECT_OPTION = 'select_option'
+
+SERVICE_TIMER_START = 'timer_start'
+SERVICE_TIMER_RESTART = 'timer_restart'
+SERVICE_TIMER_CANCEL = 'timer_cancel'
 
 # #### API / REMOTE ####
 SERVER_PORT = 8123


### PR DESCRIPTION
**THIS IS A WORK IN PROGRESS - DO NOT MERGE YET**

*(The implementation may not precisely match the description here - I will be working on that over the next few days)*

## Description:

**I'd like to propose a new automation component: a countdown timer.**  It would greatly simplify any automations which perform delayed actions, especially if that delay needs to be restarted or aborted due to future triggers.

## The Problem

Let's say we want to automate our outdoor z-wave lights - they should turn on for 10 minutes when motion is detected.  The cookbook has a simple example: https://home-assistant.io/cookbook/turn_on_light_for_10_minutes_when_motion_detected/  However, there are several issues:

1. The functionality to turn off the light requires you to know the current state.  However, Z-Wave device polling may not be configured to poll frequently enough (or at all), thus keeping the lights on longer than desired (or possibly indefinitely).
2. If I get the state polling to work, I have another problem - the light will ALWAYS turn off after 10 minutes, even if I turn it on manually (not activated by motion).  What if I want to keep the light on for a few hours?
3. The problems above multiply if I want to activate multiple lights.  How do I make them all turn on/off?  Do I monitor the state of just one light?  Do I duplicate the automation code to monior each light individually?  Or do I create a dummy entity and monitor its state for 10 minutes?
4. Even if I resolve all three issues above, there's yet another problem: if a second motion event occurs 9 minutes after the first one, my lights won't stay on for another 10 minutes - they'll shut off after 1!

## Proposed Solution

Instead of implementing complicated workarounds, I propose we introduce a new automation component: the timer.  It is a simple entity that is configured to countdown a certain amount of time (say, 10 minutes).

## Example entry for `configuration.yaml`:
```yaml
timer:
  # Define a new 10 minute timer to use in our automations
  outside_motion:
    duration: 10:00
```

## Example automation:

```yaml
automation:
- alias: Turn on front door light for 10 minutes when there is movement
  trigger:
    platform: state
    entity_id: sensor.outside_motion_sensor
    state: 'on'
  action:
    - service: timer.restart
      entity_id: timer.outside_motion
    - service: homeassistant.turn_on
      entity_id: light.front_door

- alias: Turn off front door light when motion timer expires
  trigger:
    platform: timer
    entity_id: timer.outside_motion
    event: ended
  action:
    service: homeassistant.turn_off
    entity_id: light.front_door

- alias: Cancel timer and shut off lights when I come home
  trigger:
    platform: zone
    entity_id: device_tracker.paulus
    zone: zone.home
    event: enter
  condition:
    condition: state
    entity_id: timer.outside_motion
    state: running
  action:
    - service: timer.cancel
      entity_id: timer.outside_motion
    - service: homeassistant.turn_off
      entity_id: light.front_door

```

## Proposed Implementation

It would have the following methods/services available:

 - Attributes:
   - `state`
   - `duration`
 - Methods / Services
   - `start()` / `timer.start`
   - `restart()` / `timer.restart`
   - `cancel()` / `timer.cancel`
 - Trigger Events:
   - `started`
   - `ended`
   - `canceled`

### `state`

Returns a constant of `STATE_TIMER_RUNNING = 'running'` or `STATE_TIMER_STOPPED = 'stopped'`.

### `duration`

How long the timer is configured to run for.  Configured as a `cv.time_period`.

### `start()` / `timer.start`

Starts the countdown if the timer is not already running.  Has no effect on running timers.

### `restart` / `timer.restart`

Resets and starts the countdown regardless of whether the timer is running or not.  Useful for things like motion events.

The timer would also have a `restart` method/service.  This can be called on any running timer to make it start counting down from the starting time again.  In my example, I would call `restart` every time motion is detected.  This would ensure that my lights always stay on for 10 minutes.

### `cancel` / `timer.cancel`

Stops the countdown if the timer is running.  Has no effect on stopped/canceled timers which are not running.

Lastly, the timer would have a `cancel` method/service.  This would immediately stop a running timer without triggering the automations.  In my example, this could be used to abort the 10 minute countdown and keep my lights on indefinitely (until I chose to shut them off myself).

### `started`

Trigger event fired whenever a timer is started or restarted.  Includes the `entity_id` of the timer.

```yml
  trigger:
    platform: timer
    entity_id: timer.outside_motion
    event: started
```

### `ended`

Trigger event fired whenever a timer has reached the end of its countdown.  Includes the `entity_id` of the timer.

```yml
  trigger:
    platform: timer
    entity_id: timer.outside_motion
    event: ended
```

### `canceled`

Trigger event fired whenever a running timer has been cancelled.  Includes the `entity_id` of the timer.

```yml
  trigger:
    platform: timer
    entity_id: timer.outside_motion
    event: canceled
```

## Feedback

At this point I'm really looking for the following feedback:

 - Are you open to this idea?
 - Is my implementation on the right track?
 - Are there any important features I'm missing?
   - I'm sure there are several "nice-to-have" ideas, but I'd like to focus on the core functionality first.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** **TODO**

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
