### PR TITLE
Add service_url config option to volvooncall

### DIFF
--- a/homeassistant/components/volvooncall.py
+++ b/homeassistant/components/volvooncall.py
@@ -27,7 +27,6 @@ CONF_UPDATE_INTERVAL = 'update_interval'
 MIN_UPDATE_INTERVAL = timedelta(minutes=1)
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=1)
 CONF_SERVICE_URL = 'service_url'
-DEFAULT_SERVICE_URL = 'https://vocapi.wirelesscar.net/customerapi/rest/v3.0/'
 
 RESOURCES = {'position': ('device_tracker',),
              'lock': ('lock', 'Lock'),
@@ -53,18 +52,19 @@ CONFIG_SCHEMA = vol.Schema({
             {cv.slug: cv.string}),
         vol.Optional(CONF_RESOURCES): vol.All(
             cv.ensure_list, [vol.In(RESOURCES)]),
-        vol.Optional(CONF_SERVICE_URL, default=DEFAULT_SERVICE_URL): cv.string,
+        vol.Optional(CONF_SERVICE_URL): cv.string,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Set up the Volvo On Call component."""
+    from volvooncall import DEFAULT_SERVICE_URL
     from volvooncall import Connection
     connection = Connection(
         config[DOMAIN].get(CONF_USERNAME),
         config[DOMAIN].get(CONF_PASSWORD),
-        config[DOMAIN].get(CONF_SERVICE_URL))
+        config[DOMAIN].get(CONF_SERVICE_URL, DEFAULT_SERVICE_URL))
 
     interval = config[DOMAIN].get(CONF_UPDATE_INTERVAL)
 

--- a/homeassistant/components/volvooncall.py
+++ b/homeassistant/components/volvooncall.py
@@ -26,6 +26,8 @@ _LOGGER = logging.getLogger(__name__)
 CONF_UPDATE_INTERVAL = 'update_interval'
 MIN_UPDATE_INTERVAL = timedelta(minutes=1)
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=1)
+CONF_SERVICE_URL = 'service_url'
+DEFAULT_SERVICE_URL = 'https://vocapi.wirelesscar.net/customerapi/rest/v3.0/'
 
 RESOURCES = {'position': ('device_tracker',),
              'lock': ('lock', 'Lock'),
@@ -51,6 +53,7 @@ CONFIG_SCHEMA = vol.Schema({
             {cv.slug: cv.string}),
         vol.Optional(CONF_RESOURCES): vol.All(
             cv.ensure_list, [vol.In(RESOURCES)]),
+        vol.Optional(CONF_SERVICE_URL, default=DEFAULT_SERVICE_URL): cv.string,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -60,7 +63,8 @@ def setup(hass, config):
     from volvooncall import Connection
     connection = Connection(
         config[DOMAIN].get(CONF_USERNAME),
-        config[DOMAIN].get(CONF_PASSWORD))
+        config[DOMAIN].get(CONF_PASSWORD),
+        config[DOMAIN].get(CONF_SERVICE_URL))
 
     interval = config[DOMAIN].get(CONF_UPDATE_INTERVAL)
 


### PR DESCRIPTION
## Description:
The volvooncall component lacks the ability to specify a service URL. For users in North America, the default URL needs to be replaced with `https://vocapi-na.wirelesscar.net/customerapi/rest/v3.0/`

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2774

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry for NA
volvooncall:
  username: username
  password: password
  service_url: 'https://vocapi-na.wirelesscar.net/customerapi/rest/v3.0/'
```

## Checklist:

  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
