### PR TITLE
Bump aiohttp to 2.1.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.0.7
+aiohttp==2.1.0
 async_timeout==1.2.1
 chardet==3.0.2
 astral==1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.0.7
+aiohttp==2.1.0
 async_timeout==1.2.1
 chardet==3.0.2
 astral==1.4

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     'jinja2>=2.9.5',
     'voluptuous==0.10.5',
     'typing>=3,<4',
-    'aiohttp==2.0.7',
+    'aiohttp==2.1.0',
     'async_timeout==1.2.1',
     'chardet==3.0.2',
     'astral==1.4',


### PR DESCRIPTION
## Description:
Bump aiohttp to the latest release.  This now properly handles the errors that were occurring when using mjpeg cam streams with uvloop.

**Related issue (if applicable):** fixes #6859

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
