### PR TITLE
Fix the negative values bug in history_stats

### DIFF
--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -179,7 +179,7 @@ class HistoryStatsSensor(Entity):
         end = dt_util.as_utc(end)
         p_start = dt_util.as_utc(p_start)
         p_end = dt_util.as_utc(p_end)
-        now = dt_util.as_utc(datetime.datetime.now())
+        now = datetime.datetime.now()
 
         # Compute integer timestamps
         start_timestamp = math.floor(dt_util.as_timestamp(start))


### PR DESCRIPTION
## Description:
The `history_stats` component was sometimes showing wrong values, sometimes negative :grimacing:.
This is the bug fix.

This is **not** a minor bug. I would suggest to release the fix in the **next minor version**, not in the 0.47
 
------

**Related issue (if applicable):** fixes #7924

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. They were successful before because there is no test using different time zones, and the bug is related.