### PR TITLE
Added RFXTRX UV badge

### DIFF
--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -43,7 +43,8 @@ DATA_TYPES = OrderedDict([
     ('Total usage', 'W'),
     ('Sound', ''),
     ('Sensor Status', ''),
-    ('Counter value', '')])
+    ('Counter value', ''),
+    ('UV', 'uv')])
 
 RECEIVED_EVT_SUBSCRIBERS = []
 RFX_DEVICES = {}


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [na] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [V] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [na] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [na] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [na] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [na] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [na] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [na] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
