### PR TITLE
LIFX: add support for setting infrared level

### DIFF
--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -34,7 +34,7 @@ from . import effects as lifx_effects
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['aiolifx==0.4.7']
+REQUIREMENTS = ['aiolifx==0.4.8']
 
 UDP_BROADCAST_PORT = 56700
 

--- a/homeassistant/components/light/lifx/__init__.py
+++ b/homeassistant/components/light/lifx/__init__.py
@@ -46,6 +46,7 @@ CONF_SERVER = 'server'
 SERVICE_LIFX_SET_STATE = 'lifx_set_state'
 
 ATTR_HSBK = 'hsbk'
+ATTR_INFRARED = 'infrared'
 ATTR_POWER = 'power'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -53,6 +54,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 LIFX_SET_STATE_SCHEMA = LIGHT_TURN_ON_SCHEMA.extend({
+    ATTR_INFRARED: vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255)),
     ATTR_POWER: cv.boolean,
 })
 
@@ -362,6 +364,9 @@ class LIFXLight(Light):
         if ATTR_EFFECT in kwargs:
             yield from lifx_effects.default_effect(self, **kwargs)
             return
+
+        if ATTR_INFRARED in kwargs:
+            self.device.set_infrared(convert_8_to_16(kwargs[ATTR_INFRARED]))
 
         if ATTR_TRANSITION in kwargs:
             fade = int(kwargs[ATTR_TRANSITION] * 1000)

--- a/homeassistant/components/light/lifx/services.yaml
+++ b/homeassistant/components/light/lifx/services.yaml
@@ -9,6 +9,10 @@ lifx_set_state:
     '...':
       description: All turn_on parameters can be used to specify a color
 
+    infrared:
+      description: Automatic infrared level (0..255) when light brightness is low
+      example: 255
+
     transition:
       description: Duration in seconds it takes to get to the final state
       example: 10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -49,7 +49,7 @@ aiodns==1.1.1
 aiohttp_cors==0.5.3
 
 # homeassistant.components.light.lifx
-aiolifx==0.4.7
+aiolifx==0.4.8
 
 # homeassistant.components.scene.hunterdouglas_powerview
 aiopvapi==1.4


### PR DESCRIPTION
## Description:

Support for the infrared channel in LIFX + bulbs. This is available through `lifx_set_state`.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2801

## Example entry for `configuration.yaml` (if applicable):
```yaml
    action:
      service: light.lifx_set_state
      entity_id: light.garage
      data:
        infrared: 255
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54