### PR TITLE
Update numpy 1.13.0

### DIFF
--- a/homeassistant/components/image_processing/opencv.py
+++ b/homeassistant/components/image_processing/opencv.py
@@ -17,7 +17,7 @@ from homeassistant.components.image_processing import (
     ImageProcessingEntity)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['numpy==1.12.0']
+REQUIREMENTS = ['numpy==1.13.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -398,7 +398,7 @@ netdisco==1.0.1
 neurio==0.3.1
 
 # homeassistant.components.image_processing.opencv
-numpy==1.12.0
+numpy==1.13.0
 
 # homeassistant.components.google
 oauth2client==4.0.0


### PR DESCRIPTION
## Description:

Update pypi module numpy to 1.13.0

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
