### PR TITLE
Docker cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,14 @@
-.tox
+# General files
 .git
+.github
+config
+
+# Test related files
+.tox
+
+# Other virtualization methods
+venv
+.vagrant
+
+# Temporary files
+**/__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# Notice:
+# When updating this file, please also update virtualization/Docker/Dockerfile.dev
+# This way, the development image and the production image are kept in sync.
+
 FROM python:3.6
 MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
 
@@ -21,6 +25,7 @@ RUN virtualization/Docker/setup_docker_prereqs
 
 # Install hass component dependencies
 COPY requirements_all.txt requirements_all.txt
+
 # Uninstall enum34 because some depenndecies install it but breaks Python 3.4+.
 # See PR #8103 for more info.
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -25,8 +25,12 @@ RUN virtualization/Docker/setup_docker_prereqs
 
 # Install hass component dependencies
 COPY requirements_all.txt requirements_all.txt
+
+# Uninstall enum34 because some depenndecies install it but breaks Python 3.4+.
+# See PR #8103 for more info.
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet
+    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet && \
+    pip3 uninstall -y enum34
 
 # BEGIN: Development additions
 

--- a/virtualization/Docker/scripts/coap_client
+++ b/virtualization/Docker/scripts/coap_client
@@ -6,6 +6,9 @@ set -e
 
 apt-get install -y --no-install-recommends git autoconf automake libtool
 
+cd /usr/src/app/
+mkdir -p build && cd build
+
 git clone --depth 1 --recursive -b dtls https://github.com/home-assistant/libcoap.git
 cd libcoap
 ./autogen.sh

--- a/virtualization/Docker/scripts/libcec
+++ b/virtualization/Docker/scripts/libcec
@@ -12,7 +12,7 @@ PYTHON_LDLIBRARY=$(python -c 'from distutils import sysconfig; print(sysconfig.g
 PYTHON_LIBRARY="${PYTHON_LIBDIR}/${PYTHON_LDLIBRARY}"
 PYTHON_INCLUDE_DIR=$(python -c 'from distutils import sysconfig; print(sysconfig.get_python_inc())')
 
-cd "$(dirname "$0")/.."
+cd /usr/src/app/
 mkdir -p build && cd build
 
 if [ ! -d libcec ]; then

--- a/virtualization/Docker/scripts/openalpr
+++ b/virtualization/Docker/scripts/openalpr
@@ -11,11 +11,14 @@ PACKAGES=(
 
 apt-get install -y --no-install-recommends ${PACKAGES[@]}
 
+cd /usr/src/app/
+mkdir -p build && cd build
+
 # Clone the latest code from GitHub
-git clone --depth 1 https://github.com/openalpr/openalpr.git /usr/local/src/openalpr
+git clone --depth 1 https://github.com/openalpr/openalpr.git openalpr
 
 # Setup the build directory
-cd /usr/local/src/openalpr/src
+cd openalpr/src/
 mkdir -p build
 cd build
 

--- a/virtualization/Docker/scripts/phantomjs
+++ b/virtualization/Docker/scripts/phantomjs
@@ -6,7 +6,7 @@ set -e
 
 PHANTOMJS_VERSION="2.1.1"
 
-cd "$(dirname "$0")/.."
+cd /usr/src/app/
 mkdir -p build && cd build
 
 curl -LSO https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2

--- a/virtualization/Docker/scripts/ssocr
+++ b/virtualization/Docker/scripts/ssocr
@@ -10,20 +10,15 @@ PACKAGES=(
 
 apt-get install -y --no-install-recommends ${PACKAGES[@]}
 
+cd /usr/src/app/
+mkdir -p build && cd build
+
 # Clone the latest code from GitHub
-git clone --depth 1 https://github.com/auerswal/ssocr.git /usr/local/src/ssocr
+git clone --depth 1 https://github.com/auerswal/ssocr.git ssocr
+cd ssocr/
 
-# Build ssocr
-(
-  # Setup the build directory
-  cd /usr/local/src/ssocr
+# Compile the library
+make
 
-  # compile the library
-  make
-
-  # Install the binaries/libraries to your local system (prefix is /usr/local)
-  make install
-
-  # Cleanup
-  make clean
-)
+# Install the binaries/libraries to your local system (prefix is /usr/local)
+make install

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -30,8 +30,8 @@ PACKAGES=(
 
 # Required debian packages for building dependencies
 PACKAGES_DEV=(
-  cmake git
-  # libcec
+  cmake
+  git
   swig
 )
 
@@ -73,4 +73,4 @@ apt-get -y --purge autoremove
 
 # Cleanup
 apt-get clean
-rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* build/
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/src/app/build/


### PR DESCRIPTION
Since the last Docker related cleanup, hass gained some weight again. This was mainly due to external packages that had to be compiled from source that didn't cleanup their sources after installing the binaries.

Docker-related changes:
* Completes `.dockerignore` with files that aren't related for Docker. This is mainly to speed up development in Docker, since the image that dockerhub creates is usually quite clean.
* Sync `Dockerfile.dev` with `Dockerfile` (add the uninstall of `enum34` to `Dockerfile.dev`)
* Add a warning in `Dockerfile` to also update `Dockerfile.dev`
* Have the Docker dependency build-scripts use `/usr/src/app/build/` for temporary build storage, and make sure this folder is cleaned up. All scripts install the binaries to a system path, so the sources can be removed.

Before these changes, the `setup_docker_prereqs` script added 463 MB to the image. After these changes, it adds 370 MB, so we lost 93 ~~pounds~~ megabytes!

Before:
```sh
$ docker history homeassistant/home-assistant | grep virtualization
<missing>           6 days ago          /bin/sh -c virtualization/Docker/setup_doc...   463MB               
```

After:
```sh
$ docker history home-assistant  | grep virtualization
2b934453e141        22 minutes ago      /bin/sh -c virtualization/Docker/setup_doc...   370 MB              
```