### PR TITLE
Manual alarm with MQTT control

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -199,6 +199,7 @@ omit =
 
     homeassistant/components/alarm_control_panel/alarmdotcom.py
     homeassistant/components/alarm_control_panel/concord232.py
+    homeassistant/components/alarm_control_panel/manual_mqtt.py
     homeassistant/components/alarm_control_panel/nx584.py
     homeassistant/components/alarm_control_panel/simplisafe.py
     homeassistant/components/alarm_control_panel/totalconnect.py

--- a/homeassistant/components/alarm_control_panel/manual_mqtt.py
+++ b/homeassistant/components/alarm_control_panel/manual_mqtt.py
@@ -1,0 +1,104 @@
+"""
+Support for manual alarms controllable via MQTT.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_control_panel.manual_mqtt/
+"""
+import asyncio
+import logging
+
+import homeassistant.components.mqtt as mqtt
+from homeassistant.components.alarm_control_panel import (
+    manual as manual_alarm, mqtt as mqtt_alarm)
+from homeassistant.components.alarm_control_panel.mqtt import (
+    CONF_PAYLOAD_DISARM, CONF_PAYLOAD_ARM_HOME, CONF_PAYLOAD_ARM_AWAY)
+from homeassistant.const import (
+    STATE_UNKNOWN, CONF_NAME, CONF_CODE,
+    CONF_PENDING_TIME, CONF_TRIGGER_TIME, CONF_DISARM_AFTER_TRIGGER)
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.core import callback
+
+DEFAULT_ALARM_NAME = 'HA Alarm'
+DEFAULT_PENDING_TIME = 60
+DEFAULT_TRIGGER_TIME = 120
+DEFAULT_DISARM_AFTER_TRIGGER = False
+
+PLATFORM_SCHEMA = manual_alarm.PLATFORM_SCHEMA.extend(
+    mqtt_alarm.PLATFORM_SCHEMA.schema)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the manual alarm platform."""
+    add_devices([ManualMQTTAlarm(
+        hass,
+        config[CONF_NAME],
+        config.get(CONF_CODE),
+        config.get(CONF_PENDING_TIME, DEFAULT_PENDING_TIME),
+        config.get(CONF_TRIGGER_TIME, DEFAULT_TRIGGER_TIME),
+        config.get(CONF_DISARM_AFTER_TRIGGER, DEFAULT_DISARM_AFTER_TRIGGER),
+        config.get(mqtt.CONF_STATE_TOPIC),
+        config.get(mqtt.CONF_COMMAND_TOPIC),
+        config.get(mqtt.CONF_QOS),
+        config.get(CONF_PAYLOAD_DISARM),
+        config.get(CONF_PAYLOAD_ARM_HOME),
+        config.get(CONF_PAYLOAD_ARM_AWAY))])
+
+
+class ManualMQTTAlarm(manual_alarm.ManualAlarm):
+    """
+    Representation of an alarm status.
+
+    When armed, will be pending for 'pending_time', after that armed.
+    When triggered, will be pending for 'trigger_time'. After that will be
+    triggered for 'trigger_time', after that we return to the previous state
+    or disarm if `disarm_after_trigger` is true.
+    """
+
+    def __init__(self, hass, name, code, pending_time,
+                 trigger_time, disarm_after_trigger,
+                 state_topic, command_topic, qos,
+                 payload_disarm, payload_arm_home, payload_arm_away):
+        """Init the manual MQTT alarm panel."""
+        super().__init__(hass, name, code, pending_time, trigger_time,
+                         disarm_after_trigger)
+
+        self._state = STATE_UNKNOWN
+        self._state_topic = state_topic
+        self._command_topic = command_topic
+        self._qos = qos
+        self._payload_disarm = payload_disarm
+        self._payload_arm_home = payload_arm_home
+        self._payload_arm_away = payload_arm_away
+
+    def async_added_to_hass(self):
+        """Subscribe mqtt events.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        async_track_state_change(
+            self.hass, self.entity_id, self._async_state_changed_listener
+        )
+
+        @callback
+        def message_received(topic, payload, qos):
+            """Run when new MQTT message has been received."""
+            if payload == self._payload_disarm:
+                self.async_alarm_disarm(self._code)
+            elif payload == self._payload_arm_home:
+                self.async_alarm_arm_home(self._code)
+            elif payload == self._payload_arm_away:
+                self.async_alarm_arm_away(self._code)
+            else:
+                _LOGGER.warning("Received unexpected payload: %s", payload)
+                return
+
+        return mqtt.async_subscribe(
+            self.hass, self._command_topic, message_received, self._qos)
+
+    @asyncio.coroutine
+    def _async_state_changed_listener(self, entity_id, old_state, new_state):
+        """Publish state change to MQTT."""
+        mqtt.async_publish(self.hass, self._state_topic, new_state.state,
+                           self._qos, True)

--- a/tests/components/alarm_control_panel/test_manual_mqtt.py
+++ b/tests/components/alarm_control_panel/test_manual_mqtt.py
@@ -1,0 +1,384 @@
+"""The tests for the manual_mqtt Alarm Control Panel component."""
+from datetime import timedelta
+import unittest
+from unittest.mock import patch
+
+from homeassistant.setup import setup_component
+from homeassistant.const import (
+    STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED)
+from homeassistant.components import alarm_control_panel
+import homeassistant.util.dt as dt_util
+
+from tests.common import fire_time_changed, get_test_home_assistant
+
+CODE = 'HELLO_CODE'
+
+
+class TestAlarmControlPanelManualMqtt(unittest.TestCase):
+    """Test the manual_mqtt alarm module."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_arm_home_no_pending(self):
+        """Test arm home method."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'code': CODE,
+                'pending_time': 0,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_arm_home(self.hass, CODE)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_ARMED_HOME,
+                         self.hass.states.get(entity_id).state)
+
+    def test_arm_home_with_pending(self):
+        """Test arm home method."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'code': CODE,
+                'pending_time': 1,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_arm_home(self.hass, CODE, entity_id)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_ARMED_HOME,
+                         self.hass.states.get(entity_id).state)
+
+    def test_arm_home_with_invalid_code(self):
+        """Attempt to arm home without a valid code."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'code': CODE,
+                'pending_time': 1,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_arm_home(self.hass, CODE + '2')
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+    def test_arm_away_no_pending(self):
+        """Test arm home method."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'code': CODE,
+                'pending_time': 0,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_arm_away(self.hass, CODE, entity_id)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         self.hass.states.get(entity_id).state)
+
+    def test_arm_away_with_pending(self):
+        """Test arm home method."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'code': CODE,
+                'pending_time': 1,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_arm_away(self.hass, CODE)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         self.hass.states.get(entity_id).state)
+
+    def test_arm_away_with_invalid_code(self):
+        """Attempt to arm away without a valid code."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'code': CODE,
+                'pending_time': 1,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_arm_away(self.hass, CODE + '2')
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+    def test_trigger_no_pending(self):
+        """Test triggering when no pending submitted method."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'trigger_time': 1,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_trigger(self.hass, entity_id=entity_id)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=60)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         self.hass.states.get(entity_id).state)
+
+    def test_trigger_with_pending(self):
+        """Test arm home method."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'pending_time': 2,
+                'trigger_time': 3,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_trigger(self.hass)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=2)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+    def test_trigger_with_disarm_after_trigger(self):
+        """Test disarm after trigger."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'trigger_time': 5,
+                'pending_time': 0,
+                'disarm_after_trigger': True,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_trigger(self.hass, entity_id=entity_id)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+    def test_disarm_while_pending_trigger(self):
+        """Test disarming while pending state."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'trigger_time': 5,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_trigger(self.hass)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_disarm(self.hass, entity_id=entity_id)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+    def test_disarm_during_trigger_with_invalid_code(self):
+        """Test disarming while code is invalid."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'pending_time': 5,
+                'code': CODE + '2',
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_trigger(self.hass)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_disarm(self.hass, entity_id=entity_id)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         self.hass.states.get(entity_id).state)


### PR DESCRIPTION
This PR allows a manual alarm to be controlled via MQTT.

## Description:

The MQTT alarm component allows HA to control a standard alarm panel via MQTT; commands to arm/disarm the alarm come from HA, and the physical panel determines when to trigger the alarm.

However, I'd like the opposite functionality - I want to create [a "dumb" keypad using a Raspberry Pi](https://twitter.com/colinodell/status/881258798631067648) which arms/disarms the `manual` alarm in HA (via MQTT).  HA would determine if/when to trigger the alarm based on my automations.  The Raspberry Pi would also subscribe to messages about the current state of the alarm and update its display accordingly.

## Implementation

My proposal simply extends the existing `ManualAlarm` class to do 3 things:

 1. Adds the `mqtt` alarm configuration options as well
 2. Subscribes to an MQTT command topic; calls the existing `async_alarm_disarm` / `async_alarm_arm_*` methods when it receives those commands
 3. Tracks its own state changes and publishes MQTT messages with the new state

## Why this approach?

I looked into using existing MQTT functionality and the various APIs, but none of them fit my needs:

 - The MQTT platform does allow me to publish state change messages to the Pi (via custom automations), but it does not seem to provide communication in the opposite direction - the ability to subscribe to MQTT topics and call services as a result.
 - The REST API does not offer the ability to subscribe to state changes - I'd have to DDoS HA from my Pi to get real-time info.
 - The Web Sockets API does offer subscription functionality, but not for single entities.  A Raspberry Pi Zero has relatively low processing power, especially when driving a display, so I'd like to avoid DDoSing the Pi by having to process every single state change from HA.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2921

## Example entry for `configuration.yaml` (if applicable):

```yaml
alarm_control_panel:
  platform: manual_mqtt
  state_topic: "home/alarm"
  command_topic: "home/alarm/set"
  name: Alarm
```

All other configuration options from both `manual` and `mqtt` alarms are also supported.

## Feedback Requested:

I'd greatly appreciate the following feedback:

 - Is this something you'd consider merging into HA?
 - Am I doing the async/callback stuff correctly?
 - Can you suggest a better name than `manual_mqtt` or is that fine?

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
