### PR TITLE
Change nad_receiver to pypi

### DIFF
--- a/homeassistant/components/media_player/nad.py
+++ b/homeassistant/components/media_player/nad.py
@@ -17,8 +17,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['https://github.com/joopert/nad_receiver/archive/'
-                '0.0.3.zip#nad_receiver==0.0.3']
+REQUIREMENTS = ['nad_receiver==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -288,9 +288,6 @@ https://github.com/jabesq/pybotvac/archive/v0.0.3.zip#pybotvac==0.0.3
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
-# homeassistant.components.media_player.nad
-nad_receiver==0.0.5
-
 # homeassistant.components.switch.anel_pwrctrl
 https://github.com/mweinelt/anel-pwrctrl/archive/ed26e8830e28a2bfa4260a9002db23ce3e7e63d7.zip#anel_pwrctrl==0.0.1
 
@@ -380,6 +377,9 @@ mutagen==1.37.0
 
 # homeassistant.components.sensor.usps
 myusps==1.1.1
+
+# homeassistant.components.media_player.nad
+nad_receiver==0.0.5
 
 # homeassistant.components.discovery
 netdisco==1.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -289,7 +289,7 @@ https://github.com/jabesq/pybotvac/archive/v0.0.3.zip#pybotvac==0.0.3
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
 # homeassistant.components.media_player.nad
-https://github.com/joopert/nad_receiver/archive/0.0.3.zip#nad_receiver==0.0.3
+nad_receiver==0.0.5
 
 # homeassistant.components.switch.anel_pwrctrl
 https://github.com/mweinelt/anel-pwrctrl/archive/ed26e8830e28a2bfa4260a9002db23ce3e7e63d7.zip#anel_pwrctrl==0.0.1


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** #7069

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
