### PR TITLE
Configure conversation for custom actions with keywords

### DIFF
--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import script
 REQUIREMENTS = ['fuzzywuzzy==0.15.0']
 
 ATTR_TEXT = 'text'
-
+ATTR_SENTENCE = 'sentence'
 DOMAIN = 'conversation'
 
 REGEX_TURN_COMMAND = re.compile(r'turn (?P<name>(?: |\w)+) (?P<command>\w+)')
@@ -33,7 +33,7 @@ SERVICE_PROCESS_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({
     cv.string: vol.Schema({
-        vol.Required('keywords'): cv.string,
+        vol.Required(ATTR_SENTENCE): cv.string,
         vol.Required('action'): cv.SCRIPT_SCHEMA,
     })
 })}, extra=vol.ALLOW_EXTRA)
@@ -46,9 +46,8 @@ def setup(hass, config):
 
     logger = logging.getLogger(__name__)
     config = config.get(DOMAIN, {})
-    # Right way to do this-- taken from updater.py
 
-    choices = {attrs['keywords']: script.Script(
+    choices = {attrs[ATTR_SENTENCE]: script.Script(
         hass,
         attrs['action'],
         name)

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -62,10 +62,10 @@ def setup(hass, config):
             match = fuzzyExtract.extractOne(text, choices.keys())
             scorelimit = 60  # arbitrary value
             logging.info(
-                    'matched up text %s and found %s',
-                    text,
-                    [match[0] if match[1] > scorelimit else 'nothing']
-                            )
+                'matched up text %s and found %s',
+                text,
+                [match[0] if match[1] > scorelimit else 'nothing']
+                )
             if match[1] > scorelimit:
                 choices[match[0]].run()  # run respective script
                 return

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -52,7 +52,7 @@ def setup(hass, config):
         hass,
         attrs['action'],
         name)
-        for name, attrs in config.items()}
+               for name, attrs in config.items()}
 
     def process(service):
         """Parse text into commands."""
@@ -61,10 +61,11 @@ def setup(hass, config):
             text = service.data[ATTR_TEXT]
             match = fuzzyExtract.extractOne(text, choices.keys())
             scorelimit = 60  # arbitrary value
-            logging.info('matched up text %s and found %s' % (
-                text, [match[0] if match[1] > scorelimit else 'nothing']
-                )
-            )
+            logging.info(
+                    'matched up text %s and found %s',
+                    text,
+                    [match[0] if match[1] > scorelimit else 'nothing']
+                            )
             if match[1] > scorelimit:
                 choices[match[0]].run()  # run respective script
                 return

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -54,10 +54,8 @@ def setup(hass, config):
         name)
         for name, attrs in config.items()}
 
-
     def process(service):
         """Parse text into commands."""
-
         # if actually configured
         if choices:
             text = service.data[ATTR_TEXT]

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -66,7 +66,8 @@ def setup(hass, config):
             )
         )
         if match[1] > scorelimit:
-            return choices[match[0]].run()  # run respective script
+            choices[match[0]].run()  # run respective script
+            return
 
         text = service.data[ATTR_TEXT]
         match = REGEX_TURN_COMMAND.match(text)

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -41,8 +41,8 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({
 
 def setup(hass, config):
     """Register the process service."""
-    from fuzzywuzzy import process as fuzzyExtract
     warnings.filterwarnings('ignore', module='fuzzywuzzy')
+    from fuzzywuzzy import process as fuzzyExtract
 
     logger = logging.getLogger(__name__)
     config = config.get(DOMAIN, {})

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -52,22 +52,24 @@ def setup(hass, config):
         hass,
         attrs['action'],
         name)
-        for name, attrs in config.items()} or {'': lambda: None}
-# Make sure choices isnt empty
+        for name, attrs in config.items()}
+
 
     def process(service):
         """Parse text into commands."""
 
-        text = service.data[ATTR_TEXT]
-        match = fuzzyExtract.extractOne(text, choices.keys())
-        scorelimit = 60  # arbitrary value
-        logging.info('matched up text %s and found %s' % (
-            text, [match[0] if match[1] > scorelimit else 'nothing']
+        # if actually configured
+        if choices:
+            text = service.data[ATTR_TEXT]
+            match = fuzzyExtract.extractOne(text, choices.keys())
+            scorelimit = 60  # arbitrary value
+            logging.info('matched up text %s and found %s' % (
+                text, [match[0] if match[1] > scorelimit else 'nothing']
+                )
             )
-        )
-        if match[1] > scorelimit:
-            choices[match[0]].run()  # run respective script
-            return
+            if match[1] > scorelimit:
+                choices[match[0]].run()  # run respective script
+                return
 
         text = service.data[ATTR_TEXT]
         match = REGEX_TURN_COMMAND.match(text)

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -52,7 +52,7 @@ def setup(hass, config):
         hass,
         attrs['action'],
         name)
-            for name, attrs in config.items()} or {lambda: None}
+        for name, attrs in config.items()} or {'': lambda: None}
             # Make sure choices isnt empty
 
     def process(service):

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -33,11 +33,12 @@ SERVICE_PROCESS_SCHEMA = vol.Schema({
     vol.Required(ATTR_TEXT): vol.All(cv.string, vol.Lower),
 })
 
-CONFIG_SCHEMA = vol.Schema({DOMAIN: cv.ensure_list(vol.Schema({
-    vol.Required('alias'): cv.string,
-    vol.Required('keywords'): cv.string,
-    vol.Required('action'): cv.SCRIPT_SCHEMA,
-}))}, extra=vol.ALLOW_EXTRA)
+CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({
+    cv.string: vol.Schema({
+        vol.Required('keywords'): cv.string,
+        vol.Required('action'): cv.SCRIPT_SCHEMA,
+    })
+})}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
@@ -47,11 +48,11 @@ def setup(hass, config):
     logger = logging.getLogger(__name__)
     config = config['conversation']
 
-    choices = {c['keywords']: script.Script(
+    choices = {attrs['keywords']: script.Script(
         hass,
-        c['action'],
-        c['alias'],)
-            for c in config}
+        attrs['action'],
+        name)
+            for name, attrs in config.items()}
 
     def process(service):
         """Parse text into commands."""

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -52,7 +52,8 @@ def setup(hass, config):
         hass,
         attrs['action'],
         name)
-            for name, attrs in config.items()}
+            for name, attrs in config.items()} or {lambda: None}
+            # Make sure choices isnt empty
 
     def process(service):
         """Parse text into commands."""
@@ -65,9 +66,8 @@ def setup(hass, config):
             )
         )
         if match[1] > scorelimit:
-            choices[match[0]].run()  # run respective script
+            return choices[match[0]].run()  # run respective script
 
-        return
         text = service.data[ATTR_TEXT]
         match = REGEX_TURN_COMMAND.match(text)
 

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -46,7 +46,8 @@ def setup(hass, config):
     warnings.filterwarnings('ignore', module='fuzzywuzzy')
 
     logger = logging.getLogger(__name__)
-    config = config['conversation']
+    config = config.get(DOMAIN, {})
+    # Right way to do this-- taken from updater.py
 
     choices = {attrs['keywords']: script.Script(
         hass,

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import script
-from homeassistant.helpers.typing import HomeAssistantType
 
 
 REQUIREMENTS = ['fuzzywuzzy==0.15.0']

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -17,7 +17,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import script
 from homeassistant.helpers.typing import HomeAssistantType
 
-from fuzzywuzzy import process as fuzzyExtract
 
 REQUIREMENTS = ['fuzzywuzzy==0.15.0']
 
@@ -43,6 +42,7 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({
 
 def setup(hass, config):
     """Register the process service."""
+    from fuzzywuzzy import process as fuzzyExtract
     warnings.filterwarnings('ignore', module='fuzzywuzzy')
 
     logger = logging.getLogger(__name__)

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -53,7 +53,6 @@ def setup(hass, config):
         c['alias'],)
             for c in config}
 
-
     def process(service):
         """Parse text into commands."""
 
@@ -62,7 +61,7 @@ def setup(hass, config):
         scorelimit = 60  # arbitrary value
         logging.info(f'''matched up text {text} and found
                 {match[0] if match[1] > scorelimit else "nothing"}'''
-        )
+                    )
         if match[1] > scorelimit:
             choices[match[0]].run()  # run respective script
 

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -59,9 +59,10 @@ def setup(hass, config):
         text = service.data[ATTR_TEXT]
         match = fuzzyExtract.extractOne(text, choices.keys())
         scorelimit = 60  # arbitrary value
-        logging.info(f'''matched up text {text} and found
-                {match[0] if match[1] > scorelimit else "nothing"}'''
-                    )
+        logging.info('matched up text %s and found %s' % (
+            text, [match[0] if match[1] > scorelimit else 'nothing']
+            )
+        )
         if match[1] > scorelimit:
             choices[match[0]].run()  # run respective script
 

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -53,7 +53,7 @@ def setup(hass, config):
         attrs['action'],
         name)
         for name, attrs in config.items()} or {'': lambda: None}
-            # Make sure choices isnt empty
+# Make sure choices isnt empty
 
     def process(service):
         """Parse text into commands."""

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -125,23 +125,17 @@ class TestConfiguration(unittest.TestCase):
     # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
-        self.ent_id = 'input_boolean.kitchen_lights'
         self.hass = get_test_home_assistant()
-        self.hass.states.set(self.ent_id, 'on')
-        self.assertTrue(run_coroutine_threadsafe(
-            core_components.async_setup(self.hass, {}), self.hass.loop
-        ).result())
-        with assert_setup_component(2):
-            self.assertTrue(setup_component(self.hass, conversation.DOMAIN, {
-                conversation.DOMAIN: {
-                    'test_2': {
-                        'sentence': 'please test',
-                        'action': {
-                            'service': 'input_boolean.toggle'
-                            }
-                        }
+        self.assertTrue(setup_component(self.hass, conversation.DOMAIN, {
+            conversation.DOMAIN: {
+                'test_2': {
+                    'sentence': 'please test',
+                    'action': {
+                        'service': 'input_boolean.toggle'
                     }
-            }))
+                }
+            }
+        }))
 
     # pylint: disable=invalid-name
     def tearDown(self):

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -129,7 +129,7 @@ class TestConfiguration(unittest.TestCase):
         self.assertTrue(setup_component(self.hass, conversation.DOMAIN, {
             conversation.DOMAIN: {
                 'test_2': {
-                    'sentence': 'please test',
+                    'sentence': 'switch boolean',
                     'action': {
                         'service': 'input_boolean.toggle'
                     }

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -118,9 +118,9 @@ class TestConversation(unittest.TestCase):
         self.assertTrue(mock_logger.called)
         self.assertFalse(mock_call.called)
 
+
 class TestConfiguration(unittest.TestCase):
     """Test the conversation configuration component."""
-
     # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
@@ -133,21 +133,21 @@ class TestConfiguration(unittest.TestCase):
         with assert_setup_component(2):
             self.assertTrue(setup_component(self.hass, conversation.DOMAIN, {
                 'input_boolean': {
-                    'notify_home' : {
+                    'notify_home': {
                         'name': 'Notify when someone arrives home',
                         'initial': 'off',
                         }
                     },
                 conversation.DOMAIN: {
                     'test_1': {
-                        'keywords' : 'switch boolean',
-                        'action' : {
+                        'keywords': 'switch boolean',
+                        'action': {
                             'service': 'input_boolean.toggle'
                             }
                         },
                     'test_2': {
-                        'keywords' : 'please test',
-                        'action' : {
+                        'keywords': 'please test',
+                        'action': {
                             'service': 'input_boolean.toggle'
                             }
                         }

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -133,21 +133,9 @@ class TestConfiguration(unittest.TestCase):
         ).result())
         with assert_setup_component(2):
             self.assertTrue(setup_component(self.hass, conversation.DOMAIN, {
-                'input_boolean': {
-                    'notify_home': {
-                        'name': 'Notify when someone arrives home',
-                        'initial': 'off',
-                        }
-                    },
                 conversation.DOMAIN: {
-                    'test_1': {
-                        'keywords': 'switch boolean',
-                        'action': {
-                            'service': 'input_boolean.toggle'
-                            }
-                        },
                     'test_2': {
-                        'keywords': 'please test',
+                        'sentence': 'please test',
                         'action': {
                             'service': 'input_boolean.toggle'
                             }

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -121,6 +121,7 @@ class TestConversation(unittest.TestCase):
 
 class TestConfiguration(unittest.TestCase):
     """Test the conversation configuration component."""
+
     # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""


### PR DESCRIPTION
## Description:
Added configurable conversation component, make your own custom actions based on voice

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2697


## Example entry for `configuration.yaml` (if applicable):
```yaml
conversation:
    boolean_test:
      keywords: switch boolean
      action:
        service: input_boolean.toggle
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
