### PR TITLE
Allow iteration in python_script

### DIFF
--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -92,6 +92,7 @@ def execute(hass, filename, source, data=None):
         '_print_': StubPrinter,
         '_getattr_': protected_getattr,
         '_write_': full_write_guard,
+        '_getiter_': iter,
     }
     logger = logging.getLogger('{}.{}'.format(__name__, filename))
     local = {

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -149,3 +149,18 @@ hass.stop()
     yield from hass.async_block_till_done()
 
     assert "Not allowed to access HomeAssistant.stop" in caplog.text
+
+
+@asyncio.coroutine
+def test_iterating(hass):
+    """Test compile error logs error."""
+    source = """
+for i in [1, 2]:
+    hass.states.set('hello.{}'.format(i), 'world')
+    """
+
+    hass.async_add_job(execute, hass, 'test.py', source, {})
+    yield from hass.async_block_till_done()
+
+    assert hass.states.is_state('hello.1', 'world')
+    assert hass.states.is_state('hello.2', 'world')


### PR DESCRIPTION
## Description:
This will allow us to iterate inside Python scripts and thus also use for-loops.

## Example python_script
```python
home = 0
for entity_id in hass.states.entity_ids('device_tracker'):
    state = hass.states.get(entity_id)
    if state.state == 'home':
        home = home + 1

hass.states.set('sensor.people_home', home, {
    'unit_of_measurement': 'people',
    'friendly_name': 'People home'
})
```

## Checklist:

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
