### PR TITLE
update i2csense version in requirements for sensor platforms bme280, bh1750 and htu21d

### DIFF
--- a/homeassistant/components/sensor/bh1750.py
+++ b/homeassistant/components/sensor/bh1750.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['i2csense==0.0.3',
+REQUIREMENTS = ['i2csense==0.0.4',
                 'smbus-cffi==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/sensor/bme280.py
+++ b/homeassistant/components/sensor/bme280.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.temperature import celsius_to_fahrenheit
 
-REQUIREMENTS = ['i2csense==0.0.3',
+REQUIREMENTS = ['i2csense==0.0.4',
                 'smbus-cffi==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/sensor/htu21d.py
+++ b/homeassistant/components/sensor/htu21d.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.temperature import celsius_to_fahrenheit
 
-REQUIREMENTS = ['i2csense==0.0.3',
+REQUIREMENTS = ['i2csense==0.0.4',
                 'smbus-cffi==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -318,7 +318,7 @@ https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 # homeassistant.components.sensor.bh1750
 # homeassistant.components.sensor.bme280
 # homeassistant.components.sensor.htu21d
-# i2csense==0.0.3
+# i2csense==0.0.4
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb


### PR DESCRIPTION
## Description:

Update requirements for new sensor platforms `bme280`, `bh1750` and `htu21d`: increase version of **[`i2csense`](https://pypi.python.org/pypi?:action=display&name=i2csense&version=0.0.4)** from 0.0.3 to **0.0.4**.

### Changelog:
- v0.0.4:  Recover HTU21D sensor after a bad sample is taken.