### PR TITLE
Start of migration framework, to allow moving of files in the config …

### DIFF
--- a/homeassistant/components/ios.py
+++ b/homeassistant/components/ios.py
@@ -167,7 +167,7 @@ IDENTIFY_SCHEMA = vol.Schema({
     vol.Optional(ATTR_PUSH_SOUNDS): list
 }, extra=vol.ALLOW_EXTRA)
 
-CONFIGURATION_FILE = 'ios.conf'
+CONFIGURATION_FILE = '.ios.conf'
 
 CONFIG_FILE = {ATTR_DEVICES: {}}
 

--- a/homeassistant/components/notify/ios.py
+++ b/homeassistant/components/notify/ios.py
@@ -85,7 +85,7 @@ class iOSNotificationService(BaseNotificationService):
 
         for target in targets:
             if target not in ios.enabled_push_ids():
-                _LOGGER.error("The target (%s) does not exist in ios.conf.",
+                _LOGGER.error("The target (%s) does not exist in .ios.conf.",
                               targets)
                 return
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -36,6 +36,10 @@ VERSION_FILE = '.HA_VERSION'
 CONFIG_DIR_NAME = '.homeassistant'
 DATA_CUSTOMIZE = 'hass_customize'
 
+FILE_MIGRATION = [
+    ["ios.conf", ".ios.conf"],
+    ]
+
 DEFAULT_CORE_CONFIG = (
     # Tuples (attribute, default, auto detect property, description)
     (CONF_NAME, 'Home', None, 'Name of the location where Home Assistant is '
@@ -291,6 +295,12 @@ def process_ha_config_upgrade(hass):
 
     with open(version_path, 'wt') as outp:
         outp.write(__version__)
+
+    _LOGGER.info('Migrating old system config files to new locations')
+    for mfile in FILE_MIGRATION:
+        if os.path.isfile(hass.config.path(mfile[0])):
+            _LOGGER.info('Migrating %s to %s', mfile[0], mfile[1])
+            os.rename(hass.config.path(mfile[0]), hass.config.path(mfile[1]))
 
 
 @callback

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -297,10 +297,10 @@ def process_ha_config_upgrade(hass):
         outp.write(__version__)
 
     _LOGGER.info('Migrating old system config files to new locations')
-    for mfile in FILE_MIGRATION:
-        if os.path.isfile(hass.config.path(mfile[0])):
-            _LOGGER.info('Migrating %s to %s', mfile[0], mfile[1])
-            os.rename(hass.config.path(mfile[0]), hass.config.path(mfile[1]))
+    for oldf, newf in FILE_MIGRATION:
+        if os.path.isfile(hass.config.path(oldf)):
+            _LOGGER.info('Migrating %s to %s', oldf, newf)
+            os.rename(hass.config.path(oldf), hass.config.path(newf))
 
 
 @callback

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 46
-PATCH_VERSION = '0.dev0'
+PATCH_VERSION = '0.dev1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -303,7 +303,7 @@ class TestConfig(unittest.TestCase):
     @mock.patch('homeassistant.config.shutil')
     @mock.patch('homeassistant.config.os')
     def test_migrate_file_on_upgrade(self, mock_os, mock_shutil):
-        """Test miragte of config files on upgrade."""
+        """Test migrate of config files on upgrade."""
         ha_version = '0.7.0'
 
         mock_os.path.isdir = mock.Mock(return_value=True)
@@ -328,7 +328,7 @@ class TestConfig(unittest.TestCase):
     @mock.patch('homeassistant.config.shutil')
     @mock.patch('homeassistant.config.os')
     def test_migrate_no_file_on_upgrade(self, mock_os, mock_shutil):
-        """Test not mirgating confgi files on upgrade."""
+        """Test not migrating config files on upgrade."""
         ha_version = '0.7.0'
 
         mock_os.path.isdir = mock.Mock(return_value=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -300,6 +300,56 @@ class TestConfig(unittest.TestCase):
             assert mock_os.path.isdir.call_count == 0
             assert mock_shutil.rmtree.call_count == 0
 
+    @mock.patch('homeassistant.config.shutil')
+    @mock.patch('homeassistant.config.os')
+    def test_migrate_file_on_upgrade(self, mock_os, mock_shutil):
+        """Test miragte of config files on upgrade."""
+        ha_version = '0.7.0'
+
+        mock_os.path.isdir = mock.Mock(return_value=True)
+
+        mock_open = mock.mock_open()
+
+        def mock_isfile(filename):
+            return True
+
+        with mock.patch('homeassistant.config.open', mock_open, create=True), \
+                mock.patch('homeassistant.config.os.path.isfile', mock_isfile):
+            opened_file = mock_open.return_value
+            # pylint: disable=no-member
+            opened_file.readline.return_value = ha_version
+
+            self.hass.config.path = mock.Mock()
+
+            config_util.process_ha_config_upgrade(self.hass)
+
+        assert mock_os.rename.call_count == 1
+
+    @mock.patch('homeassistant.config.shutil')
+    @mock.patch('homeassistant.config.os')
+    def test_migrate_no_file_on_upgrade(self, mock_os, mock_shutil):
+        """Test not mirgating confgi files on upgrade."""
+        ha_version = '0.7.0'
+
+        mock_os.path.isdir = mock.Mock(return_value=True)
+
+        mock_open = mock.mock_open()
+
+        def mock_isfile(filename):
+            return False
+
+        with mock.patch('homeassistant.config.open', mock_open, create=True), \
+                mock.patch('homeassistant.config.os.path.isfile', mock_isfile):
+            opened_file = mock_open.return_value
+            # pylint: disable=no-member
+            opened_file.readline.return_value = ha_version
+
+            self.hass.config.path = mock.Mock()
+
+            config_util.process_ha_config_upgrade(self.hass)
+
+        assert mock_os.rename.call_count == 0
+
     def test_loading_configuration(self):
         """Test loading core config onto hass object."""
         self.hass.config = mock.Mock()


### PR DESCRIPTION
…directory to be hidden, ios.conf used as the first one to undergo this change.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
