### PR TITLE
Constrain requests to a version

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,4 +1,4 @@
-requests>=2,<3
+requests==2.14.2
 pyyaml>=3.11,<4
 pytz>=2017.02
 pip>=7.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,5 +1,5 @@
 # Home Assistant core
-requests>=2,<3
+requests==2.14.2
 pyyaml>=3.11,<4
 pytz>=2017.02
 pip>=7.1.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ DOWNLOAD_URL = ('{}/archive/'
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
 REQUIRES = [
-    'requests>=2,<3',
+    'requests==2.14.2',
     'pyyaml>=3.11,<4',
     'pytz>=2017.02',
     'pip>=7.1.0',


### PR DESCRIPTION
## Description:
Package fun again! 🎉 

We did not pin the version of requests and so some people managed to pull in different versions as a dependency compared to what was installed when Home Assistant was installed. This pins it.
