### PR TITLE
Fix platforms being able to block Hass startup

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -151,8 +151,10 @@ class EntityComponent(object):
                     entity_platform.async_schedule_add_entities, discovery_info
                 )
             else:
-                task = self.hass.async_add_job(
-                    platform.setup_platform, self.hass, platform_config,
+                # This should not be replaced with hass.async_add_job because
+                # we don't want to track this task in case it blocks startup.
+                task = self.hass.loop.run_in_executor(
+                    None, platform.setup_platform, self.hass, platform_config,
                     entity_platform.schedule_add_entities, discovery_info
                 )
             yield from asyncio.wait_for(


### PR DESCRIPTION
## Description:
In #7739 we fixed platforms that were blocking startup. However, in #7658 I replaced every call to the executor with a call to `async_add_job`. This had the unwanted side effect that a platform setup that was being executed in the executor was tracked, and thus was still blocking startup.

This fixes it by changing it back to run in the executor.
