### PR TITLE
Fixed iTach command parsing with empty data

### DIFF
--- a/homeassistant/components/remote/itach.py
+++ b/homeassistant/components/remote/itach.py
@@ -70,7 +70,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             cmddata = cmd[CONF_DATA].strip()
             if not cmddata:
                 cmddata = '""'
-            cmddatas += cmdname + "\n" + cmddata + "\n"
+            cmddatas += "{}\n{}\n".format(cmdname, cmddata)
         itachip2ir.addDevice(name, modaddr, connaddr, cmddatas)
         devices.append(ITachIP2IRRemote(itachip2ir, name))
     add_devices(devices, True)

--- a/homeassistant/components/remote/itach.py
+++ b/homeassistant/components/remote/itach.py
@@ -62,10 +62,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         name = data.get(CONF_NAME)
         modaddr = int(data.get(CONF_MODADDR, 1))
         connaddr = int(data.get(CONF_CONNADDR, 1))
-        cmddata = ""
+        cmddatas = ""
         for cmd in data.get(CONF_COMMANDS):
-            cmddata += cmd[CONF_NAME] + "\n" + cmd[CONF_DATA] + "\n"
-        itachip2ir.addDevice(name, modaddr, connaddr, cmddata)
+            cmdname = cmd[CONF_NAME].strip()
+            if not cmdname:
+                cmdname = '""'
+            cmddata = cmd[CONF_DATA].strip()
+            if not cmddata:
+                cmddata = '""'
+            cmddatas += cmdname + "\n" + cmddata + "\n"
+        itachip2ir.addDevice(name, modaddr, connaddr, cmddatas)
         devices.append(ITachIP2IRRemote(itachip2ir, name))
     add_devices(devices, True)
     return True


### PR DESCRIPTION
## Description:
Fixes the case where an empty string would confuse any further iTach commands

**Related issue (if applicable):** fixes #7898

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
