### PR TITLE
Add initial benchmark framework

### DIFF
--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 import argparse
 from contextlib import suppress
 import logging
-import time
+from timeit import default_timer as timer
 
 from homeassistant import core
 
@@ -64,11 +64,11 @@ def async_million_events(hass):
 
     hass.bus.async_listen(event_name, listener)
 
-    start = time.time()
+    start = timer()
 
     for _ in range(10**6):
         hass.bus.async_fire(event_name)
 
     yield from event.wait()
 
-    return time.time() - start
+    return timer() - start

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -1,0 +1,74 @@
+"""Script to run benchmarks."""
+import asyncio
+import argparse
+from contextlib import suppress
+import logging
+import time
+
+from homeassistant import core
+
+BENCHMARKS = {}
+
+
+def run(args):
+    """Handle ensure config commandline script."""
+    # Disable logging
+    logging.getLogger('homeassistant.core').setLevel(logging.CRITICAL)
+
+    parser = argparse.ArgumentParser(
+        description=("Run a Home Assistant benchmark."))
+    parser.add_argument('name', choices=BENCHMARKS)
+    parser.add_argument('--script', choices=['benchmark'])
+
+    args = parser.parse_args()
+
+    bench = BENCHMARKS[args.name]
+
+    print('Using event loop:', asyncio.get_event_loop_policy().__module__)
+
+    with suppress(KeyboardInterrupt):
+        while True:
+            loop = asyncio.new_event_loop()
+            hass = core.HomeAssistant(loop)
+            hass.async_stop_track_tasks()
+            runtime = loop.run_until_complete(bench(hass))
+            print('Benchmark {} done in {}s'.format(bench.__name__, runtime))
+            loop.run_until_complete(hass.async_stop())
+            loop.close()
+
+    return 0
+
+
+def benchmark(func):
+    """Decorator to mark a benchmark."""
+    BENCHMARKS[func.__name__] = func
+    return func
+
+
+@benchmark
+@asyncio.coroutine
+def async_million_events(hass):
+    """Run a million events."""
+    count = 0
+    event_name = 'benchmark_event'
+    event = asyncio.Event(loop=hass.loop)
+
+    @core.callback
+    def listener(_):
+        """Handle event."""
+        nonlocal count
+        count += 1
+
+        if count == 10**6:
+            event.set()
+
+    hass.bus.async_listen(event_name, listener)
+
+    start = time.time()
+
+    for _ in range(10**6):
+        hass.bus.async_fire(event_name)
+
+    yield from event.wait()
+
+    return time.time() - start


### PR DESCRIPTION
## Description:
This adds an initial benchmark to be able to test performance of Home Assistant. This is an initial test just to explore how such tests should look. For now I just fire and handle a million events.

You pass in a benchmark by name and it will keep running the benchmark until you exit using control+C. This way we'll be able to better test runtimes like PyPy that will perform better after a few runs.

Run it with:

```bash
$ hass --script benchmark async_million_events
```

Suggestions for improvement welcome! Also more benchmarks welcome. Future benchmarks:
 - websocket API
 - Rest API
 - Service calls
 - sync vs async vs callback for all benchmarks ?

![image](https://cloud.githubusercontent.com/assets/1444314/26568904/cf4e7fec-44bb-11e7-8ca2-6640fb20580b.png)
