### PR TITLE
Disallow ambiguous color descriptors in the light.turn_on schema

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -77,6 +77,8 @@ EFFECT_COLORLOOP = "colorloop"
 EFFECT_RANDOM = "random"
 EFFECT_WHITE = "white"
 
+COLOR_GROUP = "Color descriptors"
+
 LIGHT_PROFILES_FILE = "light_profiles.csv"
 
 PROP_TO_ATTR = {
@@ -98,17 +100,21 @@ VALID_BRIGHTNESS_PCT = vol.All(vol.Coerce(float), vol.Range(min=0, max=100))
 
 LIGHT_TURN_ON_SCHEMA = vol.Schema({
     ATTR_ENTITY_ID: cv.entity_ids,
-    ATTR_PROFILE: cv.string,
+    vol.Exclusive(ATTR_PROFILE, COLOR_GROUP): cv.string,
     ATTR_TRANSITION: VALID_TRANSITION,
     ATTR_BRIGHTNESS: VALID_BRIGHTNESS,
     ATTR_BRIGHTNESS_PCT: VALID_BRIGHTNESS_PCT,
-    ATTR_COLOR_NAME: cv.string,
-    ATTR_RGB_COLOR: vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
-                            vol.Coerce(tuple)),
-    ATTR_XY_COLOR: vol.All(vol.ExactSequence((cv.small_float, cv.small_float)),
-                           vol.Coerce(tuple)),
-    ATTR_COLOR_TEMP: vol.All(vol.Coerce(int), vol.Range(min=1)),
-    ATTR_KELVIN: vol.All(vol.Coerce(int), vol.Range(min=0)),
+    vol.Exclusive(ATTR_COLOR_NAME, COLOR_GROUP): cv.string,
+    vol.Exclusive(ATTR_RGB_COLOR, COLOR_GROUP):
+        vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
+                vol.Coerce(tuple)),
+    vol.Exclusive(ATTR_XY_COLOR, COLOR_GROUP):
+        vol.All(vol.ExactSequence((cv.small_float, cv.small_float)),
+                vol.Coerce(tuple)),
+    vol.Exclusive(ATTR_COLOR_TEMP, COLOR_GROUP):
+        vol.All(vol.Coerce(int), vol.Range(min=1)),
+    vol.Exclusive(ATTR_KELVIN, COLOR_GROUP):
+        vol.All(vol.Coerce(int), vol.Range(min=0)),
     ATTR_WHITE_VALUE: vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
     ATTR_FLASH: vol.In([FLASH_SHORT, FLASH_LONG]),
     ATTR_EFFECT: cv.string,

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -206,10 +206,10 @@ class TestLight(unittest.TestCase):
 
         # Test light profiles
         light.turn_on(self.hass, dev1.entity_id, profile=prof_name)
-        # Specify a profile and attributes to overwrite it
+        # Specify a profile and a brightness attribute to overwrite it
         light.turn_on(
             self.hass, dev2.entity_id,
-            profile=prof_name, brightness=100, xy_color=(.4, .6))
+            profile=prof_name, brightness=100)
 
         self.hass.block_till_done()
 
@@ -222,10 +222,10 @@ class TestLight(unittest.TestCase):
         _, data = dev2.last_call('turn_on')
         self.assertEqual(
             {light.ATTR_BRIGHTNESS: 100,
-             light.ATTR_XY_COLOR: (.4, .6)},
+             light.ATTR_XY_COLOR: (.5119, .4147)},
             data)
 
-        # Test shitty data
+        # Test bad data
         light.turn_on(self.hass)
         light.turn_on(self.hass, dev1.entity_id, profile="nonexisting")
         light.turn_on(self.hass, dev2.entity_id, xy_color=["bla-di-bla", 5])
@@ -245,7 +245,10 @@ class TestLight(unittest.TestCase):
         # faulty attributes will not trigger a service call
         light.turn_on(
             self.hass, dev1.entity_id,
-            profile=prof_name, brightness='bright', rgb_color='yellowish')
+            profile=prof_name, brightness='bright')
+        light.turn_on(
+            self.hass, dev1.entity_id,
+            rgb_color='yellowish')
         light.turn_on(
             self.hass, dev2.entity_id,
             white_value='high')

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -491,8 +491,10 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual(STATE_OFF, state.state)
 
         self.mock_publish.reset_mock()
+        light.turn_on(self.hass, 'light.test',
+                      brightness=50, xy_color=[0.123, 0.123])
         light.turn_on(self.hass, 'light.test', rgb_color=[75, 75, 75],
-                      brightness=50, white_value=80, xy_color=[0.123, 0.123])
+                      white_value=80)
         self.hass.block_till_done()
 
         self.mock_publish().async_publish.assert_has_calls([

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -294,7 +294,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
 
-        light.turn_on(self.hass, 'light.test', rgb_color=[75, 75, 75],
+        light.turn_on(self.hass, 'light.test',
                       brightness=50, color_temp=155, effect='colorloop',
                       white_value=170)
         self.hass.block_till_done()
@@ -308,15 +308,11 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertEqual(50, message_json["brightness"])
         self.assertEqual(155, message_json["color_temp"])
         self.assertEqual('colorloop', message_json["effect"])
-        self.assertEqual(75, message_json["color"]["r"])
-        self.assertEqual(75, message_json["color"]["g"])
-        self.assertEqual(75, message_json["color"]["b"])
         self.assertEqual(170, message_json["white_value"])
         self.assertEqual("ON", message_json["state"])
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_ON, state.state)
-        self.assertEqual((75, 75, 75), state.attributes['rgb_color'])
         self.assertEqual(50, state.attributes['brightness'])
         self.assertEqual(155, state.attributes['color_temp'])
         self.assertEqual('colorloop', state.attributes['effect'])

--- a/tests/components/light/test_mqtt_template.py
+++ b/tests/components/light/test_mqtt_template.py
@@ -245,19 +245,27 @@ class TestLightMQTTTemplate(unittest.TestCase):
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
 
-        # turn on the light with brightness, color, color temp and white val
+        # turn on the light with brightness, color
         light.turn_on(self.hass, 'light.test', brightness=50,
-                      rgb_color=[75, 75, 75], color_temp=200, white_value=139)
+                      rgb_color=[75, 75, 75])
         self.hass.block_till_done()
 
         self.assertEqual('test_light_rgb/set',
                          self.mock_publish.mock_calls[-2][1][0])
-        self.assertEqual(2, self.mock_publish.mock_calls[-2][1][2])
-        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
 
         # check the payload
         payload = self.mock_publish.mock_calls[-2][1][1]
-        self.assertEqual('on,50,200,139,75-75-75', payload)
+        self.assertEqual('on,50,,,75-75-75', payload)
+
+        # turn on the light with color temp and white val
+        light.turn_on(self.hass, 'light.test', color_temp=200, white_value=139)
+        self.hass.block_till_done()
+
+        payload = self.mock_publish.mock_calls[-2][1][1]
+        self.assertEqual('on,,200,139,--', payload)
+
+        self.assertEqual(2, self.mock_publish.mock_calls[-2][1][2])
+        self.assertEqual(False, self.mock_publish.mock_calls[-2][1][3])
 
         # check the state
         state = self.hass.states.get('light.test')


### PR DESCRIPTION
## Description:

There are quite a lot of different ways to specify colors and making them mutally exclusive seems simpler than making rules of precedence.

Strictly speaking, this is a breaking change: previously you could have an XY and an RGB light in a group and make one light red and the other one blue with a single service call. I don't think losing that ability will be an issue. Also, profiles can no longer have their xy-value overwritten, only the brightness. Again – not a real loss.

The real breaking change is that it will now point out some configurations that have previously been ambiguous or redundant.

I have pooled `color_temp` with the color-setting ones because I think it should imply a white color.

The `white_value` is not included due to it being separate from all the others. In an RGBW light, the `white_value` affects the W while all the others affect the RGB.

Opinion can probably differ on the above points and I am prepared to adjust given some sensible arguments :)

**Breaking change notice**: The `light` component will now refuse `turn_on` calls that specify redundant or ambiguous colors, such as using both `color_name` and `color_rgb` in the same call.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
