### PR TITLE
Uninstall enum34 in python3.6 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN virtualization/Docker/setup_docker_prereqs
 # Install hass component dependencies
 COPY requirements_all.txt requirements_all.txt
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet
+    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet && \
+    pip3 uninstall enum34
 
 # Copy source
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN virtualization/Docker/setup_docker_prereqs
 
 # Install hass component dependencies
 COPY requirements_all.txt requirements_all.txt
+# Uninstall enum34 because some depenndecies install it but breaks Python 3.4+.
+# See PR #8103 for more info.
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
     pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet && \
     pip3 uninstall enum34


### PR DESCRIPTION
This is a short term fix for #7733

What's happening is the following dependencies are pulling `enum34`:
- `pygatt`
- `libsoundtouch`
- `yeelight`

However, enum34 is not meant to be installed in Python versions 3.4+
and causing the `AttributeError: module 'enum' has no attribute 'IntFlag'`

I've submitted patches to these projects so we don't have to do this
manual uninstall in the future.

- https://github.com/peplin/pygatt/pull/131
- https://github.com/CharlesBlonde/libsoundtouch/pull/10
- https://gitlab.com/stavros/python-yeelight/merge_requests/9

Let me know what you think:



