### PR TITLE
No update in MQTT Binary Sensor #7478

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -646,7 +646,7 @@ def _match_topic(subscription, topic):
         if sub_part == "+":
             reg_ex_parts.append(r"([^\/]+)")
         else:
-            reg_ex_parts.append(sub_part)
+            reg_ex_parts.append(re.escape(sub_part))
 
     reg_ex = "^" + (r'\/'.join(reg_ex_parts)) + suffix + "$"
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -249,6 +249,19 @@ class TestMQTT(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
 
+    def test_subscribe_special_characters(self):
+        """Test the subscription to topics with special characters."""
+        topic = '/test-topic/$(.)[^]{-}'
+        payload = 'p4y.l[]a|> ?'
+
+        mqtt.subscribe(self.hass, topic, self.record_calls)
+
+        fire_mqtt_message(self.hass, topic, payload)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        self.assertEqual(topic, self.calls[0][0])
+        self.assertEqual(payload, self.calls[0][1])
+
     def test_subscribe_binary_topic(self):
         """Test the subscription to a binary topic."""
         mqtt.subscribe(self.hass, 'test-topic', self.record_calls,


### PR DESCRIPTION
## Description:

This is a fix for issue #7478 where mqtt subscriptions containing special characters stopped working after PR #7269

**Related issue (if applicable):** fixes #7478

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
