### PR TITLE
Send media_stop() on turn_off()

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -524,7 +524,7 @@ class SonosDevice(MediaPlayerDevice):
             support_previous_track = False
             support_next_track = False
             support_play = False
-            support_stop = False
+            support_stop = True
             support_pause = False
 
             if is_playing_tv:
@@ -925,8 +925,8 @@ class SonosDevice(MediaPlayerDevice):
     @soco_error
     def turn_off(self):
         """Turn off media player."""
-        if self._support_pause:
-            self.media_pause()
+        if self._support_stop:
+            self.media_stop()
 
     @soco_error
     @soco_filter_upnperror(UPNP_ERRORS_TO_IGNORE)


### PR DESCRIPTION
## Description:
Instead of pausing playback upon sending 'turn_off()', now stop playback. This will prevent live streams from continuing playback when a turn_off command is sent to the speaker.

**Related issue (if applicable):** fixes #7925

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54