### PR TITLE
Allow put as method

### DIFF
--- a/tests/components/switch/test_rest.py
+++ b/tests/components/switch/test_rest.py
@@ -97,11 +97,13 @@ class TestRestSwitch:
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.name = 'foo'
+        self.method = 'post'
         self.resource = 'http://localhost/'
         self.body_on = Template('on', self.hass)
         self.body_off = Template('off', self.hass)
-        self.switch = rest.RestSwitch(self.hass, self.name, self.resource,
-                                      self.body_on, self.body_off, None, 10)
+        self.switch = rest.RestSwitch(
+            self.hass, self.name, self.resource, self.method, self.body_on,
+            self.body_off, None, 10)
 
     def teardown_method(self):
         """Stop everything that was started."""


### PR DESCRIPTION
## Description:
Allow put as method for the `rest` switch.

**Related issue (if applicable):** fixes [19611](https://community.home-assistant.io/t/put-method-for-restful-components/19611) & [5701](https://community.home-assistant.io/t/restful-api-put-request/5701)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2803

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: rest
    resource: http://IP_ADDRESS/ENDPOINT
    method: put
   ...
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
