### PR TITLE
Fix Met Office Sensor

### DIFF
--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -141,7 +141,7 @@ class MetOfficeCurrentSensor(Entity):
         attr['Sensor Id'] = self._condition
         attr['Site Id'] = self.site.id
         attr['Site Name'] = self.site.name
-        attr['Last Update'] = self.data.lastupdate
+        attr['Last Update'] = self.data.data.date
         attr[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
         return attr
 


### PR DESCRIPTION
## Description:
Fixes the Met Office sensor issues raised at https://community.home-assistant.io/t/metoffice-integration/15537. No new dependencies or files.

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/metoffice-integration/15537

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A, no configuration changes

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
