### PR TITLE
Improve executor pool size / speedup python 3.5

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -113,6 +113,8 @@ class HomeAssistant(object):
 
         executor_opts = {'max_workers': 10}
         if sys.version_info[:2] >= (3, 5):
+            # It will default set to the number of processors on the machine,
+            # multiplied by 5. That is better for overlap I/O workers.
             executor_opts['max_workers'] = None
         if sys.version_info[:2] >= (3, 6):
             executor_opts['thread_name_prefix'] = 'SyncWorker'

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -48,9 +48,6 @@ SERVICE_CALL_LIMIT = 10  # seconds
 # Pattern for validating entity IDs (format: <domain>.<entity>)
 ENTITY_ID_PATTERN = re.compile(r"^(\w+)\.(\w+)$")
 
-# Size of a executor pool
-EXECUTOR_POOL_SIZE = 10
-
 # How long to wait till things that run on startup have to finish.
 TIMEOUT_EVENT_START = 15
 
@@ -115,10 +112,11 @@ class HomeAssistant(object):
             self.loop = loop or asyncio.get_event_loop()
 
         executor_opts = {
-            'max_workers': EXECUTOR_POOL_SIZE
+            'max_workers': 10
         }
         if sys.version_info[:2] >= (3, 6):
             executor_opts['thread_name_prefix'] = 'SyncWorker'
+            executor_opts['max_workers'] = None
 
         self.executor = ThreadPoolExecutor(**executor_opts)
         self.loop.set_default_executor(self.executor)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -111,12 +111,11 @@ class HomeAssistant(object):
         else:
             self.loop = loop or asyncio.get_event_loop()
 
-        executor_opts = {
-            'max_workers': 10
-        }
+        executor_opts = {'max_workers': 10}
+        if sys.version_info[:2] >= (3, 5):
+            executor_opts['max_workers'] = None
         if sys.version_info[:2] >= (3, 6):
             executor_opts['thread_name_prefix'] = 'SyncWorker'
-            executor_opts['max_workers'] = None
 
         self.executor = ThreadPoolExecutor(**executor_opts)
         self.loop.set_default_executor(self.executor)


### PR DESCRIPTION
## Description:

Python 3.5 change calc of executor pool size depens on running hardware.
https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor

This calc is realy better as fix 10 threads like before. That should also speedup hass with a lot of IO inside threads and help to reduce worker deadlocks.
