### PR TITLE
Move consts to 'const.py'

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -22,13 +22,12 @@ from homeassistant.components.media_player import (
     SUPPORT_PLAY)
 from homeassistant.const import (
     STATE_IDLE, STATE_PAUSED, STATE_PLAYING, STATE_OFF, ATTR_ENTITY_ID,
-    CONF_HOSTS)
+    CONF_HOSTS, ATTR_TIME)
 from homeassistant.config import load_yaml_config_file
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.dt import utcnow
 
 REQUIREMENTS = ['SoCo==0.12']
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,7 +67,6 @@ ATTR_ALARM_ID = 'alarm_id'
 ATTR_VOLUME = 'volume'
 ATTR_ENABLED = 'enabled'
 ATTR_INCLUDE_LINKED_ZONES = 'include_linked_zones'
-ATTR_TIME = 'time'
 ATTR_MASTER = 'master'
 ATTR_WITH_GROUP = 'with_group'
 

--- a/homeassistant/components/sensor/imap_email_content.py
+++ b/homeassistant/components/sensor/imap_email_content.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_NAME, CONF_PORT, CONF_USERNAME, CONF_PASSWORD, CONF_VALUE_TEMPLATE,
-    CONTENT_TYPE_TEXT_PLAIN)
+    CONTENT_TYPE_TEXT_PLAIN, ATTR_DATE)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +25,6 @@ CONF_SENDERS = 'senders'
 
 ATTR_FROM = 'from'
 ATTR_BODY = 'body'
-ATTR_DATE = 'date'
 ATTR_SUBJECT = 'subject'
 
 DEFAULT_PORT = 993
@@ -59,7 +58,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
 
-class EmailReader:
+class EmailReader(object):
     """A class to read emails from an IMAP server."""
 
     def __init__(self, user, password, server, port):

--- a/homeassistant/components/sensor/waqi.py
+++ b/homeassistant/components/sensor/waqi.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.const import (
-    ATTR_ATTRIBUTION, ATTR_TEMPERATURE, STATE_UNKNOWN)
+    ATTR_ATTRIBUTION, ATTR_TIME, ATTR_TEMPERATURE, STATE_UNKNOWN)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
@@ -28,7 +28,6 @@ ATTR_PM10 = 'pm_10'
 ATTR_PM2_5 = 'pm_2_5'
 ATTR_PRESSURE = 'pressure'
 ATTR_SULFUR_DIOXIDE = 'sulfur_dioxide'
-ATTR_TIME = 'time'
 ATTRIBUTION = 'Data provided by the World Air Quality Index project'
 
 CONF_LOCATIONS = 'locations'

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -202,8 +202,10 @@ STATE_UNAVAILABLE = 'unavailable'
 # Attribution
 ATTR_ATTRIBUTION = 'attribution'
 
-# Contains current time for a TIME_CHANGED event
+# Contains time-related attributes
 ATTR_NOW = 'now'
+ATTR_DATE = 'date'
+ATTR_TIME = 'time'
 
 # Contains domain, service for a SERVICE_CALL event
 ATTR_DOMAIN = 'domain'


### PR DESCRIPTION
## Description:
Move `ATTR_TIME` and `ATTR_DATE` to `const.py`. And set the default interval to 2 minutes to avoid that the users run out of API calls.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: pvoutput
    system_id: YOUR_SYSTEM_ID
    api_key: YOUR_API_KEY
    scan_interval: 120
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
