### PR TITLE
Add optional arguments to time tracking callbacks.

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -114,14 +114,14 @@ track_template = threaded_listener_factory(async_track_template)
 
 
 @callback
-def async_track_point_in_time(hass, action, point_in_time):
+def async_track_point_in_time(hass, action, point_in_time, *args):
     """Add a listener that fires once after a specific point in time."""
     utc_point_in_time = dt_util.as_utc(point_in_time)
 
     @callback
     def utc_converter(utc_now):
         """Convert passed in UTC now to local now."""
-        hass.async_run_job(action, dt_util.as_local(utc_now))
+        hass.async_run_job(action, dt_util.as_local(utc_now), *args)
 
     return async_track_point_in_utc_time(hass, utc_converter,
                                          utc_point_in_time)
@@ -131,7 +131,7 @@ track_point_in_time = threaded_listener_factory(async_track_point_in_time)
 
 
 @callback
-def async_track_point_in_utc_time(hass, action, point_in_time):
+def async_track_point_in_utc_time(hass, action, point_in_time, *args):
     """Add a listener that fires once after a specific point in UTC time."""
     # Ensure point_in_time is UTC
     point_in_time = dt_util.as_utc(point_in_time)
@@ -152,7 +152,7 @@ def async_track_point_in_utc_time(hass, action, point_in_time):
         point_in_time_listener.run = True
         async_unsub()
 
-        hass.async_run_job(action, now)
+        hass.async_run_job(action, now, *args)
 
     async_unsub = hass.bus.async_listen(EVENT_TIME_CHANGED,
                                         point_in_time_listener)
@@ -165,7 +165,7 @@ track_point_in_utc_time = threaded_listener_factory(
 
 
 @callback
-def async_track_time_interval(hass, action, interval):
+def async_track_time_interval(hass, action, interval, *args):
     """Add a listener that fires repetitively at every timedelta interval."""
     remove = None
 
@@ -179,7 +179,7 @@ def async_track_time_interval(hass, action, interval):
         nonlocal remove
         remove = async_track_point_in_utc_time(
             hass, interval_listener, next_interval())
-        hass.async_run_job(action, now)
+        hass.async_run_job(action, now, *args)
 
     remove = async_track_point_in_utc_time(
         hass, interval_listener, next_interval())

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -48,9 +48,11 @@ class TestEventHelpers(unittest.TestCase):
         after_birthday = datetime(1987, 7, 9, 12, 0, 0, tzinfo=dt_util.UTC)
 
         runs = []
+        COUNT = 3
 
-        track_point_in_utc_time(
-            self.hass, lambda x: runs.append(1), birthday_paulus)
+        for i in range(COUNT):
+            track_point_in_utc_time(
+                self.hass, lambda x, y: runs.append(y), birthday_paulus, i)
 
         self._send_time_changed(before_birthday)
         self.hass.block_till_done()
@@ -58,19 +60,22 @@ class TestEventHelpers(unittest.TestCase):
 
         self._send_time_changed(birthday_paulus)
         self.hass.block_till_done()
-        self.assertEqual(1, len(runs))
+        self.assertEqual(COUNT, len(runs))
+        for i in range(COUNT):
+            self.assertEqual(i, runs[i])
 
         # A point in time tracker will only fire once, this should do nothing
         self._send_time_changed(birthday_paulus)
         self.hass.block_till_done()
-        self.assertEqual(1, len(runs))
+        self.assertEqual(COUNT, len(runs))
 
         track_point_in_time(
-            self.hass, lambda x: runs.append(1), birthday_paulus)
+            self.hass, lambda x: runs.append(x), birthday_paulus)
 
         self._send_time_changed(after_birthday)
         self.hass.block_till_done()
-        self.assertEqual(2, len(runs))
+        self.assertEqual(COUNT + 1, len(runs))
+        self.assertEqual(after_birthday, runs[-1])
 
         unsub = track_point_in_time(
             self.hass, lambda x: runs.append(1), birthday_paulus)
@@ -78,7 +83,8 @@ class TestEventHelpers(unittest.TestCase):
 
         self._send_time_changed(after_birthday)
         self.hass.block_till_done()
-        self.assertEqual(2, len(runs))
+        self.assertEqual(COUNT + 1, len(runs))
+        self.assertEqual(after_birthday, runs[-1])
 
     def test_track_time_change(self):
         """Test tracking time change."""
@@ -265,30 +271,51 @@ class TestEventHelpers(unittest.TestCase):
     def test_track_time_interval(self):
         """Test tracking time interval."""
         specific_runs = []
+        unsubs = []
+        COUNT = 3
 
         utc_now = dt_util.utcnow()
-        unsub = track_time_interval(
-            self.hass, lambda x: specific_runs.append(1),
-            timedelta(seconds=10)
-        )
+        for i in range(COUNT):
+            unsubs.append(track_time_interval(
+                self.hass, lambda x, y: specific_runs.append((x,y)),
+                timedelta(seconds=10), i
+            ))
 
-        self._send_time_changed(utc_now + timedelta(seconds=5))
+        time1 = utc_now + timedelta(seconds=5)
+        self._send_time_changed(time1)
         self.hass.block_till_done()
         self.assertEqual(0, len(specific_runs))
 
-        self._send_time_changed(utc_now + timedelta(seconds=13))
+        time2 = utc_now + timedelta(seconds=13)
+        self._send_time_changed(time2)
         self.hass.block_till_done()
-        self.assertEqual(1, len(specific_runs))
+        self.assertEqual(COUNT, len(specific_runs))
+        for i in range(COUNT):
+            self.assertEqual(time2, specific_runs[i][0])
+            self.assertEqual(i, specific_runs[i][1])
 
-        self._send_time_changed(utc_now + timedelta(minutes=20))
+        time3 = utc_now + timedelta(seconds=20)
+        self._send_time_changed(time3)
         self.hass.block_till_done()
-        self.assertEqual(2, len(specific_runs))
+        self.assertEqual(COUNT*2, len(specific_runs))
+        for i in range(COUNT):
+            self.assertEqual(time2, specific_runs[i][0])
+            self.assertEqual(time3, specific_runs[COUNT+i][0])
+            self.assertEqual(i, specific_runs[i][1])
+            self.assertEqual(i, specific_runs[COUNT+i][1])
 
-        unsub()
+        for unsub in unsubs:
+            unsub()
 
-        self._send_time_changed(utc_now + timedelta(seconds=30))
+        time4 = utc_now + timedelta(seconds=30)
+        self._send_time_changed(time4)
         self.hass.block_till_done()
-        self.assertEqual(2, len(specific_runs))
+        self.assertEqual(COUNT*2, len(specific_runs))
+        for i in range(COUNT):
+            self.assertEqual(time2, specific_runs[i][0])
+            self.assertEqual(time3, specific_runs[COUNT+i][0])
+            self.assertEqual(i, specific_runs[i][1])
+            self.assertEqual(i, specific_runs[COUNT+i][1])
 
     def test_track_sunrise(self):
         """Test track the sunrise."""

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -277,7 +277,7 @@ class TestEventHelpers(unittest.TestCase):
         utc_now = dt_util.utcnow()
         for i in range(COUNT):
             unsubs.append(track_time_interval(
-                self.hass, lambda x, y: specific_runs.append((x,y)),
+                self.hass, lambda x, y: specific_runs.append((x, y)),
                 timedelta(seconds=10), i
             ))
 


### PR DESCRIPTION
## Description:

Currently works with `track_time_interval` and `track_point_in_time`
(as well as the UTC version).


## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.