### PR TITLE
lock.sesame: Update pysesame, add state attributes

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -635,7 +635,7 @@ pysensibo==1.0.1
 pyserial==3.1.1
 
 # homeassistant.components.lock.sesame
-pysesame==0.0.2
+pysesame==0.1.0
 
 # homeassistant.components.sensor.sma
 pysma==0.1.3


### PR DESCRIPTION
## Description:

* Update pysesame requirement to 0.1.0 to support caching

* Set available property based on API enable status

* Add state attributes for device ID and battery level

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
