### PR TITLE
API POST has new state validation (fix for state = 0)

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -213,7 +213,7 @@ class APIEntityStateView(HomeAssistantView):
 
         new_state = data.get('state')
 
-        if not new_state:
+        if new_state is None:
             return self.json_message('No state specified', HTTP_BAD_REQUEST)
 
         attributes = data.get('attributes')

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -98,6 +98,23 @@ def test_api_state_change_with_bad_data(hass, mock_api_client):
 
 # pylint: disable=invalid-name
 @asyncio.coroutine
+def test_api_state_change_to_zero_value(hass, mock_api_client):
+    """Test if changing a state to a zero value is possible."""
+    resp = yield from mock_api_client.post(
+        const.URL_API_STATES_ENTITY.format("test_entity.with_zero_state"),
+        json={'state': 0})
+
+    assert resp.status == 201
+
+    resp = yield from mock_api_client.post(
+        const.URL_API_STATES_ENTITY.format("test_entity.with_zero_state"),
+        json={'state': 0.})
+
+    assert resp.status == 200
+
+
+# pylint: disable=invalid-name
+@asyncio.coroutine
 def test_api_state_change_push(hass, mock_api_client):
     """Test if we can push a change the state of an entity."""
     hass.states.async_set("test.test", "not_to_be_set")


### PR DESCRIPTION
## Description:

When posting a new state of an entity through the API, if the state value is `0`, the validation acts as **if a state had not been sent**, so it returns a **404 error code** and does not update the entity state.

Problem is this validation:
```python
new_state = data.get('state')
if not new_state:
    return self.json_message('No state specified', HTTP_BAD_REQUEST)
```
If `new_state` is a float or an integer, the `0 / 0.0` value returns the error! This has to be a null comparison (`if new_state  is None`).

I was going crazy until I discovered the error... I have a custom sensor in an AppDaemon app which measures the difference of temperature between the interior and  the exterior of the house, and it was failing  mysteriously when ∆T=0.

## Example entry to check the error:
```bash
curl -X POST -H "x-ha-access: [HA_PASSWD]" -H "Content-Type: application/json" -d '{"state": 0, "attributes": {"friendly_name": "Test Sensor "}}' http://[HA_IP]:8123/api/states/sensor.test_sensor
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
