### PR TITLE
Bump pyEmby version to account for API changes

### DIFF
--- a/homeassistant/components/media_player/emby.py
+++ b/homeassistant/components/media_player/emby.py
@@ -21,7 +21,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['pyemby==1.2']
+REQUIREMENTS = ['pyemby==1.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -538,7 +538,7 @@ pyebox==0.1.0
 pyeight==0.0.7
 
 # homeassistant.components.media_player.emby
-pyemby==1.2
+pyemby==1.3
 
 # homeassistant.components.envisalink
 pyenvisalink==2.1


### PR DESCRIPTION
## Description:
Emby is going through some codebase changes that are altering the API.  This PR accounts for a key change that was breaking things on the latest version.  Code fix is backwards compatible.


## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
