### PR TITLE
Added SMTP SSL/TLS support

### DIFF
--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -29,18 +29,16 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_IMAGES = 'images'  # optional embedded image file attachments
 ATTR_HTML = 'html'
 
-CONF_STARTTLS = 'starttls'
-CONF_SSLTLS = 'ssltls'
+CONF_ENCRYPTION = 'encryption'
 CONF_DEBUG = 'debug'
 CONF_SERVER = 'server'
 CONF_SENDER_NAME = 'sender_name'
 
 DEFAULT_HOST = 'localhost'
-DEFAULT_PORT = 25
+DEFAULT_PORT = 465
 DEFAULT_TIMEOUT = 5
 DEFAULT_DEBUG = False
-DEFAULT_STARTTLS = False
-DEFAULT_SSLTLS = False
+DEFAULT_ENCRYPTION = 'ssltls'
 
 # pylint: disable=no-value-for-parameter
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -49,8 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SERVER, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-    vol.Optional(CONF_STARTTLS, default=DEFAULT_STARTTLS): cv.boolean,
-    vol.Optional(CONF_SSLTLS, default=DEFAULT_SSLTLS): cv.boolean,
+    vol.Optional(CONF_ENCRYPTION, default=DEFAULT_ENCRYPTION): cv.string,
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_SENDER_NAME): cv.string,
@@ -65,8 +62,7 @@ def get_service(hass, config, discovery_info=None):
         config.get(CONF_PORT),
         config.get(CONF_TIMEOUT),
         config.get(CONF_SENDER),
-        config.get(CONF_STARTTLS),
-        config.get(CONF_SSLTLS),
+        config.get(CONF_ENCRYPTION),
         config.get(CONF_USERNAME),
         config.get(CONF_PASSWORD),
         config.get(CONF_RECIPIENT),
@@ -82,32 +78,30 @@ def get_service(hass, config, discovery_info=None):
 class MailNotificationService(BaseNotificationService):
     """Implement the notification service for E-mail messages."""
 
-    def __init__(self, server, port, timeout, sender, starttls, ssltls, username,
+    def __init__(self, server, port, timeout, sender, encryption, username,
                  password, recipients, sender_name, debug):
         """Initialize the SMTP service."""
         self._server = server
         self._port = port
         self._timeout = timeout
         self._sender = sender
-        self.starttls = starttls
-        self.ssltls = ssltls
+        self.encryption = encryption
         self.username = username
         self.password = password
         self.recipients = recipients
         self._sender_name = sender_name
-        self._timeout = timeout
         self.debug = debug
         self.tries = 2
 
     def connect(self):
         """Connect/authenticate to SMTP Server."""
-        if self.ssltls:
+        if self.encryption == "ssltls":
             mail = smtplib.SMTP_SSL(self._server, self._port, timeout=self._timeout)
-        else:
+        elif self.encryption == "none" or self.encryption == "starttls":
             mail = smtplib.SMTP(self._server, self._port, timeout=self._timeout)
         mail.set_debuglevel(self.debug)
         mail.ehlo_or_helo_if_needed()
-        if self.starttls:
+        if self.encryption == "starttls":
             mail.starttls()
             mail.ehlo()
         if self.username and self.password:

--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -98,7 +98,7 @@ class MailNotificationService(BaseNotificationService):
 
     def connect(self):
         """Connect/authenticate to SMTP Server."""
-        if self.encryption == "ssltls":
+        if self.encryption == "tls":
             mail = smtplib.SMTP_SSL(
                 self._server, self._port, timeout=self._timeout)
         else:

--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -38,7 +38,9 @@ DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 465
 DEFAULT_TIMEOUT = 5
 DEFAULT_DEBUG = False
-DEFAULT_ENCRYPTION = 'ssltls'
+DEFAULT_ENCRYPTION = 'tls'
+
+ENCRYPTION_OPTIONS = ['tls', 'starttls', 'none']
 
 # pylint: disable=no-value-for-parameter
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -47,7 +49,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SERVER, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-    vol.Optional(CONF_ENCRYPTION, default=DEFAULT_ENCRYPTION): vol.In(['ssltls','starttls','none']),
+    vol.Optional(CONF_ENCRYPTION, default=DEFAULT_ENCRYPTION):
+        vol.In(ENCRYPTION_OPTIONS),
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_SENDER_NAME): cv.string,
@@ -96,9 +99,11 @@ class MailNotificationService(BaseNotificationService):
     def connect(self):
         """Connect/authenticate to SMTP Server."""
         if self.encryption == "ssltls":
-            mail = smtplib.SMTP_SSL(self._server, self._port, timeout=self._timeout)
+            mail = smtplib.SMTP_SSL(
+                self._server, self._port, timeout=self._timeout)
         else:
-            mail = smtplib.SMTP(self._server, self._port, timeout=self._timeout)
+            mail = smtplib.SMTP(
+                self._server, self._port, timeout=self._timeout)
         mail.set_debuglevel(self.debug)
         mail.ehlo_or_helo_if_needed()
         if self.encryption == "starttls":

--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -47,7 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SERVER, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-    vol.Optional(CONF_ENCRYPTION, default=DEFAULT_ENCRYPTION): cv.string,
+    vol.Optional(CONF_ENCRYPTION, default=DEFAULT_ENCRYPTION): vol.In(['ssltls','starttls','none']),
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_SENDER_NAME): cv.string,
@@ -97,7 +97,7 @@ class MailNotificationService(BaseNotificationService):
         """Connect/authenticate to SMTP Server."""
         if self.encryption == "ssltls":
             mail = smtplib.SMTP_SSL(self._server, self._port, timeout=self._timeout)
-        elif self.encryption == "none" or self.encryption == "starttls":
+        else:
             mail = smtplib.SMTP(self._server, self._port, timeout=self._timeout)
         mail.set_debuglevel(self.debug)
         mail.ehlo_or_helo_if_needed()


### PR DESCRIPTION
## Description:
- Add SMTP SSL/TLS support from smtplib.py's class smtplib.SMTP_SSL
- configurable option like 'starttls', default to False

I ran tox and had errors, not sure how to publish results, please help.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2843

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: mail
    platform: smtp
    server: !secret smtp_server
    port: 465
    sender: !secret mail_alert
    username: !secret mail_username
    password: !secret mail_password
    recipient: !secret mail_admin
    starttls: false
    ssltls: true
    debug: true

automation:
  trigger:
    platform: homeassistant
    event: start
  action:
    - service: notify.mail
      data:
        title: "HASSdev started"

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
