### PR TITLE
Upgrade zeroconf to 0.19.1

### DIFF
--- a/homeassistant/components/zeroconf.py
+++ b/homeassistant/components/zeroconf.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['api']
 DOMAIN = 'zeroconf'
 
-REQUIREMENTS = ['zeroconf==0.19.0']
+REQUIREMENTS = ['zeroconf==0.19.1']
 
 ZEROCONF_TYPE = '_home-assistant._tcp.local.'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -921,4 +921,4 @@ yeelightsunflower==0.0.8
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.19.0
+zeroconf==0.19.1


### PR DESCRIPTION
## 0.19.1
- Allow newer netifaces releases

## Test entry for `configuration.yaml`:

```yaml
zeroconf:
```
Checked with `avahi-browse`:

```bash
$ avahi-browse -alr
+ enp0s20f0u6u1 IPv4 Home                                          _home-assistant._tcp local
+ virbr0 IPv4 Home                                          _home-assistant._tcp local
+ wlp4s0 IPv4 Home                                          _home-assistant._tcp local
+ enp0s20f0u6u1 IPv4 gw:b0-72-bf-27-a9-83                          _coap._udp           local
= enp0s20f0u6u1 IPv4 Home                                          _home-assistant._tcp local
   hostname = [Home._home-assistant._tcp.local]
   address = [192.168.0.51]
   port = [8123]
   txt = ["base_url=http://192.168.0.51:8123" "version=0.47.0.dev0" "requires_api_password=false"]
```
Discovery is working as expected.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.