### PR TITLE
Allow friendly names in the  history stats sensor configs.

### DIFF
--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -90,7 +90,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             template.hass = hass
 
     add_devices([HistoryStatsSensor(hass, entity_id, entity_state, start, end,
-                                    duration, sensor_type, name, friendly_name)])
+                                    duration, sensor_type, name,
+                                    friendly_name)])
 
     return True
 

--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -13,9 +13,9 @@ import voluptuous as vol
 import homeassistant.components.history as history
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
-from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.sensor import PLATFORM_SCHEMA, ENTITY_ID_FORMAT
 from homeassistant.const import (
-    CONF_NAME, CONF_ENTITY_ID, CONF_STATE, CONF_TYPE,
+    CONF_NAME, CONF_ENTITY_ID, CONF_STATE, CONF_TYPE, CONF_FRIENDLY_NAME,
     EVENT_HOMEASSISTANT_START)
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import Entity
@@ -69,6 +69,7 @@ PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DURATION, default=None): cv.time_period,
     vol.Optional(CONF_TYPE, default=CONF_TYPE_TIME): vol.In(CONF_TYPE_KEYS),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_FRIENDLY_NAME): cv.string,
 }), exactly_two_period_keys)
 
 
@@ -82,13 +83,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     duration = config.get(CONF_DURATION)
     sensor_type = config.get(CONF_TYPE)
     name = config.get(CONF_NAME)
+    friendly_name = config.get(CONF_FRIENDLY_NAME)
 
     for template in [start, end]:
         if template is not None:
             template.hass = hass
 
     add_devices([HistoryStatsSensor(hass, entity_id, entity_state, start, end,
-                                    duration, sensor_type, name)])
+                                    duration, sensor_type, name, friendly_name)])
 
     return True
 
@@ -98,7 +100,7 @@ class HistoryStatsSensor(Entity):
 
     def __init__(
             self, hass, entity_id, entity_state, start, end, duration,
-            sensor_type, name):
+            sensor_type, name, friendly_name):
         """Initialize the HistoryStats sensor."""
         self._hass = hass
 
@@ -108,7 +110,8 @@ class HistoryStatsSensor(Entity):
         self._start = start
         self._end = end
         self._type = sensor_type
-        self._name = name
+        self._name = friendly_name
+        self.entity_id = ENTITY_ID_FORMAT.format(name)
         self._unit_of_measurement = UNITS[sensor_type]
 
         self._period = (datetime.datetime.now(), datetime.datetime.now())


### PR DESCRIPTION
## Description:
This allows the defining of friendly names in the History Stats sensor platform. 


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2793

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: history_stats
    name: ryan
    friendly_name: Fan runtime so far Today
    entity_id: input_boolean.test
    state: 'on'
    type: time
    start: '{{ now().replace(hour=0).replace(minute=0).replace(second=0) }}'
    end: '{{ now() }}'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
