### PR TITLE
Upgrade pyowm to 2.7.1

### DIFF
--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -17,7 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyowm==2.6.1']
+REQUIREMENTS = ['pyowm==2.7.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -16,7 +16,7 @@ from homeassistant.const import (CONF_API_KEY, CONF_NAME, CONF_LATITUDE,
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyowm==2.6.1']
+REQUIREMENTS = ['pyowm==2.7.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -648,7 +648,7 @@ pynx584==0.4
 
 # homeassistant.components.sensor.openweathermap
 # homeassistant.components.weather.openweathermap
-pyowm==2.6.1
+pyowm==2.7.1
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.4


### PR DESCRIPTION
## 2.7.1
### New features:

- introduced support for Sulphur Dioxide (SO2) and Nitric Dioxide (NO2): new methods owm25.no2index_around_coords and owm25.so2index_around_coords
- implemented wind speed units specification (imperial/metric)

### Bugfixes:

- updated weather history endpoint (was broken)
- fix bug about data parsing at station_at_coords and weather_at_station methods
- now the deg attribute is correctly parsed from 16 day forecast weather data items
- fix bug on printing Unicode upon library exceptions
- fix handling of Weather objects parsing (it was failing whenever some data wasn't provided by OWM)

### Enhancements:

- shrinked city ID files size by 60% (via compression)
- reported in the Wiki a list of known projects that use PyOWM
- integrated the Say Thanks! hook
- introduced CONTRIBUTING.md and CODE_OF_CONDUCT.md files, thus welcoming GitHub's suggested best practices for building better open source communities
- introduced installation tests
- improved integrations tests organization and running

### Breaking changes:
OWM decided to change the syntax of API endpoint for fetching UV data and its format in a non-retrocompatible manner. This results into UVIndex object entity fields changing, as well as the corresponding OWM25 method signature (owm25.uvindex_around_coords).

**Related issue (if applicable):** fixes #7512

Tested with the following configuration:

``` yaml
sensor:
  - platform: openweathermap
    api_key: !secret owm_api
    forecast: 0
    monitored_conditions:
      - weather
      - temperature
      - wind_speed
      - humidity
      - pressure
weather:
  - platform: openweathermap
    api_key: !secret owm_api
```
