### PR TITLE
Fix MySensors climate current temperature

### DIFF
--- a/homeassistant/components/climate/mysensors.py
+++ b/homeassistant/components/climate/mysensors.py
@@ -67,7 +67,12 @@ class MySensorsHVAC(mysensors.MySensorsDeviceEntity, ClimateDevice):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return float(self._values.get(self.gateway.const.SetReq.V_TEMP))
+        value = self._values.get(self.gateway.const.SetReq.V_TEMP)
+
+        if value is not None:
+            value = float(value)
+
+        return value
 
     @property
     def target_temperature(self):


### PR DESCRIPTION
## Description:
MySensors sometimes doesn't return a current temperature. In that case this conversion will lead to an error. This fixes it. 

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/pull/8178#issuecomment-310823355
