### PR TITLE
Support for renaming ZWave values

### DIFF
--- a/homeassistant/components/zwave/api.py
+++ b/homeassistant/components/zwave/api.py
@@ -9,6 +9,32 @@ from . import const
 _LOGGER = logging.getLogger(__name__)
 
 
+class ZWaveNodeValueView(HomeAssistantView):
+    """View to return the node values."""
+
+    url = r"/api/zwave/values/{node_id:\d+}"
+    name = "api:zwave:values"
+
+    @ha.callback
+    def get(self, request, node_id):
+        """Retrieve groups of node."""
+        nodeid = int(node_id)
+        hass = request.app['hass']
+        values_list = hass.data[const.DATA_ENTITY_VALUES]
+
+        values_data = {}
+        # Return a list of values for this node that are used as a
+        # primary value for an entity
+        for entity_values in values_list:
+            if entity_values.primary.node.node_id != nodeid:
+                continue
+
+            values_data[entity_values.primary.value_id] = {
+                'label': entity_values.primary.label,
+            }
+        return self.json(values_data)
+
+
 class ZWaveNodeGroupView(HomeAssistantView):
     """View to return the nodes group configuration."""
 

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -20,6 +20,7 @@ DISCOVERY_DEVICE = 'device'
 
 DATA_DEVICES = 'zwave_devices'
 DATA_NETWORK = 'zwave_network'
+DATA_ENTITY_VALUES = 'zwave_entity_values'
 
 SERVICE_CHANGE_ASSOCIATION = "change_association"
 SERVICE_ADD_NODE = "add_node"
@@ -38,6 +39,7 @@ SERVICE_SET_WAKEUP = "set_wakeup"
 SERVICE_STOP_NETWORK = "stop_network"
 SERVICE_START_NETWORK = "start_network"
 SERVICE_RENAME_NODE = "rename_node"
+SERVICE_RENAME_VALUE = "rename_value"
 SERVICE_REFRESH_ENTITY = "refresh_entity"
 SERVICE_REFRESH_NODE = "refresh_node"
 SERVICE_RESET_NODE_METERS = "reset_node_meters"

--- a/homeassistant/components/zwave/services.yaml
+++ b/homeassistant/components/zwave/services.yaml
@@ -109,6 +109,19 @@ rename_node:
       description: New Name
       example: 'kitchen'
 
+rename_value:
+  description: Set the name of a node value. Value IDs can be queried from /api/zwave/values/{node_id}
+  fields:
+    node_id:
+      description: ID of the node to rename.
+      example: 10
+    value_id:
+      description: ID of the value to rename.
+      example: 72037594255792737
+    name:
+      description: New Name
+      example: 'Luminosity'
+
 reset_node_meters:
   description: Resets the meter counters of a node.
   fields:

--- a/tests/components/zwave/test_api.py
+++ b/tests/components/zwave/test_api.py
@@ -15,14 +15,17 @@ def test_get_values(hass, test_client):
     app = mock_http_component_app(hass)
     ZWaveNodeValueView().register(app.router)
 
-    node = MockNode(node_id=2)
+    node = MockNode(node_id=1)
     value = MockValue(value_id=123456, node=node, label='Test Label')
     values = MockEntityValues(primary=value)
-    hass.data[const.DATA_ENTITY_VALUES] = [values]
+    node2 = MockNode(node_id=2)
+    value2 = MockValue(value_id=234567, node=node2, label='Test Label 2')
+    values2 = MockEntityValues(primary=value2)
+    hass.data[const.DATA_ENTITY_VALUES] = [values, values2]
 
     client = yield from test_client(app)
 
-    resp = yield from client.get('/api/zwave/values/2')
+    resp = yield from client.get('/api/zwave/values/1')
 
     assert resp.status == 200
     result = yield from resp.json()

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -868,6 +868,23 @@ class TestZWaveServices(unittest.TestCase):
 
         assert self.zwave_network.nodes[11].name == 'test_name'
 
+    def test_rename_value(self):
+        """Test zwave rename_value service."""
+        node = MockNode(node_id=14)
+        value = MockValue(index=12, value_id=123456, label="Old Label")
+        node.values = {123456: value}
+        self.zwave_network.nodes = {11: node}
+
+        assert value.label == "Old Label"
+        self.hass.services.call('zwave', 'rename_value', {
+            const.ATTR_NODE_ID: 11,
+            const.ATTR_VALUE_ID: 123456,
+            const.ATTR_NAME: "New Label",
+        })
+        self.hass.block_till_done()
+
+        assert value.label == "New Label"
+
     def test_remove_failed_node(self):
         """Test zwave remove_failed_node service."""
         self.hass.services.call('zwave', 'remove_failed_node', {


### PR DESCRIPTION
## Description:
This PR adds a card to the ZWave panel that allows renaming of the ZWave values. This is important because it gives users more control over the final entity_ids. For now since this is the primary purpose, I'm filtering the list of values returned by the API call to only those that are primary values for an entity. If we expand the role of the values card or there is another reasonable use-case, we can return the full list of values for the node.

**Pull request in home-assistant-polymer:** https://github.com/home-assistant/home-assistant-polymer/pull/295

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2716