### PR TITLE
Revert "Add libboost-python1.62-dev (fixes #7851)"

### DIFF
--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -21,7 +21,7 @@ PACKAGES=(
   # homeassistant.components.device_tracker.nmap_tracker
   nmap net-tools libcurl3-dev
   # homeassistant.components.device_tracker.bluetooth_tracker
-  bluetooth libglib2.0-dev libbluetooth-dev libboost-python1.62-dev
+  bluetooth libglib2.0-dev libbluetooth-dev
   # homeassistant.components.device_tracker.owntracks
   libsodium13
   # homeassistant.components.zwave


### PR DESCRIPTION
Reverts home-assistant/home-assistant#7868

broke Docker builds

```
[91mE: Unable to locate package libboost-python1.62-dev
E: Couldn't find any package by regex 'libboost-python1.62-dev'
```