### PR TITLE
Added buienradar precipitation forecast average & total sensors

### DIFF
--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -66,9 +66,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup the buienradar sensor."""
+    from homeassistant.components.weather.buienradar import (DEFAULT_TIMEFRAME)
+
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    timeframe = config.get(CONF_TIMEFRAME)
+    timeframe = config.get(CONF_TIMEFRAME, DEFAULT_TIMEFRAME)
 
     if None in (latitude, longitude):
         _LOGGER.error("Latitude or longitude not set in HomeAssistant config")

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -266,8 +266,7 @@ class BrData(object):
                                 raincontent.get(CONTENT),
                                 self.coordinates[CONF_LATITUDE],
                                 self.coordinates[CONF_LONGITUDE],
-                                self.timeframe
-                                )
+                                self.timeframe)
             if result.get(SUCCESS):
                 self.data = result.get(DATA)
 

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -44,9 +44,9 @@ SENSOR_TYPES = {
     'windgust': ['Wind gust', 'm/s', 'mdi:weather-windy'],
     'precipitation': ['Precipitation', 'mm/h', 'mdi:weather-pouring'],
     'irradiance': ['Irradiance', 'W/m2', 'mdi:sunglasses'],
-    'precipitation_forecast_average': ['Precipitation forecast average', 
+    'precipitation_forecast_average': ['Precipitation forecast average',
                                        'mm/h', 'mdi:weather-pouring'],
-    'precipitation_forecast_total': ['Precipitation forecast total', 
+    'precipitation_forecast_total': ['Precipitation forecast total',
                                      'mm/h', 'mdi:weather-pouring']
 }
 
@@ -246,7 +246,7 @@ class BrData(object):
     @asyncio.coroutine
     def async_update(self, *_):
         """Update the data from buienradar."""
-        from buienradar.buienradar import (parse_data, CONTENT, RAINCONTENT,
+        from buienradar.buienradar import (parse_data, CONTENT,
                                            DATA, MESSAGE, STATUS_CODE, SUCCESS)
 
         content = yield from self.get_data('http://xml.buienradar.nl')
@@ -254,8 +254,9 @@ class BrData(object):
             content = yield from self.get_data('http://api.buienradar.nl')
 
         # rounding coordinates prevents unnecessary redirects/calls
-        rainurl = 'http://gadgets.buienradar.nl/data/raintext/?lat={}&lon={}'.format(
-            round(self.coordinates[CONF_LATITUDE], 2), 
+        rainurl = 'http://gadgets.buienradar.nl/data/raintext/?lat={}&lon={}'
+        rainurl = rainurl.format(
+            round(self.coordinates[CONF_LATITUDE], 2),
             round(self.coordinates[CONF_LONGITUDE], 2)
             )
         raincontent = yield from self.get_data(rainurl)

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -22,7 +22,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time)
 from homeassistant.util import dt as dt_util
-from homeassistant.components.weather.buienradar import DEFAULT_TIMEFRAME
 
 REQUIREMENTS = ['buienradar==0.6']
 
@@ -62,17 +61,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                   'Latitude and longitude must exist together'): cv.latitude,
     vol.Inclusive(CONF_LONGITUDE, 'coordinates',
                   'Latitude and longitude must exist together'): cv.longitude,
-    vol.Optional(CONF_TIMEFRAME, default=DEFAULT_TIMEFRAME):
-    cv.positive_int
+    vol.Optional(CONF_TIMEFRAME): cv.positive_int
 })
 
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup the buienradar sensor."""
+    from homeassistant.components.weather.buienradar import DEFAULT_TIMEFRAME
+
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    timeframe = config.get(CONF_TIMEFRAME)
+    timeframe = config.get(CONF_TIMEFRAME, DEFAULT_TIMEFRAME)
 
     if None in (latitude, longitude):
         _LOGGER.error("Latitude or longitude not set in HomeAssistant config")

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.event import (
     async_track_point_in_utc_time)
 from homeassistant.util import dt as dt_util
 
-REQUIREMENTS = ['buienradar==0.4']
+REQUIREMENTS = ['buienradar==0.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,7 +44,13 @@ SENSOR_TYPES = {
     'windgust': ['Wind gust', 'm/s', 'mdi:weather-windy'],
     'precipitation': ['Precipitation', 'mm/h', 'mdi:weather-pouring'],
     'irradiance': ['Irradiance', 'W/m2', 'mdi:sunglasses'],
+    'precipitation_forecast_average': ['Precipitation forecast average', 
+                                       'mm/h', 'mdi:weather-pouring'],
+    'precipitation_forecast_total': ['Precipitation forecast total', 
+                                     'mm/h', 'mdi:weather-pouring']
 }
+
+CONF_TIMEFRAME = 'timeframe'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MONITORED_CONDITIONS,
@@ -53,6 +59,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                      [vol.In(SENSOR_TYPES.keys())]),
     vol.Optional(CONF_LATITUDE): cv.latitude,
     vol.Optional(CONF_LONGITUDE): cv.longitude,
+    vol.Optional(CONF_TIMEFRAME): cv.positive_int
 })
 
 
@@ -61,6 +68,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup the buienradar sensor."""
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
+    timeframe = config.get(CONF_TIMEFRAME)
 
     if None in (latitude, longitude):
         _LOGGER.error("Latitude or longitude not set in HomeAssistant config")
@@ -74,7 +82,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         dev.append(BrSensor(sensor_type, config.get(CONF_NAME, 'br')))
     async_add_devices(dev)
 
-    data = BrData(hass, coordinates, dev)
+    data = BrData(hass, coordinates, timeframe, dev)
     # schedule the first update in 1 minute from now:
     _LOGGER.debug("Start running....")
     yield from data.schedule_update(1)
@@ -97,8 +105,8 @@ class BrSensor(Entity):
     def load_data(self, data):
         """Load the sensor with relevant data."""
         # Find sensor
-        from buienradar.buienradar import (ATTRIBUTION, IMAGE,
-                                           STATIONNAME, SYMBOL)
+        from buienradar.buienradar import (ATTRIBUTION, IMAGE, STATIONNAME,
+                                           SYMBOL, PRECIPITATION_FORECAST)
 
         self._attribution = data.get(ATTRIBUTION)
         self._stationname = data.get(STATIONNAME)
@@ -111,6 +119,14 @@ class BrSensor(Entity):
             if new_state != self._state or img != self._entity_picture:
                 self._state = new_state
                 self._entity_picture = img
+                return True
+        elif self.type.startswith(PRECIPITATION_FORECAST):
+            # update nested precipitation forecast sensors
+            nested = data.get(PRECIPITATION_FORECAST)
+            new_state = nested.get(self.type[len(PRECIPITATION_FORECAST)+1:])
+            # pylint: disable=protected-access
+            if new_state != self._state:
+                self._state = new_state
                 return True
         else:
             # update all other sensors
@@ -172,12 +188,13 @@ class BrSensor(Entity):
 class BrData(object):
     """Get the latest data and updates the states."""
 
-    def __init__(self, hass, coordinates, devices):
+    def __init__(self, hass, coordinates, timeframe, devices):
         """Initialize the data object."""
         self.devices = devices
         self.data = {}
         self.hass = hass
         self.coordinates = coordinates
+        self.timeframe = timeframe
 
     @asyncio.coroutine
     def update_devices(self):
@@ -229,17 +246,27 @@ class BrData(object):
     @asyncio.coroutine
     def async_update(self, *_):
         """Update the data from buienradar."""
-        from buienradar.buienradar import (parse_data, CONTENT,
+        from buienradar.buienradar import (parse_data, CONTENT, RAINCONTENT,
                                            DATA, MESSAGE, STATUS_CODE, SUCCESS)
 
-        result = yield from self.get_data('http://xml.buienradar.nl')
-        if result.get(SUCCESS, False) is False:
-            result = yield from self.get_data('http://api.buienradar.nl')
+        content = yield from self.get_data('http://xml.buienradar.nl')
+        if content.get(SUCCESS, False) is False:
+            content = yield from self.get_data('http://api.buienradar.nl')
 
-        if result.get(SUCCESS):
-            result = parse_data(result.get(CONTENT),
-                                latitude=self.coordinates[CONF_LATITUDE],
-                                longitude=self.coordinates[CONF_LONGITUDE])
+        # rounding coordinates prevents unnecessary redirects/calls
+        rainurl = 'http://gadgets.buienradar.nl/data/raintext/?lat={}&lon={}'.format(
+            round(self.coordinates[CONF_LATITUDE], 2), 
+            round(self.coordinates[CONF_LONGITUDE], 2)
+            )
+        raincontent = yield from self.get_data(rainurl)
+
+        if content.get(SUCCESS) and raincontent.get(SUCCESS):
+            result = parse_data(content.get(CONTENT),
+                                raincontent.get(CONTENT),
+                                self.coordinates[CONF_LATITUDE],
+                                self.coordinates[CONF_LONGITUDE],
+                                self.timeframe
+                                )
             if result.get(SUCCESS):
                 self.data = result.get(DATA)
 

--- a/homeassistant/components/weather/buienradar.py
+++ b/homeassistant/components/weather/buienradar.py
@@ -45,7 +45,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                    CONF_LONGITUDE: float(longitude)}
 
     # create weather data:
-    data = BrData(hass, coordinates, None)
+    data = BrData(hass, coordinates, None, None)
     # create weather device:
     async_add_devices([BrWeather(data, config.get(CONF_FORECAST, True),
                                  config.get(CONF_NAME, None))])

--- a/homeassistant/components/weather/buienradar.py
+++ b/homeassistant/components/weather/buienradar.py
@@ -21,6 +21,8 @@ import voluptuous as vol
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_TIMEFRAME = 60
+
 CONF_FORECAST = 'forecast'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -45,7 +47,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                    CONF_LONGITUDE: float(longitude)}
 
     # create weather data:
-    data = BrData(hass, coordinates, None, None)
+    data = BrData(hass, coordinates, DEFAULT_TIMEFRAME, None)
     # create weather device:
     async_add_devices([BrWeather(data, config.get(CONF_FORECAST, True),
                                  config.get(CONF_NAME, None))])

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -115,7 +115,7 @@ boto3==1.4.3
 broadlink==0.3
 
 # homeassistant.components.sensor.buienradar
-buienradar==0.4
+buienradar==0.6
 
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2


### PR DESCRIPTION
## Description:
Added precipitation forecast average & total sensors to the buienradar components, which are available since buienradar==0.6.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2878

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: buienradar
    monitored_conditions:
      - precipitation_forecast_total
      - precipitation_forecast_average
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
