### PR TITLE
Upgrade paho-mqtt to 1.3.0

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     CONF_PASSWORD, CONF_PORT, CONF_PROTOCOL, CONF_PAYLOAD)
 from homeassistant.components.mqtt.server import HBMQTT_CONFIG_SCHEMA
 
-REQUIREMENTS = ['paho-mqtt==1.2.3']
+REQUIREMENTS = ['paho-mqtt==1.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/shiftr.py
+++ b/homeassistant/components/shiftr.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers import state as state_helper
 
-REQUIREMENTS = ['paho-mqtt==1.2.3']
+REQUIREMENTS = ['paho-mqtt==1.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -423,7 +423,7 @@ orvibo==1.1.1
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.2.3
+paho-mqtt==1.3.0
 
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -73,7 +73,7 @@ mficlient==0.3.0
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.2.3
+paho-mqtt==1.3.0
 
 # homeassistant.components.device_tracker.aruba
 # homeassistant.components.device_tracker.asuswrt


### PR DESCRIPTION
1.3.0
=====

- **BREAKING** Requires Python 2.7 or 3.4+.
- **BREAKING** Remove support for SSL without SSLContext (Requires Python 2.7.9+ or 3.2+).
- **BREAKING** on_connect callback is now always called flags. Previously this callback could accepts 3 OR 4 arguments, now it must accepts 4.
- **BREAKING** tls_insecure_set() must now be called *after* tls_set().
- Allow username and password to be zero length (as opposed to not being present).
- Allow zero length client ids when using MQTT v3.1.1.
- Add SSLContext support, including SNI.
- Improved support for unicode topic and binary payload.
- Allow arbitrary Websocket headers and path.
- Fix issue with large inbound payload over Websocket.
- Add exponential delay for reconnection.
- Move unit tests to pytest and tox.
- Add support for standard Python logging.
- Fix duplicate incoming QoS==2 message.

Tested with the following configuration:

``` yaml
mqtt:
  broker: localhost
  discovery: True
```

```bash
$ mosquitto_pub -h 127.0.0.1 -p 1883 -t "homeassistant/binary_sensor/garden/config" -m '{"name": "garden", "device_class": "motion"}'
```
```bash
2017-06-20 19:25:08 INFO (MainThread) [homeassistant.components.mqtt.discovery] Found new component: binary_sensor garden
2017-06-20 19:25:08 INFO (MainThread) [homeassistant.core] Bus:Handling <Event platform_discovered[L]: discovered=name=garden, device_class=motion, state_topic=homeassistant/binary_sensor/garden/state, platform=mqtt, platform=mqtt, service=load_platform.binary_sensor>
2017-06-20 19:25:08 INFO (MainThread) [homeassistant.loader] Loaded binary_sensor.mqtt from homeassistant.components.binary_sensor.mqtt
2017-06-20 19:25:08 INFO (MainThread) [homeassistant.components.binary_sensor] Setting up binary_sensor.mqtt
2017-06-20 19:25:08 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: new_state=<state binary_sensor.garden=off; device_class=motion, friendly_name=garden @ 2017-06-20T19:25:08.756524+02:00>, old_state=None, entity_id=binary_sensor.garden>
```
```bash
$ mosquitto_pub -h 127.0.0.1 -p 1883 -t "homeassistant/binary_sensor/garden/state" -m ON
```
```bash
2017-06-20 19:25:50 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: new_state=<state binary_sensor.garden=on; device_class=motion, friendly_name=garden @ 2017-06-20T19:25:50.717919+02:00>, old_state=<state binary_sensor.garden=off; device_class=motion, friendly_name=garden @ 2017-06-20T19:25:08.756524+02:00>, entity_id=binary_sensor.garden>
```