### PR TITLE
Use user-set device names for Linksys Smart Wi-Fi routers (3)

### DIFF
--- a/homeassistant/components/device_tracker/linksys_smart.py
+++ b/homeassistant/components/device_tracker/linksys_smart.py
@@ -114,3 +114,4 @@ class LinksysSmartWifiDeviceScanner(DeviceScanner):
                              timeout=DEFAULT_TIMEOUT,
                              headers=headers,
                              json=data)
+    

--- a/homeassistant/components/device_tracker/linksys_smart.py
+++ b/homeassistant/components/device_tracker/linksys_smart.py
@@ -114,4 +114,3 @@ class LinksysSmartWifiDeviceScanner(DeviceScanner):
                              timeout=DEFAULT_TIMEOUT,
                              headers=headers,
                              json=data)
-    

--- a/homeassistant/components/device_tracker/linksys_smart.py
+++ b/homeassistant/components/device_tracker/linksys_smart.py
@@ -89,10 +89,7 @@ class LinksysSmartWifiDeviceScanner(DeviceScanner):
                         if prop["name"] == "userDeviceName":
                             name = prop["value"]
                     if not name:
-                        try:
-                            name = device["friendlyName"]
-                        except KeyError:
-                            name = device["deviceID"]
+                        name = device.get("friendlyName", device["deviceID"])
 
                     _LOGGER.debug("Device %s is connected", mac)
                     self.last_results[mac] = name

--- a/homeassistant/components/device_tracker/linksys_smart.py
+++ b/homeassistant/components/device_tracker/linksys_smart.py
@@ -83,11 +83,17 @@ class LinksysSmartWifiDeviceScanner(DeviceScanner):
                     if not connections:
                         _LOGGER.debug("Device %s is not connected", mac)
                         continue
-                    name = device["friendlyName"]
-                    properties = device["properties"]
-                    for prop in properties:
+
+                    name = None
+                    for prop in device["properties"]:
                         if prop["name"] == "userDeviceName":
                             name = prop["value"]
+                    if not name:
+                        try:
+                            name = device["friendlyName"]
+                        except KeyError:
+                            name = device["deviceID"]
+
                     _LOGGER.debug("Device %s is connected", mac)
                     self.last_results[mac] = name
             except (KeyError, IndexError):


### PR DESCRIPTION
## Description:
Component will now work even if some network devices have user-set names in the router interface rather than providing their own hostnames.

**Related issue (if applicable):** fixes #8299 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
