### PR TITLE
Throw exception if _convert_for_display called on non Number

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -693,8 +693,14 @@ class ClimateDevice(Entity):
 
     def _convert_for_display(self, temp):
         """Convert temperature into preferred units for display purposes."""
-        if temp is None or not isinstance(temp, Number):
+        if temp is None:
             return temp
+
+        # if the temperature is not a number this can cause issues
+        # with polymer components, so bail early there.
+        if not isinstance(temp, Number):
+            raise TypeError("Temperature is not a number: %s" % temp)
+
         if self.temperature_unit != self.unit_of_measurement:
             temp = convert_temperature(
                 temp, self.temperature_unit, self.unit_of_measurement)

--- a/homeassistant/components/climate/mysensors.py
+++ b/homeassistant/components/climate/mysensors.py
@@ -67,7 +67,7 @@ class MySensorsHVAC(mysensors.MySensorsDeviceEntity, ClimateDevice):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return self._values.get(self.gateway.const.SetReq.V_TEMP)
+        return float(self._values.get(self.gateway.const.SetReq.V_TEMP))
 
     @property
     def target_temperature(self):
@@ -79,21 +79,21 @@ class MySensorsHVAC(mysensors.MySensorsDeviceEntity, ClimateDevice):
         temp = self._values.get(set_req.V_HVAC_SETPOINT_COOL)
         if temp is None:
             temp = self._values.get(set_req.V_HVAC_SETPOINT_HEAT)
-        return temp
+        return float(temp)
 
     @property
     def target_temperature_high(self):
         """Return the highbound target temperature we try to reach."""
         set_req = self.gateway.const.SetReq
         if set_req.V_HVAC_SETPOINT_HEAT in self._values:
-            return self._values.get(set_req.V_HVAC_SETPOINT_COOL)
+            return float(self._values.get(set_req.V_HVAC_SETPOINT_COOL))
 
     @property
     def target_temperature_low(self):
         """Return the lowbound target temperature we try to reach."""
         set_req = self.gateway.const.SetReq
         if set_req.V_HVAC_SETPOINT_COOL in self._values:
-            return self._values.get(set_req.V_HVAC_SETPOINT_HEAT)
+            return float(self._values.get(set_req.V_HVAC_SETPOINT_HEAT))
 
     @property
     def current_operation(self):


### PR DESCRIPTION
In trying to come up for some reason behind issue #6365 (which only
happens on some platforms) the best guess is that some components are
managing to get a string value all the way up to the Polymer UI for
temperature, which then an increment of +0.5 is treating as a string
concat operation instead of addition. So 20 + 0.5 becomes 200.5 hits
the max thermostat value.

This will throw an exception if the climate temp value isn't a
number. That's going to turn a soft fail into a hard fail on
potentially a number of platforms. Mysensors is one of the platforms
that was reported as having the issue. So put some explicit float
casts where that might be coming from as well.

Fixes #6365