### PR TITLE
Enocean Binary Sensor: Handle click of both rockers

### DIFF
--- a/homeassistant/components/binary_sensor/enocean.py
+++ b/homeassistant/components/binary_sensor/enocean.py
@@ -80,6 +80,12 @@ class EnOceanBinarySensor(enocean.EnOceanDevice, BinarySensorDevice):
         elif value2 == 0x10:
             self.which = 1
             self.onoff = 1
+        elif value2 == 0x37:
+            self.which = 10
+            self.onoff = 0
+        elif value2 == 0x15:
+            self.which = 10
+            self.onoff = 1
         self.hass.bus.fire('button_pressed', {'id': self.dev_id,
                                               'pushed': value,
                                               'which': self.which,


### PR DESCRIPTION
## Description:

Eltako FT55 double rocker switches send a different signal when both rockers are pushed together.
The value of "which" will be set to 10 to indicate that both buttons are pushed.