### PR TITLE
Use expected behvaior for above/below

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -166,10 +166,10 @@ def async_numeric_state(hass: HomeAssistant, entity, below=None, above=None,
         _LOGGER.warning("Value cannot be processed as a number: %s", value)
         return False
 
-    if below is not None and value > below:
+    if below is not None and value >= below:
         return False
 
-    if above is not None and value < above:
+    if above is not None and value <= above:
         return False
 
     return True


### PR DESCRIPTION
## Description:
This PR makes the above/below conditions/triggers not treat equal as a match. This is what would be expected from the words above/below.

We are also considering adding new keywords min/max that use the old behavior, where an equal value is included. These are almost but not exactly the same. I'd like to get some opinions whether it's worth introducing the new keywords or not.

**Related issue (if applicable):** fixes #7170

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```
