### PR TITLE
fix permissions issue for Insteon Local #6558

### DIFF
--- a/homeassistant/components/insteon_local.py
+++ b/homeassistant/components/insteon_local.py
@@ -12,8 +12,9 @@ import voluptuous as vol
 from homeassistant.const import (
     CONF_PASSWORD, CONF_USERNAME, CONF_HOST, CONF_PORT, CONF_TIMEOUT)
 import homeassistant.helpers.config_validation as cv
+import os
 
-REQUIREMENTS = ['insteonlocal==0.48']
+REQUIREMENTS = ['insteonlocal==0.52']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,7 +48,12 @@ def setup(hass, config):
     timeout = conf.get(CONF_TIMEOUT)
 
     try:
-        insteonhub = Hub(host, username, password, port, timeout, _LOGGER)
+        if not os.path.exists(hass.config.path('.insteon_cache')):
+            os.makedirs(hass.config.path('.insteon_cache'))
+
+        insteonhub = Hub(host, username, password, port, timeout, _LOGGER,
+                         hass.config.path('.insteon_cache'))
+
         # Check for successful connection
         insteonhub.get_buffer_status()
     except requests.exceptions.ConnectTimeout:

--- a/homeassistant/components/insteon_local.py
+++ b/homeassistant/components/insteon_local.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/insteon_local/
 """
 import logging
+import os
 
 import requests
 import voluptuous as vol
@@ -12,7 +13,6 @@ import voluptuous as vol
 from homeassistant.const import (
     CONF_PASSWORD, CONF_USERNAME, CONF_HOST, CONF_PORT, CONF_TIMEOUT)
 import homeassistant.helpers.config_validation as cv
-import os
 
 REQUIREMENTS = ['insteonlocal==0.52']
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -320,7 +320,7 @@ influxdb==3.0.0
 insteon_hub==0.4.5
 
 # homeassistant.components.insteon_local
-insteonlocal==0.48
+insteonlocal==0.52
 
 # homeassistant.components.insteon_plm
 insteonplm==0.7.4


### PR DESCRIPTION
## Description:
Fix permission issue, using config folder for cache

**Related issue (if applicable):** fixes #6558

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
