### PR TITLE
Fix more deprecation warnings

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -83,7 +83,7 @@ class APIEventStream(HomeAssistantView):
         stop_obj = object()
         to_write = asyncio.Queue(loop=hass.loop)
 
-        restrict = request.GET.get('restrict')
+        restrict = request.query.get('restrict')
         if restrict:
             restrict = restrict.split(',') + [EVENT_HOMEASSISTANT_STOP]
 

--- a/homeassistant/components/binary_sensor/mystrom.py
+++ b/homeassistant/components/binary_sensor/mystrom.py
@@ -38,7 +38,7 @@ class MyStromView(HomeAssistantView):
     @asyncio.coroutine
     def get(self, request):
         """The GET request received from a myStrom button."""
-        res = yield from self._handle(request.app['hass'], request.GET)
+        res = yield from self._handle(request.app['hass'], request.query)
         return res
 
     @asyncio.coroutine

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -241,7 +241,7 @@ class CameraView(HomeAssistantView):
             return web.Response(status=status)
 
         authenticated = (request[KEY_AUTHENTICATED] or
-                         request.GET.get('token') in camera.access_tokens)
+                         request.query.get('token') in camera.access_tokens)
 
         if not authenticated:
             return web.Response(status=401)

--- a/homeassistant/components/device_tracker/gpslogger.py
+++ b/homeassistant/components/device_tracker/gpslogger.py
@@ -39,7 +39,7 @@ class GPSLoggerView(HomeAssistantView):
     @asyncio.coroutine
     def get(self, request):
         """Handle for GPSLogger message received as GET."""
-        res = yield from self._handle(request.app['hass'], request.GET)
+        res = yield from self._handle(request.app['hass'], request.query)
         return res
 
     @asyncio.coroutine

--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -41,7 +41,7 @@ class LocativeView(HomeAssistantView):
     @asyncio.coroutine
     def get(self, request):
         """Locative message received as GET."""
-        res = yield from self._handle(request.app['hass'], request.GET)
+        res = yield from self._handle(request.app['hass'], request.query)
         return res
 
     @asyncio.coroutine

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -223,7 +223,7 @@ class HistoryPeriodView(HomeAssistantView):
         if start_time > now:
             return self.json([])
 
-        end_time = request.GET.get('end_time')
+        end_time = request.query.get('end_time')
         if end_time:
             end_time = dt_util.as_utc(
                 dt_util.parse_datetime(end_time))
@@ -231,7 +231,7 @@ class HistoryPeriodView(HomeAssistantView):
                 return self.json_message('Invalid end_time', HTTP_BAD_REQUEST)
         else:
             end_time = start_time + one_day
-        entity_id = request.GET.get('filter_entity_id')
+        entity_id = request.query.get('filter_entity_id')
 
         result = yield from request.app['hass'].loop.run_in_executor(
             None, get_significant_states, request.app['hass'], start_time,

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -37,8 +37,8 @@ def auth_middleware(app, handler):
             # A valid auth header has been set
             authenticated = True
 
-        elif (DATA_API_PASSWORD in request.GET and
-              validate_password(request, request.GET[DATA_API_PASSWORD])):
+        elif (DATA_API_PASSWORD in request.query and
+              validate_password(request, request.query[DATA_API_PASSWORD])):
             authenticated = True
 
         elif is_trusted_ip(request):

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -960,7 +960,7 @@ class MediaPlayerImageView(HomeAssistantView):
             return web.Response(status=status)
 
         authenticated = (request[KEY_AUTHENTICATED] or
-                         request.GET.get('token') == player.access_token)
+                         request.query.get('token') == player.access_token)
 
         if not authenticated:
             return web.Response(status=401)

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -110,7 +110,7 @@ class SpotifyAuthCallbackView(HomeAssistantView):
     def get(self, request):
         """Receive authorization token."""
         hass = request.app['hass']
-        self.oauth.get_access_token(request.GET['code'])
+        self.oauth.get_access_token(request.query['code'])
         hass.async_add_job(setup_platform, hass, self.config, self.add_devices)
 
 

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -246,7 +246,7 @@ class HTML5PushCallbackView(HomeAssistantView):
         # 2a. If decode is successful, return the payload.
         # 2b. If decode is unsuccessful, return a 401.
 
-        target_check = jwt.decode(token, verify=False)
+        target_check = jwt.decode(token, options={'verify_signature': False})
         if target_check[ATTR_TARGET] in self.registrations:
             possible_target = self.registrations[target_check[ATTR_TARGET]]
             key = possible_target[ATTR_SUBSCRIPTION][ATTR_KEYS][ATTR_AUTH]

--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -299,7 +299,7 @@ class FitbitAuthCallbackView(HomeAssistantView):
         from oauthlib.oauth2.rfc6749.errors import MissingTokenError
 
         hass = request.app['hass']
-        data = request.GET
+        data = request.query
 
         response_message = """Fitbit has been successfully authorized!
         You can close this window now!"""

--- a/homeassistant/components/sensor/torque.py
+++ b/homeassistant/components/sensor/torque.py
@@ -75,7 +75,7 @@ class TorqueReceiveDataView(HomeAssistantView):
     def get(self, request):
         """Handle Torque data request."""
         hass = request.app['hass']
-        data = request.GET
+        data = request.query
 
         if self.email is not None and self.email != data[SENSOR_EMAIL_FIELD]:
             return

--- a/homeassistant/components/switch/netio.py
+++ b/homeassistant/components/switch/netio.py
@@ -95,7 +95,7 @@ class NetioApiView(HomeAssistantView):
     def get(self, request, host):
         """Request handler."""
         hass = request.app['hass']
-        data = request.GET
+        data = request.query
         states, consumptions, cumulated_consumptions, start_dates = \
             [], [], [], []
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,7 +8,6 @@ pydocstyle==1.1.1
 coveralls>=1.1
 pytest>=2.9.2
 pytest-aiohttp>=0.1.3
-pytest-asyncio>=0.5.0
 pytest-cov>=2.3.1
 pytest-timeout>=1.2.0
 pytest-catchlog>=1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -9,7 +9,6 @@ pydocstyle==1.1.1
 coveralls>=1.1
 pytest>=2.9.2
 pytest-aiohttp>=0.1.3
-pytest-asyncio>=0.5.0
 pytest-cov>=2.3.1
 pytest-timeout>=1.2.0
 pytest-catchlog>=1.2.2

--- a/tests/common.py
+++ b/tests/common.py
@@ -250,7 +250,7 @@ def mock_http_component_app(hass, api_password=None):
     """Create an aiohttp.web.Application instance for testing."""
     if 'http' not in hass.config.components:
         mock_http_component(hass, api_password)
-    app = web.Application(middlewares=[auth_middleware], loop=hass.loop)
+    app = web.Application(middlewares=[auth_middleware])
     app['hass'] = hass
     app[KEY_USE_X_FORWARDED_FOR] = False
     app[KEY_BANS_ENABLED] = False

--- a/tests/components/device_tracker/test_mqtt_json.py
+++ b/tests/components/device_tracker/test_mqtt_json.py
@@ -69,7 +69,6 @@ class TestComponentsDeviceTrackerJSONMQTT(unittest.TestCase):
         topic = 'location/zanzito'
         location = json.dumps(LOCATION_MESSAGE)
 
-        self.hass.config.components = set(['mqtt_json', 'zone'])
         assert setup_component(self.hass, device_tracker.DOMAIN, {
             device_tracker.DOMAIN: {
                 CONF_PLATFORM: 'mqtt_json',
@@ -88,7 +87,6 @@ class TestComponentsDeviceTrackerJSONMQTT(unittest.TestCase):
         topic = 'location/zanzito'
         location = 'home'
 
-        self.hass.config.components = set(['mqtt_json'])
         assert setup_component(self.hass, device_tracker.DOMAIN, {
             device_tracker.DOMAIN: {
                 CONF_PLATFORM: 'mqtt_json',
@@ -110,7 +108,6 @@ class TestComponentsDeviceTrackerJSONMQTT(unittest.TestCase):
         topic = 'location/zanzito'
         location = json.dumps(LOCATION_MESSAGE_INCOMPLETE)
 
-        self.hass.config.components = set(['mqtt_json'])
         assert setup_component(self.hass, device_tracker.DOMAIN, {
             device_tracker.DOMAIN: {
                 CONF_PLATFORM: 'mqtt_json',

--- a/tests/components/media_player/test_yamaha.py
+++ b/tests/components/media_player/test_yamaha.py
@@ -73,7 +73,7 @@ class TestYamaha(unittest.TestCase):
     def setUp(self):
         """Setup things to be run when tests are started."""
         super(TestYamaha, self).setUp()
-        self.rec = FakeYamaha('10.0.0.0')
+        self.rec = FakeYamaha("http://10.0.0.0:80/YamahaRemoteControl/ctrl")
 
     def test_get_playback_support(self):
         """Test the playback."""

--- a/tests/components/notify/test_command_line.py
+++ b/tests/components/notify/test_command_line.py
@@ -63,9 +63,9 @@ class TestCommandLine(unittest.TestCase):
                                         blocking=True)
             )
 
-            result = open(filename).read()
-            # the echo command adds a line break
-            self.assertEqual(result, "{}\n".format(message))
+            with open(filename) as fil:
+                # the echo command adds a line break
+                self.assertEqual(fil.read(), "{}\n".format(message))
 
     @patch('homeassistant.components.notify.command_line._LOGGER.error')
     def test_error_for_none_zero_exit_code(self, mock_error):

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -31,7 +31,7 @@ def test_generate_entity_id_given_keys():
             'test.another_entity']) == 'test.overwrite_hidden_true'
 
 
-def test_async_update_support(event_loop):
+def test_async_update_support(hass):
     """Test async update getting called."""
     sync_update = []
     async_update = []
@@ -44,13 +44,9 @@ def test_async_update_support(event_loop):
             sync_update.append([1])
 
     ent = AsyncEntity()
-    ent.hass.loop = event_loop
+    ent.hass = hass
 
-    @asyncio.coroutine
-    def test():
-        yield from ent.async_update_ha_state(True)
-
-    event_loop.run_until_complete(test())
+    hass.loop.run_until_complete(ent.async_update_ha_state(True))
 
     assert len(sync_update) == 1
     assert len(async_update) == 0
@@ -62,7 +58,7 @@ def test_async_update_support(event_loop):
 
     ent.async_update = async_update_func
 
-    event_loop.run_until_complete(test())
+    hass.loop.run_until_complete(ent.async_update_ha_state(True))
 
     assert len(sync_update) == 1
     assert len(async_update) == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Test config utils."""
 # pylint: disable=protected-access
+import asyncio
 import os
 import unittest
 import unittest.mock as mock
@@ -546,7 +547,7 @@ def test_merge_duplicate_keys(merge_log_err):
     assert len(config['input_select']) == 1
 
 
-@pytest.mark.asyncio
+@asyncio.coroutine
 def test_merge_customize(hass):
     """Test loading core config onto hass object."""
     core_config = {


### PR DESCRIPTION
## Description:
The tests have highlighted a few more deprecation warnings.

Once we have fixed them all we can setup py.test to mark deprecation warnings as hard failures 👍 

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
