### PR TITLE
Cleanup telegram / Add url to webhook

### DIFF
--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -12,7 +12,8 @@ import async_timeout
 from aiohttp.client_exceptions import ClientError
 
 from homeassistant.components.telegram_bot import (
-    CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity, PLATFORM_SCHEMA)  # NOQA
+    CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity)
+from homeassistant.components.telegram_bot import PLATFORM_SCHEMA  # NOQA
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, CONF_API_KEY)
 from homeassistant.core import callback

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -12,7 +12,7 @@ import async_timeout
 from aiohttp.client_exceptions import ClientError
 
 from homeassistant.components.telegram_bot import (
-    CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity)
+    CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity, PLATFORM_SCHEMA)  # NOQA
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, CONF_API_KEY)
 from homeassistant.core import callback

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -12,14 +12,16 @@ import async_timeout
 from aiohttp.client_exceptions import ClientError
 
 from homeassistant.components.telegram_bot import (
-    CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity)
-from homeassistant.components.telegram_bot import PLATFORM_SCHEMA  # NOQA
+    CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity,
+    PLATFORM_SCHEMA as TELEGRAM_PLATFORM_SCHEMA)
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, CONF_API_KEY)
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 _LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = TELEGRAM_PLATFORM_SCHEMA
 
 
 @asyncio.coroutine

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -6,15 +6,19 @@ https://home-assistant.io/components/telegram_bot.webhooks/
 """
 import asyncio
 import datetime as dt
+from ipaddress import ip_network
 import logging
+
+import voluptuous as vol
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.util import get_real_ip
 from homeassistant.components.telegram_bot import (
-    CONF_ALLOWED_CHAT_IDS, CONF_TRUSTED_NETWORKS, BaseTelegramBotEntity)
+    CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity, PLATFORM_SCHEMA)
 from homeassistant.const import (
-    CONF_API_KEY, EVENT_HOMEASSISTANT_STOP,
-    HTTP_BAD_REQUEST, HTTP_UNAUTHORIZED)
+    CONF_API_KEY, EVENT_HOMEASSISTANT_STOP, HTTP_BAD_REQUEST,
+    HTTP_UNAUTHORIZED, CONF_URL)
+import homeassistant.helpers.config_validation as cv
 
 DEPENDENCIES = ['http']
 
@@ -22,6 +26,24 @@ _LOGGER = logging.getLogger(__name__)
 
 TELEGRAM_HANDLER_URL = '/api/telegram_webhooks'
 REMOVE_HANDLER_URL = ''
+
+CONF_TRUSTED_NETWORKS = 'trusted_networks'
+
+DEFAULT_TRUSTED_NETWORKS = [
+    ip_network('149.154.167.197/32'),
+    ip_network('149.154.167.198/31'),
+    ip_network('149.154.167.200/29'),
+    ip_network('149.154.167.208/28'),
+    ip_network('149.154.167.224/29'),
+    ip_network('149.154.167.232/31')
+]
+
+# pylint: disable=no-value-for-parameter
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_URL): vol.Url(),
+    vol.Optional(CONF_TRUSTED_NETWORKS, default=DEFAULT_TRUSTED_NETWORKS):
+        vol.All(cv.ensure_list, [ip_network])
+})
 
 
 @asyncio.coroutine
@@ -31,6 +53,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     bot = telegram.Bot(config[CONF_API_KEY])
 
     current_status = yield from hass.async_add_job(bot.getWebhookInfo)
+    base_url = config.get(CONF_URL, hass.config.api.base_url)
 
     # Some logging of Bot current status:
     last_error_date = getattr(current_status, 'last_error_date', None)
@@ -40,8 +63,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                      last_error_date, current_status)
     else:
         _LOGGER.debug("telegram webhook Status: %s", current_status)
-    handler_url = '{0}{1}'.format(hass.config.api.base_url,
-                                  TELEGRAM_HANDLER_URL)
+
+    handler_url = "{0}{1}".format(base_url, TELEGRAM_HANDLER_URL)
     if not handler_url.startswith('https'):
         _LOGGER.error("Invalid telegram webhook %s must be https", handler_url)
         return False


### PR DESCRIPTION
## Description:

- Cleanup platform validate like other component/platforms does
- Add `url` to webhook for overwrite the base url. That is usefully if hass run on other port as 8443/443

**Breaking change**
It is now a real component/platform and the platform need to be a list.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
