### PR TITLE
Dont use default for switch name, so that the object id is used

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -43,7 +43,7 @@ SWITCH_TYPES = RM_TYPES + SP1_TYPES + SP2_TYPES
 SWITCH_SCHEMA = vol.Schema({
     vol.Optional(CONF_COMMAND_OFF, default=None): cv.string,
     vol.Optional(CONF_COMMAND_ON, default=None): cv.string,
-    vol.Optional(CONF_FRIENDLY_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_FRIENDLY_NAME): cv.string,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
## Description:
Currently the sub-switches have a default friendly_name, which prevents them from getting the entity_id from the yaml id and instead end up as "broadlink_switch", "broadlink_switch_1", "broadlink_switch_2", etc (which can change between reboots). 
This fixes it by removing the default.
