### PR TITLE
Axis service vapix call

### DIFF
--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.loader import get_component
 
 
-REQUIREMENTS = ['axis==7']
+REQUIREMENTS = ['axis==8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -65,12 +65,14 @@ SERVICE_VAPIX_CALL_RESPONSE = 'vapix_call_response'
 SERVICE_CGI = 'cgi'
 SERVICE_ACTION = 'action'
 SERVICE_PARAM = 'param'
+SERVICE_DEFAULT_CGI = 'param.cgi'
+SERVICE_DEFAULT_ACTION = 'update'
 
 SERVICE_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
     vol.Required(SERVICE_PARAM): cv.string,
-    vol.Optional(SERVICE_CGI, default='param.cgi'): cv.string,
-    vol.Optional(SERVICE_ACTION, default='update'): cv.string,
+    vol.Optional(SERVICE_CGI, default=SERVICE_DEFAULT_CGI): cv.string,
+    vol.Optional(SERVICE_ACTION, default=SERVICE_DEFAULT_ACTION): cv.string,
 })
 
 

--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -170,11 +170,10 @@ def setup(hass, base_config):
                 request_configuration(hass, name, host, serialnumber)
         else:
             # Device already registered, but on a different IP
-            print(host, name, serialnumber)
             device = AXIS_DEVICES[serialnumber]
             device.url = host
-            if host != name:
-                hass.bus.fire(DOMAIN + '_' + device.name, {CONF_HOST: host})
+            hass.bus.fire(DOMAIN + '_' + device.name + "_new_ip",
+                          {CONF_HOST: host})
 
     # Register discovery service
     discovery.listen(hass, SERVICE_AXIS, axis_device_discovered)
@@ -193,7 +192,6 @@ def setup(hass, base_config):
 
     def vapix_service(call):
         """Service to send a message."""
-        # for serial_number, device in AXIS_DEVICES.items():
         for _, device in AXIS_DEVICES.items():
             if device.name == call.data[CONF_NAME]:
                 response = device.do_request(call.data[SERVICE_CGI],

--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -19,6 +19,7 @@ from homeassistant.const import (ATTR_LOCATION, ATTR_TRIPPED,
 from homeassistant.components.discovery import SERVICE_AXIS
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import Entity
 from homeassistant.loader import get_component
 
@@ -174,8 +175,9 @@ def setup(hass, base_config):
             # Device already registered, but on a different IP
             device = AXIS_DEVICES[serialnumber]
             device.url = host
-            hass.bus.fire(DOMAIN + '_' + device.name + "_new_ip",
-                          {CONF_HOST: host})
+            async_dispatcher_send(hass,
+                                  DOMAIN + '_' + device.name + '_new_ip',
+                                  host)
 
     # Register discovery service
     discovery.listen(hass, SERVICE_AXIS, axis_device_discovered)

--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -172,12 +172,9 @@ def setup(hass, base_config):
             # Device already registered, but on a different IP
             print(host, name, serialnumber)
             device = AXIS_DEVICES[serialnumber]
-            device._url = host
-            device._metadatastream.set_up_pipeline(device.metadata_url)
-            event = DOMAIN + '_' + AXIS_DEVICES[serialnumber].name
+            device.url = host
             if host != name:
-                print(host, name, 'is not same')
-                hass.bus.fire(event, {CONF_HOST: host})
+                hass.bus.fire(DOMAIN + '_' + device.name, {CONF_HOST: host})
 
     # Register discovery service
     discovery.listen(hass, SERVICE_AXIS, axis_device_discovered)
@@ -193,10 +190,11 @@ def setup(hass, base_config):
     # Services to communicate with device.
     descriptions = load_yaml_config_file(
         os.path.join(os.path.dirname(__file__), 'services.yaml'))
-# {"name":"3","cgi":"param.cgi","action":"list","param":"Properties.Firmware.Version"}
+
     def vapix_service(call):
         """Service to send a message."""
-        for serial_number, device in AXIS_DEVICES.items():
+        # for serial_number, device in AXIS_DEVICES.items():
+        for _, device in AXIS_DEVICES.items():
             if device.name == call.data[CONF_NAME]:
                 response = device.do_request(call.data[SERVICE_CGI],
                                              call.data[SERVICE_ACTION],
@@ -370,4 +368,4 @@ REMAP = [{'type': 'motion',
           'class': 'input',
           'topic': 'tns1:Device/tnsaxis:IO/Port',
           'subscribe': 'onvif:Device/axis:IO/Port',
-          'platform': 'sensor'}, ]
+          'platform': 'binary_sensor'}, ]

--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -149,7 +149,7 @@ def setup(hass, base_config):
 
     def axis_device_discovered(service, discovery_info):
         """Called when axis devices has been found."""
-        host = discovery_info['host']
+        host = discovery_info[CONF_HOST]
         name = discovery_info['hostname']
         serialnumber = discovery_info['properties']['macaddress']
 
@@ -158,6 +158,7 @@ def setup(hass, base_config):
             if serialnumber in config_file:
                 try:
                     config = DEVICE_SCHEMA(config_file[serialnumber])
+                    config[CONF_HOST] = host
                 except vol.Invalid as err:
                     _LOGGER.error("Bad data from %s. %s", CONFIG_FILE, err)
                     return False
@@ -232,7 +233,7 @@ def setup_device(hass, config):
         if not device.initiate_metadatastream():
             notification = get_component('persistent_notification')
             notification.create(hass,
-                                'Dependency missing for sensors,'
+                                'Dependency missing for sensors, '
                                 'please check documentation',
                                 title=DOMAIN,
                                 notification_id='axis_notification')

--- a/homeassistant/components/camera/axis.py
+++ b/homeassistant/components/camera/axis.py
@@ -40,7 +40,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class AxisCamera(MjpegCamera):
-    """AxisCamera """
+    """AxisCamera class."""
+
     def __init__(self, hass, config):
         """Initialize Axis Communications camera component."""
         super().__init__(hass, config)
@@ -48,7 +49,7 @@ class AxisCamera(MjpegCamera):
                         self.new_ip)
 
     def new_ip(self, event):
-        """Set new IP for video stream"""
+        """Set new IP for video stream."""
         self._mjpeg_url = _get_image_url(event.data.get(CONF_HOST), 'mjpeg')
         self._still_image_url = _get_image_url(event.data.get(CONF_HOST),
                                                'mjpeg')

--- a/homeassistant/components/camera/axis.py
+++ b/homeassistant/components/camera/axis.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/camera.axis/
 import logging
 
 from homeassistant.const import (
-    CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
+    CONF_HOST, CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
     CONF_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION)
 from homeassistant.components.camera.mjpeg import (
     CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, MjpegCamera)
@@ -27,12 +27,27 @@ def _get_image_url(host, mode):
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup Axis camera."""
-    device_info = {
-        CONF_NAME: discovery_info['name'],
-        CONF_USERNAME: discovery_info['username'],
-        CONF_PASSWORD: discovery_info['password'],
-        CONF_MJPEG_URL: _get_image_url(discovery_info['host'], 'mjpeg'),
-        CONF_STILL_IMAGE_URL: _get_image_url(discovery_info['host'], 'single'),
+    config = {
+        CONF_NAME: discovery_info[CONF_NAME],
+        CONF_USERNAME: discovery_info[CONF_USERNAME],
+        CONF_PASSWORD: discovery_info[CONF_PASSWORD],
+        CONF_MJPEG_URL: _get_image_url(discovery_info[CONF_HOST], 'mjpeg'),
+        CONF_STILL_IMAGE_URL: _get_image_url(discovery_info[CONF_HOST],
+                                             'single'),
         CONF_AUTHENTICATION: HTTP_DIGEST_AUTHENTICATION,
     }
-    add_devices([MjpegCamera(hass, device_info)])
+    add_devices([AxisCamera(hass, config)])
+
+
+class AxisCamera(MjpegCamera):
+    """Bla"""
+    def __init__(self, hass, config):
+        """Initialize Axis Communications camera component."""
+        super().__init__(hass, config)
+        hass.bus.listen(DOMAIN + '_' + config[CONF_NAME], self.new_ip)
+
+    def new_ip(self, event):
+        """Set new IP for video stream"""
+        self._mjpeg_url = _get_image_url(event.data.get(CONF_HOST), 'mjpeg')
+        self._still_image_url = _get_image_url(event.data.get(CONF_HOST),
+                                               'mjpeg')

--- a/homeassistant/components/camera/axis.py
+++ b/homeassistant/components/camera/axis.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     CONF_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION)
 from homeassistant.components.camera.mjpeg import (
     CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, MjpegCamera)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,11 +46,11 @@ class AxisCamera(MjpegCamera):
     def __init__(self, hass, config):
         """Initialize Axis Communications camera component."""
         super().__init__(hass, config)
-        hass.bus.listen(DOMAIN + '_' + config[CONF_NAME] + "_new_ip",
-                        self.new_ip)
+        async_dispatcher_connect(hass,
+                                 DOMAIN + '_' + config[CONF_NAME] + '_new_ip',
+                                 self._new_ip)
 
-    def new_ip(self, event):
+    def _new_ip(self, host):
         """Set new IP for video stream."""
-        self._mjpeg_url = _get_image_url(event.data.get(CONF_HOST), 'mjpeg')
-        self._still_image_url = _get_image_url(event.data.get(CONF_HOST),
-                                               'mjpeg')
+        self._mjpeg_url = _get_image_url(host, 'mjpeg')
+        self._still_image_url = _get_image_url(host, 'mjpeg')

--- a/homeassistant/components/camera/axis.py
+++ b/homeassistant/components/camera/axis.py
@@ -14,8 +14,8 @@ from homeassistant.components.camera.mjpeg import (
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ['axis']
 DOMAIN = 'axis'
+DEPENDENCIES = [DOMAIN]
 
 
 def _get_image_url(host, mode):
@@ -40,7 +40,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class AxisCamera(MjpegCamera):
-    """Bla"""
+    """AxisCamera """
     def __init__(self, hass, config):
         """Initialize Axis Communications camera component."""
         super().__init__(hass, config)

--- a/homeassistant/components/camera/axis.py
+++ b/homeassistant/components/camera/axis.py
@@ -44,7 +44,8 @@ class AxisCamera(MjpegCamera):
     def __init__(self, hass, config):
         """Initialize Axis Communications camera component."""
         super().__init__(hass, config)
-        hass.bus.listen(DOMAIN + '_' + config[CONF_NAME], self.new_ip)
+        hass.bus.listen(DOMAIN + '_' + config[CONF_NAME] + "_new_ip",
+                        self.new_ip)
 
     def new_ip(self, event):
         """Set new IP for video stream"""

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -402,3 +402,20 @@ eight_sleep:
       duration:
         description: Duration to heat at the target level in seconds.
         example: 3600
+
+axis:
+  vapix_call:
+    description: Configure device using Vapix parameter management.
+    fields:
+      name:
+        description: Name of device to Configure. [Required]
+        example: M1065-W
+      cgi:
+        description: Which cgi to call on device. [Optional] Default is 'param.cgi'
+        example: 'applications/control.cgi'
+      action:
+        description: What type of call. [Optional] Default is 'update'
+        example: 'start'
+      param:
+        description: What parameter to operate on. [Required]
+        example: 'package=VideoMotionDetection'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -71,7 +71,7 @@ apns2==0.1.1
 # avion==0.6
 
 # homeassistant.components.axis
-axis==7
+axis==8
 
 # homeassistant.components.sensor.modem_callerid
 basicmodem==0.7


### PR DESCRIPTION
## Description:
* Fix inputs to register as binary sensor
* Bump axis dependency to 8
* Improved error handling of external dependency
* Added reconnection behaviour when discovery identifies an already connected device but with a different IP
* Service to do Vapix calls to device, response on event 'vapix_call_response'

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io):** home-assistant/home-assistant.github.io#2720


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54