### PR TITLE
Added 'change' field to statistics sensor

### DIFF
--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -21,9 +21,11 @@ from homeassistant.helpers.event import async_track_state_change
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_MIN_VALUE = 'min_value'
-ATTR_MAX_VALUE = 'max_value'
+ATTR_AVERAGE_CHANGE = 'average_change'
+ATTR_CHANGE = 'change'
 ATTR_COUNT = 'count'
+ATTR_MAX_VALUE = 'max_value'
+ATTR_MIN_VALUE = 'min_value'
 ATTR_MEAN = 'mean'
 ATTR_MEDIAN = 'median'
 ATTR_VARIANCE = 'variance'
@@ -76,6 +78,7 @@ class StatisticsSensor(Entity):
             self.states = deque(maxlen=self._sampling_size)
         self.median = self.mean = self.variance = self.stdev = 0
         self.min = self.max = self.total = self.count = 0
+        self.average_change = self.change = 0
 
         @callback
         # pylint: disable=invalid-name
@@ -130,6 +133,8 @@ class StatisticsSensor(Entity):
                 ATTR_STANDARD_DEVIATION: self.stdev,
                 ATTR_TOTAL: self.total,
                 ATTR_VARIANCE: self.variance,
+                ATTR_CHANGE: self.change,
+                ATTR_AVERAGE_CHANGE: self.average_change,
             }
 
     @property
@@ -154,5 +159,10 @@ class StatisticsSensor(Entity):
                 self.total = round(sum(self.states), 2)
                 self.min = min(self.states)
                 self.max = max(self.states)
+                self.change = self.states[-1] - self.states[0]
+                self.average_change = self.change
+                if len(self.states) > 1:
+                    self.average_change /= len(self.states) - 1
             else:
                 self.min = self.max = self.total = STATE_UNKNOWN
+                self.average_change = self.change = STATE_UNKNOWN

--- a/tests/components/sensor/test_statistics.py
+++ b/tests/components/sensor/test_statistics.py
@@ -22,6 +22,8 @@ class TestStatisticsSensor(unittest.TestCase):
         self.median = round(statistics.median(self.values), 2)
         self.deviation = round(statistics.stdev(self.values), 2)
         self.variance = round(statistics.variance(self.values), 2)
+        self.change = self.values[-1] - self.values[0]
+        self.average_change = self.change / (len(self.values) - 1)
 
     def teardown_method(self, method):
         """Stop everything that was started."""
@@ -74,6 +76,8 @@ class TestStatisticsSensor(unittest.TestCase):
         self.assertEqual(self.count, state.attributes.get('count'))
         self.assertEqual(self.total, state.attributes.get('total'))
         self.assertEqual('°C', state.attributes.get('unit_of_measurement'))
+        self.assertEqual(self.change, state.attributes.get('change'))
+        self.assertEqual(self.average_change, state.attributes.get('average_change'))
 
     def test_sampling_size(self):
         """Test rotation."""

--- a/tests/components/sensor/test_statistics.py
+++ b/tests/components/sensor/test_statistics.py
@@ -77,7 +77,8 @@ class TestStatisticsSensor(unittest.TestCase):
         self.assertEqual(self.total, state.attributes.get('total'))
         self.assertEqual('°C', state.attributes.get('unit_of_measurement'))
         self.assertEqual(self.change, state.attributes.get('change'))
-        self.assertEqual(self.average_change, state.attributes.get('average_change'))
+        self.assertEqual(self.average_change,
+                         state.attributes.get('average_change'))
 
     def test_sampling_size(self):
         """Test rotation."""


### PR DESCRIPTION
## Description:
Add 'change' field to statistics sensor to provide basic rate-of-change info. Also added an 'average_change' field to provide the average change between samples in case 'sampling_rate' is > 2.
Use case: I have a sensor that just reads a counter and I want to see the rate of change over the last update interval.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
