### PR TITLE
telegram_bot: increase timeout for setWebhook to 10s to fix #8085

### DIFF
--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/telegram_bot.webhooks/
 """
 import asyncio
 import datetime as dt
+from functools import partial
 from ipaddress import ip_network
 import logging
 
@@ -70,7 +71,8 @@ def async_setup_platform(hass, config):
         return False
 
     if current_status and current_status['url'] != handler_url:
-        result = yield from hass.async_add_job(bot.setWebhook, handler_url)
+        result = yield from hass.async_add_job(
+            partial(bot.setWebhook, handler_url, timeout=10))
         if result:
             _LOGGER.info("Set new telegram webhook %s", handler_url)
         else:


### PR DESCRIPTION
## Description:
**Increase timeout for setting webhook from 5s to 10s** to try to reduce the number of bad setups of the `telegram_bot` component with platform `webhooks`.

**Related issue (if applicable):** fixes #8085


## Example entry for `configuration.yaml` (if applicable):
```yaml
telegram_bot:
  platform: webhooks
  api_key: !secret telegram_bot_api_key
  allowed_chat_ids:
    - !secret telegram_bot_chat_id_admin
    - !secret telegram_bot_chat_id_2
    - !secret telegram_bot_group
```
