### PR TITLE
Upgrade pysnmp to 4.3.8

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -19,7 +19,7 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pysnmp==4.3.7']
+REQUIREMENTS = ['pysnmp==4.3.8']
 
 CONF_COMMUNITY = 'community'
 CONF_AUTHKEY = 'authkey'

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pysnmp==4.3.7']
+REQUIREMENTS = ['pysnmp==4.3.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -649,7 +649,7 @@ pysma==0.1.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
-pysnmp==4.3.7
+pysnmp==4.3.8
 
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner


### PR DESCRIPTION
## 4.3.8
- Security fix to the bug introduced in 4.3.6: msgAuthoritativeEngineTime   stopped changing over time and was returning the same timestamp (process  start time). This fix makes it growing as it should.

Tested with the following configuration:

``` yaml
sensor:
  - platform: snmp
    name: SNMP TEST String
    host: demo.snmplabs.com
    community: public
    baseoid: 1.3.6.1.4.1.2021.10.1.3.1
    unit_of_measurement: "load"
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.