### PR TITLE
Use 'hass.data' instead of global

### DIFF
--- a/homeassistant/components/digital_ocean.py
+++ b/homeassistant/components/digital_ocean.py
@@ -29,7 +29,7 @@ ATTR_VCPUS = 'vcpus'
 
 CONF_DROPLETS = 'droplets'
 
-DIGITAL_OCEAN = None
+DATA_DIGITAL_OCEAN = 'data_do'
 DIGITAL_OCEAN_PLATFORMS = ['switch', 'binary_sensor']
 DOMAIN = 'digital_ocean'
 
@@ -47,12 +47,13 @@ def setup(hass, config):
     conf = config[DOMAIN]
     access_token = conf.get(CONF_ACCESS_TOKEN)
 
-    global DIGITAL_OCEAN
-    DIGITAL_OCEAN = DigitalOcean(access_token)
+    digital = DigitalOcean(access_token)
 
-    if not DIGITAL_OCEAN.manager.get_account():
+    if not digital.manager.get_account():
         _LOGGER.error("No Digital Ocean account found for the given API Token")
         return False
+
+    hass.data[DATA_DIGITAL_OCEAN] = digital
 
     return True
 

--- a/homeassistant/components/switch/digital_ocean.py
+++ b/homeassistant/components/switch/digital_ocean.py
@@ -8,13 +8,12 @@ import logging
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.components.digital_ocean import (
     CONF_DROPLETS, ATTR_CREATED_AT, ATTR_DROPLET_ID, ATTR_DROPLET_NAME,
     ATTR_FEATURES, ATTR_IPV4_ADDRESS, ATTR_IPV6_ADDRESS, ATTR_MEMORY,
-    ATTR_REGION, ATTR_VCPUS)
-from homeassistant.loader import get_component
-import homeassistant.helpers.config_validation as cv
+    ATTR_REGION, ATTR_VCPUS, DATA_DIGITAL_OCEAN)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,19 +28,21 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Digital Ocean droplet switch."""
-    digital_ocean = get_component('digital_ocean')
+    digital = hass.data.get(DATA_DIGITAL_OCEAN)
+    if not digital:
+        return False
+
     droplets = config.get(CONF_DROPLETS)
 
     dev = []
     for droplet in droplets:
-        droplet_id = digital_ocean.DIGITAL_OCEAN.get_droplet_id(droplet)
+        droplet_id = digital.get_droplet_id(droplet)
         if droplet_id is None:
             _LOGGER.error("Droplet %s is not available", droplet)
             return False
-        dev.append(DigitalOceanSwitch(
-            digital_ocean.DIGITAL_OCEAN, droplet_id))
+        dev.append(DigitalOceanSwitch(digital, droplet_id))
 
-    add_devices(dev)
+    add_devices(dev, True)
 
 
 class DigitalOceanSwitch(SwitchDevice):
@@ -53,8 +54,6 @@ class DigitalOceanSwitch(SwitchDevice):
         self._droplet_id = droplet_id
         self.data = None
         self._state = None
-
-        self.update()
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:
Use 'hass.data' instead of global and don't call update() in constructor..

## Example entry for `configuration.yaml` (if applicable):
```yaml
digital_ocean:
  access_token: !secret do_token

binary_sensor:
  - platform: digital_ocean
    droplets:
      - 'fedora-512mb-nyc3-01'

switch:
  - platform: digital_ocean
    droplets:
      - 'fedora-512mb-nyc3-01'
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
