### PR TITLE
Make deps directory persistent over upgrades

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 import logging.handlers
 import os
-from subprocess import Popen, PIPE
 import sys
 from time import time
 from collections import OrderedDict
@@ -20,6 +19,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
 from homeassistant.setup import async_setup_component
 import homeassistant.loader as loader
 from homeassistant.util.logging import AsyncHandler
+from homeassistant.util.package import async_get_user_site, get_user_site
 from homeassistant.util.yaml import clear_secret_cache
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.signal import async_register_signal_handling
@@ -49,7 +49,8 @@ def from_config_dict(config: Dict[str, Any],
         if config_dir is not None:
             config_dir = os.path.abspath(config_dir)
             hass.config.config_dir = config_dir
-            mount_local_lib_path(config_dir)
+            hass.loop.run_until_complete(
+                async_mount_local_lib_path(config_dir, hass.loop))
 
     # run task
     hass = hass.loop.run_until_complete(
@@ -184,7 +185,8 @@ def async_from_config_file(config_path: str,
     # Set config dir to directory holding config file
     config_dir = os.path.abspath(os.path.dirname(config_path))
     hass.config.config_dir = config_dir
-    yield from hass.async_add_job(mount_local_lib_path, config_dir)
+    yield from hass.async_add_job(
+        async_mount_local_lib_path, config_dir, hass.loop)
 
     async_enable_logging(hass, verbose, log_rotate_days)
 
@@ -277,17 +279,23 @@ def async_enable_logging(hass: core.HomeAssistant, verbose: bool=False,
 
 
 def mount_local_lib_path(config_dir: str) -> str:
+    """Add local library to Python Path."""
+    deps_dir = os.path.join(config_dir, 'deps')
+    lib_dir = get_user_site(deps_dir)
+    if lib_dir not in sys.path:
+        sys.path.insert(0, lib_dir)
+    return deps_dir
+
+
+@asyncio.coroutine
+def async_mount_local_lib_path(config_dir: str,
+                               loop: asyncio.AbstractEventLoop) -> str:
     """Add local library to Python Path.
 
-    Async friendly.
+    This function is a coroutine.
     """
     deps_dir = os.path.join(config_dir, 'deps')
-    env = os.environ.copy()
-    env['PYTHONUSERBASE'] = os.path.abspath(deps_dir)
-    args = [sys.executable, '-m', 'site', '--user-site']
-    process = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=env)
-    stdout, _ = process.communicate()
-    lib_dir = stdout.decode().strip()
+    lib_dir = yield from async_get_user_site(deps_dir, loop=loop)
     if lib_dir not in sys.path:
         sys.path.insert(0, lib_dir)
     return deps_dir

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -185,8 +185,7 @@ def async_from_config_file(config_path: str,
     # Set config dir to directory holding config file
     config_dir = os.path.abspath(os.path.dirname(config_path))
     hass.config.config_dir = config_dir
-    yield from hass.async_add_job(
-        async_mount_local_lib_path, config_dir, hass.loop)
+    yield from async_mount_local_lib_path(config_dir, hass.loop)
 
     async_enable_logging(hass, verbose, log_rotate_days)
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import logging.handlers
 import os
+from subprocess import Popen, PIPE
 import sys
 from time import time
 from collections import OrderedDict
@@ -281,6 +282,12 @@ def mount_local_lib_path(config_dir: str) -> str:
     Async friendly.
     """
     deps_dir = os.path.join(config_dir, 'deps')
-    if deps_dir not in sys.path:
-        sys.path.insert(0, os.path.join(config_dir, 'deps'))
+    env = os.environ.copy()
+    env['PYTHONUSERBASE'] = os.path.abspath(deps_dir)
+    args = [sys.executable, '-m', 'site', '--user-site']
+    process = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=env)
+    stdout, _ = process.communicate()
+    lib_dir = stdout.decode().strip()
+    if lib_dir not in sys.path:
+        sys.path.insert(0, lib_dir)
     return deps_dir

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -297,8 +297,8 @@ def process_ha_config_upgrade(hass):
     _LOGGER.info('Upgrading config directory from %s to %s', conf_version,
                  __version__)
 
-    if LooseVersion(conf_version) < LooseVersion('0.46'):
-        # 0.46 introduced persistent deps dir.
+    if LooseVersion(conf_version) < LooseVersion('0.49'):
+        # 0.49 introduced persistent deps dir.
         lib_path = hass.config.path('deps')
         if os.path.isdir(lib_path):
             shutil.rmtree(lib_path)

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -1,9 +1,12 @@
 """Module to help with parsing and generating configuration files."""
 import asyncio
 from collections import OrderedDict
+# pylint: disable=no-name-in-module
+from distutils.version import LooseVersion  # pylint: disable=import-error
 import logging
 import os
 import re
+import shutil
 import sys
 # pylint: disable=unused-import
 from typing import Any, List, Tuple  # NOQA
@@ -293,6 +296,12 @@ def process_ha_config_upgrade(hass):
 
     _LOGGER.info('Upgrading config directory from %s to %s', conf_version,
                  __version__)
+
+    if LooseVersion(conf_version) < LooseVersion('0.46'):
+        # 0.46 introduced persistent deps dir.
+        lib_path = hass.config.path('deps')
+        if os.path.isdir(lib_path):
+            shutil.rmtree(lib_path)
 
     with open(version_path, 'wt') as outp:
         outp.write(__version__)

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 import logging
 import os
 import re
-import shutil
 import sys
 # pylint: disable=unused-import
 from typing import Any, List, Tuple  # NOQA
@@ -294,10 +293,6 @@ def process_ha_config_upgrade(hass):
 
     _LOGGER.info('Upgrading config directory from %s to %s', conf_version,
                  __version__)
-
-    lib_path = hass.config.path('deps')
-    if os.path.isdir(lib_path):
-        shutil.rmtree(lib_path)
 
     with open(version_path, 'wt') as outp:
         outp.write(__version__)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,7 +1,7 @@
 requests==2.14.2
 pyyaml>=3.11,<4
 pytz>=2017.02
-pip>=7.1.0
+pip>=8.0.3
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -7,7 +7,7 @@ import logging
 from typing import List
 
 from homeassistant.config import get_default_config_dir
-from homeassistant.util.package import install_package
+from homeassistant.util.package import install_package, is_virtual_env
 from homeassistant.bootstrap import mount_local_lib_path
 
 
@@ -40,7 +40,7 @@ def run(args: List) -> int:
 
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     for req in getattr(script, 'REQUIREMENTS', []):
-        if hasattr(sys, 'real_prefix'):
+        if is_virtual_env():
             returncode = install_package(req)
         else:
             returncode = install_package(req, target=deps_dir)

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -40,7 +40,11 @@ def run(args: List) -> int:
 
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     for req in getattr(script, 'REQUIREMENTS', []):
-        if not install_package(req, target=deps_dir):
+        if hasattr(sys, 'real_prefix'):
+            returncode = install_package(req)
+        else:
+            returncode = install_package(req, target=deps_dir)
+        if not returncode:
             print('Aborting scipt, could not install dependency', req)
             return 1
 

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -7,6 +7,7 @@ import logging
 from typing import List
 
 from homeassistant.config import get_default_config_dir
+from homeassistant.const import CONSTRAINT_FILE
 from homeassistant.util.package import install_package, is_virtual_env
 from homeassistant.bootstrap import mount_local_lib_path
 
@@ -41,9 +42,12 @@ def run(args: List) -> int:
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     for req in getattr(script, 'REQUIREMENTS', []):
         if is_virtual_env():
-            returncode = install_package(req)
+            returncode = install_package(req, constraints=os.path.join(
+                os.path.dirname(__file__), os.pardir, CONSTRAINT_FILE))
         else:
-            returncode = install_package(req, target=deps_dir)
+            returncode = install_package(
+                req, target=deps_dir, constraints=os.path.join(
+                    os.path.dirname(__file__), os.pardir, CONSTRAINT_FILE))
         if not returncode:
             print('Aborting scipt, could not install dependency', req)
             return 1

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import logging.handlers
 import os
+import sys
 from timeit import default_timer as timer
 
 from types import ModuleType
@@ -77,6 +78,10 @@ def _async_process_requirements(hass: core.HomeAssistant, name: str,
 
     def pip_install(mod):
         """Install packages."""
+        if hasattr(sys, 'real_prefix'):
+            return pkg_util.install_package(
+                mod, constraints=os.path.join(
+                    os.path.dirname(__file__), CONSTRAINT_FILE))
         return pkg_util.install_package(
             mod, target=hass.config.path('deps'),
             constraints=os.path.join(

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 import logging.handlers
 import os
-import sys
 from timeit import default_timer as timer
 
 from types import ModuleType
@@ -78,7 +77,7 @@ def _async_process_requirements(hass: core.HomeAssistant, name: str,
 
     def pip_install(mod):
         """Install packages."""
-        if hasattr(sys, 'real_prefix'):
+        if pkg_util.is_virtual_env():
             return pkg_util.install_package(
                 mod, constraints=os.path.join(
                     os.path.dirname(__file__), CONSTRAINT_FILE))

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -25,7 +25,7 @@ def install_package(package: str, upgrade: bool=True,
     """
     # Not using 'import pip; pip.main([])' because it breaks the logger
     with INSTALL_LOCK:
-        if check_package_exists(package, target):
+        if check_package_exists(package):
             return True
 
         _LOGGER.info('Attempting install of %s', package)
@@ -36,6 +36,7 @@ def install_package(package: str, upgrade: bool=True,
         if constraints is not None:
             args += ['--constraint', constraints]
         if target:
+            assert not is_virtual_env()
             # This only works if not running in venv
             args += ['--user']
             env['PYTHONUSERBASE'] = os.path.abspath(target)
@@ -53,7 +54,7 @@ def install_package(package: str, upgrade: bool=True,
         return True
 
 
-def check_package_exists(package: str, lib_dir: str) -> bool:
+def check_package_exists(package: str) -> bool:
     """Check if a package is installed globally or in lib_dir.
 
     Returns True when the requirement is met.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2,7 +2,7 @@
 requests==2.14.2
 pyyaml>=3.11,<4
 pytz>=2017.02
-pip>=7.1.0
+pip>=8.0.3
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ REQUIRES = [
     'requests==2.14.2',
     'pyyaml>=3.11,<4',
     'pytz>=2017.02',
-    'pip>=7.1.0',
+    'pip>=8.0.3',
     'jinja2>=2.9.5',
     'voluptuous==0.10.5',
     'typing>=3,<4',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -257,13 +257,9 @@ class TestConfig(unittest.TestCase):
 
         assert state.attributes['hidden']
 
-    @mock.patch('homeassistant.config.shutil')
-    @mock.patch('homeassistant.config.os')
-    def test_remove_lib_on_upgrade(self, mock_os, mock_shutil):
-        """Test removal of library on upgrade."""
-        ha_version = '0.7.0'
-
-        mock_os.path.isdir = mock.Mock(return_value=True)
+    def test_process_config_upgrade(self):
+        """Test update of version on upgrade."""
+        ha_version = '0.8.0'
 
         mock_open = mock.mock_open()
         with mock.patch('homeassistant.config.open', mock_open, create=True):
@@ -271,42 +267,38 @@ class TestConfig(unittest.TestCase):
             # pylint: disable=no-member
             opened_file.readline.return_value = ha_version
 
-            self.hass.config.path = mock.Mock()
-
             config_util.process_ha_config_upgrade(self.hass)
 
-            hass_path = self.hass.config.path.return_value
-
-            self.assertEqual(mock_os.path.isdir.call_count, 1)
+            self.assertEqual(opened_file.write.call_count, 1)
             self.assertEqual(
-                mock_os.path.isdir.call_args, mock.call(hass_path)
+                opened_file.write.call_args, mock.call(__version__)
             )
 
-            self.assertEqual(mock_shutil.rmtree.call_count, 1)
-            self.assertEqual(
-                mock_shutil.rmtree.call_args, mock.call(hass_path)
-            )
-
-    @mock.patch('homeassistant.config.shutil')
-    @mock.patch('homeassistant.config.os')
-    def test_not_remove_lib_if_not_upgrade(self, mock_os, mock_shutil):
-        """Test removal of library with no upgrade."""
+    def test_config_upgrade_same_version(self):
+        """Test no update of version on no upgrade."""
         ha_version = __version__
 
-        mock_os.path.isdir = mock.Mock(return_value=True)
-
         mock_open = mock.mock_open()
         with mock.patch('homeassistant.config.open', mock_open, create=True):
             opened_file = mock_open.return_value
             # pylint: disable=no-member
             opened_file.readline.return_value = ha_version
 
-            self.hass.config.path = mock.Mock()
-
             config_util.process_ha_config_upgrade(self.hass)
 
-            assert mock_os.path.isdir.call_count == 0
-            assert mock_shutil.rmtree.call_count == 0
+            assert opened_file.write.call_count == 0
+
+    def test_config_upgrade_no_file(self):
+        """Test update of version on upgrade, with no version file."""
+        mock_open = mock.mock_open()
+        mock_open.side_effect = [FileNotFoundError(), mock.DEFAULT]
+        with mock.patch('homeassistant.config.open', mock_open, create=True):
+            opened_file = mock_open.return_value
+            # pylint: disable=no-member
+            config_util.process_ha_config_upgrade(self.hass)
+            self.assertEqual(opened_file.write.call_count, 1)
+            self.assertEqual(
+                opened_file.write.call_args, mock.call(__version__))
 
     @mock.patch('homeassistant.config.shutil')
     @mock.patch('homeassistant.config.os')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -260,8 +260,8 @@ class TestConfig(unittest.TestCase):
     @mock.patch('homeassistant.config.shutil')
     @mock.patch('homeassistant.config.os')
     def test_remove_lib_on_upgrade(self, mock_os, mock_shutil):
-        """Test removal of library on upgrade from before 0.46."""
-        ha_version = '0.45.0'
+        """Test removal of library on upgrade from before 0.49."""
+        ha_version = '0.48.0'
         mock_os.path.isdir = mock.Mock(return_value=True)
         mock_open = mock.mock_open()
         with mock.patch('homeassistant.config.open', mock_open, create=True):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.const import EVENT_HOMEASSISTANT_START, CONSTRAINT_FILE
 import homeassistant.config as config_util
 from homeassistant import setup, loader
 import homeassistant.util.dt as dt_util
@@ -202,6 +202,41 @@ class TestSetup:
 
         assert not setup.setup_component(self.hass, 'comp')
         assert 'comp' not in self.hass.config.components
+
+    @mock.patch('homeassistant.setup.os.path.dirname')
+    @mock.patch('homeassistant.setup.sys')
+    @mock.patch('homeassistant.util.package.install_package',
+                return_value=True)
+    def test_requirement_installed_in_venv(
+            self, mock_install, mock_sys, mock_dirname):
+        """Test requirement installed in virtual environment."""
+        mock_sys.real_prefix = 'pythonpath'
+        mock_dirname.return_value = 'ha_package_path'
+        self.hass.config.skip_pip = False
+        loader.set_component(
+            'comp', MockModule('comp', requirements=['package==0.0.1']))
+        assert setup.setup_component(self.hass, 'comp')
+        assert 'comp' in self.hass.config.components
+        assert mock_install.call_args == mock.call(
+            'package==0.0.1',
+            constraints=os.path.join('ha_package_path', CONSTRAINT_FILE))
+
+    @mock.patch('homeassistant.setup.os.path.dirname')
+    @mock.patch('homeassistant.setup.sys', spec=object())
+    @mock.patch('homeassistant.util.package.install_package',
+                return_value=True)
+    def test_requirement_installed_in_deps(
+            self, mock_install, mock_sys, mock_dirname):
+        """Test requirement installed in deps directory."""
+        mock_dirname.return_value = 'ha_package_path'
+        self.hass.config.skip_pip = False
+        loader.set_component(
+            'comp', MockModule('comp', requirements=['package==0.0.1']))
+        assert setup.setup_component(self.hass, 'comp')
+        assert 'comp' in self.hass.config.components
+        assert mock_install.call_args == mock.call(
+            'package==0.0.1', target=self.hass.config.path('deps'),
+            constraints=os.path.join('ha_package_path', CONSTRAINT_FILE))
 
     def test_component_not_setup_twice_if_loaded_during_other_setup(self):
         """Test component setup while waiting for lock is not setup twice."""

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -204,7 +204,7 @@ class TestSetup:
         assert 'comp' not in self.hass.config.components
 
     @mock.patch('homeassistant.setup.os.path.dirname')
-    @mock.patch('homeassistant.setup.sys')
+    @mock.patch('homeassistant.util.package.sys')
     @mock.patch('homeassistant.util.package.install_package',
                 return_value=True)
     def test_requirement_installed_in_venv(
@@ -222,7 +222,7 @@ class TestSetup:
             constraints=os.path.join('ha_package_path', CONSTRAINT_FILE))
 
     @mock.patch('homeassistant.setup.os.path.dirname')
-    @mock.patch('homeassistant.setup.sys', spec=object())
+    @mock.patch('homeassistant.util.package.sys', spec=object())
     @mock.patch('homeassistant.util.package.install_package',
                 return_value=True)
     def test_requirement_installed_in_deps(


### PR DESCRIPTION
## Description:
* Install requirements to venv with pip if venv is active.
* Install requirements with --user option if venv is not active.
* Set PYTHONUSERBASE environment variable to deps directory, when installing with --user option.
* Reset --prefix option to workaround incompatibility when installing with --user option. This requires pip version 8.0.0 or greater.
* Require pip version 8.0.3.
* Do not delete deps directory on home assistant upgrade.
* Fix local lib mount and check package exist.
* Add and update tests.
* Fix upgrade from before version 0.49, by removing deps directory one final time.

**Related issue (if applicable):**
fixes #3807 
Background: #5892

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
