### PR TITLE
telegram_bot: better logging when a message is not sent

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -423,11 +423,11 @@ class TelegramNotificationService:
                     [_make_row_inline_keyboard(row) for row in keys])
         return params
 
-    def _send_msg(self, func_send, msg_error, *args_rep, **kwargs_rep):
+    def _send_msg(self, func_send, msg_error, *args_msg, **kwargs_msg):
         """Send one message."""
         from telegram.error import TelegramError
         try:
-            out = func_send(*args_rep, **kwargs_rep)
+            out = func_send(*args_msg, **kwargs_msg)
             if not isinstance(out, bool) and hasattr(out, ATTR_MESSAGEID):
                 chat_id = out.chat_id
                 self._last_message_id[chat_id] = out[ATTR_MESSAGEID]
@@ -437,8 +437,9 @@ class TelegramNotificationService:
                 _LOGGER.warning("Update last message: out_type:%s, out=%s",
                                 type(out), out)
             return out
-        except TelegramError:
-            _LOGGER.exception(msg_error)
+        except TelegramError as exc:
+            _LOGGER.error("%s: %s. Args: %s, kwargs: %s",
+                          msg_error, exc, args_msg, kwargs_msg)
 
     def send_message(self, message="", target=None, **kwargs):
         """Send a message to one or multiple pre-allowed chat IDs."""


### PR DESCRIPTION
## Description:

The telegram service parses the text messages for formatting in markup or html styles, but this is very prone to errors, and when they occur, the log is not much of help there. Other errors, like bad metadata args also will be better debugged with this change.

The error log now:
```
2017-06-29 15:28:53 ERROR (Thread-21) [homeassistant.components.telegram_bot] Error sending message
Traceback (most recent call last):
  File "/Users/uge/Dropbox/PYTHON/PYPROJECTS/contrib/hass/home-assistant/homeassistant/components/telegram_bot/__init__.py", line 430, in _send_msg
    out = func_send(*args_msg, **kwargs_msg)
  File "/Users/uge/Dropbox/PYTHON/PYPROJECTS/contrib/ha_test1/deps/telegram/bot.py", line 52, in decorator
    result = func(self, *args, **kwargs)
  File "/Users/uge/Dropbox/PYTHON/PYPROJECTS/contrib/ha_test1/deps/telegram/bot.py", line 64, in decorator
    return self._message_wrapper(url, data, *args, **kwargs)
  File "/Users/uge/Dropbox/PYTHON/PYPROJECTS/contrib/ha_test1/deps/telegram/bot.py", line 156, in _message_wrapper
    result = self._request.post(url, data, timeout=kwargs.get('timeout'))
  File "/Users/uge/Dropbox/PYTHON/PYPROJECTS/contrib/ha_test1/deps/telegram/utils/request.py", line 252, in post
    **urlopen_kwargs)
  File "/Users/uge/Dropbox/PYTHON/PYPROJECTS/contrib/ha_test1/deps/telegram/utils/request.py", line 194, in _request_wrapper
    raise BadRequest(message)
telegram.error.BadRequest: Can't parse entities in message text: can't find end of the entity starting at byte offset 18
```

**A better approach to help debugging the error**, simply showing the args and kwargs for the failed message:

```
2017-06-29 15:28:53 ERROR (Thread-21) [homeassistant.components.telegram_bot] Error sending message: Can't parse entities in message text: can't find end of the entity starting at byte offset 18. Args: (-12345678, '*Asterisks* go in *pairs\nThe _underscores_ also go in _pairs, so this is going to fail.'), kwargs: {'reply_to_message_id': None, 'parse_mode': 'Markdown', 'disable_web_page_preview': None, 'disable_notification': False, 'timeout': None, 'reply_markup': None}
```

## Example entry for `configuration.yaml` (if applicable):
```yaml
telegram_bot:
  platform: broadcast
  api_key: !secret telegram_bot_api_key
  allowed_chat_ids:
    - -12345678

notify:
  - platform: telegram
    name: telegram_bot
    chat_id: -12345678

script:
  test_bad_parsing:
    alias: Try to send a wrong formatted message
    sequence:
      - service: notify.telegram_bot
        data_template:
          title: "*Asterisks* go in *pairs"
          message: "The _underscores_ also go in _pairs, so this is going to fail."
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**