### PR TITLE
Telegram send image: fix mimetype detection

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -180,6 +180,7 @@ def load_data(url=None, filepath=None,
                     data = io.BytesIO(req.content)
                     if data.read():
                         data.seek(0)
+                        data.name = url
                         return data
                     _LOGGER.warning("Empty data (retry #%s) in %s).",
                                     retry_num + 1, url)
@@ -502,9 +503,10 @@ class TelegramNotificationService:
             for chat_id in self._get_target_chat_ids(target):
                 _LOGGER.debug("send file to chat_id %s. Caption: %s.",
                               chat_id, caption)
+                content = io.BytesIO(file_content.read())
+                content.name = file_content.name
                 self._send_msg(func_send, "Error sending file",
-                               chat_id, io.BytesIO(file_content.read()),
-                               caption=caption, **params)
+                               chat_id, content, caption=caption, **params)
                 file_content.seek(0)
         else:
             _LOGGER.error("Can't send file with kwargs: %s", kwargs)

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -503,10 +503,9 @@ class TelegramNotificationService:
             for chat_id in self._get_target_chat_ids(target):
                 _LOGGER.debug("send file to chat_id %s. Caption: %s.",
                               chat_id, caption)
-                content = io.BytesIO(file_content.read())
-                content.name = file_content.name
                 self._send_msg(func_send, "Error sending file",
-                               chat_id, content, caption=caption, **params)
+                               chat_id, file_content,
+                               caption=caption, **params)
                 file_content.seek(0)
         else:
             _LOGGER.error("Can't send file with kwargs: %s", kwargs)


### PR DESCRIPTION
## Description:

Sometimes the `python-telegram-bot` module doesn't recognise the mimetype of the file and looks after a `name` variable to deduce it.

**Related issue (if applicable):** fixes #7413

## Example entry for `configuration.yaml` (if applicable):

```yaml

telegram_bot:
  platform: polling
  api_key: !secret telegram_bot_api_key
  allowed_chat_ids:
    - !secret telegram_bot_chat_id_1
    - !secret telegram_bot_group

script:
  test_telegram_bot_send_image:
    alias: Test Telegram Bot send image
    sequence:
      - service: telegram_bot.send_photo
        data:
          caption: 'Test image'
          url: 'https://cloud.githubusercontent.com/assets/6839756/26528267/0df8c88e-43a8-11e7-9e7a-d3820533e437.jpg'
```
