### PR TITLE
Revert pyhydroquebec version to 1.1.1

### DIFF
--- a/homeassistant/components/sensor/hydroquebec.py
+++ b/homeassistant/components/sensor/hydroquebec.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyhydroquebec==1.2.0']
+REQUIREMENTS = ['pyhydroquebec==1.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description:
There is a bug in version 1.2.0 that breaks the component. I was unable to narrow down why i was getting an error on this line of version 1.2.0 (line 279: contract_data = {"balance": balances[balance_id]}) giving "index out of range exception". Reverting back to the old version solved the problem.

```
contract_data = {"balance": balances[balance_id]} IndexError: list index out of range
```

**Related issue (if applicable):** none
