### PR TITLE
Add icons to device tracker.

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -35,7 +35,8 @@ from homeassistant.util.yaml import dump
 from homeassistant.helpers.event import async_track_utc_time_change
 from homeassistant.const import (
     ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_NAME, CONF_MAC,
-    DEVICE_DEFAULT_NAME, STATE_HOME, STATE_NOT_HOME, ATTR_ENTITY_ID)
+    DEVICE_DEFAULT_NAME, STATE_HOME, STATE_NOT_HOME, ATTR_ENTITY_ID,
+    CONF_ICON, ATTR_ICON)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -381,6 +382,7 @@ class Device(Entity):
     battery = None  # type: str
     attributes = None  # type: dict
     vendor = None  # type: str
+    icon = None  # type: str
 
     # Track if the last update of this device was HOME.
     last_update_home = False
@@ -388,7 +390,7 @@ class Device(Entity):
 
     def __init__(self, hass: HomeAssistantType, consider_home: timedelta,
                  track: bool, dev_id: str, mac: str, name: str=None,
-                 picture: str=None, gravatar: str=None,
+                 picture: str=None, gravatar: str=None, icon: str=None,
                  hide_if_away: bool=False, vendor: str=None) -> None:
         """Initialize a device."""
         self.hass = hass
@@ -413,6 +415,8 @@ class Device(Entity):
             self.config_picture = get_gravatar_for_email(gravatar)
         else:
             self.config_picture = picture
+
+        self.icon = icon
 
         self.away_hide = hide_if_away
         self.vendor = vendor
@@ -637,6 +641,8 @@ def async_load_config(path: str, hass: HomeAssistantType,
     """
     dev_schema = vol.Schema({
         vol.Required(CONF_NAME): cv.string,
+        vol.Optional(CONF_ICON, default=False):
+            vol.Any(None, cv.icon),
         vol.Optional('track', default=False): cv.boolean,
         vol.Optional(CONF_MAC, default=None):
             vol.Any(None, vol.All(cv.string, vol.Upper)),
@@ -728,6 +734,7 @@ def update_config(path: str, dev_id: str, device: Device):
         device = {device.dev_id: {
             ATTR_NAME: device.name,
             ATTR_MAC: device.mac,
+            ATTR_ICON: device.icon,
             'picture': device.config_picture,
             'track': device.track,
             CONF_AWAY_HIDE: device.away_hide,

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -17,7 +17,7 @@ from homeassistant.util.async import run_coroutine_threadsafe
 import homeassistant.util.dt as dt_util
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME, ATTR_HIDDEN,
-    STATE_HOME, STATE_NOT_HOME, CONF_PLATFORM)
+    STATE_HOME, STATE_NOT_HOME, CONF_PLATFORM, ATTR_ICON)
 import homeassistant.components.device_tracker as device_tracker
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.remote import JSONEncoder
@@ -98,7 +98,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id,
             'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
-            hide_if_away=True)
+            hide_if_away=True, icon='mdi:kettle')
         device_tracker.update_config(self.yaml_devices, dev_id, device)
         with assert_setup_component(1, device_tracker.DOMAIN):
             assert setup_component(self.hass, device_tracker.DOMAIN,
@@ -112,6 +112,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         self.assertEqual(device.away_hide, config.away_hide)
         self.assertEqual(device.consider_home, config.consider_home)
         self.assertEqual(device.vendor, config.vendor)
+        self.assertEqual(device.icon, config.icon)
 
     # pylint: disable=invalid-name
     @patch('homeassistant.components.device_tracker._LOGGER.warning')
@@ -377,10 +378,11 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
         friendly_name = 'Paulus'
         picture = 'http://placehold.it/200x200'
+        icon = 'mdi:kettle'
 
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id, None,
-            friendly_name, picture, hide_if_away=True)
+            friendly_name, picture, hide_if_away=True, icon=icon)
         device_tracker.update_config(self.yaml_devices, dev_id, device)
 
         with assert_setup_component(1, device_tracker.DOMAIN):
@@ -390,6 +392,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         attrs = self.hass.states.get(entity_id).attributes
 
         self.assertEqual(friendly_name, attrs.get(ATTR_FRIENDLY_NAME))
+        self.assertEqual(icon, attrs.get(ATTR_ICON))
         self.assertEqual(picture, attrs.get(ATTR_ENTITY_PICTURE))
 
     def test_device_hidden(self):


### PR DESCRIPTION
## Description:
Add `icon` support to `device_tracker`.

**Related issue (if applicable):** fixes #1237.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/2709

## Example entry for `known_devices.yaml`:
```yaml
devicename:
  name: My Teapot
  mac: EA:AA:55:E7:C6:94
  icon: mdi:kettle
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54