### PR TITLE
Upgrade RestrictedPython dependency

### DIFF
--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -9,7 +9,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import sanitize_filename
 
 DOMAIN = 'python_script'
-REQUIREMENTS = ['restrictedpython==4.0a2']
+REQUIREMENTS = ['restrictedpython==4.0a3']
 FOLDER = 'python_scripts'
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -770,7 +770,7 @@ radiotherm==1.2
 # raspihats==2.2.1
 
 # homeassistant.components.python_script
-restrictedpython==4.0a2
+restrictedpython==4.0a3
 
 # homeassistant.components.rflink
 rflink==0.0.34

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -108,7 +108,7 @@ pyunifi==2.13
 pywebpush==1.0.5
 
 # homeassistant.components.python_script
-restrictedpython==4.0a2
+restrictedpython==4.0a3
 
 # homeassistant.components.rflink
 rflink==0.0.34


### PR DESCRIPTION
## Description:
This upgrades RestrictedPython to 4.0a3. This should remove an invisible non-ascii character from the README that was causing issues on OS X.

**Related issue (if applicable):** fixes #8026

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
