### PR TITLE
Add send_command service to RFLink platform

### DIFF
--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -8,13 +8,15 @@ import asyncio
 from collections import defaultdict
 import functools as ft
 import logging
+import os
 
 import async_timeout
 import voluptuous as vol
 
+from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (
-    ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP,
-    STATE_UNKNOWN)
+    ATTR_ENTITY_ID, CONF_COMMAND, CONF_HOST, CONF_PORT,
+    EVENT_HOMEASSISTANT_STOP, STATE_UNKNOWN)
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
@@ -32,6 +34,7 @@ CONF_GROUP_ALIASSES = 'group_aliasses'
 CONF_GROUP = 'group'
 CONF_NOGROUP_ALIASSES = 'nogroup_aliasses'
 CONF_DEVICE_DEFAULTS = 'device_defaults'
+CONF_DEVICE_ID = 'device_id'
 CONF_DEVICES = 'devices'
 CONF_AUTOMATIC_ADD = 'automatic_add'
 CONF_FIRE_EVENT = 'fire_event'
@@ -57,6 +60,8 @@ RFLINK_GROUP_COMMANDS = ['allon', 'alloff']
 
 DOMAIN = 'rflink'
 
+SERVICE_SEND_COMMAND = 'send_command'
+
 DEVICE_DEFAULTS_SCHEMA = vol.Schema({
     vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
     vol.Optional(CONF_SIGNAL_REPETITIONS,
@@ -74,6 +79,11 @@ CONFIG_SCHEMA = vol.Schema({
             vol.All(cv.ensure_list, [cv.string]),
     }),
 }, extra=vol.ALLOW_EXTRA)
+
+SEND_COMMAND_SCHEMA = vol.Schema({
+    vol.Required(CONF_DEVICE_ID): cv.string,
+    vol.Required(CONF_COMMAND): cv.string,
+})
 
 
 def identify_event_type(event):
@@ -108,6 +118,24 @@ def async_setup(hass, config):
 
     # Allow platform to specify function to register new unknown devices
     hass.data[DATA_DEVICE_REGISTER] = {}
+
+    @asyncio.coroutine
+    def async_send_command(call):
+        """Send Rflink command."""
+        _LOGGER.debug('Rflink command for %s', str(call.data))
+        if not (yield from RflinkCommand.send_command(
+                call.data.get(CONF_DEVICE_ID),
+                call.data.get(CONF_COMMAND))):
+            _LOGGER.error('Failed Rflink command for %s', str(call.data))
+
+    descriptions = yield from hass.async_add_job(
+        load_yaml_config_file, os.path.join(
+            os.path.dirname(__file__), 'services.yaml')
+    )
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_SEND_COMMAND, async_send_command,
+        descriptions[DOMAIN][SERVICE_SEND_COMMAND], SEND_COMMAND_SCHEMA)
 
     @callback
     def event_callback(event):
@@ -309,6 +337,12 @@ class RflinkCommand(RflinkDevice):
     def is_connected(cls):
         """Return connection status."""
         return bool(cls._protocol)
+
+    @classmethod
+    @asyncio.coroutine
+    def send_command(cls, device_id, action):
+        """Send device command to Rflink and wait for acknowledgement."""
+        return (yield from cls._protocol.send_command_ack(device_id, action))
 
     @asyncio.coroutine
     def _async_handle_command(self, command, *args):

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -410,3 +410,16 @@ eight_sleep:
       duration:
         description: Duration to heat at the target level in seconds.
         example: 3600
+
+rflink:
+  send_command:
+    description: Send device command through RFLink
+
+    fields:
+      device_id:
+        description: RFLink device ID
+        example: 'newkaku_0000c6c2_1'
+
+      command:
+        description: The command to be sent
+        example: 'on'


### PR DESCRIPTION
## Description:

RFLink platform doesn't provide a service to send commands to devices through RFLink. This complicates its usage in automations and template sensors/switches.

The `rflink.send_command` service provides this functionality by accepting two parameters (both are required):

| Parameter  | Description | Example |
| --- | --- | --- |
| device_id | RFLink device ID | newkaku_0000c6c2_1 |
| command | The command to be sent | on |