### PR TITLE
Upgrade python-digitalocean to 1.12

### DIFF
--- a/homeassistant/components/digital_ocean.py
+++ b/homeassistant/components/digital_ocean.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-digitalocean==1.11']
+REQUIREMENTS = ['python-digitalocean==1.12']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -680,7 +680,7 @@ python-blockchain-api==0.0.2
 python-clementine-remote==1.0.1
 
 # homeassistant.components.digital_ocean
-python-digitalocean==1.11
+python-digitalocean==1.12
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.0.7


### PR DESCRIPTION
## 1.12
- Tags support
- Better pagination support
- Human readable classes
- general bug fixes

Tested with the following configuration:

``` yaml
digital_ocean:
  access_token: !secret do_api

switch:
  - platform: digital_ocean
    droplets:
      - 'fedora-512mb-nyc2-02'
```