### PR TITLE
telegram_bot bug: `last_name` account field is optional

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -543,9 +543,10 @@ class BaseTelegramBotEntity:
 
         data = {
             ATTR_USER_ID: msg_data['from']['id'],
-            ATTR_FROM_FIRST: msg_data['from']['first_name'],
-            ATTR_FROM_LAST: msg_data['from']['last_name']
+            ATTR_FROM_FIRST: msg_data['from']['first_name']
         }
+        if 'last_name' in msg_data['from']:
+            data[ATTR_FROM_LAST] = msg_data['from']['last_name']
         if 'chat' in msg_data:
             data[ATTR_CHAT_ID] = msg_data['chat']['id']
 


### PR DESCRIPTION
## Description:

Because it is optional to define a 'last_name' in a telegram account, Home Assistant users have reported KeyErrors when receiving messages from these accounts, so: **make optional the `last_name` field**.

**Related issue (if applicable):** fixes partially #7938 (for some users like: https://github.com/home-assistant/home-assistant/issues/7938#issuecomment-307357069