### PR TITLE
Fix attribute entity

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -321,7 +321,7 @@ class Entity(object):
 
         value = getattr(self, name)
 
-        if value is None:
+        if value is None or value == '':
             return
 
         try:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -321,7 +321,7 @@ class Entity(object):
 
         value = getattr(self, name)
 
-        if value is None or value == '':
+        if value is None:
             return
 
         try:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -321,7 +321,7 @@ class Entity(object):
 
         value = getattr(self, name)
 
-        if not value:
+        if value is None:
             return
 
         try:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -146,7 +146,7 @@ class Entity(object):
     @property
     def assumed_state(self) -> bool:
         """Return True if unable to access real state of the entity."""
-        return False
+        return None
 
     @property
     def force_update(self) -> bool:

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -228,7 +228,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertIsNone(state.attributes.get('effect'))
         self.assertIsNone(state.attributes.get('white_value'))
         self.assertIsNone(state.attributes.get('xy_color'))
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         fire_mqtt_message(self.hass, 'test_light_rgb/status', '1')
         self.hass.block_till_done()
@@ -320,7 +320,7 @@ class TestLightMQTT(unittest.TestCase):
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
         self.assertIsNone(state.attributes.get('brightness'))
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         fire_mqtt_message(self.hass, 'test_scale/status', 'on')
         self.hass.block_till_done()
@@ -367,7 +367,7 @@ class TestLightMQTT(unittest.TestCase):
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
         self.assertIsNone(state.attributes.get('white_value'))
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         fire_mqtt_message(self.hass, 'test_scale/status', 'on')
         self.hass.block_till_done()

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -175,7 +175,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertIsNone(state.attributes.get('effect'))
         self.assertIsNone(state.attributes.get('white_value'))
         self.assertIsNone(state.attributes.get('xy_color'))
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         # Turn on the light, full white
         fire_mqtt_message(self.hass, 'test_light_rgb',
@@ -424,7 +424,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertIsNone(state.attributes.get('rgb_color'))
         self.assertIsNone(state.attributes.get('brightness'))
         self.assertIsNone(state.attributes.get('white_value'))
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         # Turn on the light
         fire_mqtt_message(self.hass, 'test_light_rgb',

--- a/tests/components/light/test_mqtt_template.py
+++ b/tests/components/light/test_mqtt_template.py
@@ -88,7 +88,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.assertIsNone(state.attributes.get('brightness'))
         self.assertIsNone(state.attributes.get('color_temp'))
         self.assertIsNone(state.attributes.get('white_value'))
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         fire_mqtt_message(self.hass, 'test_light_rgb', 'on')
         self.hass.block_till_done()
@@ -141,7 +141,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.assertIsNone(state.attributes.get('effect'))
         self.assertIsNone(state.attributes.get('color_temp'))
         self.assertIsNone(state.attributes.get('white_value'))
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         # turn on the light, full white
         fire_mqtt_message(self.hass, 'test_light_rgb',
@@ -401,7 +401,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.assertIsNone(state.attributes.get('color_temp'))
         self.assertIsNone(state.attributes.get('effect'))
         self.assertIsNone(state.attributes.get('white_value'))
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         # turn on the light, full white
         fire_mqtt_message(self.hass, 'test_light_rgb',

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -70,7 +70,7 @@ def test_default_setup(hass, monkeypatch):
     light_after_first_command = hass.states.get(DOMAIN + '.test')
     assert light_after_first_command.state == 'on'
     # also after receiving first command state not longer has to be assumed
-    assert 'assumed_state' not in light_after_first_command.attributes
+    assert not light_after_first_command.attributes.get('assumed_state')
 
     # mock incoming command event for this device
     event_callback({

--- a/tests/components/lock/test_mqtt.py
+++ b/tests/components/lock/test_mqtt.py
@@ -36,7 +36,7 @@ class TestLockMQTT(unittest.TestCase):
 
         state = self.hass.states.get('lock.test')
         self.assertEqual(STATE_UNLOCKED, state.state)
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         fire_mqtt_message(self.hass, 'state-topic', 'LOCK')
         self.hass.block_till_done()

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -88,7 +88,7 @@ def test_default_setup(hass, mock_connection_factory):
     # tariff should be translated in human readable and have no unit
     power_tariff = hass.states.get('sensor.power_tariff')
     assert power_tariff.state == 'low'
-    assert power_tariff.attributes.get('unit_of_measurement') is None
+    assert power_tariff.attributes.get('unit_of_measurement') == ''
 
 
 @asyncio.coroutine

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -72,7 +72,7 @@ class TestTemplateSensor:
         self.hass.block_till_done()
 
         state = self.hass.states.get('sensor.test_template_sensor')
-        assert 'icon' not in state.attributes
+        assert state.attributes.get('icon') == ''
 
         self.hass.states.set('sensor.test_state', 'Works')
         self.hass.block_till_done()

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -35,7 +35,7 @@ class TestSensorMQTT(unittest.TestCase):
 
         state = self.hass.states.get('switch.test')
         self.assertEqual(STATE_OFF, state.state)
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         fire_mqtt_message(self.hass, 'state-topic', '1')
         self.hass.block_till_done()

--- a/tests/components/switch/test_rflink.py
+++ b/tests/components/switch/test_rflink.py
@@ -59,7 +59,7 @@ def test_default_setup(hass, monkeypatch):
     switch_after_first_command = hass.states.get('switch.test')
     assert switch_after_first_command.state == 'on'
     # also after receiving first command state not longer has to be assumed
-    assert 'assumed_state' not in switch_after_first_command.attributes
+    assert not switch_after_first_command.attributes.get('assumed_state')
 
     # mock incoming command event for this device
     event_callback({

--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -161,7 +161,7 @@ class TestTemplateSwitch:
         self.hass.block_till_done()
 
         state = self.hass.states.get('switch.test_template_switch')
-        assert 'icon' not in state.attributes
+        assert state.attributes.get('icon') == ''
 
         state = self.hass.states.set('switch.test_state', STATE_ON)
         self.hass.block_till_done()

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -306,7 +306,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.hass.block_till_done()
 
         state = self.hass.states.get(test_group.entity_id)
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
     def test_group_updated_after_device_tracker_zone_change(self):
         """Test group state when device tracker in group changes zone."""

--- a/tests/components/test_group.py
+++ b/tests/components/test_group.py
@@ -292,7 +292,7 @@ class TestComponentsGroup(unittest.TestCase):
             ['light.Bowl', 'light.Ceiling', 'sensor.no_exist'])
 
         state = self.hass.states.get(test_group.entity_id)
-        self.assertIsNone(state.attributes.get(ATTR_ASSUMED_STATE))
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         self.hass.states.set('light.Bowl', STATE_ON, {
             ATTR_ASSUMED_STATE: True

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -109,7 +109,7 @@ class TestComponentsCore(unittest.TestCase):
         state = self.hass.states.get('test.entity')
         assert state is not None
         assert state.state == 'unknown'
-        assert state.attributes == {"assumed_state": False}
+        assert state.attributes == {}
 
         files = {
             config.YAML_CONFIG_FILE: yaml.dump({

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -109,7 +109,7 @@ class TestComponentsCore(unittest.TestCase):
         state = self.hass.states.get('test.entity')
         assert state is not None
         assert state.state == 'unknown'
-        assert state.attributes == {}
+        assert state.attributes == {"assumed_state": False}
 
         files = {
             config.YAML_CONFIG_FILE: yaml.dump({


### PR DESCRIPTION
## Description:

Fix a bug that attribute entity not present if they is `False` or `0`

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
