### PR TITLE
Use upstream RachioPy, fix manual run switches

### DIFF
--- a/homeassistant/components/switch/rachio.py
+++ b/homeassistant/components/switch/rachio.py
@@ -8,7 +8,7 @@ import homeassistant.util as util
 from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['rachiopy==0.1.2']
+REQUIREMENTS = ['rachiopy==0.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,7 +17,7 @@ DATA_RACHIO = 'rachio'
 CONF_MANUAL_RUN_MINS = 'manual_run_mins'
 DEFAULT_MANUAL_RUN_MINS = 10
 
-MIN_UPDATE_INTERVAL = timedelta(minutes=5)
+MIN_UPDATE_INTERVAL = timedelta(seconds=30)
 MIN_FORCED_UPDATE_INTERVAL = timedelta(seconds=1)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -27,7 +27,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# noinspection PyUnusedLocal
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the component."""
     # Get options
@@ -215,14 +214,11 @@ class RachioZone(SwitchDevice):
 
     def turn_on(self):
         """Start the zone."""
-        # Convert minutes to seconds
-        seconds = self._manual_run_secs * 60
-
         # Stop other zones first
         self.turn_off()
 
-        _LOGGER.info("Watering %s for %d sec", self.name, seconds)
-        self.rachio.zone.start(self.zone_id, seconds)
+        _LOGGER.info("Watering %s for %d s", self.name, self._manual_run_secs)
+        self.rachio.zone.start(self.zone_id, self._manual_run_secs)
 
     def turn_off(self):
         """Stop all zones."""

--- a/homeassistant/components/switch/rachio.py
+++ b/homeassistant/components/switch/rachio.py
@@ -8,7 +8,7 @@ import homeassistant.util as util
 from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-REQUIREMENTS = ['rachiopy==0.1.1']
+REQUIREMENTS = ['rachiopy==0.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -775,7 +775,7 @@ pyzabbix==0.7.4
 qnapstats==0.2.4
 
 # homeassistant.components.switch.rachio
-rachiopy==0.1.1
+rachiopy==0.1.2
 
 # homeassistant.components.climate.radiotherm
 radiotherm==1.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -775,7 +775,7 @@ pyzabbix==0.7.4
 qnapstats==0.2.4
 
 # homeassistant.components.switch.rachio
-rachiopy==0.1.2
+rachiopy==0.1.1
 
 # homeassistant.components.climate.radiotherm
 radiotherm==1.3


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #7921 #7973 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
