### PR TITLE
Upgrade libnacl to 1.5.1

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -21,7 +21,7 @@ from homeassistant.components import zone as zone_comp
 from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 
 DEPENDENCIES = ['mqtt']
-REQUIREMENTS = ['libnacl==1.5.0']
+REQUIREMENTS = ['libnacl==1.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -347,7 +347,7 @@ keyring>=9.3,<10.0
 knxip==0.3.3
 
 # homeassistant.components.device_tracker.owntracks
-libnacl==1.5.0
+libnacl==1.5.1
 
 # homeassistant.components.dyson
 libpurecoollink==0.1.5


### PR DESCRIPTION
## 1.5.1
- Add Sealed Box Support

Tested with the following configuration:

``` yaml
device_tracker:
  - platform: owntracks
    secret: xyz
```