### PR TITLE
log time delay of domain setup in info level

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import logging.handlers
 import os
+from time import time
 
 from types import ModuleType
 from typing import Optional, Dict
@@ -175,6 +176,7 @@ def _async_setup_component(hass: core.HomeAssistant,
 
     async_comp = hasattr(component, 'async_setup')
 
+    tic = time()
     _LOGGER.info("Setting up %s", domain)
     warn_task = hass.loop.call_later(
         SLOW_SETUP_WARNING, _LOGGER.warning,
@@ -191,6 +193,8 @@ def _async_setup_component(hass: core.HomeAssistant,
         async_notify_setup_error(hass, domain, True)
         return False
     finally:
+        _LOGGER.info("Setup of domain %s took %.1f seconds.",
+                     domain, time() - tic)
         warn_task.cancel()
 
     if result is False:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 import logging.handlers
 import os
-from time import time
+from timeit import default_timer as timer
 
 from types import ModuleType
 from typing import Optional, Dict
@@ -176,7 +176,7 @@ def _async_setup_component(hass: core.HomeAssistant,
 
     async_comp = hasattr(component, 'async_setup')
 
-    tic = time()
+    start = timer()
     _LOGGER.info("Setting up %s", domain)
     warn_task = hass.loop.call_later(
         SLOW_SETUP_WARNING, _LOGGER.warning,
@@ -193,9 +193,9 @@ def _async_setup_component(hass: core.HomeAssistant,
         async_notify_setup_error(hass, domain, True)
         return False
     finally:
-        _LOGGER.info("Setup of domain %s took %.1f seconds.",
-                     domain, time() - tic)
+        end = timer()
         warn_task.cancel()
+    _LOGGER.info("Setup of domain %s took %.1f seconds.", domain, end - start)
 
     if result is False:
         log_error("Component failed to initialize.")


### PR DESCRIPTION
## Description:

When setup problems appear in a complex config, it's difficult to debug which are the components that took a lot to set up. This minimal change goes further than the 'slow setup warning' and measures the setup time interval for each domain.

## Example entry for `configuration.yaml` (if applicable):
```yaml
logger:
  default: warn
  logs:
    homeassistant.setup: info
```
