### PR TITLE
Add libboost-python1.62-dev (fixes #7851)

### DIFF
--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -20,7 +20,7 @@ PACKAGES=(
   # homeassistant.components.device_tracker.nmap_tracker
   nmap net-tools libcurl3-dev
   # homeassistant.components.device_tracker.bluetooth_tracker
-  bluetooth libglib2.0-dev libbluetooth-dev
+  bluetooth libglib2.0-dev libbluetooth-dev libboost-python1.62-dev
   # homeassistant.components.device_tracker.owntracks
   libsodium13
   # homeassistant.components.zwave


### PR DESCRIPTION
## Description:
`bluetooth_le_tracker` and `bluetooth_tracker` require `gattlib`. In the Docker container an installation seems only possible if libboost-python is present.

Can somebody please confirm that the Bluetooth platforms are working with this change? 

**Related issue (if applicable):** fixes #7851