### PR TITLE
Bugfix entity attribute setter

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -146,7 +146,7 @@ class Entity(object):
     @property
     def assumed_state(self) -> bool:
         """Return True if unable to access real state of the entity."""
-        return False
+        return None
 
     @property
     def force_update(self) -> bool:
@@ -321,7 +321,7 @@ class Entity(object):
 
         value = getattr(self, name)
 
-        if not value:
+        if value is None:
             return
 
         try:

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -88,7 +88,7 @@ def test_default_setup(hass, mock_connection_factory):
     # tariff should be translated in human readable and have no unit
     power_tariff = hass.states.get('sensor.power_tariff')
     assert power_tariff.state == 'low'
-    assert power_tariff.attributes.get('unit_of_measurement') is None
+    assert power_tariff.attributes.get('unit_of_measurement') == ''
 
 
 @asyncio.coroutine

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -72,7 +72,7 @@ class TestTemplateSensor:
         self.hass.block_till_done()
 
         state = self.hass.states.get('sensor.test_template_sensor')
-        assert 'icon' not in state.attributes
+        assert state.attributes.get('icon') == ''
 
         self.hass.states.set('sensor.test_state', 'Works')
         self.hass.block_till_done()

--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -161,7 +161,7 @@ class TestTemplateSwitch:
         self.hass.block_till_done()
 
         state = self.hass.states.get('switch.test_template_switch')
-        assert 'icon' not in state.attributes
+        assert state.attributes.get('icon') == ''
 
         state = self.hass.states.set('switch.test_state', STATE_ON)
         self.hass.block_till_done()


### PR DESCRIPTION
## Description:

Replace: https://github.com/home-assistant/home-assistant/pull/8066

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
