### PR TITLE
Failed to parse response from WU API: 'record' (and 'recordyear') #7747

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -658,7 +658,7 @@ class WUndergroundSensor(Entity):
         try:
             val = val(self.rest)
         except (KeyError, IndexError) as err:
-            _LOGGER.error("Failed to parse response from WU API: %s", err)
+            _LOGGER.warning("Failed to parse response from WU API: %s", err)
             val = default
         except TypeError:
             pass  # val was not callable - keep original value
@@ -684,6 +684,9 @@ class WUndergroundSensor(Entity):
                 attrs[attr] = callback(self.rest)
             except TypeError:
                 attrs[attr] = callback
+            except (KeyError, IndexError) as err:
+                _LOGGER.warning("Failed to parse response from WU API: %s",
+                                err)
 
         attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
         attrs[ATTR_FRIENDLY_NAME] = self._cfg_expand("friendly_name")


### PR DESCRIPTION
## Description:

Changes errors to warning when there are data missing in the WU API response.

**Related issue (if applicable):** fixes #7747

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

Note: tests not added as there isn't really anything to test.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
