### PR TITLE
eliqonline: print error when failure

### DIFF
--- a/homeassistant/components/sensor/eliqonline.py
+++ b/homeassistant/components/sensor/eliqonline.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/sensor.eliqonline/
 """
 from datetime import timedelta
 import logging
-from urllib.error import URLError
 
 import voluptuous as vol
 
@@ -49,9 +48,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         _LOGGER.debug("Probing for access to ELIQ Online API")
         api.get_data_now(channelid=channel_id)
-    except URLError:
+    except OSError as error:
         _LOGGER.error("Could not access the ELIQ Online API. "
-                      "Is the configuration valid?")
+                      "Is the configuration valid? %s", error)
         return False
 
     add_devices([EliqSensor(api, channel_id, name)])
@@ -94,5 +93,6 @@ class EliqSensor(Entity):
             response = self._api.get_data_now(channelid=self._channel_id)
             self._state = int(response.power)
             _LOGGER.debug("Updated power from server %d W", self._state)
-        except URLError:
-            _LOGGER.warning("Could not connect to the ELIQ Online API")
+        except OSError as error:
+            _LOGGER.warning("Could not connect to the ELIQ Online API: %s",
+                            error)


### PR DESCRIPTION
Print error when failure

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
