### PR TITLE
Implement frost-guard mode for netatmo thermostat

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -500,7 +500,8 @@ class ClimateDevice(Entity):
 
         is_frostguard = self.is_frostguard_mode_on
         if is_frostguard is not None:
-            data[ATTR_FROSTGUARD_MODE] = STATE_ON if is_frostguard else STATE_OFF
+            data[ATTR_FROSTGUARD_MODE] = STATE_ON if is_frostguard \
+                else STATE_OFF
 
         is_away = self.is_away_mode_on
         if is_away is not None:

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -28,6 +28,7 @@ DOMAIN = 'climate'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 SCAN_INTERVAL = timedelta(seconds=60)
 
+SERVICE_SET_HG_MODE = 'set_hg_mode'
 SERVICE_SET_AWAY_MODE = 'set_away_mode'
 SERVICE_SET_AUX_HEAT = 'set_aux_heat'
 SERVICE_SET_TEMPERATURE = 'set_temperature'
@@ -50,6 +51,7 @@ ATTR_MIN_TEMP = 'min_temp'
 ATTR_TARGET_TEMP_HIGH = 'target_temp_high'
 ATTR_TARGET_TEMP_LOW = 'target_temp_low'
 ATTR_TARGET_TEMP_STEP = 'target_temp_step'
+ATTR_HG_MODE = 'hg_mode'
 ATTR_AWAY_MODE = 'away_mode'
 ATTR_AUX_HEAT = 'aux_heat'
 ATTR_FAN_MODE = 'fan_mode'
@@ -77,6 +79,10 @@ CONVERTIBLE_ATTRIBUTE = [
 
 _LOGGER = logging.getLogger(__name__)
 
+SET_HG_MODE_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_HG_MODE): cv.boolean,
+})
 SET_AWAY_MODE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_AWAY_MODE): cv.boolean,
@@ -112,6 +118,18 @@ SET_SWING_MODE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_SWING_MODE): cv.string,
 })
+
+
+def set_hg_mode(hass, hg_mode, entity_id=None):
+    """Turn all or specified climate devices frost-guard mode on."""
+    data = {
+        ATTR_HG_MODE: hg_mode
+    }
+
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    hass.services.call(DOMAIN, SERVICE_SET_HG_MODE, data)
 
 
 def set_away_mode(hass, away_mode, entity_id=None):
@@ -234,6 +252,26 @@ def async_setup(hass, config):
 
         if update_tasks:
             yield from asyncio.wait(update_tasks, loop=hass.loop)
+
+    @asyncio.coroutine
+    def async_hg_mode_set_service(service):
+        """Set frost-guard mode on target climate devices."""
+        target_climate = component.async_extract_from_service(service)
+
+        hg_mode = service.data.get(ATTR_HG_MODE)
+
+        for climate in target_climate:
+            if hg_mode:
+                yield from climate.async_turn_hg_mode_on()
+            else:
+                yield from climate.async_turn_hg_mode_off()
+
+        yield from _async_update_climate(target_climate)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_SET_HG_MODE, async_hg_mode_set_service,
+        descriptions.get(SERVICE_SET_HG_MODE),
+        schema=SET_HG_MODE_SCHEMA)
 
     @asyncio.coroutine
     def async_away_mode_set_service(service):
@@ -460,6 +498,10 @@ class ClimateDevice(Entity):
             if self.swing_list:
                 data[ATTR_SWING_LIST] = self.swing_list
 
+        is_hg = self.is_hg_mode_on
+        if is_hg is not None:
+            data[ATTR_HG_MODE] = STATE_ON if is_hg else STATE_OFF
+
         is_away = self.is_away_mode_on
         if is_away is not None:
             data[ATTR_AWAY_MODE] = STATE_ON if is_away else STATE_OFF
@@ -523,6 +565,11 @@ class ClimateDevice(Entity):
     @property
     def target_temperature_low(self):
         """Return the lowbound target temperature we try to reach."""
+        return None
+
+    @property
+    def is_hg_mode_on(self):
+        """Return true if hg mode is on."""
         return None
 
     @property
@@ -619,6 +666,30 @@ class ClimateDevice(Entity):
         """
         return self.hass.loop.run_in_executor(
             None, self.set_swing_mode, swing_mode)
+
+    def turn_hg_mode_on(self):
+        """Turn frost-guard mode on."""
+        raise NotImplementedError()
+
+    def async_turn_hg_mode_on(self):
+        """Turn frost-guard mode on.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.loop.run_in_executor(
+            None, self.turn_hg_mode_on)
+
+    def turn_hg_mode_off(self):
+        """Turn frost-guard mode off."""
+        raise NotImplementedError()
+
+    def async_turn_away_mode_off(self):
+        """Turn frost-guard mode off.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.loop.run_in_executor(
+            None, self.turn_hg_mode_off)
 
     def turn_away_mode_on(self):
         """Turn away mode on."""

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -254,7 +254,7 @@ def async_setup(hass, config):
             yield from asyncio.wait(update_tasks, loop=hass.loop)
 
     @asyncio.coroutine
-    def async_frostguard_mode_set_service(service):
+    def async_frostguard_mode_set(service):
         """Set frost-guard mode on target climate devices."""
         target_climate = component.async_extract_from_service(service)
 
@@ -269,7 +269,7 @@ def async_setup(hass, config):
         yield from _async_update_climate(target_climate)
 
     hass.services.async_register(
-        DOMAIN, SERVICE_SET_FROSTGUARD_MODE, async_frostguard_mode_set_service,
+        DOMAIN, SERVICE_SET_FROSTGUARD_MODE, async_frostguard_mode_set,
         descriptions.get(SERVICE_SET_FROSTGUARD_MODE),
         schema=SET_FROSTGUARD_MODE_SCHEMA)
 

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -683,7 +683,7 @@ class ClimateDevice(Entity):
         """Turn frost-guard mode off."""
         raise NotImplementedError()
 
-    def async_turn_away_mode_off(self):
+    def async_turn_hg_mode_off(self):
         """Turn frost-guard mode off.
 
         This method must be run in the event loop and returns a coroutine.

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -28,7 +28,7 @@ DOMAIN = 'climate'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 SCAN_INTERVAL = timedelta(seconds=60)
 
-SERVICE_SET_HG_MODE = 'set_hg_mode'
+SERVICE_SET_FROSTGUARD_MODE = 'set_frostguard_mode'
 SERVICE_SET_AWAY_MODE = 'set_away_mode'
 SERVICE_SET_AUX_HEAT = 'set_aux_heat'
 SERVICE_SET_TEMPERATURE = 'set_temperature'
@@ -51,7 +51,7 @@ ATTR_MIN_TEMP = 'min_temp'
 ATTR_TARGET_TEMP_HIGH = 'target_temp_high'
 ATTR_TARGET_TEMP_LOW = 'target_temp_low'
 ATTR_TARGET_TEMP_STEP = 'target_temp_step'
-ATTR_HG_MODE = 'hg_mode'
+ATTR_FROSTGUARD_MODE = 'frostguard_mode'
 ATTR_AWAY_MODE = 'away_mode'
 ATTR_AUX_HEAT = 'aux_heat'
 ATTR_FAN_MODE = 'fan_mode'
@@ -79,9 +79,9 @@ CONVERTIBLE_ATTRIBUTE = [
 
 _LOGGER = logging.getLogger(__name__)
 
-SET_HG_MODE_SCHEMA = vol.Schema({
+SET_FROSTGUARD_MODE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Required(ATTR_HG_MODE): cv.boolean,
+    vol.Required(ATTR_FROSTGUARD_MODE): cv.boolean,
 })
 SET_AWAY_MODE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
@@ -120,16 +120,16 @@ SET_SWING_MODE_SCHEMA = vol.Schema({
 })
 
 
-def set_hg_mode(hass, hg_mode, entity_id=None):
+def set_frostguard_mode(hass, frostguard_mode, entity_id=None):
     """Turn all or specified climate devices frost-guard mode on."""
     data = {
-        ATTR_HG_MODE: hg_mode
+        ATTR_FROSTGUARD_MODE: frostguard_mode
     }
 
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.services.call(DOMAIN, SERVICE_SET_HG_MODE, data)
+    hass.services.call(DOMAIN, SERVICE_SET_FROSTGUARD_MODE, data)
 
 
 def set_away_mode(hass, away_mode, entity_id=None):
@@ -254,24 +254,24 @@ def async_setup(hass, config):
             yield from asyncio.wait(update_tasks, loop=hass.loop)
 
     @asyncio.coroutine
-    def async_hg_mode_set_service(service):
+    def async_frostguard_mode_set_service(service):
         """Set frost-guard mode on target climate devices."""
         target_climate = component.async_extract_from_service(service)
 
-        hg_mode = service.data.get(ATTR_HG_MODE)
+        frostguard_mode = service.data.get(ATTR_FROSTGUARD_MODE)
 
         for climate in target_climate:
-            if hg_mode:
-                yield from climate.async_turn_hg_mode_on()
+            if frostguard_mode:
+                yield from climate.async_turn_frostguard_mode_on()
             else:
-                yield from climate.async_turn_hg_mode_off()
+                yield from climate.async_turn_frostguard_mode_off()
 
         yield from _async_update_climate(target_climate)
 
     hass.services.async_register(
-        DOMAIN, SERVICE_SET_HG_MODE, async_hg_mode_set_service,
-        descriptions.get(SERVICE_SET_HG_MODE),
-        schema=SET_HG_MODE_SCHEMA)
+        DOMAIN, SERVICE_SET_FROSTGUARD_MODE, async_frostguard_mode_set_service,
+        descriptions.get(SERVICE_SET_FROSTGUARD_MODE),
+        schema=SET_FROSTGUARD_MODE_SCHEMA)
 
     @asyncio.coroutine
     def async_away_mode_set_service(service):
@@ -498,9 +498,9 @@ class ClimateDevice(Entity):
             if self.swing_list:
                 data[ATTR_SWING_LIST] = self.swing_list
 
-        is_hg = self.is_hg_mode_on
-        if is_hg is not None:
-            data[ATTR_HG_MODE] = STATE_ON if is_hg else STATE_OFF
+        is_frostguard = self.is_frostguard_mode_on
+        if is_frostguard is not None:
+            data[ATTR_FROSTGUARD_MODE] = STATE_ON if is_frostguard else STATE_OFF
 
         is_away = self.is_away_mode_on
         if is_away is not None:
@@ -568,8 +568,8 @@ class ClimateDevice(Entity):
         return None
 
     @property
-    def is_hg_mode_on(self):
-        """Return true if hg mode is on."""
+    def is_frostguard_mode_on(self):
+        """Return true if frostguard mode is on."""
         return None
 
     @property
@@ -667,29 +667,29 @@ class ClimateDevice(Entity):
         return self.hass.loop.run_in_executor(
             None, self.set_swing_mode, swing_mode)
 
-    def turn_hg_mode_on(self):
+    def turn_frostguard_mode_on(self):
         """Turn frost-guard mode on."""
         raise NotImplementedError()
 
-    def async_turn_hg_mode_on(self):
+    def async_turn_frostguard_mode_on(self):
         """Turn frost-guard mode on.
 
         This method must be run in the event loop and returns a coroutine.
         """
         return self.hass.loop.run_in_executor(
-            None, self.turn_hg_mode_on)
+            None, self.turn_frostguard_mode_on)
 
-    def turn_hg_mode_off(self):
+    def turn_frostguard_mode_off(self):
         """Turn frost-guard mode off."""
         raise NotImplementedError()
 
-    def async_turn_hg_mode_off(self):
+    def async_turn_frostguard_mode_off(self):
         """Turn frost-guard mode off.
 
         This method must be run in the event loop and returns a coroutine.
         """
         return self.hass.loop.run_in_executor(
-            None, self.turn_hg_mode_off)
+            None, self.turn_frostguard_mode_off)
 
     def turn_away_mode_on(self):
         """Turn away mode on."""

--- a/homeassistant/components/climate/netatmo.py
+++ b/homeassistant/components/climate/netatmo.py
@@ -123,21 +123,21 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def is_hg_mode_on(self):
         """Return true if frost-guard mode is on."""
-        return self._away
+        return self._hg
 
     def turn_hg_mode_on(self):
         """Turn frost-guard on."""
         mode = "hg"
         temp = None
         self._data.thermostatdata.setthermpoint(mode, temp, endTimeOffset=None)
-        self._away = True
+        self._hg = True
 
     def turn_hg_mode_off(self):
         """Turn frost-guard off."""
         mode = "program"
         temp = None
         self._data.thermostatdata.setthermpoint(mode, temp, endTimeOffset=None)
-        self._away = False
+        self._hg = False
 
     def set_temperature(self, endTimeOffset=DEFAULT_TIME_OFFSET, **kwargs):
         """Set new target temperature for 2 hours."""
@@ -149,6 +149,7 @@ class NetatmoThermostat(ClimateDevice):
             mode, temperature, endTimeOffset)
         self._target_temperature = temperature
         self._away = False
+        self._hg = False
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/climate/netatmo.py
+++ b/homeassistant/components/climate/netatmo.py
@@ -22,7 +22,6 @@ _LOGGER = logging.getLogger(__name__)
 CONF_RELAY = 'relay'
 CONF_THERMOSTAT = 'thermostat'
 
-DEFAULT_AWAY_TEMPERATURE = 14
 # # The default offeset is 2 hours (when you use the thermostat itself)
 DEFAULT_TIME_OFFSET = 7200
 # # Return cached results if last scan was less then this time ago
@@ -57,7 +56,7 @@ def setup_platform(hass, config, add_callback_devices, discovery_info=None):
 class NetatmoThermostat(ClimateDevice):
     """Representation of a Netatmo thermostat."""
 
-    def __init__(self, data, module_name, away_temp=None):
+    def __init__(self, data, module_name):
         """Initialize the sensor."""
         self._data = data
         self._state = None

--- a/homeassistant/components/climate/netatmo.py
+++ b/homeassistant/components/climate/netatmo.py
@@ -119,7 +119,7 @@ class NetatmoThermostat(ClimateDevice):
         temp = None
         self._data.thermostatdata.setthermpoint(mode, temp, endTimeOffset=None)
         self._away = False
-    
+
     @property
     def is_frostguard_mode_on(self):
         """Return true if frost-guard mode is on."""

--- a/homeassistant/components/climate/netatmo.py
+++ b/homeassistant/components/climate/netatmo.py
@@ -111,6 +111,7 @@ class NetatmoThermostat(ClimateDevice):
         temp = None
         self._data.thermostatdata.setthermpoint(mode, temp, endTimeOffset=None)
         self._away = True
+        self._hg = False
 
     def turn_away_mode_off(self):
         """Turn away off."""
@@ -130,6 +131,7 @@ class NetatmoThermostat(ClimateDevice):
         temp = None
         self._data.thermostatdata.setthermpoint(mode, temp, endTimeOffset=None)
         self._hg = True
+        self._away = False
 
     def turn_hg_mode_off(self):
         """Turn frost-guard off."""

--- a/homeassistant/components/climate/netatmo.py
+++ b/homeassistant/components/climate/netatmo.py
@@ -63,7 +63,7 @@ class NetatmoThermostat(ClimateDevice):
         self._name = module_name
         self._target_temperature = None
         self._away = None
-        self._hg = None
+        self._frostguard = None
         self.update()
 
     @property
@@ -111,7 +111,7 @@ class NetatmoThermostat(ClimateDevice):
         temp = None
         self._data.thermostatdata.setthermpoint(mode, temp, endTimeOffset=None)
         self._away = True
-        self._hg = False
+        self._frostguard = False
 
     def turn_away_mode_off(self):
         """Turn away off."""
@@ -121,24 +121,24 @@ class NetatmoThermostat(ClimateDevice):
         self._away = False
     
     @property
-    def is_hg_mode_on(self):
+    def is_frostguard_mode_on(self):
         """Return true if frost-guard mode is on."""
-        return self._hg
+        return self._frostguard
 
-    def turn_hg_mode_on(self):
+    def turn_frostguard_mode_on(self):
         """Turn frost-guard on."""
-        mode = "hg"
+        mode = "frostguard"
         temp = None
         self._data.thermostatdata.setthermpoint(mode, temp, endTimeOffset=None)
-        self._hg = True
+        self._frostguard = True
         self._away = False
 
-    def turn_hg_mode_off(self):
+    def turn_frostguard_mode_off(self):
         """Turn frost-guard off."""
         mode = "program"
         temp = None
         self._data.thermostatdata.setthermpoint(mode, temp, endTimeOffset=None)
-        self._hg = False
+        self._frostguard = False
 
     def set_temperature(self, endTimeOffset=DEFAULT_TIME_OFFSET, **kwargs):
         """Set new target temperature for 2 hours."""
@@ -150,7 +150,7 @@ class NetatmoThermostat(ClimateDevice):
             mode, temperature, endTimeOffset)
         self._target_temperature = temperature
         self._away = False
-        self._hg = False
+        self._frostguard = False
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
@@ -158,7 +158,7 @@ class NetatmoThermostat(ClimateDevice):
         self._data.update()
         self._target_temperature = self._data.thermostatdata.setpoint_temp
         self._away = self._data.setpoint_mode == 'away'
-        self._hg = self._data.setpoint_mode == 'hg'
+        self._frostguard = self._data.setpoint_mode == 'frostguard'
 
 
 class ThermostatData(object):

--- a/homeassistant/components/climate/netatmo.py
+++ b/homeassistant/components/climate/netatmo.py
@@ -37,7 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_callback_devices, discovery_info=None):
-    """Set up the NetAtmo Thermostat."""
+    """Set up the Netatmo Thermostat."""
     netatmo = get_component('netatmo')
     device = config.get(CONF_RELAY)
 
@@ -55,7 +55,7 @@ def setup_platform(hass, config, add_callback_devices, discovery_info=None):
 
 
 class NetatmoThermostat(ClimateDevice):
-    """Representation a Netatmo thermostat."""
+    """Representation of a Netatmo thermostat."""
 
     def __init__(self, data, module_name, away_temp=None):
         """Initialize the sensor."""
@@ -64,6 +64,7 @@ class NetatmoThermostat(ClimateDevice):
         self._name = module_name
         self._target_temperature = None
         self._away = None
+        self._hg = None
         self.update()
 
     @property
@@ -118,6 +119,25 @@ class NetatmoThermostat(ClimateDevice):
         temp = None
         self._data.thermostatdata.setthermpoint(mode, temp, endTimeOffset=None)
         self._away = False
+    
+    @property
+    def is_hg_mode_on(self):
+        """Return true if frost-guard mode is on."""
+        return self._away
+
+    def turn_hg_mode_on(self):
+        """Turn frost-guard on."""
+        mode = "hg"
+        temp = None
+        self._data.thermostatdata.setthermpoint(mode, temp, endTimeOffset=None)
+        self._away = True
+
+    def turn_hg_mode_off(self):
+        """Turn frost-guard off."""
+        mode = "program"
+        temp = None
+        self._data.thermostatdata.setthermpoint(mode, temp, endTimeOffset=None)
+        self._away = False
 
     def set_temperature(self, endTimeOffset=DEFAULT_TIME_OFFSET, **kwargs):
         """Set new target temperature for 2 hours."""
@@ -136,6 +156,7 @@ class NetatmoThermostat(ClimateDevice):
         self._data.update()
         self._target_temperature = self._data.thermostatdata.setpoint_temp
         self._away = self._data.setpoint_mode == 'away'
+        self._hg = self._data.setpoint_mode == 'hg'
 
 
 class ThermostatData(object):

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -22,6 +22,18 @@ set_away_mode:
       description: New value of away mode
       example: true
 
+set_hg_mode:
+  description: Turn frost guard mode on/off for climate device
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to change
+      example: 'climate.kitchen'
+
+    hg_mode:
+      description: New value of frost-guard mode
+      example: true
+
 set_hold_mode:
   description: Turn hold mode for climate device
 


### PR DESCRIPTION
## Description:
This pull request contains changes to add the frost guard mode switch to the Netatmo Thermostat component.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) with documentation (if applicable):** home-assistant/home-assistant-polymer#292

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54