### PR TITLE
Add citybikes component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -209,6 +209,7 @@ omit =
     homeassistant/components/camera/mjpeg.py
     homeassistant/components/camera/rpi_camera.py
     homeassistant/components/camera/synology.py
+    homeassistant/components/citybikes.py
     homeassistant/components/climate/eq3btsmart.py
     homeassistant/components/climate/heatmiser.py
     homeassistant/components/climate/homematic.py

--- a/homeassistant/components/citybikes.py
+++ b/homeassistant/components/citybikes.py
@@ -1,0 +1,315 @@
+"""
+CityBikes component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/citybikes/
+"""
+import logging
+import voluptuous as vol
+from datetime import timedelta
+
+import asyncio
+import aiohttp
+import async_timeout
+
+from homeassistant.const import (
+    CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE,
+    ATTR_ATTRIBUTION, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_FRIENDLY_NAME,
+    LENGTH_METERS, LENGTH_FEET)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers import event
+from homeassistant.util import location, distance, slugify, dt
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_ENDPOINT = 'https://api.citybik.es/{uri}'
+NETWORKS_URI = 'v2/networks'
+STATIONS_URI = 'v2/networks/{uid}?fields=network.stations'
+
+SCAN_INTERVAL = timedelta(seconds=15)  # Timely, and doesn't suffocate the API
+DOMAIN = 'citybikes'
+CONF_NETWORK = 'network'
+CONF_RADIUS = 'radius'
+CONF_STATIONS_LIST = 'stations'
+ATTR_NETWORK_ID = 'id'
+ATTR_STATION_ID = 'id'
+ATTR_STATION_UID = 'uid'
+ATTR_STATION_NAME = 'name'
+ATTR_EXTRA = 'extra'
+ATTR_EMPTY_SLOTS = 'empty_slots'
+ATTR_FREE_BIKES = 'free_bikes'
+ATTR_TIMESTAMP = 'timestamp'
+CITYBIKES_ATTRIBUTION = "Information provided by the CityBikes Project "\
+                        "(https://citybik.es/#about)"
+
+LOCATION_SCHEMA = vol.All(
+    cv.has_at_least_one_key(CONF_RADIUS, CONF_STATIONS_LIST),
+    vol.Schema({
+        vol.Optional(CONF_NAME, default=""): cv.string,
+        vol.Optional(CONF_NETWORK, default=""): cv.string,
+        vol.Inclusive(CONF_LATITUDE, 'coordinates'): cv.latitude,
+        vol.Inclusive(CONF_LONGITUDE, 'coordinates'): cv.longitude,
+        vol.Exclusive(CONF_RADIUS, 'station_filter'):
+            cv.positive_int,
+        vol.Exclusive(CONF_STATIONS_LIST, 'station_filter'):
+            vol.All(
+                cv.ensure_list,
+                vol.Length(min=1),
+                [cv.string])
+    }))
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.All(cv.ensure_list, [LOCATION_SCHEMA])
+}, extra=vol.ALLOW_EXTRA)
+
+NETWORK_SCHEMA = vol.Schema({
+    vol.Required('networks'): [
+        vol.Schema({
+            vol.Optional('company'): vol.All(
+                cv.ensure_list, [cv.string]),
+            vol.Required('href'): cv.string,
+            vol.Required('id'): cv.string,
+            vol.Required('name'): cv.string,
+            vol.Required('location'): vol.Schema({
+                vol.Optional('city'): cv.string,
+                vol.Optional('country'): cv.string,
+                vol.Required('latitude'): vol.Coerce(float),
+                vol.Required('longitude'): vol.Coerce(float),
+                }),
+            }, extra=vol.ALLOW_EXTRA),
+        ],
+    })
+
+STATIONS_SCHEMA = vol.Schema({
+    vol.Required('network'): vol.Schema({
+        vol.Required('stations'): [
+            vol.Schema({
+                vol.Required('free_bikes'): cv.positive_int,
+                vol.Required('empty_slots'): cv.positive_int,
+                vol.Required('latitude'): vol.Coerce(float),
+                vol.Required('longitude'): vol.Coerce(float),
+                vol.Required('id'): cv.string,
+                vol.Required('name'): cv.string,
+                vol.Required('timestamp'): cv.string,
+                vol.Optional('extra'): vol.Schema({
+                    vol.Optional('uid'): cv.string
+                    }, extra=vol.ALLOW_EXTRA)
+                }, extra=vol.ALLOW_EXTRA)
+            ]
+        }, extra=vol.ALLOW_EXTRA)
+    })
+
+@asyncio.coroutine
+def _get_closest_network_id(hass, latitude, longitude):
+    try:
+        dist = -1
+        session = async_get_clientsession(hass)
+        with async_timeout.timeout(5, loop=hass.loop):
+            req = yield from session.get(DEFAULT_ENDPOINT.format(
+                uri=NETWORKS_URI))
+        res = yield from req.json()
+        res = NETWORK_SCHEMA(res)
+        network = res['networks'][0]
+        result = network['id']
+        minimum_dist = location.distance(latitude, longitude,
+                                         network['location']['latitude'],
+                                         network['location']['longitude'])
+        for network in res['networks'][1:]:
+            dist = location.distance(latitude, longitude,
+                                     network['location']['latitude'],
+                                     network['location']['longitude'])
+            if dist < minimum_dist:
+                minimum_dist = dist
+                result = network['id']
+
+        return result
+    except (asyncio.TimeoutError, aiohttp.ClientError):
+        _LOGGER.error("Could not connect to CityBikes API endpoint")
+        return None
+    except ValueError:
+        _LOGGER.error("Received non-JSON data from CityBikes API endpoint")
+        return None
+    except vol.Invalid as err:
+        _LOGGER.error("Received unexpected JSON from CityBikes API endpoint: "
+                      " {}".format(err))
+        return None
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up the Citybikes bike sharing system component."""
+    networks = {}
+
+    for location_config in config.get(DOMAIN):
+        @asyncio.coroutine
+        def async_setup_single_network(now):
+            """Set up a single CityBikes network."""
+            network_id = location_config.get(CONF_NETWORK)
+
+            latitude = location_config.get(CONF_LATITUDE,
+                hass.config.latitude)
+            longitude = location_config.get(CONF_LONGITUDE,
+                hass.config.longitude)
+
+            if not network_id:
+                # Autodetect network from location
+                network_id = yield from _get_closest_network_id(hass,
+                    latitude, longitude)
+
+                if not network_id:
+                    # Autodetection failed - try again later
+                    one_minute_later = dt.utcnow() + timedelta(minutes=1)
+                    event.async_track_point_in_utc_time(hass,
+                        async_setup_single_network, one_minute_later)
+                    return
+
+            if network_id not in networks:
+                network = CityBikesNetwork(hass, network_id)
+                @asyncio.coroutine
+                def async_update_single_network(now):
+                    yield from network.async_update_ha_state(True)
+                    event.async_track_point_in_utc_time(
+                        hass, async_update_single_network,
+                        dt.utcnow() + SCAN_INTERVAL)
+                yield from async_update_single_network(None)
+                networks[network_id] = network
+            
+            if CONF_STATIONS_LIST in location_config:
+                networks[network_id].start_monitoring_stations(
+                    *location_config.get(CONF_STATIONS_LIST))
+            else:
+                radius = location_config.get(CONF_RADIUS)
+                networks[network_id].start_monitoring_area(latitude, longitude,
+                    radius)
+        
+        yield from async_setup_single_network(None)
+
+    return True
+
+
+class CityBikesNetwork(Entity):
+    """Representation of a bike sharing network."""
+
+    def __init__(self, hass, network_id):
+        """Initialize the Network entity."""
+        self.hass = hass
+        self._network_id = network_id
+        self._stations_data = []
+        self._stations = {}
+        self._monitored_areas = set()
+        self._monitored_stations = set()
+    
+    @property
+    def name(self):
+        return self._network_id
+
+    @property
+    def entity_id(self):
+        return "{}.{}".format(DOMAIN, slugify(self.name))
+
+    @asyncio.coroutine
+    def _fetch_stations(self):
+        try:
+            session = async_get_clientsession(self.hass)
+            with async_timeout.timeout(5, loop=self.hass.loop):
+                req = yield from session.get(DEFAULT_ENDPOINT.format(
+                    uri=STATIONS_URI.format(uid=self._network_id)))
+            res = yield from req.json()
+            res = STATIONS_SCHEMA(res)
+            self._stations_data = res.get('network').get('stations')
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            _LOGGER.error("Could not connect to CityBikes API endpoint")
+        except ValueError:
+            _LOGGER.error("Received non-JSON data from CityBikes API"
+                          " endpoint")
+        except vol.Invalid as err:
+            _LOGGER.error("Received unexpected JSON from CityBikes API"
+                          " endpoint: {}".format(err))
+
+    @asyncio.coroutine
+    def async_update(self):
+        yield from self._fetch_stations()
+        for station in self._stations_data:
+            for latitude, longitude, radius in self._monitored_areas:
+                dist = location.distance(latitude, longitude,
+                    station.get('latitude'), station.get('longitude'))
+                if dist < radius:
+                    self._add_station_entity_if_necessary(station)
+            
+            station_id = station.get('id')
+            
+            if station_id in self._monitored_stations or \
+                'extra' in station and 'uid' in station.get('extra') and \
+                station.get('extra').get('uid') in self._monitored_stations:
+                self._add_station_entity_if_necessary(station)
+            
+            if station_id in self._stations:
+                yield from self._stations[station_id].async_update_data(station)
+
+    def _add_station_entity_if_necessary(self, station):
+        entity_id = CityBikesStation.make_entity_id(self.entity_id,
+            station.get('id'))
+        if not self.hass.states.get(entity_id):
+            self._stations[station.get('id')] = CityBikesStation(self.hass,
+                self._network_id, station)
+
+    def start_monitoring_area(self, latitude, longitude, radius):
+        """Start monitoring stations in an area."""
+        self._monitored_areas.update([(latitude, longitude, radius)])
+
+    def start_monitoring_stations(self, *stations):
+        """Start monitoring specific stations."""
+        self._monitored_stations.update(stations)
+
+
+class CityBikesStation(Entity):
+    """Representation of a bike sharing station."""
+
+    @staticmethod
+    def make_entity_id(network_id, station_id):
+        return "{}.{}_{}".format(DOMAIN, network_id, station_id)
+
+    def __init__(self, hass, network_id, station_data):
+        """Initialize the Station entity."""
+        self.hass = hass
+        self._network_id = network_id
+        self._station_data = station_data
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def name(self):
+        return self._station_data.get('name')
+
+    @property
+    def entity_id(self):
+        return CityBikesStation.make_entity_id(self._network_id,
+            self._station_data.get('id'))
+
+    @property
+    def state(self):
+        return self._station_data.get(ATTR_FREE_BIKES)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return dict({ATTR_ATTRIBUTION: CITYBIKES_ATTRIBUTION},
+            **self._station_data)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return 'bikes'
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return 'mdi:bike'
+    
+    @asyncio.coroutine
+    def async_update_data(self, station_data):
+        self._station_data = station_data
+        yield from self.async_update_ha_state()

--- a/homeassistant/components/citybikes.py
+++ b/homeassistant/components/citybikes.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import (
     async_track_time_interval, async_track_point_in_utc_time)
 from homeassistant.util import location, dt, slugify

--- a/homeassistant/components/citybikes.py
+++ b/homeassistant/components/citybikes.py
@@ -149,9 +149,9 @@ def async_setup(hass, config):
             network_id = location_config.get(CONF_NETWORK)
 
             latitude = location_config.get(CONF_LATITUDE,
-                hass.config.latitude)
+                                           hass.config.latitude)
             longitude = location_config.get(CONF_LONGITUDE,
-                hass.config.longitude)
+                                            hass.config.longitude)
 
             if not network_id:
                 # Autodetect network from location
@@ -167,12 +167,14 @@ def async_setup(hass, config):
 
             if network_id not in networks:
                 network = CityBikesNetwork(hass, network_id)
+                
                 @asyncio.coroutine
                 def async_update_single_network(now):
                     yield from network.async_update_ha_state(True)
                     event.async_track_point_in_utc_time(
                         hass, async_update_single_network,
                         dt.utcnow() + SCAN_INTERVAL)
+                
                 yield from async_update_single_network(None)
                 networks[network_id] = network
             

--- a/homeassistant/components/citybikes.py
+++ b/homeassistant/components/citybikes.py
@@ -16,11 +16,10 @@ from homeassistant.const import (
     CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE,
     ATTR_ATTRIBUTION, ATTR_LOCATION, ATTR_LATITUDE, ATTR_LONGITUDE)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.entity_compoonent import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     async_track_time_interval, async_track_point_in_utc_time)
-from homeassistant.util import location, slugify, dt
+from homeassistant.util import location, dt
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -206,7 +205,7 @@ class CityBikesNetwork:
                     uri=STATIONS_URI.format(uid=self._network_id)))
 
             json_response = yield from req.json()
-            network = STATIONS_RESPONSE_SCHEMA(response)
+            network = STATIONS_RESPONSE_SCHEMA(json_response)
             self._stations_data = network[ATTR_NETWORK][ATTR_STATIONS_LIST]
 
         except (asyncio.TimeoutError, aiohttp.ClientError):
@@ -232,8 +231,9 @@ class CityBikesNetwork:
             station_id = station[ATTR_ID]
 
             if station_id in self._monitored_stations or \
-                ATTR_EXTRA in station and ATTR_UID in station[ATTR_EXTRA] and \
-                station[ATTR_EXTRA][ATTR_UID] in self._monitored_stations:
+                    ATTR_EXTRA in station and \
+                    ATTR_UID in station[ATTR_EXTRA] and \
+                    station[ATTR_EXTRA][ATTR_UID] in self._monitored_stations:
                 self._add_station_entity_if_necessary(station)
 
             if station_id in self._stations:

--- a/homeassistant/components/citybikes.py
+++ b/homeassistant/components/citybikes.py
@@ -155,8 +155,8 @@ def async_setup(hass, config):
 
             if not network_id:
                 # Autodetect network from location
-                network_id = yield from _get_closest_network_id(hass,
-                    latitude, longitude)
+                network_id = yield from _get_closest_network_id(hass, latitude,
+                                                                longitude)
 
                 if not network_id:
                     # Autodetection failed - try again later
@@ -174,18 +174,18 @@ def async_setup(hass, config):
                     event.async_track_point_in_utc_time(
                         hass, async_update_single_network,
                         dt.utcnow() + SCAN_INTERVAL)
-                
+
                 yield from async_update_single_network(None)
                 networks[network_id] = network
-            
+
             if CONF_STATIONS_LIST in location_config:
                 networks[network_id].start_monitoring_stations(
                     *location_config.get(CONF_STATIONS_LIST))
             else:
                 radius = location_config.get(CONF_RADIUS)
                 networks[network_id].start_monitoring_area(latitude, longitude,
-                    radius)
-        
+                                                           radius)
+
         yield from async_setup_single_network(None)
 
     return True

--- a/homeassistant/components/citybikes.py
+++ b/homeassistant/components/citybikes.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     async_track_time_interval, async_track_point_in_utc_time)
-from homeassistant.util import location, dt
+from homeassistant.util import location, dt, slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -269,7 +269,7 @@ class CityBikesStation(Entity):
     @staticmethod
     def make_entity_id(network_id, station_id):
         """Generate an entity ID."""
-        return "{}.{}_{}".format(DOMAIN, network_id, station_id)
+        return "{}.{}_{}".format(DOMAIN, slugify(network_id), station_id)
 
     def __init__(self, hass, network_id, station_data):
         """Initialize the Station entity."""

--- a/homeassistant/components/citybikes.py
+++ b/homeassistant/components/citybikes.py
@@ -5,13 +5,12 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/citybikes/
 """
 import logging
-import voluptuous as vol
-from datetime import timedelta
-
 import asyncio
 import aiohttp
 import async_timeout
+import voluptuous as vol
 
+from datetime import timedelta
 from homeassistant.const import (
     CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE,
     ATTR_ATTRIBUTION, ATTR_LOCATION, ATTR_LATITUDE, ATTR_LONGITUDE)
@@ -132,7 +131,7 @@ def _get_closest_network_id(hass, latitude, longitude):
         return None
     except vol.Invalid as err:
         _LOGGER.error("Received unexpected JSON from CityBikes API endpoint: "
-                      " {}".format(err))
+                      " %s", err)
         return None
 
 
@@ -214,7 +213,7 @@ class CityBikesNetwork:
                           " endpoint")
         except vol.Invalid as err:
             _LOGGER.error("Received unexpected JSON from CityBikes API"
-                          " endpoint: {}".format(err))
+                          " endpoint: %s", err)
 
     @asyncio.coroutine
     def async_update(self, now):
@@ -230,7 +229,7 @@ class CityBikesNetwork:
                                          station.get(ATTR_LATITUDE),
                                          station.get(ATTR_LONGITUDE))
                 if dist < radius:
-                    self._add_station_entity_if_necessary(station)
+                    self._add_station_entity(station)
 
             station_id = station[ATTR_ID]
 
@@ -238,13 +237,13 @@ class CityBikesNetwork:
                     ATTR_EXTRA in station and \
                     ATTR_UID in station[ATTR_EXTRA] and \
                     station[ATTR_EXTRA][ATTR_UID] in self._monitored_stations:
-                self._add_station_entity_if_necessary(station)
+                self._add_station_entity(station)
 
             if station_id in self._stations:
                 yield from self._stations[station_id].async_update_data(
                     station)
 
-    def _add_station_entity_if_necessary(self, station):
+    def _add_station_entity(self, station):
         entity_id = CityBikesStation.make_entity_id(self._network_id,
                                                     station[ATTR_ID])
         if not self.hass.states.get(entity_id):

--- a/homeassistant/components/citybikes.py
+++ b/homeassistant/components/citybikes.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import (
     async_track_time_interval, async_track_point_in_utc_time)
 from homeassistant.util import location, dt, slugify
@@ -103,7 +104,6 @@ STATIONS_RESPONSE_SCHEMA = vol.Schema({
 @asyncio.coroutine
 def _get_closest_network_id(hass, latitude, longitude):
     try:
-        dist = -1
         session = async_get_clientsession(hass)
         with async_timeout.timeout(5, loop=hass.loop):
             req = yield from session.get(DEFAULT_ENDPOINT.format(

--- a/homeassistant/components/citybikes.py
+++ b/homeassistant/components/citybikes.py
@@ -5,12 +5,13 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/citybikes/
 """
 import logging
+from datetime import timedelta
+
 import asyncio
 import aiohttp
 import async_timeout
 import voluptuous as vol
 
-from datetime import timedelta
 from homeassistant.const import (
     CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE, EVENT_TIME_CHANGED,
     ATTR_ATTRIBUTION, ATTR_LOCATION, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_NOW)


### PR DESCRIPTION
_Conversion of the CityBikes platform (home-assistant/home-assistant#7914) into a component_
## Description:

[CityBikes](https://citybik.es/#about) is an open API platform, that provides data about bike sharing systems around the world. It allows real-time monitoring of bike availability at bike sharing stations.

This component connects the CityBikes API to home assistant, opening up the possibilities for advanced automations, such as recommending the user a bike sharing station based on the amount of bikes available, upon leaving the house.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** _To be updated, once we decide on whether to use the component or the platform version_

## Example entry for `configuration.yaml` (if applicable):
```yaml
citybikes:
  - name: Home Stations
    # HASS instance location is the default location
    radius: 500

  - name: Work Stations
    latitude: [xxx]
    longitude: [yyy]
    radius: 600

  - name: Extra Stations
    network: [another_bike_sharing_network]
    stations:
      - [station ID 1]
      - [station ID 2]
      - ...
```

## Additional Considerations:

1. I haven't had a chance to add the imperial to metric conversion present in the platform PR, I'll port it ASAP.
2. Another option for making such a configuration would be making several `citybikes` entries, one per location (using `config_per_platform` helper), instead of using a list under one `citybikes` entry. What do you think?
3. I chose to access the API directly here, instead of using a Python library, since I wanted to make the component asynchronous. When I have the time, I'll wrap that in a code and either create a new async library, or, if possible, incorporate the async code into the existing library (the main issue would be to maintain Python 2.7 compatibility) [_Edit: Not gonna happen. The library isn't written in a way that would support both async and regular approaches. Making a copy of every object there with async decorations feels like the worst kind of code reuse._].

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.