### PR TITLE
Adding ssocr to docker to support Seven Segments Display

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
 #ENV INSTALL_LIBCEC no
 #ENV INSTALL_PHANTOMJS no
 #ENV INSTALL_COAP_CLIENT no
+#ENV INSTALL_SSOCR no
 
 VOLUME /config
 

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -12,6 +12,7 @@ MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
 #ENV INSTALL_LIBCEC no
 #ENV INSTALL_PHANTOMJS no
 #ENV INSTALL_COAP_CLIENT no
+#ENV INSTALL_SSOCR no
 
 VOLUME /config
 

--- a/virtualization/Docker/scripts/ssocr
+++ b/virtualization/Docker/scripts/ssocr
@@ -23,4 +23,7 @@ git clone --depth 1 https://github.com/auerswal/ssocr.git /usr/local/src/ssocr
 
   # Install the binaries/libraries to your local system (prefix is /usr/local)
   make install
+
+  # Cleanup
+  make clean
 )

--- a/virtualization/Docker/scripts/ssocr
+++ b/virtualization/Docker/scripts/ssocr
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Sets up ssocr to support Seven Segments Display.
+
+# Stop on errors
+set -e
+
+PACKAGES=(
+  libimlib2 libimlib2-dev
+)
+
+apt-get install -y --no-install-recommends ${PACKAGES[@]}
+
+# Clone the latest code from GitHub
+git clone --depth 1 https://github.com/auerswal/ssocr.git /usr/local/src/ssocr
+
+# Build ssocr
+(
+  # Setup the build directory
+  cd /usr/local/src/ssocr
+
+  # compile the library
+  make
+
+  # Install the binaries/libraries to your local system (prefix is /usr/local)
+  make install
+)

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -10,6 +10,7 @@ INSTALL_FFMPEG="${INSTALL_FFMPEG:-yes}"
 INSTALL_LIBCEC="${INSTALL_LIBCEC:-yes}"
 INSTALL_PHANTOMJS="${INSTALL_PHANTOMJS:-yes}"
 INSTALL_COAP_CLIENT="${INSTALL_COAP_CLIENT:-yes}"
+INSTALL_SSOCR="${INSTALL_SSOCR:-yes}"
 
 # Required debian packages for running hass or components
 PACKAGES=(
@@ -60,6 +61,10 @@ fi
 
 if [ "$INSTALL_COAP_CLIENT" == "yes" ]; then
   virtualization/Docker/scripts/coap_client
+fi
+
+if [ "$INSTALL_SSOCR" == "yes" ]; then
+  virtualization/Docker/scripts/ssocr
 fi
 
 # Remove packages


### PR DESCRIPTION
## Description:
Cloning and building ssocr in Docker image to support Seven Segments Display Image Processing Component

**Related issue (if applicable):** fixes #7774

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [N/A] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [N/A] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [N/A] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [N/A] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [N/A] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [N/A] Tests have been added to verify that the new code works.

