### PR TITLE
Change setup script to use pip install instead of setup.py develop

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -7,4 +7,5 @@ set -e
 cd "$(dirname "$0")/.."
 git submodule init
 script/bootstrap
-python3 setup.py develop
+
+pip3 install -e .


### PR DESCRIPTION
## Description:

Using `python setup.py develop` did not manage to install the required dependencies.
This updates `script/setup` to use `pip install -e .` instead in order to resolve the required dependencies.

## Checklist:

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
