### PR TITLE
Updater improvements to send option component information

### DIFF
--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -32,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_RELEASE_NOTES = 'release_notes'
 
 CONF_REPORTING = 'reporting'
-CONF_COMPONENT_REPORTING = 'share_components_info'
+CONF_COMPONENT_REPORTING = 'include_used_components'
 
 DOMAIN = 'updater'
 

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -90,7 +90,7 @@ def async_setup(hass, config):
     @asyncio.coroutine
     def check_new_version(now):
         """Check if a new version is available and report if one is."""
-        result = yield from get_newest_version(hass, huuid, 
+        result = yield from get_newest_version(hass, huuid,
                                                include_components)
 
         if result is None:
@@ -136,8 +136,6 @@ def get_system_info(hass, include_components):
 
     if include_components:
         info_object['components'] = list(hass.config.components)
-    #info_object['components'] = list(hass.config.components)
-
 
     if platform.system() == 'Windows':
         info_object['os_version'] = platform.win32_ver()[0]

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -85,10 +85,13 @@ def async_setup(hass, config):
     else:
         huuid = None
 
+    include_components = config.get(CONF_COMPONENT_REPORTING)
+
     @asyncio.coroutine
     def check_new_version(now):
         """Check if a new version is available and report if one is."""
-        result = yield from get_newest_version(hass, huuid, config)
+        result = yield from get_newest_version(hass, huuid, 
+                                               include_components)
 
         if result is None:
             return
@@ -118,7 +121,7 @@ def async_setup(hass, config):
 
 
 @asyncio.coroutine
-def get_system_info(hass, config):
+def get_system_info(hass, include_components):
     """Return info about the system."""
     info_object = {
         'arch': platform.machine(),
@@ -131,8 +134,10 @@ def get_system_info(hass, config):
         'virtualenv': os.environ.get('VIRTUAL_ENV') is not None,
     }
 
-    if config.get(CONF_COMPONENT_REPORTING):
+    if include_components:
         info_object['components'] = list(hass.config.components)
+    #info_object['components'] = list(hass.config.components)
+
 
     if platform.system() == 'Windows':
         info_object['os_version'] = platform.win32_ver()[0]
@@ -152,10 +157,10 @@ def get_system_info(hass, config):
 
 
 @asyncio.coroutine
-def get_newest_version(hass, huuid, config):
+def get_newest_version(hass, huuid, include_components):
     """Get the newest Home Assistant version."""
     if huuid:
-        info_object = yield from get_system_info(hass, config)
+        info_object = yield from get_system_info(hass, include_components)
         info_object['huuid'] = huuid
     else:
         info_object = {}

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -19,6 +19,9 @@ MOCK_RESPONSE = {
     'version': '0.15',
     'release-notes': 'https://home-assistant.io'
 }
+MOCK_CONFIG = {updater.DOMAIN: {
+    'reporting': True
+}}
 
 
 @pytest.fixture
@@ -94,9 +97,26 @@ def test_disable_reporting(hass, mock_get_uuid, mock_get_newest_version):
         yield from hass.async_block_till_done()
 
     assert hass.states.get(updater.ENTITY_ID) is None
+    res = yield from updater.get_newest_version(hass, MOCK_HUUID, MOCK_CONFIG)
     call = mock_get_newest_version.mock_calls[0][1]
     assert call[0] is hass
     assert call[1] is None
+
+
+@asyncio.coroutine
+def test_enabled_component_info(hass, mock_get_uuid):
+    """Test if new entity is created if new version is available."""
+    with patch('homeassistant.components.updater.platform.system', Mock(return_value="junk")):
+        res = yield from updater.get_system_info(hass, True)
+        assert 'components' in res, 'Updater failed to generate component list'
+
+
+@asyncio.coroutine
+def test_disable_component_info(hass, mock_get_uuid):
+    """Test if new entity is created if new version is available."""
+    with patch('homeassistant.components.updater.platform.system', Mock(return_value="junk")):
+        res = yield from updater.get_system_info(hass, False)
+        assert 'components' not in res, 'Updater failed to NOT generate component list'
 
 
 @asyncio.coroutine
@@ -106,7 +126,7 @@ def test_get_newest_version_no_analytics_when_no_huuid(hass, aioclient_mock):
 
     with patch('homeassistant.components.updater.get_system_info',
                side_effect=Exception):
-        res = yield from updater.get_newest_version(hass, None)
+        res = yield from updater.get_newest_version(hass, None, False)
         assert res == (MOCK_RESPONSE['version'],
                        MOCK_RESPONSE['release-notes'])
 
@@ -118,7 +138,7 @@ def test_get_newest_version_analytics_when_huuid(hass, aioclient_mock):
 
     with patch('homeassistant.components.updater.get_system_info',
                Mock(return_value=mock_coro({'fake': 'bla'}))):
-        res = yield from updater.get_newest_version(hass, MOCK_HUUID)
+        res = yield from updater.get_newest_version(hass, MOCK_HUUID, False)
         assert res == (MOCK_RESPONSE['version'],
                        MOCK_RESPONSE['release-notes'])
 
@@ -129,7 +149,7 @@ def test_error_fetching_new_version_timeout(hass):
     with patch('homeassistant.components.updater.get_system_info',
                Mock(return_value=mock_coro({'fake': 'bla'}))), \
             patch('async_timeout.timeout', side_effect=asyncio.TimeoutError):
-        res = yield from updater.get_newest_version(hass, MOCK_HUUID)
+        res = yield from updater.get_newest_version(hass, MOCK_HUUID, False)
         assert res is None
 
 
@@ -140,7 +160,7 @@ def test_error_fetching_new_version_bad_json(hass, aioclient_mock):
 
     with patch('homeassistant.components.updater.get_system_info',
                Mock(return_value=mock_coro({'fake': 'bla'}))):
-        res = yield from updater.get_newest_version(hass, MOCK_HUUID)
+        res = yield from updater.get_newest_version(hass, MOCK_HUUID, False)
         assert res is None
 
 
@@ -154,5 +174,5 @@ def test_error_fetching_new_version_invalid_response(hass, aioclient_mock):
 
     with patch('homeassistant.components.updater.get_system_info',
                Mock(return_value=mock_coro({'fake': 'bla'}))):
-        res = yield from updater.get_newest_version(hass, MOCK_HUUID)
+        res = yield from updater.get_newest_version(hass, MOCK_HUUID, False)
         assert res is None

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -106,7 +106,8 @@ def test_disable_reporting(hass, mock_get_uuid, mock_get_newest_version):
 @asyncio.coroutine
 def test_enabled_component_info(hass, mock_get_uuid):
     """Test if new entity is created if new version is available."""
-    with patch('homeassistant.components.updater.platform.system', Mock(return_value="junk")):
+    with patch('homeassistant.components.updater.platform.system',
+               Mock(return_value="junk")):
         res = yield from updater.get_system_info(hass, True)
         assert 'components' in res, 'Updater failed to generate component list'
 
@@ -114,9 +115,10 @@ def test_enabled_component_info(hass, mock_get_uuid):
 @asyncio.coroutine
 def test_disable_component_info(hass, mock_get_uuid):
     """Test if new entity is created if new version is available."""
-    with patch('homeassistant.components.updater.platform.system', Mock(return_value="junk")):
+    with patch('homeassistant.components.updater.platform.system',
+               Mock(return_value="junk")):
         res = yield from updater.get_system_info(hass, False)
-        assert 'components' not in res, 'Updater failed to NOT generate component list'
+        assert 'components' not in res, 'Updater failed, components generate'
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2698

## Example entry for `configuration.yaml` (if applicable):
```yaml
updater:
  share_components_info: true
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
