### PR TITLE
Upgrade aiohttp to 2.2.2

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.2.0
+aiohttp==2.2.1
 async_timeout==1.2.1
 chardet==3.0.2
 astral==1.4

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.2.1
+aiohttp==2.2.2
 async_timeout==1.2.1
 chardet==3.0.2
 astral==1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.2.1
+aiohttp==2.2.2
 async_timeout==1.2.1
 chardet==3.0.2
 astral==1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ pip>=7.1.0
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.2.0
+aiohttp==2.2.1
 async_timeout==1.2.1
 chardet==3.0.2
 astral==1.4

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     'jinja2>=2.9.5',
     'voluptuous==0.10.5',
     'typing>=3,<4',
-    'aiohttp==2.2.1',
+    'aiohttp==2.2.2',
     'async_timeout==1.2.1',
     'chardet==3.0.2',
     'astral==1.4',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     'jinja2>=2.9.5',
     'voluptuous==0.10.5',
     'typing>=3,<4',
-    'aiohttp==2.2.0',
+    'aiohttp==2.2.1',
     'async_timeout==1.2.1',
     'chardet==3.0.2',
     'astral==1.4',


### PR DESCRIPTION
## 2.2.2
- Allow await session.close() along with yield from session.close()

## 2.2.1
- Relax yarl requirement to 0.11+
- Backport #2026: session.close is a coroutine (#2029)

Tested with: 

```yaml
http:
```