### PR TITLE
Etherscan.io sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -391,6 +391,7 @@ omit =
     homeassistant/components/sensor/eliqonline.py
     homeassistant/components/sensor/emoncms.py
     homeassistant/components/sensor/envirophat.py
+    homeassistant/components/sensor/etherscan.py
     homeassistant/components/sensor/fastdotcom.py
     homeassistant/components/sensor/fedex.py
     homeassistant/components/sensor/fido.py

--- a/homeassistant/components/sensor/etherscan.py
+++ b/homeassistant/components/sensor/etherscan.py
@@ -1,0 +1,55 @@
+"""
+Support for Etherscan sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.etherscan/
+"""
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+
+REQUIREMENTS = ['python-etherscan-api==0.0.1']
+CONF_ADDRESS = 'address'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ADDRESS): cv.string
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the etherscan sensors."""
+    add_devices([EtherscanSensor('Ethereum Balance',
+                                 config.get(CONF_ADDRESS))])
+
+
+class EtherscanSensor(Entity):
+    """Representation of an Etherscan.io sensor."""
+
+    def __init__(self, name, address):
+        """Initialize the sensor."""
+        self._name = name
+        self.address = address
+        self._state = None
+        self._unit_of_measurement = 'ETH'
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name.rstrip()
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement this sensor expresses itself in."""
+        return self._unit_of_measurement
+
+    def update(self):
+        """Get the latest state of the sensor."""
+        from pyetherscan import get_balance
+        self._state = get_balance(self.address)

--- a/homeassistant/components/sensor/etherscan.py
+++ b/homeassistant/components/sensor/etherscan.py
@@ -37,7 +37,7 @@ class EtherscanSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return self._name.rstrip()
+        return self._name
 
     @property
     def state(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -654,6 +654,9 @@ python-ecobee-api==0.0.7
 # homeassistant.components.climate.eq3btsmart
 # python-eq3bt==0.1.5
 
+# homeassistant.components.sensor.etherscan
+python-etherscan-api==0.0.1
+
 # homeassistant.components.sensor.darksky
 python-forecastio==1.3.5
 


### PR DESCRIPTION
## Description:
Etherscan.io sensor to monitor the balance in an Ethereum address.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2734

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: etherscan
    address: '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
