### PR TITLE
telegram_bot platform to only send messages

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -227,7 +227,7 @@ def async_setup(hass, config):
     try:
         receiver_service = yield from \
             platform.async_setup_platform(hass, p_config)
-        if receiver_service is None:
+        if receiver_service is False:
             _LOGGER.error(
                 "Failed to initialize Telegram bot %s", p_type)
             return False

--- a/homeassistant/components/telegram_bot/broadcast.py
+++ b/homeassistant/components/telegram_bot/broadcast.py
@@ -22,5 +22,7 @@ def async_setup_platform(hass, config):
     # Check the API key works
     import telegram
     bot = telegram.Bot(config[CONF_API_KEY])
-    _LOGGER.debug("Telegram broadcast platform setup with bot %s", bot.name)
+    bot_config = yield from hass.async_add_job(bot.getMe)
+    _LOGGER.debug("Telegram broadcast platform setup with bot %s",
+                  bot_config['username'])
     return True

--- a/homeassistant/components/telegram_bot/broadcast.py
+++ b/homeassistant/components/telegram_bot/broadcast.py
@@ -1,0 +1,26 @@
+"""
+Telegram bot implementation to send messages only.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/telegram_bot.broadcast/
+"""
+import asyncio
+import logging
+
+from homeassistant.components.telegram_bot import (
+    PLATFORM_SCHEMA as TELEGRAM_PLATFORM_SCHEMA)
+from homeassistant.const import CONF_API_KEY
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = TELEGRAM_PLATFORM_SCHEMA
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config):
+    """Set up the Telegram broadcast platform."""
+    # Check the API key works
+    import telegram
+    bot = telegram.Bot(config[CONF_API_KEY])
+    _LOGGER.debug("Telegram broadcast platform setup with bot %s", bot.name)
+    return True


### PR DESCRIPTION
## Description:
When the `notify.telegram`platform went included in the component `telegram_bot` (used to send **and receive** messages), some users using the same Telegram account from multiple devices were abandoned... (See #8183).

This is a dummy `telegram_bot` platform for these users (and any user who doesn't need to receive any messages). It has the capacity of sending any type of Telegram message, but it cannot receive anything.

**Related issue (if applicable):** fixes #8183

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2882

## Example entry for `configuration.yaml` (if applicable):
```yaml
telegram_bot:
  platform: broadcast
  api_key: !secret telegram_bot_api_key
  allowed_chat_ids:
    - !secret telegram_bot_chat_id_admin
    - !secret telegram_bot_group
  
notify:
  - platform: telegram
    chat_id: !secret telegram_bot_chat_id_admin
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)