### PR TITLE
Add ClickSend notify service.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -342,6 +342,7 @@ omit =
     homeassistant/components/notify/aws_sns.py
     homeassistant/components/notify/aws_sqs.py
     homeassistant/components/notify/ciscospark.py
+    homeassistant/components/notify/clicksend.py
     homeassistant/components/notify/discord.py
     homeassistant/components/notify/facebook.py
     homeassistant/components/notify/free_mobile.py

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -12,8 +12,9 @@ import base64
 
 import voluptuous as vol
 
-from homeassistant.const import (CONF_USERNAME, CONF_API_KEY, CONF_RECIPIENT,
-    HTTP_HEADER_CONTENT_TYPE, CONTENT_TYPE_JSON, HTTP_BASIC_AUTHENTICATION)
+from homeassistant.const import (CONF_USERNAME, CONF_API_KEY,
+                                 CONF_RECIPIENT,HTTP_HEADER_CONTENT_TYPE,
+                                 CONTENT_TYPE_JSON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
     PLATFORM_SCHEMA, BaseNotificationService)
@@ -60,7 +61,7 @@ class ClicksendNotificationService(BaseNotificationService):
         api_url = "{}/sms/send".format(BASE_API_URL)
 
         resp = requests.post(api_url, data=json.dumps(data), headers=headers,
-                            auth=(self.username, self.api_key), timeout=5)
+                             auth=(self.username, self.api_key), timeout=5)
 
         obj = json.loads(resp.text)
         response_msg = obj['response_msg']
@@ -71,13 +72,14 @@ class ClicksendNotificationService(BaseNotificationService):
             _LOGGER.error("Error %s : %s (Code %s)", resp.status_code,
                           response_msg, response_code)
 
-
+                          
 def _authenticate(config):
     """Authenticate with ClickSend."""
     api_url = '{}/account'.format(BASE_API_URL)
     headers = {HTTP_HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON}
 
-    resp = requests.get(api_url, auth=(config.get(CONF_USERNAME),
+    resp = requests.get(api_url, headers=headers,
+                        auth=(config.get(CONF_USERNAME),
                         config.get(CONF_API_KEY)), timeout=5)
 
     if resp.status_code != 200:

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -1,0 +1,71 @@
+"""
+Clicksend platform for notify component.
+For more details about this platform, please refer to the documentation at
+https://clicksend.com/help
+"""
+
+# Import dependencies.
+import logging
+import requests
+import json
+import base64
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.notify import (
+    PLATFORM_SCHEMA, BaseNotificationService)
+
+# Get logger instance.
+_LOGGER = logging.getLogger(__name__)
+
+# Set platform  parameters.
+CONF_API_URL = 'https://rest.clicksend.com/v3/sms/send'
+CONF_USERNAME = 'username'
+CONF_API_KEY = 'api_key'
+CONF_TO_NO = 'to_no'
+
+# Validate parameter schema.
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_TO_NO): cv.string,
+})
+
+# Define service instance.
+def get_service(hass, config, discovery_info=None):
+
+    # Set notification service instance.
+    return ClicksendNotificationService(config[CONF_USERNAME], config[CONF_API_KEY], config[CONF_TO_NO])
+
+# Implement the notification service.
+class ClicksendNotificationService(BaseNotificationService):
+    """Implementation of a notification service for the Twitter service."""
+
+    def __init__(self, username, api_key, to_no):
+
+        # Set variables.
+        self.username = username
+        self.api_key = api_key
+        self.to_no = to_no
+
+    def send_message(self, message="", **kwargs):
+
+        # Send request.
+        auth = self.username + ':' + self.api_key
+        auth = base64.b64encode(bytes(auth, 'utf-8'))
+        auth = 'Basic ' + auth.decode('utf-8')
+
+        data = {'messages': [{'source': 'hass.notify', 'from': self.to_no, 'to': self.to_no, 'body': message}]}
+        headers = {'Content-type': 'application/json', 'Authorization': auth}
+
+        resp = requests.post(CONF_API_URL, data=json.dumps(data), headers=headers)
+
+        obj = json.loads(resp.text)
+        response_msg = obj['response_msg']
+        response_code = obj['response_code']
+
+        # Display error when failed.
+        if resp.status_code != 200:
+            _LOGGER.error("Error %s : %s (Code %s)", resp.status_code,
+                          response_msg, response_code)

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -8,7 +8,6 @@ https://home-assistant.io/components/notify.clicksend/
 import logging
 import requests
 import json
-import base64
 
 import voluptuous as vol
 

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -4,28 +4,25 @@ Clicksend platform for notify component.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.clicksend/
 """
-
-# Import dependencies.
-import logging
 import json
+import logging
 import requests
 
 import voluptuous as vol
 
-from homeassistant.const import (CONF_USERNAME, CONF_API_KEY,
-                                 CONF_RECIPIENT, HTTP_HEADER_CONTENT_TYPE,
-                                 CONTENT_TYPE_JSON)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    CONF_USERNAME, CONF_API_KEY, CONF_RECIPIENT, HTTP_HEADER_CONTENT_TYPE,
+    CONTENT_TYPE_JSON)
 from homeassistant.components.notify import (
     PLATFORM_SCHEMA, BaseNotificationService)
 
-# Get logger instance.
 _LOGGER = logging.getLogger(__name__)
 
-# Set platform  parameters.
 BASE_API_URL = 'https://rest.clicksend.com/v3'
 
-# Validate parameter schema.
+HEADERS = {HTTP_HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON}
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
@@ -36,7 +33,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def get_service(hass, config, discovery_info=None):
     """Get the ClickSend notification service."""
     if _authenticate(config) is False:
-        _LOGGER.exception("You are not authorized to access ClickSend.")
+        _LOGGER.exception("You are not authorized to access ClickSend")
         return None
 
     return ClicksendNotificationService(config)
@@ -56,18 +53,15 @@ class ClicksendNotificationService(BaseNotificationService):
         data = ({'messages': [{'source': 'hass.notify', 'from': self.recipient,
                                'to': self.recipient, 'body': message}]})
 
-        headers = {HTTP_HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON}
-
         api_url = "{}/sms/send".format(BASE_API_URL)
 
-        resp = requests.post(api_url, data=json.dumps(data), headers=headers,
+        resp = requests.post(api_url, data=json.dumps(data), headers=HEADERS,
                              auth=(self.username, self.api_key), timeout=5)
 
         obj = json.loads(resp.text)
         response_msg = obj['response_msg']
         response_code = obj['response_code']
 
-        # Display error when failed.
         if resp.status_code != 200:
             _LOGGER.error("Error %s : %s (Code %s)", resp.status_code,
                           response_msg, response_code)
@@ -76,9 +70,7 @@ class ClicksendNotificationService(BaseNotificationService):
 def _authenticate(config):
     """Authenticate with ClickSend."""
     api_url = '{}/account'.format(BASE_API_URL)
-    headers = {HTTP_HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON}
-
-    resp = requests.get(api_url, headers=headers,
+    resp = requests.get(api_url, headers=HEADERS,
                         auth=(config.get(CONF_USERNAME),
                               config.get(CONF_API_KEY)), timeout=5)
 

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -1,13 +1,14 @@
 """
 Clicksend platform for notify component.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.clicksend/
 """
 
 # Import dependencies.
 import logging
-import requests
 import json
+import requests
 
 import voluptuous as vol
 

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -13,7 +13,7 @@ import base64
 import voluptuous as vol
 
 from homeassistant.const import (CONF_USERNAME, CONF_API_KEY,
-                                 CONF_RECIPIENT,HTTP_HEADER_CONTENT_TYPE,
+                                 CONF_RECIPIENT, HTTP_HEADER_CONTENT_TYPE,
                                  CONTENT_TYPE_JSON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
@@ -54,7 +54,7 @@ class ClicksendNotificationService(BaseNotificationService):
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
         data = ({'messages': [{'source': 'hass.notify', 'from': self.recipient,
-                'to': self.recipient, 'body': message}]})
+                               'to': self.recipient, 'body': message}]})
 
         headers = {HTTP_HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON}
 
@@ -72,7 +72,7 @@ class ClicksendNotificationService(BaseNotificationService):
             _LOGGER.error("Error %s : %s (Code %s)", resp.status_code,
                           response_msg, response_code)
 
-                          
+
 def _authenticate(config):
     """Authenticate with ClickSend."""
     api_url = '{}/account'.format(BASE_API_URL)
@@ -80,7 +80,7 @@ def _authenticate(config):
 
     resp = requests.get(api_url, headers=headers,
                         auth=(config.get(CONF_USERNAME),
-                        config.get(CONF_API_KEY)), timeout=5)
+                              config.get(CONF_API_KEY)), timeout=5)
 
     if resp.status_code != 200:
         return False


### PR DESCRIPTION
The `clicksend` platform uses [ClickSend](https://clicksend.com) to deliver notifications from Home Assistant.

### Get your ClickSend API Credentials
Go to your [ClickSend Dashboard](https://dashboard.clicksend.com) section and create your new project. After creating your project, you should now be able to obtain your `username` and `api_key`.

### Checklist:

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated in home-assistant.github.io. See: [PR #2868](https://github.com/home-assistant/home-assistant.github.io/pull/2868)

If the code communicates with devices, web services, or third-party tools:

 - [x] Local tests with tox run successfully. Your PR cannot be merged unless tests pass
 - [x] New files were added to .coveragerc.