### PR TITLE
Added ONVIF camera component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -211,6 +211,7 @@ omit =
     homeassistant/components/camera/foscam.py
     homeassistant/components/camera/mjpeg.py
     homeassistant/components/camera/rpi_camera.py
+    homeassistant/components/camera/onvif.py
     homeassistant/components/camera/synology.py
     homeassistant/components/climate/eq3btsmart.py
     homeassistant/components/climate/flexit.py

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -1,0 +1,108 @@
+"""
+Support for ONVIF Cameras with FFmpeg as decoder.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/camera.onvif/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import (CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_PORT)
+from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
+from homeassistant.components.ffmpeg import (
+    DATA_FFMPEG, CONF_INPUT, CONF_EXTRA_ARGUMENTS)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.aiohttp_client import (
+    async_aiohttp_proxy_stream)
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['onvif-py3==0.1.3','suds-py3==1.3.3.0','http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a']
+DEPENDENCIES = ['ffmpeg']
+DEFAULT_NAME = 'ONVIF Camera'
+DEFAULT_PORT = 5000
+DEFAULT_USERNAME = 'admin'
+DEFAULT_PASSWORD = '888888'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_INPUT): cv.string,
+    vol.Optional(CONF_EXTRA_ARGUMENTS): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+    vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up a ONVIF camera."""
+    if not hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
+        return
+    async_add_devices([ONVIFCamera(hass, config)])
+
+
+class ONVIFCamera(Camera):
+    """An implementation of an ONVIF camera."""
+
+    def __init__(self, hass, config):
+        """Initialize a ONVIF camera."""
+        from onvif import ONVIFService
+        super().__init__()
+
+        self._manager = hass.data[DATA_FFMPEG]
+        self._name = config.get(CONF_NAME)
+        self._input = config.get(CONF_INPUT)
+        self._extra_arguments = config.get(CONF_EXTRA_ARGUMENTS)
+        port = config.get(CONF_PORT)
+        wsdl = hass.config.config_dir + '/deps/onvif/wsdl/'
+        self._base_url = 'http://{}:{}/'.format(self._input, port)
+        device_url = self._base_url + 'onvif/device_service'
+        self._username = config.get(CONF_USERNAME)
+        self._password = config.get(CONF_PASSWORD)
+        media = ONVIFService(device_url,self._username, self._password, wsdl + 'media.wsdl')
+        media_profile = media.GetProfiles()[0]
+        self._input = media.GetStreamUri().Uri
+        _LOGGER.debug("Using the following URL for %s: %s",
+                     self._name, self._input)
+        _LOGGER.debug("Using the base URL for %s: %s",
+                     self._name, self._base_url)
+        _LOGGER.debug("Using the device URL for %s: %s",
+                     self._name, device_url)
+        _LOGGER.debug("WSDL for %s: %s",
+                     self._name, wsdl)
+        _LOGGER.debug("Login details for %s: %s %s",
+                     self._name, self._username, self._password)
+
+
+    @asyncio.coroutine
+    def async_camera_image(self):
+        """Return a still image response from the camera."""
+        from haffmpeg import ImageFrame, IMAGE_JPEG
+        ffmpeg = ImageFrame(self._manager.binary, loop=self.hass.loop)
+
+        image = yield from ffmpeg.get_image(
+            self._input, output_format=IMAGE_JPEG,
+            extra_cmd=self._extra_arguments)
+        return image
+
+    @asyncio.coroutine
+    def handle_async_mjpeg_stream(self, request):
+        """Generate an HTTP MJPEG stream from the camera."""
+        from haffmpeg import CameraMjpeg
+
+        stream = CameraMjpeg(self._manager.binary, loop=self.hass.loop)
+        yield from stream.open_camera(
+            self._input, extra_cmd=self._extra_arguments)
+
+        yield from async_aiohttp_proxy_stream(
+            self.hass, request, stream,
+            'multipart/x-mixed-replace;boundary=ffserver')
+        yield from stream.close()
+
+    @property
+    def name(self):
+        """Return the name of this camera."""
+        return self._name

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -9,8 +9,9 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import (CONF_NAME, CONF_USERNAME,
-    CONF_PASSWORD, CONF_PORT)
+from homeassistant.const import (
+                                CONF_NAME, CONF_USERNAME,
+                                CONF_PASSWORD, CONF_PORT)
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.components.ffmpeg import (
     DATA_FFMPEG, CONF_INPUT, CONF_EXTRA_ARGUMENTS)

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -30,11 +30,11 @@ DEFAULT_NAME = 'ONVIF Camera'
 DEFAULT_PORT = 5000
 DEFAULT_USERNAME = 'admin'
 DEFAULT_PASSWORD = '888888'
-DEFAULT_FFMPEG_ARGUMENTS= '-q:v 2'
+CONF_FFMPEG_ARGUMENTS= '-q:v 2'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_FFMPEG_ARGUMENTS, default=DEFAULT_FFMPEG_ARGUMENTS): cv.string,
+    vol.Optional(CONF_FFMPEG_ARGUMENTS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -68,8 +68,8 @@ class ONVIFCamera(Camera):
         device_url = self._base_url + 'onvif/device_service'
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)
-        media = ONVIFService(device_url, self._username, 
-                            self._password, wsdl + 'media.wsdl')
+        media = ONVIFService(device_url, self._username,
+                             self._password, wsdl + 'media.wsdl')
         self._input = media.GetStreamUri().Uri
         _LOGGER.debug("Using the following URL for %s: %s",
                       self._name, self._input)

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -30,11 +30,11 @@ DEFAULT_NAME = 'ONVIF Camera'
 DEFAULT_PORT = 5000
 DEFAULT_USERNAME = 'admin'
 DEFAULT_PASSWORD = '888888'
-CONF_FFMPEG_ARGUMENTS= '-q:v 2'
+DEFAULT_FFMPEG_ARGUMENTS = '-q:v 2'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_FFMPEG_ARGUMENTS): cv.string,
+    vol.Optional(CONF_FFMPEG_ARGUMENTS, default=DEFAULT_FFMPEG_ARGUMENTS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -59,13 +59,13 @@ class ONVIFCamera(Camera):
         self._name = config.get(CONF_NAME)
         self._ffmpeg_arguments = '-q:v 2'
         media = ONVIFService('http://{}:{}/onvif/device_service'.format(
-                             config.get(CONF_HOST),
-                             config.get(CONF_PORT)),
+            config.get(CONF_HOST),
+            config.get(CONF_PORT)),
                              config.get(CONF_USERNAME),
                              config.get(CONF_PASSWORD),
                              '{}/deps/onvif/wsdl/media.wsdl'.format(
-                             hass.config.config_dir)
-                             )
+                                 hass.config.config_dir)
+                            )
         self._input = media.GetStreamUri().Uri
         _LOGGER.debug("ONVIF Camera Using the following URL for %s: %s",
                       self._name, self._input)

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -58,12 +58,14 @@ class ONVIFCamera(Camera):
 
         self._name = config.get(CONF_NAME)
         self._ffmpeg_arguments = '-q:v 2'
-        media = ONVIFService('http://{}:{}/'.format(config.get(CONF_HOST),
-                                                    config.get(CONF_PORT))
-                             + 'onvif/device_service',
+        media = ONVIFService('http://{}:{}/onvif/device_service'.format(
+                             config.get(CONF_HOST),
+                             config.get(CONF_PORT)),
                              config.get(CONF_USERNAME),
-                             config.get(CONF_PASSWORD), hass.config.config_dir
-                             + '/deps/onvif/wsdl/media.wsdl')
+                             config.get(CONF_PASSWORD),
+                             '{}/deps/onvif/wsdl/media.wsdl'.format(
+                             hass.config.config_dir)
+                             )
         self._input = media.GetStreamUri().Uri
         _LOGGER.debug("ONVIF Camera Using the following URL for %s: %s",
                       self._name, self._input)

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -20,11 +20,11 @@ from homeassistant.helpers.aiohttp_client import (
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['onvif-py3==0.1.3', 
-    'suds-py3==1.3.3.0', 
-    'http://github.com/tgaugry/suds-passworddigest-py3'
-    '/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip'
-    '#suds-passworddigest-py3==0.1.2a']
+REQUIREMENTS = ['onvif-py3==0.1.3',
+                'suds-py3==1.3.3.0',
+                'http://github.com/tgaugry/suds-passworddigest-py3'
+                '/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip'
+                '#suds-passworddigest-py3==0.1.2a']
 DEPENDENCIES = ['ffmpeg']
 DEFAULT_NAME = 'ONVIF Camera'
 DEFAULT_PORT = 5000
@@ -67,19 +67,19 @@ class ONVIFCamera(Camera):
         device_url = self._base_url + 'onvif/device_service'
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)
-        media = ONVIFService(device_url,self._username, 
-            self._password, wsdl + 'media.wsdl')
+        media = ONVIFService(device_url, self._username, 
+                            self._password, wsdl + 'media.wsdl')
         self._input = media.GetStreamUri().Uri
         _LOGGER.debug("Using the following URL for %s: %s",
-                       self._name, self._input)
+                      self._name, self._input)
         _LOGGER.debug("Using the base URL for %s: %s",
-                       self._name, self._base_url)
+                      self._name, self._base_url)
         _LOGGER.debug("Using the device URL for %s: %s",
-                       self._name, device_url)
+                      self._name, device_url)
         _LOGGER.debug("WSDL for %s: %s",
-                       self._name, wsdl)
+                      self._name, wsdl)
         _LOGGER.debug("Login details for %s: %s %s",
-                       self._name, self._username, self._password)
+                      self._name, self._username, self._password)
 
     @asyncio.coroutine
     def async_camera_image(self):

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -9,8 +9,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_PORT)
+from homeassistant.const import (CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_PORT)
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.components.ffmpeg import (
     DATA_FFMPEG, CONF_INPUT, CONF_EXTRA_ARGUMENTS)
@@ -20,11 +19,7 @@ from homeassistant.helpers.aiohttp_client import (
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['onvif-py3==0.1.3',
-                'suds-py3==1.3.3.0',
-                'http://github.com/tgaugry/suds-passworddigest-py3'
-                '/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip'
-                '#suds-passworddigest-py3==0.1.2a']
+REQUIREMENTS = ['onvif-py3==0.1.3','suds-py3==1.3.3.0','http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a']
 DEPENDENCIES = ['ffmpeg']
 DEFAULT_NAME = 'ONVIF Camera'
 DEFAULT_PORT = 5000
@@ -67,19 +62,20 @@ class ONVIFCamera(Camera):
         device_url = self._base_url + 'onvif/device_service'
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)
-        media = ONVIFService(device_url, self._username,
-                             self._password, wsdl + 'media.wsdl')
+        media = ONVIFService(device_url,self._username, self._password, wsdl + 'media.wsdl')
+        media_profile = media.GetProfiles()[0]
         self._input = media.GetStreamUri().Uri
         _LOGGER.debug("Using the following URL for %s: %s",
-                      self._name, self._input)
+                     self._name, self._input)
         _LOGGER.debug("Using the base URL for %s: %s",
-                      self._name, self._base_url)
+                     self._name, self._base_url)
         _LOGGER.debug("Using the device URL for %s: %s",
-                      self._name, device_url)
+                     self._name, device_url)
         _LOGGER.debug("WSDL for %s: %s",
-                      self._name, wsdl)
+                     self._name, wsdl)
         _LOGGER.debug("Login details for %s: %s %s",
-                      self._name, self._username, self._password)
+                     self._name, self._username, self._password)
+
 
     @asyncio.coroutine
     def async_camera_image(self):

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -70,6 +70,8 @@ class ONVIFCamera(Camera):
         media = ONVIFService(device_url, self._username,
                              self._password, wsdl + 'media.wsdl')
         self._input = media.GetStreamUri().Uri
+        _LOGGER.info("ONVIF Camera Using the following URL for %s: %s",
+                    self._name, self._input)
 
     @asyncio.coroutine
     def async_camera_image(self):

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -58,14 +58,13 @@ class ONVIFCamera(Camera):
 
         self._name = config.get(CONF_NAME)
         self._ffmpeg_arguments = '-q:v 2'
-        media = ONVIFService('http://{}:{}/onvif/device_service'.format(
-            config.get(CONF_HOST),
-            config.get(CONF_PORT)),
-                             config.get(CONF_USERNAME),
-                             config.get(CONF_PASSWORD),
-                             '{}/deps/onvif/wsdl/media.wsdl'.format(
-                                 hass.config.config_dir)
-                            )
+        media = ONVIFService(
+            'http://{}:{}/onvif/device_service'.format(
+                config.get(CONF_HOST), config.get(CONF_PORT)),
+            config.get(CONF_USERNAME),
+            config.get(CONF_PASSWORD),
+            '{}/deps/onvif/wsdl/media.wsdl'.format(hass.config.config_dir)
+        )
         self._input = media.GetStreamUri().Uri
         _LOGGER.debug("ONVIF Camera Using the following URL for %s: %s",
                       self._name, self._input)
@@ -74,8 +73,8 @@ class ONVIFCamera(Camera):
     def async_camera_image(self):
         """Return a still image response from the camera."""
         from haffmpeg import ImageFrame, IMAGE_JPEG
-        ffmpeg = ImageFrame(self.hass.data[DATA_FFMPEG].binary,
-                            loop=self.hass.loop)
+        ffmpeg = ImageFrame(
+            self.hass.data[DATA_FFMPEG].binary, loop=self.hass.loop)
 
         image = yield from ffmpeg.get_image(
             self._input, output_format=IMAGE_JPEG,

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -71,7 +71,7 @@ class ONVIFCamera(Camera):
                              self._password, wsdl + 'media.wsdl')
         self._input = media.GetStreamUri().Uri
         _LOGGER.info("ONVIF Camera Using the following URL for %s: %s",
-                    self._name, self._input)
+                     self._name, self._input)
 
     @asyncio.coroutine
     def async_camera_image(self):

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -9,9 +9,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import (
-                                CONF_NAME, CONF_USERNAME,
-                                CONF_PASSWORD, CONF_PORT)
+from homeassistant.const import (CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_PORT)
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.components.ffmpeg import (
     DATA_FFMPEG, CONF_INPUT, CONF_EXTRA_ARGUMENTS)
@@ -21,11 +19,7 @@ from homeassistant.helpers.aiohttp_client import (
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['onvif-py3==0.1.3',
-                'suds-py3==1.3.3.0',
-                'http://github.com/tgaugry/suds-passworddigest-py3'
-                '/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip'
-                '#suds-passworddigest-py3==0.1.2a']
+REQUIREMENTS = ['onvif-py3==0.1.3','suds-py3==1.3.3.0','http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a']
 DEPENDENCIES = ['ffmpeg']
 DEFAULT_NAME = 'ONVIF Camera'
 DEFAULT_PORT = 5000
@@ -68,19 +62,20 @@ class ONVIFCamera(Camera):
         device_url = self._base_url + 'onvif/device_service'
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)
-        media = ONVIFService(device_url, self._username,
-                             self._password, wsdl + 'media.wsdl')
+        media = ONVIFService(device_url,self._username, self._password, wsdl + 'media.wsdl')
+        media_profile = media.GetProfiles()[0]
         self._input = media.GetStreamUri().Uri
         _LOGGER.debug("Using the following URL for %s: %s",
-                      self._name, self._input)
+                     self._name, self._input)
         _LOGGER.debug("Using the base URL for %s: %s",
-                      self._name, self._base_url)
+                     self._name, self._base_url)
         _LOGGER.debug("Using the device URL for %s: %s",
-                      self._name, device_url)
+                     self._name, device_url)
         _LOGGER.debug("WSDL for %s: %s",
-                      self._name, wsdl)
+                     self._name, wsdl)
         _LOGGER.debug("Login details for %s: %s %s",
-                      self._name, self._username, self._password)
+                     self._name, self._username, self._password)
+
 
     @asyncio.coroutine
     def async_camera_image(self):

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -70,16 +70,6 @@ class ONVIFCamera(Camera):
         media = ONVIFService(device_url, self._username,
                              self._password, wsdl + 'media.wsdl')
         self._input = media.GetStreamUri().Uri
-        _LOGGER.debug("Using the following URL for %s: %s",
-                      self._name, self._input)
-        _LOGGER.debug("Using the base URL for %s: %s",
-                      self._name, self._base_url)
-        _LOGGER.debug("Using the device URL for %s: %s",
-                      self._name, device_url)
-        _LOGGER.debug("WSDL for %s: %s",
-                      self._name, wsdl)
-        _LOGGER.debug("Login details for %s: %s %s",
-                      self._name, self._username, self._password)
 
     @asyncio.coroutine
     def async_camera_image(self):

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -9,7 +9,8 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import (CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_PORT)
+from homeassistant.const import (CONF_NAME, CONF_USERNAME,
+    CONF_PASSWORD, CONF_PORT)
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.components.ffmpeg import (
     DATA_FFMPEG, CONF_INPUT, CONF_EXTRA_ARGUMENTS)
@@ -19,7 +20,11 @@ from homeassistant.helpers.aiohttp_client import (
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['onvif-py3==0.1.3','suds-py3==1.3.3.0','http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a']
+REQUIREMENTS = ['onvif-py3==0.1.3', 
+    'suds-py3==1.3.3.0', 
+    'http://github.com/tgaugry/suds-passworddigest-py3'
+    '/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip'
+    '#suds-passworddigest-py3==0.1.2a']
 DEPENDENCIES = ['ffmpeg']
 DEFAULT_NAME = 'ONVIF Camera'
 DEFAULT_PORT = 5000
@@ -62,20 +67,19 @@ class ONVIFCamera(Camera):
         device_url = self._base_url + 'onvif/device_service'
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)
-        media = ONVIFService(device_url,self._username, self._password, wsdl + 'media.wsdl')
-        media_profile = media.GetProfiles()[0]
+        media = ONVIFService(device_url,self._username, 
+            self._password, wsdl + 'media.wsdl')
         self._input = media.GetStreamUri().Uri
         _LOGGER.debug("Using the following URL for %s: %s",
-                     self._name, self._input)
+                       self._name, self._input)
         _LOGGER.debug("Using the base URL for %s: %s",
-                     self._name, self._base_url)
+                       self._name, self._base_url)
         _LOGGER.debug("Using the device URL for %s: %s",
-                     self._name, device_url)
+                       self._name, device_url)
         _LOGGER.debug("WSDL for %s: %s",
-                     self._name, wsdl)
+                       self._name, wsdl)
         _LOGGER.debug("Login details for %s: %s %s",
-                     self._name, self._username, self._password)
-
+                       self._name, self._username, self._password)
 
     @asyncio.coroutine
     def async_camera_image(self):

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -60,7 +60,7 @@ class ONVIFCamera(Camera):
 
         self._name = config.get(CONF_NAME)
         self._ffmpeg_arguments = config.get(CONF_FFMPEG_ARGUMENTS)
-        media = ONVIFService('http://{}:{}/'.format(config.get(CONF_HOST), 
+        media = ONVIFService('http://{}:{}/'.format(config.get(CONF_HOST),
                                                     config.get(CONF_PORT))
                              + 'onvif/device_service',
                              config.get(CONF_USERNAME),
@@ -74,7 +74,8 @@ class ONVIFCamera(Camera):
     def async_camera_image(self):
         """Return a still image response from the camera."""
         from haffmpeg import ImageFrame, IMAGE_JPEG
-        ffmpeg = ImageFrame(self.hass.data[DATA_FFMPEG].binary, loop=self.hass.loop)
+        ffmpeg = ImageFrame(self.hass.data[DATA_FFMPEG].binary,
+                            loop=self.hass.loop)
 
         image = yield from ffmpeg.get_image(
             self._input, output_format=IMAGE_JPEG,
@@ -86,7 +87,8 @@ class ONVIFCamera(Camera):
         """Generate an HTTP MJPEG stream from the camera."""
         from haffmpeg import CameraMjpeg
 
-        stream = CameraMjpeg(self.hass.data[DATA_FFMPEG].binary, loop=self.hass.loop)
+        stream = CameraMjpeg(self.hass.data[DATA_FFMPEG].binary,
+                             loop=self.hass.loop)
         yield from stream.open_camera(
             self._input, extra_cmd=self._ffmpeg_arguments)
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -30,11 +30,9 @@ DEFAULT_NAME = 'ONVIF Camera'
 DEFAULT_PORT = 5000
 DEFAULT_USERNAME = 'admin'
 DEFAULT_PASSWORD = '888888'
-DEFAULT_FFMPEG_ARGUMENTS = '-q:v 2'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_FFMPEG_ARGUMENTS, default=DEFAULT_FFMPEG_ARGUMENTS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
@@ -59,7 +57,7 @@ class ONVIFCamera(Camera):
         super().__init__()
 
         self._name = config.get(CONF_NAME)
-        self._ffmpeg_arguments = config.get(CONF_FFMPEG_ARGUMENTS)
+        self._ffmpeg_arguments = '-q:v 2'
         media = ONVIFService('http://{}:{}/'.format(config.get(CONF_HOST),
                                                     config.get(CONF_PORT))
                              + 'onvif/device_service',

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -10,8 +10,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.const import (
-                                CONF_NAME, CONF_USERNAME,
-                                CONF_PASSWORD, CONF_PORT)
+    CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_PORT)
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.components.ffmpeg import (
     DATA_FFMPEG, CONF_INPUT, CONF_EXTRA_ARGUMENTS)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -267,6 +267,9 @@ hikvision==0.4
 # homeassistant.components.binary_sensor.workday
 holidays==0.8.1
 
+# homeassistant.components.camera.onvif
+http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a
+
 # homeassistant.components.switch.rachio
 https://github.com/Klikini/rachiopy/archive/2c8996fcfa97a9f361a789e0c998797ed2805281.zip#rachiopy==0.1.1
 
@@ -405,6 +408,9 @@ oemthermostat==1.1
 
 # homeassistant.components.media_player.onkyo
 onkyo-eiscp==1.1
+
+# homeassistant.components.camera.onvif
+onvif-py3==0.1.3
 
 # homeassistant.components.sensor.openevse
 openevsewifi==0.4
@@ -832,6 +838,9 @@ statsd==3.2.1
 
 # homeassistant.components.sensor.steam_online
 steamodd==4.21
+
+# homeassistant.components.camera.onvif
+suds-py3==1.3.3.0
 
 # homeassistant.components.binary_sensor.tapsaff
 tapsaff==0.1.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -21,7 +21,7 @@ freezegun>=0.3.8
 
 
 # homeassistant.components.notify.html5
-PyJWT==1.4.2
+PyJWT==1.5.0
 
 # homeassistant.components.media_player.sonos
 SoCo==0.12
@@ -37,7 +37,7 @@ aiohttp_cors==0.5.3
 apns2==0.1.1
 
 # homeassistant.components.sensor.dsmr
-dsmr_parser==0.9
+dsmr_parser==0.8
 
 # homeassistant.components.climate.honeywell
 evohomeclient==0.2.5
@@ -101,7 +101,10 @@ pynx584==0.4
 python-forecastio==1.3.5
 
 # homeassistant.components.notify.html5
-pywebpush==1.0.0
+pywebpush==1.0.4
+
+# homeassistant.components.python_script
+restrictedpython==4.0a2
 
 # homeassistant.components.rflink
 rflink==0.0.34

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -21,7 +21,7 @@ freezegun>=0.3.8
 
 
 # homeassistant.components.notify.html5
-PyJWT==1.5.0
+PyJWT==1.4.2
 
 # homeassistant.components.media_player.sonos
 SoCo==0.12
@@ -37,7 +37,7 @@ aiohttp_cors==0.5.3
 apns2==0.1.1
 
 # homeassistant.components.sensor.dsmr
-dsmr_parser==0.8
+dsmr_parser==0.9
 
 # homeassistant.components.climate.honeywell
 evohomeclient==0.2.5
@@ -101,10 +101,7 @@ pynx584==0.4
 python-forecastio==1.3.5
 
 # homeassistant.components.notify.html5
-pywebpush==1.0.4
-
-# homeassistant.components.python_script
-restrictedpython==4.0a2
+pywebpush==1.0.0
 
 # homeassistant.components.rflink
 rflink==0.0.34


### PR DESCRIPTION
## Description:
Added support for ONVIF IP camera's. This discovers the stream url via ONVIF.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2794

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
    platform: onvif
    host: 192.168.1.111
    name: onviftest
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

