### PR TITLE
Added support for upload of remote or local files to slack

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -5,11 +5,15 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.slack/
 """
 import logging
+import requests
+from requests.auth import HTTPDigestAuth
+from requests.auth import HTTPBasicAuth
 
 import voluptuous as vol
 
 from homeassistant.components.notify import (
-    ATTR_TARGET, PLATFORM_SCHEMA, BaseNotificationService)
+    ATTR_TARGET, ATTR_TITLE, ATTR_DATA,
+    PLATFORM_SCHEMA, BaseNotificationService)
 from homeassistant.const import (
     CONF_API_KEY, CONF_USERNAME, CONF_ICON)
 import homeassistant.helpers.config_validation as cv
@@ -19,6 +23,19 @@ REQUIREMENTS = ['slacker==0.9.50']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_CHANNEL = 'default_channel'
+CONF_TIMEOUT = 15
+
+# Top level attributes in 'data'
+ATTR_ATTACHMENTS = 'attachments'
+ATTR_FILE = 'file'
+# Attributes contained in file
+ATTR_FILE_URL = 'url'
+ATTR_FILE_PATH = 'path'
+ATTR_FILE_USERNAME = 'username'
+ATTR_FILE_PASSWORD = 'password'
+ATTR_FILE_AUTH = 'auth'
+# Any other value or absense of 'auth' lead to basic authentication being used
+ATTR_FILE_AUTH_DIGEST = 'digest'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
@@ -43,6 +60,38 @@ def get_service(hass, config, discovery_info=None):
     except slacker.Error:
         _LOGGER.exception("Authentication failed")
         return None
+
+
+def load_file(url=None, local_path=None,
+              username=None, password=None, auth=None):
+    """Load image/document/etc from a local path or url."""
+    try:
+        if url is not None:
+            # check whether authentication parameters are provided
+            if username is not None and password is not None:
+                # Use digest or basic authentication
+                if ATTR_FILE_AUTH_DIGEST == auth:
+                    auth_ = HTTPDigestAuth(username, password)
+                else:
+                    auth_ = HTTPBasicAuth(username, password)
+                # load file from url with authentication
+                req = requests.get(url, auth=auth_, timeout=CONF_TIMEOUT)
+            else:
+                # load file from url without authentication
+                req = requests.get(url, timeout=CONF_TIMEOUT)
+            return req.content
+
+        elif local_path is not None:
+            # load file from local path on server
+            return open(local_path, "rb")
+        else:
+            # neither url nor path provided
+            _LOGGER.warning("Neither url nor local path found in params!")
+
+    except OSError as error:
+        _LOGGER.error("Can't load from url or local path: %s", error)
+
+    return None
 
 
 class SlackNotificationService(BaseNotificationService):
@@ -72,14 +121,44 @@ class SlackNotificationService(BaseNotificationService):
         else:
             targets = kwargs.get(ATTR_TARGET)
 
-        data = kwargs.get('data')
-        attachments = data.get('attachments') if data else None
+        data = kwargs.get(ATTR_DATA)
+        attachments = data.get(ATTR_ATTACHMENTS) if data else None
+        file = data.get(ATTR_FILE) if data else None
+        title = kwargs.get(ATTR_TITLE)
 
         for target in targets:
             try:
-                self.slack.chat.post_message(
-                    target, message, as_user=self._as_user,
-                    username=self._username, icon_emoji=self._icon,
-                    attachments=attachments, link_names=True)
+                if file is not None:
+                    # Load from file or url
+                    file_as_bytes = load_file(
+                        url=file.get(ATTR_FILE_URL),
+                        local_path=file.get(ATTR_FILE_PATH),
+                        username=file.get(ATTR_FILE_USERNAME),
+                        password=file.get(ATTR_FILE_PASSWORD),
+                        auth=file.get(ATTR_FILE_AUTH))
+                    # Choose filename
+                    if file.get(ATTR_FILE_URL):
+                        filename = file.get(ATTR_FILE_URL)
+                    else:
+                        filename = file.get(ATTR_FILE_PATH)
+                    # Prepare structure for slack API
+                    data = {
+                        'content': None,
+                        'filetype': None,
+                        'filename': filename,
+                        # if optional title is none use the filename
+                        'title': title if title else filename,
+                        'initial_comment': message,
+                        'channels': target
+                    }
+                    # Post to slack
+                    self.slack.files.post('files.upload',
+                                          data=data,
+                                          files={'file': file_as_bytes})
+                else:
+                    self.slack.chat.post_message(
+                        target, message, as_user=self._as_user,
+                        username=self._username, icon_emoji=self._icon,
+                        attachments=attachments, link_names=True)
             except slacker.Error as err:
                 _LOGGER.error("Could not send notification. Error: %s", err)


### PR DESCRIPTION
## Description:
The notify.slack platform currently supports sending text messages and structured message attachments (see [chat.postMessage](https://api.slack.com/methods/chat.postMessage)). This PR's intention is to add support for uploading files either from the local machine/server or from a remote url (See [files.upload](https://api.slack.com/methods/files.upload)).

I am using this feature to post security camera still pictures to a slack channel when certain events occur. Might be useful to others...?

### Example: Post file or image by url
Use the following service data for notify.slack in order to directly post a remote file:
```
{
  "message":"Message that will be added as a comment to the file, e.g. photo.",
  "title":"Title of the file, e.g. photo",
  "data":{
    "file":{
      "url":"http://<url to file, photo, security camera etc>",
      "username":"optional user, if necessary",
      "password":"optional password, if necessary",
      "auth":"digest"
    }
  }
}
```
`"auth":"digest"` is optional, too. If omitted basic authentication is used. 
### Example: Post file or image by local path
Use the following service data for notify.slack in order to post local file
```
{
  "message":"Message that will be added as a comment to the file, e.g. photo.",
  "title":"Title of the file, e.g. photo",
  "data":{
    "file":{
      "path":"/path/to/file.ext"
    }
  }
}
```
### Sidenote
This is my first PR (at all) and I am no python developer. I tried to familiarize with applying rules and conventions, running tests etc. Still I might have missed something ... please excuse any mistakes.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2949

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
