### PR TITLE
Add option to set language of openweathermap sensor, and handle updating errors

### DIFF
--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -183,7 +183,10 @@ class WeatherData(object):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from OpenWeatherMap."""
-        obs = self.owm.weather_at_coords(self.latitude, self.longitude)
+        try:
+            obs = self.owm.weather_at_coords(self.latitude, self.longitude)
+        except TypeError:
+            obs = None
         if obs is None:
             _LOGGER.warning("Failed to fetch data from OpenWeatherMap")
             return
@@ -191,6 +194,9 @@ class WeatherData(object):
         self.data = obs.get_weather()
 
         if self.forecast == 1:
-            obs = self.owm.three_hours_forecast_at_coords(
-                self.latitude, self.longitude)
-            self.fc_data = obs.get_forecast()
+            try:
+                obs = self.owm.three_hours_forecast_at_coords(
+                    self.latitude, self.longitude)
+                self.fc_data = obs.get_forecast()
+            except TypeError:
+                _LOGGER.warning("Failed to fetch forecast from OpenWeatherMap")

--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -23,6 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_ATTRIBUTION = "Data provided by OpenWeatherMap"
 CONF_FORECAST = 'forecast'
+CONF_LANGUAGE = 'language'
 
 DEFAULT_NAME = 'OWM'
 
@@ -45,7 +46,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MONITORED_CONDITIONS, default=[]):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_FORECAST, default=False): cv.boolean
+    vol.Optional(CONF_FORECAST, default=False): cv.boolean,
+    vol.Optional(CONF_LANGUAGE, default=None): cv.string,
 })
 
 
@@ -61,8 +63,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     name = config.get(CONF_NAME)
     forecast = config.get(CONF_FORECAST)
+    language = config.get(CONF_LANGUAGE)
+    if isinstance(language, str):
+        language = language.lower()[:2]
 
-    owm = OWM(config.get(CONF_API_KEY))
+    owm = OWM(API_key=config.get(CONF_API_KEY), language=language)
 
     if not owm:
         _LOGGER.error("Unable to connect to OpenWeatherMap")


### PR DESCRIPTION
## Description:

Add new config option `language` to **set the language code** (two-characters string) in which you want text results to be returned by the `PyOWM` library.

Also, handle KeyErrors occurring in the library when trying to parse `None` strings.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2819

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: openweathermap
    name: Local Weather
    api_key: !secret openweathermap_api_key
    forecast: 1
    language: es
    monitored_conditions:
      - weather
      - temperature
      - wind_speed
      - humidity
      - pressure
      - clouds
      - rain
    scan_interval: 180
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)