### PR TITLE
Api states restrict

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -188,11 +188,14 @@ class APIStatesView(HomeAssistantView):
 
         restrict = request.query.get('restrict')
 
-        for entity in hass.states.async_all():
-            if restrict and entity.domain not in restrict:
-                continue
+        if restrict:
+            for entity in hass.states.async_all():
+                if restrict and entity.domain not in restrict:
+                    continue
 
-            json_response.append(entity)
+                json_response.append(entity)
+        else:
+            json_response = hass.states.async_all()
 
         return self.json(json_response)
 
@@ -329,11 +332,14 @@ class APIDomainServicesView(HomeAssistantView):
         with AsyncTrackStates(hass) as changed_states:
             yield from hass.services.async_call(domain, service, data, True)
 
-        for entity in changed_states:
-            if restrict and entity.domain not in restrict:
-                continue
+        if restrict:
+            for entity in changed_states:
+                if restrict and entity.domain not in restrict:
+                    continue
 
-            json_response.append(entity)
+                json_response.append(entity)
+        else:
+            json_response = changed_states
 
         return self.json(json_response)
 

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -183,7 +183,18 @@ class APIStatesView(HomeAssistantView):
     @ha.callback
     def get(self, request):
         """Get current states."""
-        return self.json(request.app['hass'].states.async_all())
+        hass = request.app['hass']
+        json_response = []
+
+        restrict = request.query.get('restrict')
+
+        for entity in hass.states.async_all():
+            if restrict and entity.domain not in restrict:
+                continue
+
+            json_response.append(entity)
+
+        return self.json(json_response)
 
 
 class APIEntityStateView(HomeAssistantView):
@@ -311,11 +322,20 @@ class APIDomainServicesView(HomeAssistantView):
         hass = request.app['hass']
         body = yield from request.text()
         data = json.loads(body) if body else None
+        json_response = []
+
+        restrict = request.query.get('restrict')
 
         with AsyncTrackStates(hass) as changed_states:
             yield from hass.services.async_call(domain, service, data, True)
 
-        return self.json(changed_states)
+        for entity in changed_states:
+            if restrict and entity.domain not in restrict:
+                continue
+
+            json_response.append(entity)
+
+        return self.json(json_response)
 
 
 class APIComponentsView(HomeAssistantView):

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -30,6 +30,21 @@ def test_api_list_state_entities(hass, mock_api_client):
 
 
 @asyncio.coroutine
+def test_api_state_with_restricted(hass, mock_api_client):
+    """Test the states with restrictions."""
+    hass.states.async_set('show.hello', 'hello')
+    hass.states.async_set('hide.bye', 'bye')
+    resp = yield from mock_api_client.get(
+        '{}?restrict=show'.format(const.URL_API_STATES))
+    assert resp.status == 200
+    json = yield from resp.json()
+
+    remote_data = [ha.State.from_dict(item) for item in json]
+
+    assert len(remote_data) == 1 and remote_data[0].domain == 'show'
+
+
+@asyncio.coroutine
 def test_api_get_state(hass, mock_api_client):
     """Test if the debug interface allows us to get a state."""
     hass.states.async_set('hello.world', 'nice', {


### PR DESCRIPTION
## Description:
I'm not sure this pull request is desired, so I have no problem closing it if it's not.

This adds the same "restrict" concept that's in the api event stream to the states & services response.

In developing an app on an embedded device that communicates with hass, I had the need to restrict the amount of data returned by domain.  Initially I had a separate component but realised it fit into the api component fairly simply.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
