### PR TITLE
Upgrade libsoundtouch to prevent Python3.6 errors with enum34

### DIFF
--- a/homeassistant/components/media_player/soundtouch.py
+++ b/homeassistant/components/media_player/soundtouch.py
@@ -20,7 +20,7 @@ from homeassistant.const import (CONF_HOST, CONF_NAME, STATE_OFF, CONF_PORT,
                                  STATE_PAUSED, STATE_PLAYING,
                                  STATE_UNAVAILABLE)
 
-REQUIREMENTS = ['libsoundtouch==0.3.0']
+REQUIREMENTS = ['libsoundtouch==0.6.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -351,7 +351,7 @@ libpurecoollink==0.1.5
 librouteros==1.0.2
 
 # homeassistant.components.media_player.soundtouch
-libsoundtouch==0.3.0
+libsoundtouch==0.6.1
 
 # homeassistant.components.light.lifx_legacy
 liffylights==0.9.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -65,7 +65,7 @@ influxdb==3.0.0
 libpurecoollink==0.1.5
 
 # homeassistant.components.media_player.soundtouch
-libsoundtouch==0.3.0
+libsoundtouch==0.6.1
 
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi


### PR DESCRIPTION
## Description:

Update Soundtouch underlying library to prevent enum34 to be imported and raise exception with Python3.6 (unable to reproduce myself).

**Related issue (if applicable):** partially fixes #7733

2 other libraries are importing enum34 so it is only 1/3 of the solution.

## Checklist:

If user exposed functionality or configuration variables are added/changed:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
