### PR TITLE
Decora light: Fix brightness level in UI

### DIFF
--- a/homeassistant/components/light/decora.py
+++ b/homeassistant/components/light/decora.py
@@ -14,7 +14,7 @@ from homeassistant.components.light import (
     PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['decora==0.4']
+REQUIREMENTS = ['decora==0.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class DecoraLight(Light):
         self._switch = decora.decora(self._address, self._key)
         self._switch.connect()
         self._state = self._switch.get_on()
-        self._brightness = self._switch.get_brightness()
+        self._brightness = self._switch.get_brightness() * 2.55
         self.is_valid = True
 
     @property
@@ -99,7 +99,7 @@ class DecoraLight(Light):
 
     def set_state(self, brightness):
         """Set the state of this lamp to the provided brightness."""
-        self._switch.set_brightness(brightness)
+        self._switch.set_brightness(int(brightness / 2.55))
         self._brightness = brightness
         return True
 
@@ -120,5 +120,5 @@ class DecoraLight(Light):
 
     def update(self):
         """Synchronise internal state with the actual light state."""
-        self._brightness = self._switch.get_brightness()
+        self._brightness = self._switch.get_brightness() * 2.55
         self._state = self._switch.get_on()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -141,7 +141,7 @@ datadog==0.15.0
 datapoint==0.4.3
 
 # homeassistant.components.light.decora
-# decora==0.4
+# decora==0.6
 
 # homeassistant.components.media_player.denonavr
 denonavr==0.4.4


### PR DESCRIPTION
## Description:

Decora light return brightness level between 0 and 100.
This fixes brightness level in UI.

## Checklist:

  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
