### PR TITLE
Add component for xiaomi robot vacuum (switch.xiaomi_vacuum)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -493,6 +493,7 @@ omit =
     homeassistant/components/switch/tplink.py
     homeassistant/components/switch/transmission.py
     homeassistant/components/switch/wake_on_lan.py
+    homeassistant/components/switch/xiaomi_vacuum.py
     homeassistant/components/telegram_bot/*
     homeassistant/components/thingspeak.py
     homeassistant/components/tts/amazon_polly.py

--- a/homeassistant/components/switch/xiaomi_vacuum.py
+++ b/homeassistant/components/switch/xiaomi_vacuum.py
@@ -1,0 +1,123 @@
+"""
+Support for Xiaomi Vacuum cleaner robot.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/switch.xiaomi_vacuum/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.const import (DEVICE_DEFAULT_NAME,
+                                 CONF_NAME, CONF_HOST, CONF_TOKEN)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_TOKEN): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+
+})
+
+REQUIREMENTS = ['python-mirobo==0.0.7']
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Setup the vacuum from config."""
+    host = config.get(CONF_HOST)
+    name = config.get(CONF_NAME)
+    token = config.get(CONF_TOKEN)
+
+    add_devices_callback([MiroboSwitch(name, host, token)])
+
+
+class MiroboSwitch(SwitchDevice):
+    """Representation of a Xiaomi Vacuum."""
+
+    def __init__(self, name, host, token):
+        """Initialize the vacuum switch."""
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._icon = 'mdi:broom'
+        self.host = host
+        self.token = token
+
+        self._vacuum = None
+        self._state = None
+        self._state_attrs = {}
+        self._is_on = False
+        _LOGGER.info("hello I'm %s", self._name)
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon to use for device if any."""
+        return self._icon
+
+    @property
+    def available(self):
+        """Return true when state is known."""
+        return self._state is not None
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the device."""
+        return self._state_attrs
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._is_on
+
+    @property
+    def vacuum(self):
+        """Property accessor for vacuum object."""
+        if not self._vacuum:
+            from mirobo import Vacuum
+            _LOGGER.info("initializing with host %s token %s",
+                         self.host, self.token)
+            self._vacuum = Vacuum(self.host, self.token)
+
+        return self._vacuum
+
+    def turn_on(self, **kwargs):
+        """Turn the vacuum on."""
+        try:
+            self.vacuum.start()
+            self._is_on = True
+        except Exception as ex:
+            _LOGGER.error("Unable to start the vacuum: %s", ex)
+
+    def turn_off(self, **kwargs):
+        """Turn the vacuum off and return to home."""
+        try:
+            self.vacuum.stop()
+            self.vacuum.home()
+            self._is_on = False
+        except Exception as ex:
+            _LOGGER.error("Unable to turn off and return home: %s", ex)
+
+    def update(self):
+        """Fetch state from the device."""
+        try:
+            state = self.vacuum.status()
+            _LOGGER.debug("got state from the vacuum: %s", state)
+
+            self._state_attrs = {
+                'Status': state.state, 'Error': state.error,
+                'Battery': state.battery, 'Fan': state.fanspeed,
+                'Cleaning time': str(state.clean_time),
+                'Cleaned area': state.clean_area}
+
+            self._state = state.state_code
+            self._is_on = state.is_on
+        except Exception as ex:
+            _LOGGER.error("Got exception while fetching the state: %s", ex)

--- a/homeassistant/components/switch/xiaomi_vacuum.py
+++ b/homeassistant/components/switch/xiaomi_vacuum.py
@@ -22,7 +22,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-mirobo==0.0.7']
+REQUIREMENTS = ['python-mirobo==0.0.8']
 
 
 # pylint: disable=unused-argument
@@ -88,23 +88,26 @@ class MiroboSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the vacuum on."""
+        from mirobo import VacuumException
         try:
             self.vacuum.start()
             self._is_on = True
-        except Exception as ex:
+        except VacuumException as ex:
             _LOGGER.error("Unable to start the vacuum: %s", ex)
 
     def turn_off(self, **kwargs):
         """Turn the vacuum off and return to home."""
+        from mirobo import VacuumException
         try:
             self.vacuum.stop()
             self.vacuum.home()
             self._is_on = False
-        except Exception as ex:
+        except VacuumException as ex:
             _LOGGER.error("Unable to turn off and return home: %s", ex)
 
     def update(self):
         """Fetch state from the device."""
+        from mirobo import VacuumException
         try:
             state = self.vacuum.status()
             _LOGGER.debug("got state from the vacuum: %s", state)
@@ -117,5 +120,5 @@ class MiroboSwitch(SwitchDevice):
 
             self._state = state.state_code
             self._is_on = state.is_on
-        except Exception as ex:
+        except VacuumException as ex:
             _LOGGER.error("Got exception while fetching the state: %s", ex)

--- a/homeassistant/components/switch/xiaomi_vacuum.py
+++ b/homeassistant/components/switch/xiaomi_vacuum.py
@@ -18,9 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_TOKEN): cv.string,
+    vol.Required(CONF_TOKEN): vol.All(str, vol.Length(min=32, max=32)),
     vol.Optional(CONF_NAME): cv.string,
-
 })
 
 REQUIREMENTS = ['python-mirobo==0.0.7']
@@ -28,7 +27,7 @@ REQUIREMENTS = ['python-mirobo==0.0.7']
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
-    """Setup the vacuum from config."""
+    """Set up the vacuum from config."""
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
     token = config.get(CONF_TOKEN)
@@ -50,7 +49,6 @@ class MiroboSwitch(SwitchDevice):
         self._state = None
         self._state_attrs = {}
         self._is_on = False
-        _LOGGER.info("hello I'm %s", self._name)
 
     @property
     def name(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -680,7 +680,7 @@ python-join-api==0.0.2
 # python-lirc==1.2.3
 
 # homeassistant.components.switch.xiaomi_vacuum
-python-mirobo==0.0.7
+python-mirobo==0.0.8
 
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -679,6 +679,9 @@ python-join-api==0.0.2
 # homeassistant.components.lirc
 # python-lirc==1.2.3
 
+# homeassistant.components.switch.xiaomi_vacuum
+python-mirobo==0.0.7
+
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5
 


### PR DESCRIPTION
## Description:
Adds support for [Xiaomi MiJia vacuum cleaner](https://xiaomi-mi.com/appliances/xiaomi-mijia-robot-vacuum-cleaner-white/), uses [python-mirobo](https://github.com/rytilahti/python-mirobo) for device communication. Only basic functionality (starting, stopping & returning to the base, and informing about its state through state attributes) is currently implemented.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2771

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: xiaomi_vacuum
    host: 192.168.123.123
    name: 'My vacuum'
    token: '123abc70343055483230644c53707aaa'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
