### PR TITLE
Add initial support for Shiftr.io

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -474,6 +474,7 @@ omit =
     homeassistant/components/sensor/xbox_live.py
     homeassistant/components/sensor/yweather.py
     homeassistant/components/sensor/zamg.py
+    homeassistant/components/shiftr.py
     homeassistant/components/spc.py
     homeassistant/components/switch/acer_projector.py
     homeassistant/components/switch/anel_pwrctrl.py

--- a/homeassistant/components/shiftr.py
+++ b/homeassistant/components/shiftr.py
@@ -1,0 +1,81 @@
+"""
+Support for Shiftr.io.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/shiftr/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+import homeassistant.components.mqtt as mqtt
+from homeassistant.const import (
+    CONF_PASSWORD, CONF_USERNAME, EVENT_STATE_CHANGED,
+    EVENT_HOMEASSISTANT_STOP)
+from homeassistant.helpers import state as state_helper
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'shiftr'
+
+SHIFTR_BROKER = 'broker.shiftr.io'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Initialize the Shiftr.io MQTT consumer."""
+    conf = config[DOMAIN]
+    username = conf.get(CONF_USERNAME)
+    password = conf.get(CONF_PASSWORD)
+
+    client_id = 'HomeAssistant'
+    port = 1883
+    keepalive = 600
+
+    shiftr_mqtt = mqtt.MQTT(
+        hass, SHIFTR_BROKER, port, client_id, keepalive, username,
+        password, certificate=None, client_key=None, client_cert=None,
+        tls_insecure=False, protocol='3.1.1', will_message=None,
+        birth_message=None, tls_version=1.2)
+
+    success = yield from shiftr_mqtt.async_connect()
+    if not success:
+        return False
+
+    @asyncio.coroutine
+    def async_stop_shiftr(event):
+        """Stop the Shiftr.io MQTT component."""
+        yield from shiftr_mqtt.async_disconnect()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_shiftr)
+
+    @asyncio.coroutine
+    def async_shiftr_event_listener(event):
+        """Listen for new messages on the bus and sends them to Shiftr.io."""
+        state = event.data.get('new_state')
+        topic = state.entity_id.replace('.', '/')
+
+        try:
+            _state = state_helper.state_as_number(state)
+        except ValueError:
+            _state = state.state
+
+        yield from shiftr_mqtt.async_publish(topic, _state, 0, False)
+
+        if state.attributes:
+            for k, v in state.attributes.items():
+                yield from shiftr_mqtt.async_publish(
+                    '/{}/{}'.format(topic, k), str(v), 0, False)
+
+    hass.bus.async_listen(EVENT_STATE_CHANGED, async_shiftr_event_listener)
+
+    return True

--- a/homeassistant/components/shiftr.py
+++ b/homeassistant/components/shiftr.py
@@ -72,9 +72,9 @@ def async_setup(hass, config):
         yield from shiftr_mqtt.async_publish(topic, _state, 0, False)
 
         if state.attributes:
-            for k, v in state.attributes.items():
+            for attribute, data in state.attributes.items():
                 yield from shiftr_mqtt.async_publish(
-                    '/{}/{}'.format(topic, k), str(v), 0, False)
+                    '/{}/{}'.format(topic, attribute), str(data), 0, False)
 
     hass.bus.async_listen(EVENT_STATE_CHANGED, async_shiftr_event_listener)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -409,6 +409,7 @@ openhomedevice==0.4.2
 orvibo==1.1.1
 
 # homeassistant.components.mqtt
+# homeassistant.components.shiftr
 paho-mqtt==1.2.3
 
 # homeassistant.components.media_player.panasonic_viera

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -69,6 +69,7 @@ libsoundtouch==0.3.0
 mficlient==0.3.0
 
 # homeassistant.components.mqtt
+# homeassistant.components.shiftr
 paho-mqtt==1.2.3
 
 # homeassistant.components.device_tracker.aruba


### PR DESCRIPTION
## Description:
This component simply make the events from Home Assistant available in the communication infrastructure on [shiftr.io](https://shiftr.io). This allows one to share data and see the flows in a realtime graph that visualizes all events happening in a namespace.

![shiftr-io](https://user-images.githubusercontent.com/116184/26974222-9a6457f4-4d1a-11e7-93bd-f064f17d4d7b.png)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2827

## Example entry for `configuration.yaml` (if applicable):
```yaml
shiftr:
  username: 7879cb40
  password: 5e8bh7bebe4c0cc0
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
