### PR TITLE
Fixed rfxtrx binary_sensor off command

### DIFF
--- a/homeassistant/components/binary_sensor/rfxtrx.py
+++ b/homeassistant/components/binary_sensor/rfxtrx.py
@@ -19,7 +19,7 @@ from homeassistant.components.rfxtrx import (
     ATTR_DATA_BITS, CONF_DEVICES
 )
 from homeassistant.const import (
-    CONF_SENSOR_CLASS, CONF_COMMAND_ON, CONF_COMMAND_OFF
+    CONF_DEVICE_CLASS, CONF_COMMAND_ON, CONF_COMMAND_OFF
 )
 
 DEPENDENCIES = ["rfxtrx"]
@@ -52,10 +52,10 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                                                     entity[ATTR_DATA_BITS]))
 
         _LOGGER.info("Add %s rfxtrx.binary_sensor (class %s)",
-                     entity[ATTR_NAME], entity[CONF_SENSOR_CLASS])
+                     entity[ATTR_NAME], entity[CONF_DEVICE_CLASS])
 
         device = RfxtrxBinarySensor(event, entity[ATTR_NAME],
-                                    entity[CONF_SENSOR_CLASS],
+                                    entity[CONF_DEVICE_CLASS],
                                     entity[ATTR_FIREEVENT],
                                     entity[ATTR_OFF_DELAY],
                                     entity[ATTR_DATA_BITS],
@@ -141,14 +141,14 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class RfxtrxBinarySensor(BinarySensorDevice):
     """An Rfxtrx binary sensor."""
 
-    def __init__(self, event, name, sensor_class=None,
+    def __init__(self, event, name, device_class=None,
                  should_fire=False, off_delay=None, data_bits=None,
                  cmd_on=None, cmd_off=None):
         """Initialize the sensor."""
         self.event = event
         self._name = name
         self._should_fire_event = should_fire
-        self._sensor_class = sensor_class
+        self._device_class = device_class
         self._off_delay = off_delay
         self._state = False
         self.delay_listener = None
@@ -206,9 +206,9 @@ class RfxtrxBinarySensor(BinarySensorDevice):
         return self._should_fire_event
 
     @property
-    def sensor_class(self):
+    def device_class(self):
         """Return the sensor class."""
-        return self._sensor_class
+        return self._device_class
 
     @property
     def off_delay(self):
@@ -230,4 +230,4 @@ class RfxtrxBinarySensor(BinarySensorDevice):
     def update_state(self, state):
         """Update the state of the device."""
         self._state = state
-        self.update_ha_state()
+        self.schedule_update_ha_state()

--- a/homeassistant/components/binary_sensor/rfxtrx.py
+++ b/homeassistant/components/binary_sensor/rfxtrx.py
@@ -118,8 +118,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
                          cmd, sensor.masked_id)
             sensor.apply_cmd(int(cmd, 16))
         else:
-            if not sensor.is_on or sensor.should_fire_event:
-                sensor.update_state(True)
+            rfxtrx.apply_received_command(event)
 
         if (sensor.is_on and sensor.off_delay is not None and
                 sensor.delay_listener is None):

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -13,7 +13,7 @@ from homeassistant.util import slugify
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     ATTR_ENTITY_ID, TEMP_CELSIUS,
-    CONF_SENSOR_CLASS, CONF_COMMAND_ON, CONF_COMMAND_OFF
+    CONF_DEVICE_CLASS, CONF_COMMAND_ON, CONF_COMMAND_OFF
 )
 from homeassistant.helpers.entity import Entity
 
@@ -123,7 +123,7 @@ DEVICE_SCHEMA_SENSOR = vol.Schema({
 
 DEVICE_SCHEMA_BINARYSENSOR = vol.Schema({
     vol.Optional(ATTR_NAME, default=None): cv.string,
-    vol.Optional(CONF_SENSOR_CLASS, default=None): cv.string,
+    vol.Optional(CONF_DEVICE_CLASS, default=None): cv.string,
     vol.Optional(ATTR_FIREEVENT, default=False): cv.boolean,
     vol.Optional(ATTR_OFF_DELAY, default=None):
         vol.Any(cv.time_period, cv.positive_timedelta),


### PR DESCRIPTION
## Description:
Fixed rfxtrx binary_sensor off command implementation, the needed code was already in the rfxtrx component. Now, a binary rfxtrx sensor can be turned off by the device's off command OR a configured off_delay time.
In addition, fixed some deprecation warnings (sensor_class / update_ha_state()).

Test with: KaKu AMST-606 & AYCT-102

**Related issue (if applicable):** fixes # https://github.com/home-assistant/home-assistant/pull/6794#discussion_r123433274

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2336

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
binary_sensor:
  platform: rfxtrx
  automatic_add: True
  devices:
    091300006ca2c6001080:
      name: motion_hall
      device_class: motion
      off_delay:
        seconds: 5
    0913000022670e013b70:
      name: window_room2
      device_class: opening
      data_bits: 4
      command_on: 0x0e
      command_off: 0x07
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
