### PR TITLE
Get rid of mock http component app

### DIFF
--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -4,22 +4,18 @@ from unittest.mock import patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
-from homeassistant.components.config.core import CheckConfigView
-from tests.common import mock_http_component_app, mock_coro
+from tests.common import mock_coro
 
 
 @asyncio.coroutine
 def test_validate_config_ok(hass, test_client):
     """Test checking config."""
-    app = mock_http_component_app(hass)
     with patch.object(config, 'SECTIONS', ['core']):
         yield from async_setup_component(hass, 'config', {})
 
-    # yield from hass.async_block_till_done()
     yield from asyncio.sleep(0.1, loop=hass.loop)
 
-    hass.http.views[CheckConfigView.name].register(app.router)
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
 
     with patch(
         'homeassistant.components.config.core.async_check_ha_config_file',

--- a/tests/components/config/test_group.py
+++ b/tests/components/config/test_group.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
-from tests.common import mock_http_component_app
 
 
 VIEW_NAME = 'api:config:group:config'
@@ -14,14 +13,10 @@ VIEW_NAME = 'api:config:group:config'
 @asyncio.coroutine
 def test_get_device_config(hass, test_client):
     """Test getting device config."""
-    app = mock_http_component_app(hass)
-
     with patch.object(config, 'SECTIONS', ['group']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[VIEW_NAME].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
 
     def mock_read(path):
         """Mock reading data."""
@@ -47,14 +42,10 @@ def test_get_device_config(hass, test_client):
 @asyncio.coroutine
 def test_update_device_config(hass, test_client):
     """Test updating device config."""
-    app = mock_http_component_app(hass)
-
     with patch.object(config, 'SECTIONS', ['group']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[VIEW_NAME].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
 
     orig_data = {
         'hello.beer': {
@@ -96,14 +87,10 @@ def test_update_device_config(hass, test_client):
 @asyncio.coroutine
 def test_update_device_config_invalid_key(hass, test_client):
     """Test updating device config."""
-    app = mock_http_component_app(hass)
-
     with patch.object(config, 'SECTIONS', ['group']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[VIEW_NAME].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
 
     resp = yield from client.post(
         '/api/config/group/config/not a slug', data=json.dumps({
@@ -116,14 +103,10 @@ def test_update_device_config_invalid_key(hass, test_client):
 @asyncio.coroutine
 def test_update_device_config_invalid_data(hass, test_client):
     """Test updating device config."""
-    app = mock_http_component_app(hass)
-
     with patch.object(config, 'SECTIONS', ['group']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[VIEW_NAME].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
 
     resp = yield from client.post(
         '/api/config/group/config/hello_beer', data=json.dumps({
@@ -136,14 +119,10 @@ def test_update_device_config_invalid_data(hass, test_client):
 @asyncio.coroutine
 def test_update_device_config_invalid_json(hass, test_client):
     """Test updating device config."""
-    app = mock_http_component_app(hass)
-
     with patch.object(config, 'SECTIONS', ['group']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[VIEW_NAME].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
 
     resp = yield from client.post(
         '/api/config/group/config/hello_beer', data='not json')

--- a/tests/components/config/test_hassbian.py
+++ b/tests/components/config/test_hassbian.py
@@ -7,44 +7,40 @@ from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
 from homeassistant.components.config.hassbian import (
     HassbianSuitesView, HassbianSuiteInstallView)
-from tests.common import (
-    mock_http_component, mock_http_component_app)
 
 
 def test_setup_check_env_prevents_load(hass, loop):
     """Test it does not set up hassbian if environment var not present."""
-    mock_http_component(hass)
     with patch.dict(os.environ, clear=True), \
-            patch.object(config, 'SECTIONS', ['hassbian']):
+            patch.object(config, 'SECTIONS', ['hassbian']), \
+            patch('homeassistant.components.http.'
+                  'HomeAssistantWSGI.register_view') as reg_view:
         loop.run_until_complete(async_setup_component(hass, 'config', {}))
     assert 'config' in hass.config.components
-    assert HassbianSuitesView.name not in hass.http.views
-    assert HassbianSuiteInstallView.name not in hass.http.views
+    assert reg_view.called is False
 
 
 def test_setup_check_env_works(hass, loop):
     """Test it sets up hassbian if environment var present."""
-    mock_http_component(hass)
     with patch.dict(os.environ, {'FORCE_HASSBIAN': '1'}), \
-            patch.object(config, 'SECTIONS', ['hassbian']):
+            patch.object(config, 'SECTIONS', ['hassbian']), \
+            patch('homeassistant.components.http.'
+                  'HomeAssistantWSGI.register_view') as reg_view:
         loop.run_until_complete(async_setup_component(hass, 'config', {}))
     assert 'config' in hass.config.components
-    assert HassbianSuitesView.name in hass.http.views
-    assert HassbianSuiteInstallView.name in hass.http.views
+    assert len(reg_view.mock_calls) == 2
+    assert isinstance(reg_view.mock_calls[0][1][0], HassbianSuitesView)
+    assert isinstance(reg_view.mock_calls[1][1][0], HassbianSuiteInstallView)
 
 
 @asyncio.coroutine
 def test_get_suites(hass, test_client):
     """Test getting suites."""
-    app = mock_http_component_app(hass)
-
     with patch.dict(os.environ, {'FORCE_HASSBIAN': '1'}), \
             patch.object(config, 'SECTIONS', ['hassbian']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[HassbianSuitesView.name].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
     resp = yield from client.get('/api/config/hassbian/suites')
     assert resp.status == 200
     result = yield from resp.json()
@@ -59,15 +55,11 @@ def test_get_suites(hass, test_client):
 @asyncio.coroutine
 def test_install_suite(hass, test_client):
     """Test getting suites."""
-    app = mock_http_component_app(hass)
-
     with patch.dict(os.environ, {'FORCE_HASSBIAN': '1'}), \
             patch.object(config, 'SECTIONS', ['hassbian']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[HassbianSuiteInstallView.name].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
     resp = yield from client.post(
         '/api/config/hassbian/suites/openzwave/install')
     assert resp.status == 200

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
-from tests.common import mock_http_component_app
 
 
 VIEW_NAME = 'api:config:zwave:device_config'
@@ -14,14 +13,10 @@ VIEW_NAME = 'api:config:zwave:device_config'
 @asyncio.coroutine
 def test_get_device_config(hass, test_client):
     """Test getting device config."""
-    app = mock_http_component_app(hass)
-
     with patch.object(config, 'SECTIONS', ['zwave']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[VIEW_NAME].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
 
     def mock_read(path):
         """Mock reading data."""
@@ -47,14 +42,10 @@ def test_get_device_config(hass, test_client):
 @asyncio.coroutine
 def test_update_device_config(hass, test_client):
     """Test updating device config."""
-    app = mock_http_component_app(hass)
-
     with patch.object(config, 'SECTIONS', ['zwave']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[VIEW_NAME].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
 
     orig_data = {
         'hello.beer': {
@@ -94,14 +85,10 @@ def test_update_device_config(hass, test_client):
 @asyncio.coroutine
 def test_update_device_config_invalid_key(hass, test_client):
     """Test updating device config."""
-    app = mock_http_component_app(hass)
-
     with patch.object(config, 'SECTIONS', ['zwave']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[VIEW_NAME].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
 
     resp = yield from client.post(
         '/api/config/zwave/device_config/invalid_entity', data=json.dumps({
@@ -114,14 +101,10 @@ def test_update_device_config_invalid_key(hass, test_client):
 @asyncio.coroutine
 def test_update_device_config_invalid_data(hass, test_client):
     """Test updating device config."""
-    app = mock_http_component_app(hass)
-
     with patch.object(config, 'SECTIONS', ['zwave']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[VIEW_NAME].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
 
     resp = yield from client.post(
         '/api/config/zwave/device_config/hello.beer', data=json.dumps({
@@ -134,14 +117,10 @@ def test_update_device_config_invalid_data(hass, test_client):
 @asyncio.coroutine
 def test_update_device_config_invalid_json(hass, test_client):
     """Test updating device config."""
-    app = mock_http_component_app(hass)
-
     with patch.object(config, 'SECTIONS', ['zwave']):
         yield from async_setup_component(hass, 'config', {})
 
-    hass.http.views[VIEW_NAME].register(app.router)
-
-    client = yield from test_client(app)
+    client = yield from test_client(hass.http.app)
 
     resp = yield from client.post(
         '/api/config/zwave/device_config/hello.beer', data='not json')

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -16,8 +16,7 @@ from homeassistant.components.emulated_hue.hue_api import (
     HueAllLightsStateView, HueOneLightStateView, HueOneLightChangeView)
 from homeassistant.components.emulated_hue import Config
 
-from tests.common import (
-    get_test_instance_port, mock_http_component_app)
+from tests.common import get_test_instance_port
 
 HTTP_SERVER_PORT = get_test_instance_port()
 BRIDGE_SERVER_PORT = get_test_instance_port()
@@ -114,7 +113,7 @@ def hass_hue(loop, hass):
 @pytest.fixture
 def hue_client(loop, hass_hue, test_client):
     """Create web client for emulated hue api."""
-    web_app = mock_http_component_app(hass_hue)
+    web_app = hass_hue.http.app
     config = Config(None, {'type': 'alexa'})
 
     HueUsernameView().register(web_app.router)


### PR DESCRIPTION
## Description:
I realized that since our http server is only setup during the tests and never started, we don't need to mock it out. This simplifies the tests and should set a good example moving forward.

I'll remove the other usages in other PRs.


## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
