### PR TITLE
Upgrade python-telegram-bot to 6.0.3

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -24,7 +24,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import TemplateError
 from homeassistant.setup import async_prepare_setup_platform
 
-REQUIREMENTS = ['python-telegram-bot==6.0.1']
+REQUIREMENTS = ['python-telegram-bot==6.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -690,7 +690,7 @@ python-roku==3.1.3
 python-synology==0.1.0
 
 # homeassistant.components.telegram_bot
-python-telegram-bot==6.0.1
+python-telegram-bot==6.0.3
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0


### PR DESCRIPTION
## 6.0.3
- Changelog: https://github.com/python-telegram-bot/python-telegram-bot/commits/master

## 6.0.2

- Avoid confusion with user's urllib3 by renaming vendored urllib3 to ptb_urllib3

Tested with the following configuration:

``` yaml
telegram_bot:
  - platform: polling
    api_key: !secret telegram_api
    allowed_chat_ids:
      - !secret telegram_client

notify:
  - platform: telegram
    name: telegram
    chat_id: !secret telegram_client
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```

Thanks to #7877, it's working :smile: 