### PR TITLE
Switch to new zwave entity ids by default

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -151,7 +151,7 @@ CONFIG_SCHEMA = vol.Schema({
             cv.positive_int,
         vol.Optional(CONF_USB_STICK_PATH, default=DEFAULT_CONF_USB_STICK_PATH):
             cv.string,
-        vol.Optional(CONF_NEW_ENTITY_IDS, default=False): cv.boolean,
+        vol.Optional(CONF_NEW_ENTITY_IDS, default=True): cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
 


### PR DESCRIPTION
## Description:
Switch Z-Wave entity_ids to new format by default.

Continuation of #7786.

See also https://home-assistant.io/blog/2017/06/15/zwave-entity-ids/