### PR TITLE
LIFX: multiple modes for pulse effect

### DIFF
--- a/homeassistant/components/light/lifx/services.yaml
+++ b/homeassistant/components/light/lifx/services.yaml
@@ -23,36 +23,7 @@ lifx_set_state:
 
 
 lifx_effect_breathe:
-  description: Run a breathe effect by fading to a color and back.
-
-  fields:
-    entity_id:
-      description: Name(s) of entities to run the effect on
-      example: 'light.kitchen'
-
-    brightness:
-      description: Number between 0..255 indicating brightness when the effect peaks
-      example: 120
-
-    color_name:
-      description: A human readable color name
-      example: 'red'
-
-    rgb_color:
-      description: Color for the fade in RGB-format
-      example: '[255, 100, 100]'
-
-    period:
-      description: Duration of the effect in seconds (default 1.0)
-      example: 3
-
-    cycles:
-      description: Number of times the effect should run (default 1.0)
-      example: 2
-
-    power_on:
-      description: Powered off lights are temporarily turned on during the effect (default True)
-      example: False
+  description: Deprecated, use lifx_effect_pulse
 
 lifx_effect_pulse:
   description: Run a flash effect by changing to a color and back.
@@ -61,6 +32,10 @@ lifx_effect_pulse:
     entity_id:
       description: Name(s) of entities to run the effect on
       example: 'light.kitchen'
+
+    mode:
+      description: 'Decides how colors are changed. Possible values: blink, breathe, ping, strobe, solid'
+      example: strobe
 
     brightness:
       description: Number between 0..255 indicating brightness of the temporary color


### PR DESCRIPTION
## Description:

Adds these modes to the `lifx_effect_pulse` effect, selected with a new `mode` attribute:

* `blink`: the existing 50/50 flashing between base color and effect color
* `breathe`: a lifx_effect_breathe replacement
* `ping`: mostly base color with a short flash at the end of the cycle
* `strobe`: dark base color and short cycles by default
* `solid`: temporary color change, base color not visible during effect

Adding a service call for each mode is a bit extravagant so instead
`lifx_effect_breathe` has been folded in as an option and that service
call is deprecated.

**Breaking change:** The `lifx_effect_breathe` call has been deprecated. Use `lifx_effect_pulse` with the new `mode: breathe` attribute instead.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2806

## Example entry for `configuration.yaml` (if applicable):
```yaml
      - service: light.lifx_effect_pulse
        entity_id: light.hall
        data:
          color_name: green
          period: 300
          mode: solid
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).</s>
  - [ ] <s>New dependencies are only imported inside functions that use them ([example][ex-import]).</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54