### PR TITLE
Implement date countdown sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -366,6 +366,7 @@ omit =
     homeassistant/components/sensor/bitcoin.py
     homeassistant/components/sensor/bom.py
     homeassistant/components/sensor/broadlink.py
+    homeassistant/components/sensor/date_countdown.py
     homeassistant/components/sensor/dublin_bus_transport.py
     homeassistant/components/sensor/coinmarketcap.py
     homeassistant/components/sensor/cert_expiry.py

--- a/homeassistant/components/sensor/date_countdown.py
+++ b/homeassistant/components/sensor/date_countdown.py
@@ -19,9 +19,9 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_DAYS = 'Days'
-ATTR_HOURS = 'Hours'
-ATTR_MINUTES = 'Minutes'
+ATTR_DAYS = 'days'
+ATTR_HOURS = 'hours'
+ATTR_MINUTES = 'minutes'
 
 DEFAULT_NAME = "Countdown"
 CONF_DATE = 'date'

--- a/homeassistant/components/sensor/date_countdown.py
+++ b/homeassistant/components/sensor/date_countdown.py
@@ -1,0 +1,69 @@
+"""
+Date Countdown
+For more details about this sensor please refer to the documentation at
+https://home-assistant.io/components/sensor.date_countdown/
+
+"""
+
+import datetime
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "DateCountdown"
+CONF_DATE = 'date'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_DATE): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up certificate expiry sensor."""
+    end_date = config.get(CONF_DATE)
+    sensor_name = config.get(CONF_NAME)
+
+    add_devices([Countdown(sensor_name, end_date)])
+
+
+class Countdown(Entity):
+    """Implementation of the date countdown sensor."""
+
+    def __init__(self, sensor_name, end_date):
+        """Initialize the sensor."""
+        self.end_date = end_date
+        self._name = sensor_name
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return 'mdi:calendar'
+
+    def update(self):
+        end_date = datetime.datetime.strptime(self.end_date, '%m-%d-%Y %H:%M')
+        days = (end_date - datetime.datetime.now())
+
+        days, seconds = days.days, days.seconds
+        hours = seconds // 3600
+        minutes = (seconds % 3600) // 60
+        seconds = seconds % 60
+        self._state = str(days) + " days " + str(hours) + " hours " + str(minutes) + " minutes"

--- a/homeassistant/components/sensor/date_countdown.py
+++ b/homeassistant/components/sensor/date_countdown.py
@@ -2,10 +2,10 @@
 Date Countdown
 For more details about this sensor please refer to the documentation at
 https://home-assistant.io/components/sensor.date_countdown/
-
 """
 
 import datetime
+from datetime import timedelta
 import logging
 
 import voluptuous as vol
@@ -14,11 +14,19 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_DAYS = 'Days'
+ATTR_HOURS = 'Hours'
+ATTR_MINUTES = 'Minutes'
+
 DEFAULT_NAME = "Countdown"
 CONF_DATE = 'date'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DATE): cv.string,
@@ -42,6 +50,8 @@ class Countdown(Entity):
         self.end_date = end_date
         self._name = sensor_name
         self._state = None
+        self._data = {}
+        self.update()
 
     @property
     def name(self):
@@ -52,19 +62,34 @@ class Countdown(Entity):
     def state(self):
         """Return the state of the sensor."""
         return self._state
+    
+    @property
+    def device_state_attributes(self):
+        return {
+            ATTR_DAYS: self._data.get("days"),
+            ATTR_HOURS: self._data.get("hours"),
+            ATTR_MINUTES: self._data.get("minutes")
+        }
 
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
         return 'mdi:calendar'
 
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        end_date = datetime.datetime.strptime(self.end_date, '%m-%d-%Y %H:%M')
+        """Calculate time until end"""
+        end_date = datetime.datetime.strptime(self.end_date, '%d-%m-%Y %H:%M')
         days = (end_date - datetime.datetime.now())
 
         days, seconds = days.days, days.seconds
         hours = seconds // 3600
         minutes = (seconds % 3600) // 60
         seconds = seconds % 60
+        
+        self._data["days"] = days
+        self._data["hours"] = hours
+        self._data["minutes"] = minutes
+        
         self._state = str(days) + " days " + str(hours) \
             + " hours " + str(minutes) + " minutes"

--- a/homeassistant/components/sensor/date_countdown.py
+++ b/homeassistant/components/sensor/date_countdown.py
@@ -62,7 +62,7 @@ class Countdown(Entity):
     def state(self):
         """Return the state of the sensor."""
         return self._state
-    
+
     @property
     def device_state_attributes(self):
         return {
@@ -86,10 +86,10 @@ class Countdown(Entity):
         hours = seconds // 3600
         minutes = (seconds % 3600) // 60
         seconds = seconds % 60
-        
+
         self._data["days"] = days
         self._data["hours"] = hours
         self._data["minutes"] = minutes
-        
+
         self._state = str(days) + " days " + str(hours) \
             + " hours " + str(minutes) + " minutes"

--- a/homeassistant/components/sensor/date_countdown.py
+++ b/homeassistant/components/sensor/date_countdown.py
@@ -66,4 +66,5 @@ class Countdown(Entity):
         hours = seconds // 3600
         minutes = (seconds % 3600) // 60
         seconds = seconds % 60
-        self._state = str(days) + " days " + str(hours) + " hours " + str(minutes) + " minutes"
+        self._state = str(days) + " days " + str(hours) \
+        + " hours " + str(minutes) + " minutes"

--- a/homeassistant/components/sensor/date_countdown.py
+++ b/homeassistant/components/sensor/date_countdown.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_NAME = "DateCountdown"
+DEFAULT_NAME = "Countdown"
 CONF_DATE = 'date'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -27,7 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up certificate expiry sensor."""
+    """Set up date countdown sensor."""
     end_date = config.get(CONF_DATE)
     sensor_name = config.get(CONF_NAME)
 

--- a/homeassistant/components/sensor/date_countdown.py
+++ b/homeassistant/components/sensor/date_countdown.py
@@ -67,4 +67,4 @@ class Countdown(Entity):
         minutes = (seconds % 3600) // 60
         seconds = seconds % 60
         self._state = str(days) + " days " + str(hours) \
-        + " hours " + str(minutes) + " minutes"
+            + " hours " + str(minutes) + " minutes"


### PR DESCRIPTION
## Description:

The `date_countdown` sensor provides the ability to show a countdown to a date and time in the future. 

Pull request in home-assistant.github.io with documentation (if applicable): home-assistant/home-assistant.github.io#2717

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: date_countdown
    name: Wedding Countdown
    date: "05-20-2018 18:00"
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
