### PR TITLE
Split mock_service

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -177,7 +177,8 @@ def get_test_instance_port():
     return _TEST_INSTANCE_PORT
 
 
-def mock_service(hass, domain, service):
+@ha.callback
+def async_mock_service(hass, domain, service):
     """Set up a fake service & return a calls log list to this service."""
     calls = []
 
@@ -186,12 +187,12 @@ def mock_service(hass, domain, service):
         """Mock service call."""
         calls.append(call)
 
-    if hass.loop.__dict__.get("_thread_ident", 0) == threading.get_ident():
-        hass.services.async_register(domain, service, mock_service_log)
-    else:
-        hass.services.register(domain, service, mock_service_log)
+    hass.services.async_register(domain, service, mock_service_log)
 
     return calls
+
+
+mock_service = threadsafe_callback_factory(async_mock_service)
 
 
 @ha.callback

--- a/tests/components/automation/test_homeassistant.py
+++ b/tests/components/automation/test_homeassistant.py
@@ -6,13 +6,13 @@ from homeassistant.core import CoreState
 from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
 
-from tests.common import mock_service, mock_coro
+from tests.common import async_mock_service, mock_coro
 
 
 @asyncio.coroutine
 def test_if_fires_on_hass_start(hass):
     """Test the firing when HASS starts."""
-    calls = mock_service(hass, 'test', 'automation')
+    calls = async_mock_service(hass, 'test', 'automation')
     hass.state = CoreState.not_running
     config = {
         automation.DOMAIN: {
@@ -48,7 +48,7 @@ def test_if_fires_on_hass_start(hass):
 @asyncio.coroutine
 def test_if_fires_on_hass_shutdown(hass):
     """Test the firing when HASS starts."""
-    calls = mock_service(hass, 'test', 'automation')
+    calls = async_mock_service(hass, 'test', 'automation')
     hass.state = CoreState.not_running
 
     res = yield from async_setup_component(hass, automation.DOMAIN, {

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -14,7 +14,7 @@ import homeassistant.util.dt as dt_util
 
 from tests.common import (
     assert_setup_component, get_test_home_assistant, fire_time_changed,
-    mock_service, mock_restore_cache)
+    mock_service, async_mock_service, mock_restore_cache)
 
 
 # pylint: disable=invalid-name
@@ -565,7 +565,7 @@ def test_automation_restore_state(hass):
     assert state.state == STATE_OFF
     assert state.attributes.get('last_triggered') == time
 
-    calls = mock_service(hass, 'test', 'automation')
+    calls = async_mock_service(hass, 'test', 'automation')
 
     assert automation.is_on(hass, 'automation.bye') is False
 
@@ -584,7 +584,7 @@ def test_automation_restore_state(hass):
 @asyncio.coroutine
 def test_initial_value_off(hass):
     """Test initial value off."""
-    calls = mock_service(hass, 'test', 'automation')
+    calls = async_mock_service(hass, 'test', 'automation')
 
     res = yield from async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
@@ -611,7 +611,7 @@ def test_initial_value_off(hass):
 @asyncio.coroutine
 def test_initial_value_on(hass):
     """Test initial value on."""
-    calls = mock_service(hass, 'test', 'automation')
+    calls = async_mock_service(hass, 'test', 'automation')
 
     res = yield from async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
@@ -638,7 +638,7 @@ def test_initial_value_on(hass):
 @asyncio.coroutine
 def test_initial_value_off_but_restore_on(hass):
     """Test initial value off and restored state is turned on."""
-    calls = mock_service(hass, 'test', 'automation')
+    calls = async_mock_service(hass, 'test', 'automation')
     mock_restore_cache(hass, (
         State('automation.hello', STATE_ON),
     ))
@@ -668,7 +668,7 @@ def test_initial_value_off_but_restore_on(hass):
 @asyncio.coroutine
 def test_initial_value_on_but_restore_off(hass):
     """Test initial value on and restored state is turned off."""
-    calls = mock_service(hass, 'test', 'automation')
+    calls = async_mock_service(hass, 'test', 'automation')
     mock_restore_cache(hass, (
         State('automation.hello', STATE_OFF),
     ))
@@ -698,7 +698,7 @@ def test_initial_value_on_but_restore_off(hass):
 @asyncio.coroutine
 def test_no_initial_value_and_restore_off(hass):
     """Test initial value off and restored state is turned on."""
-    calls = mock_service(hass, 'test', 'automation')
+    calls = async_mock_service(hass, 'test', 'automation')
     mock_restore_cache(hass, (
         State('automation.hello', STATE_OFF),
     ))
@@ -727,7 +727,7 @@ def test_no_initial_value_and_restore_off(hass):
 @asyncio.coroutine
 def test_automation_is_on_if_no_initial_state_or_restore(hass):
     """Test initial value is on when no initial state or restored state."""
-    calls = mock_service(hass, 'test', 'automation')
+    calls = async_mock_service(hass, 'test', 'automation')
 
     res = yield from async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
@@ -754,7 +754,7 @@ def test_automation_is_on_if_no_initial_state_or_restore(hass):
 def test_automation_not_trigger_on_bootstrap(hass):
     """Test if automation is not trigger on bootstrap."""
     hass.state = CoreState.not_running
-    calls = mock_service(hass, 'test', 'automation')
+    calls = async_mock_service(hass, 'test', 'automation')
 
     res = yield from async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -16,7 +16,8 @@ from homeassistant.helpers import entity
 from homeassistant.util.async import run_coroutine_threadsafe
 
 from tests.common import (
-    get_test_home_assistant, mock_service, patch_yaml_files, mock_coro)
+    get_test_home_assistant, mock_service, patch_yaml_files, mock_coro,
+    async_mock_service)
 
 
 class TestComponentsCore(unittest.TestCase):
@@ -77,7 +78,7 @@ class TestComponentsCore(unittest.TestCase):
     @patch('homeassistant.core.ServiceRegistry.call')
     def test_turn_on_to_not_block_for_domains_without_service(self, mock_call):
         """Test if turn_on is blocking domain with no service."""
-        mock_service(self.hass, 'light', SERVICE_TURN_ON)
+        async_mock_service(self.hass, 'light', SERVICE_TURN_ON)
 
         # We can't test if our service call results in services being called
         # because by mocking out the call service method, we mock out all


### PR DESCRIPTION
## Description:
`mock_service` in our tests tried to be smart about if it was called from a sync or async context. We don't want any test functionality to depend on `_thread_ident` so I have split the function.

**Related issue (if applicable):** Related to #8194
