### PR TITLE
Make Android app shortcut use 'Home Assistant' as name.

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -31,7 +31,7 @@ MANIFEST_JSON = {
     'icons': [],
     'lang': 'en-US',
     'name': 'Home Assistant',
-    'short_name': 'Assistant',
+    'short_name': 'Home Assistant',
     'start_url': '/',
     'theme_color': '#03A9F4'
 }


### PR DESCRIPTION
Currently, when you create a shortcut to Home Assistant on Android, it suggests the name "Assistant" instead of "Home Assistant".

I think "Home Assistant" is the correct name for the app to clearly differentiate with Google Assistant or other Assistants.

Check out the animation on [this page](https://home-assistant.io/docs/frontend/mobile/) to see the "Assistant" name. 