### PR TITLE
Plex: Add exception handler when connection fails

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -148,6 +148,10 @@ def setup_plexserver(host, token, hass, config, add_devices_callback):
             _LOGGER.error("Could not connect to plex server at http://%s",
                           host)
             return
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("Could not connect to plex server at http://%s",
+                          host)
+            return
 
         new_plex_clients = []
         for device in devices:
@@ -192,6 +196,10 @@ def setup_plexserver(host, token, hass, config, add_devices_callback):
             sessions = plexserver.sessions()
         except plexapi.exceptions.BadRequest:
             _LOGGER.exception("Error listing plex sessions")
+            return
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("Could not connect to plex server at http://%s",
+                          host)
             return
 
         plex_sessions.clear()

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -144,10 +144,6 @@ def setup_plexserver(host, token, hass, config, add_devices_callback):
         except plexapi.exceptions.BadRequest:
             _LOGGER.exception("Error listing plex devices")
             return
-        except OSError:
-            _LOGGER.error("Could not connect to plex server at http://%s",
-                          host)
-            return
         except requests.exceptions.RequestException as ex:
             _LOGGER.error("Could not connect to plex server at http://%s (%s)",
                           host, ex)

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -148,9 +148,9 @@ def setup_plexserver(host, token, hass, config, add_devices_callback):
             _LOGGER.error("Could not connect to plex server at http://%s",
                           host)
             return
-        except requests.exceptions.ConnectionError:
-            _LOGGER.error("Could not connect to plex server at http://%s",
-                          host)
+        except requests.exceptions.RequestException as ex:
+            _LOGGER.error("Could not connect to plex server at http://%s (%s)",
+                          host, ex)
             return
 
         new_plex_clients = []
@@ -197,9 +197,9 @@ def setup_plexserver(host, token, hass, config, add_devices_callback):
         except plexapi.exceptions.BadRequest:
             _LOGGER.exception("Error listing plex sessions")
             return
-        except requests.exceptions.ConnectionError:
-            _LOGGER.error("Could not connect to plex server at http://%s",
-                          host)
+        except requests.exceptions.RequestException as ex:
+            _LOGGER.error("Could not connect to plex server at http://%s (%s)",
+                          host, ex)
             return
 
         plex_sessions.clear()


### PR DESCRIPTION
## Description:
Add exception handler for when the connection fails (server is down).

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
