### PR TITLE
Add current balance to hydroquebec sensor

### DIFF
--- a/homeassistant/components/sensor/hydroquebec.py
+++ b/homeassistant/components/sensor/hydroquebec.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyhydroquebec==1.1.0']
+REQUIREMENTS = ['pyhydroquebec==1.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,6 +36,8 @@ REQUESTS_TIMEOUT = 15
 MIN_TIME_BETWEEN_UPDATES = timedelta(hours=1)
 
 SENSOR_TYPES = {
+    'balance':
+    ['Balance', PRICE, 'mdi:square-inc-cash'],
     'period_total_bill':
     ['Current period bill', PRICE, 'mdi:square-inc-cash'],
     'period_length':

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -568,7 +568,7 @@ pyhik==0.1.2
 pyhomematic==0.1.28
 
 # homeassistant.components.sensor.hydroquebec
-pyhydroquebec==1.1.0
+pyhydroquebec==1.2.0
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.9.1


### PR DESCRIPTION
## Description:

Add current balance to Hydroquebec sensor

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2861

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: hydroquebec
    username: MYUSERNAME
    password: MYPASSWORD
    contract: '123456789'
    monitored_variables:
     - balance
     - period_total_bill
     ...
```

## Checklist:

  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
