### PR TITLE
zha: Strip whitespace from device names

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -273,7 +273,7 @@ def _discover_endpoint_info(endpoint):
     for key, value in extra_info.items():
         if isinstance(value, bytes):
             try:
-                extra_info[key] = value.decode('ascii')
+                extra_info[key] = value.decode('ascii').strip()
             except UnicodeDecodeError:
                 # Unsure what the best behaviour here is. Unset the key?
                 pass


### PR DESCRIPTION
## Description:

Entity IDs and friendly names are derived from information returned from the device. Some devices pad with a lot of whitespace. This makes the strings in Home Assistant more sensible.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
