### PR TITLE
HomeMatic: Updated dependency

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['pyhomematic==0.1.27']
+REQUIREMENTS = ['pyhomematic==0.1.28']
 
 DOMAIN = 'homematic'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -551,7 +551,7 @@ pyharmony==1.0.16
 pyhik==0.1.2
 
 # homeassistant.components.homematic
-pyhomematic==0.1.27
+pyhomematic==0.1.28
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==1.1.0


### PR DESCRIPTION
## Description:
Updating pyhomematic, fixes HmIP-BDT device.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
