### PR TITLE
0.47.1

### DIFF
--- a/homeassistant/components/fan/dyson.py
+++ b/homeassistant/components/fan/dyson.py
@@ -75,7 +75,7 @@ class DysonPureCoolLinkDevice(FanEntity):
     def async_added_to_hass(self):
         """Callback when entity is added to hass."""
         self.hass.async_add_job(
-            self._device.add_message_listener(self.on_message))
+            self._device.add_message_listener, self.on_message)
 
     def on_message(self, message):
         """Called when new messages received from the fan."""

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -79,5 +79,8 @@ class VeraLight(VeraDevice, Light):
     def update(self):
         """Call to update state."""
         self._state = self.vera_device.is_switched_on()
-        self._brightness = self.vera_device.get_brightness()
-        self._color = self.vera_device.get_color()
+        if self.vera_device.is_dimmable:
+            # If it is dimmable, both functions exist. In case color
+            # is not supported, it will return None
+            self._brightness = self.vera_device.get_brightness()
+            self._color = self.vera_device.get_color()

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -92,6 +92,7 @@ def execute(hass, filename, source, data=None):
         '_print_': StubPrinter,
         '_getattr_': protected_getattr,
         '_write_': full_write_guard,
+        '_getiter_': iter,
     }
     logger = logging.getLogger('{}.{}'.format(__name__, filename))
     local = {

--- a/homeassistant/components/remote/itach.py
+++ b/homeassistant/components/remote/itach.py
@@ -62,10 +62,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         name = data.get(CONF_NAME)
         modaddr = int(data.get(CONF_MODADDR, 1))
         connaddr = int(data.get(CONF_CONNADDR, 1))
-        cmddata = ""
+        cmddatas = ""
         for cmd in data.get(CONF_COMMANDS):
-            cmddata += cmd[CONF_NAME] + "\n" + cmd[CONF_DATA] + "\n"
-        itachip2ir.addDevice(name, modaddr, connaddr, cmddata)
+            cmdname = cmd[CONF_NAME].strip()
+            if not cmdname:
+                cmdname = '""'
+            cmddata = cmd[CONF_DATA].strip()
+            if not cmddata:
+                cmddata = '""'
+            cmddatas += "{}\n{}\n".format(cmdname, cmddata)
+        itachip2ir.addDevice(name, modaddr, connaddr, cmddatas)
         devices.append(ITachIP2IRRemote(itachip2ir, name))
     add_devices(devices, True)
     return True

--- a/homeassistant/components/sensor/dyson.py
+++ b/homeassistant/components/sensor/dyson.py
@@ -38,7 +38,7 @@ class DysonFilterLifeSensor(Entity):
     def async_added_to_hass(self):
         """Callback when entity is added to hass."""
         self.hass.async_add_job(
-            self._device.add_message_listener(self.on_message))
+            self._device.add_message_listener, self.on_message)
 
     def on_message(self, message):
         """Called when new messages received from the fan."""

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 47
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -1,5 +1,6 @@
 """The tests for the InfluxDB component."""
 import unittest
+import datetime
 from unittest import mock
 
 import influxdb as influx_client
@@ -123,7 +124,9 @@ class TestInfluxDB(unittest.TestCase):
                 'latitude': '2.2',
                 'battery_level': '99%',
                 'temperature': '20c',
-                'last_seen': 'Last seen 23 minutes ago'
+                'last_seen': 'Last seen 23 minutes ago',
+                'updated_at': datetime.datetime(2017, 1, 1, 0, 0),
+                'multi_periods': '0.120.240.2023873'
             }
             state = mock.MagicMock(
                 state=in_, domain='fake', object_id='entity', attributes=attrs)
@@ -144,7 +147,11 @@ class TestInfluxDB(unittest.TestCase):
                         'battery_level': 99.0,
                         'temperature_str': '20c',
                         'temperature': 20.0,
-                        'last_seen_str': 'Last seen 23 minutes ago'
+                        'last_seen_str': 'Last seen 23 minutes ago',
+                        'last_seen': 23.0,
+                        'updated_at_str': '2017-01-01 00:00:00',
+                        'updated_at': 20170101000000,
+                        'multi_periods_str': '0.120.240.2023873'
                     },
                 }]
 
@@ -164,7 +171,11 @@ class TestInfluxDB(unittest.TestCase):
                         'battery_level': 99.0,
                         'temperature_str': '20c',
                         'temperature': 20.0,
-                        'last_seen_str': 'Last seen 23 minutes ago'
+                        'last_seen_str': 'Last seen 23 minutes ago',
+                        'last_seen': 23.0,
+                        'updated_at_str': '2017-01-01 00:00:00',
+                        'updated_at': 20170101000000,
+                        'multi_periods_str': '0.120.240.2023873'
                     },
                 }]
             self.handler_method(event)

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -149,3 +149,18 @@ hass.stop()
     yield from hass.async_block_till_done()
 
     assert "Not allowed to access HomeAssistant.stop" in caplog.text
+
+
+@asyncio.coroutine
+def test_iterating(hass):
+    """Test compile error logs error."""
+    source = """
+for i in [1, 2]:
+    hass.states.set('hello.{}'.format(i), 'world')
+    """
+
+    hass.async_add_job(execute, hass, 'test.py', source, {})
+    yield from hass.async_block_till_done()
+
+    assert hass.states.is_state('hello.1', 'world')
+    assert hass.states.is_state('hello.2', 'world')


### PR DESCRIPTION
- Fix Vera lights issue #8098 ([@tsvi] - [#8101]) ([light.vera docs])
- Fix Dyson async_add_job ([@CharlesBlonde] - [#8113]) ([fan.dyson docs]) ([sensor.dyson docs])
- Update InfluxDB to handle datetime objects and multiple decimal points ([@philhawthorne] - [#8080]) ([influxdb docs])
- Fixed iTach command parsing with empty data ([@alanfischer] - [#8104]) ([remote.itach docs])
- Allow iteration in python_script ([@balloob] - [#8134]) ([python_script docs])

[#8080]: https://github.com/home-assistant/home-assistant/pull/8080
[#8101]: https://github.com/home-assistant/home-assistant/pull/8101
[#8104]: https://github.com/home-assistant/home-assistant/pull/8104
[#8113]: https://github.com/home-assistant/home-assistant/pull/8113
[#8134]: https://github.com/home-assistant/home-assistant/pull/8134
[@CharlesBlonde]: https://github.com/CharlesBlonde
[@alanfischer]: https://github.com/alanfischer
[@balloob]: https://github.com/balloob
[@philhawthorne]: https://github.com/philhawthorne
[@tsvi]: https://github.com/tsvi
[fan.dyson docs]: https://home-assistant.io/components/fan.dyson/
[influxdb docs]: https://home-assistant.io/components/influxdb/
[light.vera docs]: https://home-assistant.io/components/light.vera/
[python_script docs]: https://home-assistant.io/components/python_script/
[remote.itach docs]: https://home-assistant.io/components/remote.itach/
[sensor.dyson docs]: https://home-assistant.io/components/sensor.dyson/
