### PR TITLE
Tado fix

### DIFF
--- a/homeassistant/components/tado.py
+++ b/homeassistant/components/tado.py
@@ -16,8 +16,8 @@ from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.util import Throttle
 
 REQUIREMENTS = ['https://github.com/wmalgadey/PyTado/archive/'
-                '0.2.10.zip#'
-                'PyTado==0.2.10']
+                '0.2.1.zip#'
+                'PyTado==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tado.py
+++ b/homeassistant/components/tado.py
@@ -16,8 +16,8 @@ from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.util import Throttle
 
 REQUIREMENTS = ['https://github.com/wmalgadey/PyTado/archive/'
-                '0.1.10.zip#'
-                'PyTado==0.1.10']
+                '0.2.10.zip#'
+                'PyTado==0.2.10']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -307,7 +307,7 @@ https://github.com/soldag/pyflic/archive/0.4.zip#pyflic==0.4
 https://github.com/tfriedel/python-lightify/archive/1bb1db0e7bd5b14304d7bb267e2398cd5160df46.zip#lightify==1.0.5
 
 # homeassistant.components.tado
-https://github.com/wmalgadey/PyTado/archive/0.1.10.zip#PyTado==0.1.10
+https://github.com/wmalgadey/PyTado/archive/0.2.1.zip#PyTado==0.2.1
 
 # homeassistant.components.media_player.lg_netcast
 https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0


### PR DESCRIPTION
## Description:
Updated reference to PyTodo.
Fixed Tado component - updated reference to PyTado==0.2.1 from PyTado==0.1.10.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
fixes #8010 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
