### PR TITLE
Fixed bug in spotify component.

### DIFF
--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -161,16 +161,16 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         player_devices = self._player.devices()
         if player_devices is not None:
             devices = player_devices.get('devices')
-        if devices is not None:
-            old_devices = self._devices
-            self._devices = {self._aliases.get(device.get('id'),
-                                               device.get('name')):
-                             device.get('id')
-                             for device in devices}
-            device_diff = {name: id for name, id in self._devices.items()
-                           if old_devices.get(name, None) is None}
-            if len(device_diff) > 0:
-                _LOGGER.info("New Devices: %s", str(device_diff))
+            if devices is not None:
+                old_devices = self._devices
+                self._devices = {self._aliases.get(device.get('id'),
+                                                   device.get('name')):
+                                 device.get('id')
+                                 for device in devices}
+                device_diff = {name: id for name, id in self._devices.items()
+                               if old_devices.get(name, None) is None}
+                if len(device_diff) > 0:
+                    _LOGGER.info("New Devices: %s", str(device_diff))
         # Current playback state
         current = self._player.current_playback()
         if current is None:


### PR DESCRIPTION
## Description:
Fixed bug that causes errors while updating state of spotify component. Error occurred when `player_devices` is None, because in this case`devices` is referenced in line 164 before assignment. 

If the code communicates with devices, web services, or third-party tools:
  - [] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
