### PR TITLE
Mqtt cover modifications

### DIFF
--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -16,6 +16,7 @@ from homeassistant.components.cover import (
     SUPPORT_CLOSE_TILT, SUPPORT_STOP_TILT, SUPPORT_SET_TILT_POSITION,
     SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_STOP, SUPPORT_SET_POSITION,
     ATTR_POSITION)
+from homeassistant.exceptions import TemplateError
 from homeassistant.const import (
     CONF_NAME, CONF_VALUE_TEMPLATE, CONF_OPTIMISTIC, STATE_OPEN,
     STATE_CLOSED, STATE_UNKNOWN)
@@ -98,7 +99,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if value_template is not None:
         value_template.hass = hass
 
-    async_add_devices([MqttCover(hass,
+    async_add_devices([MqttCover(
+        hass,
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_COMMAND_TOPIC),
@@ -127,7 +129,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class MqttCover(CoverDevice):
     """Representation of a cover that can be controlled using MQTT."""
 
-    def __init__(self, hass, name, state_topic, command_topic, tilt_command_topic,
+    def __init__(self, hass, name, state_topic, command_topic,
+                 tilt_command_topic,
                  tilt_status_topic, qos, retain, state_open, state_closed,
                  payload_open, payload_close, payload_stop,
                  optimistic, value_template, tilt_open_position,
@@ -335,7 +338,7 @@ class MqttCover(CoverDevice):
 
         mqtt.async_publish(self.hass, self._tilt_command_topic,
                            level, self._qos, self._retain)
-    
+
     @asyncio.coroutine
     def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
@@ -347,10 +350,9 @@ class MqttCover(CoverDevice):
                 except TemplateError as ex:
                     _LOGGER.error(ex)
                     self._state = None
-            
-            mqtt.async_publish(self.hass, self._position_topic,
-                           position, self._qos, self._retain)
 
+            mqtt.async_publish(self.hass, self._position_topic,
+                               position, self._qos, self._retain)
 
     def find_percentage_in_range(self, position):
         """Find the 0-100% value within the specified range."""

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -570,7 +570,7 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_defaults(self):
         """Test find percentage in range with default range."""
         mqtt_cover = MqttCover(
-            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
             100, 0, 0, 100, False, False, None, None)
 
@@ -579,7 +579,7 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_altered(self):
         """Test find percentage in range with altered range."""
         mqtt_cover = MqttCover(
-            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
             180, 80, 80, 180, False, False, None, None)
 
@@ -588,7 +588,7 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_defaults_inverted(self):
         """Test find percentage in range with default range but inverted."""
         mqtt_cover = MqttCover(
-            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
             100, 0, 0, 100, False, True, None, None)
 
@@ -597,7 +597,7 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_altered_inverted(self):
         """Test find percentage in range with altered range and inverted."""
         mqtt_cover = MqttCover(
-            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
             180, 80, 80, 180, False, True, None, None)
 
@@ -606,7 +606,7 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_defaults(self):
         """Test find in range with default range."""
         mqtt_cover = MqttCover(
-            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
             100, 0, 0, 100, False, False, None, None)
 
@@ -615,7 +615,7 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_altered(self):
         """Test find in range with altered range."""
         mqtt_cover = MqttCover(
-            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
             180, 80, 80, 180, False, False, None, None)
 
@@ -624,7 +624,7 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_defaults_inverted(self):
         """Test find in range with default range but inverted."""
         mqtt_cover = MqttCover(
-            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
             100, 0, 0, 100, False, True, None, None)
 
@@ -633,7 +633,7 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_altered_inverted(self):
         """Test find in range with altered range and inverted."""
         mqtt_cover = MqttCover(
-            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
             180, 80, 80, 180, False, True, None, None)
 

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -274,7 +274,7 @@ class TestCoverMQTT(unittest.TestCase):
         current_cover_position = self.hass.states.get(
             'cover.test').attributes['current_position']
         self.assertEqual(22, current_cover_position)
-    
+
     def test_set_position_templated(self):
         """Test setting cover position via template."""
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
@@ -318,7 +318,6 @@ class TestCoverMQTT(unittest.TestCase):
         self.assertEqual(('position-topic', 62, 0, False),
                          self.mock_publish.mock_calls[-2][1])
 
-
     def test_no_command_topic(self):
         """Test with no command topic."""
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
@@ -333,9 +332,6 @@ class TestCoverMQTT(unittest.TestCase):
                 'tilt_status_topic': 'tilt-status'
             }
         }))
-
-        state_attributes_dict = self.hass.states.get(
-            'cover.test').attributes
 
         self.assertEqual(240, self.hass.states.get(
             'cover.test').attributes['supported_features'])
@@ -355,9 +351,6 @@ class TestCoverMQTT(unittest.TestCase):
                 'tilt_status_topic': 'tilt-status'
             }
         }))
-
-        state_attributes_dict = self.hass.states.get(
-            'cover.test').attributes
 
         self.assertEqual(251, self.hass.states.get(
             'cover.test').attributes['supported_features'])

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -215,6 +215,8 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test').attributes
         self.assertFalse('current_position' in state_attributes_dict)
         self.assertFalse('current_tilt_position' in state_attributes_dict)
+        self.assertFalse(4 & self.hass.states.get(
+            'cover.test').attributes['supported_features'] == 4)
 
         fire_mqtt_message(self.hass, 'state-topic', '0')
         self.hass.block_till_done()
@@ -239,6 +241,126 @@ class TestCoverMQTT(unittest.TestCase):
         current_cover_position = self.hass.states.get(
             'cover.test').attributes['current_position']
         self.assertEqual(50, current_cover_position)
+
+    def test_set_cover_position(self):
+        """Test setting cover position."""
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'set_position_topic': 'position-topic',
+                'payload_open': 'OPEN',
+                'payload_close': 'CLOSE',
+                'payload_stop': 'STOP'
+            }
+        }))
+
+        state_attributes_dict = self.hass.states.get(
+            'cover.test').attributes
+        self.assertFalse('current_position' in state_attributes_dict)
+        self.assertFalse('current_tilt_position' in state_attributes_dict)
+
+        self.assertTrue(4 & self.hass.states.get(
+            'cover.test').attributes['supported_features'] == 4)
+
+        fire_mqtt_message(self.hass, 'state-topic', '22')
+        self.hass.block_till_done()
+        state_attributes_dict = self.hass.states.get(
+            'cover.test').attributes
+        self.assertTrue('current_position' in state_attributes_dict)
+        self.assertFalse('current_tilt_position' in state_attributes_dict)
+        current_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_position']
+        self.assertEqual(22, current_cover_position)
+    
+    def test_set_position_templated(self):
+        """Test setting cover position via template."""
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'set_position_topic': 'position-topic',
+                'set_position_template': '{{100-62}}',
+                'payload_open': 'OPEN',
+                'payload_close': 'CLOSE',
+                'payload_stop': 'STOP'
+            }
+        }))
+
+        cover.set_cover_position(self.hass, 100, 'cover.test')
+        self.hass.block_till_done()
+
+        self.assertEqual(('position-topic', '38', 0, False),
+                         self.mock_publish.mock_calls[-2][1])
+
+    def test_set_position_untemplated(self):
+        """Test setting cover position via template."""
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'set_position_topic': 'position-topic',
+                'payload_open': 'OPEN',
+                'payload_close': 'CLOSE',
+                'payload_stop': 'STOP'
+            }
+        }))
+
+        cover.set_cover_position(self.hass, 62, 'cover.test')
+        self.hass.block_till_done()
+
+        self.assertEqual(('position-topic', 62, 0, False),
+                         self.mock_publish.mock_calls[-2][1])
+
+
+    def test_no_command_topic(self):
+        """Test with no command topic."""
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'qos': 0,
+                'payload_open': 'OPEN',
+                'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'tilt_command_topic': 'tilt-command',
+                'tilt_status_topic': 'tilt-status'
+            }
+        }))
+
+        state_attributes_dict = self.hass.states.get(
+            'cover.test').attributes
+
+        self.assertEqual(240, self.hass.states.get(
+            'cover.test').attributes['supported_features'])
+
+    def test_with_command_topic_and_tilt(self):
+        """Test with command topic and tilt config."""
+        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'command_topic': 'test',
+                'platform': 'mqtt',
+                'name': 'test',
+                'qos': 0,
+                'payload_open': 'OPEN',
+                'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'tilt_command_topic': 'tilt-command',
+                'tilt_status_topic': 'tilt-status'
+            }
+        }))
+
+        state_attributes_dict = self.hass.states.get(
+            'cover.test').attributes
+
+        self.assertEqual(251, self.hass.states.get(
+            'cover.test').attributes['supported_features'])
 
     def test_tilt_defaults(self):
         """Test the defaults."""
@@ -455,71 +577,71 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_defaults(self):
         """Test find percentage in range with default range."""
         mqtt_cover = MqttCover(
-            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
-            100, 0, 0, 100, False, False)
+            100, 0, 0, 100, False, False, None, None)
 
         self.assertEqual(44, mqtt_cover.find_percentage_in_range(44))
 
     def test_find_percentage_in_range_altered(self):
         """Test find percentage in range with altered range."""
         mqtt_cover = MqttCover(
-            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
-            180, 80, 80, 180, False, False)
+            180, 80, 80, 180, False, False, None, None)
 
         self.assertEqual(40, mqtt_cover.find_percentage_in_range(120))
 
     def test_find_percentage_in_range_defaults_inverted(self):
         """Test find percentage in range with default range but inverted."""
         mqtt_cover = MqttCover(
-            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
-            100, 0, 0, 100, False, True)
+            100, 0, 0, 100, False, True, None, None)
 
         self.assertEqual(56, mqtt_cover.find_percentage_in_range(44))
 
     def test_find_percentage_in_range_altered_inverted(self):
         """Test find percentage in range with altered range and inverted."""
         mqtt_cover = MqttCover(
-            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
-            180, 80, 80, 180, False, True)
+            180, 80, 80, 180, False, True, None, None)
 
         self.assertEqual(60, mqtt_cover.find_percentage_in_range(120))
 
     def test_find_in_range_defaults(self):
         """Test find in range with default range."""
         mqtt_cover = MqttCover(
-            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
-            100, 0, 0, 100, False, False)
+            100, 0, 0, 100, False, False, None, None)
 
         self.assertEqual(44, mqtt_cover.find_in_range_from_percent(44))
 
     def test_find_in_range_altered(self):
         """Test find in range with altered range."""
         mqtt_cover = MqttCover(
-            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
-            180, 80, 80, 180, False, False)
+            180, 80, 80, 180, False, False, None, None)
 
         self.assertEqual(120, mqtt_cover.find_in_range_from_percent(40))
 
     def test_find_in_range_defaults_inverted(self):
         """Test find in range with default range but inverted."""
         mqtt_cover = MqttCover(
-            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
-            100, 0, 0, 100, False, True)
+            100, 0, 0, 100, False, True, None, None)
 
         self.assertEqual(44, mqtt_cover.find_in_range_from_percent(56))
 
     def test_find_in_range_altered_inverted(self):
         """Test find in range with altered range and inverted."""
         mqtt_cover = MqttCover(
-            'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
+            None, 'cover.test', 'foo', 'bar', 'fooBar', "fooBarBaz", 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', False, None,
-            180, 80, 80, 180, False, True)
+            180, 80, 80, 180, False, True, None, None)
 
         self.assertEqual(120, mqtt_cover.find_in_range_from_percent(60))


### PR DESCRIPTION
## Description:
Making command topic optional so a tilt-only cover doesn't show up/down controls
Adding ability to set up/down position including ability to template the value

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2729

**also has modifications for polymer project - PR not ready yet

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  - platform: mqtt,
    name: test,
    state_topic: 'state-topic',
    command_topic: 'command-topic',
    set_position_topic: 'position-topic',
    set_position_template: '{{100-62}}',
    payload_open: 'OPEN',
    payload_close: 'CLOSE',
    payload_stop: 'STOP'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

