### PR TITLE
Upgrade sendgrid to 4.2.0

### DIFF
--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import (CONF_API_KEY, CONF_SENDER, CONF_RECIPIENT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['sendgrid==4.1.0']
+REQUIREMENTS = ['sendgrid==4.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -762,7 +762,7 @@ schiene==0.18
 scsgate==0.1.0
 
 # homeassistant.components.notify.sendgrid
-sendgrid==4.1.0
+sendgrid==4.2.0
 
 # homeassistant.components.light.sensehat
 # homeassistant.components.sensor.sensehat


### PR DESCRIPTION
## 4.2.0
- Add ability to reset request headers on client attribute

Tested with the following configuration:

``` yaml
notify:
  - name: sendgrid
    platform: sendgrid
    api_key: !secret sendgrid_api
    sender: !secret sendgrid_sender
    recipient: !secret sendgrid_recipient
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```