### PR TITLE
Update mailgun

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -77,6 +77,9 @@ omit =
     homeassistant/components/lutron_caseta.py
     homeassistant/components/*/lutron_caseta.py
 
+    homeassistant/components/mailgun.py
+    homeassistant/components/*/mailgun.py
+
     homeassistant/components/modbus.py
     homeassistant/components/*/modbus.py
 
@@ -347,7 +350,6 @@ omit =
     homeassistant/components/notify/kodi.py
     homeassistant/components/notify/lannouncer.py
     homeassistant/components/notify/llamalab_automate.py
-    homeassistant/components/notify/mailgun.py
     homeassistant/components/notify/matrix.py
     homeassistant/components/notify/message_bird.py
     homeassistant/components/notify/nfandroidtv.py

--- a/homeassistant/components/mailgun.py
+++ b/homeassistant/components/mailgun.py
@@ -1,0 +1,51 @@
+"""
+Support for Mailgun.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/mailgun/
+"""
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_API_KEY, CONF_DOMAIN
+from homeassistant.core import callback
+from homeassistant.components.http import HomeAssistantView
+
+
+DOMAIN = 'mailgun'
+API_PATH = '/api/{}'.format(DOMAIN)
+DATA_MAILGUN = DOMAIN
+DEPENDENCIES = ['http']
+MESSAGE_RECEIVED = '{}_message_received'.format(DOMAIN)
+CONF_SANDBOX = 'sandbox'
+DEFAULT_SANDBOX = False
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_API_KEY): cv.string,
+        vol.Required(CONF_DOMAIN): cv.string,
+        vol.Optional(CONF_SANDBOX, default=DEFAULT_SANDBOX): cv.boolean
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Set up the Mailgun component."""
+    hass.data[DATA_MAILGUN] = config[DOMAIN]
+    hass.http.register_view(MailgunReceiveMessageView())
+    return True
+
+
+class MailgunReceiveMessageView(HomeAssistantView):
+    """Handle data from Mailgun inbound messages."""
+
+    url = API_PATH
+    name = 'api:{}'.format(DOMAIN)
+
+    @callback
+    def post(self, request):  # pylint: disable=no-self-use
+        """Handle Mailgun message POST."""
+        hass = request.app['hass']
+        data = yield from request.post()
+        hass.bus.async_fire(MESSAGE_RECEIVED, dict(data))
+        return

--- a/homeassistant/components/notify/mailgun.py
+++ b/homeassistant/components/notify/mailgun.py
@@ -8,40 +8,37 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.mailgun import CONF_SANDBOX, DATA_MAILGUN
 from homeassistant.components.notify import (
     PLATFORM_SCHEMA, BaseNotificationService, ATTR_TITLE, ATTR_TITLE_DEFAULT,
     ATTR_DATA)
 from homeassistant.const import (
-    CONF_TOKEN, CONF_DOMAIN, CONF_RECIPIENT, CONF_SENDER)
-import homeassistant.helpers.config_validation as cv
+    CONF_API_KEY, CONF_DOMAIN, CONF_RECIPIENT, CONF_SENDER)
 
 _LOGGER = logging.getLogger(__name__)
 
+DEPENDENCIES = ['mailgun']
 REQUIREMENTS = ['pymailgunner==1.4']
 
 # Images to attach to notification
 ATTR_IMAGES = 'images'
-
-CONF_SANDBOX = 'sandbox'
 
 DEFAULT_SENDER = 'hass@{domain}'
 DEFAULT_SANDBOX = False
 
 # pylint: disable=no-value-for-parameter
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_TOKEN): cv.string,
     vol.Required(CONF_RECIPIENT): vol.Email(),
-    vol.Optional(CONF_DOMAIN): cv.string,
-    vol.Optional(CONF_SENDER): vol.Email(),
-    vol.Optional(CONF_SANDBOX, default=DEFAULT_SANDBOX): cv.boolean,
+    vol.Optional(CONF_SENDER): vol.Email()
 })
 
 
 def get_service(hass, config, discovery_info=None):
     """Get the Mailgun notification service."""
+    data = hass.data[DATA_MAILGUN]
     mailgun_service = MailgunNotificationService(
-        config.get(CONF_DOMAIN), config.get(CONF_SANDBOX),
-        config.get(CONF_TOKEN), config.get(CONF_SENDER),
+        data.get(CONF_DOMAIN), data.get(CONF_SANDBOX),
+        data.get(CONF_API_KEY), config.get(CONF_SENDER),
         config.get(CONF_RECIPIENT))
     if mailgun_service.connection_is_valid():
         return mailgun_service
@@ -52,19 +49,19 @@ def get_service(hass, config, discovery_info=None):
 class MailgunNotificationService(BaseNotificationService):
     """Implement a notification service for the Mailgun mail service."""
 
-    def __init__(self, domain, sandbox, token, sender, recipient):
+    def __init__(self, domain, sandbox, api_key, sender, recipient):
         """Initialize the service."""
         self._client = None  # Mailgun API client
         self._domain = domain
         self._sandbox = sandbox
-        self._token = token
+        self._api_key = api_key
         self._sender = sender
         self._recipient = recipient
 
     def initialize_client(self):
         """Initialize the connection to Mailgun."""
         from pymailgunner import Client
-        self._client = Client(self._token, self._domain, self._sandbox)
+        self._client = Client(self._api_key, self._domain, self._sandbox)
         _LOGGER.debug("Mailgun domain: %s", self._client.domain)
         self._domain = self._client.domain
         if not self._sender:


### PR DESCRIPTION
## Description:

Adds a [mailgun](https://www.mailgun.com/) component. Refactored the existing mailgun notify platform to use `mailgun` component config. Further, the component supports push messages and generates events based on inbound data. To use, add a Route set to Store and Notify with a URL of the following form: `https://<domain>/api/mailgun?api_password=<password>`

This is a breaking change because the core config options have moved, and I renamed the `token` config option to `api_key`, which is more accurate per the mailgun documentation.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
mailgun:
  domain: !secret mailgun_domain
  api_key: !secret mailgun_api_key
  sandbox: False

notify:
  - name: mailgun
    platform: mailgun
    recipient: !secret mailgun_recipient
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
`script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
