### PR TITLE
Fix homeassistant.start trigger

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -182,6 +182,8 @@ class HomeAssistant(object):
                 'report the following info at http://bit.ly/2ogP58T : %s',
                 ', '.join(self.config.components))
 
+        # Allow automations to set up the start triggers before changing state
+        yield from asyncio.sleep(0, loop=self.loop)
         self.state = CoreState.running
         _async_create_timer(self)
 
@@ -262,8 +264,8 @@ class HomeAssistant(object):
             self._pending_tasks.clear()
             if pending:
                 yield from asyncio.wait(pending, loop=self.loop)
-
-        yield from asyncio.sleep(0, loop=self.loop)
+            else:
+                yield from asyncio.sleep(0, loop=self.loop)
 
     def stop(self) -> None:
         """Stop Home Assistant and shuts down all threads."""

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -256,14 +256,14 @@ class HomeAssistant(object):
         # To flush out any call_soon_threadsafe
         yield from asyncio.sleep(0, loop=self.loop)
 
-        while self._pending_tasks:
+        if self._pending_tasks:
             pending = [task for task in self._pending_tasks
                        if not task.done()]
             self._pending_tasks.clear()
             if pending:
                 yield from asyncio.wait(pending, loop=self.loop)
-            else:
-                yield from asyncio.sleep(0, loop=self.loop)
+
+        yield from asyncio.sleep(0, loop=self.loop)
 
     def stop(self) -> None:
         """Stop Home Assistant and shuts down all threads."""

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -256,7 +256,7 @@ class HomeAssistant(object):
         # To flush out any call_soon_threadsafe
         yield from asyncio.sleep(0, loop=self.loop)
 
-        if self._pending_tasks:
+        while self._pending_tasks:
             pending = [task for task in self._pending_tasks
                        if not task.done()]
             self._pending_tasks.clear()


### PR DESCRIPTION
## Description:

Fix the `async_block_till_done` coroutine in order to fix the `homeassistant.start` trigger.

In my experience, when passing through `components/automation/homeassistant.py:async_trigger()`,   `core.py:async_start()` is finished, so state is `CoreState.running` and condition is never met (as commented in #8185)

~The `while` loop has no meaning there with the call to `list.clear()` in its body, and~ It looks like a last `yield from asyncio.sleep(0)` is needed to trigger the automations as expected.

_Second attempt_, I think a little more elegant than #8216 (I couldn't integrate changes in the same branch, so I'm making a new PR here), which I'm closing now.

**Related issue (if applicable):** fixes #8185 / #7058

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
- alias: TEST HA start
  trigger:
    platform: homeassistant
    event: start
  action:
    - service: persistent_notification.create
      data:
        title: 'HA init'
        message: "Home Assistant start: {{ as_timestamp(now())| timestamp_local}}."
        notification_id: "init_notif"
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**