### PR TITLE
LIFX: support for multizone

### DIFF
--- a/homeassistant/components/light/lifx/services.yaml
+++ b/homeassistant/components/light/lifx/services.yaml
@@ -13,6 +13,10 @@ lifx_set_state:
       description: Automatic infrared level (0..255) when light brightness is low
       example: 255
 
+    zones:
+      description: List of zone numbers to affect (8 per LIFX Z, starts at 0)
+      example: '[0,5]'
+
     transition:
       description: Duration in seconds it takes to get to the final state
       example: 10


### PR DESCRIPTION
## Description:

Support multizone lights like LIFX Z. This is available through `lifx_set_state` and allows setting each zone to a different color/brightness. Unfortunately, I do not see a way to make this work with scenes.

This implementation also fixes an issue where adjusting the brightness in the UI would make all zones the same color.

The first commits rearrange things, making it quite simple to add the multizone support in the final commit.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2804

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  red_white_blue:
    sequence:
      - service: light.lifx_set_state
        data:
          entity_id: light.z
          color_name: 'red'
          brightness_pct: 80
          transition: 10
          zones: [0,3,6]
      - service: light.lifx_set_state
        data:
          entity_id: light.z
          kelvin: 5600
          brightness_pct: 60
          transition: 10
          zones: [1,4,7]
      - service: light.lifx_set_state
        data:
          entity_id: light.z
          color_name: 'blue'
          brightness_pct: 80
          transition: 10
          zones: [2,5]
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running`script/gen_requirements_all.py`.
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54