### PR TITLE
Add Gitter.im sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -406,6 +406,7 @@ omit =
     homeassistant/components/sensor/fixer.py
     homeassistant/components/sensor/fritzbox_callmonitor.py
     homeassistant/components/sensor/fritzbox_netmonitor.py
+    homeassistant/components/sensor/gitter.py
     homeassistant/components/sensor/glances.py
     homeassistant/components/sensor/google_travel_time.py
     homeassistant/components/sensor/gpsd.py

--- a/homeassistant/components/sensor/gitter.py
+++ b/homeassistant/components/sensor/gitter.py
@@ -1,0 +1,103 @@
+"""
+Support for displaying details about a Gitter.im chat room.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.gitter/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME, CONF_API_KEY
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['gitterpy==0.1.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_MENTION = 'mention'
+ATTR_ROOM = 'room'
+ATTR_USERNAME = 'username'
+
+CONF_ROOM = 'room'
+
+DEFAULT_NAME = 'Gitter messages'
+DEFAULT_ROOM = 'home-assistant/home-assistant'
+
+ICON = 'mdi:message-settings-variant'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_ROOM, default=DEFAULT_ROOM): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Gitter sensor."""
+    from gitterpy.client import GitterClient
+    from gitterpy.errors import GitterTokenError
+
+    name = config.get(CONF_NAME)
+    api_key = config.get(CONF_API_KEY)
+    room = config.get(CONF_ROOM)
+
+    gitter = GitterClient(api_key)
+    try:
+        username = gitter.auth.get_my_id['name']
+    except GitterTokenError:
+        _LOGGER.error("Token is not valid")
+        return False
+
+    add_devices([GitterSensor(gitter, room, name, username)], True)
+
+
+class GitterSensor(Entity):
+    """Representation of a Gitter sensor."""
+
+    def __init__(self, data, room, name, username):
+        """Initialize the sensor."""
+        self._name = name
+        self._data = data
+        self._room = room
+        self._username = username
+        self._state = None
+        self._mention = 0
+        self._unit_of_measurement = 'Msg'
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit_of_measurement
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_USERNAME: self._username,
+            ATTR_ROOM: self._room,
+            ATTR_MENTION: self._mention,
+        }
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return ICON
+
+    def update(self):
+        """Get the latest data and updates the state."""
+        data = self._data.user.unread_items(self._room)
+        self._mention = len(data['mention'])
+        self._state = len(data['chat'])

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -231,6 +231,9 @@ gTTS-token==1.1.1
 # homeassistant.components.device_tracker.bluetooth_le_tracker
 # gattlib==0.20150805
 
+# homeassistant.components.sensor.gitter
+gitterpy==0.1.5
+
 # homeassistant.components.notify.gntp
 gntp==1.0.3
 


### PR DESCRIPTION
## Description:


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2800

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: gitter
    api_key: aferfSdss80980effsdfafröljlgkjoier793j838fjjfj
    room: home-assistant/hassio
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
