### PR TITLE
Fixed openhome metadata issue

### DIFF
--- a/homeassistant/components/media_player/openhome.py
+++ b/homeassistant/components/media_player/openhome.py
@@ -14,7 +14,7 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (
     STATE_IDLE, STATE_PAUSED, STATE_PLAYING, STATE_OFF)
 
-REQUIREMENTS = ['openhomedevice==0.4.0']
+REQUIREMENTS = ['openhomedevice==0.4.2']
 
 SUPPORT_OPENHOME = SUPPORT_SELECT_SOURCE | \
     SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET | \
@@ -60,7 +60,6 @@ class OpenhomeDevice(MediaPlayerDevice):
         self._track_information = {}
         self._in_standby = None
         self._transport_state = None
-        self._track_information = None
         self._volume_level = None
         self._volume_muted = None
         self._supported_features = SUPPORT_OPENHOME
@@ -173,27 +172,29 @@ class OpenhomeDevice(MediaPlayerDevice):
     @property
     def media_image_url(self):
         """Image url of current playing media."""
-        return self._track_information["albumArtwork"]
+        return self._track_information.get('albumArtwork')
 
     @property
     def media_artist(self):
         """Artist of current playing media, music track only."""
-        return self._track_information["artist"][0]
+        artists = self._track_information.get('artist')
+        if artists:
+            return artists[0]
 
     @property
     def media_album_name(self):
         """Album name of current playing media, music track only."""
-        return self._track_information["albumTitle"]
+        return self._track_information.get('albumTitle')
 
     @property
     def media_title(self):
         """Title of current playing media."""
-        return self._track_information["title"]
+        return self._track_information.get('title')
 
     @property
     def source(self):
         """Name of the current input source."""
-        return self._source["name"]
+        return self._source.get('name')
 
     @property
     def volume_level(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -406,7 +406,7 @@ onkyo-eiscp==1.1
 openevsewifi==0.4
 
 # homeassistant.components.media_player.openhome
-openhomedevice==0.4.0
+openhomedevice==0.4.2
 
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1


### PR DESCRIPTION
## Description:

A change in the openhomedevice library now means some metadata might not be present when requesting track information. I forgot to defend against this and as a result when the metadata is not present an key exception is thrown. 

This also stops devices from being registered on discovery due to the call of 'update' when adding. 

**Related issue (if applicable):** fixes #7926 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.