### PR TITLE
Take in account Spotify account permissions

### DIFF
--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -33,7 +33,7 @@ SUPPORT_SPOTIFY = SUPPORT_VOLUME_SET | SUPPORT_PAUSE | SUPPORT_PLAY |\
     SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK | SUPPORT_SELECT_SOURCE |\
     SUPPORT_PLAY_MEDIA | SUPPORT_SHUFFLE_SET
 
-SCOPE = 'user-read-playback-state user-modify-playback-state'
+SCOPE = 'user-read-playback-state user-modify-playback-state user-read-private'
 DEFAULT_CACHE_PATH = '.spotify-token-cache'
 AUTH_CALLBACK_PATH = '/api/spotify'
 AUTH_CALLBACK_NAME = 'api:spotify'
@@ -135,6 +135,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         self._volume = None
         self._shuffle = False
         self._player = None
+        self._user = None
         self._aliases = aliases
         self._token_info = self._oauth.get_cached_token()
 
@@ -153,6 +154,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         if self._player is None or token_refreshed:
             self._player = \
                 spotipy.Spotify(auth=self._token_info.get('access_token'))
+            self._user = self._player.me()
 
     def update(self):
         """Update state and attributes."""
@@ -308,4 +310,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Return the media player features that are supported."""
-        return SUPPORT_SPOTIFY
+        if self._user is not None and self._user['product'] == 'premium':
+          return SUPPORT_SPOTIFY
+        else:
+          return None

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -311,6 +311,6 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
     def supported_features(self):
         """Return the media player features that are supported."""
         if self._user is not None and self._user['product'] == 'premium':
-          return SUPPORT_SPOTIFY
+            return SUPPORT_SPOTIFY
         else:
-          return None
+            return None


### PR DESCRIPTION
## Description:
When using a Spotify free account, the actions on the frontend all throw errors, because they are only accessible to Premium account users.
This change adds an additional scope to be used, getting the subscription type.
If this type is `Premium`, it will show the action buttons, otherwise nothing will be shown.

NOTE 1: I know in the docs it does say only Premium accounts can be used, but just being able to show what is played is nice imo
NOTE 2: It might be possible Spotify uses other product names as well, currently I only found `open`, `free` and `premium` as known types. (I'm guessing Family might be 1 as well)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2809

## Example entry for `configuration.yaml` (if applicable):
No changes

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

