### PR TITLE
Add online tracking

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -103,7 +103,7 @@ def is_on(hass: HomeAssistantType, entity_id: str=None):
 def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
         host_name: str=None, location_name: str=None,
         gps: GPSType=None, gps_accuracy=None,
-        battery=None, attributes: dict=None):
+        battery=None, attributes: dict=None, source_type: str=None):
     """Call service to notify you see device."""
     data = {key: value for key, value in
             ((ATTR_MAC, mac),
@@ -112,7 +112,8 @@ def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
              (ATTR_LOCATION_NAME, location_name),
              (ATTR_GPS, gps),
              (ATTR_GPS_ACCURACY, gps_accuracy),
-             (ATTR_BATTERY, battery)) if value is not None}
+             (ATTR_BATTERY, battery),
+             (ATTR_SOURCE_TYPE, source_type)) if value is not None}
     if attributes:
         data[ATTR_ATTRIBUTES] = attributes
     hass.services.call(DOMAIN, SERVICE_SEE, data)
@@ -208,7 +209,8 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
         """Service to see a device."""
         args = {key: value for key, value in call.data.items() if key in
                 (ATTR_MAC, ATTR_DEV_ID, ATTR_HOST_NAME, ATTR_LOCATION_NAME,
-                 ATTR_GPS, ATTR_GPS_ACCURACY, ATTR_BATTERY, ATTR_ATTRIBUTES)}
+                 ATTR_GPS, ATTR_GPS_ACCURACY, ATTR_BATTERY, ATTR_ATTRIBUTES,
+                 ATTR_SOURCE_TYPE)}
         yield from tracker.async_see(**args)
 
     descriptions = yield from hass.async_add_job(

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -63,6 +63,7 @@ CONF_AWAY_HIDE = 'hide_if_away'
 DEFAULT_AWAY_HIDE = False
 
 EVENT_NEW_DEVICE = 'device_tracker_new_device'
+EVENT_DEVICE_SEEN_ONLINE = 'device_tracker_seen_online'
 
 SERVICE_SEE = 'see'
 
@@ -483,6 +484,12 @@ class Device(Entity):
             self._attributes.update(attributes)
 
         self.gps = None
+
+        if source_type == SOURCE_TYPE_ROUTER:
+            self.hass.bus.async_fire(EVENT_DEVICE_SEEN_ONLINE, {
+                ATTR_DEV_ID: self.dev_id,
+                ATTR_MAC: self.mac
+            })
 
         if gps is not None:
             try:

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -496,10 +496,11 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         }
 
     def test_seen_online_event_fired(self):
-        """Tests the firing of the EVENT_DEVICE_SEEN_ONLINE event.
+        """Test the firing of the EVENT_DEVICE_SEEN_ONLINE event.
 
         Verifies that the device tracker fires the event each time
-        a device is seen, including the initial time."""
+        a device is seen, including the initial time.
+        """
         with assert_setup_component(1, device_tracker.DOMAIN):
             assert setup_component(self.hass, device_tracker.DOMAIN,
                                    TEST_PLATFORM)
@@ -530,10 +531,11 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         }
 
     def test_seen_online_event_not_fired(self):
-        """Tests the firing of the EVENT_DEVICE_SEEN_ONLINE event.
+        """Test the firing of the EVENT_DEVICE_SEEN_ONLINE event.
 
         Verifies that the device tracker does not fire the event when
-        the source is not a ROUTER."""
+        the source is not a ROUTER.
+        """
         with assert_setup_component(1, device_tracker.DOMAIN):
             assert setup_component(self.hass, device_tracker.DOMAIN,
                                    TEST_PLATFORM)

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -495,6 +495,66 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             'host_name': 'hello',
         }
 
+    def test_seen_online_event_fired(self):
+        """Tests the firing of the EVENT_DEVICE_SEEN_ONLINE event.
+
+        Verifies that the device tracker fires the event each time
+        a device is seen, including the initial time."""
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN,
+                                   TEST_PLATFORM)
+        test_events = []
+
+        @callback
+        def listener(event):
+            """Helper method that will verify our event got called."""
+            test_events.append(event)
+
+        self.hass.bus.listen("device_tracker_seen_online", listener)
+
+        device_tracker.see(self.hass, 'mac_1', host_name='hello',
+                           source_type=device_tracker.SOURCE_TYPE_ROUTER)
+        device_tracker.see(self.hass, 'mac_1', host_name='hello',
+                           source_type=device_tracker.SOURCE_TYPE_ROUTER)
+
+        self.hass.block_till_done()
+
+        assert len(test_events) == 2
+
+        # Assert we can serialize the event
+        json.dumps(test_events[0].as_dict(), cls=JSONEncoder)
+
+        assert test_events[0].data == {
+            'dev_id': 'hello',
+            'mac': 'MAC_1',
+        }
+
+    def test_seen_online_event_not_fired(self):
+        """Tests the firing of the EVENT_DEVICE_SEEN_ONLINE event.
+
+        Verifies that the device tracker does not fire the event when
+        the source is not a ROUTER."""
+        with assert_setup_component(1, device_tracker.DOMAIN):
+            assert setup_component(self.hass, device_tracker.DOMAIN,
+                                   TEST_PLATFORM)
+        test_events = []
+
+        @callback
+        def listener(event):
+            """Helper method that will verify our event got called."""
+            test_events.append(event)
+
+        self.hass.bus.listen("device_tracker_seen_online", listener)
+
+        device_tracker.see(self.hass, 'mac_1', host_name='hello',
+                           source_type=device_tracker.SOURCE_TYPE_GPS)
+        device_tracker.see(self.hass, 'mac_1', host_name='hello',
+                           source_type=device_tracker.SOURCE_TYPE_GPS)
+
+        self.hass.block_till_done()
+
+        assert len(test_events) == 0
+
     # pylint: disable=invalid-name
     def test_not_write_duplicate_yaml_keys(self):
         """Test that the device tracker will not generate invalid YAML."""


### PR DESCRIPTION
## Description:

Fire an event on the bus each time a device is seen online by the `device_tracker` component. This is for use by other components that rely on network connectivity to devices.
Currently, if a device is offline, the component usually scans the state of the device at certain intervals, attempting to reconnect, until it is successful.
With this feature, a component will be able to listen to this event on the bus, and become aware of the online status of the related device much sooner. Especially relevant to devices that are switched off, such as smart lamps.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
