### PR TITLE
device_tracker.ubus: Attempt to re-authenticate on permission denied

### DIFF
--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -173,7 +173,6 @@ class UbusDeviceScanner(DeviceScanner):
                 # Indicates a blank response from the server
                 return
 
-
     def _get_new_session_id(self):
         """Get a new authentication token (aka session id)."""
         self.session_id = _NULL_SESSION_ID


### PR DESCRIPTION
## Description:

If OpenWRT is restarted after Home Assistant is restarted then the session ID used by `device_tracker.ubus` becomes invalid. This change handles that by re-requesting the session id.

**Related issue (if applicable):** fixes #7812

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** No documentation changes required

## Example entry for `configuration.yaml` (if applicable):

No configuration changes required

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

