### PR TITLE
Expose the node name on the zwave node entity

### DIFF
--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -17,6 +17,7 @@ ATTR_READY = 'is_ready'
 ATTR_FAILED = 'is_failed'
 ATTR_PRODUCT_NAME = 'product_name'
 ATTR_MANUFACTURER_NAME = 'manufacturer_name'
+ATTR_NODE_NAME = 'node_name'
 
 STAGE_COMPLETE = 'Complete'
 
@@ -165,6 +166,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         """Return the device specific state attributes."""
         attrs = {
             ATTR_NODE_ID: self.node_id,
+            ATTR_NODE_NAME: self._name,
             ATTR_MANUFACTURER_NAME: self._manufacturer_name,
             ATTR_PRODUCT_NAME: self._product_name,
         }

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -83,6 +83,7 @@ class TestZWaveNodeEntity(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(
             {'node_id': self.node.node_id,
+             'node_name': 'Mock Node',
              'manufacturer_name': 'Test Manufacturer',
              'product_name': 'Test Product'},
             self.entity.device_state_attributes)
@@ -140,6 +141,7 @@ class TestZWaveNodeEntity(unittest.TestCase):
         self.entity.node_changed()
         self.assertEqual(
             {'node_id': self.node.node_id,
+             'node_name': 'Mock Node',
              'manufacturer_name': 'Test Manufacturer',
              'product_name': 'Test Product',
              'query_stage': 'Dynamic',


### PR DESCRIPTION
## Description:
This PR exposes the node name on the zwave node entity for use in the frontend. Friendly name doesn't quite work because it could be overwritten in customization.

For: https://github.com/home-assistant/home-assistant-polymer/pull/296
