### PR TITLE
Fix pathlib resolve

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1079,7 +1079,7 @@ class Config(object):
         """Check if the path is valid for access from outside."""
         parent = pathlib.Path(path).parent
         try:
-            parent.resolve()  # pylint: disable=no-member
+            parent = parent.resolve()  # pylint: disable=no-member
         except (FileNotFoundError, RuntimeError, PermissionError):
             return False
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -821,13 +821,13 @@ class TestConfig(unittest.TestCase):
             for path in valid:
                 assert self.config.is_allowed_path(path)
 
-            self.config.whitelist_external_dirs = set(('/home', '/tmp'))
+            self.config.whitelist_external_dirs = set(('/home', '/var'))
 
             unvalid = [
                 "/hass/config/secure",
                 "/etc/passwd",
                 "/root/secure_file",
-                "/tmp/../etc/passwd",
+                "/var/../etc/passwd",
                 test_file,
             ]
             for path in unvalid:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -821,13 +821,13 @@ class TestConfig(unittest.TestCase):
             for path in valid:
                 assert self.config.is_allowed_path(path)
 
-            self.config.whitelist_external_dirs = set(('/home',))
+            self.config.whitelist_external_dirs = set(('/home', '/tmp'))
 
             unvalid = [
                 "/hass/config/secure",
                 "/etc/passwd",
                 "/root/secure_file",
-                "/hass/config/test/../../../etc/passwd",
+                "/tmp/../etc/passwd",
                 test_file,
             ]
             for path in unvalid:


### PR DESCRIPTION
## Description:

Fix to save the return value of resove.

**Related issue (if applicable):** fixes #8291

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
