### PR TITLE
index on sql database to allow hass to startup quickly with a large sql database

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -64,6 +64,8 @@ def _apply_update(engine, new_version):
         # Create indexes for states
         _create_index(engine, "states", "ix_states_last_updated")
         _create_index(engine, "states", "ix_states_entity_id_created")
+    elif new_version == 3:
+        _create_index(engine, "states", "ix_states_created_domain")
     else:
         raise ValueError("No schema migration defined for version {}"
                          .format(new_version))

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -16,7 +16,7 @@ from homeassistant.remote import JSONEncoder
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,7 +75,9 @@ class States(Base):   # type: ignore
                       Index('states__significant_changes',
                             'domain', 'last_updated', 'entity_id'),
                       Index('ix_states_entity_id_created',
-                            'entity_id', 'created'),)
+                            'entity_id', 'created'),
+                      Index('ix_states_created_domain',
+                            'created', 'domain'),)
 
     @staticmethod
     def from_event(event):


### PR DESCRIPTION
## Description:
hass starts up very slow with a large SQL database. This adds an index to the states table to help (tremendously) with startup speed.

**Related issue (if applicable):** fixes #8176 

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [na ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [na] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
