### PR TITLE
Make monkey patch work in Python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,4 @@ RUN pip3 install --no-cache-dir -r requirements_all.txt && \
 # Copy source
 COPY . .
 
-ENV HASS_MONKEYPATCH_ASYNCIO 1
 CMD [ "python", "-m", "homeassistant", "--config", "/config" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
 
 # Uncomment any of the following lines to disable the installation.
@@ -26,4 +26,5 @@ RUN pip3 install --no-cache-dir -r requirements_all.txt && \
 # Copy source
 COPY . .
 
+ENV HASS_MONKEYPATCH_ASYNCIO 1
 CMD [ "python", "-m", "homeassistant", "--config", "/config" ]

--- a/homeassistant/monkey_patch.py
+++ b/homeassistant/monkey_patch.py
@@ -1,0 +1,70 @@
+"""Monkey patch Python to work around issues causing segfaults.
+
+Under heavy threading operations that schedule calls into
+the asyncio event loop, Task objects are created. Due to
+a bug in Python, GC may have an issue when switching between
+the threads and objects with __del__ (which various components
+in HASS have).
+
+This monkey-patch removes the weakref.Weakset, and replaces it
+with an object that ignores the only call utilizing it (the
+Task.__init__ which calls _all_tasks.add(self)). It also removes
+the __del__ which could trigger the future objects __del__ at
+unpredictable times.
+
+The side-effect of this manipulation of the Task is that
+Task.all_tasks() is no longer accurate, and there will be no
+warning emitted if a Task is GC'd while in use.
+
+Related Python bugs:
+ - https://bugs.python.org/issue26617
+"""
+import sys
+
+
+def patch_weakref_tasks():
+    """Replace weakref.WeakSet to address Python 3 bug."""
+    # pylint: disable=no-self-use, protected-access, bare-except
+    import asyncio.tasks
+
+    class IgnoreCalls:
+        """Ignore add calls."""
+
+        def add(self, other):
+            """No-op add."""
+            return
+
+    asyncio.tasks.Task._all_tasks = IgnoreCalls()
+    try:
+        del asyncio.tasks.Task.__del__
+    except:
+        pass
+
+
+def disable_c_asyncio():
+    """Disable using C implementation of asyncio.
+
+    Required to be able to apply the weakref monkey patch.
+
+    Requires Python 3.6+.
+    """
+    class AsyncioImportFinder:
+        PATH_TRIGGER = '_asyncio'
+
+        def __init__(self, path_entry):
+            if path_entry != self.PATH_TRIGGER:
+                raise ImportError()
+            return
+
+        def find_module(self, fullname, path=None):
+            if fullname == self.PATH_TRIGGER:
+                raise ModuleNotFoundError()
+            return None
+
+    sys.path_hooks.append(AsyncioImportFinder)
+    sys.path.insert(0, AsyncioImportFinder.PATH_TRIGGER)
+
+    try:
+        import _asyncio
+    except ImportError:
+        pass

--- a/homeassistant/monkey_patch.py
+++ b/homeassistant/monkey_patch.py
@@ -49,6 +49,7 @@ def disable_c_asyncio():
     Requires Python 3.6+.
     """
     class AsyncioImportFinder:
+        """Finder that blocks C version of asyncio being loaded."""
         PATH_TRIGGER = '_asyncio'
 
         def __init__(self, path_entry):
@@ -57,6 +58,7 @@ def disable_c_asyncio():
             return
 
         def find_module(self, fullname, path=None):
+            """Find a module."""
             if fullname == self.PATH_TRIGGER:
                 raise ModuleNotFoundError()
             return None
@@ -65,6 +67,6 @@ def disable_c_asyncio():
     sys.path.insert(0, AsyncioImportFinder.PATH_TRIGGER)
 
     try:
-        import _asyncio
+        import _asyncio  # noqa
     except ImportError:
         pass

--- a/homeassistant/monkey_patch.py
+++ b/homeassistant/monkey_patch.py
@@ -50,6 +50,7 @@ def disable_c_asyncio():
     """
     class AsyncioImportFinder:
         """Finder that blocks C version of asyncio being loaded."""
+
         PATH_TRIGGER = '_asyncio'
 
         def __init__(self, path_entry):
@@ -60,7 +61,9 @@ def disable_c_asyncio():
         def find_module(self, fullname, path=None):
             """Find a module."""
             if fullname == self.PATH_TRIGGER:
-                raise ModuleNotFoundError()
+                # We lint in Py34, exception is introduced in Py36
+                # pylint: disable=undefined-variable
+                raise ModuleNotFoundError()  # noqa
             return None
 
     sys.path_hooks.append(AsyncioImportFinder)

--- a/script/bootstrap_server
+++ b/script/bootstrap_server
@@ -7,4 +7,4 @@ set -e
 cd "$(dirname "$0")/.."
 
 echo "Installing test dependencies..."
-python3 -m pip install tox
+python3 -m pip install tox colorlog

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -2,7 +2,7 @@
 # Based on the production Dockerfile, but with development additions.
 # Keep this file as close as possible to the production Dockerfile, so the environments match.
 
-FROM python:3.5
+FROM python:3.6
 MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
 
 # Uncomment any of the following lines to disable the installation.
@@ -48,4 +48,5 @@ RUN tox -e py36 --notest
 # Copy source
 COPY . .
 
+ENV HASS_MONKEYPATCH_ASYNCIO 1
 CMD [ "python", "-m", "homeassistant", "--config", "/config" ]

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -48,5 +48,4 @@ RUN tox -e py36 --notest
 # Copy source
 COPY . .
 
-ENV HASS_MONKEYPATCH_ASYNCIO 1
 CMD [ "python", "-m", "homeassistant", "--config", "/config" ]


### PR DESCRIPTION
When we initially introduced the asyncio core we started to run into segfaults. Eventually we managed to track it down to [Python bug 26617](https://bugs.python.org/issue26617). This was fixed in Python 3.5.3 and up. However, it seems that there is another bug in Python that is causing segfaults as reported in #7752.

We have not been able to track it down properly yet. We do have a hint that it is again related to GC as @AlexMekkering managed to capture the following GDB stacktrace: https://github.com/home-assistant/home-assistant/issues/7752#issuecomment-305100009 : 

```
Thread 1 (Thread 0x76f34010 (LWP 1904)):
#0  0x76dc5298 in PyObject_GC_Del () from /usr/lib/libpython3.6m.so.1.0
#1  0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```

In Python 3.6, the Task class in asyncio has been converted to C. This has the problem that we're unable to apply our monkey patch. So @bbangert came up with a way to avoid loading the C extensions so we can still apply our monkey patch.

Since this hack is very invasive, it will have to be activated via an environment variable that has to be set while running hass:

```
HASS_MONKEYPATCH_ASYNCIO=1 hass -c config
```

This should allow us to keep using the latest version of Python in our Dockerfile while we try to track down the issue.