### PR TITLE
added turn_on (wakeonlan) capability to media_player.kodi

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -25,7 +25,7 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (
     STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING, CONF_HOST, CONF_NAME,
     CONF_PORT, CONF_SSL, CONF_PROXY_SSL, CONF_USERNAME, CONF_PASSWORD,
-    CONF_TIMEOUT, EVENT_HOMEASSISTANT_STOP)
+    CONF_TIMEOUT, CONF_MAC, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -41,7 +41,6 @@ EVENT_KODI_CALL_METHOD_RESULT = 'kodi_call_method_result'
 CONF_TCP_PORT = 'tcp_port'
 CONF_TURN_OFF_ACTION = 'turn_off_action'
 CONF_ENABLE_WEBSOCKET = 'enable_websocket'
-CONF_MAC = 'mac'
 
 DEFAULT_NAME = 'Kodi'
 DEFAULT_PORT = 8080

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -537,12 +537,14 @@ class KodiDevice(MediaPlayerDevice):
         return supported_features
 
     @cmd
+    @asyncio.coroutine
     def async_turn_on(self):
-        """Execute wol to turn on media player."""
+        """Execute turn_on action to turn on media player with WakeOnLan."""
         if self._mac:
-            return self._wol.send_magic_packet(self._mac)
+            yield from self.hass.async_add_job(
+                self._wol.send_magic_packet, self._mac)
         else:
-            _LOGGER.warning("turn_on requested but mac is none")
+            _LOGGER.warning("turn_on requested but MAC address is none")
 
     @cmd
     @asyncio.coroutine

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -904,6 +904,7 @@ vsure==1.3.6
 # homeassistant.components.sensor.vasttrafik
 vtjp==0.1.14
 
+# homeassistant.components.media_player.kodi
 # homeassistant.components.media_player.panasonic_viera
 # homeassistant.components.media_player.samsungtv
 # homeassistant.components.media_player.webostv


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2900

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
media_player:
  - platform: kodi
    host: 192.168.0.123
    mac: 11:22:33:44:55:66
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] ~New files were added to `.coveragerc`.~

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] ~Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
