### PR TITLE
media_player.firetv - Adding support for https.

### DIFF
--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -15,7 +15,7 @@ from homeassistant.components.media_player import (
     MediaPlayerDevice)
 from homeassistant.const import (
     STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING, STATE_STANDBY,
-    STATE_UNKNOWN, CONF_HOST, CONF_PORT, CONF_NAME, CONF_DEVICE, CONF_DEVICES)
+    STATE_UNKNOWN, CONF_HOST, CONF_PORT, CONF_SSL, CONF_NAME, CONF_DEVICE, CONF_DEVICES)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,19 +24,21 @@ SUPPORT_FIRETV = SUPPORT_PAUSE | \
     SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PREVIOUS_TRACK | \
     SUPPORT_NEXT_TRACK | SUPPORT_VOLUME_SET | SUPPORT_PLAY
 
+DEFAULT_SSL = False
 DEFAULT_DEVICE = 'default'
 DEFAULT_HOST = 'localhost'
 DEFAULT_NAME = 'Amazon Fire TV'
 DEFAULT_PORT = 5556
-DEVICE_ACTION_URL = 'http://{0}:{1}/devices/action/{2}/{3}'
-DEVICE_LIST_URL = 'http://{0}:{1}/devices/list'
-DEVICE_STATE_URL = 'http://{0}:{1}/devices/state/{2}'
+DEVICE_ACTION_URL = '{0}://{1}:{2}/devices/action/{3}/{4}'
+DEVICE_LIST_URL = '{0}://{1}:{2}/devices/list'
+DEVICE_STATE_URL = '{0}://{1}:{2}/devices/state/{3}'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DEVICE, default=DEFAULT_DEVICE): cv.string,
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
 })
 
 
@@ -44,14 +46,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the FireTV platform."""
     name = config.get(CONF_NAME)
+    ssl = config.get(CONF_SSL)
+    proto = 'https' if ssl else 'http'
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
     device_id = config.get(CONF_DEVICE)
 
     try:
-        response = requests.get(DEVICE_LIST_URL.format(host, port)).json()
+        response = requests.get(DEVICE_LIST_URL.format(proto, host, port)).json()
         if device_id in response[CONF_DEVICES].keys():
-            add_devices([FireTVDevice(host, port, device_id, name)])
+            add_devices([FireTVDevice(proto, host, port, device_id, name)])
             _LOGGER.info("Device %s accessible and ready for control",
                          device_id)
         else:
@@ -72,8 +76,9 @@ class FireTV(object):
     be running via Python 2).
     """
 
-    def __init__(self, host, port, device_id):
+    def __init__(self, proto, host, port, device_id):
         """Initialize the FireTV server."""
+        self.proto = proto
         self.host = host
         self.port = port
         self.device_id = device_id
@@ -84,7 +89,7 @@ class FireTV(object):
         try:
             response = requests.get(
                 DEVICE_STATE_URL.format(
-                    self.host, self.port, self.device_id), timeout=10).json()
+                    self.proto, self.host, self.port, self.device_id), timeout=10).json()
             return response.get('state', STATE_UNKNOWN)
         except requests.exceptions.RequestException:
             _LOGGER.error(
@@ -95,7 +100,7 @@ class FireTV(object):
         """Perform an action on the device."""
         try:
             requests.get(DEVICE_ACTION_URL.format(
-                self.host, self.port, self.device_id, action_id), timeout=10)
+                self.proto, self.host, self.port, self.device_id, action_id), timeout=10)
         except requests.exceptions.RequestException:
             _LOGGER.error(
                 "Action request for %s was not accepted for device %s",
@@ -105,9 +110,9 @@ class FireTV(object):
 class FireTVDevice(MediaPlayerDevice):
     """Representation of an Amazon Fire TV device on the network."""
 
-    def __init__(self, host, port, device, name):
+    def __init__(self, proto, host, port, device, name):
         """Initialize the FireTV device."""
-        self._firetv = FireTV(host, port, device)
+        self._firetv = FireTV(proto, host, port, device)
         self._name = name
         self._state = STATE_UNKNOWN
 

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -15,7 +15,8 @@ from homeassistant.components.media_player import (
     MediaPlayerDevice)
 from homeassistant.const import (
     STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING, STATE_STANDBY,
-    STATE_UNKNOWN, CONF_HOST, CONF_PORT, CONF_SSL, CONF_NAME, CONF_DEVICE, CONF_DEVICES)
+    STATE_UNKNOWN, CONF_HOST, CONF_PORT, CONF_SSL, CONF_NAME, CONF_DEVICE,
+    CONF_DEVICES)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,7 +54,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     device_id = config.get(CONF_DEVICE)
 
     try:
-        response = requests.get(DEVICE_LIST_URL.format(proto, host, port)).json()
+        response = requests.get(
+            DEVICE_LIST_URL.format(proto, host, port)).json()
         if device_id in response[CONF_DEVICES].keys():
             add_devices([FireTVDevice(proto, host, port, device_id, name)])
             _LOGGER.info("Device %s accessible and ready for control",
@@ -89,7 +91,8 @@ class FireTV(object):
         try:
             response = requests.get(
                 DEVICE_STATE_URL.format(
-                    self.proto, self.host, self.port, self.device_id), timeout=10).json()
+                    self.proto, self.host, self.port, self.device_id
+                    ), timeout=10).json()
             return response.get('state', STATE_UNKNOWN)
         except requests.exceptions.RequestException:
             _LOGGER.error(
@@ -100,7 +103,8 @@ class FireTV(object):
         """Perform an action on the device."""
         try:
             requests.get(DEVICE_ACTION_URL.format(
-                self.proto, self.host, self.port, self.device_id, action_id), timeout=10)
+                self.proto, self.host, self.port, self.device_id, action_id
+                ), timeout=10)
         except requests.exceptions.RequestException:
             _LOGGER.error(
                 "Action request for %s was not accepted for device %s",


### PR DESCRIPTION
This change allows to access a firetv-server instance that runs over https (behind reverse proxy for exemple).
Default stays http, but if `ssl: true` is set in the configuration the connection goes over https.

Full configuration exemple:
```yml
media_player firetv:
  platform: firetv
  host: firetv-server.domain.com
  port: 443
  ssl: true
  device: firetv
  name: FireTV
```

Successfully tested.