### PR TITLE
Added handling of an AssertionError from pxssh failed login

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -348,6 +348,10 @@ class SshConnection(_Connection):
             _LOGGER.error("Unexpected SSH error: %s", str(err))
             self.disconnect()
             return None
+        except AssertionError:
+            _LOGGER.error("Connection to router unavailable.")
+            self.disconnect()
+            return None
 
     def connect(self):
         """Connect to the ASUS-WRT SSH server."""

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -296,11 +296,9 @@ class SshConnection(_Connection):
 
     def __init__(self, host, port, username, password, ssh_key, ap):
         """Initialize the SSH connection properties."""
-        from pexpect import pxssh
-
         super(SshConnection, self).__init__()
 
-        self._ssh = pxssh.pxssh()
+        self._ssh = None
         self._host = host
         self._port = port
         self._username = username
@@ -348,13 +346,16 @@ class SshConnection(_Connection):
             _LOGGER.error("Unexpected SSH error: %s", str(err))
             self.disconnect()
             return None
-        except AssertionError:
-            _LOGGER.error("Connection to router unavailable.")
+        except AssertionError as err:
+            _LOGGER.error("Connection to router unavailable: %s", str(err))
             self.disconnect()
             return None
 
     def connect(self):
         """Connect to the ASUS-WRT SSH server."""
+        from pexpect import pxssh
+
+        self._ssh = pxssh.pxssh()
         if self._ssh_key:
             self._ssh.login(self._host, self._username,
                             ssh_key=self._ssh_key, port=self._port)
@@ -371,6 +372,8 @@ class SshConnection(_Connection):
             self._ssh.logout()
         except Exception:
             pass
+        finally:
+            self._ssh = None
 
         super(SshConnection, self).disconnect()
 


### PR DESCRIPTION
## Description:
When an Asus router is restarted, during the downtime consequent login attempts fail. However, ```pxssh``` fails to throw a proper exception, and lets an ```AssertionError``` to propagate upwards.

This change handles these ```AssertionError```s, in order to avoid flooding the log with tracebacks while the connection to the router is down.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
