### PR TITLE
media player Kodi: handle TransportError exceptions when calling JSONRPC API methods

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -705,10 +705,8 @@ class KodiDevice(MediaPlayerDevice):
                           self.entity_id, method, kwargs, result)
         except jsonrpc_base.jsonrpc.TransportError:
             result = None
-            _LOGGER.info("TransportError trying to run API method %s.%s(%s)",
-                         self.entity_id, method, kwargs)
-            _LOGGER.debug("TransportError trying to run API method %s.%s(%s)",
-                          self.entity_id, method, kwargs, exc_info=True)
+            _LOGGER.warning("TransportError trying to run API method "
+                            "%s.%s(%s)", self.entity_id, method, kwargs)
 
         if isinstance(result, dict):
             event_data = {'entity_id': self.entity_id,
@@ -762,10 +760,8 @@ class KodiDevice(MediaPlayerDevice):
                 _LOGGER.error("Run API method %s.Playlist.Add(%s) error: %s",
                               self.entity_id, media_type, result)
             except jsonrpc_base.jsonrpc.TransportError:
-                _LOGGER.info("TransportError trying to add playlist to %s",
-                             self.entity_id)
-                _LOGGER.debug("TransportError trying to add playlist to %s",
-                              self.entity_id, exc_info=True)
+                _LOGGER.warning("TransportError trying to add playlist to %s",
+                                self.entity_id)
         else:
             _LOGGER.warning("No media detected for Playlist.Add")
 

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -540,7 +540,7 @@ class KodiDevice(MediaPlayerDevice):
         elif self._turn_off_action == 'shutdown':
             yield from self.server.System.Shutdown()
         else:
-            _LOGGER.warning('turn_off requested but turn_off_action is none')
+            _LOGGER.warning("turn_off requested but turn_off_action is none")
 
     @cmd
     @asyncio.coroutine
@@ -694,26 +694,28 @@ class KodiDevice(MediaPlayerDevice):
     def async_call_method(self, method, **kwargs):
         """Run Kodi JSONRPC API method with params."""
         import jsonrpc_base
-        _LOGGER.debug('Run API method "%s", kwargs=%s', method, kwargs)
+        _LOGGER.debug("Run API method %s, kwargs=%s", method, kwargs)
         result_ok = False
         try:
             result = yield from getattr(self.server, method)(**kwargs)
             result_ok = True
         except jsonrpc_base.jsonrpc.ProtocolError as exc:
             result = exc.args[2]['error']
-            _LOGGER.error('Run API method %s.%s(%s) error: %s',
+            _LOGGER.error("Run API method %s.%s(%s) error: %s",
                           self.entity_id, method, kwargs, result)
         except jsonrpc_base.jsonrpc.TransportError:
             result = None
-            _LOGGER.error('TransportError trying to run API method %s.%s(%s)',
-                          self.entity_id, method, kwargs)
+            _LOGGER.info("TransportError trying to run API method %s.%s(%s)",
+                         self.entity_id, method, kwargs)
+            _LOGGER.debug("TransportError trying to run API method %s.%s(%s)",
+                          self.entity_id, method, kwargs, exc_info=True)
 
         if isinstance(result, dict):
             event_data = {'entity_id': self.entity_id,
                           'result': result,
                           'result_ok': result_ok,
                           'input': {'method': method, 'params': kwargs}}
-            _LOGGER.debug('EVENT kodi_call_method_result: %s', event_data)
+            _LOGGER.debug("EVENT kodi_call_method_result: %s", event_data)
             self.hass.bus.async_fire(EVENT_KODI_CALL_METHOD_RESULT,
                                      event_data=event_data)
         return result
@@ -757,13 +759,15 @@ class KodiDevice(MediaPlayerDevice):
                 yield from self.server.Playlist.Add(params)
             except jsonrpc_base.jsonrpc.ProtocolError as exc:
                 result = exc.args[2]['error']
-                _LOGGER.error('Run API method %s.Playlist.Add(%s) error: %s',
+                _LOGGER.error("Run API method %s.Playlist.Add(%s) error: %s",
                               self.entity_id, media_type, result)
             except jsonrpc_base.jsonrpc.TransportError:
-                _LOGGER.error('TransportError trying to add playlist',
-                              self.entity_id)
+                _LOGGER.info("TransportError trying to add playlist",
+                             self.entity_id)
+                _LOGGER.debug("TransportError trying to add playlist",
+                              self.entity_id, exc_info = True)
         else:
-            _LOGGER.warning('No media detected for Playlist.Add')
+            _LOGGER.warning("No media detected for Playlist.Add")
 
     @asyncio.coroutine
     def async_add_all_albums(self, artist_name):
@@ -807,7 +811,7 @@ class KodiDevice(MediaPlayerDevice):
                 artist_name, [a['artist'] for a in artists['artists']])
             return artists['artists'][out[0][0]]['artistid']
         except KeyError:
-            _LOGGER.warning('No artists were found: %s', artist_name)
+            _LOGGER.warning("No artists were found: %s", artist_name)
             return None
 
     @asyncio.coroutine
@@ -846,7 +850,7 @@ class KodiDevice(MediaPlayerDevice):
                 album_name, [a['label'] for a in albums['albums']])
             return albums['albums'][out[0][0]]['albumid']
         except KeyError:
-            _LOGGER.warning('No albums were found with artist: %s, album: %s',
+            _LOGGER.warning("No albums were found with artist: %s, album: %s",
                             artist_name, album_name)
             return None
 

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -762,9 +762,9 @@ class KodiDevice(MediaPlayerDevice):
                 _LOGGER.error("Run API method %s.Playlist.Add(%s) error: %s",
                               self.entity_id, media_type, result)
             except jsonrpc_base.jsonrpc.TransportError:
-                _LOGGER.info("TransportError trying to add playlist",
+                _LOGGER.info("TransportError trying to add playlist to %s",
                              self.entity_id)
-                _LOGGER.debug("TransportError trying to add playlist",
+                _LOGGER.debug("TransportError trying to add playlist to %s",
                               self.entity_id, exc_info=True)
         else:
             _LOGGER.warning("No media detected for Playlist.Add")

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -703,6 +703,10 @@ class KodiDevice(MediaPlayerDevice):
             result = exc.args[2]['error']
             _LOGGER.error('Run API method %s.%s(%s) error: %s',
                           self.entity_id, method, kwargs, result)
+        except jsonrpc_base.jsonrpc.TransportError:
+            result = None
+            _LOGGER.error('TransportError trying to run API method %s.%s(%s)',
+                          self.entity_id, method, kwargs)
 
         if isinstance(result, dict):
             event_data = {'entity_id': self.entity_id,
@@ -755,6 +759,9 @@ class KodiDevice(MediaPlayerDevice):
                 result = exc.args[2]['error']
                 _LOGGER.error('Run API method %s.Playlist.Add(%s) error: %s',
                               self.entity_id, media_type, result)
+            except jsonrpc_base.jsonrpc.TransportError:
+                _LOGGER.error('TransportError trying to add playlist',
+                              self.entity_id)
         else:
             _LOGGER.warning('No media detected for Playlist.Add')
 

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -765,7 +765,7 @@ class KodiDevice(MediaPlayerDevice):
                 _LOGGER.info("TransportError trying to add playlist",
                              self.entity_id)
                 _LOGGER.debug("TransportError trying to add playlist",
-                              self.entity_id, exc_info = True)
+                              self.entity_id, exc_info=True)
         else:
             _LOGGER.warning("No media detected for Playlist.Add")
 


### PR DESCRIPTION
## Description:

Handle TransportError exceptions when calling JSONRPC API services. This exception raises when Kodi is not present or there is a problem in the websocket connection.

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: kodi
    name: Kodi
    host: 192.168.1.X
    port: 8080
    enable_websocket: true
    turn_off_action: quit
    timeout: 10
```
