### PR TITLE
Add Dyson Pure Cool Link support

### DIFF
--- a/homeassistant/components/dyson.py
+++ b/homeassistant/components/dyson.py
@@ -1,0 +1,90 @@
+"""Parent component for Dyson Pure Cool Link devices."""
+
+import logging
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['libpurecoollink==0.1.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"
+CONF_LANGUAGE = "language"
+CONF_TIMEOUT = "timeout"
+CONF_RETRY = "retry"
+CONF_DEVICES = "devices"
+
+DEFAULT_TIMEOUT = 5
+DEFAULT_RETRY = 10
+
+DOMAIN = "dyson"
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_LANGUAGE): cv.string,
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+        vol.Optional(CONF_RETRY, default=DEFAULT_RETRY): cv.positive_int,
+        vol.Optional(CONF_DEVICES, default=[]):
+            vol.All(cv.ensure_list, [dict]),
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+DYSON_DEVICES = "dyson_devices"
+
+
+def setup(hass, config):
+    """Set up the Dyson parent component."""
+    _LOGGER.info("Creating new Dyson component")
+
+    if DYSON_DEVICES not in hass.data:
+        hass.data[DYSON_DEVICES] = []
+
+    from libpurecoollink.dyson import DysonAccount
+    dyson_account = DysonAccount(config[DOMAIN].get(CONF_USERNAME),
+                                 config[DOMAIN].get(CONF_PASSWORD),
+                                 config[DOMAIN].get(CONF_LANGUAGE))
+
+    logged = dyson_account.login()
+
+    timeout = config[DOMAIN].get(CONF_TIMEOUT)
+    retry = config[DOMAIN].get(CONF_RETRY)
+
+    if logged:
+        _LOGGER.info("Connected to Dyson account")
+        dyson_devices = dyson_account.devices()
+        if CONF_DEVICES in config[DOMAIN] and config[DOMAIN].get(CONF_DEVICES):
+            configured_devices = config[DOMAIN].get(CONF_DEVICES)
+            for device in configured_devices:
+                dyson_device = next((d for d in dyson_devices if
+                                     d.serial == device["device_id"]), None)
+                if dyson_device:
+                    connected = dyson_device.connect(None, device["device_ip"],
+                                                     timeout, retry)
+                    if connected:
+                        _LOGGER.info("Connected to device %s", dyson_device)
+                        hass.data[DYSON_DEVICES].append(dyson_device)
+                    else:
+                        _LOGGER.warning("Unable to connect to device %s",
+                                        dyson_device)
+                else:
+                    _LOGGER.warning(
+                        "Unable to find device %s in Dyson account",
+                        device["device_id"])
+        else:
+            # Not yet reliable
+            for device in dyson_devices:
+                _LOGGER.info("Trying to connect to device %s with timeout=%i "
+                             "and retry=%i", device, timeout, retry)
+                connected = device.connect(None, None, timeout, retry)
+                if connected:
+                    _LOGGER.info("Connected to device %s", device)
+                    hass.data[DYSON_DEVICES].append(device)
+                else:
+                    _LOGGER.warning("Unable to connect to device %s", device)
+        return True
+    else:
+        _LOGGER.error("Not connected to Dyson account. Unable to add devices")
+        return False

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -37,10 +37,14 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 SUPPORT_SET_SPEED = 1
 SUPPORT_OSCILLATE = 2
 SUPPORT_DIRECTION = 4
+SUPPORT_NIGHT_MODE = 8
+SUPPORT_AUTO_MODE = 16
 
 SERVICE_SET_SPEED = 'set_speed'
 SERVICE_OSCILLATE = 'oscillate'
 SERVICE_SET_DIRECTION = 'set_direction'
+SERVICE_NIGHT_MODE = 'set_night_mode'
+SERVICE_AUTO_MODE = 'set_auto_mode'
 
 SPEED_OFF = 'off'
 SPEED_LOW = 'low'
@@ -54,12 +58,16 @@ ATTR_SPEED = 'speed'
 ATTR_SPEED_LIST = 'speed_list'
 ATTR_OSCILLATING = 'oscillating'
 ATTR_DIRECTION = 'direction'
+ATTR_NIGHT_MODE = 'night_mode'
+ATTR_AUTO_MODE = 'auto_mode'
 
 PROP_TO_ATTR = {
     'speed': ATTR_SPEED,
     'speed_list': ATTR_SPEED_LIST,
     'oscillating': ATTR_OSCILLATING,
     'direction': ATTR_DIRECTION,
+    'is_night_mode': ATTR_NIGHT_MODE,
+    'is_auto_mode': ATTR_AUTO_MODE
 }  # type: dict
 
 FAN_SET_SPEED_SCHEMA = vol.Schema({
@@ -79,6 +87,16 @@ FAN_TURN_OFF_SCHEMA = vol.Schema({
 FAN_OSCILLATE_SCHEMA = vol.Schema({
     vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_OSCILLATING): cv.boolean
+})  # type: dict
+
+FAN_NIGHT_MODE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_NIGHT_MODE): cv.boolean
+})  # type: dict
+
+FAN_AUTO_MODE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_AUTO_MODE): cv.boolean
 })  # type: dict
 
 FAN_TOGGLE_SCHEMA = vol.Schema({
@@ -114,6 +132,14 @@ SERVICE_TO_METHOD = {
     SERVICE_SET_DIRECTION: {
         'method': 'async_set_direction',
         'schema': FAN_SET_DIRECTION_SCHEMA,
+    },
+    SERVICE_NIGHT_MODE: {
+        'method': 'async_night_mode',
+        'schema': FAN_NIGHT_MODE_SCHEMA,
+    },
+    SERVICE_AUTO_MODE: {
+        'method': 'async_auto_mode',
+        'schema': FAN_AUTO_MODE_SCHEMA,
     },
 }
 
@@ -187,6 +213,30 @@ def set_direction(hass, entity_id: str=None, direction: str=None) -> None:
     }
 
     hass.services.call(DOMAIN, SERVICE_SET_DIRECTION, data)
+
+
+def set_auto_mode(hass, entity_id: str=None, auto_mode: bool=False) -> None:
+    """Set auto mode for all or specified fan."""
+    data = {
+        key: value for key, value in [
+            (ATTR_ENTITY_ID, entity_id),
+            (ATTR_AUTO_MODE, auto_mode),
+        ] if value is not None
+    }
+
+    hass.services.call(DOMAIN, SERVICE_AUTO_MODE, data)
+
+
+def set_night_mode(hass, entity_id: str=None, night_mode: bool=False) -> None:
+    """Set night mode for all or specified fan."""
+    data = {
+        key: value for key, value in [
+            (ATTR_ENTITY_ID, entity_id),
+            (ATTR_NIGHT_MODE, night_mode),
+        ] if value is not None
+    }
+
+    hass.services.call(DOMAIN, SERVICE_NIGHT_MODE, data)
 
 
 @asyncio.coroutine
@@ -290,6 +340,28 @@ class FanEntity(ToggleEntity):
         This method must be run in the event loop and returns a coroutine.
         """
         return self.hass.async_add_job(self.oscillate, oscillating)
+
+    def night_mode(self: ToggleEntity, night_mode: bool) -> None:
+        """Turn fan in night mode."""
+        pass
+
+    def async_night_mode(self: ToggleEntity, night_mode: bool):
+        """Turn fan in night mode.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.async_add_job(self.night_mode, night_mode)
+
+    def auto_mode(self: ToggleEntity, auto_mode: bool) -> None:
+        """Turn fan in auto mode."""
+        pass
+
+    def async_auto_mode(self: ToggleEntity, auto_mode: bool):
+        """Turn fan in auto mode.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.async_add_job(self.auto_mode, auto_mode)
 
     @property
     def is_on(self):

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -37,14 +37,10 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 SUPPORT_SET_SPEED = 1
 SUPPORT_OSCILLATE = 2
 SUPPORT_DIRECTION = 4
-SUPPORT_NIGHT_MODE = 8
-SUPPORT_AUTO_MODE = 16
 
 SERVICE_SET_SPEED = 'set_speed'
 SERVICE_OSCILLATE = 'oscillate'
 SERVICE_SET_DIRECTION = 'set_direction'
-SERVICE_NIGHT_MODE = 'set_night_mode'
-SERVICE_AUTO_MODE = 'set_auto_mode'
 
 SPEED_OFF = 'off'
 SPEED_LOW = 'low'
@@ -58,16 +54,12 @@ ATTR_SPEED = 'speed'
 ATTR_SPEED_LIST = 'speed_list'
 ATTR_OSCILLATING = 'oscillating'
 ATTR_DIRECTION = 'direction'
-ATTR_NIGHT_MODE = 'night_mode'
-ATTR_AUTO_MODE = 'auto_mode'
 
 PROP_TO_ATTR = {
     'speed': ATTR_SPEED,
     'speed_list': ATTR_SPEED_LIST,
     'oscillating': ATTR_OSCILLATING,
     'direction': ATTR_DIRECTION,
-    'is_night_mode': ATTR_NIGHT_MODE,
-    'is_auto_mode': ATTR_AUTO_MODE
 }  # type: dict
 
 FAN_SET_SPEED_SCHEMA = vol.Schema({
@@ -87,16 +79,6 @@ FAN_TURN_OFF_SCHEMA = vol.Schema({
 FAN_OSCILLATE_SCHEMA = vol.Schema({
     vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_OSCILLATING): cv.boolean
-})  # type: dict
-
-FAN_NIGHT_MODE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Required(ATTR_NIGHT_MODE): cv.boolean
-})  # type: dict
-
-FAN_AUTO_MODE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Required(ATTR_AUTO_MODE): cv.boolean
 })  # type: dict
 
 FAN_TOGGLE_SCHEMA = vol.Schema({
@@ -132,14 +114,6 @@ SERVICE_TO_METHOD = {
     SERVICE_SET_DIRECTION: {
         'method': 'async_set_direction',
         'schema': FAN_SET_DIRECTION_SCHEMA,
-    },
-    SERVICE_NIGHT_MODE: {
-        'method': 'async_night_mode',
-        'schema': FAN_NIGHT_MODE_SCHEMA,
-    },
-    SERVICE_AUTO_MODE: {
-        'method': 'async_auto_mode',
-        'schema': FAN_AUTO_MODE_SCHEMA,
     },
 }
 
@@ -213,30 +187,6 @@ def set_direction(hass, entity_id: str=None, direction: str=None) -> None:
     }
 
     hass.services.call(DOMAIN, SERVICE_SET_DIRECTION, data)
-
-
-def set_auto_mode(hass, entity_id: str=None, auto_mode: bool=False) -> None:
-    """Set auto mode for all or specified fan."""
-    data = {
-        key: value for key, value in [
-            (ATTR_ENTITY_ID, entity_id),
-            (ATTR_AUTO_MODE, auto_mode),
-        ] if value is not None
-    }
-
-    hass.services.call(DOMAIN, SERVICE_AUTO_MODE, data)
-
-
-def set_night_mode(hass, entity_id: str=None, night_mode: bool=False) -> None:
-    """Set night mode for all or specified fan."""
-    data = {
-        key: value for key, value in [
-            (ATTR_ENTITY_ID, entity_id),
-            (ATTR_NIGHT_MODE, night_mode),
-        ] if value is not None
-    }
-
-    hass.services.call(DOMAIN, SERVICE_NIGHT_MODE, data)
 
 
 @asyncio.coroutine
@@ -340,28 +290,6 @@ class FanEntity(ToggleEntity):
         This method must be run in the event loop and returns a coroutine.
         """
         return self.hass.async_add_job(self.oscillate, oscillating)
-
-    def night_mode(self: ToggleEntity, night_mode: bool) -> None:
-        """Turn fan in night mode."""
-        pass
-
-    def async_night_mode(self: ToggleEntity, night_mode: bool):
-        """Turn fan in night mode.
-
-        This method must be run in the event loop and returns a coroutine.
-        """
-        return self.hass.async_add_job(self.night_mode, night_mode)
-
-    def auto_mode(self: ToggleEntity, auto_mode: bool) -> None:
-        """Turn fan in auto mode."""
-        pass
-
-    def async_auto_mode(self: ToggleEntity, auto_mode: bool):
-        """Turn fan in auto mode.
-
-        This method must be run in the event loop and returns a coroutine.
-        """
-        return self.hass.async_add_job(self.auto_mode, auto_mode)
 
     @property
     def is_on(self):

--- a/homeassistant/components/fan/dyson.py
+++ b/homeassistant/components/fan/dyson.py
@@ -1,5 +1,6 @@
 """Support for Dyson Pure Cool link fan."""
 import logging
+import asyncio
 from os import path
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
@@ -69,14 +70,18 @@ class DysonPureCoolLinkDevice(FanEntity):
         _LOGGER.info("Creating device %s", device.name)
         self.hass = hass
         self._device = device
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
         self._device.add_message_listener(self.on_message)
 
     def on_message(self, message):
         """Called when new messages received from the fan."""
         _LOGGER.debug("Message received for fan device %s : %s", self.name,
                       message)
-        if self.entity_id:
-            self.schedule_update_ha_state()
+
+        self.schedule_update_ha_state()
 
     @property
     def should_poll(self):

--- a/homeassistant/components/fan/dyson.py
+++ b/homeassistant/components/fan/dyson.py
@@ -1,0 +1,153 @@
+"""Support for Dyson Pure Cool link fan."""
+import logging
+from homeassistant.components.fan import (FanEntity,
+                                          SUPPORT_OSCILLATE, SUPPORT_SET_SPEED)
+from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.components.dyson import DYSON_DEVICES
+
+DEPENDENCIES = ['dyson']
+REQUIREMENTS = ['libpurecoollink==0.1.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+NIGHT_MODE = 'NIGHT_MODE'
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Dyson fan components."""
+    _LOGGER.info("Creating new Dyson fans")
+    devices = []
+    # Get Dyson Devices from parent component
+    for device in hass.data[DYSON_DEVICES]:
+        devices.append(DysonPureCoolLinkDevice(hass, device))
+    add_devices(devices)
+
+
+class DysonPureCoolLinkDevice(FanEntity):
+    """Representation of a Dyson fan."""
+
+    def on_message(self, message):
+        """Called when new messages received from the fan."""
+        _LOGGER.debug("Message received for fan device %s : %s", self.name,
+                      message)
+        if self.hass and self.entity_id:
+            self.schedule_update_ha_state()
+
+    def __init__(self, hass, device):
+        """Initialize the fan."""
+        _LOGGER.info("Creating device %s", device.name)
+        self.hass = hass
+        self._device = device
+        self._device.add_message_listener(self.on_message)
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return the display name of this fan."""
+        return self._device.name
+
+    def set_speed(self: ToggleEntity, speed: str) -> None:
+        """Set the speed of the fan. Never called ??."""
+        _LOGGER.debug("Set fan speed to: " + speed)
+        from libpurecoollink.const import FanSpeed, FanMode, NightMode
+        fan_speed = FanSpeed(speed)
+        self._device.set_configuration(fan_mode=FanMode.FAN,
+                                       night_mode=NightMode.NIGHT_MODE_OFF,
+                                       fan_speed=fan_speed)
+
+    def turn_on(self: ToggleEntity, speed: str=None, **kwargs) -> None:
+        """Turn on the fan."""
+        _LOGGER.debug("Turn on fan %s with speed %s", self.name, speed)
+        from libpurecoollink.const import FanSpeed, FanMode, NightMode
+        if speed:
+            # Turn on fan with specified speed
+            if speed == NIGHT_MODE:
+                night_mode = NightMode.NIGHT_MODE_ON
+                self._device.set_configuration(fan_mode=FanMode.AUTO,
+                                               night_mode=night_mode)
+            else:
+                fan_speed = FanSpeed(speed)
+                night_mode = NightMode.NIGHT_MODE_OFF
+                if fan_speed == FanSpeed.FAN_SPEED_AUTO:
+                    self._device.set_configuration(fan_mode=FanMode.AUTO,
+                                                   night_mode=night_mode)
+                else:
+                    self._device.set_configuration(fan_mode=FanMode.FAN,
+                                                   night_mode=night_mode,
+                                                   fan_speed=fan_speed)
+        else:
+            # Speed not set, just turn on
+            self._device.set_configuration(fan_mode=FanMode.FAN)
+
+    def turn_off(self: ToggleEntity, **kwargs) -> None:
+        """Turn off the fan."""
+        _LOGGER.debug("Turn off fan %s", self.name)
+        from libpurecoollink.const import FanMode
+        self._device.set_configuration(fan_mode=FanMode.OFF)
+
+    def oscillate(self: ToggleEntity, oscillating: bool) -> None:
+        """Turn on/off oscillating."""
+        _LOGGER.debug("Turn oscillation %s for device %s", oscillating,
+                      self.name)
+        from libpurecoollink.const import Oscillation
+
+        if oscillating:
+            self._device.set_configuration(
+                oscillation=Oscillation.OSCILLATION_ON)
+        else:
+            self._device.set_configuration(
+                oscillation=Oscillation.OSCILLATION_OFF)
+
+    @property
+    def oscillating(self):
+        """Return the oscillation state."""
+        return self._device.state and self._device.state.oscillation == "ON"
+
+    @property
+    def is_on(self):
+        """Return true if the entity is on."""
+        if self._device.state:
+            return self._device.state.fan_mode in ['FAN', 'AUTO']
+        return False
+
+    @property
+    def speed(self) -> str:
+        """Return the current speed."""
+        if self._device.state:
+            if self._device.state.night_mode == 'ON':
+                return NIGHT_MODE
+            else:
+                return self._device.state.speed
+        return None
+
+    @property
+    def current_direction(self):
+        """Return direction of the fan [forward, reverse]."""
+        return None
+
+    @property
+    def speed_list(self: ToggleEntity) -> list:
+        """Get the list of available speeds."""
+        from libpurecoollink.const import FanSpeed
+        supported_speeds = [FanSpeed.FAN_SPEED_AUTO.value, NIGHT_MODE,
+                            FanSpeed.FAN_SPEED_1.value,
+                            FanSpeed.FAN_SPEED_2.value,
+                            FanSpeed.FAN_SPEED_3.value,
+                            FanSpeed.FAN_SPEED_4.value,
+                            FanSpeed.FAN_SPEED_5.value,
+                            FanSpeed.FAN_SPEED_6.value,
+                            FanSpeed.FAN_SPEED_7.value,
+                            FanSpeed.FAN_SPEED_8.value,
+                            FanSpeed.FAN_SPEED_9.value,
+                            FanSpeed.FAN_SPEED_10.value]
+
+        return supported_speeds
+
+    @property
+    def supported_features(self: ToggleEntity) -> int:
+        """Flag supported features."""
+        return SUPPORT_OSCILLATE | SUPPORT_SET_SPEED

--- a/homeassistant/components/fan/dyson.py
+++ b/homeassistant/components/fan/dyson.py
@@ -74,13 +74,13 @@ class DysonPureCoolLinkDevice(FanEntity):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Callback when entity is added to hass."""
-        self._device.add_message_listener(self.on_message)
+        self.hass.async_add_job(
+            self._device.add_message_listener(self.on_message))
 
     def on_message(self, message):
         """Called when new messages received from the fan."""
-        _LOGGER.debug("Message received for fan device %s : %s", self.name,
-                      message)
-
+        _LOGGER.debug(
+            "Message received for fan device %s : %s", self.name, message)
         self.schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -63,18 +63,7 @@ set_direction:
       description: The direction to rotate
       example: 'left'
 
-set_auto_mode:
-  description: Set the fan in auto mode
-
-  fields:
-    entity_id:
-      description: Name(s) of the entities to enable/disable auto mode
-      example: 'fan.living_room'
-    auto_mode:
-      description: Auto mode status
-      example: true
-
-set_night_mode:
+dyson_set_night_mode:
   description: Set the fan in night mode
 
   fields:
@@ -82,5 +71,5 @@ set_night_mode:
       description: Name(s) of the entities to enable/disable night mode
       example: 'fan.living_room'
     night_mode:
-      description: Auto mode status
+      description: Night mode status
       example: true

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -58,7 +58,29 @@ set_direction:
   fields:
     entity_id:
       description: Name(s) of the entities to toggle
-      exampl: 'fan.living_room'
+      example: 'fan.living_room'
     direction:
       description: The direction to rotate
       example: 'left'
+
+set_auto_mode:
+  description: Set the fan in auto mode
+
+  fields:
+    entity_id:
+      description: Name(s) of the entities to enable/disable auto mode
+      example: 'fan.living_room'
+    auto_mode:
+      description: Auto mode status
+      example: true
+
+set_night_mode:
+  description: Set the fan in night mode
+
+  fields:
+    entity_id:
+      description: Name(s) of the entities to enable/disable night mode
+      example: 'fan.living_room'
+    night_mode:
+      description: Auto mode status
+      example: true

--- a/homeassistant/components/sensor/dyson.py
+++ b/homeassistant/components/sensor/dyson.py
@@ -1,0 +1,67 @@
+"""Support for Dyson Pure Cool Link Sensors."""
+import logging
+
+from homeassistant.components.dyson import DYSON_DEVICES
+
+from homeassistant.helpers.entity import Entity
+
+DEPENDENCIES = ['dyson']
+
+SENSOR_UNITS = {'filter_life': 'hours'}
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Dyson Sensors."""
+    _LOGGER.info("Creating new Dyson fans")
+    devices = []
+    # Get Dyson Devices from parent component
+    for device in hass.data[DYSON_DEVICES]:
+        devices.append(DysonFilterLifeSensor(hass, device))
+    add_devices(devices)
+
+
+class DysonFilterLifeSensor(Entity):
+    """Representation of Dyson filter life sensor (in hours)."""
+
+    def on_message(self, message):
+        """Called when new messages received from the fan."""
+        _LOGGER.debug("Message received for %s device: %s", self.name,
+                      message)
+        if self.hass and self.entity_id:
+            # Prevent refreshing if not needed
+            if self._old_value is None or self._old_value != self.state:
+                self._old_value = self.state
+                self.schedule_update_ha_state()
+
+    def __init__(self, hass, device):
+        """Create a new Dyson filter life sensor."""
+        self.hass = hass
+        self._device = device
+        self._name = "{} filter life".format(self._device.name)
+        self._device.add_message_listener(self.on_message)
+        self._old_value = None
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def state(self):
+        """Return filter life in hours.."""
+        if self._device.state:
+            return self._device.state.filter_life
+        else:
+            return None
+
+    @property
+    def name(self):
+        """Return the name of the dyson sensor name."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return SENSOR_UNITS['filter_life']

--- a/homeassistant/components/sensor/dyson.py
+++ b/homeassistant/components/sensor/dyson.py
@@ -37,12 +37,13 @@ class DysonFilterLifeSensor(Entity):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Callback when entity is added to hass."""
-        self._device.add_message_listener(self.on_message)
+        self.hass.async_add_job(
+            self._device.add_message_listener(self.on_message))
 
     def on_message(self, message):
         """Called when new messages received from the fan."""
-        _LOGGER.debug("Message received for %s device: %s", self.name,
-                      message)
+        _LOGGER.debug(
+            "Message received for %s device: %s", self.name, message)
         # Prevent refreshing if not needed
         if self._old_value is None or self._old_value != self.state:
             self._old_value = self.state

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -341,6 +341,10 @@ knxip==0.3.3
 # homeassistant.components.device_tracker.owntracks
 libnacl==1.5.0
 
+# homeassistant.components.dyson
+# homeassistant.components.fan.dyson
+libpurecoollink==0.1.5
+
 # homeassistant.components.device_tracker.mikrotik
 librouteros==1.0.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -342,7 +342,6 @@ knxip==0.3.3
 libnacl==1.5.0
 
 # homeassistant.components.dyson
-# homeassistant.components.fan.dyson
 libpurecoollink==0.1.5
 
 # homeassistant.components.device_tracker.mikrotik

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -61,6 +61,10 @@ holidays==0.8.1
 # homeassistant.components.sensor.influxdb
 influxdb==3.0.0
 
+# homeassistant.components.dyson
+# homeassistant.components.fan.dyson
+libpurecoollink==0.1.5
+
 # homeassistant.components.media_player.soundtouch
 libsoundtouch==0.3.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -62,7 +62,6 @@ holidays==0.8.1
 influxdb==3.0.0
 
 # homeassistant.components.dyson
-# homeassistant.components.fan.dyson
 libpurecoollink==0.1.5
 
 # homeassistant.components.media_player.soundtouch

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -40,6 +40,7 @@ TEST_REQUIREMENTS = (
     'aioautomatic',
     'SoCo',
     'libsoundtouch',
+    'libpurecoollink',
     'rxv',
     'apns2',
     'sqlalchemy',

--- a/tests/components/fan/test_dyson.py
+++ b/tests/components/fan/test_dyson.py
@@ -1,0 +1,201 @@
+"""Test the Dyson fan component."""
+import unittest
+from unittest import mock
+
+from homeassistant.components.fan import dyson
+from tests.common import get_test_home_assistant
+from libpurecoollink.const import FanSpeed, FanMode, NightMode, Oscillation
+
+
+def _get_device_with_no_state():
+    """Return a device with no state."""
+    device = mock.Mock()
+    device.name = "Device_name"
+    device.state = None
+    return device
+
+
+def _get_device_off():
+    """Return a device with state off."""
+    device = mock.Mock()
+    device.name = "Device_name"
+    device.state = mock.Mock()
+    device.state.fan_mode = "OFF"
+    device.state.night_mode = "ON"
+    return device
+
+
+def _get_device_on():
+    """Return a valid state on."""
+    device = mock.Mock()
+    device.name = "Device_name"
+    device.state = mock.Mock()
+    device.state.fan_mode = "FAN"
+    device.state.oscillation = "ON"
+    device.state.speed = "0001"
+    return device
+
+
+class DysonTest(unittest.TestCase):
+    """Dyson Sensor component test class."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_setup_component_with_no_devices(self):
+        """Test setup component with no devices."""
+        self.hass.data[dyson.DYSON_DEVICES] = []
+        add_devices = mock.MagicMock()
+        dyson.setup_platform(self.hass, None, add_devices)
+        add_devices.assert_called_with([])
+
+    def test_setup_component(self):
+        """Test setup component with devices."""
+        def _add_device(devices):
+            assert len(devices) == 1
+            assert devices[0].name == "Device_name"
+
+        device = _get_device_on()
+        self.hass.data[dyson.DYSON_DEVICES] = [device]
+        dyson.setup_platform(self.hass, None, _add_device)
+
+    def test_dyson_set_speed(self):
+        """Test set fan speed."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertFalse(component.should_poll)
+        component.set_speed("0001")
+        set_config = device.set_configuration
+        set_config.assert_called_with(fan_mode=FanMode.FAN,
+                                      fan_speed=FanSpeed.FAN_SPEED_1,
+                                      night_mode=NightMode.NIGHT_MODE_OFF)
+
+    def test_dyson_turn_on(self):
+        """Test turn on fan."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertFalse(component.should_poll)
+        component.turn_on()
+        set_config = device.set_configuration
+        set_config.assert_called_with(fan_mode=FanMode.FAN)
+
+    def test_dyson_turn_on_night_mode(self):
+        """Test turn on fan with night mode."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertFalse(component.should_poll)
+        component.turn_on("NIGHT_MODE")
+        set_config = device.set_configuration
+        set_config.assert_called_with(fan_mode=FanMode.AUTO,
+                                      night_mode=NightMode.NIGHT_MODE_ON)
+
+    def test_dyson_turn_on_auto_mode(self):
+        """Test turn on fan with auto mode."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertFalse(component.should_poll)
+        component.turn_on("AUTO")
+        set_config = device.set_configuration
+        set_config.assert_called_with(fan_mode=FanMode.AUTO,
+                                      night_mode=NightMode.NIGHT_MODE_OFF)
+
+    def test_dyson_turn_on_speed(self):
+        """Test turn on fan with specified speed."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertFalse(component.should_poll)
+        component.turn_on("0001")
+        set_config = device.set_configuration
+        set_config.assert_called_with(fan_mode=FanMode.FAN,
+                                      fan_speed=FanSpeed.FAN_SPEED_1,
+                                      night_mode=NightMode.NIGHT_MODE_OFF)
+
+    def test_dyson_turn_off(self):
+        """Test turn off fan."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertFalse(component.should_poll)
+        component.turn_off()
+        set_config = device.set_configuration
+        set_config.assert_called_with(fan_mode=FanMode.OFF)
+
+    def test_dyson_oscillate_off(self):
+        """Test turn off oscillation."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        component.oscillate(False)
+        set_config = device.set_configuration
+        set_config.assert_called_with(oscillation=Oscillation.OSCILLATION_OFF)
+
+    def test_dyson_oscillate_on(self):
+        """Test turn on oscillation."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        component.oscillate(True)
+        set_config = device.set_configuration
+        set_config.assert_called_with(oscillation=Oscillation.OSCILLATION_ON)
+
+    def test_dyson_oscillate_value_on(self):
+        """Test get oscillation value on."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertTrue(component.oscillating)
+
+    def test_dyson_oscillate_value_off(self):
+        """Test get oscillation value off."""
+        device = _get_device_off()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertFalse(component.oscillating)
+
+    def test_dyson_on(self):
+        """Test device is on."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertTrue(component.is_on)
+
+    def test_dyson_off(self):
+        """Test device is off."""
+        device = _get_device_off()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertFalse(component.is_on)
+
+        device = _get_device_with_no_state()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertFalse(component.is_on)
+
+    def test_dyson_get_speed(self):
+        """Test get device speed."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertEqual(component.speed, "0001")
+
+        device = _get_device_off()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertEqual(component.speed, "NIGHT_MODE")
+
+        device = _get_device_with_no_state()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertIsNone(component.speed)
+
+    def test_dyson_get_direction(self):
+        """Test get device direction."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertIsNone(component.current_direction)
+
+    def test_dyson_get_speed_list(self):
+        """Test get speeds list."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertEqual(len(component.speed_list), 12)
+
+    def test_dyson_supported_features(self):
+        """Test supported features."""
+        device = _get_device_on()
+        component = dyson.DysonPureCoolLinkDevice(self.hass, device)
+        self.assertEqual(component.supported_features, 3)

--- a/tests/components/sensor/test_dyson.py
+++ b/tests/components/sensor/test_dyson.py
@@ -1,0 +1,75 @@
+"""Test the Dyson sensor(s) component."""
+import unittest
+from unittest import mock
+
+from homeassistant.components.sensor import dyson
+from tests.common import get_test_home_assistant
+
+
+def _get_device_without_state():
+    """Return a valid device provide by Dyson web services."""
+    device = mock.Mock()
+    device.name = "Device_name"
+    device.state = None
+    return device
+
+
+def _get_with_state():
+    """Return a valid device with state values."""
+    device = mock.Mock()
+    device.name = "Device_name"
+    device.state = mock.Mock()
+    device.state.filter_life = 100
+    return device
+
+
+class DysonTest(unittest.TestCase):
+    """Dyson Sensor component test class."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_setup_component_with_no_devices(self):
+        """Test setup component with no devices."""
+        self.hass.data[dyson.DYSON_DEVICES] = []
+        add_devices = mock.MagicMock()
+        dyson.setup_platform(self.hass, None, add_devices)
+        add_devices.assert_called_with([])
+
+    def test_setup_component(self):
+        """Test setup component with devices."""
+        def _add_device(devices):
+            assert len(devices) == 1
+            assert devices[0].name == "Device_name filter life"
+
+        device = _get_device_without_state()
+        self.hass.data[dyson.DYSON_DEVICES] = [device]
+        dyson.setup_platform(self.hass, None, _add_device)
+
+    def test_dyson_filter_life_sensor(self):
+        """Test sensor with no value."""
+        sensor = dyson.DysonFilterLifeSensor(self.hass,
+                                             _get_device_without_state())
+        sensor.entity_id = "sensor.dyson_1"
+        self.assertFalse(sensor.should_poll)
+        self.assertIsNone(sensor.state)
+        self.assertEqual(sensor.unit_of_measurement, "hours")
+        self.assertEqual(sensor.name, "Device_name filter life")
+        self.assertEqual(sensor.entity_id, "sensor.dyson_1")
+        sensor.on_message('message')
+
+    def test_dyson_filter_life_sensor_with_values(self):
+        """Test sensor with values."""
+        sensor = dyson.DysonFilterLifeSensor(self.hass, _get_with_state())
+        sensor.entity_id = "sensor.dyson_1"
+        self.assertFalse(sensor.should_poll)
+        self.assertEqual(sensor.state, 100)
+        self.assertEqual(sensor.unit_of_measurement, "hours")
+        self.assertEqual(sensor.name, "Device_name filter life")
+        self.assertEqual(sensor.entity_id, "sensor.dyson_1")
+        sensor.on_message('message')

--- a/tests/components/sensor/test_dyson.py
+++ b/tests/components/sensor/test_dyson.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest import mock
 
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.components.sensor import dyson
 from tests.common import get_test_home_assistant
 
@@ -57,7 +58,7 @@ class DysonTest(unittest.TestCase):
                                              _get_device_without_state())
         sensor.entity_id = "sensor.dyson_1"
         self.assertFalse(sensor.should_poll)
-        self.assertIsNone(sensor.state)
+        self.assertEqual(sensor.state, STATE_UNKNOWN)
         self.assertEqual(sensor.unit_of_measurement, "hours")
         self.assertEqual(sensor.name, "Device_name filter life")
         self.assertEqual(sensor.entity_id, "sensor.dyson_1")

--- a/tests/components/test_dyson.py
+++ b/tests/components/test_dyson.py
@@ -97,11 +97,13 @@ class DysonTest(unittest.TestCase):
         self.assertEqual(mocked_devices.call_count, 1)
         self.assertEqual(len(self.hass.data[dyson.DYSON_DEVICES]), 0)
 
+    @mock.patch('homeassistant.helpers.discovery.load_platform')
     @mock.patch('libpurecoollink.dyson.DysonAccount.devices',
                 return_value=[_get_dyson_account_device_available()])
     @mock.patch('libpurecoollink.dyson.DysonAccount.login', return_value=True)
     def test_dyson_custom_conf_with_unknown_device(self, mocked_login,
-                                                   mocked_devices):
+                                                   mocked_devices,
+                                                   mocked_discovery):
         """Test device connection with custom conf and unknown device."""
         dyson.setup(self.hass, {dyson.DOMAIN: {
             dyson.CONF_USERNAME: "email",
@@ -117,11 +119,14 @@ class DysonTest(unittest.TestCase):
         self.assertEqual(mocked_login.call_count, 1)
         self.assertEqual(mocked_devices.call_count, 1)
         self.assertEqual(len(self.hass.data[dyson.DYSON_DEVICES]), 0)
+        self.assertEqual(mocked_discovery.call_count, 0)
 
+    @mock.patch('homeassistant.helpers.discovery.load_platform')
     @mock.patch('libpurecoollink.dyson.DysonAccount.devices',
                 return_value=[_get_dyson_account_device_available()])
     @mock.patch('libpurecoollink.dyson.DysonAccount.login', return_value=True)
-    def test_dyson_discovery(self, mocked_login, mocked_devices):
+    def test_dyson_discovery(self, mocked_login, mocked_devices,
+                             mocked_discovery):
         """Test device connection using discovery."""
         dyson.setup(self.hass, {dyson.DOMAIN: {
             dyson.CONF_USERNAME: "email",
@@ -133,6 +138,7 @@ class DysonTest(unittest.TestCase):
         self.assertEqual(mocked_login.call_count, 1)
         self.assertEqual(mocked_devices.call_count, 1)
         self.assertEqual(len(self.hass.data[dyson.DYSON_DEVICES]), 1)
+        self.assertEqual(mocked_discovery.call_count, 2)
 
     @mock.patch('libpurecoollink.dyson.DysonAccount.devices',
                 return_value=[_get_dyson_account_device_not_available()])

--- a/tests/components/test_dyson.py
+++ b/tests/components/test_dyson.py
@@ -1,0 +1,152 @@
+"""Test the parent Dyson component."""
+import unittest
+from unittest import mock
+
+from homeassistant.components import dyson
+from tests.common import get_test_home_assistant
+
+
+def _get_dyson_account_device_available():
+    """Return a valid device provide by Dyson web services."""
+    device = mock.Mock()
+    device.serial = "XX-XXXXX-XX"
+    device.connect = mock.Mock(return_value=True)
+    return device
+
+
+def _get_dyson_account_device_not_available():
+    """Return an invalid device provide by Dyson web services."""
+    device = mock.Mock()
+    device.serial = "XX-XXXXX-XX"
+    device.connect = mock.Mock(return_value=False)
+    return device
+
+
+class DysonTest(unittest.TestCase):
+    """Dyson parent component test class."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @mock.patch('libpurecoollink.dyson.DysonAccount.login', return_value=False)
+    def test_dyson_login_failed(self, mocked_login):
+        """Test if Dyson connection failed."""
+        dyson.setup(self.hass, {dyson.DOMAIN: {
+            dyson.CONF_USERNAME: "email",
+            dyson.CONF_PASSWORD: "password",
+            dyson.CONF_LANGUAGE: "FR"
+        }})
+        self.assertEqual(mocked_login.call_count, 1)
+
+    @mock.patch('libpurecoollink.dyson.DysonAccount.devices', return_value=[])
+    @mock.patch('libpurecoollink.dyson.DysonAccount.login', return_value=True)
+    def test_dyson_login(self, mocked_login, mocked_devices):
+        """Test valid connection to dyson web service."""
+        dyson.setup(self.hass, {dyson.DOMAIN: {
+            dyson.CONF_USERNAME: "email",
+            dyson.CONF_PASSWORD: "password",
+            dyson.CONF_LANGUAGE: "FR"
+        }})
+        self.assertEqual(mocked_login.call_count, 1)
+        self.assertEqual(mocked_devices.call_count, 1)
+        self.assertEqual(len(self.hass.data[dyson.DYSON_DEVICES]), 0)
+
+    @mock.patch('libpurecoollink.dyson.DysonAccount.devices',
+                return_value=[_get_dyson_account_device_available()])
+    @mock.patch('libpurecoollink.dyson.DysonAccount.login', return_value=True)
+    def test_dyson_custom_conf(self, mocked_login, mocked_devices):
+        """Test device connection using custom configuration."""
+        dyson.setup(self.hass, {dyson.DOMAIN: {
+            dyson.CONF_USERNAME: "email",
+            dyson.CONF_PASSWORD: "password",
+            dyson.CONF_LANGUAGE: "FR",
+            dyson.CONF_DEVICES: [
+                {
+                    "device_id": "XX-XXXXX-XX",
+                    "device_ip": "192.168.0.1"
+                }
+            ]
+        }})
+        self.assertEqual(mocked_login.call_count, 1)
+        self.assertEqual(mocked_devices.call_count, 1)
+        self.assertEqual(len(self.hass.data[dyson.DYSON_DEVICES]), 1)
+
+    @mock.patch('libpurecoollink.dyson.DysonAccount.devices',
+                return_value=[_get_dyson_account_device_not_available()])
+    @mock.patch('libpurecoollink.dyson.DysonAccount.login', return_value=True)
+    def test_dyson_custom_conf_device_not_available(self, mocked_login,
+                                                    mocked_devices):
+        """Test device connection with an invalid device."""
+        dyson.setup(self.hass, {dyson.DOMAIN: {
+            dyson.CONF_USERNAME: "email",
+            dyson.CONF_PASSWORD: "password",
+            dyson.CONF_LANGUAGE: "FR",
+            dyson.CONF_DEVICES: [
+                {
+                    "device_id": "XX-XXXXX-XX",
+                    "device_ip": "192.168.0.1"
+                }
+            ]
+        }})
+        self.assertEqual(mocked_login.call_count, 1)
+        self.assertEqual(mocked_devices.call_count, 1)
+        self.assertEqual(len(self.hass.data[dyson.DYSON_DEVICES]), 0)
+
+    @mock.patch('libpurecoollink.dyson.DysonAccount.devices',
+                return_value=[_get_dyson_account_device_available()])
+    @mock.patch('libpurecoollink.dyson.DysonAccount.login', return_value=True)
+    def test_dyson_custom_conf_with_unknown_device(self, mocked_login,
+                                                   mocked_devices):
+        """Test device connection with custom conf and unknown device."""
+        dyson.setup(self.hass, {dyson.DOMAIN: {
+            dyson.CONF_USERNAME: "email",
+            dyson.CONF_PASSWORD: "password",
+            dyson.CONF_LANGUAGE: "FR",
+            dyson.CONF_DEVICES: [
+                {
+                    "device_id": "XX-XXXXX-XY",
+                    "device_ip": "192.168.0.1"
+                }
+            ]
+        }})
+        self.assertEqual(mocked_login.call_count, 1)
+        self.assertEqual(mocked_devices.call_count, 1)
+        self.assertEqual(len(self.hass.data[dyson.DYSON_DEVICES]), 0)
+
+    @mock.patch('libpurecoollink.dyson.DysonAccount.devices',
+                return_value=[_get_dyson_account_device_available()])
+    @mock.patch('libpurecoollink.dyson.DysonAccount.login', return_value=True)
+    def test_dyson_discovery(self, mocked_login, mocked_devices):
+        """Test device connection using discovery."""
+        dyson.setup(self.hass, {dyson.DOMAIN: {
+            dyson.CONF_USERNAME: "email",
+            dyson.CONF_PASSWORD: "password",
+            dyson.CONF_LANGUAGE: "FR",
+            dyson.CONF_TIMEOUT: 5,
+            dyson.CONF_RETRY: 2
+        }})
+        self.assertEqual(mocked_login.call_count, 1)
+        self.assertEqual(mocked_devices.call_count, 1)
+        self.assertEqual(len(self.hass.data[dyson.DYSON_DEVICES]), 1)
+
+    @mock.patch('libpurecoollink.dyson.DysonAccount.devices',
+                return_value=[_get_dyson_account_device_not_available()])
+    @mock.patch('libpurecoollink.dyson.DysonAccount.login', return_value=True)
+    def test_dyson_discovery_device_not_available(self, mocked_login,
+                                                  mocked_devices):
+        """Test device connection with discovery and invalid device."""
+        dyson.setup(self.hass, {dyson.DOMAIN: {
+            dyson.CONF_USERNAME: "email",
+            dyson.CONF_PASSWORD: "password",
+            dyson.CONF_LANGUAGE: "FR",
+            dyson.CONF_TIMEOUT: 5,
+            dyson.CONF_RETRY: 2
+        }})
+        self.assertEqual(mocked_login.call_count, 1)
+        self.assertEqual(mocked_devices.call_count, 1)
+        self.assertEqual(len(self.hass.data[dyson.DYSON_DEVICES]), 0)

--- a/tests/components/test_dyson.py
+++ b/tests/components/test_dyson.py
@@ -56,10 +56,12 @@ class DysonTest(unittest.TestCase):
         self.assertEqual(mocked_devices.call_count, 1)
         self.assertEqual(len(self.hass.data[dyson.DYSON_DEVICES]), 0)
 
+    @mock.patch('homeassistant.helpers.discovery.load_platform')
     @mock.patch('libpurecoollink.dyson.DysonAccount.devices',
                 return_value=[_get_dyson_account_device_available()])
     @mock.patch('libpurecoollink.dyson.DysonAccount.login', return_value=True)
-    def test_dyson_custom_conf(self, mocked_login, mocked_devices):
+    def test_dyson_custom_conf(self, mocked_login, mocked_devices,
+                               mocked_discovery):
         """Test device connection using custom configuration."""
         dyson.setup(self.hass, {dyson.DOMAIN: {
             dyson.CONF_USERNAME: "email",
@@ -75,6 +77,7 @@ class DysonTest(unittest.TestCase):
         self.assertEqual(mocked_login.call_count, 1)
         self.assertEqual(mocked_devices.call_count, 1)
         self.assertEqual(len(self.hass.data[dyson.DYSON_DEVICES]), 1)
+        self.assertEqual(mocked_discovery.call_count, 2)
 
     @mock.patch('libpurecoollink.dyson.DysonAccount.devices',
                 return_value=[_get_dyson_account_device_not_available()])


### PR DESCRIPTION
## Description:


This PR add Dyson [purifier fans](http://www.dyson.co.uk/fans-and-heaters/purifiers/dyson-pure-hot-cool-link-evo/overview.aspx) support.

This component is still in development and will be improve but I'm using it since months and I have been able to have successful feedback from other users: https://community.home-assistant.io/t/dyson-link-action-and-sensor/10145

So I think it is reliable enough to submit a first release. I have in mind other improvements (other sensors, heating and why not the vacuum 360 robot) so I decided to create a parent Dyson component with Dyson account information and fan/sensors child components.

One word on auto-discovery (mDNS): for an unknown reason, it's not very reliable (sometime it's work, sometime not). So in the documentation I'll add a word on how to setup the component using discovery and how to manually configure it if it's not working.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2721

## Example entry for `configuration.yaml` (if applicable):
```yaml
dyson:
  username: <dyson_account_user_email>
  password: <dyson_acount_password>
  language: <dyson_account_language>
  devices:
    - device_id: <device_id_1>
      device_ip: <device_ip_1>
    - device_id: <device_id_2>
      device_ip: <device_ip_2>
    ...

fan:
  - platform: dyson

sensor:
  - platform: dyson
```



## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass** (not tested with Python 3.6)
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
