### PR TITLE
Upgrade pysnmp to 4.3.6

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -19,7 +19,7 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pysnmp==4.3.5']
+REQUIREMENTS = ['pysnmp==4.3.6']
 
 CONF_COMMUNITY = 'community'
 CONF_AUTHKEY = 'authkey'

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pysnmp==4.3.5']
+REQUIREMENTS = ['pysnmp==4.3.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -630,7 +630,7 @@ pysma==0.1.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
-pysnmp==4.3.5
+pysnmp==4.3.6
 
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner


### PR DESCRIPTION
## 4.3.6
- More instrumentation hooks added addressing security failures auditing needs.
- SNMP table indices correlation implemented within SMI framework.The opaque InetAddress type implemented. INET-ADDRESS-MIB included into the distribution.
- SNMP table indices resolution logic made more robust against malformed indices.
- Fixes to *lexicographicMode* option documentation to make it unambiguous.
- The `ErrorIndication` object is now derived from `Exception` so that it could be raised in exceptions.
- The `errorIndication` values produced by various parts of SNMP engine unified to be `ErrorIndication` instances. This fixes an issue with Twisted.
- Embedded MIB modules rebuilt with the latest pysmi adding previously missing attributes like `status`, `description` etc.
- Fixed potential SNMP engine crash on handling incoming message at unsupported security level

Tested with the following configuration:

``` yaml
sensor:
  - platform: snmp
    name: SNMP TEST String
    host: demo.snmplabs.com
    community: public
    baseoid: 1.3.6.1.4.1.2021.10.1.3.1
    unit_of_measurement: "load"
```
