### PR TITLE
Restrict Python Script

### DIFF
--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -120,4 +120,32 @@ raise Exception('boom')
     hass.async_add_job(execute, hass, 'test.py', source, {})
     yield from hass.async_block_till_done()
 
-    assert "Error executing script test.py" in caplog.text
+    assert "Error executing script: boom" in caplog.text
+
+
+@asyncio.coroutine
+def test_accessing_async_methods(hass, caplog):
+    """Test compile error logs error."""
+    caplog.set_level(logging.ERROR)
+    source = """
+hass.async_stop()
+    """
+
+    hass.async_add_job(execute, hass, 'test.py', source, {})
+    yield from hass.async_block_till_done()
+
+    assert "Not allowed to access async methods" in caplog.text
+
+
+@asyncio.coroutine
+def test_accessing_forbidden_methods(hass, caplog):
+    """Test compile error logs error."""
+    caplog.set_level(logging.ERROR)
+    source = """
+hass.stop()
+    """
+
+    hass.async_add_job(execute, hass, 'test.py', source, {})
+    yield from hass.async_block_till_done()
+
+    assert "Not allowed to access HomeAssistant.stop" in caplog.text


### PR DESCRIPTION
## Description:
This will put some restrictions on what can be called from the Python Script environment. Protects any async method from being accessed and whitelists only a few methods on the hass object.

![image](https://user-images.githubusercontent.com/1444314/27211720-15b9fa5e-5210-11e7-9dbd-981116dac708.png)

## Example entry for `configuration.yaml` (if applicable):
```yaml
python_script:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
