### PR TITLE
Fix Dyson async_add_job

### DIFF
--- a/homeassistant/components/fan/dyson.py
+++ b/homeassistant/components/fan/dyson.py
@@ -75,7 +75,7 @@ class DysonPureCoolLinkDevice(FanEntity):
     def async_added_to_hass(self):
         """Callback when entity is added to hass."""
         self.hass.async_add_job(
-            self._device.add_message_listener(self.on_message))
+            self._device.add_message_listener, self.on_message)
 
     def on_message(self, message):
         """Called when new messages received from the fan."""

--- a/homeassistant/components/sensor/dyson.py
+++ b/homeassistant/components/sensor/dyson.py
@@ -38,7 +38,7 @@ class DysonFilterLifeSensor(Entity):
     def async_added_to_hass(self):
         """Callback when entity is added to hass."""
         self.hass.async_add_job(
-            self._device.add_message_listener(self.on_message))
+            self._device.add_message_listener, self.on_message)
 
     def on_message(self, message):
         """Called when new messages received from the fan."""


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #8097

There was a bug in dyson fan and dyson sensor entities while using `async_call_job`. This PR fix the bug.

It is a bug fix for version 0.47.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
