### PR TITLE
dismiss service for persistent notifications

### DIFF
--- a/homeassistant/components/persistent_notification.py
+++ b/homeassistant/components/persistent_notification.py
@@ -70,11 +70,7 @@ def async_create(hass, message, title=None, notification_id=None):
 @callback
 def async_dismiss(hass, notification_id):
     """Remove a notification."""
-    data = {
-        key: value for key, value in [
-            (ATTR_NOTIFICATION_ID, notification_id),
-        ]
-    }
+    data = {ATTR_NOTIFICATION_ID: notification_id}
 
     hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_DISMISS, data))
 

--- a/homeassistant/components/persistent_notification.py
+++ b/homeassistant/components/persistent_notification.py
@@ -26,11 +26,16 @@ DOMAIN = 'persistent_notification'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 SERVICE_CREATE = 'create'
+SERVICE_DISMISS = 'dismiss'
 
 SCHEMA_SERVICE_CREATE = vol.Schema({
     vol.Required(ATTR_MESSAGE): cv.template,
     vol.Optional(ATTR_TITLE): cv.template,
     vol.Optional(ATTR_NOTIFICATION_ID): cv.string,
+})
+
+SCHEMA_SERVICE_DISMISS = vol.Schema({
+    vol.Required(ATTR_NOTIFICATION_ID): cv.string,
 })
 
 
@@ -41,6 +46,11 @@ _LOGGER = logging.getLogger(__name__)
 def create(hass, message, title=None, notification_id=None):
     """Generate a notification."""
     hass.add_job(async_create, hass, message, title, notification_id)
+
+
+def dismiss(hass, notification_id):
+    """Remove a notification."""
+    hass.add_job(async_dismiss, hass, notification_id)
 
 
 @callback
@@ -55,6 +65,18 @@ def async_create(hass, message, title=None, notification_id=None):
     }
 
     hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_CREATE, data))
+
+
+@callback
+def async_dismiss(hass, notification_id):
+    """Remove a notification."""
+    data = {
+        key: value for key, value in [
+            (ATTR_NOTIFICATION_ID, notification_id),
+        ]
+    }
+
+    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_DISMISS, data))
 
 
 @asyncio.coroutine
@@ -92,12 +114,25 @@ def async_setup(hass, config):
 
         hass.states.async_set(entity_id, message, attr)
 
+    @callback
+    def dismiss_service(call):
+        """Handle the dismiss notification service call."""
+        notification_id = call.data.get(ATTR_NOTIFICATION_ID)
+        entity_id = ENTITY_ID_FORMAT.format(slugify(notification_id))
+
+        hass.states.async_remove(entity_id)
+
     descriptions = yield from hass.async_add_job(
         load_yaml_config_file, os.path.join(
             os.path.dirname(__file__), 'services.yaml')
     )
+
     hass.services.async_register(DOMAIN, SERVICE_CREATE, create_service,
                                  descriptions[DOMAIN][SERVICE_CREATE],
                                  SCHEMA_SERVICE_CREATE)
+
+    hass.services.async_register(DOMAIN, SERVICE_DISMISS, dismiss_service,
+                                 descriptions[DOMAIN][SERVICE_DISMISS],
+                                 SCHEMA_SERVICE_DISMISS)
 
     return True

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -72,6 +72,14 @@ persistent_notification:
       notification_id:
         description: Target ID of the notification, will replace a notification with the same Id. [Optional]
         example: 1234
+        
+  dismiss:
+    description: Remove a notification from the frontend
+
+    fields:
+      notification_id:
+        description: Target ID of the notification, which should be removed. [Required]
+        example: 1234
 
 homematic:
   virtualkey:

--- a/tests/components/test_persistent_notification.py
+++ b/tests/components/test_persistent_notification.py
@@ -64,3 +64,16 @@ class TestPersistentNotification:
         state = self.hass.states.get(entity_ids[0])
         assert state.state == '{{ message + 1 }}'
         assert state.attributes.get('title') == '{{ title + 1 }}'
+
+    def test_dismiss_notification(self):
+        """Ensure removal of specific notification."""
+        assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0
+
+        pn.create(self.hass, 'test', notification_id='Beer 2')
+        self.hass.block_till_done()
+
+        assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 1
+        pn.dismiss(self.hass, notification_id='Beer 2')
+        self.hass.block_till_done()
+
+        assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0


### PR DESCRIPTION
## Description:
Unnecessary notifications can now be removed automatically. Added a
dismiss service to remove persistent notifications via script and/or
automation.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://community.home-assistant.io/t/programmatically-dismissing-a-persistent-notification/10968

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2693

## Example entry for `configuration.yaml` (if applicable):
```yaml
it rather concerns scripts and automations
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
https://github.com/home-assistant/home-assistant.github.io/pull/2693

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

[ex-requir]:
[ex-import]: