### PR TITLE
Upgrade py-cpuinfo to 3.3.0

### DIFF
--- a/homeassistant/components/sensor/cpuspeed.py
+++ b/homeassistant/components/sensor/cpuspeed.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['py-cpuinfo==3.2.0']
+REQUIREMENTS = ['py-cpuinfo==3.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -473,7 +473,7 @@ pwaqi==3.0
 pwmled==1.1.1
 
 # homeassistant.components.sensor.cpuspeed
-py-cpuinfo==3.2.0
+py-cpuinfo==3.3.0
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13


### PR DESCRIPTION
3.3.0
------
* subprocess.Popen breaks under Windows GUI app
* Fails to parse invalid CPUID result.

Tested with the following configuration:

``` yaml
sensor:
  - platform: cpuspeed
    name: CPU
```