### PR TITLE
LIFX: disable color features for white-only bulbs

### DIFF
--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -54,9 +54,6 @@ ATTR_POWER = 'power'
 BYTE_MAX = 255
 SHORT_MAX = 65535
 
-SUPPORT_LIFX = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_RGB_COLOR |
-                SUPPORT_XY_COLOR | SUPPORT_TRANSITION | SUPPORT_EFFECT)
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SERVER, default='0.0.0.0'): cv.string,
 })
@@ -230,6 +227,12 @@ class LIFXLight(Light):
         self.set_color(*device.color)
 
     @property
+    def lifxwhite(self):
+        """Return whether this is a white-only bulb."""
+        # https://lan.developer.lifx.com/docs/lifx-products
+        return self.product in [10, 11, 18]
+
+    @property
     def available(self):
         """Return the availability of the device."""
         return self.registered
@@ -273,8 +276,7 @@ class LIFXLight(Light):
     def min_mireds(self):
         """Return the coldest color_temp that this light supports."""
         # The 3 LIFX "White" products supported a limited temperature range
-        # https://lan.developer.lifx.com/docs/lifx-products
-        if self.product in [10, 11, 18]:
+        if self.lifxwhite:
             kelvin = 6500
         else:
             kelvin = 9000
@@ -284,8 +286,7 @@ class LIFXLight(Light):
     def max_mireds(self):
         """Return the warmest color_temp that this light supports."""
         # The 3 LIFX "White" products supported a limited temperature range
-        # https://lan.developer.lifx.com/docs/lifx-products
-        if self.product in [10, 11, 18]:
+        if self.lifxwhite:
             kelvin = 2700
         else:
             kelvin = 2500
@@ -305,12 +306,18 @@ class LIFXLight(Light):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_LIFX
+        features = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP |
+                    SUPPORT_TRANSITION | SUPPORT_EFFECT)
+
+        if not self.lifxwhite:
+            features |= SUPPORT_RGB_COLOR | SUPPORT_XY_COLOR
+
+        return features
 
     @property
     def effect_list(self):
         """Return the list of supported effects."""
-        return lifx_effects.effect_list()
+        return lifx_effects.effect_list(self)
 
     @asyncio.coroutine
     def update_after_transition(self, now):


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
