### PR TITLE
Upgrade slacker to 0.9.50

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_API_KEY, CONF_USERNAME, CONF_ICON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['slacker==0.9.42']
+REQUIREMENTS = ['slacker==0.9.50']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -769,7 +769,7 @@ sharp_aquos_rc==0.3.2
 simplisafe-python==1.0.2
 
 # homeassistant.components.notify.slack
-slacker==0.9.42
+slacker==0.9.50
 
 # homeassistant.components.notify.xmpp
 sleekxmpp==1.3.2


### PR DESCRIPTION
## 0.9.50

- https://github.com/os/slacker/commits/master

Tested with the following configuration:

``` yaml
notify:
  - name: slack
    platform: slack
    api_key: !secret slack_api
    default_channel: '#ha'
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```