### PR TITLE
Add I2c HTU21D temperature and humidity sensor for Raspberry Pi

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -419,6 +419,7 @@ omit =
     homeassistant/components/sensor/haveibeenpwned.py
     homeassistant/components/sensor/hddtemp.py
     homeassistant/components/sensor/hp_ilo.py
+    homeassistant/components/sensor/htu21d.py
     homeassistant/components/sensor/hydroquebec.py
     homeassistant/components/sensor/imap.py
     homeassistant/components/sensor/imap_email_content.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -406,6 +406,7 @@ omit =
     homeassistant/components/sensor/haveibeenpwned.py
     homeassistant/components/sensor/hddtemp.py
     homeassistant/components/sensor/hp_ilo.py
+    homeassistant/components/sensor/htu21d.py
     homeassistant/components/sensor/hydroquebec.py
     homeassistant/components/sensor/imap.py
     homeassistant/components/sensor/imap_email_content.py

--- a/homeassistant/components/sensor/htu21d.py
+++ b/homeassistant/components/sensor/htu21d.py
@@ -6,9 +6,8 @@ https://home-assistant.io/components/sensor.htu21d/
 """
 import asyncio
 from datetime import timedelta
-from math import log10
+from functools import partial
 import logging
-import time
 
 import voluptuous as vol
 
@@ -19,12 +18,12 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.temperature import celsius_to_fahrenheit
 
-REQUIREMENTS = ['smbus-cffi==0.5.1']
+REQUIREMENTS = ['i2csense==0.0.2',
+                'smbus-cffi==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_I2C_BUS = 'i2c_bus'
-I2C_ADDRESS = 0x40
 DEFAULT_I2C_BUS = 1
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
@@ -39,16 +38,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_I2C_BUS, default=DEFAULT_I2C_BUS): vol.Coerce(int),
 })
 
-# Byte codes from the data sheet
-CMD_READ_TEMP_HOLD = 0xE3
-CMD_READ_HUM_HOLD = 0xE5
-CMD_READ_TEMP_NOHOLD = 0xF3
-CMD_READ_HUM_NOHOLD = 0xF5
-CMD_WRITE_USER_REG = 0xE6
-CMD_READ_USER_REG = 0xE7
-CMD_SOFT_RESET = 0xFE
-MEASUREMENT_WAIT_TIME = 0.055
-
 
 # noinspection PyUnusedLocal
 @asyncio.coroutine
@@ -60,138 +49,41 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     try:
         # noinspection PyUnresolvedReferences
         import smbus
-        bus = smbus.SMBus(bus_number)
+        from i2csense.htu21d import HTU21D
     except ImportError as exc:
         _LOGGER.error("ImportError: %s", exc)
         return False
 
-    sensor = yield from hass.async_add_job(HTU21D, bus)
-    if not sensor.detected:
+    bus = smbus.SMBus(config.get(CONF_I2C_BUS))
+    sensor = yield from hass.async_add_job(
+        partial(HTU21D, bus, logger=_LOGGER)
+    )
+    if not sensor.sample_ok:
         _LOGGER.error("HTU21D sensor not detected in bus %s", bus_number)
         return False
 
-    dev = [HTU21DSensor(sensor, name, SENSOR_TEMPERATURE, temp_unit),
-           HTU21DSensor(sensor, name, SENSOR_HUMIDITY, '%')]
+    sensor_handler = yield from hass.async_add_job(HTU21DHandler, sensor)
+
+    dev = [HTU21DSensor(sensor_handler, name, SENSOR_TEMPERATURE, temp_unit),
+           HTU21DSensor(sensor_handler, name, SENSOR_HUMIDITY, '%')]
     async_add_devices(dev)
 
 
-class HTU21D:
+class HTU21DHandler:
     """Implement HTU21D communication."""
 
-    def __init__(self, bus):
+    def __init__(self, sensor):
         """Initialize the sensor handler."""
-        self._bus = bus
-        self._ok = self._soft_reset()
-        self.temperature = -255
-        self.humidity = -255
-        if self._ok:
-            self.update()
-
-    def _soft_reset(self) -> bool:
-        try:
-            self._bus.write_byte(I2C_ADDRESS, CMD_SOFT_RESET)
-            time.sleep(MEASUREMENT_WAIT_TIME)
-            return True
-        except OSError as exc:
-            _LOGGER.error("Bad writing in bus: %s", exc)
-            return False
-
-    @property
-    def detected(self) -> bool:
-        """Sensor is working ok."""
-        return self._ok
-
-    @staticmethod
-    def _calc_temp(sensor_temp) -> float:
-        t_sensor_temp = sensor_temp / 65536.0
-        return -46.85 + (175.72 * t_sensor_temp)
-
-    @staticmethod
-    def _calc_humid(sensor_humid) -> float:
-        t_sensor_humid = sensor_humid / 65536.0
-        return -6.0 + (125.0 * t_sensor_humid)
-
-    @staticmethod
-    def _temp_coefficient(rh_actual, temp_actual) -> float:
-        return rh_actual - 0.15 * (25 - temp_actual)
-
-    @staticmethod
-    def _crc8check(value) -> bool:
-        # Ported from Sparkfun Arduino HTU21D Library:
-        # https://github.com/sparkfun/HTU21D_Breakout
-        remainder = ((value[0] << 8) + value[1]) << 8
-        remainder |= value[2]
-
-        # POLYNOMIAL = 0x0131 = x^8 + x^5 + x^4 + 1
-        # divisor = 0x988000 is the 0x0131 polynomial shifted to farthest
-        # left of three bytes
-        divisor = 0x988000
-
-        for i in range(0, 16):
-            if remainder & 1 << (23 - i):
-                remainder ^= divisor
-            divisor >>= 1
-
-        if remainder == 0:
-            return True
-        else:
-            _LOGGER.error("Bad CRC: remainder=%s", remainder)
-            return False
-
-    @property
-    def valid_measurement(self) -> bool:
-        """Return True for a valid measurement data."""
-        return self._ok and self.temperature > -100 and self.humidity > -1
-
-    @property
-    def dew_point_temperature(self) -> float:
-        """Get the dew point temperature in ºC for the last measurement."""
-        if self.valid_measurement:
-            coef_a, coef_b, coef_c = 8.1332, 1762.39, 235.66
-            part_press = 10 ** (coef_a - coef_b / (self.temperature + coef_c))
-            dewp = - coef_c
-            dewp -= (coef_b /
-                     (log10(self.humidity * part_press / 100.) - coef_a))
-            return dewp
-        return -255
+        self.sensor = sensor
+        self.sensor.update()
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Read raw data and calculate temperature and humidity."""
-        try:
-            self._bus.write_byte(I2C_ADDRESS, CMD_READ_TEMP_NOHOLD)
-            time.sleep(MEASUREMENT_WAIT_TIME)
-            buf_t = self._bus.read_i2c_block_data(
-                I2C_ADDRESS, CMD_READ_TEMP_HOLD, 3)
-
-            self._bus.write_byte(I2C_ADDRESS, CMD_READ_HUM_NOHOLD)
-            time.sleep(MEASUREMENT_WAIT_TIME)
-            buf_h = self._bus.read_i2c_block_data(
-                I2C_ADDRESS, CMD_READ_HUM_HOLD, 3)
-        except OSError as exc:
-            self._ok = False
-            _LOGGER.error("Bad reading: %s", exc)
-            return
-
-        if self._crc8check(buf_t):
-            temp = (buf_t[0] << 8 | buf_t[1]) & 0xFFFC
-            self.temperature = self._calc_temp(temp)
-
-            if self._crc8check(buf_h):
-                humid = (buf_h[0] << 8 | buf_h[1]) & 0xFFFC
-                rh_actual = self._calc_humid(humid)
-                # For temperature coefficient compensation
-                rh_final = self._temp_coefficient(rh_actual, self.temperature)
-                rh_final = 100.0 if rh_final > 100 else rh_final  # Clamp > 100
-                rh_final = 0.0 if rh_final < 0 else rh_final  # Clamp < 0
-                self.humidity = rh_final
-            else:
-                self.humidity = -255
-        else:
-            self.temperature = -255
-        _LOGGER.debug("HTU21D values: %.2f ºC, %.2f %%. Dew point: %.2f",
-                      self.temperature, self.humidity,
-                      self.dew_point_temperature)
+        self.sensor.update()
+        _LOGGER.debug("HTU21D values: {:.2f} ºC, {:.2f} %. Dew point: {:.2f}"
+                      .format(self.sensor.temperature, self.sensor.humidity,
+                              self.sensor.dew_point_temperature))
 
 
 class HTU21DSensor(Entity):
@@ -224,11 +116,11 @@ class HTU21DSensor(Entity):
     def async_update(self):
         """Get the latest data from the HTU21D sensor and update the state."""
         yield from self.hass.async_add_job(self._client.update)
-        if self._client.valid_measurement:
+        if self._client.sensor.sample_ok:
             if self._variable == SENSOR_TEMPERATURE:
-                value = round(self._client.temperature, 1)
+                value = round(self._client.sensor.temperature, 1)
                 if self.unit_of_measurement == TEMP_FAHRENHEIT:
                     value = celsius_to_fahrenheit(value)
             else:
-                value = round(self._client.humidity, 1)
+                value = round(self._client.sensor.humidity, 1)
             self._state = value

--- a/homeassistant/components/sensor/htu21d.py
+++ b/homeassistant/components/sensor/htu21d.py
@@ -1,0 +1,233 @@
+"""
+Support for HTU21D temperature and humidity sensor.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.htu21d/
+"""
+import asyncio
+from datetime import timedelta
+from math import log10
+import logging
+import time
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_NAME, TEMP_FAHRENHEIT
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+from homeassistant.util.temperature import celsius_to_fahrenheit
+
+REQUIREMENTS = ['smbus-cffi==0.5.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_I2C_BUS = 'i2c_bus'
+I2C_ADDRESS = 0x40
+DEFAULT_I2C_BUS = 1
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
+
+DEFAULT_NAME = 'HTU21D Sensor'
+
+SENSOR_TEMPERATURE = 'temperature'
+SENSOR_HUMIDITY = 'humidity'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_I2C_BUS, default=DEFAULT_I2C_BUS): vol.Coerce(int),
+})
+
+# Byte codes from the data sheet
+CMD_READ_TEMP_HOLD = 0xE3
+CMD_READ_HUM_HOLD = 0xE5
+CMD_READ_TEMP_NOHOLD = 0xF3
+CMD_READ_HUM_NOHOLD = 0xF5
+CMD_WRITE_USER_REG = 0xE6
+CMD_READ_USER_REG = 0xE7
+CMD_SOFT_RESET = 0xFE
+MEASUREMENT_WAIT_TIME = 0.055
+
+
+# noinspection PyUnusedLocal
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the HTU21D sensor."""
+    name = config.get(CONF_NAME)
+    bus_number = config.get(CONF_I2C_BUS)
+    temp_unit = hass.config.units.temperature_unit
+    try:
+        # noinspection PyUnresolvedReferences
+        import smbus
+        bus = smbus.SMBus(bus_number)
+    except ImportError as exc:
+        _LOGGER.error("ImportError: %s", exc)
+        return False
+
+    sensor = yield from hass.async_add_job(HTU21D, bus)
+    if not sensor.detected:
+        _LOGGER.error("HTU21D sensor not detected in bus %s", bus_number)
+        return False
+
+    dev = [HTU21DSensor(sensor, name, SENSOR_TEMPERATURE, temp_unit),
+           HTU21DSensor(sensor, name, SENSOR_HUMIDITY, '%')]
+    async_add_devices(dev)
+
+
+class HTU21D:
+    """Implement HTU21D communication."""
+
+    def __init__(self, bus):
+        """Initialize the sensor handler."""
+        self._bus = bus
+        self.ok = self._soft_reset()
+        self.temperature = -255
+        self.humidity = -255
+        if self.ok:
+            self.update()
+
+    def _soft_reset(self) -> bool:
+        try:
+            self._bus.write_byte(I2C_ADDRESS, CMD_SOFT_RESET)
+            time.sleep(MEASUREMENT_WAIT_TIME)
+            return True
+        except OSError as exc:
+            _LOGGER.error("Bad writing in bus: %s", exc)
+            return False
+
+    @property
+    def detected(self) -> bool:
+        """Sensor is working ok."""
+        return self.ok
+
+    @staticmethod
+    def _calc_temp(sensor_temp) -> float:
+        t_sensor_temp = sensor_temp / 65536.0
+        return -46.85 + (175.72 * t_sensor_temp)
+
+    @staticmethod
+    def _calc_humid(sensor_humid) -> float:
+        t_sensor_humid = sensor_humid / 65536.0
+        return -6.0 + (125.0 * t_sensor_humid)
+
+    @staticmethod
+    def _temp_coefficient(rh_actual, temp_actual) -> float:
+        return rh_actual - 0.15 * (25 - temp_actual)
+
+    @staticmethod
+    def _crc8check(value) -> bool:
+        # Ported from Sparkfun Arduino HTU21D Library:
+        # https://github.com/sparkfun/HTU21D_Breakout
+        remainder = ((value[0] << 8) + value[1]) << 8
+        remainder |= value[2]
+
+        # POLYNOMIAL = 0x0131 = x^8 + x^5 + x^4 + 1
+        # divisor = 0x988000 is the 0x0131 polynomial shifted to farthest
+        # left of three bytes
+        divisor = 0x988000
+
+        for i in range(0, 16):
+            if remainder & 1 << (23 - i):
+                remainder ^= divisor
+            divisor >>= 1
+
+        if remainder == 0:
+            return True
+        else:
+            _LOGGER.error('Bad CRC: remainder=%s', remainder)
+            return False
+
+    @property
+    def valid_measurement(self) -> bool:
+        """Return True for a valid measurement data."""
+        return self.ok and self.temperature > -100 and self.humidity > -1
+
+    @property
+    def dew_point_temperature(self) -> float:
+        """Get the dew point temperature in ºC for the last measurement."""
+        if self.valid_measurement:
+            coef_a, coef_b, coef_c = 8.1332, 1762.39, 235.66
+            part_press = 10 ** (coef_a - coef_b / (self.temperature + coef_c))
+            dp = - coef_c
+            dp -= coef_b / (log10(self.humidity * part_press / 100.) - coef_a)
+            return dp
+        return -255
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Read raw data and calculate temperature and humidity."""
+        try:
+            self._bus.write_byte(I2C_ADDRESS, CMD_READ_TEMP_NOHOLD)
+            time.sleep(MEASUREMENT_WAIT_TIME)
+            buf_t = self._bus.read_i2c_block_data(
+                I2C_ADDRESS, CMD_READ_TEMP_HOLD, 3)
+
+            self._bus.write_byte(I2C_ADDRESS, CMD_READ_HUM_NOHOLD)
+            time.sleep(MEASUREMENT_WAIT_TIME)
+            buf_h = self._bus.read_i2c_block_data(
+                I2C_ADDRESS, CMD_READ_HUM_HOLD, 3)
+        except OSError as exc:
+            self.ok = False
+            _LOGGER.error("Bad reading: %s", exc)
+            return
+
+        if self._crc8check(buf_t):
+            temp = (buf_t[0] << 8 | buf_t[1]) & 0xFFFC
+            self.temperature = self._calc_temp(temp)
+
+            if self._crc8check(buf_h):
+                humid = (buf_h[0] << 8 | buf_h[1]) & 0xFFFC
+                rh_actual = self._calc_humid(humid)
+                # For temperature coefficient compensation
+                rh_final = self._temp_coefficient(rh_actual, self.temperature)
+                rh_final = 100.0 if rh_final > 100 else rh_final  # Clamp > 100
+                rh_final = 0.0 if rh_final < 0 else rh_final  # Clamp < 0
+                self.humidity = rh_final
+            else:
+                self.humidity = -255
+        else:
+            self.temperature = -255
+        _LOGGER.debug("HTU21D values: {:.2f} ºC, {:.2f} %. Dew point: {:.2f}"
+                      .format(self.temperature, self.humidity,
+                              self.dew_point_temperature))
+
+
+class HTU21DSensor(Entity):
+    """Implementation of the HTU21D sensor."""
+
+    def __init__(self, htu21d_client, name, variable, unit):
+        """Initialize the sensor."""
+        self._name = '{}_{}'.format(name, variable)
+        self._variable = variable
+        self._unit_of_measurement = unit
+        self._client = htu21d_client
+        self._state = None
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self) -> int:
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self) -> str:
+        """Return the unit of measurement of the sensor."""
+        return self._unit_of_measurement
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Get the latest data from the HTU21D sensor and update the state."""
+        yield from self.hass.async_add_job(self._client.update)
+        if self._client.valid_measurement:
+            if self._variable == SENSOR_TEMPERATURE:
+                value = round(self._client.temperature, 1)
+                if self.unit_of_measurement == TEMP_FAHRENHEIT:
+                    value = celsius_to_fahrenheit(value)
+            else:
+                value = round(self._client.humidity, 1)
+            self._state = value

--- a/homeassistant/components/sensor/htu21d.py
+++ b/homeassistant/components/sensor/htu21d.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.temperature import celsius_to_fahrenheit
 
-REQUIREMENTS = ['i2csense==0.0.2',
+REQUIREMENTS = ['i2csense==0.0.3',
                 'smbus-cffi==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,7 +39,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# noinspection PyUnusedLocal
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the HTU21D sensor."""
@@ -47,8 +46,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     bus_number = config.get(CONF_I2C_BUS)
     temp_unit = hass.config.units.temperature_unit
     try:
-        # noinspection PyUnresolvedReferences
+        # pylint: disable=import-error
         import smbus
+        # pylint: disable=import-error
         from i2csense.htu21d import HTU21D
     except ImportError as exc:
         _LOGGER.error("ImportError: %s", exc)
@@ -121,3 +121,5 @@ class HTU21DSensor(Entity):
             else:
                 value = round(self._client.sensor.humidity, 1)
             self._state = value
+        else:
+            _LOGGER.warning("Bad sample")

--- a/homeassistant/components/sensor/htu21d.py
+++ b/homeassistant/components/sensor/htu21d.py
@@ -81,9 +81,6 @@ class HTU21DHandler:
     def update(self):
         """Read raw data and calculate temperature and humidity."""
         self.sensor.update()
-        _LOGGER.debug("HTU21D values: {:.2f} ºC, {:.2f} %. Dew point: {:.2f}"
-                      .format(self.sensor.temperature, self.sensor.humidity,
-                              self.sensor.dew_point_temperature))
 
 
 class HTU21DSensor(Entity):

--- a/homeassistant/components/sensor/htu21d.py
+++ b/homeassistant/components/sensor/htu21d.py
@@ -39,20 +39,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
+# pylint: disable=import-error
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the HTU21D sensor."""
+    import smbus
+    from i2csense.htu21d import HTU21D
+
     name = config.get(CONF_NAME)
     bus_number = config.get(CONF_I2C_BUS)
     temp_unit = hass.config.units.temperature_unit
-    try:
-        # pylint: disable=import-error
-        import smbus
-        # pylint: disable=import-error
-        from i2csense.htu21d import HTU21D
-    except ImportError as exc:
-        _LOGGER.error("ImportError: %s", exc)
-        return False
 
     bus = smbus.SMBus(config.get(CONF_I2C_BUS))
     sensor = yield from hass.async_add_job(
@@ -66,6 +62,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     dev = [HTU21DSensor(sensor_handler, name, SENSOR_TEMPERATURE, temp_unit),
            HTU21DSensor(sensor_handler, name, SENSOR_HUMIDITY, '%')]
+
     async_add_devices(dev)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -316,6 +316,7 @@ https://github.com/wmalgadey/PyTado/archive/0.1.10.zip#PyTado==0.1.10
 https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 
 # homeassistant.components.sensor.bme280
+# homeassistant.components.sensor.htu21d
 # i2csense==0.0.3
 
 # homeassistant.components.influxdb

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -306,6 +306,9 @@ https://github.com/wmalgadey/PyTado/archive/0.1.10.zip#PyTado==0.1.10
 # homeassistant.components.media_player.lg_netcast
 https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 
+# homeassistant.components.sensor.htu21d
+i2csense==0.0.2
+
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
 influxdb==3.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -784,6 +784,7 @@ sleekxmpp==1.3.2
 sleepyq==0.6
 
 # homeassistant.components.sensor.envirophat
+# homeassistant.components.sensor.htu21d
 # smbus-cffi==0.5.1
 
 # homeassistant.components.media_player.snapcast

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -823,6 +823,7 @@ sleepyq==0.6
 
 # homeassistant.components.sensor.bme280
 # homeassistant.components.sensor.envirophat
+# homeassistant.components.sensor.htu21d
 # smbus-cffi==0.5.1
 
 # homeassistant.components.media_player.snapcast

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -307,7 +307,7 @@ https://github.com/wmalgadey/PyTado/archive/0.1.10.zip#PyTado==0.1.10
 https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 
 # homeassistant.components.sensor.htu21d
-i2csense==0.0.2
+# i2csense==0.0.3
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -28,7 +28,8 @@ COMMENT_REQUIREMENTS = (
     'face_recognition',
     'blinkt',
     'smbus-cffi',
-    'envirophat'
+    'envirophat',
+    'i2csense'
 )
 
 TEST_REQUIREMENTS = (


### PR DESCRIPTION
## Introduction:

Many of us use a Raspberry Pi to run Home Assistant, and we have different sensors connected to it, but for many of them there is no direct support, and it is necessary to use template sensors or command line sensors to make them work within Home Assistant.

Problem is using shell commands to retrieve the values of some sensors limits the working modes of these sensors, and, IMHO, it could be an entry barrier for some beginners. 

I think that, as it exists for sensors like the DHT11/22 or the onewire ones, **specific platforms for good and cheap digital sensors**, with a simple configuration in Home Assistant, are very convenient.

This is the second of a series of PR that I intend to propose for supporting I2c digital sensors compatible with Raspberry Pi. First was #7989 (BME280 sensor), and next will be a light level sensor (BH1750).

## Description:

**HTU21D sensor** support as a sensor platform. Senses **temperature** and **humidity**.

The docs include a section to easy install the `i2c` and `smbus` support for the `home_assistant` user, to get things done quickly.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2820

## Example entry for `configuration.yaml` (if applicable):
```yaml 
sensor:
   - platform: htu21d
     name: Ambient 
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54