### PR TITLE
Update apcaccess to 0.0.13. 

### DIFF
--- a/homeassistant/components/apcupsd.py
+++ b/homeassistant/components/apcupsd.py
@@ -13,7 +13,7 @@ from homeassistant.const import (CONF_HOST, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['apcaccess==0.0.10']
+REQUIREMENTS = ['apcaccess==0.0.13']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/apcupsd.py
+++ b/homeassistant/components/sensor/apcupsd.py
@@ -96,6 +96,7 @@ INFERRED_UNITS = {
     ' Watts': 'W',
     ' Hz': 'Hz',
     ' C': TEMP_CELSIUS,
+    ' Percent Load Capacity': '%',
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -68,7 +68,7 @@ amcrest==1.2.0
 anthemav==1.1.8
 
 # homeassistant.components.apcupsd
-apcaccess==0.0.10
+apcaccess==0.0.13
 
 # homeassistant.components.notify.apns
 apns2==0.1.1


### PR DESCRIPTION
Update `apcaccess` to 0.0.13 and add "Percent Load Capacity" to INFERRED_UNITS.

This fixes the issue where the current load capacity was displayed as **25.0 Percent Load Capacity %** instead of just **25.0 %**.