### PR TITLE
Provide entity_id to avoid sensor mixup (fixes #7636). Use async_dispatcher. Provide icon.

### DIFF
--- a/homeassistant/components/device_tracker/volvooncall.py
+++ b/homeassistant/components/device_tracker/volvooncall.py
@@ -7,7 +7,10 @@ https://home-assistant.io/components/device_tracker.volvooncall/
 import logging
 
 from homeassistant.util import slugify
-from homeassistant.components.volvooncall import DOMAIN
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect, async_dispatcher_send)
+from homeassistant.components.volvooncall import (
+    DATA_KEY, SIGNAL_VEHICLE_SEEN)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,19 +21,19 @@ def setup_scanner(hass, config, see, discovery_info=None):
         return
 
     vin, _ = discovery_info
-    vehicle = hass.data[DOMAIN].vehicles[vin]
-
-    host_name = vehicle.registration_number
-    dev_id = 'volvo_' + slugify(host_name)
+    vehicle = hass.data[DATA_KEY].vehicles[vin]
 
     def see_vehicle(vehicle):
         """Handle the reporting of the vehicle position."""
+        host_name = vehicle.registration_number
+        dev_id = 'volvo_{}'.format(slugify(host_name))
         see(dev_id=dev_id,
             host_name=host_name,
             gps=(vehicle.position['latitude'],
-                 vehicle.position['longitude']))
+                 vehicle.position['longitude']),
+            icon='mdi:car')
 
-    hass.data[DOMAIN].entities[vin].append(see_vehicle)
-    see_vehicle(vehicle)
+    async_dispatcher_connect(hass, SIGNAL_VEHICLE_SEEN, see_vehicle)
+    async_dispatcher_send(hass, SIGNAL_VEHICLE_SEEN, vehicle)
 
     return True

--- a/homeassistant/components/device_tracker/volvooncall.py
+++ b/homeassistant/components/device_tracker/volvooncall.py
@@ -8,7 +8,7 @@ import logging
 
 from homeassistant.util import slugify
 from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect, async_dispatcher_send)
+    dispatcher_connect, dispatcher_send)
 from homeassistant.components.volvooncall import (
     DATA_KEY, SIGNAL_VEHICLE_SEEN)
 
@@ -33,7 +33,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
                  vehicle.position['longitude']),
             icon='mdi:car')
 
-    async_dispatcher_connect(hass, SIGNAL_VEHICLE_SEEN, see_vehicle)
-    async_dispatcher_send(hass, SIGNAL_VEHICLE_SEEN, vehicle)
+    dispatcher_connect(hass, SIGNAL_VEHICLE_SEEN, see_vehicle)
+    dispatcher_send(hass, SIGNAL_VEHICLE_SEEN, vehicle)
 
     return True

--- a/homeassistant/components/volvooncall.py
+++ b/homeassistant/components/volvooncall.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_point_in_utc_time
-from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.util.dt import utcnow
 import voluptuous as vol
 
@@ -100,7 +100,7 @@ def setup(hass, config):
         for entity in state.entities[vehicle.vin]:
             entity.schedule_update_ha_state()
 
-        async_dispatcher_send(hass, SIGNAL_VEHICLE_SEEN, vehicle)
+        dispatcher_send(hass, SIGNAL_VEHICLE_SEEN, vehicle)
 
     def update(now):
         """Update status from the online service."""

--- a/homeassistant/components/volvooncall.py
+++ b/homeassistant/components/volvooncall.py
@@ -14,10 +14,13 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_point_in_utc_time
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util.dt import utcnow
 import voluptuous as vol
 
 DOMAIN = 'volvooncall'
+
+DATA_KEY = DOMAIN
 
 REQUIREMENTS = ['volvooncall==0.3.3']
 
@@ -28,12 +31,15 @@ MIN_UPDATE_INTERVAL = timedelta(minutes=1)
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=1)
 CONF_SERVICE_URL = 'service_url'
 
+SIGNAL_VEHICLE_SEEN = '{}.vehicle_seen'.format(DOMAIN)
+
 RESOURCES = {'position': ('device_tracker',),
              'lock': ('lock', 'Lock'),
              'heater': ('switch', 'Heater', 'mdi:radiator'),
              'odometer': ('sensor', 'Odometer', 'mdi:speedometer', 'km'),
-             'fuel_amount': ('sensor', 'Fuel', 'mdi:gas-station', 'L'),
-             'fuel_amount_level': ('sensor', 'Fuel', 'mdi:water-percent', '%'),
+             'fuel_amount': ('sensor', 'Fuel amount', 'mdi:gas-station', 'L'),
+             'fuel_amount_level': (
+                 'sensor', 'Fuel level', 'mdi:water-percent', '%'),
              'distance_to_empty': ('sensor', 'Range', 'mdi:ruler', 'km'),
              'washer_fluid_level': ('binary_sensor', 'Washer fluid'),
              'brake_fluid': ('binary_sensor', 'Brake Fluid'),
@@ -59,8 +65,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 def setup(hass, config):
     """Set up the Volvo On Call component."""
-    from volvooncall import DEFAULT_SERVICE_URL
-    from volvooncall import Connection
+    from volvooncall import Connection, DEFAULT_SERVICE_URL
     connection = Connection(
         config[DOMAIN].get(CONF_USERNAME),
         config[DOMAIN].get(CONF_PASSWORD),
@@ -75,7 +80,7 @@ def setup(hass, config):
         vehicles = {}
         names = config[DOMAIN].get(CONF_NAME)
 
-    hass.data[DOMAIN] = state
+    hass.data[DATA_KEY] = state
 
     def discover_vehicle(vehicle):
         """Load relevant platforms."""
@@ -93,10 +98,9 @@ def setup(hass, config):
             discover_vehicle(vehicle)
 
         for entity in state.entities[vehicle.vin]:
-            if isinstance(entity, Entity):
-                entity.schedule_update_ha_state()
-            else:
-                entity(vehicle)  # device tracker
+            entity.schedule_update_ha_state()
+
+        async_dispatcher_send(hass, SIGNAL_VEHICLE_SEEN, vehicle)
 
     def update(now):
         """Update status from the online service."""
@@ -128,7 +132,7 @@ class VolvoEntity(Entity):
 
     @property
     def _state(self):
-        return self._hass.data[DOMAIN]
+        return self._hass.data[DATA_KEY]
 
     @property
     def vehicle(self):
@@ -149,7 +153,7 @@ class VolvoEntity(Entity):
     @property
     def name(self):
         """Return full name of the entity."""
-        return '%s %s' % (
+        return '{} {}'.format(
             self._vehicle_name,
             self._entity_name)
 
@@ -166,6 +170,6 @@ class VolvoEntity(Entity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        return dict(model='%s/%s' % (
+        return dict(model='{}/{}'.format(
             self.vehicle.vehicle_type,
             self.vehicle.model_year))


### PR DESCRIPTION
## Description:
1. Do not mix up fuel sensor (litres) with fuel sensor (percent). Resolves https://github.com/home-assistant/home-assistant/issues/7636
2. Use async dispatcher instead of storing function callback
3. Provide default icon (mdi:car)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://github.com/home-assistant/home-assistant/issues/7636

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
