### PR TITLE
Add new feature to Apple TV platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,6 +14,9 @@ omit =
     homeassistant/components/apcupsd.py
     homeassistant/components/*/apcupsd.py
 
+    homeassistant/components/apple_tv.py
+    homeassistant/components/*/apple_tv.py
+
     homeassistant/components/arduino.py
     homeassistant/components/*/arduino.py
 
@@ -302,7 +305,6 @@ omit =
     homeassistant/components/lock/lockitron.py
     homeassistant/components/lock/sesame.py
     homeassistant/components/media_player/anthemav.py
-    homeassistant/components/media_player/apple_tv.py
     homeassistant/components/media_player/aquostv.py
     homeassistant/components/media_player/braviatv.py
     homeassistant/components/media_player/cast.py

--- a/homeassistant/components/apple_tv.py
+++ b/homeassistant/components/apple_tv.py
@@ -1,0 +1,135 @@
+"""
+Support for Apple TV.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/apple_tv/
+"""
+import asyncio
+
+import voluptuous as vol
+
+from homeassistant.const import (CONF_HOST, CONF_NAME)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import discovery
+from homeassistant.components.discovery import SERVICE_APPLE_TV
+import homeassistant.helpers.config_validation as cv
+
+
+REQUIREMENTS = ['pyatv==0.3.2']
+
+DOMAIN = 'apple_tv'
+
+ATTR_ATV = 'atv'
+ATTR_POWER = 'power'
+
+CONF_LOGIN_ID = 'login_id'
+CONF_START_OFF = 'start_off'
+CONF_CREDENTIALS = 'credentials'
+
+DEFAULT_NAME = 'Apple TV'
+
+DATA_APPLE_TV = 'data_apple_tv'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.All(cv.ensure_list, [vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_LOGIN_ID): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_CREDENTIALS, default=None): cv.string,
+        vol.Optional(CONF_START_OFF, default=False): cv.boolean
+    })])
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up the Apple TV component."""
+    if DATA_APPLE_TV not in hass.data:
+        hass.data[DATA_APPLE_TV] = {}
+
+    @asyncio.coroutine
+    def atv_discovered(service, info):
+        """Setup an Apple TV that was auto discovered."""
+        yield from _setup_atv(hass, {
+            CONF_NAME: info['name'],
+            CONF_HOST: info['host'],
+            CONF_LOGIN_ID: info['properties']['hG'],
+            CONF_START_OFF: False
+        })
+
+    discovery.async_listen(hass, SERVICE_APPLE_TV, atv_discovered)
+
+    tasks = [_setup_atv(hass, conf) for conf in config.get(DOMAIN, [])]
+    if tasks:
+        yield from asyncio.wait(tasks, loop=hass.loop)
+
+    return True
+
+
+@asyncio.coroutine
+def _setup_atv(hass, atv_config):
+    """Setup an Apple TV."""
+    import pyatv
+    name = atv_config.get(CONF_NAME)
+    host = atv_config.get(CONF_HOST)
+    login_id = atv_config.get(CONF_LOGIN_ID)
+    start_off = atv_config.get(CONF_START_OFF)
+    credentials = atv_config.get(CONF_CREDENTIALS)
+
+    if host in hass.data[DATA_APPLE_TV]:
+        return
+
+    details = pyatv.AppleTVDevice(name, host, login_id)
+    session = async_get_clientsession(hass)
+    atv = pyatv.connect_to_apple_tv(details, hass.loop, session=session)
+    if credentials:
+        yield from atv.airplay.load_credentials(credentials)
+
+    power = AppleTVPowerManager(hass, atv, start_off)
+    hass.data[DATA_APPLE_TV][host] = {
+        ATTR_ATV: atv,
+        ATTR_POWER: power
+    }
+
+    hass.async_add_job(discovery.async_load_platform(
+        hass, 'media_player', DOMAIN, atv_config))
+
+    hass.async_add_job(discovery.async_load_platform(
+        hass, 'remote', DOMAIN, atv_config))
+
+
+class AppleTVPowerManager:
+    """Manager for global power management of an Apple TV.
+
+    An instance is used per device to share the same power state between
+    several platforms.
+    """
+
+    def __init__(self, hass, atv, is_off):
+        """Initialize power manager."""
+        self.hass = hass
+        self.atv = atv
+        self.listeners = []
+        self._is_on = not is_off
+
+    def init(self):
+        """Initialize power management."""
+        if self._is_on:
+            self.atv.push_updater.start()
+
+    @property
+    def turned_on(self):
+        """If device is on or off."""
+        return self._is_on
+
+    def set_power_on(self, value):
+        """Change if a device is on or off."""
+        if value != self._is_on:
+            self._is_on = value
+            if not self._is_on:
+                self.atv.push_updater.stop()
+            else:
+                self.atv.push_updater.start()
+
+            for listener in self.listeners:
+                self.hass.async_add_job(listener.async_update_ha_state())

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -32,6 +32,7 @@ SERVICE_HASS_IOS_APP = 'hass_ios'
 SERVICE_IKEA_TRADFRI = 'ikea_tradfri'
 SERVICE_HASSIO = 'hassio'
 SERVICE_AXIS = 'axis'
+SERVICE_APPLE_TV = 'apple_tv'
 
 SERVICE_HANDLERS = {
     SERVICE_HASS_IOS_APP: ('ios', None),
@@ -40,6 +41,7 @@ SERVICE_HANDLERS = {
     SERVICE_IKEA_TRADFRI: ('tradfri', None),
     SERVICE_HASSIO: ('hassio', None),
     SERVICE_AXIS: ('axis', None),
+    SERVICE_APPLE_TV: ('apple_tv', None),
     'philips_hue': ('light', 'hue'),
     'google_cast': ('media_player', 'cast'),
     'panasonic_viera': ('media_player', 'panasonic_viera'),
@@ -52,7 +54,6 @@ SERVICE_HANDLERS = {
     'denonavr': ('media_player', 'denonavr'),
     'samsung_tv': ('media_player', 'samsungtv'),
     'yeelight': ('light', 'yeelight'),
-    'apple_tv': ('media_player', 'apple_tv'),
     'frontier_silicon': ('media_player', 'frontier_silicon'),
     'openhome': ('media_player', 'openhome'),
     'harmony': ('remote', 'harmony'),

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -316,11 +316,3 @@ kodi_call_method:
     method:
       description: Name of the Kodi JSONRPC API method to be called.
       example: 'VideoLibrary.GetRecentlyAddedEpisodes'
-
-apple_tv_authenticate:
-  description: Start AirPlay device authentication.
-
-  fields:
-    entity_id:
-      description: Name(s) of entities to authenticate with.
-      example: 'media_player.apple_tv'

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -316,3 +316,14 @@ kodi_call_method:
     method:
       description: Name of the Kodi JSONRPC API method to be called.
       example: 'VideoLibrary.GetRecentlyAddedEpisodes'
+
+apple_tv_press_buttons:
+  description: Press one or more remote control buttons
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to press buttons on.
+      example: 'media_player.apple_tv'
+    button:
+      description: Buttons to press.
+      example: ['top_menu', 'left', 'left', 'select']

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -317,17 +317,6 @@ kodi_call_method:
       description: Name of the Kodi JSONRPC API method to be called.
       example: 'VideoLibrary.GetRecentlyAddedEpisodes'
 
-apple_tv_press_buttons:
-  description: Press one or more remote control buttons
-
-  fields:
-    entity_id:
-      description: Name(s) of entities to press buttons on.
-      example: 'media_player.apple_tv'
-    button:
-      description: Buttons to press.
-      example: ['top_menu', 'left', 'left', 'select']
-
 apple_tv_authenticate:
   description: Start AirPlay device authentication.
 

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -327,3 +327,11 @@ apple_tv_press_buttons:
     button:
       description: Buttons to press.
       example: ['top_menu', 'left', 'left', 'select']
+
+apple_tv_authenticate:
+  description: Start AirPlay device authentication.
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to authenticate with.
+      example: 'media_player.apple_tv'

--- a/homeassistant/components/remote/apple_tv.py
+++ b/homeassistant/components/remote/apple_tv.py
@@ -1,0 +1,87 @@
+"""
+Remote control support for Apple TV.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/remote.apple_tv/
+"""
+import asyncio
+
+from homeassistant.components.apple_tv import (
+    ATTR_ATV, ATTR_POWER, DATA_APPLE_TV)
+from homeassistant.components.remote import ATTR_COMMAND
+from homeassistant.components import remote
+from homeassistant.const import (CONF_NAME, CONF_HOST)
+
+
+DEPENDENCIES = ['apple_tv']
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Apple TV remote platform."""
+    if not discovery_info:
+        return
+
+    name = discovery_info[CONF_NAME]
+    host = discovery_info[CONF_HOST]
+    atv = hass.data[DATA_APPLE_TV][host][ATTR_ATV]
+    power = hass.data[DATA_APPLE_TV][host][ATTR_POWER]
+    async_add_devices([AppleTVRemote(atv, power, name)])
+
+
+class AppleTVRemote(remote.RemoteDevice):
+    """Device that sends commands to an Apple TV."""
+
+    def __init__(self, atv, power, name):
+        """Initialize device."""
+        self._atv = atv
+        self._name = name
+        self._power = power
+        self._power.listeners.append(self)
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._power.turned_on
+
+    @property
+    def should_poll(self):
+        """No polling needed for Apple TV."""
+        return False
+
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """Turn the device on.
+
+        This method is a coroutine.
+        """
+        self._power.set_power_on(True)
+
+    @asyncio.coroutine
+    def async_turn_off(self):
+        """Turn the device off.
+
+        This method is a coroutine.
+        """
+        self._power.set_power_on(False)
+
+    def async_send_command(self, **kwargs):
+        """Send a command to one device.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        # Send commands in specified order but schedule only one coroutine
+        @asyncio.coroutine
+        def _send_commads():
+            for command in kwargs[ATTR_COMMAND]:
+                if not hasattr(self._atv.remote_control, command):
+                    continue
+
+                yield from getattr(self._atv.remote_control, command)()
+
+        return _send_commads()

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -471,10 +471,15 @@ axis:
         description: What parameter to operate on. [Required]
         example: 'package=VideoMotionDetection'
 
-apple_tv_authenticate:
-  description: Start AirPlay device authentication.
+apple_tv:
+  apple_tv_authenticate:
+    description: Start AirPlay device authentication.
 
-  fields:
-    entity_id:
-      description: Name(s) of entities to authenticate with.
-      example: 'media_player.apple_tv'
+    fields:
+      entity_id:
+        description: Name(s) of entities to authenticate with.
+        example: 'media_player.apple_tv'
+
+  apple_tv_scan:
+    description: Scan for Apple TV devices.
+

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -470,3 +470,11 @@ axis:
       param:
         description: What parameter to operate on. [Required]
         example: 'package=VideoMotionDetection'
+
+apple_tv_authenticate:
+  description: Start AirPlay device authentication.
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to authenticate with.
+      example: 'media_player.apple_tv'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -515,7 +515,7 @@ pyasn1-modules==0.0.9
 pyasn1==0.2.3
 
 # homeassistant.components.media_player.apple_tv
-pyatv==0.2.1
+pyatv==0.3.2
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -514,7 +514,7 @@ pyasn1-modules==0.0.9
 # homeassistant.components.notify.xmpp
 pyasn1==0.2.3
 
-# homeassistant.components.media_player.apple_tv
+# homeassistant.components.apple_tv
 pyatv==0.3.2
 
 # homeassistant.components.device_tracker.bbox


### PR DESCRIPTION
## Description:
This PR updates pyatv to 0.3.2 and adds new features, mainly:

- Support for "stop"
- Remote control buttons (e.g. menu, arrow keys)
- Device authentication needed for play_media on tvOS 10.2+
- Scanning for devices

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2858

## Example entry for `configuration.yaml` (if applicable):
```yaml
apple_tv:
  - name: Apple TV
    host: 10.0.10.20
    login_id: 00000000-1234-5678-9012-345678901234
    start_off: true
    credentials: 8660DEA5154FB46B:20B94847926112B3F46F85DB3A7311830463BF65570C22C3786E27F38C3326CF
```
``credentials`` is new and user by the device authentication feature.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
