### PR TITLE
zha: Try multiple reads to get manufacturer/model

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -264,11 +264,20 @@ def _discover_endpoint_info(endpoint):
     if 0 not in endpoint.clusters:
         return extra_info
 
-    result, _ = yield from endpoint.clusters[0].read_attributes(
-        ['manufacturer', 'model'],
-        allow_cache=True,
-    )
-    extra_info.update(result)
+    @asyncio.coroutine
+    def read(attributes):
+        """Read attributes and update extra_info convenience function."""
+        result, _ = yield from endpoint.clusters[0].read_attributes(
+            attributes,
+            allow_cache=True,
+        )
+        extra_info.update(result)
+
+    yield from read(['manufacturer', 'model'])
+    if extra_info['manufacturer'] is None or extra_info['model'] is None:
+        # Some devices fail at returning multiple results. Attempt separately.
+        yield from read(['manufacturer'])
+        yield from read(['model'])
 
     for key, value in extra_info.items():
         if isinstance(value, bytes):


### PR DESCRIPTION
Some devices don't seem to return the information properly when asked for
multiple attributes in one read. This separates out the reads if it didn't
work as expected the first time.

Because this data is cached in bellows, I don't expect any extra reads in
the "happy" case.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
