### PR TITLE
Added host variable to Splunk.py and updated tox tests

### DIFF
--- a/homeassistant/components/splunk.py
+++ b/homeassistant/components/splunk.py
@@ -1,5 +1,6 @@
 """
 Support to send data to an Splunk instance.
+
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/splunk/
 """

--- a/homeassistant/components/splunk.py
+++ b/homeassistant/components/splunk.py
@@ -1,6 +1,5 @@
 """
 Support to send data to an Splunk instance.
-
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/splunk/
 """
@@ -11,7 +10,7 @@ import requests
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONF_HOST, CONF_PORT, CONF_SSL, CONF_TOKEN, EVENT_STATE_CHANGED)
+    CONF_NAME, CONF_HOST, CONF_PORT, CONF_SSL, CONF_TOKEN, EVENT_STATE_CHANGED)
 from homeassistant.helpers import state as state_helper
 import homeassistant.helpers.config_validation as cv
 
@@ -22,6 +21,7 @@ DOMAIN = 'splunk'
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 8088
 DEFAULT_SSL = False
+DEFAULT_NAME = 'HASS'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -29,6 +29,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_SSL, default=False): cv.boolean,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -40,6 +41,7 @@ def setup(hass, config):
     port = conf.get(CONF_PORT)
     token = conf.get(CONF_TOKEN)
     use_ssl = conf.get(CONF_SSL)
+    name = conf.get(CONF_NAME)
 
     if use_ssl:
         uri_scheme = 'https://'
@@ -69,6 +71,7 @@ def setup(hass, config):
                 'attributes': dict(state.attributes),
                 'time': str(event.time_fired),
                 'value': _state,
+                'host': name,
             }
         ]
 
@@ -85,3 +88,4 @@ def setup(hass, config):
     hass.bus.listen(EVENT_STATE_CHANGED, splunk_event_listener)
 
     return True
+

--- a/homeassistant/components/splunk.py
+++ b/homeassistant/components/splunk.py
@@ -88,4 +88,3 @@ def setup(hass, config):
     hass.bus.listen(EVENT_STATE_CHANGED, splunk_event_listener)
 
     return True
-

--- a/tests/components/test_splunk.py
+++ b/tests/components/test_splunk.py
@@ -28,6 +28,7 @@ class TestSplunk(unittest.TestCase):
                 'port': 123,
                 'token': 'secret',
                 'ssl': 'False',
+                'name': 'hostname',
             }
         }
 
@@ -96,6 +97,7 @@ class TestSplunk(unittest.TestCase):
                 'attributes': {},
                 'time': '12345',
                 'value': out,
+                'host': 'HASS',
             }]
 
             payload = {'host': 'http://host:8088/services/collector/event',


### PR DESCRIPTION
This change is to allow the user to send a variable "name" in configuration.yaml that will send Splunk a friendly name for your HASS instance. PR also contains updated tests

Description:

Related issue (if applicable): fixes #

Pull request in home-assistant.github.io with documentation (if applicable): home-assistant/home-assistant.github.io#2817

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
