### PR TITLE
Added 'all_plants' group and support for plant groups state.

### DIFF
--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -96,7 +96,7 @@ CONFIG_SCHEMA = vol.Schema({
 # List of ON/OFF state tuples for groupable states
 _GROUP_TYPES = [(STATE_ON, STATE_OFF), (STATE_HOME, STATE_NOT_HOME),
                 (STATE_OPEN, STATE_CLOSED), (STATE_LOCKED, STATE_UNLOCKED),
-                (STATE_OK, STATE_PROBLEM)]
+                (STATE_PROBLEM, STATE_OK)]
 
 
 def _get_group_on_off(state):

--- a/homeassistant/components/group.py
+++ b/homeassistant/components/group.py
@@ -14,7 +14,8 @@ from homeassistant import config as conf_util, core as ha
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_ICON, CONF_NAME, STATE_CLOSED, STATE_HOME,
     STATE_NOT_HOME, STATE_OFF, STATE_ON, STATE_OPEN, STATE_LOCKED,
-    STATE_UNLOCKED, STATE_UNKNOWN, ATTR_ASSUMED_STATE, SERVICE_RELOAD)
+    STATE_UNLOCKED, STATE_OK, STATE_PROBLEM, STATE_UNKNOWN,
+    ATTR_ASSUMED_STATE, SERVICE_RELOAD)
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
@@ -94,7 +95,8 @@ CONFIG_SCHEMA = vol.Schema({
 
 # List of ON/OFF state tuples for groupable states
 _GROUP_TYPES = [(STATE_ON, STATE_OFF), (STATE_HOME, STATE_NOT_HOME),
-                (STATE_OPEN, STATE_CLOSED), (STATE_LOCKED, STATE_UNLOCKED)]
+                (STATE_OPEN, STATE_CLOSED), (STATE_LOCKED, STATE_UNLOCKED),
+                (STATE_OK, STATE_PROBLEM)]
 
 
 def _get_group_on_off(state):

--- a/homeassistant/components/plant.py
+++ b/homeassistant/components/plant.py
@@ -10,8 +10,9 @@ import asyncio
 import voluptuous as vol
 
 from homeassistant.const import (
-    STATE_UNKNOWN, TEMP_CELSIUS, ATTR_TEMPERATURE, CONF_SENSORS,
-    ATTR_UNIT_OF_MEASUREMENT, ATTR_ICON)
+    STATE_OK, STATE_PROBLEM, STATE_UNKNOWN, TEMP_CELSIUS, ATTR_TEMPERATURE,
+    CONF_SENSORS, ATTR_UNIT_OF_MEASUREMENT, ATTR_ICON)
+from homeassistant.components import group
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
@@ -69,6 +70,10 @@ PLANT_SCHEMA = vol.Schema({
 })
 
 DOMAIN = 'plant'
+DEPENDENCIES = ['zone', 'group']
+
+GROUP_NAME_ALL_PLANTS = 'all plants'
+ENTITY_ID_ALL_PLANTS = group.ENTITY_ID_FORMAT.format('all_plants')
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: {
@@ -80,7 +85,8 @@ CONFIG_SCHEMA = vol.Schema({
 @asyncio.coroutine
 def async_setup(hass, config):
     """Set up the Plant component."""
-    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    component = EntityComponent(_LOGGER, DOMAIN, hass,
+                                group_name=GROUP_NAME_ALL_PLANTS)
 
     entities = []
     for plant_name, plant_config in config[DOMAIN].items():
@@ -199,11 +205,11 @@ class Plant(Entity):
                         self._icon = params['icon']
 
         if len(result) == 0:
-            self._state = 'ok'
+            self._state = STATE_OK
             self._icon = 'mdi:thumb-up'
             self._problems = PROBLEM_NONE
         else:
-            self._state = 'problem'
+            self._state = STATE_PROBLEM
             self._problems = ','.join(result)
         _LOGGER.debug("New data processed")
         self.hass.async_add_job(self.async_update_ha_state())

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -199,6 +199,8 @@ STATE_ALARM_TRIGGERED = 'triggered'
 STATE_LOCKED = 'locked'
 STATE_UNLOCKED = 'unlocked'
 STATE_UNAVAILABLE = 'unavailable'
+STATE_OK = 'ok'
+STATE_PROBLEM = 'problem'
 
 # #### STATE AND EVENT ATTRIBUTES ####
 # Attribution


### PR DESCRIPTION
## Description:

Like switches, lights, and devices, plants deserve a group of their own! Here, I added the group `all_plants`, using `EntityComponent`'s built-in functionality.

Additionally, I created the `STATE_OK` and `STATE_PROBLEM` states, and introduced them into the group component - so that a group of plants can show the `STATE_PROBLEM` state whenever one of its plants has a problem. Great for automations!

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
