### PR TITLE
Only mark active DHCP clients as present

### DIFF
--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -158,6 +158,11 @@ class MikrotikScanner(DeviceScanner):
                     for device in devices
                 }
             else:
-                self.last_results = mac_names
+                self.last_results = {
+                    device.get('mac-address'):
+                        mac_names.get(device.get('mac-address'))
+                    for device in device_names
+                    if device.get('active-address')
+                }
 
             return True


### PR DESCRIPTION
We only want to know which of the DHCP clients are indeed active.

For example: I've a table of static DHCP leases with most of the IPs of my network, so this module is always detecting them as present. With my patch only the active ones will be detected as present.

I already mentioned here: https://github.com/home-assistant/home-assistant/pull/7366#issuecomment-302950139

## Description:
Only mark active DHCP clients as present

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
