### PR TITLE
Use version 1.3 of radiotherm

### DIFF
--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -15,7 +15,7 @@ from homeassistant.components.climate import (
 from homeassistant.const import CONF_HOST, TEMP_FAHRENHEIT, ATTR_TEMPERATURE
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['radiotherm==1.2']
+REQUIREMENTS = ['radiotherm==1.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -769,7 +769,7 @@ qnapstats==0.2.4
 rachiopy==0.1.2
 
 # homeassistant.components.climate.radiotherm
-radiotherm==1.2
+radiotherm==1.3
 
 # homeassistant.components.raspihats
 # raspihats==2.2.1


### PR DESCRIPTION
## Description:

Upgrade required version of radiotherm library to 1.3 to add support for CT80 Rev B V1.09 and a number of other models.

**Related issue (if applicable):** fixes #2576

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** Unable to patch docs due to my employer's policy on Non-Commercial license patching.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ No - see above ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
