### PR TITLE
Added a Taps Aff binary sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -197,6 +197,7 @@ omit =
     homeassistant/components/binary_sensor/pilight.py
     homeassistant/components/binary_sensor/ping.py
     homeassistant/components/binary_sensor/rest.py
+    homeassistant/components/binary_sensor/tapsaff.py
     homeassistant/components/browser.py
     homeassistant/components/camera/amcrest.py
     homeassistant/components/camera/bloomsky.py

--- a/homeassistant/components/binary_sensor/tapsaff.py
+++ b/homeassistant/components/binary_sensor/tapsaff.py
@@ -1,37 +1,37 @@
 """
-Support for Taps Aff binary sensor.
+Support for Taps Affs.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.tapsaff/
 """
-from datetime import timedelta
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_NAME)
-import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['tapsaff==0.1.3']
 
-CONF_LOCATION = "location"
-
 _LOGGER = logging.getLogger(__name__)
+
+CONF_LOCATION = 'location'
 
 DEFAULT_NAME = 'Taps Aff'
 
 SCAN_INTERVAL = timedelta(minutes=30)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_LOCATION): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the taps aff sensor."""
+    """Set up the Taps Aff binary sensor."""
     name = config.get(CONF_NAME)
     location = config.get(CONF_LOCATION)
 
@@ -41,10 +41,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class TapsAffSensor(BinarySensorDevice):
-    """Implementation of a taps aff sensor."""
+    """Implementation of a Taps Aff binary sensor."""
 
     def __init__(self, taps_aff_data, name):
-        """Initialize the sensor."""
+        """Initialize the Taps Aff sensor."""
         self.data = taps_aff_data
         self._name = name
 
@@ -83,4 +83,4 @@ class TapsAffData(object):
         try:
             self._is_taps_aff = self.taps_aff.is_taps_aff
         except RuntimeError:
-            logging.error("TapsAff Update failed, check configured location")
+            _LOGGER.error("Update failed. Check configured location")

--- a/homeassistant/components/binary_sensor/tapsaff.py
+++ b/homeassistant/components/binary_sensor/tapsaff.py
@@ -1,0 +1,85 @@
+"""
+Support for Taps Aff binary sensor.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.tapsaff/
+"""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.binary_sensor \
+    import (BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_NAME)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
+
+REQUIREMENTS = ['tapsaff==0.1.0']
+
+CONF_LOCATION = "location"
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Taps Aff'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Required(CONF_LOCATION): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the taps aff sensor."""
+    name = config.get(CONF_NAME)
+    location = config.get(CONF_LOCATION)
+
+    taps_aff_data = TapsAffData(location)
+
+    add_devices([TapsAffSensor(taps_aff_data, name)], True)
+
+
+class TapsAffSensor(BinarySensorDevice):
+    """Implementation of a taps aff sensor."""
+
+    def __init__(self, taps_aff_data, name):
+        """Initialize the sensor."""
+        self.data = taps_aff_data
+        self._name = name
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{}'.format(self._name)
+
+    @property
+    def is_on(self):
+        """Return true if taps aff."""
+        return self.data.is_taps_aff
+
+    def update(self):
+        """Get the latest data."""
+        self.data.update()
+
+
+class TapsAffData(object):
+    """Class for handling the data retrieval for pins."""
+
+    def __init__(self, location):
+        """Initialize the sensor."""
+        from tapsaff import TapsAff
+
+        self._is_taps_aff = None
+        self.taps_aff = TapsAff(location)
+
+    @property
+    def is_taps_aff(self):
+        """Return true if taps aff."""
+        return self._is_taps_aff
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest data from the Taps Aff API and updates the states."""
+        self._is_taps_aff = self.taps_aff.is_taps_aff

--- a/homeassistant/components/binary_sensor/tapsaff.py
+++ b/homeassistant/components/binary_sensor/tapsaff.py
@@ -9,11 +9,10 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor \
-    import (BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_NAME)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import Throttle
 
 REQUIREMENTS = ['tapsaff==0.1.0']
 
@@ -23,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Taps Aff'
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
+SCAN_INTERVAL = timedelta(minutes=30)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -79,7 +78,6 @@ class TapsAffData(object):
         """Return true if taps aff."""
         return self._is_taps_aff
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from the Taps Aff API and updates the states."""
         self._is_taps_aff = self.taps_aff.is_taps_aff

--- a/homeassistant/components/binary_sensor/tapsaff.py
+++ b/homeassistant/components/binary_sensor/tapsaff.py
@@ -14,7 +14,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import (CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['tapsaff==0.1.0']
+REQUIREMENTS = ['tapsaff==0.1.3']
 
 CONF_LOCATION = "location"
 
@@ -80,4 +80,7 @@ class TapsAffData(object):
 
     def update(self):
         """Get the latest data from the Taps Aff API and updates the states."""
-        self._is_taps_aff = self.taps_aff.is_taps_aff
+        try:
+            self._is_taps_aff = self.taps_aff.is_taps_aff
+        except RuntimeError:
+            logging.error("TapsAff Update failed, check configured location")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -806,7 +806,7 @@ statsd==3.2.1
 steamodd==4.21
 
 # homeassistant.components.binary_sensor.tapsaff
-tapsaff==0.1.0
+tapsaff==0.1.3
 
 # homeassistant.components.tellstick
 # homeassistant.components.sensor.tellstick

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -805,6 +805,9 @@ statsd==3.2.1
 # homeassistant.components.sensor.steam_online
 steamodd==4.21
 
+# homeassistant.components.binary_sensor.tapsaff
+tapsaff==0.1.0
+
 # homeassistant.components.tellstick
 # homeassistant.components.sensor.tellstick
 tellcore-py==1.1.2


### PR DESCRIPTION
## Description:

This adds a binary sensor using the 'tapsaff.co.uk' service to indicate whether it is 'taps aff' in a specified location. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2746

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: tapsaff
    location: Glasgow
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
