### PR TITLE
Adding done_message to alert

### DIFF
--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -199,6 +199,7 @@ class TestAlert(unittest.TestCase):
         self.assertEqual(True, entity.hidden)
 
     def test_done_message_state_tracker_reset_on_cancel(self):
+        """Test that the done message is reset when cancelled."
         entity = alert.Alert(self.hass, *TEST_NOACK)
         entity._cancel = lambda *args: None
         assert entity._send_done_message is False

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -199,7 +199,7 @@ class TestAlert(unittest.TestCase):
         self.assertEqual(True, entity.hidden)
 
     def test_done_message_state_tracker_reset_on_cancel(self):
-        """Test that the done message is reset when cancelled."
+        """Test that the done message is reset when cancelled."""
         entity = alert.Alert(self.hass, *TEST_NOACK)
         entity._cancel = lambda *args: None
         assert entity._send_done_message is False

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -13,19 +13,21 @@ from homeassistant.const import (CONF_ENTITY_ID, STATE_IDLE, CONF_NAME,
 from tests.common import get_test_home_assistant
 
 NAME = "alert_test"
+DONE_MESSAGE = "alert_gone"
 NOTIFIER = 'test'
 TEST_CONFIG = \
     {alert.DOMAIN: {
         NAME: {
             CONF_NAME: NAME,
+            alert.CONF_DONE_MESSAGE: DONE_MESSAGE,
             CONF_ENTITY_ID: "sensor.test",
             CONF_STATE: STATE_ON,
             alert.CONF_REPEAT: 30,
             alert.CONF_SKIP_FIRST: False,
             alert.CONF_NOTIFIERS: [NOTIFIER]}
         }}
-TEST_NOACK = [NAME, NAME, "sensor.test", STATE_ON,
-              [30], False, NOTIFIER, False]
+TEST_NOACK = [NAME, NAME, DONE_MESSAGE, "sensor.test",
+              STATE_ON, [30], False, NOTIFIER, False]
 ENTITY_ID = alert.ENTITY_ID_FORMAT.format(NAME)
 
 
@@ -119,6 +121,31 @@ class TestAlert(unittest.TestCase):
         hidden = self.hass.states.get(ENTITY_ID).attributes.get('hidden')
         self.assertFalse(hidden)
 
+    def test_notification_no_done_message(self):
+        """Test notifications."""
+        events = []
+        config = deepcopy(TEST_CONFIG)
+        del(config[alert.DOMAIN][NAME][alert.CONF_DONE_MESSAGE])
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.services.register(
+            notify.DOMAIN, NOTIFIER, record_event)
+
+        assert setup_component(self.hass, alert.DOMAIN, config)
+        self.assertEqual(0, len(events))
+
+        self.hass.states.set("sensor.test", STATE_ON)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(events))
+
+        self.hass.states.set("sensor.test", STATE_OFF)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(events))
+
     def test_notification(self):
         """Test notifications."""
         events = []
@@ -140,7 +167,7 @@ class TestAlert(unittest.TestCase):
 
         self.hass.states.set("sensor.test", STATE_OFF)
         self.hass.block_till_done()
-        self.assertEqual(1, len(events))
+        self.assertEqual(2, len(events))
 
     def test_skipfirst(self):
         """Test skipping first notification."""
@@ -170,3 +197,12 @@ class TestAlert(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(True, entity.hidden)
+
+    def test_done_message_state_tracker_reset_on_cancel(self):
+        entity = alert.Alert(self.hass, *TEST_NOACK)
+        entity._cancel = lambda *args: None
+        assert entity._send_done_message is False
+        entity._send_done_message = True
+        self.hass.add_job(entity.end_alerting)
+        self.hass.block_till_done()
+        assert entity._send_done_message is False


### PR DESCRIPTION
Adding an optional entry to the config that will send a notification when an
alarm goes from on to off.

## Description:


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/2852

## Example entry for `configuration.yaml` (if applicable):
```yaml
 alert:
   garage_door:
     name: Garage is open
     done_message: Garage is closed
     entity_id: input_boolean.garage_door
     state: 'on'
     repeat: 30
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. - the files that I changed aren't throwing errors, but I'm getting errors in other unrelated files for flake8 and mypy.  Unit tests are passing.  We'll see what Travis says ...
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
