### PR TITLE
Add option to display all input sources / Add support for favourite channels / Treat Marantz SR5008 as Denon AVR-X device

### DIFF
--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -39,7 +39,8 @@ SUPPORT_MEDIA_MODES = SUPPORT_PLAY_MEDIA | \
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_SHOW_ALL_SOURCES, default=DEFAULT_SHOW_SOURCES): cv.boolean,
+    vol.Optional(CONF_SHOW_ALL_SOURCES, default=DEFAULT_SHOW_SOURCES):
+        cv.boolean,
 })
 
 

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -24,6 +24,7 @@ REQUIREMENTS = ['denonavr==0.4.3']
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = None
+DEFAULT_SHOW_SOURCES = False
 CONF_SHOW_ALL_SOURCES = 'show_all_sources'
 KEY_DENON_CACHE = 'denonavr_hosts'
 
@@ -38,7 +39,7 @@ SUPPORT_MEDIA_MODES = SUPPORT_PLAY_MEDIA | \
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_SHOW_ALL_SOURCES, default=False): cv.boolean,
+    vol.Optional(CONF_SHOW_ALL_SOURCES, default=DEFAULT_SHOW_SOURCES): cv.boolean,
 })
 
 

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -19,11 +19,12 @@ from homeassistant.const import (
     CONF_NAME, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['denonavr==0.4.2']
+REQUIREMENTS = ['denonavr==0.4.3']
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = None
+CONF_SHOW_ALL_SOURCES = 'show_all_sources'
 KEY_DENON_CACHE = 'denonavr_hosts'
 
 SUPPORT_DENON = SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | \
@@ -37,6 +38,7 @@ SUPPORT_MEDIA_MODES = SUPPORT_PLAY_MEDIA | \
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SHOW_ALL_SOURCES, default=False): cv.boolean,
 })
 
 
@@ -56,11 +58,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if config.get(CONF_HOST) is not None:
         host = config.get(CONF_HOST)
         name = config.get(CONF_NAME)
+        show_all_sources = config.get(CONF_SHOW_ALL_SOURCES)
         # Check if host not in cache, append it and save for later starting
         if host not in cache:
             cache.add(host)
             receivers.append(
-                DenonDevice(denonavr.DenonAVR(host, name)))
+                DenonDevice(denonavr.DenonAVR(host, name, show_all_sources)))
             _LOGGER.info("Denon receiver at host %s initialized", host)
     # 2. option: discovery using netdisco
     if discovery_info is not None:

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -54,11 +54,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         cache = hass.data[KEY_DENON_CACHE] = set()
 
     # Start assignment of host and name
+    show_all_sources = config.get(CONF_SHOW_ALL_SOURCES)
     # 1. option: manual setting
     if config.get(CONF_HOST) is not None:
         host = config.get(CONF_HOST)
         name = config.get(CONF_NAME)
-        show_all_sources = config.get(CONF_SHOW_ALL_SOURCES)
         # Check if host not in cache, append it and save for later starting
         if host not in cache:
             cache.add(host)
@@ -73,7 +73,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if host not in cache:
             cache.add(host)
             receivers.append(
-                DenonDevice(denonavr.DenonAVR(host, name)))
+                DenonDevice(denonavr.DenonAVR(host, name, show_all_sources)))
             _LOGGER.info("Denon receiver at host %s initialized", host)
     # 3. option: discovery using denonavr library
     if config.get(CONF_HOST) is None and discovery_info is None:
@@ -88,7 +88,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 if host not in cache:
                     cache.add(host)
                     receivers.append(
-                        DenonDevice(denonavr.DenonAVR(host, name)))
+                        DenonDevice(
+                            denonavr.DenonAVR(host, name, show_all_sources)))
                     _LOGGER.info("Denon receiver at host %s initialized", host)
 
     # Add all freshly discovered receivers

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -144,7 +144,7 @@ datapoint==0.4.3
 # decora==0.4
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.4.2
+denonavr==0.4.3
 
 # homeassistant.components.media_player.directv
 directpy==0.1


### PR DESCRIPTION
## Description:
Pushed to version 0.4.3 of the library including following changes:
- Add option (show_all_sources) to display all input sources also those marked as deleted
- Add support for favourite channels
- Treat Marantz SR5008 as Denon AVR-X device
- Add Marantz NETWORK audio source

Config
```
 media_player:
    - platform: denonavr
      host: IP_ADDRESS (optional)
      name: RECEIVER_NAME (optional)
      show_all_sources: True / False (optional)
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2786

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
