### PR TITLE
Fix Wink RGB bulbs now showing color picker

### DIFF
--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -19,8 +19,6 @@ DEPENDENCIES = ['wink']
 
 SUPPORT_WINK = SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_RGB_COLOR
 
-RGB_MODES = ['hsb', 'rgb']
-
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Wink lights."""
@@ -62,8 +60,6 @@ class WinkLight(WinkDevice, Light):
         """Define current bulb color in RGB."""
         if not self.wink.supports_hue_saturation():
             return None
-        elif self.wink.color_model() not in RGB_MODES:
-            return False
         else:
             hue = self.wink.color_hue()
             saturation = self.wink.color_saturation()


### PR DESCRIPTION
## Description:
While trying to fix an issue where the HomeAssistant frontend displays the color of the bulb when the bulb isn't in color mode, I manged to break the ability to change the color of the bulb if it was in color_temperature mode.

Question, is it possible to only return the color of the bulb to Ploymer if color mode is enabled but still be able to display the color picker in the more info state card? The problem is Wink always returns the RGB color of the bulb even if it isn't in RGB mode.

**Related issue (if applicable):** fixes Issue reported in python-wink gitter

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
