### PR TITLE
Add support of Zone2 and Zone3

### DIFF
--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/media_player.denon/
 """
 
 import logging
+from collections import namedtuple
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -28,6 +29,7 @@ DEFAULT_SHOW_SOURCES = False
 CONF_SHOW_ALL_SOURCES = 'show_all_sources'
 CONF_ZONES = 'zones'
 CONF_VALID_ZONES = ['Zone2', 'Zone3']
+CONF_INVALID_ZONES_ERR = 'Invalid Zone (expected Zone2 or Zone3)'
 KEY_DENON_CACHE = 'denonavr_hosts'
 
 SUPPORT_DENON = SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | \
@@ -38,17 +40,8 @@ SUPPORT_MEDIA_MODES = SUPPORT_PLAY_MEDIA | \
     SUPPORT_PAUSE | SUPPORT_PREVIOUS_TRACK | \
     SUPPORT_NEXT_TRACK | SUPPORT_VOLUME_SET | SUPPORT_PLAY
 
-
-def denon_zone(value) -> str:
-    """Validate if Zone is correct ."""
-    if value in CONF_VALID_ZONES:
-        return value
-    raise vol.Invalid(
-        'invalid Zone: {} (expected Zone2 or Zone3)'.format(value))
-
-
 DENON_ZONE_SCHEMA = vol.Schema({
-    vol.Required(CONF_ZONE): denon_zone,
+    vol.Required(CONF_ZONE): vol.In(CONF_VALID_ZONES, CONF_INVALID_ZONES_ERR),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
@@ -60,6 +53,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ZONES):
         vol.All(cv.ensure_list, [DENON_ZONE_SCHEMA])
 })
+
+NewHost = namedtuple('NewHost', ['host', 'name'])
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -75,7 +70,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         cache = hass.data[KEY_DENON_CACHE] = set()
 
     # Get config option for show_all_sources
-    show_all_sources = config.get(CONF_SHOW_ALL_SOURCES) if not None else False
+    show_all_sources = config.get(CONF_SHOW_ALL_SOURCES)
 
     # Get config option for additional zones
     zones = config.get(CONF_ZONES)
@@ -87,30 +82,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         add_zones = None
 
     # Start assignment of host and name
+    new_hosts = []
     # 1. option: manual setting
     if config.get(CONF_HOST) is not None:
         host = config.get(CONF_HOST)
         name = config.get(CONF_NAME)
-        # Check if host not in cache, append it and save for later starting
-        if host not in cache:
-            new_device = denonavr.DenonAVR(
-                host, name, show_all_sources, add_zones)
-            for new_zone in new_device.zones.values():
-                receivers.append(DenonDevice(new_zone))
-            cache.add(host)
-            _LOGGER.info("Denon receiver at host %s initialized", host)
+        new_hosts.append(NewHost(host=host, name=name))
+
     # 2. option: discovery using netdisco
     if discovery_info is not None:
         host = discovery_info.get('host')
         name = discovery_info.get('name')
-        # Check if host not in cache, append it and save for later starting
-        if host not in cache:
-            new_device = denonavr.DenonAVR(
-                host, name, show_all_sources, add_zones)
-            for new_zone in new_device.zones.values():
-                receivers.append(DenonDevice(new_zone))
-            cache.add(host)
-            _LOGGER.info("Denon receiver at host %s initialized", host)
+        new_hosts.append(NewHost(host=host, name=name))
+
     # 3. option: discovery using denonavr library
     if config.get(CONF_HOST) is None and discovery_info is None:
         d_receivers = denonavr.discover()
@@ -119,15 +103,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             for d_receiver in d_receivers:
                 host = d_receiver["host"]
                 name = d_receiver["friendlyName"]
-                # Check if host not in cache, append it and save for later
-                # starting
-                if host not in cache:
-                    new_device = denonavr.DenonAVR(
-                        host, name, show_all_sources, add_zones)
-                    for new_zone in new_device.zones.values():
-                        receivers.append(DenonDevice(new_zone))
-                    cache.add(host)
-                    _LOGGER.info("Denon receiver at host %s initialized", host)
+                new_hosts.append(NewHost(host=host, name=name))
+
+    for entry in new_hosts:
+        # Check if host not in cache, append it and save for later
+        # starting
+        if entry.host not in cache:
+            new_device = denonavr.DenonAVR(
+                entry.host, entry.name, show_all_sources, add_zones)
+            for new_zone in new_device.zones.values():
+                receivers.append(DenonDevice(new_zone))
+            cache.add(host)
+            _LOGGER.info("Denon receiver at host %s initialized", host)
 
     # Add all freshly discovered receivers
     if receivers:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -144,7 +144,7 @@ datapoint==0.4.3
 # decora==0.4
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.4.4
+denonavr==0.5.0
 
 # homeassistant.components.media_player.directv
 directpy==0.1


### PR DESCRIPTION
## Description:
Support for Zone2 and Zone3 of the the receiver was added. If configured, new instances of media_player are created for the additional zones.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2786

## Example entry for `configuration.yaml` (if applicable):
```yaml
# media player
media_player:
  - platform: denonavr
    host: 192.168.0.250
    name: receiver living room
    zones:
      - zone: Zone2
      - zone: Zone3
        name: balcony
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
