### PR TITLE
assertEquals is deprecated

### DIFF
--- a/tests/components/binary_sensor/test_aurora.py
+++ b/tests/components/binary_sensor/test_aurora.py
@@ -91,5 +91,5 @@ class TestAuroraSensorSetUp(unittest.TestCase):
         aurora.setup_platform(self.hass, config, mock_add_entities)
 
         aurora_component = entities[0]
-        self.assertEquals(aurora_component.aurora_data.visibility_level, '5')
+        self.assertEqual(aurora_component.aurora_data.visibility_level, '5')
         self.assertTrue(aurora_component.is_on)

--- a/tests/components/calendar/test_google.py
+++ b/tests/components/calendar/test_google.py
@@ -86,13 +86,13 @@ class TestComponentsGoogleCalendar(unittest.TestCase):
         cal = calendar.GoogleCalendarEventDevice(self.hass, None,
                                                  '', {'name': device_name})
 
-        self.assertEquals(cal.name, device_name)
+        self.assertEqual(cal.name, device_name)
 
-        self.assertEquals(cal.state, STATE_OFF)
+        self.assertEqual(cal.state, STATE_OFF)
 
         self.assertFalse(cal.offset_reached())
 
-        self.assertEquals(cal.device_state_attributes, {
+        self.assertEqual(cal.device_state_attributes, {
             'message': event['summary'],
             'all_day': True,
             'offset_reached': False,
@@ -145,13 +145,13 @@ class TestComponentsGoogleCalendar(unittest.TestCase):
         cal = calendar.GoogleCalendarEventDevice(self.hass, None, device_id,
                                                  {'name': device_name})
 
-        self.assertEquals(cal.name, device_name)
+        self.assertEqual(cal.name, device_name)
 
-        self.assertEquals(cal.state, STATE_OFF)
+        self.assertEqual(cal.state, STATE_OFF)
 
         self.assertFalse(cal.offset_reached())
 
-        self.assertEquals(cal.device_state_attributes, {
+        self.assertEqual(cal.device_state_attributes, {
             'message': event['summary'],
             'all_day': False,
             'offset_reached': False,
@@ -207,13 +207,13 @@ class TestComponentsGoogleCalendar(unittest.TestCase):
         cal = calendar.GoogleCalendarEventDevice(self.hass, None, device_id,
                                                  {'name': device_name})
 
-        self.assertEquals(cal.name, device_name)
+        self.assertEqual(cal.name, device_name)
 
-        self.assertEquals(cal.state, STATE_ON)
+        self.assertEqual(cal.state, STATE_ON)
 
         self.assertFalse(cal.offset_reached())
 
-        self.assertEquals(cal.device_state_attributes, {
+        self.assertEqual(cal.device_state_attributes, {
             'message': event['summary'],
             'all_day': False,
             'offset_reached': False,
@@ -270,13 +270,13 @@ class TestComponentsGoogleCalendar(unittest.TestCase):
         cal = calendar.GoogleCalendarEventDevice(self.hass, None, device_id,
                                                  {'name': device_name})
 
-        self.assertEquals(cal.name, device_name)
+        self.assertEqual(cal.name, device_name)
 
-        self.assertEquals(cal.state, STATE_OFF)
+        self.assertEqual(cal.state, STATE_OFF)
 
         self.assertTrue(cal.offset_reached())
 
-        self.assertEquals(cal.device_state_attributes, {
+        self.assertEqual(cal.device_state_attributes, {
             'message': event_summary,
             'all_day': False,
             'offset_reached': True,
@@ -339,13 +339,13 @@ class TestComponentsGoogleCalendar(unittest.TestCase):
         cal = calendar.GoogleCalendarEventDevice(self.hass, None, device_id,
                                                  {'name': device_name})
 
-        self.assertEquals(cal.name, device_name)
+        self.assertEqual(cal.name, device_name)
 
-        self.assertEquals(cal.state, STATE_OFF)
+        self.assertEqual(cal.state, STATE_OFF)
 
         self.assertTrue(cal.offset_reached())
 
-        self.assertEquals(cal.device_state_attributes, {
+        self.assertEqual(cal.device_state_attributes, {
             'message': event_summary,
             'all_day': True,
             'offset_reached': True,
@@ -406,13 +406,13 @@ class TestComponentsGoogleCalendar(unittest.TestCase):
         cal = calendar.GoogleCalendarEventDevice(self.hass, None, device_id,
                                                  {'name': device_name})
 
-        self.assertEquals(cal.name, device_name)
+        self.assertEqual(cal.name, device_name)
 
-        self.assertEquals(cal.state, STATE_OFF)
+        self.assertEqual(cal.state, STATE_OFF)
 
         self.assertFalse(cal.offset_reached())
 
-        self.assertEquals(cal.device_state_attributes, {
+        self.assertEqual(cal.device_state_attributes, {
             'message': event_summary,
             'all_day': True,
             'offset_reached': False,

--- a/tests/components/device_tracker/test_tplink.py
+++ b/tests/components/device_tracker/test_tplink.py
@@ -65,4 +65,4 @@ class TestTplink4DeviceScanner(unittest.TestCase):
         expected_mac_results = [mac.replace('-', ':') for mac in
                                 [FAKE_MAC_1, FAKE_MAC_2, FAKE_MAC_3]]
 
-        self.assertEquals(tplink.last_results, expected_mac_results)
+        self.assertEqual(tplink.last_results, expected_mac_results)

--- a/tests/components/test_google.py
+++ b/tests/components/test_google.py
@@ -52,7 +52,7 @@ class TestGoogle(unittest.TestCase):
         }
 
         calendar_info = google.get_calendar_info(self.hass, calendar)
-        self.assertEquals(calendar_info, {
+        self.assertEqual(calendar_info, {
             'cal_id': 'qwertyuiopasdfghjklzxcvbnm@import.calendar.google.com',
             'entities': [{
                 'device_id': 'we_are_we_are_a_test_calendar',
@@ -80,7 +80,7 @@ class TestGoogle(unittest.TestCase):
         # }
 
         # self.assertIsInstance(self.hass.data[google.DATA_INDEX], dict)
-        # self.assertEquals(self.hass.data[google.DATA_INDEX], {})
+        # self.assertEqual(self.hass.data[google.DATA_INDEX], {})
 
         calendar_service = google.GoogleCalendarService(
             self.hass.config.path(google.TOKEN_FILE))

--- a/tests/scripts/test_init.py
+++ b/tests/scripts/test_init.py
@@ -12,7 +12,7 @@ class TestScripts(unittest.TestCase):
            return_value='/default')
     def test_config_per_platform(self, mock_def):
         """Test config per platform method."""
-        self.assertEquals(scripts.get_default_config_dir(), '/default')
+        self.assertEqual(scripts.get_default_config_dir(), '/default')
         self.assertEqual(scripts.extract_config_dir(), '/default')
         self.assertEqual(scripts.extract_config_dir(['']), '/default')
         self.assertEqual(scripts.extract_config_dir(['-c', '/arg']), '/arg')

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -117,7 +117,7 @@ class TestDateUtil(unittest.TestCase):
         # confirm the ability to handle a string passed in
         delta = dt_util.as_timestamp("2016-01-01 12:12:12")
         delta -= dt_util.as_timestamp("2016-01-01 12:12:11")
-        self.assertEquals(1, delta)
+        self.assertEqual(1, delta)
 
     def test_parse_datetime_converts_correctly(self):
         """Test parse_datetime converts strings."""


### PR DESCRIPTION
## Description:
The latest Py.Test will print deprecation warnings at the end of a test run… and we've got a lot.

This was an easy warning to fix, use `self.assertEqual` instead of `self.assertEquals`

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
