### PR TITLE
zha light: Refresh at startup

### DIFF
--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -29,7 +29,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     except (AttributeError, KeyError):
         pass
 
-    async_add_devices([Light(**discovery_info)])
+    async_add_devices([Light(**discovery_info)], update_before_add=True)
 
 
 class Light(zha.Entity, light.Light):
@@ -99,16 +99,19 @@ class Light(zha.Entity, light.Light):
                 duration
             )
             self._state = 1
+            self.hass.async_add_job(self.async_update_ha_state())
             return
 
         yield from self._endpoint.on_off.on()
         self._state = 1
+        self.hass.async_add_job(self.async_update_ha_state())
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the entity off."""
         yield from self._endpoint.on_off.off()
         self._state = 0
+        self.hass.async_add_job(self.async_update_ha_state())
 
     @property
     def brightness(self):
@@ -129,3 +132,51 @@ class Light(zha.Entity, light.Light):
     def supported_features(self):
         """Flag supported features."""
         return self._supported_features
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Retrieve latest state."""
+        _LOGGER.debug("%s async_update", self.entity_id)
+
+        def safe_read(cluster, attributes):
+            """Swallow all exceptions from network read.
+
+            If we throw during initialization, setup fails. Rather have an
+            entity that exists, but is in a maybe wrong state, than no entity.
+            """
+            try:
+                result, _ = yield from cluster.read_attributes(
+                    attributes,
+                    allow_cache=False,
+                )
+                return result
+            except Exception:  # pylint: disable=broad-except
+                return {}
+
+        result = yield from safe_read(self._endpoint.on_off, ['on_off'])
+        self._state = result.get('on_off', self._state)
+
+        if self._supported_features & light.SUPPORT_BRIGHTNESS:
+            result = yield from safe_read(self._endpoint.level,
+                                          ['current_level'])
+            self._brightness = result.get('current_level', self._brightness)
+
+        if self._supported_features & light.SUPPORT_COLOR_TEMP:
+            result = yield from safe_read(self._endpoint.light_color,
+                                          ['color_temperature'])
+            self._color_temp = result.get('color_temperature',
+                                          self._color_temp)
+
+        if self._supported_features & light.SUPPORT_XY_COLOR:
+            result = yield from safe_read(self._endpoint.light_color,
+                                          ['current_x', 'current_y'])
+            if 'current_x' in result and 'current_y' in result:
+                self._xy_color = (result['current_x'], result['current_y'])
+
+    @property
+    def should_poll(self) -> bool:
+        """Return True if entity has to be polled for state.
+
+        False if entity pushes its state to HA.
+        """
+        return False

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -138,6 +138,7 @@ class Light(zha.Entity, light.Light):
         """Retrieve latest state."""
         _LOGGER.debug("%s async_update", self.entity_id)
 
+        @asyncio.coroutine
         def safe_read(cluster, attributes):
             """Swallow all exceptions from network read.
 


### PR DESCRIPTION
## Description: Read states from devices during initialization, so that the state is known to hass.


**Related issue (if applicable):** fixes #7967

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
