### PR TITLE
Upgrade python-telegram-bot to 6.1.0

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -24,7 +24,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import TemplateError
 from homeassistant.setup import async_prepare_setup_platform
 
-REQUIREMENTS = ['python-telegram-bot==6.0.3']
+REQUIREMENTS = ['python-telegram-bot==6.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -727,7 +727,7 @@ python-roku==3.1.3
 python-synology==0.1.0
 
 # homeassistant.components.telegram_bot
-python-telegram-bot==6.0.3
+python-telegram-bot==6.1.0
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0


### PR DESCRIPTION
## 6.1.0
- Fully support Bot API 3.0
- Add more fine-grained filters for status updates
- Bug fixes and other improvements

Tested with the following configuration:

``` yaml
telegram_bot:
  - platform: polling
    api_key: !secret telegram_api
    allowed_chat_ids:
      - !secret telegram_client

notify:
  - platform: telegram
    name: telegram
    chat_id: !secret telegram_client
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```