### PR TITLE
Openhardwaremonitor

### DIFF
--- a/homeassistant/components/sensor/openhardwaremonitor.py
+++ b/homeassistant/components/sensor/openhardwaremonitor.py
@@ -6,7 +6,6 @@ import requests
 import voluptuous as vol
 
 from homeassistant.util.dt import utcnow
-from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.const import CONF_HOST, CONF_PORT
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA

--- a/homeassistant/components/sensor/openhardwaremonitor.py
+++ b/homeassistant/components/sensor/openhardwaremonitor.py
@@ -1,13 +1,10 @@
-"""
-Support for Open Hardware Monitor Sensor Platform.
-"""
+"""Support for Open Hardware Monitor Sensor Platform."""
 
 from threading import Timer
 from datetime import timedelta
 import logging
-import json
 
-import urllib.request
+import requests
 import voluptuous as vol
 
 from homeassistant.const import CONF_HOST, CONF_PORT
@@ -33,6 +30,18 @@ OHM_MAX = 'Max'
 OHM_CHILDREN = 'Children'
 OHM_NAME = 'Text'
 
+ATTR_COMPUTER_NAME = 'computer_name'
+ATTR_DEVICE_NAME = 'device_name'
+ATTR_SPEC_NAME = 'spec_name'
+ATTR_VALUE_NAME = 'value_name'
+
+ATTRIBUTES = [
+    ATTR_COMPUTER_NAME,
+    ATTR_DEVICE_NAME,
+    ATTR_SPEC_NAME,
+    ATTR_VALUE_NAME
+]
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=8085): cv.port
@@ -41,33 +50,22 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Open Hardware Monitor platform."""
-    # update_json(config, add_devices)
-
     data = OpenHardwareMonitorData(config)
-    add_devices(data.devices)
+    add_devices(data.devices, True)
 
 
 class OpenHardwareMonitorDevice(Entity):
     """Device used to display information from OpenHardwareMonitor."""
 
-    def __init__(self, data, name, path, obj, attributes):
-        """Initialize a OpenHardwareMonitor sensor."""
+    def __init__(self, data, name, path, unit_of_measurement):
+        """Initialize an OpenHardwareMonitor sensor."""
         self._name = name
         self._data = data
+        self.path = path
+        self.attributes = {}
+        self._unit_of_measurement = unit_of_measurement
 
-        self._path = path
-        self._obj = obj
-        self._attributes = attributes
-
-        self._state = None
-        self._min = None
-        self._max = None
-
-        parts = obj[OHM_VALUE].split(' ')
-        self._state = parts[0]
-        self._unit_of_measurement = parts[1]
-        self._min = self._obj[OHM_MIN].split(' ')[0]
-        self._max = self._obj[OHM_MAX].split(' ')[0]
+        self.value = None
 
     @property
     def name(self):
@@ -82,26 +80,17 @@ class OpenHardwareMonitorDevice(Entity):
     @property
     def state(self):
         """Return the state of the device."""
-        return self._state
+        return self.value
 
     @property
     def state_attributes(self):
         """Return the state attributes of the sun."""
-        result = self._attributes.copy()
-        result.update({
-            STATE_MIN_VALUE: self._min,
-            STATE_MAX_VALUE: self._max
-        })
-        return result
+        return self.attributes
 
     def update(self):
         """Update the device from a new JSON object."""
         self._data.update()
-        self._obj = self._data.update_object(self._path)
-
-        self._state = self._obj[OHM_VALUE].split(' ')[0]
-        self._min = self._obj[OHM_MIN].split(' ')[0]
-        self._max = self._obj[OHM_MAX].split(' ')[0]
+        self._data.update_device(self)
 
 
 class OpenHardwareMonitorData(object):
@@ -124,19 +113,15 @@ class OpenHardwareMonitorData(object):
 
     def refresh(self):
         """Download and parse JSON from OHM."""
-        host = self._config.get(CONF_HOST)
-        port = self._config.get(CONF_PORT)
-        data_url = "http://%s:%d/data.json" % (host, port)
-        _LOGGER.info("Download from %s", data_url)
+        data_url = "http://%s:%d/data.json" % (
+            self._config.get(CONF_HOST),
+            self._config.get(CONF_PORT))
 
         try:
-            with urllib.request.urlopen(data_url) as url:
-                self._data = json.loads(url.read().decode())
-        except urllib.error.URLError:
-            _LOGGER.error("URLError: Is OpenHardwareMonitor running?")
-        except ConnectionRefusedError:
-            _LOGGER.error(
-                "Connection refused, is OpenHardwareMonitor running?")
+            response = requests.get(data_url)
+            self._data = response.json()
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("ConnectionError: Is OpenHardwareMonitor running?")
 
     def schedule_retry(self):
         """Schedule a retry in 30 seconds."""
@@ -145,7 +130,7 @@ class OpenHardwareMonitorData(object):
         timer.start()
 
     def initialize(self):
-        """Initial parsing of the sensors and adding of deviced."""
+        """Initial parsing of the sensors and adding of devices."""
         self.refresh()
 
         if self._data is None:
@@ -153,60 +138,64 @@ class OpenHardwareMonitorData(object):
             return
 
         computer_count = len(self._data[OHM_CHILDREN])
-        _LOGGER.info("Detected %d PC(s)", computer_count)
 
-        if computer_count > 0:
-            for computer_index in range(0, computer_count):
-                computer = self._data[OHM_CHILDREN][computer_index]
-                computer_name = computer[OHM_NAME]
+        for computer_index in range(0, computer_count):
+            computer = self._data[OHM_CHILDREN][computer_index]
+            computer_name = computer[OHM_NAME]
 
-                devices = computer[OHM_CHILDREN]
-                for device_index in range(0, len(devices)):
-                    device = devices[device_index]
-                    device_name = device[OHM_NAME]
+            devices = computer[OHM_CHILDREN]
+            for device_index in range(0, len(devices)):
+                device = devices[device_index]
+                device_name = device[OHM_NAME]
 
-                    specs = device[OHM_CHILDREN]
-                    for spec_index in range(0, len(specs)):
-                        spec = specs[spec_index]
-                        spec_name = spec[OHM_NAME]
+                specs = device[OHM_CHILDREN]
+                for spec_index in range(0, len(specs)):
+                    spec = specs[spec_index]
+                    spec_name = spec[OHM_NAME]
 
-                        values = spec[OHM_CHILDREN]
-                        for value_index in range(0, len(values)):
-                            value = values[value_index]
-                            value_name = value[OHM_NAME]
+                    values = spec[OHM_CHILDREN]
+                    for value_index in range(0, len(values)):
+                        value = values[value_index]
+                        value_name = value[OHM_NAME]
 
-                            path = []
-                            path.append(computer_index)
-                            path.append(device_index)
-                            path.append(spec_index)
-                            path.append(value_index)
+                        path = []
+                        path.append(computer_index)
+                        path.append(device_index)
+                        path.append(spec_index)
+                        path.append(value_index)
 
-                            attributes = {
-                                "computer_name": computer_name,
-                                "device_name": device_name,
-                                "spec_name": spec_name,
-                                "value_name": value_name
-                            }
+                        unit_of_measurement = value[OHM_VALUE].split(' ')[1]
+                        dev = OpenHardwareMonitorDevice(
+                            self,
+                            "%s_%s_%s_%s" % (
+                                computer_name,
+                                device_name,
+                                spec_name,
+                                value_name),
+                            path, unit_of_measurement)
 
-                            dev = OpenHardwareMonitorDevice(
-                                self,
-                                "%s_%s_%s_%s" % (
-                                    computer_name,
-                                    device_name,
-                                    spec_name,
-                                    value_name),
-                                path, value, attributes)
+                        self.devices.append(dev)
 
-                            self.devices.append(dev)
-
-    def update_object(self, path):
-        """Get the object by specified path."""
+    def update_device(self, device):
+        """Update ."""
         array = self._data[OHM_CHILDREN]
 
-        for path_index in range(0, len(path)):
-            path_number = path[path_index]
+        attributes = {}
+        for path_index in range(0, len(device.path)):
+            path_number = device.path[path_index]
+            values = array[path_number]
 
-            if path_index == len(path) - 1:
-                return array[path_number]
+            attributes.update({
+                ATTRIBUTES[path_index]: values[OHM_NAME]
+            })
+
+            if path_index == len(device.path) - 1:
+                device.value = values[OHM_VALUE].split(' ')[0]
+                attributes.update({
+                    STATE_MIN_VALUE: values[OHM_MIN].split(' ')[0],
+                    STATE_MAX_VALUE: values[OHM_MAX].split(' ')[0]
+                })
+                device.attributes = attributes
+                return
             else:
                 array = array[path_number][OHM_CHILDREN]

--- a/homeassistant/components/sensor/openhardwaremonitor.py
+++ b/homeassistant/components/sensor/openhardwaremonitor.py
@@ -1,0 +1,214 @@
+"""
+Support for Open Hardware Monitor Sensor Platform.
+
+(c) 2017 by Wim Haanstra
+"""
+
+from threading import Timer
+from datetime import timedelta
+import logging
+import json
+
+import urllib.request
+import voluptuous as vol
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+_LOGGER = logging.getLogger(__name__)
+
+STATE_MIN_VALUE = 'minimal_value'
+STATE_MAX_VALUE = 'maximum_value'
+STATE_VALUE = 'value'
+STATE_OBJECT = 'object'
+CONF_INTERVAL = 'interval'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1)
+SCAN_INTERVAL = timedelta(seconds=5)
+
+OHM_VALUE = 'Value'
+OHM_MIN = 'Min'
+OHM_MAX = 'Max'
+OHM_CHILDREN = 'Children'
+OHM_NAME = 'Text'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=8085): cv.port
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Open Hardware Monitor platform."""
+    # update_json(config, add_devices)
+
+    data = OpenHardwareMonitorData(config)
+    add_devices(data.devices)
+
+
+class OpenHardwareMonitorDevice(Entity):
+    """Device used to display information from OpenHardwareMonitor."""
+
+    def __init__(self, data, name, path, obj, attributes):
+        """Initialize a OpenHardwareMonitor sensor."""
+        self._name = name
+        self._data = data
+
+        self._path = path
+        self._obj = obj
+        self._attributes = attributes
+
+        self._state = None
+        self._min = None
+        self._max = None
+
+        parts = obj[OHM_VALUE].split(' ')
+        self._state = parts[0]
+        self._unit_of_measurement = parts[1]
+        self._min = self._obj[OHM_MIN].split(' ')[0]
+        self._max = self._obj[OHM_MAX].split(' ')[0]
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._unit_of_measurement
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the sun."""
+        result = self._attributes.copy()
+        result.update({
+            STATE_MIN_VALUE: self._min,
+            STATE_MAX_VALUE: self._max
+        })
+        return result
+
+    def update(self):
+        """Update the device from a new JSON object."""
+        self._data.update()
+        self._obj = self._data.update_object(self._path)
+
+        self._state = self._obj[OHM_VALUE].split(' ')[0]
+        self._min = self._obj[OHM_MIN].split(' ')[0]
+        self._max = self._obj[OHM_MAX].split(' ')[0]
+
+
+class OpenHardwareMonitorData(object):
+    """Class used to pull data from OHM and create sensors."""
+
+    def __init__(self, config):
+        """Initialize the Open Hardware Monitor data-handler."""
+        self._data = None
+        self._config = config
+        self.devices = []
+        self.initialize()
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Hit by the timer with the configured interval."""
+        if self._data is None:
+            self.initialize()
+        else:
+            self.refresh()
+
+    def refresh(self):
+        """Download and parse JSON from OHM."""
+        host = self._config.get(CONF_HOST)
+        port = self._config.get(CONF_PORT)
+        data_url = "http://%s:%d/data.json" % (host, port)
+        _LOGGER.info("Download from %s", data_url)
+
+        try:
+            with urllib.request.urlopen(data_url) as url:
+                self._data = json.loads(url.read().decode())
+        except urllib.error.URLError:
+            _LOGGER.error("URLError: Is OpenHardwareMonitor running?")
+        except ConnectionRefusedError:
+            _LOGGER.error(
+                "Connection refused, is OpenHardwareMonitor running?")
+
+    def schedule_retry(self):
+        """Schedule a retry in 30 seconds."""
+        _LOGGER.info("Retrying in 30 seconds")
+        timer = Timer(30, self.initialize)
+        timer.start()
+
+    def initialize(self):
+        """Initial parsing of the sensors and adding of deviced."""
+        self.refresh()
+
+        if self._data is None:
+            self.schedule_retry()
+            return
+
+        computer_count = len(self._data[OHM_CHILDREN])
+        _LOGGER.info("Detected %d PC(s)", computer_count)
+
+        if computer_count > 0:
+            for computer_index in range(0, computer_count):
+                computer = self._data[OHM_CHILDREN][computer_index]
+                computer_name = computer[OHM_NAME]
+
+                devices = computer[OHM_CHILDREN]
+                for device_index in range(0, len(devices)):
+                    device = devices[device_index]
+                    device_name = device[OHM_NAME]
+
+                    specs = device[OHM_CHILDREN]
+                    for spec_index in range(0, len(specs)):
+                        spec = specs[spec_index]
+                        spec_name = spec[OHM_NAME]
+
+                        values = spec[OHM_CHILDREN]
+                        for value_index in range(0, len(values)):
+                            value = values[value_index]
+                            value_name = value[OHM_NAME]
+
+                            path = []
+                            path.append(computer_index)
+                            path.append(device_index)
+                            path.append(spec_index)
+                            path.append(value_index)
+
+                            attributes = {
+                                "computer_name": computer_name,
+                                "device_name": device_name,
+                                "spec_name": spec_name,
+                                "value_name": value_name
+                            }
+
+                            dev = OpenHardwareMonitorDevice(
+                                self,
+                                "%s_%s_%s_%s" % (
+                                    computer_name,
+                                    device_name,
+                                    spec_name,
+                                    value_name),
+                                path, value, attributes)
+
+                            self.devices.append(dev)
+
+    def update_object(self, path):
+        """Get the object by specified path."""
+        array = self._data[OHM_CHILDREN]
+
+        for path_index in range(0, len(path)):
+            path_number = path[path_index]
+
+            if path_index == len(path) - 1:
+                return array[path_number]
+            else:
+                array = array[path_number][OHM_CHILDREN]

--- a/homeassistant/components/sensor/openhardwaremonitor.py
+++ b/homeassistant/components/sensor/openhardwaremonitor.py
@@ -1,7 +1,5 @@
 """
 Support for Open Hardware Monitor Sensor Platform.
-
-(c) 2017 by Wim Haanstra
 """
 
 from threading import Timer

--- a/homeassistant/components/sensor/openhardwaremonitor.py
+++ b/homeassistant/components/sensor/openhardwaremonitor.py
@@ -177,7 +177,7 @@ class OpenHardwareMonitorData(object):
                         self.devices.append(dev)
 
     def update_device(self, device):
-        """Update ."""
+        """Update device."""
         array = self._data[OHM_CHILDREN]
 
         attributes = {}

--- a/tests/components/sensor/test_openhardwaremonitor.py
+++ b/tests/components/sensor/test_openhardwaremonitor.py
@@ -1,52 +1,40 @@
 """The tests for the Open Hardware Monitor platform."""
 import unittest
 import requests_mock
-from homeassistant.components.sensor import openhardwaremonitor
 from homeassistant.setup import setup_component
-
 from tests.common import load_fixture, get_test_home_assistant
 
 
 class TestOpenHardwareMonitorSetup(unittest.TestCase):
     """Test the Open Hardware Monitor platform."""
 
-    def add_entities(self, new_entities, update_before_add=False):
-        """Mock add entities."""
-        if update_before_add:
-            for entity in new_entities:
-                entity.update()
-
-        for entity in new_entities:
-            self.entities.append(entity)
-
     def setUp(self):
         """Initialize values for this testcase class."""
         self.hass = get_test_home_assistant()
         self.config = {
-            'host': 'localhost',
-            'port': 8085
+            'sensor': {
+                'platform': 'openhardwaremonitor',
+                'host': 'localhost',
+                'port': 8085
+            }
         }
-        self.entities = []
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""
         self.hass.stop()
 
-    def test_setup_with_config(self):
-        """Test the platform setup with configuration."""
-        self.assertTrue(
-            setup_component(self.hass, 'sensor', {
-                'openhardwaremonitor': self.config}))
-
     @requests_mock.Mocker()
     def test_setup(self, mock_req):
         """Test for successfully setting up the platform."""
-        mock_req.get('/data.json',
+        mock_req.get('http://localhost:8085/data.json',
                      text=load_fixture('openhardwaremonitor.json'))
-        openhardwaremonitor.setup_platform(
-            self.hass, self.config, self.add_entities)
-        self.assertEqual(len(self.entities), 38)
-        self.assertEqual(self.entities[0].name,
-                         "TEST-PC_Intel_Core_i7-7700_Clocks_Bus_Speed")
-        self.assertEqual(self.entities[0].state, '100')
-        self.assertEqual(self.entities[0].unit_of_measurement, 'MHz')
+
+        self.assertTrue(setup_component(self.hass, 'sensor', self.config))
+        entities = self.hass.states.async_entity_ids('sensor')
+        self.assertEqual(len(entities), 38)
+
+        state = self.hass.states.get(
+            'sensor.testpc_intel_core_i77700_clocks_bus_speed')
+
+        self.assertIsNot(state, None)
+        self.assertEqual(state.state, '100')

--- a/tests/components/sensor/test_openhardwaremonitor.py
+++ b/tests/components/sensor/test_openhardwaremonitor.py
@@ -47,5 +47,6 @@ class TestOpenHardwareMonitorSetup(unittest.TestCase):
             self.hass, self.config, self.add_entities)
         self.assertEqual(len(self.entities), 38)
         self.assertEqual(self.entities[0].name,
-                         "TEST-PC_Intel Core i7-7700_Clocks_Bus Speed")
+                         "TEST-PC_Intel_Core_i7-7700_Clocks_Bus_Speed")
         self.assertEqual(self.entities[0].state, '100')
+        self.assertEqual(self.entities[0].unit_of_measurement, 'MHz')

--- a/tests/components/sensor/test_openhardwaremonitor.py
+++ b/tests/components/sensor/test_openhardwaremonitor.py
@@ -1,0 +1,51 @@
+"""The tests for the Open Hardware Monitor platform."""
+import unittest
+import requests_mock
+from homeassistant.components.sensor import openhardwaremonitor
+from homeassistant.setup import setup_component
+
+from tests.common import load_fixture, get_test_home_assistant
+
+
+class TestOpenHardwareMonitorSetup(unittest.TestCase):
+    """Test the Open Hardware Monitor platform."""
+
+    def add_entities(self, new_entities, update_before_add=False):
+        """Mock add entities."""
+        if update_before_add:
+            for entity in new_entities:
+                entity.update()
+
+        for entity in new_entities:
+            self.entities.append(entity)
+
+    def setUp(self):
+        """Initialize values for this testcase class."""
+        self.hass = get_test_home_assistant()
+        self.config = {
+            'host': 'localhost',
+            'port': 8085
+        }
+        self.entities = []
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_setup_with_config(self):
+        """Test the platform setup with configuration."""
+        self.assertTrue(
+            setup_component(self.hass, 'sensor', {
+                'openhardwaremonitor': self.config}))
+
+    @requests_mock.Mocker()
+    def test_setup(self, mock_req):
+        """Test for successfully setting up the platform."""
+        mock_req.get('/data.json',
+                     text=load_fixture('openhardwaremonitor.json'))
+        openhardwaremonitor.setup_platform(
+            self.hass, self.config, self.add_entities)
+        self.assertEqual(len(self.entities), 38)
+        self.assertEqual(self.entities[0].name,
+                         "TEST-PC_Intel Core i7-7700_Clocks_Bus Speed")
+        self.assertEqual(self.entities[0].state, '100')

--- a/tests/fixtures/openhardwaremonitor.json
+++ b/tests/fixtures/openhardwaremonitor.json
@@ -1,0 +1,571 @@
+{
+    "id": 0,
+    "Text": "Sensor",
+    "Children": [
+        {
+            "id": 1,
+            "Text": "TEST-PC",
+            "Children": [
+                {
+                    "id": 2,
+                    "Text": "ASUS PRIME Z270-P",
+                    "Children": [],
+                    "Min": "",
+                    "Value": "",
+                    "Max": "",
+                    "ImageURL": "images_icon/mainboard.png"
+                },
+                {
+                    "id": 3,
+                    "Text": "Intel Core i7-7700",
+                    "Children": [
+                        {
+                            "id": 4,
+                            "Text": "Clocks",
+                            "Children": [
+                                {
+                                    "id": 5,
+                                    "Text": "Bus Speed",
+                                    "Children": [],
+                                    "Min": "100 MHz",
+                                    "Value": "100 MHz",
+                                    "Max": "100 MHz",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 6,
+                                    "Text": "CPU Core #1",
+                                    "Children": [],
+                                    "Min": "800 MHz",
+                                    "Value": "800 MHz",
+                                    "Max": "4200 MHz",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 7,
+                                    "Text": "CPU Core #2",
+                                    "Children": [],
+                                    "Min": "800 MHz",
+                                    "Value": "800 MHz",
+                                    "Max": "4200 MHz",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 8,
+                                    "Text": "CPU Core #3",
+                                    "Children": [],
+                                    "Min": "800 MHz",
+                                    "Value": "800 MHz",
+                                    "Max": "4200 MHz",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 9,
+                                    "Text": "CPU Core #4",
+                                    "Children": [],
+                                    "Min": "800 MHz",
+                                    "Value": "800 MHz",
+                                    "Max": "4200 MHz",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/clock.png"
+                        },
+                        {
+                            "id": 10,
+                            "Text": "Temperatures",
+                            "Children": [
+                                {
+                                    "id": 11,
+                                    "Text": "CPU Core #1",
+                                    "Children": [],
+                                    "Min": "29.0 °C",
+                                    "Value": "31.0 °C",
+                                    "Max": "60.0 °C",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 12,
+                                    "Text": "CPU Core #2",
+                                    "Children": [],
+                                    "Min": "29.0 °C",
+                                    "Value": "30.0 °C",
+                                    "Max": "61.0 °C",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 13,
+                                    "Text": "CPU Core #3",
+                                    "Children": [],
+                                    "Min": "28.0 °C",
+                                    "Value": "29.0 °C",
+                                    "Max": "58.0 °C",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 14,
+                                    "Text": "CPU Core #4",
+                                    "Children": [],
+                                    "Min": "29.0 °C",
+                                    "Value": "31.0 °C",
+                                    "Max": "57.0 °C",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 15,
+                                    "Text": "CPU Package",
+                                    "Children": [],
+                                    "Min": "30.0 °C",
+                                    "Value": "31.0 °C",
+                                    "Max": "61.0 °C",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/temperature.png"
+                        },
+                        {
+                            "id": 16,
+                            "Text": "Load",
+                            "Children": [
+                                {
+                                    "id": 17,
+                                    "Text": "CPU Total",
+                                    "Children": [],
+                                    "Min": "0.0 %",
+                                    "Value": "1.0 %",
+                                    "Max": "42.2 %",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 18,
+                                    "Text": "CPU Core #1",
+                                    "Children": [],
+                                    "Min": "0.0 %",
+                                    "Value": "1.6 %",
+                                    "Max": "50.8 %",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 19,
+                                    "Text": "CPU Core #2",
+                                    "Children": [],
+                                    "Min": "0.0 %",
+                                    "Value": "1.6 %",
+                                    "Max": "52.0 %",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 20,
+                                    "Text": "CPU Core #3",
+                                    "Children": [],
+                                    "Min": "0.0 %",
+                                    "Value": "0.0 %",
+                                    "Max": "52.2 %",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 21,
+                                    "Text": "CPU Core #4",
+                                    "Children": [],
+                                    "Min": "0.0 %",
+                                    "Value": "0.8 %",
+                                    "Max": "51.8 %",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/load.png"
+                        },
+                        {
+                            "id": 22,
+                            "Text": "Powers",
+                            "Children": [
+                                {
+                                    "id": 23,
+                                    "Text": "CPU Package",
+                                    "Children": [],
+                                    "Min": "4.4 W",
+                                    "Value": "12.1 W",
+                                    "Max": "44.6 W",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 24,
+                                    "Text": "CPU Cores",
+                                    "Children": [],
+                                    "Min": "0.9 W",
+                                    "Value": "1.0 W",
+                                    "Max": "33.5 W",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 25,
+                                    "Text": "CPU Graphics",
+                                    "Children": [],
+                                    "Min": "0.0 W",
+                                    "Value": "0.0 W",
+                                    "Max": "0.0 W",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 26,
+                                    "Text": "CPU DRAM",
+                                    "Children": [],
+                                    "Min": "1.0 W",
+                                    "Value": "1.0 W",
+                                    "Max": "2.4 W",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/power.png"
+                        }
+                    ],
+                    "Min": "",
+                    "Value": "",
+                    "Max": "",
+                    "ImageURL": "images_icon/cpu.png"
+                },
+                {
+                    "id": 27,
+                    "Text": "Generic Memory",
+                    "Children": [
+                        {
+                            "id": 28,
+                            "Text": "Load",
+                            "Children": [
+                                {
+                                    "id": 29,
+                                    "Text": "Memory",
+                                    "Children": [],
+                                    "Min": "13.1 %",
+                                    "Value": "13.6 %",
+                                    "Max": "14.5 %",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/load.png"
+                        },
+                        {
+                            "id": 30,
+                            "Text": "Data",
+                            "Children": [
+                                {
+                                    "id": 31,
+                                    "Text": "Used Memory",
+                                    "Children": [],
+                                    "Min": "4.2 GB",
+                                    "Value": "4.3 GB",
+                                    "Max": "4.6 GB",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 32,
+                                    "Text": "Available Memory",
+                                    "Children": [],
+                                    "Min": "27.2 GB",
+                                    "Value": "27.5 GB",
+                                    "Max": "27.7 GB",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/power.png"
+                        }
+                    ],
+                    "Min": "",
+                    "Value": "",
+                    "Max": "",
+                    "ImageURL": "images_icon/ram.png"
+                },
+                {
+                    "id": 33,
+                    "Text": "NVIDIA GeForce GTX 1080",
+                    "Children": [
+                        {
+                            "id": 34,
+                            "Text": "Clocks",
+                            "Children": [
+                                {
+                                    "id": 35,
+                                    "Text": "GPU Core",
+                                    "Children": [],
+                                    "Min": "215 MHz",
+                                    "Value": "215 MHz",
+                                    "Max": "1683 MHz",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 36,
+                                    "Text": "GPU Memory",
+                                    "Children": [],
+                                    "Min": "405 MHz",
+                                    "Value": "405 MHz",
+                                    "Max": "5006 MHz",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 37,
+                                    "Text": "GPU Shader",
+                                    "Children": [],
+                                    "Min": "430 MHz",
+                                    "Value": "430 MHz",
+                                    "Max": "3366 MHz",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/clock.png"
+                        },
+                        {
+                            "id": 38,
+                            "Text": "Temperatures",
+                            "Children": [
+                                {
+                                    "id": 39,
+                                    "Text": "GPU Core",
+                                    "Children": [],
+                                    "Min": "38.0 °C",
+                                    "Value": "39.0 °C",
+                                    "Max": "42.0 °C",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/temperature.png"
+                        },
+                        {
+                            "id": 40,
+                            "Text": "Load",
+                            "Children": [
+                                {
+                                    "id": 41,
+                                    "Text": "GPU Core",
+                                    "Children": [],
+                                    "Min": "0.0 %",
+                                    "Value": "0.0 %",
+                                    "Max": "19.0 %",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 42,
+                                    "Text": "GPU Memory Controller",
+                                    "Children": [],
+                                    "Min": "0.0 %",
+                                    "Value": "0.0 %",
+                                    "Max": "2.0 %",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 43,
+                                    "Text": "GPU Video Engine",
+                                    "Children": [],
+                                    "Min": "0.0 %",
+                                    "Value": "0.0 %",
+                                    "Max": "0.0 %",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 44,
+                                    "Text": "GPU Memory",
+                                    "Children": [],
+                                    "Min": "3.9 %",
+                                    "Value": "3.9 %",
+                                    "Max": "4.1 %",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/load.png"
+                        },
+                        {
+                            "id": 45,
+                            "Text": "Fans",
+                            "Children": [
+                                {
+                                    "id": 46,
+                                    "Text": "GPU",
+                                    "Children": [],
+                                    "Min": "0 RPM",
+                                    "Value": "0 RPM",
+                                    "Max": "0 RPM",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/fan.png"
+                        },
+                        {
+                            "id": 47,
+                            "Text": "Controls",
+                            "Children": [
+                                {
+                                    "id": 48,
+                                    "Text": "GPU Fan",
+                                    "Children": [],
+                                    "Min": "0.0 %",
+                                    "Value": "0.0 %",
+                                    "Max": "0.0 %",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/control.png"
+                        },
+                        {
+                            "id": 49,
+                            "Text": "Data",
+                            "Children": [
+                                {
+                                    "id": 50,
+                                    "Text": "GPU Memory Free",
+                                    "Children": [],
+                                    "Min": "7854.8 MB",
+                                    "Value": "7873.1 MB",
+                                    "Max": "7873.1 MB",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 51,
+                                    "Text": "GPU Memory Used",
+                                    "Children": [],
+                                    "Min": "318.9 MB",
+                                    "Value": "318.9 MB",
+                                    "Max": "337.2 MB",
+                                    "ImageURL": "images/transparent.png"
+                                },
+                                {
+                                    "id": 52,
+                                    "Text": "GPU Memory Total",
+                                    "Children": [],
+                                    "Min": "8192.0 MB",
+                                    "Value": "8192.0 MB",
+                                    "Max": "8192.0 MB",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/power.png"
+                        }
+                    ],
+                    "Min": "",
+                    "Value": "",
+                    "Max": "",
+                    "ImageURL": "images_icon/nvidia.png"
+                },
+                {
+                    "id": 53,
+                    "Text": "Generic Hard Disk",
+                    "Children": [
+                        {
+                            "id": 54,
+                            "Text": "Load",
+                            "Children": [
+                                {
+                                    "id": 55,
+                                    "Text": "Used Space",
+                                    "Children": [],
+                                    "Min": "74.6 %",
+                                    "Value": "75.3 %",
+                                    "Max": "75.6 %",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/load.png"
+                        }
+                    ],
+                    "Min": "",
+                    "Value": "",
+                    "Max": "",
+                    "ImageURL": "images_icon/hdd.png"
+                },
+                {
+                    "id": 56,
+                    "Text": "WDC WD30EZRZ-00Z5HB0",
+                    "Children": [
+                        {
+                            "id": 57,
+                            "Text": "Temperatures",
+                            "Children": [
+                                {
+                                    "id": 58,
+                                    "Text": "Temperature",
+                                    "Children": [],
+                                    "Min": "30.0 °C",
+                                    "Value": "30.0 °C",
+                                    "Max": "32.0 °C",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/temperature.png"
+                        },
+                        {
+                            "id": 59,
+                            "Text": "Load",
+                            "Children": [
+                                {
+                                    "id": 60,
+                                    "Text": "Used Space",
+                                    "Children": [],
+                                    "Min": "14.4 %",
+                                    "Value": "14.4 %",
+                                    "Max": "14.4 %",
+                                    "ImageURL": "images/transparent.png"
+                                }
+                            ],
+                            "Min": "",
+                            "Value": "",
+                            "Max": "",
+                            "ImageURL": "images_icon/load.png"
+                        }
+                    ],
+                    "Min": "",
+                    "Value": "",
+                    "Max": "",
+                    "ImageURL": "images_icon/hdd.png"
+                }
+            ],
+            "Min": "",
+            "Value": "",
+            "Max": "",
+            "ImageURL": "images_icon/computer.png"
+        }
+    ],
+    "Min": "Min",
+    "Value": "Value",
+    "Max": "Max",
+    "ImageURL": ""
+}


### PR DESCRIPTION
## Description:
Adds a Open Hardware Monitor platform, that enables Home Assistant to connect to another host.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2824

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: openhardwaremonitor
    host: HOSTNAME_OF_OPENHARDWAREMONITOR
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
