### PR TITLE
guess the content_type in local_file cameras

### DIFF
--- a/homeassistant/components/camera/local_file.py
+++ b/homeassistant/components/camera/local_file.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.local_file/
 """
 import logging
+import mimetypes
 import os
 
 import voluptuous as vol
@@ -46,6 +47,10 @@ class LocalFile(Camera):
 
         self._name = name
         self._file_path = file_path
+        # Set content type of local file
+        content, _ = mimetypes.guess_type(file_path)
+        if content is not None:
+            self.content_type = content
 
     def camera_image(self):
         """Return image response."""

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -6,7 +6,7 @@ from unittest import mock
 # https://bugs.python.org/issue23004
 from mock_open import MockOpen
 
-from homeassistant.setup import setup_component
+from homeassistant.setup import setup_component, async_setup_component
 
 from tests.common import mock_http_component
 import logging
@@ -65,3 +65,64 @@ def test_file_not_readable(hass, caplog):
         assert 'mock.file' in caplog.text
 
     yield from hass.loop.run_in_executor(None, run_test)
+
+
+@asyncio.coroutine
+def test_camera_content_type(hass, test_client):
+    """Test local_file camera content_type."""
+    cam_config_jpg = {
+        'name': 'test_jpg',
+        'platform': 'local_file',
+        'file_path': '/path/to/image.jpg',
+    }
+    cam_config_png = {
+        'name': 'test_png',
+        'platform': 'local_file',
+        'file_path': '/path/to/image.png',
+    }
+    cam_config_svg = {
+        'name': 'test_svg',
+        'platform': 'local_file',
+        'file_path': '/path/to/image.svg',
+    }
+    cam_config_noext = {
+        'name': 'test_no_ext',
+        'platform': 'local_file',
+        'file_path': '/path/to/image',
+    }
+
+    yield from async_setup_component(hass, 'camera', {
+        'camera': [cam_config_jpg, cam_config_png,
+                   cam_config_svg, cam_config_noext]})
+
+    client = yield from test_client(hass.http.app)
+
+    image = 'hello'
+    m_open = MockOpen(read_data=image.encode())
+    with mock.patch('homeassistant.components.camera.local_file.open',
+                    m_open, create=True):
+        resp_1 = yield from client.get('/api/camera_proxy/camera.test_jpg')
+        resp_2 = yield from client.get('/api/camera_proxy/camera.test_png')
+        resp_3 = yield from client.get('/api/camera_proxy/camera.test_svg')
+        resp_4 = yield from client.get('/api/camera_proxy/camera.test_no_ext')
+
+    assert resp_1.status == 200
+    assert resp_1.content_type == 'image/jpeg'
+    body = yield from resp_1.text()
+    assert body == image
+
+    assert resp_2.status == 200
+    assert resp_2.content_type == 'image/png'
+    body = yield from resp_2.text()
+    assert body == image
+
+    assert resp_3.status == 200
+    assert resp_3.content_type == 'image/svg+xml'
+    body = yield from resp_3.text()
+    assert body == image
+
+    # default mime type
+    assert resp_4.status == 200
+    assert resp_4.content_type == 'image/jpeg'
+    body = yield from resp_4.text()
+    assert body == image


### PR DESCRIPTION
## Description:

Guess the _mime type_ of the `local_file` camera to set it correctly for each file, instead of using always the `image/jpeg` type.
This change **allows to include local SVG files as Home Assistant cameras**, and it's the analogous change to that produced for the `generic` cameras in PR #8188.

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: local_file
    file_path: /path/to/file.svg
    name: SVG Camera

  - platform: local_file
    file_path: /path/to/file.png
    name: PNG Camera
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.