### PR TITLE
Fix EntityComponent handle entities without a name

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -1,6 +1,5 @@
 """Helpers for components that manage entities."""
 import asyncio
-from collections import OrderedDict
 from datetime import timedelta
 
 from homeassistant import config as conf_util
@@ -38,7 +37,7 @@ class EntityComponent(object):
         self.scan_interval = scan_interval
         self.group_name = group_name
 
-        self.entities = OrderedDict()
+        self.entities = {}
         self.config = None
 
         self._platforms = {
@@ -239,10 +238,12 @@ class EntityComponent(object):
         This method must be run in the event loop.
         """
         if self.group_name is not None:
+            ids = sorted(self.entities,
+                         key=lambda x: self.entities[x].name or x)
             group = get_component('group')
             group.async_set_group(
                 self.hass, slugify(self.group_name), name=self.group_name,
-                visible=False, entity_ids=self.entities
+                visible=False, entity_ids=ids
             )
 
     def reset(self):
@@ -264,7 +265,7 @@ class EntityComponent(object):
         self._platforms = {
             'core': self._platforms['core']
         }
-        self.entities = OrderedDict()
+        self.entities = {}
         self.config = None
 
         if self.group_name is not None:

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -1,5 +1,6 @@
 """Helpers for components that manage entities."""
 import asyncio
+from collections import OrderedDict
 from datetime import timedelta
 
 from homeassistant import config as conf_util
@@ -37,7 +38,7 @@ class EntityComponent(object):
         self.scan_interval = scan_interval
         self.group_name = group_name
 
-        self.entities = {}
+        self.entities = OrderedDict()
         self.config = None
 
         self._platforms = {
@@ -238,11 +239,10 @@ class EntityComponent(object):
         This method must be run in the event loop.
         """
         if self.group_name is not None:
-            ids = sorted(self.entities, key=lambda x: self.entities[x].name)
             group = get_component('group')
             group.async_set_group(
                 self.hass, slugify(self.group_name), name=self.group_name,
-                visible=False, entity_ids=ids
+                visible=False, entity_ids=self.entities
             )
 
     def reset(self):
@@ -264,7 +264,7 @@ class EntityComponent(object):
         self._platforms = {
             'core': self._platforms['core']
         }
-        self.entities = {}
+        self.entities = OrderedDict()
         self.config = None
 
         if self.group_name is not None:

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -103,7 +103,7 @@ class TestHelpersEntityComponent(unittest.TestCase):
 
         # Ordered in order of added to the group
         assert group.attributes.get('entity_id') == \
-            ('test_domain.unnamed_device', 'test_domain.goodbye')
+            ('test_domain.goodbye', 'test_domain.unnamed_device')
 
     def test_polling_only_updates_entities_it_should_poll(self):
         """Test the polling of only updated entities."""

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -84,7 +84,7 @@ class TestHelpersEntityComponent(unittest.TestCase):
         # No group after setup
         assert len(self.hass.states.entity_ids()) == 0
 
-        component.add_entities([EntityTest(name='hello')])
+        component.add_entities([EntityTest()])
 
         # group exists
         assert len(self.hass.states.entity_ids()) == 2
@@ -92,7 +92,8 @@ class TestHelpersEntityComponent(unittest.TestCase):
 
         group = self.hass.states.get('group.everyone')
 
-        assert group.attributes.get('entity_id') == ('test_domain.hello',)
+        assert group.attributes.get('entity_id') == \
+            ('test_domain.unnamed_device',)
 
         # group extended
         component.add_entities([EntityTest(name='goodbye')])
@@ -100,9 +101,9 @@ class TestHelpersEntityComponent(unittest.TestCase):
         assert len(self.hass.states.entity_ids()) == 3
         group = self.hass.states.get('group.everyone')
 
-        # Sorted order
+        # Ordered in order of added to the group
         assert group.attributes.get('entity_id') == \
-            ('test_domain.goodbye', 'test_domain.hello')
+            ('test_domain.unnamed_device', 'test_domain.goodbye')
 
     def test_polling_only_updates_entities_it_should_poll(self):
         """Test the polling of only updated entities."""


### PR DESCRIPTION
## Description:
In #7681 we added ordering to groups created by the EntityComponent. That PR incorrectly assumed that all entities always return a name.

To keep consistent ordering, entities have been converted to an ordered dictionary.

CC @amelchio 

**Related issue (if applicable):** Reported by @arraylabs on Gitter:

```
File "/usr/src/app/homeassistant/helpers/entity_component.py", line 376,
  in async_add_entities yield from self.component.async_update_group()
File "/usr/src/app/homeassistant/helpers/entity_component.py", line 243,
  in async_update_group sorted(self.entities, key=lambda x: self.entities[x].name),
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
