### PR TITLE
Allow sonos to select playlists as a source

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -901,10 +901,10 @@ class SonosDevice(MediaPlayerDevice):
 
                     root = ET.fromstring(src['meta'])
                     namespaces = {'item':
-                        'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/',
-                        'desc': 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/'}
-                    desc = root.find('item:item', namespaces).find('desc:desc',
-                        namespaces).text
+                                  'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/',
+                                  'desc': 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/'}
+                    desc = root.find('item:item', namespaces).
+                        find('desc:desc', namespaces).text
 
                     res = [soco.data_structures.DidlResource(uri=src['uri'],
                                                              protocol_info="DUMMY")]
@@ -921,7 +921,7 @@ class SonosDevice(MediaPlayerDevice):
                     self._player.play_from_queue(0)
                 else:
                     self._player.play_uri(src['uri'], src['meta'],
-                            src['title'])
+                                          src['title'])
 
     @property
     def source_list(self):

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -902,10 +902,13 @@ class SonosDevice(MediaPlayerDevice):
                                           src['title'])
 
     def _replace_queue_with_playlist(self, src):
-        """Playlists can't be played directly with the self._player.play_uri
+        """Replace queue with playlist represented by src.
+
+        Playlists can't be played directly with the self._player.play_uri
         API as they are actually composed of mulitple URLs. Until soco has
         suppport for playing a playlist, we'll need to parse the playlist item
-        and replace the current queue in order to play it."""
+        and replace the current queue in order to play it.
+        """
         import soco
         import xml.etree.ElementTree as ET
 

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -900,15 +900,19 @@ class SonosDevice(MediaPlayerDevice):
                     import xml.etree.ElementTree as ET
 
                     root = ET.fromstring(src['meta'])
-                    namespaces = { 'item' : 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/', 'desc': 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/' }
-                    desc = root.find('item:item', namespaces).find('desc:desc', namespaces).text
+                    namespaces = {'item':
+                        'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/',
+                        'desc': 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/'}
+                    desc = root.find('item:item', namespaces).find('desc:desc',
+                        namespaces).text
 
-                    res = [soco.data_structures.DidlResource(uri=src['uri'], protocol_info="DUMMY")]
-                    didl = soco.data_structures.DidlItem(title="DUMMY", # Sonos gets the title from the item_id
-                        parent_id="DUMMY",  # Ditto
-                        item_id=src['uri'],
-                        desc=desc,
-                        resources=res)
+                    res = [soco.data_structures.DidlResource(uri=src['uri'],
+                                                             protocol_info="DUMMY")]
+                    didl = soco.data_structures.DidlItem(title="DUMMY",
+                                                         parent_id="DUMMY",
+                                                         item_id=src['uri'],
+                                                         desc=desc,
+                                                         resources=res)
 
                     self._player.stop()
                     self._player.clear_queue()
@@ -916,7 +920,8 @@ class SonosDevice(MediaPlayerDevice):
                     self._player.add_to_queue(didl)
                     self._player.play_from_queue(0)
                 else:
-                    self._player.play_uri(src['uri'], src['meta'], src['title'])
+                    self._player.play_uri(src['uri'], src['meta'],
+                            src['title'])
 
     @property
     def source_list(self):

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -903,8 +903,8 @@ class SonosDevice(MediaPlayerDevice):
                     namespaces = {'item':
                                   'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/',
                                   'desc': 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/'}
-                    desc = root.find('item:item', namespaces).
-                        find('desc:desc', namespaces).text
+                    desc = root.find('item:item', namespaces).find('desc:desc',
+                                                                   namespaces).text
 
                     res = [soco.data_structures.DidlResource(uri=src['uri'],
                                                              protocol_info="DUMMY")]

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -895,33 +895,37 @@ class SonosDevice(MediaPlayerDevice):
                 self._source_name = src['title']
 
                 if 'object.container.playlistContainer' in src['meta']:
-                    """Favorite is a playlist"""
-                    import soco
-                    import xml.etree.ElementTree as ET
-
-                    root = ET.fromstring(src['meta'])
-                    namespaces = {'item':
-                                  'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/',
-                                  'desc': 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/'}
-                    desc = root.find('item:item', namespaces).find('desc:desc',
-                                                                   namespaces).text
-
-                    res = [soco.data_structures.DidlResource(uri=src['uri'],
-                                                             protocol_info="DUMMY")]
-                    didl = soco.data_structures.DidlItem(title="DUMMY",
-                                                         parent_id="DUMMY",
-                                                         item_id=src['uri'],
-                                                         desc=desc,
-                                                         resources=res)
-
-                    self._player.stop()
-                    self._player.clear_queue()
-                    self._player.play_mode = 'NORMAL'
-                    self._player.add_to_queue(didl)
+                    self.replace_queue_with_playlist(src)
                     self._player.play_from_queue(0)
                 else:
                     self._player.play_uri(src['uri'], src['meta'],
                                           src['title'])
+
+    @soco_error
+    @soco_coordinator
+    def replace_queue_with_playlist(self, src):
+        import soco
+        import xml.etree.ElementTree as ET
+
+        root = ET.fromstring(src['meta'])
+        namespaces = {'item':
+                      'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/',
+                      'desc': 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/'}
+        desc = root.find('item:item', namespaces).find('desc:desc',
+                                                       namespaces).text
+
+        res = [soco.data_structures.DidlResource(uri=src['uri'],
+                                                 protocol_info="DUMMY")]
+        didl = soco.data_structures.DidlItem(title="DUMMY",
+                                             parent_id="DUMMY",
+                                             item_id=src['uri'],
+                                             desc=desc,
+                                             resources=res)
+
+        self._player.stop()
+        self._player.clear_queue()
+        self._player.play_mode = 'NORMAL'
+        self._player.add_to_queue(didl)
 
     @property
     def source_list(self):

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -895,7 +895,7 @@ class SonosDevice(MediaPlayerDevice):
                 self._source_name = src['title']
 
                 if 'object.container.playlistContainer' in src['meta']:
-                    self.replace_queue_with_playlist(src)
+                    self._replace_queue_with_playlist(src)
                     self._player.play_from_queue(0)
                 else:
                     self._player.play_uri(src['uri'], src['meta'],
@@ -903,7 +903,11 @@ class SonosDevice(MediaPlayerDevice):
 
     @soco_error
     @soco_coordinator
-    def replace_queue_with_playlist(self, src):
+    def _replace_queue_with_playlist(self, src):
+        """Playlists can't be played directly with the self._player.play_uri
+        API as they are actually composed of mulitple URLs. Until soco has
+        suppport for playing a playlist, we'll need to parse the playlist item
+        and replace the current queue in order to play it."""
         import soco
         import xml.etree.ElementTree as ET
 

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -901,8 +901,6 @@ class SonosDevice(MediaPlayerDevice):
                     self._player.play_uri(src['uri'], src['meta'],
                                           src['title'])
 
-    @soco_error
-    @soco_coordinator
     def _replace_queue_with_playlist(self, src):
         """Playlists can't be played directly with the self._player.play_uri
         API as they are actually composed of mulitple URLs. Until soco has


### PR DESCRIPTION

## Description:

Most of this was taken from https://github.com/home-assistant/home-assistant/issues/5598#issuecomment-278229895 however I made a few small improvements so that it works for other services than Spotify and it should properly switch to playing the queue if you had another song playing previously.

### Known Issues

I'm still struggling with how to make sure that the source is properly selected in the UI afterwards. If someone could help me out with that it would be appreciated.

**Related issue:** fixes #5598 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


/cc @PatBoud since you did the heavy lifting here.