### PR TITLE
Fix homeassistant.start trigger

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -262,7 +262,6 @@ class HomeAssistant(object):
             self._pending_tasks.clear()
             if pending:
                 yield from asyncio.wait(pending, loop=self.loop)
-
         yield from asyncio.sleep(0, loop=self.loop)
 
     def stop(self) -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -256,14 +256,14 @@ class HomeAssistant(object):
         # To flush out any call_soon_threadsafe
         yield from asyncio.sleep(0, loop=self.loop)
 
-        while self._pending_tasks:
+        if self._pending_tasks:
             pending = [task for task in self._pending_tasks
                        if not task.done()]
             self._pending_tasks.clear()
             if pending:
                 yield from asyncio.wait(pending, loop=self.loop)
-            else:
-                yield from asyncio.sleep(0, loop=self.loop)
+
+        yield from asyncio.sleep(0, loop=self.loop)
 
     def stop(self) -> None:
         """Stop Home Assistant and shuts down all threads."""


### PR DESCRIPTION
## Description:

Provide a chance to init automations with `CoreState.starting` state, in order to fix the `homeassistant.start` trigger.

In my experience, when passing through `components/automation/homeassistant.py:async_trigger()`,   `core.py:async_start()` is finished, so state is `CoreState.running` and condition is never met (as commented in #8185)

Simply adding one more `yield from asyncio.sleep(0)` is working for me, triggering the automations as expected.

**Related issue (if applicable):** fixes #8185 / #7058

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
- alias: TEST HA start
  trigger:
    platform: homeassistant
    event: start
  action:
    - service: persistent_notification.create
      data:
        title: 'HA init'
        message: "Home Assistant start: {{ as_timestamp(now())| timestamp_local}}."
        notification_id: "init_notif"
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
