### PR TITLE
Rest notify data

### DIFF
--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -92,7 +92,7 @@ class RestNotificationService(BaseNotificationService):
 
         if self._data:
             data.update(self._data)
-        if self._data_template:
+        elif self._data_template:
             def _data_template_creator(value):
                 """Recursive template creator helper function."""
                 if isinstance(value, list):
@@ -102,9 +102,7 @@ class RestNotificationService(BaseNotificationService):
                             for key, item in value.items()}
                 value.hass = self._hass
                 return value.async_render(kwargs)
-            _LOGGER.info('Data Template; ' + str(self._data_template))
             data.update(_data_template_creator(self._data_template))
-
 
         if self._method == 'POST':
             response = requests.post(self._resource, data=data, timeout=10)

--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -39,7 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DATA,
                  default=None): dict,
     vol.Optional(CONF_DATA_TEMPLATE,
-                 default=None): { cv.match_all: cv.template_complex }
+                 default=None): {cv.match_all: cv.template_complex}
 })
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -15,6 +15,8 @@ from homeassistant.components.notify import (
 from homeassistant.const import (CONF_RESOURCE, CONF_METHOD, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
+CONF_DATA = 'data'
+CONF_DATA_TEMPLATE = 'data_template'
 CONF_MESSAGE_PARAMETER_NAME = 'message_param_name'
 CONF_TARGET_PARAMETER_NAME = 'target_param_name'
 CONF_TITLE_PARAMETER_NAME = 'title_param_name'
@@ -34,6 +36,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                  default=DEFAULT_TARGET_PARAM_NAME): cv.string,
     vol.Optional(CONF_TITLE_PARAMETER_NAME,
                  default=DEFAULT_TITLE_PARAM_NAME): cv.string,
+    vol.Optional(CONF_DATA,
+                 default=None): dict,
+    vol.Optional(CONF_DATA_TEMPLATE,
+                 default=None): { cv.match_all: cv.template_complex }
 })
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,23 +52,28 @@ def get_service(hass, config, discovery_info=None):
     message_param_name = config.get(CONF_MESSAGE_PARAMETER_NAME)
     title_param_name = config.get(CONF_TITLE_PARAMETER_NAME)
     target_param_name = config.get(CONF_TARGET_PARAMETER_NAME)
+    data = config.get(CONF_DATA)
+    data_template = config.get(CONF_DATA_TEMPLATE)
 
     return RestNotificationService(
-        resource, method, message_param_name, title_param_name,
-        target_param_name)
+        hass, resource, method, message_param_name,
+        title_param_name, target_param_name, data, data_template)
 
 
 class RestNotificationService(BaseNotificationService):
     """Implementation of a notification service for REST."""
 
-    def __init__(self, resource, method, message_param_name, title_param_name,
-                 target_param_name):
+    def __init__(self, hass, resource, method, message_param_name,
+                 title_param_name, target_param_name, data, data_template):
         """Initialize the service."""
         self._resource = resource
+        self._hass = hass
         self._method = method.upper()
         self._message_param_name = message_param_name
         self._title_param_name = title_param_name
         self._target_param_name = target_param_name
+        self._data = data
+        self._data_template = data_template
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
@@ -78,6 +89,22 @@ class RestNotificationService(BaseNotificationService):
             # Target is a list as of 0.29 and we don't want to break existing
             # integrations, so just return the first target in the list.
             data[self._target_param_name] = kwargs[ATTR_TARGET][0]
+
+        if self._data:
+            data.update(self._data)
+        if self._data_template:
+            def _data_template_creator(value):
+                """Recursive template creator helper function."""
+                if isinstance(value, list):
+                    return [_data_template_creator(item) for item in value]
+                elif isinstance(value, dict):
+                    return {key: _data_template_creator(item)
+                            for key, item in value.items()}
+                value.hass = self._hass
+                return value.async_render(kwargs)
+            _LOGGER.info('Data Template; ' + str(self._data_template))
+            data.update(_data_template_creator(self._data_template))
+
 
         if self._method == 'POST':
             response = requests.post(self._resource, data=data, timeout=10)


### PR DESCRIPTION
## Description:
Add ability to push extra data to the rest notification component

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2708

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: NOTIFIER_NAME
    platform: rest
    resource: http://IP_ADDRESS/ENDPOINT
    data:
       actions:
         - title: ACTION_TITLE
            topic: ACTION_TOPIC
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.