### PR TITLE
Use standard entity_ids for zwave entities

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -47,11 +47,11 @@ TEMP_COLD_HASS = (TEMP_COLOR_MAX - TEMP_COLOR_MIN) / 3 + TEMP_COLOR_MIN
 
 def get_device(node, values, node_config, **kwargs):
     """Create Z-Wave entity device."""
-    name = '{}.{}'.format(DOMAIN, zwave.object_id(values.primary))
     refresh = node_config.get(zwave.CONF_REFRESH_VALUE)
     delay = node_config.get(zwave.CONF_REFRESH_DELAY)
-    _LOGGER.debug("name=%s node_config=%s CONF_REFRESH_VALUE=%s"
-                  " CONF_REFRESH_DELAY=%s", name, node_config, refresh, delay)
+    _LOGGER.debug("node=%d value=%d node_config=%s CONF_REFRESH_VALUE=%s"
+                  " CONF_REFRESH_DELAY=%s", node.node_id,
+                  values.primary.value_id, node_config, refresh, delay)
 
     if node.has_command_class(zwave.const.COMMAND_CLASS_SWITCH_COLOR):
         return ZwaveColorLight(values, refresh, delay)

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -802,10 +802,10 @@ class ZWaveDeviceEntityValues():
             self._workaround_ignore = True
             return
 
-        device._old_entity_id = "{}.{}".format(
+        device.old_entity_id = "{}.{}".format(
             component, object_id(self.primary))
         if not self._zwave_config[DOMAIN][CONF_NEW_ENTITY_IDS]:
-            device.entity_id = device._old_entity_id
+            device.entity_id = device.old_entity_id
 
         self._entity = device
 
@@ -899,7 +899,9 @@ class ZWaveDeviceEntity(ZWaveBaseEntity):
         """Return the device specific state attributes."""
         attrs = {
             const.ATTR_NODE_ID: self.node_id,
-            'old_entity_id': self._old_entity_id,
+            const.ATTR_VALUE_INDEX: self.values.primary.index,
+            const.ATTR_VALUE_INSTANCE: self.values.primary.instance,
+            'old_entity_id': self.old_entity_id,
         }
 
         if self.power_consumption is not None:

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -259,7 +259,7 @@ def setup(hass, config):
             "ZWave entity_ids will soon be changing. To opt in to new "
             "entity_ids now, set `new_entity_ids: true` under zwave in your "
             "configuration.yaml. See the following blog post for details: "
-            "")
+            "https://home-assistant.io/blog/2017/06/15/zwave-entity-ids/")
 
     # Setup options
     options = ZWaveOption(

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -804,6 +804,7 @@ class ZWaveDeviceEntityValues():
 
         device.old_entity_id = "{}.{}".format(
             component, object_id(self.primary))
+        device.new_entity_id = "{}.{}".format(component, slugify(device.name))
         if not self._zwave_config[DOMAIN][CONF_NEW_ENTITY_IDS]:
             device.entity_id = device.old_entity_id
 
@@ -902,6 +903,7 @@ class ZWaveDeviceEntity(ZWaveBaseEntity):
             const.ATTR_VALUE_INDEX: self.values.primary.index,
             const.ATTR_VALUE_INSTANCE: self.values.primary.instance,
             'old_entity_id': self.old_entity_id,
+            'new_entity_id': self.new_entity_id,
         }
 
         if self.power_consumption is not None:

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -802,9 +802,10 @@ class ZWaveDeviceEntityValues():
             self._workaround_ignore = True
             return
 
+        device._old_entity_id = "{}.{}".format(
+            component, object_id(self.primary))
         if not self._zwave_config[DOMAIN][CONF_NEW_ENTITY_IDS]:
-            device.entity_id = "{}.{}".format(
-                component, object_id(self.primary))
+            device.entity_id = device._old_entity_id
 
         self._entity = device
 
@@ -898,6 +899,7 @@ class ZWaveDeviceEntity(ZWaveBaseEntity):
         """Return the device specific state attributes."""
         attrs = {
             const.ATTR_NODE_ID: self.node_id,
+            'old_entity_id': self._old_entity_id,
         }
 
         if self.power_consumption is not None:

--- a/homeassistant/components/zwave/api.py
+++ b/homeassistant/components/zwave/api.py
@@ -31,6 +31,8 @@ class ZWaveNodeValueView(HomeAssistantView):
 
             values_data[entity_values.primary.value_id] = {
                 'label': entity_values.primary.label,
+                'index': entity_values.primary.index,
+                'instance': entity_values.primary.instance,
             }
         return self.json(values_data)
 

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -14,6 +14,8 @@ ATTR_BASIC_LEVEL = "basic_level"
 ATTR_CONFIG_PARAMETER = "parameter"
 ATTR_CONFIG_SIZE = "size"
 ATTR_CONFIG_VALUE = "value"
+ATTR_VALUE_INDEX = "value_index"
+ATTR_VALUE_INSTANCE = "value_instance"
 NETWORK_READY_WAIT_SECS = 30
 
 DISCOVERY_DEVICE = 'device'

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -4,10 +4,11 @@ import logging
 from homeassistant.core import callback
 from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_WAKEUP, ATTR_ENTITY_ID
 from homeassistant.helpers.entity import Entity
+from homeassistant.util import slugify
 
 from .const import (
     ATTR_NODE_ID, COMMAND_CLASS_WAKE_UP, ATTR_SCENE_ID, ATTR_BASIC_LEVEL,
-    EVENT_NODE_EVENT, EVENT_SCENE_ACTIVATED)
+    EVENT_NODE_EVENT, EVENT_SCENE_ACTIVATED, DOMAIN)
 from .util import node_name
 
 _LOGGER = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ def sub_status(status, stage):
 class ZWaveNodeEntity(ZWaveBaseEntity):
     """Representation of a Z-Wave node."""
 
-    def __init__(self, node, network):
+    def __init__(self, node, network, new_entity_ids):
         """Initialize node."""
         # pylint: disable=import-error
         super().__init__()
@@ -85,6 +86,9 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         self._name = node_name(self.node)
         self._product_name = node.product_name
         self._manufacturer_name = node.manufacturer_name
+        if not new_entity_ids:
+            self.entity_id = "{}.{}_{}".format(
+                DOMAIN, slugify(self._name), self.node_id)
         self._attributes = {}
         self.wakeup_interval = None
         self.location = None

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -40,6 +40,7 @@ class ZWaveBaseEntity(Entity):
     def __init__(self):
         """Initialize the base Z-Wave class."""
         self._update_scheduled = False
+        self._old_entity_id = None
 
     def maybe_schedule_update(self):
         """Maybe schedule state update.
@@ -86,9 +87,10 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         self._name = node_name(self.node)
         self._product_name = node.product_name
         self._manufacturer_name = node.manufacturer_name
+        self._old_entity_id = "{}.{}_{}".format(
+            DOMAIN, slugify(self._name), self.node_id)
         if not new_entity_ids:
-            self.entity_id = "{}.{}_{}".format(
-                DOMAIN, slugify(self._name), self.node_id)
+            self.entity_id = self._old_entity_id
         self._attributes = {}
         self.wakeup_interval = None
         self.location = None
@@ -208,6 +210,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
             ATTR_NODE_NAME: self._name,
             ATTR_MANUFACTURER_NAME: self._manufacturer_name,
             ATTR_PRODUCT_NAME: self._product_name,
+            'old_entity_id': self._old_entity_id,
         }
         attrs.update(self._attributes)
         if self.battery_level is not None:

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -40,7 +40,7 @@ class ZWaveBaseEntity(Entity):
     def __init__(self):
         """Initialize the base Z-Wave class."""
         self._update_scheduled = False
-        self._old_entity_id = None
+        self.old_entity_id = None
 
     def maybe_schedule_update(self):
         """Maybe schedule state update.
@@ -87,10 +87,10 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         self._name = node_name(self.node)
         self._product_name = node.product_name
         self._manufacturer_name = node.manufacturer_name
-        self._old_entity_id = "{}.{}_{}".format(
+        self.old_entity_id = "{}.{}_{}".format(
             DOMAIN, slugify(self._name), self.node_id)
         if not new_entity_ids:
-            self.entity_id = self._old_entity_id
+            self.entity_id = self.old_entity_id
         self._attributes = {}
         self.wakeup_interval = None
         self.location = None
@@ -210,7 +210,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
             ATTR_NODE_NAME: self._name,
             ATTR_MANUFACTURER_NAME: self._manufacturer_name,
             ATTR_PRODUCT_NAME: self._product_name,
-            'old_entity_id': self._old_entity_id,
+            'old_entity_id': self.old_entity_id,
         }
         attrs.update(self._attributes)
         if self.battery_level is not None:

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -41,6 +41,7 @@ class ZWaveBaseEntity(Entity):
         """Initialize the base Z-Wave class."""
         self._update_scheduled = False
         self.old_entity_id = None
+        self.new_entity_id = None
 
     def maybe_schedule_update(self):
         """Maybe schedule state update.
@@ -89,6 +90,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         self._manufacturer_name = node.manufacturer_name
         self.old_entity_id = "{}.{}_{}".format(
             DOMAIN, slugify(self._name), self.node_id)
+        self.new_entity_id = "{}.{}".format(DOMAIN, slugify(self._name))
         if not new_entity_ids:
             self.entity_id = self.old_entity_id
         self._attributes = {}
@@ -211,6 +213,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
             ATTR_MANUFACTURER_NAME: self._manufacturer_name,
             ATTR_PRODUCT_NAME: self._product_name,
             'old_entity_id': self.old_entity_id,
+            'new_entity_id': self.new_entity_id,
         }
         attrs.update(self._attributes)
         if self.battery_level is not None:

--- a/tests/components/zwave/test_api.py
+++ b/tests/components/zwave/test_api.py
@@ -16,7 +16,8 @@ def test_get_values(hass, test_client):
     ZWaveNodeValueView().register(app.router)
 
     node = MockNode(node_id=1)
-    value = MockValue(value_id=123456, node=node, label='Test Label')
+    value = MockValue(value_id=123456, node=node, label='Test Label',
+                      instance=1, index=2)
     values = MockEntityValues(primary=value)
     node2 = MockNode(node_id=2)
     value2 = MockValue(value_id=234567, node=node2, label='Test Label 2')
@@ -33,6 +34,8 @@ def test_get_values(hass, test_client):
     assert result == {
         '123456': {
             'label': 'Test Label',
+            'instance': 1,
+            'index': 2,
         }
     }
 

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -442,6 +442,11 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
     @patch.object(zwave, 'discovery')
     def test_entity_discovery(self, discovery, get_platform):
         """Test the creation of a new entity."""
+        mock_platform = MagicMock()
+        get_platform.return_value = mock_platform
+        mock_device = MagicMock()
+        mock_device.name = 'test_device'
+        mock_platform.get_device.return_value = mock_device
         values = zwave.ZWaveDeviceEntityValues(
             hass=self.hass,
             schema=self.mock_schema,
@@ -501,6 +506,11 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
     @patch.object(zwave, 'discovery')
     def test_entity_existing_values(self, discovery, get_platform):
         """Test the loading of already discovered values."""
+        mock_platform = MagicMock()
+        get_platform.return_value = mock_platform
+        mock_device = MagicMock()
+        mock_device.name = 'test_device'
+        mock_platform.get_device.return_value = mock_device
         self.node.values = {
             self.primary.value_id: self.primary,
             self.secondary.value_id: self.secondary,
@@ -564,6 +574,11 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
     @patch.object(zwave, 'discovery')
     def test_entity_workaround_component(self, discovery, get_platform):
         """Test ignore workaround."""
+        mock_platform = MagicMock()
+        get_platform.return_value = mock_platform
+        mock_device = MagicMock()
+        mock_device.name = 'test_device'
+        mock_platform.get_device.return_value = mock_device
         self.node.manufacturer_id = '010f'
         self.node.product_type = '0b00'
         self.primary.command_class = const.COMMAND_CLASS_SENSOR_ALARM
@@ -671,6 +686,11 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
     @patch.object(zwave, 'discovery')
     def test_config_polling_intensity(self, discovery, get_platform):
         """Test polling intensity."""
+        mock_platform = MagicMock()
+        get_platform.return_value = mock_platform
+        mock_device = MagicMock()
+        mock_device.name = 'test_device'
+        mock_platform.get_device.return_value = mock_device
         self.node.values = {
             self.primary.value_id: self.primary,
             self.secondary.value_id: self.secondary,

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -222,7 +222,7 @@ def test_node_discovery(hass, mock_openzwave):
     hass.async_add_job(mock_receivers[0], node)
     yield from hass.async_block_till_done()
 
-    assert hass.states.get('zwave.mock_node_14').state is 'unknown'
+    assert hass.states.get('zwave.mock_node').state is 'unknown'
 
 
 @asyncio.coroutine
@@ -237,7 +237,7 @@ def test_node_ignored(hass, mock_openzwave):
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
         yield from async_setup_component(hass, 'zwave', {'zwave': {
             'device_config': {
-                'zwave.mock_node_14': {
+                'zwave.mock_node': {
                     'ignored': True,
                     }}}})
 
@@ -247,7 +247,7 @@ def test_node_ignored(hass, mock_openzwave):
     hass.async_add_job(mock_receivers[0], node)
     yield from hass.async_block_till_done()
 
-    assert hass.states.get('zwave.mock_node_14') is None
+    assert hass.states.get('zwave.mock_node') is None
 
 
 @asyncio.coroutine
@@ -272,7 +272,7 @@ def test_value_discovery(hass, mock_openzwave):
     yield from hass.async_block_till_done()
 
     assert hass.states.get(
-        'binary_sensor.mock_node_mock_value_11_12_13').state is 'off'
+        'binary_sensor.mock_node_mock_value').state is 'off'
 
 
 @asyncio.coroutine
@@ -297,9 +297,9 @@ def test_value_discovery_existing_entity(hass, mock_openzwave):
     hass.async_add_job(mock_receivers[0], node, setpoint)
     yield from hass.async_block_till_done()
 
-    assert hass.states.get('climate.mock_node_mock_value_11_12_13').attributes[
+    assert hass.states.get('climate.mock_node_mock_value').attributes[
         'temperature'] == 22.0
-    assert hass.states.get('climate.mock_node_mock_value_11_12_13').attributes[
+    assert hass.states.get('climate.mock_node_mock_value').attributes[
         'current_temperature'] is None
 
     def mock_update(self):
@@ -314,73 +314,10 @@ def test_value_discovery_existing_entity(hass, mock_openzwave):
         hass.async_add_job(mock_receivers[0], node, temperature)
         yield from hass.async_block_till_done()
 
-    assert hass.states.get('climate.mock_node_mock_value_11_12_13').attributes[
+    assert hass.states.get('climate.mock_node_mock_value').attributes[
         'temperature'] == 22.0
-    assert hass.states.get('climate.mock_node_mock_value_11_12_13').attributes[
+    assert hass.states.get('climate.mock_node_mock_value').attributes[
         'current_temperature'] == 23.5
-
-
-@asyncio.coroutine
-def test_scene_activated(hass, mock_openzwave):
-    """Test scene activated event."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_SCENE_EVENT:
-            mock_receivers.append(receiver)
-
-    with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
-
-    assert len(mock_receivers) == 1
-
-    events = []
-
-    def listener(event):
-        events.append(event)
-
-    hass.bus.async_listen(const.EVENT_SCENE_ACTIVATED, listener)
-
-    node = MockNode(node_id=11)
-    scene_id = 123
-    hass.async_add_job(mock_receivers[0], node, scene_id)
-    yield from hass.async_block_till_done()
-
-    assert len(events) == 1
-    assert events[0].data[ATTR_ENTITY_ID] == "mock_node_11"
-    assert events[0].data[const.ATTR_OBJECT_ID] == "mock_node_11"
-    assert events[0].data[const.ATTR_SCENE_ID] == scene_id
-
-
-@asyncio.coroutine
-def test_node_event_activated(hass, mock_openzwave):
-    """Test Node event activated event."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_NODE_EVENT:
-            mock_receivers.append(receiver)
-
-    with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
-
-    assert len(mock_receivers) == 1
-
-    events = []
-
-    def listener(event):
-        events.append(event)
-
-    hass.bus.async_listen(const.EVENT_NODE_EVENT, listener)
-
-    node = MockNode(node_id=11)
-    value = 234
-    hass.async_add_job(mock_receivers[0], node, value)
-    yield from hass.async_block_till_done()
-
-    assert len(events) == 1
-    assert events[0].data[const.ATTR_OBJECT_ID] == "mock_node_11"
-    assert events[0].data[const.ATTR_BASIC_LEVEL] == value
 
 
 @asyncio.coroutine
@@ -478,8 +415,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         self.no_match_value = MockValue(
             command_class='mock_bad_class', node=self.node)
 
-        self.entity_id = '{}.{}'.format('mock_component',
-                                        zwave.object_id(self.primary))
+        self.entity_id = 'mock_component.mock_node_mock_value'
         self.zwave_config = {}
         self.device_config = {self.entity_id: {}}
 
@@ -616,8 +552,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         self.node.manufacturer_id = '010f'
         self.node.product_type = '0b00'
         self.primary.command_class = const.COMMAND_CLASS_SENSOR_ALARM
-        self.entity_id = '{}.{}'.format('binary_sensor',
-                                        zwave.object_id(self.primary))
+        self.entity_id = 'binary_sensor.mock_node_mock_value'
         self.device_config = {self.entity_id: {}}
 
         self.mock_schema = {

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -214,7 +214,9 @@ def test_node_discovery(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
+        yield from async_setup_component(hass, 'zwave', {'zwave': {
+            'new_entity_ids': True,
+            }})
 
     assert len(mock_receivers) == 1
 
@@ -236,6 +238,7 @@ def test_node_ignored(hass, mock_openzwave):
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
         yield from async_setup_component(hass, 'zwave', {'zwave': {
+            'new_entity_ids': True,
             'device_config': {
                 'zwave.mock_node': {
                     'ignored': True,
@@ -260,7 +263,9 @@ def test_value_discovery(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
+        yield from async_setup_component(hass, 'zwave', {'zwave': {
+            'new_entity_ids': True,
+            }})
 
     assert len(mock_receivers) == 1
 
@@ -285,7 +290,9 @@ def test_value_discovery_existing_entity(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
+        yield from async_setup_component(hass, 'zwave', {'zwave': {
+            'new_entity_ids': True,
+            }})
 
     assert len(mock_receivers) == 1
 
@@ -330,7 +337,9 @@ def test_network_ready(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
+        yield from async_setup_component(hass, 'zwave', {'zwave': {
+            'new_entity_ids': True,
+            }})
 
     assert len(mock_receivers) == 1
 
@@ -357,7 +366,9 @@ def test_network_complete(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
+        yield from async_setup_component(hass, 'zwave', {'zwave': {
+            'new_entity_ids': True,
+            }})
 
     assert len(mock_receivers) == 1
 
@@ -387,7 +398,9 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         self.hass = get_test_home_assistant()
         self.hass.start()
 
-        setup_component(self.hass, 'zwave', {'zwave': {}})
+        setup_component(self.hass, 'zwave', {'zwave': {
+            'new_entity_ids': True,
+            }})
         self.hass.block_till_done()
 
         self.node = MockNode()
@@ -416,7 +429,9 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
             command_class='mock_bad_class', node=self.node)
 
         self.entity_id = 'mock_component.mock_node_mock_value'
-        self.zwave_config = {}
+        self.zwave_config = {'zwave': {
+            'new_entity_ids': True,
+        }}
         self.device_config = {self.entity_id: {}}
 
     def tearDown(self):  # pylint: disable=invalid-name
@@ -705,7 +720,9 @@ class TestZWaveServices(unittest.TestCase):
         self.hass.start()
 
         # Initialize zwave
-        setup_component(self.hass, 'zwave', {'zwave': {}})
+        setup_component(self.hass, 'zwave', {'zwave': {
+            'new_entity_ids': True,
+            }})
         self.hass.block_till_done()
         self.zwave_network = self.hass.data[DATA_NETWORK]
         self.zwave_network.state = MockNetwork.STATE_READY

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -173,6 +173,7 @@ class TestZWaveNodeEntity(unittest.TestCase):
              'node_name': 'Mock Node',
              'manufacturer_name': 'Test Manufacturer',
              'old_entity_id': 'zwave.mock_node_567',
+             'new_entity_id': 'zwave.mock_node',
              'product_name': 'Test Product'},
             self.entity.device_state_attributes)
 
@@ -232,6 +233,7 @@ class TestZWaveNodeEntity(unittest.TestCase):
              'node_name': 'Mock Node',
              'manufacturer_name': 'Test Manufacturer',
              'old_entity_id': 'zwave.mock_node_567',
+             'new_entity_id': 'zwave.mock_node',
              'product_name': 'Test Product',
              'query_stage': 'Dynamic',
              'is_awake': True,

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -4,7 +4,8 @@ import unittest
 from unittest.mock import patch, MagicMock
 import tests.mock.zwave as mock_zwave
 import pytest
-from homeassistant.components.zwave import node_entity
+from homeassistant.components.zwave import node_entity, const
+from homeassistant.const import ATTR_ENTITY_ID
 
 
 @asyncio.coroutine
@@ -28,6 +29,92 @@ def test_maybe_schedule_update(hass, mock_openzwave):
 
         base_entity._schedule_update()
         assert len(mock_call_later.mock_calls) == 2
+
+
+@asyncio.coroutine
+def test_node_event_activated(hass, mock_openzwave):
+    """Test Node event activated event."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == mock_zwave.MockNetwork.SIGNAL_NODE_EVENT:
+            mock_receivers.append(receiver)
+
+    node = mock_zwave.MockNode(node_id=11)
+
+    with patch('pydispatch.dispatcher.connect', new=mock_connect):
+        entity = node_entity.ZWaveNodeEntity(node, mock_openzwave)
+
+    assert len(mock_receivers) == 1
+
+    events = []
+
+    def listener(event):
+        events.append(event)
+
+    hass.bus.async_listen(const.EVENT_NODE_EVENT, listener)
+
+    # Test event before entity added to hass
+    value = 234
+    hass.async_add_job(mock_receivers[0], node, value)
+    yield from hass.async_block_till_done()
+    assert len(events) == 0
+
+    # Add entity to hass
+    entity.hass = hass
+    entity.entity_id = 'zwave.mock_node'
+
+    value = 234
+    hass.async_add_job(mock_receivers[0], node, value)
+    yield from hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data[ATTR_ENTITY_ID] == "zwave.mock_node"
+    assert events[0].data[const.ATTR_NODE_ID] == 11
+    assert events[0].data[const.ATTR_BASIC_LEVEL] == value
+
+
+@asyncio.coroutine
+def test_scene_activated(hass, mock_openzwave):
+    """Test scene activated event."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == mock_zwave.MockNetwork.SIGNAL_SCENE_EVENT:
+            mock_receivers.append(receiver)
+
+    node = mock_zwave.MockNode(node_id=11)
+
+    with patch('pydispatch.dispatcher.connect', new=mock_connect):
+        entity = node_entity.ZWaveNodeEntity(node, mock_openzwave)
+
+    assert len(mock_receivers) == 1
+
+    events = []
+
+    def listener(event):
+        events.append(event)
+
+    hass.bus.async_listen(const.EVENT_SCENE_ACTIVATED, listener)
+
+    # Test event before entity added to hass
+    scene_id = 123
+    hass.async_add_job(mock_receivers[0], node, scene_id)
+    yield from hass.async_block_till_done()
+    assert len(events) == 0
+
+    # Add entity to hass
+    entity.hass = hass
+    entity.entity_id = 'zwave.mock_node'
+
+    scene_id = 123
+    hass.async_add_job(mock_receivers[0], node, scene_id)
+    yield from hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data[ATTR_ENTITY_ID] == "zwave.mock_node"
+    assert events[0].data[const.ATTR_NODE_ID] == 11
+    assert events[0].data[const.ATTR_SCENE_ID] == scene_id
 
 
 @pytest.mark.usefixtures('mock_openzwave')

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -172,6 +172,7 @@ class TestZWaveNodeEntity(unittest.TestCase):
             {'node_id': self.node.node_id,
              'node_name': 'Mock Node',
              'manufacturer_name': 'Test Manufacturer',
+             'old_entity_id': 'zwave.mock_node_567',
              'product_name': 'Test Product'},
             self.entity.device_state_attributes)
 
@@ -230,6 +231,7 @@ class TestZWaveNodeEntity(unittest.TestCase):
             {'node_id': self.node.node_id,
              'node_name': 'Mock Node',
              'manufacturer_name': 'Test Manufacturer',
+             'old_entity_id': 'zwave.mock_node_567',
              'product_name': 'Test Product',
              'query_stage': 'Dynamic',
              'is_awake': True,

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -43,7 +43,7 @@ def test_node_event_activated(hass, mock_openzwave):
     node = mock_zwave.MockNode(node_id=11)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        entity = node_entity.ZWaveNodeEntity(node, mock_openzwave)
+        entity = node_entity.ZWaveNodeEntity(node, mock_openzwave, True)
 
     assert len(mock_receivers) == 1
 
@@ -86,7 +86,7 @@ def test_scene_activated(hass, mock_openzwave):
     node = mock_zwave.MockNode(node_id=11)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        entity = node_entity.ZWaveNodeEntity(node, mock_openzwave)
+        entity = node_entity.ZWaveNodeEntity(node, mock_openzwave, True)
 
     assert len(mock_receivers) == 1
 
@@ -131,7 +131,7 @@ class TestZWaveNodeEntity(unittest.TestCase):
         self.node.manufacturer_name = 'Test Manufacturer'
         self.node.product_name = 'Test Product'
         self.entity = node_entity.ZWaveNodeEntity(self.node,
-                                                  self.zwave_network)
+                                                  self.zwave_network, True)
 
     def test_network_node_changed_from_value(self):
         """Test for network_node_changed."""


### PR DESCRIPTION
## Description:
This PR removes the entity_id generation logic, and allows zwave entities to use the normal hass entity_id generation from the entity name. After this change, if two entities would be given the same name, hass will automatically suffix them `_2`, `_3`, etc. using the normal conflict resolution logic used by other platforms. This creates non-deterministic entity naming, since they may be added in any order. This was previously not correctable by the user, so the node/index workarounds were introduced. After #7780 is merged, users will have the tools necessary to disambiguate these names themselves. The end result will bring the zwave behavior closer in line with other platforms, and give users greater control over the final entity_id names, without introducing additional layers of workarounds.

This also introduces a small API breakage, where `EVENT_SCENE_ACTIVATED` and `EVENT_NODE_EVENT` will no longer supply an `object_id`. They will now be tied to the node `entity_id`.

**Pull request in Polymer:** https://github.com/home-assistant/home-assistant-polymer/pull/305

## See also:
#3759
#6912 
#7089

CC: @balloob @andrey-git @turbokongen 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2815
https://github.com/home-assistant/home-assistant.github.io/pull/2816