### PR TITLE
Upgrade pysnmp to 4.3.7

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -19,7 +19,7 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pysnmp==4.3.6']
+REQUIREMENTS = ['pysnmp==4.3.7']
 
 CONF_COMMUNITY = 'community'
 CONF_AUTHKEY = 'authkey'

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pysnmp==4.3.6']
+REQUIREMENTS = ['pysnmp==4.3.7']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -633,7 +633,7 @@ pysma==0.1.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
-pysnmp==4.3.6
+pysnmp==4.3.7
 
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner


### PR DESCRIPTION
## 4.3.7
- This is a patch release addressing bad import accidentally slipped into pre-release code.

Tested with the following configuration:

``` yaml
sensor:
  - platform: snmp
    name: SNMP TEST String
    host: demo.snmplabs.com
    community: public
    baseoid: 1.3.6.1.4.1.2021.10.1.3.1
    unit_of_measurement: "load"
```
