### PR TITLE
Add citybikes platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -376,7 +376,7 @@ omit =
     homeassistant/components/sensor/bom.py
     homeassistant/components/sensor/broadlink.py
     homeassistant/components/sensor/buienradar.py
-    homeassistant/components/sensor/dublin_bus_transport.py
+    homeassistant/components/sensor/citybikes.py
     homeassistant/components/sensor/coinmarketcap.py
     homeassistant/components/sensor/cert_expiry.py
     homeassistant/components/sensor/comed_hourly_pricing.py
@@ -390,6 +390,7 @@ omit =
     homeassistant/components/sensor/dnsip.py
     homeassistant/components/sensor/dovado.py
     homeassistant/components/sensor/dte_energy_bridge.py
+    homeassistant/components/sensor/dublin_bus_transport.py
     homeassistant/components/sensor/ebox.py
     homeassistant/components/sensor/eddystone_temperature.py
     homeassistant/components/sensor/eliqonline.py

--- a/homeassistant/components/sensor/citybikes.py
+++ b/homeassistant/components/sensor/citybikes.py
@@ -15,8 +15,7 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_FRIENDLY_NAME,
     LENGTH_METERS, LENGTH_FEET)
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import (
-    Throttle, location, distance)
+from homeassistant.util import Throttle, location, distance
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['python-citybikes==0.1.3']

--- a/homeassistant/components/sensor/citybikes.py
+++ b/homeassistant/components/sensor/citybikes.py
@@ -23,7 +23,7 @@ REQUIREMENTS = ['python-citybikes==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(seconds=12)  # Arbitrary
+SCAN_INTERVAL = timedelta(minutes=5)  # Timely, and doesn't suffocate the API
 DOMAIN = 'citybikes'
 CONF_NETWORK = 'network'
 CONF_RADIUS = 'radius'

--- a/homeassistant/components/sensor/citybikes.py
+++ b/homeassistant/components/sensor/citybikes.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     LENGTH_METERS, LENGTH_FEET)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import (
-    Throttle, slugify, location, distance)
+    Throttle, location, distance)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['python-citybikes==0.1.3']
@@ -29,7 +29,7 @@ CONF_NETWORK = 'network'
 CONF_RADIUS = 'radius'
 CONF_STATIONS_LIST = 'stations'
 ATTR_STATION_ID = 'id'
-ATTR_STATION_UID = 'id'
+ATTR_STATION_UID = 'uid'
 ATTR_STATION_NAME = 'name'
 ATTR_EXTRA = 'extra'
 ATTR_EMPTY_SLOTS = 'empty_slots'
@@ -97,7 +97,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     poller = CityBikesNetworkPoller(network)
 
     add_devices(CityBikesStationSensor(poller, station,
-                                       config.get(CONF_NAME, DOMAIN))
+                                       config.get(CONF_NAME, network['id']))
                 for station in _filter_stations(network, radius, latitude,
                                                 longitude, stations_list))
 
@@ -134,8 +134,8 @@ class CityBikesStationSensor(Entity):
 
     def _update(self, station):
         self._id = station[ATTR_STATION_ID]
-        self._uid = station[ATTR_EXTRA]['uid'] if ATTR_EXTRA in station \
-            and 'uid' in station[ATTR_EXTRA] \
+        self._uid = station[ATTR_EXTRA][ATTR_STATION_UID] if \
+            ATTR_EXTRA in station and ATTR_STATION_UID in station[ATTR_EXTRA] \
             else None
         self._latitude = station[ATTR_LATITUDE]
         self._longitude = station[ATTR_LONGITUDE]
@@ -143,8 +143,8 @@ class CityBikesStationSensor(Entity):
         self._free_bikes = station[ATTR_FREE_BIKES]
         self._timestamp = station[ATTR_TIMESTAMP]
         self._friendly_name = station[ATTR_STATION_NAME]
-        self._name = slugify("{}_{}".format(self._base_name,
-                                            station[ATTR_STATION_NAME]))
+        self._name = "{} {}".format(self._base_name,
+                                    station[ATTR_STATION_NAME])
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/citybikes.py
+++ b/homeassistant/components/sensor/citybikes.py
@@ -60,7 +60,7 @@ PLATFORM_SCHEMA = vol.All(
 MONITORED_NETWORKS = {}
 
 
-def _filter_stations(network, radius, latitude, longitude, stations_list):
+def _filter_stations(network, radius, latitude, longitude, stations):
     if radius > 0:
         for station, dist in network.stations.near(latitude, longitude):
             # 'dist' is in weird units, let's calculate again
@@ -72,12 +72,12 @@ def _filter_stations(network, radius, latitude, longitude, stations_list):
             yield station
     else:
         for station in network.stations:
-            if station['id'] in stations_list:
+            if station[ATTR_STATION_ID] in stations:
                 yield station
                 continue
-            if 'extra' in station:
-                if 'uid' in station['extra']:
-                    if str(station['extra']['uid']) in stations_list:
+            if ATTR_EXTRA in station:
+                if ATTR_STATION_UID in station[ATTR_EXTRA]:
+                    if str(station[ATTR_EXTRA][ATTR_STATION_UID]) in stations:
                         yield station
 
 

--- a/homeassistant/components/sensor/citybikes.py
+++ b/homeassistant/components/sensor/citybikes.py
@@ -1,0 +1,171 @@
+"""
+Sensor for the CityBikes data.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.citybikes/
+"""
+import logging
+### from datetime import timedelta
+
+### import requests
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE,
+    ATTR_ATTRIBUTION, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_FRIENDLY_NAME)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+from homeassistant.util import slugify
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['python-citybikes==0.1.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=12)  # opensky public limit is 10 seconds
+DOMAIN = 'citybikes'
+CONF_NETWORK = 'network'
+CONF_RADIUS = 'radius'
+CONF_STATIONS_LIST = 'stations'
+ATTR_STATION_ID = 'id'
+ATTR_STATION_NAME = 'name'
+ATTR_EXTRA = 'extra'
+ATTR_EMPTY_SLOTS = 'empty_slots'
+ATTR_FREE_BIKES = 'free_bikes'
+ATTR_TIMESTAMP = 'timestamp'
+CITYBIKES_ATTRIBUTION = "Information provided by the CityBikes Project "\
+                        "(https://citybik.es/#about)"
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_NETWORK): cv.string,
+    vol.Inclusive(CONF_LATITUDE, 'coordinates'): cv.latitude,
+    vol.Inclusive(CONF_LONGITUDE, 'coordinates'): cv.longitude,
+    vol.Exclusive(CONF_RADIUS, 'station_filter'): cv.positive_int,
+    vol.Exclusive(CONF_STATIONS_LIST, 'station_filter'):
+        vol.All(cv.ensure_list, [cv.string])
+})
+
+
+def _filter_stations(network, radius, latitude, longitude, stations_list):
+        if radius > 0:
+            for station, distance in network.stations.near(latitude, longitude):
+                if distance * 1000 > radius:
+                    break
+                yield station
+        else:
+            for station in network.stations:
+                if station['id'] in stations_list:
+                    yield station
+                    continue
+                if 'extra' in station
+                    and 'uid' in station['extra']
+                    and str(station['extra']['uid']) in stations_list:
+                        yield station
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the CityBikes platform."""
+    from citybikes import Client, Network
+
+    latitude = config.get(CONF_LATITUDE, hass.config.latitude)
+    longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
+    
+    network_uid = config.get(CONF_NETWORK)
+    if not network_uid:
+        network = Client().networks.near(latitude, longitude)[0][0]
+    else:
+        network = Network(Client(), uid=network_uid)
+
+    stations_list = config.get(CONF_STATIONS_LIST, [])
+    radius = config.get(CONF_RADIUS, 0)
+    poller = CityBikesNetworkPoller(network)
+
+    add_devices(CityBikesStationSensor(poller, station,
+                    config.get(CONF_NAME, DOMAIN))
+                    for station in _filter_stations(
+                        network, radius, latitude, longitude, stations_list))
+
+
+class CityBikesNetworkPoller(object):
+    """A wrapper around a CityBikes Network object."""
+
+    def __init__(self, network):
+        """Initialize the poller."""
+        self._network = network
+
+    def get(self, station_id, update=True):
+        """Return the station with the given id."""
+        if update:
+            self.update()
+        for station in self._network.stations:
+            if station[ATTR_STATION_ID] == station_id:
+                return station
+
+    @Throttle
+    def _update(self):
+        """Update the state of the network."""
+        self._network.request()
+
+class CityBikesStationSensor(Entity):
+    """CityBikes API Sensor."""
+
+    def __init__(self, poller, station, base_name):
+        """Initialize the sensor."""
+        self._poller = poller
+        self._base_name = base_name
+        self._update(station)
+
+    def _update(self, station):
+        self._id = station[ATTR_STATION_ID]
+        self._uid = station[ATTR_EXTRA]['uid'] if ATTR_EXTRA in station
+                                            and 'uid' in station[ATTR_EXTRA]
+                                            else None
+        self._latitude = station[ATTR_LATITUDE]
+        self._longitude = station[ATTR_LONGITUDE]
+        self._empty_slots = station[ATTR_EMPTY_SLOTS]
+        self._free_bikes = station[ATTR_FREE_BIKES]
+        self._timestamp = station[ATTR_TIMESTAMP]
+        self._friendly_name = station[ATTR_STATION_NAME]
+        self._name = slugify(self._base_name + station[ATTR_STATION_NAME])
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._free_bikes
+
+    def update(self):
+        """Update device state."""
+        self._update(self._poller.get(self._id))
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_ATTRIBUTION: CITYBIKES_ATTRIBUTION,
+            ATTR_STATION_ID: self._id,
+            ATTR_LATITUDE: self._latitude,
+            ATTR_LONGITUDE: self._longitude,
+            ATTR_EMPTY_SLOTS: self._empty_slots,
+            ATTR_FREE_BIKES: self._free_bikes,
+            ATTR_TIMESTAMP: self._timestamp,
+            ATTR_FRIENDLY_NAME: self._friendly_name,
+        }
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return 'bikes'
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return 'mdi:bike'

--- a/homeassistant/components/sensor/citybikes.py
+++ b/homeassistant/components/sensor/citybikes.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/sensor.citybikes/
 import logging
 from datetime import timedelta
 
-### import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -48,7 +47,10 @@ PLATFORM_SCHEMA = vol.All(
         vol.Inclusive(CONF_LONGITUDE, 'coordinates'): cv.longitude,
         vol.Exclusive(CONF_RADIUS, 'station_filter'): cv.positive_int,
         vol.Exclusive(CONF_STATIONS_LIST, 'station_filter'):
-            vol.All(cv.ensure_list, [cv.string]) # TODO: Make sure list is not empty
+            vol.All(
+                cv.ensure_list,
+                vol.Length(min=1),
+                [cv.string]) # TODO: Make sure list is not empty
     }))
 
 

--- a/homeassistant/components/sensor/citybikes.py
+++ b/homeassistant/components/sensor/citybikes.py
@@ -56,24 +56,24 @@ PLATFORM_SCHEMA = vol.All(
 
 
 def _filter_stations(network, radius, latitude, longitude, stations_list):
-        if radius > 0:
-            for station, dist in network.stations.near(latitude, longitude):
-                # 'dist' is in weird units, let's calculate again
-                dist = location.distance(latitude, longitude,
-                                         station[ATTR_LATITUDE],
-                                         station[ATTR_LONGITUDE])
-                if dist > radius:
-                    break
+    if radius > 0:
+        for station, dist in network.stations.near(latitude, longitude):
+            # 'dist' is in weird units, let's calculate again
+            dist = location.distance(latitude, longitude,
+                                     station[ATTR_LATITUDE],
+                                     station[ATTR_LONGITUDE])
+            if dist > radius:
+                break
+            yield station
+    else:
+        for station in network.stations:
+            if station['id'] in stations_list:
                 yield station
-        else:
-            for station in network.stations:
-                if station['id'] in stations_list:
-                    yield station
-                    continue
-                if 'extra' in station:
-                    if 'uid' in station['extra']:
-                        if str(station['extra']['uid']) in stations_list:
-                            yield station
+                continue
+            if 'extra' in station:
+                if 'uid' in station['extra']:
+                    if str(station['extra']['uid']) in stations_list:
+                        yield station
 
 
 # pylint: disable=unused-argument
@@ -97,9 +97,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     poller = CityBikesNetworkPoller(network)
 
     add_devices(CityBikesStationSensor(poller, station,
-                config.get(CONF_NAME, DOMAIN))
-                for station in _filter_stations(
-                    network, radius, latitude, longitude, stations_list))
+                                       config.get(CONF_NAME, DOMAIN))
+                for station in _filter_stations(network, radius, latitude,
+                                                longitude, stations_list))
 
 
 class CityBikesNetworkPoller(object):
@@ -144,7 +144,7 @@ class CityBikesStationSensor(Entity):
         self._timestamp = station[ATTR_TIMESTAMP]
         self._friendly_name = station[ATTR_STATION_NAME]
         self._name = slugify("{}_{}".format(self._base_name,
-                             station[ATTR_STATION_NAME]))
+                                            station[ATTR_STATION_NAME]))
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/citybikes.py
+++ b/homeassistant/components/sensor/citybikes.py
@@ -18,7 +18,9 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle, location, distance
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-citybikes==0.1.3']
+REQUIREMENTS = ['https://github.com/aronsky/python-citybikes'
+                '/archive/2b9af9c424b169bcfcabe4a3c1ef54ff7841f00b.zip'
+                '#python-citybikes==0.1.3-async']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,9 +87,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     network_uid = config.get(CONF_NETWORK)
     if not network_uid:
-        network = Client().networks.near(latitude, longitude)[0][0]
+        network = Client(loop=hass.loop).networks.near(latitude, longitude)[0][0]
     else:
-        network = Network(Client(), uid=network_uid)
+        network = Network(Client(loop=hass.loop), uid=network_uid)
 
     stations_list = config.get(CONF_STATIONS_LIST, [])
     radius = config.get(CONF_RADIUS, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -651,6 +651,9 @@ pythinkingcleaner==0.0.3
 # homeassistant.components.sensor.blockchain
 python-blockchain-api==0.0.2
 
+# homeassistant.components.sensor.citybikes
+python-citybikes==0.1.3
+
 # homeassistant.components.media_player.clementine
 python-clementine-remote==1.0.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -651,9 +651,6 @@ pythinkingcleaner==0.0.3
 # homeassistant.components.sensor.blockchain
 python-blockchain-api==0.0.2
 
-# homeassistant.components.sensor.citybikes
-python-citybikes==0.1.3
-
 # homeassistant.components.media_player.clementine
 python-clementine-remote==1.0.1
 


### PR DESCRIPTION
## Description:

[CityBikes](https://citybik.es/#about) is an open API platform, that provides data about bike sharing systems around the world. It allows real-time monitoring of bike availability at bike sharing stations.

This platform connects the CityBikes API to home assistant, opening up the possibilities for advanced automations, such as recommending the user a bike sharing station based on the amount of bikes available, upon leaving the house.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2770

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: citybikes
    radius: 500
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.