### PR TITLE
Upgrade discord.py to 0.16.8

### DIFF
--- a/homeassistant/components/notify/discord.py
+++ b/homeassistant/components/notify/discord.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['discord.py==0.16.0']
+REQUIREMENTS = ['discord.py==0.16.8']
 
 CONF_TOKEN = 'token'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -153,7 +153,7 @@ denonavr==0.5.1
 directpy==0.1
 
 # homeassistant.components.notify.discord
-discord.py==0.16.0
+discord.py==0.16.8
 
 # homeassistant.components.updater
 distro==1.0.4


### PR DESCRIPTION
## 0.16.8
- [Commit log](https://github.com/Rapptz/discord.py/commits/async)

Tested with the following configuration:

``` yaml
notify:
  - name: discord
    platform: discord
    token: !secret discord
```

Message sent with "Call Service"

``` json
{
  "message": "A message from Home Assistant",
  "target": [
    "3342155142827212455"
    ]
}
```