### PR TITLE
DHT support for temperature_offset and humidity_offset

### DIFF
--- a/homeassistant/components/sensor/dht.py
+++ b/homeassistant/components/sensor/dht.py
@@ -12,7 +12,8 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    TEMP_FAHRENHEIT, CONF_NAME, CONF_MONITORED_CONDITIONS)
+    TEMP_FAHRENHEIT, CONF_NAME, CONF_MONITORED_CONDITIONS,
+    CONF_TEMPERATURE_OFFSET, CONF_HUMIDITY_OFFSET)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.temperature import celsius_to_fahrenheit
@@ -45,6 +46,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MONITORED_CONDITIONS, default=[]):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_TEMPERATURE_OFFSET, default=0): vol.All(vol.Coerce(float), vol.Range(min=-500, max=1000)),
+    vol.Optional(CONF_HUMIDITY_OFFSET, default=0): vol.All(vol.Coerce(float), vol.Range(min=-100, max=100))
 })
 
 
@@ -61,6 +64,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     }
     sensor = available_sensors.get(config.get(CONF_SENSOR))
     pin = config.get(CONF_PIN)
+    temperature_offset = config.get(CONF_TEMPERATURE_OFFSET)
+    humidity_offset = config.get(CONF_HUMIDITY_OFFSET)
 
     if not sensor:
         _LOGGER.error("DHT sensor type is not supported")
@@ -73,7 +78,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         for variable in config[CONF_MONITORED_CONDITIONS]:
             dev.append(DHTSensor(
-                data, variable, SENSOR_TYPES[variable][1], name))
+                data, variable, SENSOR_TYPES[variable][1], name, temperature_offset, humidity_offset))
     except KeyError:
         pass
 
@@ -83,13 +88,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class DHTSensor(Entity):
     """Implementation of the DHT sensor."""
 
-    def __init__(self, dht_client, sensor_type, temp_unit, name):
+    def __init__(self, dht_client, sensor_type, temp_unit, name, temperature_offset, humidity_offset):
         """Initialize the sensor."""
         self.client_name = name
         self._name = SENSOR_TYPES[sensor_type][0]
         self.dht_client = dht_client
         self.temp_unit = temp_unit
         self.type = sensor_type
+        self.temperature_offset = temperature_offset
+        self.humidity_offset = humidity_offset
         self._state = None
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
         self.update()
@@ -112,18 +119,22 @@ class DHTSensor(Entity):
     def update(self):
         """Get the latest data from the DHT and updates the states."""
         self.dht_client.update()
+        temperature_offset = self.temperature_offset
+        humidity_offset = self.humidity_offset
         data = self.dht_client.data
 
         if self.type == SENSOR_TEMPERATURE:
             temperature = round(data[SENSOR_TEMPERATURE], 1)
             if (temperature >= -20) and (temperature < 80):
-                self._state = temperature
+                self._state = round(temperature + temperature_offset, 1)
+                _LOGGER.debug("Sensor reported temperature %s \u00b0C + temperature_offset %s", temperature, temperature_offset)
                 if self.temp_unit == TEMP_FAHRENHEIT:
                     self._state = round(celsius_to_fahrenheit(temperature), 1)
         elif self.type == SENSOR_HUMIDITY:
             humidity = round(data[SENSOR_HUMIDITY], 1)
             if (humidity >= 0) and (humidity <= 100):
-                self._state = humidity
+                self._state = round(humidity + humidity_offset, 1)
+                _LOGGER.debug("Sensor reported humidity %s%% + humidity_offset %s", humidity, humidity_offset)
 
 
 class DHTClient(object):


### PR DESCRIPTION
## Description:
Added CONF_TEMPERATURE_OFFSET and CONF_HUMIDITY_OFFSET to be used by temperature and humidity sensors for offset calculation.
Support was added for the sensor DHT.

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: dht
    sensor: DHT22
    pin: 4
    temperature_offset: 2.1
    humidity_offset: -3.2
    monitored_conditions:
      - temperature
      - humidity

```
Documentation is still open. Will be updated if the request is accepted.