### PR TITLE
update to pywebpush 1.0.4

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -25,7 +25,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.frontend import add_manifest_json_key
 from homeassistant.helpers import config_validation as cv
 
-REQUIREMENTS = ['pywebpush==1.0.0', 'PyJWT==1.4.2']
+REQUIREMENTS = ['pywebpush==1.0.4', 'PyJWT==1.5.0']
 
 DEPENDENCIES = ['frontend']
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -21,7 +21,7 @@ astral==1.4
 PyISY==1.0.7
 
 # homeassistant.components.notify.html5
-PyJWT==1.4.2
+PyJWT==1.5.0
 
 # homeassistant.components.sensor.mvglive
 PyMVGLive==1.1.4
@@ -729,7 +729,7 @@ pyunifi==2.12
 pyvera==0.2.31
 
 # homeassistant.components.notify.html5
-pywebpush==1.0.0
+pywebpush==1.0.4
 
 # homeassistant.components.wemo
 pywemo==0.4.19

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -21,7 +21,7 @@ freezegun>=0.3.8
 
 
 # homeassistant.components.notify.html5
-PyJWT==1.4.2
+PyJWT==1.5.0
 
 # homeassistant.components.media_player.sonos
 SoCo==0.12
@@ -98,7 +98,7 @@ pynx584==0.4
 python-forecastio==1.3.5
 
 # homeassistant.components.notify.html5
-pywebpush==1.0.0
+pywebpush==1.0.4
 
 # homeassistant.components.rflink
 rflink==0.0.34


### PR DESCRIPTION
update pywebpush to allow updated cryptography dependency which allows install on system with openssl-1.1.0 (cryptography dep)

## Checklist:

If user exposed functionality or configuration variables are added/changed:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
