### PR TITLE
Stopping the logfile spam by piping STDERR to /dev/null

### DIFF
--- a/homeassistant/components/switch/wake_on_lan.py
+++ b/homeassistant/components/switch/wake_on_lan.py
@@ -101,5 +101,5 @@ class WOLSwitch(SwitchDevice):
             ping_cmd = ['ping', '-c', '1', '-W',
                         str(DEFAULT_PING_TIMEOUT), str(self._host)]
 
-        status = sp.call(ping_cmd, stdout=sp.DEVNULL)
+        status = sp.call(ping_cmd, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
         self._state = not bool(status)


### PR DESCRIPTION
When pinging computers using the Wake On LAN switch, the log files get spammed with

```bash
ping: cannot resolve computer.local: Unknown host
```

which makes sense, if the computer is turned off. However, this isn't really an error.

This patch pipes STDERR to /dev/null, cleaning up the log a little.