### PR TITLE
Remove unnecessary thread_ident assignment

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -85,7 +85,6 @@ def get_test_home_assistant():
     def run_loop():
         """Run event loop."""
         # pylint: disable=protected-access
-        loop._thread_ident = threading.get_ident()
         loop.run_forever()
         stop_event.set()
 
@@ -113,8 +112,6 @@ def get_test_home_assistant():
 @asyncio.coroutine
 def async_test_home_assistant(loop):
     """Return a Home Assistant object pointing at test config dir."""
-    loop._thread_ident = threading.get_ident()
-
     hass = ha.HomeAssistant(loop)
     INSTANCES.append(hass)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -85,6 +85,7 @@ def get_test_home_assistant():
     def run_loop():
         """Run event loop."""
         # pylint: disable=protected-access
+        loop._thread_ident = threading.get_ident()
         loop.run_forever()
         stop_event.set()
 


### PR DESCRIPTION
## Description:
I'm hoping this will help fix some of the test instability. `get_test_home_assistant` calls `async_test_home_assistant`, which is running the event loop normally, so the patching isn't necessary.