### PR TITLE
support devices that present as wemo with each one on its own port

### DIFF
--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -74,7 +74,7 @@ class WemoSwitch(SwitchDevice):
     @property
     def should_poll(self):
         """No polling needed with subscriptions."""
-        if self._model_name == 'Insight':
+        if self._model_name in ['Insight', 'DLI emulated Belkin Socket']:
             return True
         return False
 

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -26,7 +26,8 @@ WEMO_MODEL_DISPATCH = {
     'Sensor':  'binary_sensor',
     'Socket':  'switch',
     'LightSwitch': 'switch',
-    'CoffeeMaker': 'switch'
+    'CoffeeMaker': 'switch',
+    'DLI emulated Belkin Socket': 'switch'
 }
 
 SUBSCRIPTION_REGISTRY = None

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -87,7 +87,12 @@ def setup(hass, config):
                    for address in config.get(DOMAIN, {}).get(CONF_STATIC, []))
 
     for address, device in devices:
-        port = pywemo.ouimeaux_device.probe_wemo(address, device.name)
+        # static configured devices do not have device defined
+        # they can only have one device per IP
+        if device is None:
+            port = pywemo.ouimeaux_device.probe_wemo(address)
+        else:
+            port = pywemo.ouimeaux_device.probe_wemo(address, device.name)
         if not port:
             _LOGGER.warning('Unable to probe wemo at %s', address)
             continue

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -87,7 +87,7 @@ def setup(hass, config):
                    for address in config.get(DOMAIN, {}).get(CONF_STATIC, []))
 
     for address, device in devices:
-        port = pywemo.ouimeaux_device.probe_wemo(address)
+        port = pywemo.ouimeaux_device.probe_wemo(address, device.name)
         if not port:
             _LOGGER.warning('Unable to probe wemo at %s', address)
             continue


### PR DESCRIPTION
## Description:
The newest digital loggers web based switches https://www.digital-loggers.com/pro.html present themselves as a emulated wemo device. they offer all 8 ports on a single IP with each socket on a different tcp port.

This requires a pywemo change that is pending in https://github.com/pavoni/pywemo/pull/78 With the changes in pywemo and this PR homeassistant can autodetect and subscribe to all 8 ports. without changes to the configuration format statically defining the IP will only detect the first socket, I could write the chages to do so if desired.  

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**