### PR TITLE
Asuswrt continuous ssh

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -349,11 +349,11 @@ class SshConnection(_Connection):
     def connect(self):
         """Connect to the ASUS-WRT SSH server."""
         if self._ssh_key:
-            self._ssh.login(host=self._host, port=self._port,
-                            username=self._username, ssh_key=self._ssh_key)
+            self._ssh.login(host=self._host, username=self._username,
+                            ssh_key=self._ssh_key, port=self._port)
         else:
-            self._ssh.login(host=self._host, port=self._port,
-                            username=self._username, password=self._password)
+            self._ssh.login(host=self._host, username=self._username,
+                            password=self._password, port=self._port)
 
         super(SshConnection, self).connect()
 

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -349,10 +349,10 @@ class SshConnection(_Connection):
     def connect(self):
         """Connect to the ASUS-WRT SSH server."""
         if self._ssh_key:
-            self._ssh.login(host=self._host, username=self._username,
+            self._ssh.login(self._host, self._username,
                             ssh_key=self._ssh_key, port=self._port)
         else:
-            self._ssh.login(host=self._host, username=self._username,
+            self._ssh.login(self._host, self._username,
                             password=self._password, port=self._port)
 
         super(SshConnection, self).connect()

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -279,12 +279,15 @@ class _Connection:
 
     @property
     def connected(self):
+        """Return connection state."""
         return self._connected
 
     def connect(self):
+        """Mark currenct connection state as connected."""
         self._connected = True
 
     def disconnect(self):
+        """Mark current connection state as disconnected."""
         self._connected = False
 
 
@@ -380,6 +383,7 @@ class TelnetConnection(_Connection):
         self._username = username
         self._password = password
         self._ap = ap
+        self._prompt_string = None
 
     def get_result(self):
         """Retrieve a single AsusWrtResult through a Telnet connection.
@@ -431,11 +435,11 @@ class TelnetConnection(_Connection):
 
     def connect(self):
         """Connect to the ASUS-WRT Telnet server."""
-        self._telnet = telnetlib.Telnet(self.host)
+        self._telnet = telnetlib.Telnet(self._host)
         self._telnet.read_until(b'login: ')
-        self._telnet.write((self.username + '\n').encode('ascii'))
+        self._telnet.write((self._username + '\n').encode('ascii'))
         self._telnet.read_until(b'Password: ')
-        self._telnet.write((self.password + '\n').encode('ascii'))
+        self._telnet.write((self._password + '\n').encode('ascii'))
         self._prompt_string = self._telnet.read_until(b'#').split(b'\n')[-1]
 
         super(TelnetConnection, self).connect()
@@ -443,8 +447,8 @@ class TelnetConnection(_Connection):
     def disconnect(self):
         """Disconnect the current Telnet connection."""
         try:
-            self._ssh.logout()
-        except:
+            self._telnet.write('exit\n'.encode('ascii'))
+        except Exception:
             pass
 
         super(TelnetConnection, self).disconnect()

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -360,11 +360,12 @@ class SshConnection(_Connection):
 
         super(SshConnection, self).connect()
 
-    def disconnect(self):
+    def disconnect(self):   \
+            # pylint: disable=broad-except
         """Disconnect the current SSH connection."""
         try:
             self._ssh.logout()
-        except:
+        except Exception:
             pass
 
         super(SshConnection, self).disconnect()
@@ -444,7 +445,8 @@ class TelnetConnection(_Connection):
 
         super(TelnetConnection, self).connect()
 
-    def disconnect(self):
+    def disconnect(self):   \
+            # pylint: disable=broad-except
         """Disconnect the current Telnet connection."""
         try:
             self._telnet.write('exit\n'.encode('ascii'))

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -348,9 +348,12 @@ class SshConnection(_Connection):
 
     def connect(self):
         """Connect to the ASUS-WRT SSH server."""
-        self._ssh.login(host=self._host, port=self._port,
-                        username=self._username, password=self._password,
-                        ssh_key=self._ssh_key)
+        if self._ssh_key:
+            self._ssh.login(host=self._host, port=self._port,
+                            username=self._username, ssh_key=self._ssh_key)
+        else:
+            self._ssh.login(host=self._host, port=self._port,
+                            username=self._username, password=self._password)
 
         super(SshConnection, self).connect()
 

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -160,7 +160,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         update_mock.start()
         self.addCleanup(update_mock.stop)
         asuswrt = device_tracker.asuswrt.AsusWrtDeviceScanner(conf_dict)
-        asuswrt.onnection.get_result()
+        asuswrt.connection.get_result()
         self.assertEqual(ssh.login.call_count, 1)
         self.assertEqual(
             ssh.login.call_args,

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -139,7 +139,8 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.assertEqual(ssh.login.call_count, 1)
         self.assertEqual(
             ssh.login.call_args,
-            mock.call('fake_host', 'fake_user', port=22, ssh_key=FAKEFILE)
+            mock.call(host='fake_host', username='fake_user',
+                      ssh_key=FAKEFILE, port=22)
         )
 
     def test_ssh_login_with_password(self):
@@ -164,7 +165,8 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.assertEqual(ssh.login.call_count, 1)
         self.assertEqual(
             ssh.login.call_args,
-            mock.call('fake_host', 'fake_user', password='fake_pass', port=22)
+            mock.call(host='fake_host', username='fake_user',
+                      password='fake_pass', port=22)
         )
 
     def test_ssh_login_without_password_or_pubkey(self):  \

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -139,7 +139,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.assertEqual(ssh.login.call_count, 1)
         self.assertEqual(
             ssh.login.call_args,
-            mock.call(host='fake_host', username='fake_user',
+            mock.call('fake_host', 'fake_user',
                       ssh_key=FAKEFILE, port=22)
         )
 
@@ -165,7 +165,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.assertEqual(ssh.login.call_count, 1)
         self.assertEqual(
             ssh.login.call_args,
-            mock.call(host='fake_host', username='fake_user',
+            mock.call('fake_host', 'fake_user',
                       password='fake_pass', port=22)
         )
 

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -217,8 +217,8 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.addCleanup(update_mock.stop)
         asuswrt = device_tracker.asuswrt.AsusWrtDeviceScanner(conf_dict)
         asuswrt.connection.get_result()
-        self.assertEqual(telnet.read_until.call_count, 5) # Login + data retrieval
-        self.assertEqual(telnet.write.call_count, 4) # Login + data retrieval
+        self.assertEqual(telnet.read_until.call_count, 5)
+        self.assertEqual(telnet.write.call_count, 4)
         self.assertEqual(
             telnet.read_until.call_args_list[0],
             mock.call(b'login: ')

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -135,7 +135,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         update_mock.start()
         self.addCleanup(update_mock.stop)
         asuswrt = device_tracker.asuswrt.AsusWrtDeviceScanner(conf_dict)
-        asuswrt.ssh_connection()
+        asuswrt.connection.get_result()
         self.assertEqual(ssh.login.call_count, 1)
         self.assertEqual(
             ssh.login.call_args,
@@ -160,7 +160,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         update_mock.start()
         self.addCleanup(update_mock.stop)
         asuswrt = device_tracker.asuswrt.AsusWrtDeviceScanner(conf_dict)
-        asuswrt.ssh_connection()
+        asuswrt.onnection.get_result()
         self.assertEqual(ssh.login.call_count, 1)
         self.assertEqual(
             ssh.login.call_args,

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -196,3 +196,75 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
             assert setup_component(self.hass, DOMAIN,
                                    {DOMAIN: conf_dict})
         ssh.login.assert_not_called()
+
+    def test_telnet_login_with_password(self):
+        """Test that login is done with password when configured to."""
+        telnet = mock.MagicMock()
+        telnet_mock = mock.patch('telnetlib.Telnet', return_value=telnet)
+        telnet_mock.start()
+        self.addCleanup(telnet_mock.stop)
+        conf_dict = PLATFORM_SCHEMA({
+            CONF_PLATFORM: 'asuswrt',
+            CONF_PROTOCOL: 'telnet',
+            CONF_HOST: 'fake_host',
+            CONF_USERNAME: 'fake_user',
+            CONF_PASSWORD: 'fake_pass'
+        })
+        update_mock = mock.patch(
+            'homeassistant.components.device_tracker.asuswrt.'
+            'AsusWrtDeviceScanner.get_asuswrt_data')
+        update_mock.start()
+        self.addCleanup(update_mock.stop)
+        asuswrt = device_tracker.asuswrt.AsusWrtDeviceScanner(conf_dict)
+        asuswrt.connection.get_result()
+        self.assertEqual(telnet.read_until.call_count, 5) # Login + data retrieval
+        self.assertEqual(telnet.write.call_count, 4) # Login + data retrieval
+        self.assertEqual(
+            telnet.read_until.call_args_list[0],
+            mock.call(b'login: ')
+        )
+        self.assertEqual(
+            telnet.write.call_args_list[0],
+            mock.call(b'fake_user\n')
+        )
+        self.assertEqual(
+            telnet.read_until.call_args_list[1],
+            mock.call(b'Password: ')
+        )
+        self.assertEqual(
+            telnet.write.call_args_list[1],
+            mock.call(b'fake_pass\n')
+        )
+        self.assertEqual(
+            telnet.read_until.call_args_list[2],
+            mock.call(b'#')
+        )
+
+    def test_telnet_login_without_password(self):  \
+            # pylint: disable=invalid-name
+        """Test that login is not called without password or pub_key."""
+        telnet = mock.MagicMock()
+        telnet_mock = mock.patch('telnetlib.Telnet', return_value=telnet)
+        telnet_mock.start()
+        self.addCleanup(telnet_mock.stop)
+
+        conf_dict = {
+            CONF_PLATFORM: 'asuswrt',
+            CONF_PROTOCOL: 'telnet',
+            CONF_HOST: 'fake_host',
+            CONF_USERNAME: 'fake_user',
+        }
+
+        with self.assertRaises(vol.Invalid):
+            conf_dict = PLATFORM_SCHEMA(conf_dict)
+
+        update_mock = mock.patch(
+            'homeassistant.components.device_tracker.asuswrt.'
+            'AsusWrtDeviceScanner.get_asuswrt_data')
+        update_mock.start()
+        self.addCleanup(update_mock.stop)
+
+        with assert_setup_component(0):
+            assert setup_component(self.hass, DOMAIN,
+                                   {DOMAIN: conf_dict})
+        telnet.login.assert_not_called()


### PR DESCRIPTION
## Description:
An update to the Asus WRT device tracker component, which changes its low-level behavior: instead of connecting to the SSH or Telnet server upon each iteration, the connection is maintained, and the commands are issued over it.

This change fixes issue #7713, and eliminates the need for repetitive (and unnecessary) logins/logouts.

**Related issue (if applicable):** fixes #7713 

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
