### PR TITLE
New component: Python Script

### DIFF
--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -3,10 +3,16 @@ import glob
 import os
 import logging
 
+import voluptuous as vol
+
 DOMAIN = 'python_script'
 REQUIREMENTS = ['restrictedpython==4.0a2']
 FOLDER = 'python_scripts'
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({})
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
@@ -77,4 +83,4 @@ class StubPrinter:
         """Print text."""
         # pylint: disable=no-self-use
         _LOGGER.warning(
-            "Don't print inside scripts. Use logger.info() instead.")
+            "Don't use print() inside scripts. Use logger.info() instead.")

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -1,0 +1,73 @@
+"""Component to allow running Python scripts."""
+import glob
+import os
+import logging
+
+DOMAIN = 'python_script'
+REQUIREMENTS = ['restrictedpython==4.0a2']
+FOLDER = 'python_scripts'
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup(hass, config):
+    """Initialize the python_script component."""
+    path = hass.config.path(FOLDER)
+
+    if not os.path.isdir(path):
+        _LOGGER.warning('Folder %s not found in config folder', FOLDER)
+        return False
+
+    def service_handler(call):
+        """Handle python script service calls."""
+        execute(hass, call.service, call.data)
+
+    for fil in glob.iglob(os.path.join(path, '*.py')):
+        name = os.path.splitext(os.path.basename(fil))[0]
+        hass.services.register(DOMAIN, name, service_handler)
+
+    return True
+
+
+def execute(hass, name, data):
+    """Execute a script."""
+    from RestrictedPython import compile_restricted_exec
+    from RestrictedPython.Guards import safe_builtins, full_write_guard
+
+    filename = '{}.py'.format(name)
+    try:
+        with open(hass.config.path(FOLDER, filename)) as fil:
+            compiled = compile_restricted_exec(fil.read(), filename=filename)
+    except SyntaxError as err:
+        _LOGGER.error('Error loading script: %s', err)
+        return
+
+    restricted_globals = {
+        '__builtins__': safe_builtins,
+        '_print_': Printer,
+        '_getattr_': getattr,
+        '_write_': full_write_guard,
+    }
+    local = {
+        'hass': hass,
+        'data': data,
+    }
+
+    try:
+        _LOGGER.info('Executing %s: %s', name, data)
+        # pylint: disable=exec-used
+        exec(compiled.code, restricted_globals, local)
+    except Exception as err:  # pylint: disable=broad-except
+        _LOGGER.exception('Error executing script: %s', err)
+
+
+class Printer:
+    """Class to handle printing inside scripts."""
+
+    def __init__(self, _getattr_):
+        """Initialize our printer."""
+        pass
+
+    def _call_print(self, *objects, **kwargs):
+        """Print text."""
+        # pylint: disable=no-self-use
+        print(*objects, **kwargs)

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -34,12 +34,17 @@ def execute(hass, name, data):
     from RestrictedPython.Guards import safe_builtins, full_write_guard
 
     filename = '{}.py'.format(name)
-    try:
-        with open(hass.config.path(FOLDER, filename)) as fil:
-            compiled = compile_restricted_exec(fil.read(), filename=filename)
-    except SyntaxError as err:
-        _LOGGER.error('Error loading script: %s', err)
+    with open(hass.config.path(FOLDER, filename)) as fil:
+        compiled = compile_restricted_exec(fil.read(), filename=filename)
+
+    if compiled.errors:
+        _LOGGER.error('Error loading script: %s',
+                      ', '.join(compiled.errors))
         return
+
+    if compiled.warnings:
+        _LOGGER.warning('Warning loading script: %s',
+                        ', '.join(compiled.warnings))
 
     restricted_globals = {
         '__builtins__': safe_builtins,

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -11,7 +11,7 @@ FOLDER = 'python_scripts'
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({})
+    DOMAIN: vol.Schema(dict)
 }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -113,7 +113,8 @@ class HomeAssistant(object):
         else:
             self.loop = loop or asyncio.get_event_loop()
 
-        self.executor = ThreadPoolExecutor(max_workers=EXECUTOR_POOL_SIZE)
+        self.executor = ThreadPoolExecutor(max_workers=EXECUTOR_POOL_SIZE,
+                                           thread_name_prefix='SyncWorker')
         self.loop.set_default_executor(self.executor)
         self.loop.set_exception_handler(async_loop_exception_handler)
         self._pending_tasks = []

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -113,8 +113,13 @@ class HomeAssistant(object):
         else:
             self.loop = loop or asyncio.get_event_loop()
 
-        self.executor = ThreadPoolExecutor(max_workers=EXECUTOR_POOL_SIZE,
-                                           thread_name_prefix='SyncWorker')
+        executor_opts = {
+            'max_workers': EXECUTOR_POOL_SIZE
+        }
+        if sys.version_info[:2] >= (3, 6):
+            executor_opts['thread_name_prefix'] = 'SyncWorker'
+
+        self.executor = ThreadPoolExecutor(**executor_opts)
         self.loop.set_default_executor(self.executor)
         self.loop.set_exception_handler(async_loop_exception_handler)
         self._pending_tasks = []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -755,6 +755,9 @@ radiotherm==1.2
 # homeassistant.components.raspihats
 # raspihats==2.2.1
 
+# homeassistant.components.python_script
+restrictedpython==4.0a2
+
 # homeassistant.components.rflink
 rflink==0.0.34
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -100,6 +100,9 @@ python-forecastio==1.3.5
 # homeassistant.components.notify.html5
 pywebpush==1.0.4
 
+# homeassistant.components.python_script
+restrictedpython==4.0a2
+
 # homeassistant.components.rflink
 rflink==0.0.34
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -65,6 +65,7 @@ TEST_REQUIREMENTS = (
     'gTTS-token',
     'pywebpush',
     'PyJWT',
+    'restrictedpython',
 )
 
 IGNORE_PACKAGES = (

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -1,0 +1,122 @@
+"""Test the python_script component."""
+import asyncio
+import logging
+from unittest.mock import patch, mock_open
+
+from homeassistant.setup import async_setup_component
+from homeassistant.components.python_script import execute
+
+
+@asyncio.coroutine
+def test_setup(hass):
+    """Test we can discover scripts."""
+    scripts = [
+        '/some/config/dir/python_scripts/hello.py',
+        '/some/config/dir/python_scripts/world_beer.py'
+    ]
+    with patch('homeassistant.components.python_script.os.path.isdir',
+               return_value=True), \
+            patch('homeassistant.components.python_script.glob.iglob',
+                  return_value=scripts):
+        res = yield from async_setup_component(hass, 'python_script', {})
+
+    assert res
+    assert hass.services.has_service('python_script', 'hello')
+    assert hass.services.has_service('python_script', 'world_beer')
+
+    with patch('homeassistant.components.python_script.open',
+               mock_open(read_data='fake source'), create=True), \
+            patch('homeassistant.components.python_script.execute') as mock_ex:
+        yield from hass.services.async_call(
+            'python_script', 'hello', { 'some': 'data' }, blocking=True)
+
+    assert len(mock_ex.mock_calls) == 1
+    hass, script, source, data = mock_ex.mock_calls[0][1]
+
+    assert hass is hass
+    assert script == 'hello.py'
+    assert source == 'fake source'
+    assert data == { 'some': 'data' }
+
+
+@asyncio.coroutine
+def test_setup_fails_on_no_dir(hass, caplog):
+    """Test we fail setup when no dir found."""
+    with patch('homeassistant.components.python_script.os.path.isdir',
+               return_value=False):
+        res = yield from async_setup_component(hass, 'python_script', {})
+
+    assert not res
+    assert 'Folder python_scripts not found in config folder' in caplog.text
+
+@asyncio.coroutine
+def test_execute_with_data(hass, caplog):
+    """Test executing a script."""
+    caplog.set_level(logging.WARNING)
+    source = """
+hass.states.set('test.entity', data.get('name', 'not set'))
+    """
+
+    hass.async_add_job(execute, hass, 'test.py', source, { 'name': 'paulus' })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.is_state('test.entity', 'paulus')
+
+    # No errors logged = good
+    assert caplog.text == ''
+
+
+@asyncio.coroutine
+def test_execute_warns_print(hass, caplog):
+    """Test print triggers warning."""
+    caplog.set_level(logging.WARNING)
+    source = """
+print("This triggers warning.")
+    """
+
+    hass.async_add_job(execute, hass, 'test.py', source, {})
+    yield from hass.async_block_till_done()
+
+    assert "Don't use print() inside scripts." in caplog.text
+
+
+@asyncio.coroutine
+def test_execute_logging(hass, caplog):
+    """Test logging works."""
+    caplog.set_level(logging.INFO)
+    source = """
+logger.info('Logging from inside script')
+    """
+
+    hass.async_add_job(execute, hass, 'test.py', source, {})
+    yield from hass.async_block_till_done()
+
+    assert "Logging from inside script" in caplog.text
+
+
+@asyncio.coroutine
+def test_execute_compile_error(hass, caplog):
+    """Test compile error logs error."""
+    caplog.set_level(logging.ERROR)
+    source = """
+this is not valid Python
+    """
+
+    hass.async_add_job(execute, hass, 'test.py', source, {})
+    yield from hass.async_block_till_done()
+
+    assert "Error loading script test.py" in caplog.text
+
+
+@asyncio.coroutine
+def test_execute_runtime_error(hass, caplog):
+    """Test compile error logs error."""
+    caplog.set_level(logging.ERROR)
+    source = """
+raise Exception('boom')
+    """
+
+    hass.async_add_job(execute, hass, 'test.py', source, {})
+    yield from hass.async_block_till_done()
+
+    assert "Error executing script test.py" in caplog.text

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -28,7 +28,7 @@ def test_setup(hass):
                mock_open(read_data='fake source'), create=True), \
             patch('homeassistant.components.python_script.execute') as mock_ex:
         yield from hass.services.async_call(
-            'python_script', 'hello', { 'some': 'data' }, blocking=True)
+            'python_script', 'hello', {'some': 'data'}, blocking=True)
 
     assert len(mock_ex.mock_calls) == 1
     hass, script, source, data = mock_ex.mock_calls[0][1]
@@ -36,7 +36,7 @@ def test_setup(hass):
     assert hass is hass
     assert script == 'hello.py'
     assert source == 'fake source'
-    assert data == { 'some': 'data' }
+    assert data == {'some': 'data'}
 
 
 @asyncio.coroutine
@@ -49,6 +49,7 @@ def test_setup_fails_on_no_dir(hass, caplog):
     assert not res
     assert 'Folder python_scripts not found in config folder' in caplog.text
 
+
 @asyncio.coroutine
 def test_execute_with_data(hass, caplog):
     """Test executing a script."""
@@ -57,7 +58,7 @@ def test_execute_with_data(hass, caplog):
 hass.states.set('test.entity', data.get('name', 'not set'))
     """
 
-    hass.async_add_job(execute, hass, 'test.py', source, { 'name': 'paulus' })
+    hass.async_add_job(execute, hass, 'test.py', source, {'name': 'paulus'})
     yield from hass.async_block_till_done()
 
     assert hass.states.is_state('test.entity', 'paulus')


### PR DESCRIPTION
## Description:
This is an experimental component. Hacked together after a discussion with @bbangert about adding Lambda support to Hass.

So what is it? This is a component to allow you to write Python scripts that are exposed as services in Home Assistant. Each Python file created in the `<config>/python_scripts/` folder will be exposed as a service. The content is not cached so you can easily develop: edit file, save changes, call service. The scripts are run in a sandboxed environment with access to the `hass` object, the service call data as `data` and a logger as `logger`.

The idea is that writing Python automation components is often overlooked as an option. This will make it easier to use our existing automation component for the trigger and then use a Python script to handle the execution.

So, to try this out:

 - Add to `configuration.yaml`: `python_script:`
 - Create folder `<config>/python_scripts`
 - Create a file `hello_world.py` and give it this content:

```python
name = data.get('name', 'world')
logger.info("Hello {}".format(name))
hass.bus.fire(name, { "wow": "from a Python script!" })
```

 - Start Home Assistant
 - Call service `python_script/hello_world`

![image](https://user-images.githubusercontent.com/1444314/26915704-f97a6a52-4bdb-11e7-8e21-d6d79025976b.png)

And look at your console:

![image](https://user-images.githubusercontent.com/1444314/26915740-14dd154c-4bdc-11e7-9b1c-2591e4b958c7.png)

To do:
 - [ ] think about if this is a good idea
 - [ ] tests
 - [ ] docs

Feedback welcome if this would be a good idea or not.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
python_script:
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
