### PR TITLE
Update InfluxDB to handle datetime objects and multiple decimal points

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -8,8 +8,6 @@ import logging
 
 import re
 
-import datetime
-
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -107,10 +105,6 @@ def setup(hass, config):
                       "the database exists and is READ/WRITE.", exc)
         return False
 
-    def decreplace(matchobj):
-        """Convert values such as 1.2.3.4 to 1.234 for Influx"""
-        return matchobj.group(1) + re.sub(r'\.', '', matchobj.group(2))
-
     def influx_event_listener(event):
         """Listen for new messages on the bus and sends them to Influx."""
         state = event.data.get('new_state')
@@ -172,14 +166,12 @@ def setup(hass, config):
                     new_key = "{}_str".format(key)
                     json_body[0]['fields'][new_key] = str(value)
                     if non_digit_tail.match(
-                            json_body[0]['fields'][new_key]) and not (
-                                isinstance(value, datetime.datetime)):
+                            json_body[0]['fields'][new_key]):
                         try:
                             json_body[0]['fields'][key] = float(
                                 non_decimal.sub('', value))
                         except (ValueError, TypeError):
-                            json_body[0]['fields'][key] = float(
-                                re.sub(r'^([^.]*\.)(.*)$', decreplace, value))
+                            pass
 
         json_body[0]['tags'].update(tags)
 

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -58,6 +58,8 @@ CONFIG_SCHEMA = vol.Schema({
     }),
 }, extra=vol.ALLOW_EXTRA)
 
+NON_DIGIT_TAIL = re.compile(r'[\d.]+')
+NON_DECIMAL = re.compile(r'[^\d.]+')
 
 def setup(hass, config):
     """Set up the InfluxDB component."""
@@ -149,8 +151,6 @@ def setup(hass, config):
             }
         ]
 
-        non_digit_tail = re.compile(r'[\d.]+')
-        non_decimal = re.compile(r'[^\d.]+')
         for key, value in state.attributes.items():
             if key != 'unit_of_measurement':
                 # If the key is already in fields
@@ -165,11 +165,11 @@ def setup(hass, config):
                 except (ValueError, TypeError):
                     new_key = "{}_str".format(key)
                     json_body[0]['fields'][new_key] = str(value)
-                    if non_digit_tail.match(
+                    if NON_DIGIT_TAIL.match(
                             json_body[0]['fields'][new_key]):
                         try:
                             json_body[0]['fields'][key] = float(
-                                non_decimal.sub('', value))
+                                NON_DECIMAL.sub('', value))
                         except (ValueError, TypeError):
                             pass
 

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -165,11 +165,12 @@ def setup(hass, config):
                     json_body[0]['fields'][key] = float(value)
                 except (ValueError, TypeError):
                     new_key = "{}_str".format(key)
-                    json_body[0]['fields'][new_key] = str(value)
+                    new_value = str(value)
+                    json_body[0]['fields'][new_key] = new_value
 
-                    if RE_DIGIT_TAIL.match(json_body[0]['fields'][new_key]):
+                    if RE_DIGIT_TAIL.match(new_value):
                         json_body[0]['fields'][key] = float(
-                            RE_DECIMAL.sub('', value))
+                            RE_DECIMAL.sub('', new_value))
 
         json_body[0]['tags'].update(tags)
 

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -172,8 +172,8 @@ def setup(hass, config):
                     new_key = "{}_str".format(key)
                     json_body[0]['fields'][new_key] = str(value)
                     if non_digit_tail.match(
-                            json_body[0]['fields'][new_key]) and not isinstance(
-                                value, datetime.datetime):
+                            json_body[0]['fields'][new_key]) and not (
+                                isinstance(value, datetime.datetime)):
                         try:
                             json_body[0]['fields'][key] = float(
                                 non_decimal.sub('', value))

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -58,7 +58,7 @@ CONFIG_SCHEMA = vol.Schema({
     }),
 }, extra=vol.ALLOW_EXTRA)
 
-RE_DIGIT_TAIL = re.compile(r'^\w*\d+\.?\d+\w*$')
+RE_DIGIT_TAIL = re.compile(r'^[^\.]*\d+\.?\d+[^\.]*$')
 RE_DECIMAL = re.compile(r'[^\d.]+')
 
 

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -167,8 +167,9 @@ def setup(hass, config):
                 except (ValueError, TypeError):
                     new_key = "{}_str".format(key)
                     json_body[0]['fields'][new_key] = str(value)
-                    if non_digit_tail.match(json_body[0]['fields'][new_key]) and not isinstance(
-                            value, datetime.datetime):
+                    if non_digit_tail.match(
+                            json_body[0]['fields'][new_key]) and not isinstance(
+                                value, datetime.datetime):
                         json_body[0]['fields'][key] = float(
                             non_decimal.sub('', value))
 

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -58,8 +58,8 @@ CONFIG_SCHEMA = vol.Schema({
     }),
 }, extra=vol.ALLOW_EXTRA)
 
-NON_DIGIT_TAIL = re.compile(r'[\d.]+')
-NON_DECIMAL = re.compile(r'[^\d.]+')
+RE_DIGIT_TAIL = re.compile(r'^\w*\d+\.?\d+\w*$')
+RE_DECIMAL = re.compile(r'[^\d.]+')
 
 def setup(hass, config):
     """Set up the InfluxDB component."""
@@ -165,13 +165,10 @@ def setup(hass, config):
                 except (ValueError, TypeError):
                     new_key = "{}_str".format(key)
                     json_body[0]['fields'][new_key] = str(value)
-                    if NON_DIGIT_TAIL.match(
-                            json_body[0]['fields'][new_key]):
-                        try:
-                            json_body[0]['fields'][key] = float(
-                                NON_DECIMAL.sub('', value))
-                        except (ValueError, TypeError):
-                            pass
+
+                    if RE_DIGIT_TAIL.match(json_body[0]['fields'][new_key]):
+                        json_body[0]['fields'][key] = float(
+                            RE_DECIMAL.sub('', value))
 
         json_body[0]['tags'].update(tags)
 

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -61,6 +61,7 @@ CONFIG_SCHEMA = vol.Schema({
 RE_DIGIT_TAIL = re.compile(r'^\w*\d+\.?\d+\w*$')
 RE_DECIMAL = re.compile(r'[^\d.]+')
 
+
 def setup(hass, config):
     """Set up the InfluxDB component."""
     from influxdb import InfluxDBClient, exceptions

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -8,6 +8,8 @@ import logging
 
 import re
 
+import datetime
+
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -165,7 +167,8 @@ def setup(hass, config):
                 except (ValueError, TypeError):
                     new_key = "{}_str".format(key)
                     json_body[0]['fields'][new_key] = str(value)
-                    if non_digit_tail.match(json_body[0]['fields'][new_key]):
+                    if non_digit_tail.match(json_body[0]['fields'][new_key]) and not isinstance(
+                            value, datetime.datetime):
                         json_body[0]['fields'][key] = float(
                             non_decimal.sub('', value))
 

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -1,5 +1,6 @@
 """The tests for the InfluxDB component."""
 import unittest
+import datetime
 from unittest import mock
 
 import influxdb as influx_client
@@ -123,7 +124,8 @@ class TestInfluxDB(unittest.TestCase):
                 'latitude': '2.2',
                 'battery_level': '99%',
                 'temperature': '20c',
-                'last_seen': 'Last seen 23 minutes ago'
+                'last_seen': 'Last seen 23 minutes ago',
+                'updated_at': datetime.datetime(2017, 1, 1, 0, 0)
             }
             state = mock.MagicMock(
                 state=in_, domain='fake', object_id='entity', attributes=attrs)
@@ -144,7 +146,8 @@ class TestInfluxDB(unittest.TestCase):
                         'battery_level': 99.0,
                         'temperature_str': '20c',
                         'temperature': 20.0,
-                        'last_seen_str': 'Last seen 23 minutes ago'
+                        'last_seen_str': 'Last seen 23 minutes ago',
+                        'updated_at_str': '2017-01-01 00:00:00'
                     },
                 }]
 
@@ -164,7 +167,8 @@ class TestInfluxDB(unittest.TestCase):
                         'battery_level': 99.0,
                         'temperature_str': '20c',
                         'temperature': 20.0,
-                        'last_seen_str': 'Last seen 23 minutes ago'
+                        'last_seen_str': 'Last seen 23 minutes ago',
+                        'updated_at_str': '2017-01-01 00:00:00' 
                     },
                 }]
             self.handler_method(event)

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -175,7 +175,8 @@ class TestInfluxDB(unittest.TestCase):
                         'last_seen': 23.0,
                         'updated_at_str': '2017-01-01 00:00:00',
                         'updated_at': 20170101000000,
-                        'multi_periods_str': '0.120.240.2023873'                    },
+                        'multi_periods_str': '0.120.240.2023873'
+                    },
                 }]
             self.handler_method(event)
             self.assertEqual(

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -149,8 +149,7 @@ class TestInfluxDB(unittest.TestCase):
                         'temperature': 20.0,
                         'last_seen_str': 'Last seen 23 minutes ago',
                         'updated_at_str': '2017-01-01 00:00:00',
-                        'multi_periods_str': '0.120.240.2023873',
-                        'multi_periods': 0.1202402023873
+                        'multi_periods_str': '0.120.240.2023873'
                     },
                 }]
 
@@ -172,8 +171,7 @@ class TestInfluxDB(unittest.TestCase):
                         'temperature': 20.0,
                         'last_seen_str': 'Last seen 23 minutes ago',
                         'updated_at_str': '2017-01-01 00:00:00',
-                        'multi_periods_str': '0.120.240.2023873',
-                        'multi_periods': 0.1202402023873
+                        'multi_periods_str': '0.120.240.2023873'
                     },
                 }]
             self.handler_method(event)

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -125,7 +125,8 @@ class TestInfluxDB(unittest.TestCase):
                 'battery_level': '99%',
                 'temperature': '20c',
                 'last_seen': 'Last seen 23 minutes ago',
-                'updated_at': datetime.datetime(2017, 1, 1, 0, 0)
+                'updated_at': datetime.datetime(2017, 1, 1, 0, 0),
+                'multi_periods': '0.120.240.2023873'
             }
             state = mock.MagicMock(
                 state=in_, domain='fake', object_id='entity', attributes=attrs)
@@ -147,7 +148,9 @@ class TestInfluxDB(unittest.TestCase):
                         'temperature_str': '20c',
                         'temperature': 20.0,
                         'last_seen_str': 'Last seen 23 minutes ago',
-                        'updated_at_str': '2017-01-01 00:00:00'
+                        'updated_at_str': '2017-01-01 00:00:00',
+                        'multi_periods_str': '0.120.240.2023873',
+                        'multi_periods': 0.1202402023873
                     },
                 }]
 
@@ -168,7 +171,9 @@ class TestInfluxDB(unittest.TestCase):
                         'temperature_str': '20c',
                         'temperature': 20.0,
                         'last_seen_str': 'Last seen 23 minutes ago',
-                        'updated_at_str': '2017-01-01 00:00:00'
+                        'updated_at_str': '2017-01-01 00:00:00',
+                        'multi_periods_str': '0.120.240.2023873',
+                        'multi_periods': 0.1202402023873
                     },
                 }]
             self.handler_method(event)

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -148,7 +148,9 @@ class TestInfluxDB(unittest.TestCase):
                         'temperature_str': '20c',
                         'temperature': 20.0,
                         'last_seen_str': 'Last seen 23 minutes ago',
+                        'last_seen': 23.0,
                         'updated_at_str': '2017-01-01 00:00:00',
+                        'updated_at': 20170101000000,
                         'multi_periods_str': '0.120.240.2023873'
                     },
                 }]
@@ -170,9 +172,10 @@ class TestInfluxDB(unittest.TestCase):
                         'temperature_str': '20c',
                         'temperature': 20.0,
                         'last_seen_str': 'Last seen 23 minutes ago',
+                        'last_seen': 23.0,
                         'updated_at_str': '2017-01-01 00:00:00',
-                        'multi_periods_str': '0.120.240.2023873'
-                    },
+                        'updated_at': 20170101000000,
+                        'multi_periods_str': '0.120.240.2023873'                    },
                 }]
             self.handler_method(event)
             self.assertEqual(

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -168,7 +168,7 @@ class TestInfluxDB(unittest.TestCase):
                         'temperature_str': '20c',
                         'temperature': 20.0,
                         'last_seen_str': 'Last seen 23 minutes ago',
-                        'updated_at_str': '2017-01-01 00:00:00' 
+                        'updated_at_str': '2017-01-01 00:00:00'
                     },
                 }]
             self.handler_method(event)


### PR DESCRIPTION
## Description:
Updates the InfluxDB regex to ignore datetime objects being coverted
into float values.

Adds tests to the component to ensure datetime objects are corectly
handled.

**Related issue (if applicable):** fixes #8042

## Checklist:

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
