### PR TITLE
entity_id for service fan.turn_off is optional

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -73,7 +73,7 @@ FAN_TURN_ON_SCHEMA = vol.Schema({
 })  # type: dict
 
 FAN_TURN_OFF_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_ids
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
 })  # type: dict
 
 FAN_OSCILLATE_SCHEMA = vol.Schema({
@@ -140,7 +140,9 @@ def turn_on(hass, entity_id: str=None, speed: str=None) -> None:
 def turn_off(hass, entity_id: str=None) -> None:
     """Turn all or specified fan off."""
     data = {
-        ATTR_ENTITY_ID: entity_id,
+        key: value for key, value in [
+            (ATTR_ENTITY_ID, entity_id),
+        ] if value is not None
     }
 
     hass.services.call(DOMAIN, SERVICE_TURN_OFF, data)

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -139,11 +139,7 @@ def turn_on(hass, entity_id: str=None, speed: str=None) -> None:
 
 def turn_off(hass, entity_id: str=None) -> None:
     """Turn all or specified fan off."""
-    data = {
-        key: value for key, value in [
-            (ATTR_ENTITY_ID, entity_id),
-        ] if value is not None
-    }
+    data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
 
     hass.services.call(DOMAIN, SERVICE_TURN_OFF, data)
 

--- a/tests/components/fan/test_demo.py
+++ b/tests/components/fan/test_demo.py
@@ -55,6 +55,18 @@ class TestDemoFan(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(STATE_OFF, self.get_entity().state)
 
+    def test_turn_off_without_entity_id(self):
+        """Test turning off all fans."""
+        self.assertEqual(STATE_OFF, self.get_entity().state)
+
+        fan.turn_on(self.hass, FAN_ENTITY_ID)
+        self.hass.block_till_done()
+        self.assertNotEqual(STATE_OFF, self.get_entity().state)
+
+        fan.turn_off(self.hass)
+        self.hass.block_till_done()
+        self.assertEqual(STATE_OFF, self.get_entity().state)
+
     def test_set_direction(self):
         """Test setting the direction of the device."""
         self.assertEqual(STATE_OFF, self.get_entity().state)


### PR DESCRIPTION
## Description:
The `entity_id` for the `fan.turn_off` service should be optional. Given an `entity_id` the service will turn off the specified entity. Without an `entity_id` the service will turn off all fans.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
- id: test automation
  alias: test automatin
  trigger:
    platform: time
    at: '23:00:00'
  action:
    service: fan.turn_off
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
