### PR TITLE
Upgrade aiohttp to 2.2.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.1.0
+aiohttp==2.2.0
 async_timeout==1.2.1
 chardet==3.0.2
 astral==1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.1.0
+aiohttp==2.2.0
 async_timeout==1.2.1
 chardet==3.0.2
 astral==1.4

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     'jinja2>=2.9.5',
     'voluptuous==0.10.5',
     'typing>=3,<4',
-    'aiohttp==2.1.0',
+    'aiohttp==2.2.0',
     'async_timeout==1.2.1',
     'chardet==3.0.2',
     'astral==1.4',


### PR DESCRIPTION
## 2.2.0
- Add doc for add_head, update doc for add_get.
- Fixed consecutive calls for `Response.write_eof`.
- Retain method attributes (e.g. :code:`__doc__`) when registering synchronous handlers for resources.
- Added signal TERM handling in `run_app` to gracefully exit
- Fix websocket issues caused by frame fragmentation.
- Raise RuntimeError is you try to set the Content Length and enable chunked encoding at the same time
- Small update for `unittest_run_loop`
- Use CIMultiDict for ClientRequest.skip_auto_headers
- Fix wrong startup sequence: test server and `run_app()` are not raise `DeprecationWarning` now
- Make sure cleanup signal is sent if startup signal has been sent
- Fixed server keep-alive handler, could cause 100% cpu utilization
- Connection can be destroyed before response get processed if  `await aiohttp.request(..)` is used
- MultipartReader does not work with -OO
- Fixed `ClientPayloadError` with blank `Content-Encoding` header
- Support `deflate` encoding implemented in `httpbin.org/deflate`
- Fix BadStatusLine caused by extra `CRLF` after `POST` data
- Keep a reference to `ClientSession` in response object
- Deprecate undocumented `app.on_loop_available` signal

Tested with: 
```yaml
http:
```