### PR TITLE
Allow 'base_url' (fixes #7784)

### DIFF
--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -1,10 +1,11 @@
 """
 This module will attempt to open a port in your router for Home Assistant.
 
-For more details about UPnP, please refer to the documentation at
+For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/upnp/
 """
 import logging
+from urllib.parse import urlsplit
 
 import voluptuous as vol
 
@@ -32,11 +33,15 @@ def setup(hass, config):
     try:
         upnp.selectigd()
     except Exception:
-        _LOGGER.exception("Error when attempting to discover a UPnP IGD")
+        _LOGGER.exception("Error when attempting to discover an UPnP IGD")
         return False
 
-    upnp.addportmapping(hass.config.api.port, 'TCP', hass.config.api.host,
-                        hass.config.api.port, 'Home Assistant', '')
+    base_url = urlsplit(hass.config.api.base_url)
+    host = base_url.hostname
+    external_port = internal_port = base_url.port
+
+    upnp.addportmapping(
+        external_port, 'TCP', host, internal_port, 'Home Assistant', '')
 
     def deregister_port(event):
         """De-register the UPnP port mapping."""


### PR DESCRIPTION
## Description:
Allow the combination of `base_url` and `upnp:`.

**Related issue (if applicable):** fixes #7784

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
  base_url: example.duckdns.org:8123
upnp:
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
