### PR TITLE
test that all lights turn off when no entity id is given

### DIFF
--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -71,6 +71,15 @@ class TestDemoLight(unittest.TestCase):
         self.hass.block_till_done()
         self.assertFalse(light.is_on(self.hass, ENTITY_LIGHT))
 
+    def test_turn_off_without_entity_id(self):
+        """Test light turn off all lights."""
+        light.turn_on(self.hass, ENTITY_LIGHT)
+        self.hass.block_till_done()
+        self.assertTrue(light.is_on(self.hass, ENTITY_LIGHT))
+        light.turn_off(self.hass)
+        self.hass.block_till_done()
+        self.assertFalse(light.is_on(self.hass, ENTITY_LIGHT))
+
 
 @asyncio.coroutine
 def test_restore_state(hass):


### PR DESCRIPTION
## Description:

This is to add a test to assert that the `lights.turn_off` service will turn off all lights when an `entity_id` is not given.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
Here's the PR to correct the documentation: https://github.com/home-assistant/home-assistant.github.io/pull/2795

## Example entry for `configuration.yaml` (if applicable):
```yaml
- id: test automation
  alias: test automatin
  trigger:
    platform: time
    at: '23:00:00'
  action:
    service: light.turn_off
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
