### PR TITLE
influxdb: test connection without needing admin rights

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -96,7 +96,7 @@ def setup(hass, config):
 
     try:
         influx = InfluxDBClient(**kwargs)
-        influx.query("SHOW DIAGNOSTICS;", database=conf[CONF_DB_NAME])
+        influx.query("SHOW SERIES LIMIT 1;", database=conf[CONF_DB_NAME])
     except exceptions.InfluxDBClientError as exc:
         _LOGGER.error("Database host is not accessible due to '%s', please "
                       "check your entries in the configuration file and that "


### PR DESCRIPTION
## Description:
SHOW DIAGNOSTICS always needs admin privileges on influxdb. For
the purposes of home-assistant this is too much.
Use 'SHOW SERIES' to have a relatively lightweight query which
only needs READ privileges.

**Related issue (if applicable):** fixes #7844

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2787

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
