### PR TITLE
Fix the "302" error in the UPC Connect component and remove the need to specify the router password

### DIFF
--- a/homeassistant/components/device_tracker/upc_connect.py
+++ b/homeassistant/components/device_tracker/upc_connect.py
@@ -12,11 +12,10 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
-from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.const import CONF_HOST
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 
@@ -25,7 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_IP = '192.168.0.1'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_HOST, default=DEFAULT_IP): cv.string,
 })
 
@@ -48,7 +46,6 @@ class UPCDeviceScanner(DeviceScanner):
         """Initialize the scanner."""
         self.hass = hass
         self.host = config[CONF_HOST]
-        self.password = config[CONF_PASSWORD]
 
         self.data = {}
         self.token = None

--- a/homeassistant/components/device_tracker/upc_connect.py
+++ b/homeassistant/components/device_tracker/upc_connect.py
@@ -108,7 +108,6 @@ class UPCDeviceScanner(DeviceScanner):
     @asyncio.coroutine
     def _async_ws_function(self, function):
         """Execute a command on UPC firmware webservice."""
-
         try:
             with async_timeout.timeout(10, loop=self.hass.loop):
                 # The 'token' parameter has to be first, and 'fun' second

--- a/homeassistant/components/device_tracker/upc_connect.py
+++ b/homeassistant/components/device_tracker/upc_connect.py
@@ -108,16 +108,14 @@ class UPCDeviceScanner(DeviceScanner):
     @asyncio.coroutine
     def _async_ws_function(self, function):
         """Execute a command on UPC firmware webservice."""
-        form_data = {
-            'token': self.token,
-            'fun': function
-        }
 
         try:
             with async_timeout.timeout(10, loop=self.hass.loop):
+                # The 'token' parameter has to be first, and 'fun' second
+                # or the UPC firmware will return an error
                 response = yield from self.websession.post(
                     "http://{}/xml/getter.xml".format(self.host),
-                    data=form_data,
+                    data="token={}&fun={}".format(self.token, function),
                     headers=self.headers,
                     allow_redirects=False
                 )

--- a/homeassistant/components/device_tracker/upc_connect.py
+++ b/homeassistant/components/device_tracker/upc_connect.py
@@ -29,8 +29,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_IP): cv.string,
 })
 
-CMD_LOGIN = 15
-CMD_LOGOUT = 16
 CMD_DEVICES = 123
 
 
@@ -38,7 +36,7 @@ CMD_DEVICES = 123
 def async_get_scanner(hass, config):
     """Return the UPC device scanner."""
     scanner = UPCDeviceScanner(hass, config[DOMAIN])
-    success_init = yield from scanner.async_login()
+    success_init = yield from scanner.async_initialize_token()
 
     return scanner if success_init else None
 
@@ -65,21 +63,12 @@ class UPCDeviceScanner(DeviceScanner):
 
         self.websession = async_get_clientsession(hass)
 
-        @asyncio.coroutine
-        def async_logout(event):
-            """Logout from upc connect box."""
-            yield from self._async_ws_function(CMD_LOGOUT)
-            self.token = None
-
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, async_logout)
-
     @asyncio.coroutine
     def async_scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
         if self.token is None:
-            reconnect = yield from self.async_login()
-            if not reconnect:
+            token_initialized = yield from self.async_initialize_token()
+            if not token_initialized:
                 _LOGGER.error("Not connected to %s", self.host)
                 return []
 
@@ -95,55 +84,45 @@ class UPCDeviceScanner(DeviceScanner):
 
     @asyncio.coroutine
     def async_get_device_name(self, device):
-        """Ge the firmware doesn't save the name of the wireless device."""
+        """The firmware doesn't save the name of the wireless device."""
         return None
 
     @asyncio.coroutine
-    def async_login(self):
-        """Login into firmware and get first token."""
+    def async_initialize_token(self):
+        """Get first token."""
         try:
             # get first token
             with async_timeout.timeout(10, loop=self.hass.loop):
                 response = yield from self.websession.get(
-                    "http://{}/common_page/login.html".format(self.host)
+                    "http://{}/common_page/login.html".format(self.host),
+                    headers=self.headers
                 )
 
                 yield from response.text()
 
             self.token = response.cookies['sessionToken'].value
 
-            # login
-            data = yield from self._async_ws_function(CMD_LOGIN, {
-                'Username': 'NULL',
-                'Password': self.password,
-            })
-
-            # Successful?
-            return data is not None
+            return True
 
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can not load login page from %s", self.host)
             return False
 
     @asyncio.coroutine
-    def _async_ws_function(self, function, additional_form=None):
+    def _async_ws_function(self, function):
         """Execute a command on UPC firmware webservice."""
         form_data = {
             'token': self.token,
             'fun': function
         }
 
-        if additional_form:
-            form_data.update(additional_form)
-
-        redirects = function != CMD_DEVICES
         try:
             with async_timeout.timeout(10, loop=self.hass.loop):
                 response = yield from self.websession.post(
                     "http://{}/xml/getter.xml".format(self.host),
                     data=form_data,
                     headers=self.headers,
-                    allow_redirects=redirects
+                    allow_redirects=False
                 )
 
                 # error?

--- a/tests/components/device_tracker/test_upc_connect.py
+++ b/tests/components/device_tracker/test_upc_connect.py
@@ -7,7 +7,7 @@ import logging
 from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.const import (
-    CONF_PLATFORM, CONF_HOST, CONF_PASSWORD)
+    CONF_PLATFORM, CONF_HOST)
 from homeassistant.components.device_tracker import DOMAIN
 import homeassistant.components.device_tracker.upc_connect as platform
 from homeassistant.util.async import run_coroutine_threadsafe
@@ -62,43 +62,10 @@ class TestUPCConnect(object):
             assert setup_component(
                 self.hass, DOMAIN, {DOMAIN: {
                     CONF_PLATFORM: 'upc_connect',
-                    CONF_HOST: self.host,
-                    CONF_PASSWORD: '123456'
+                    CONF_HOST: self.host
                 }})
 
-        assert len(aioclient_mock.mock_calls) == 2
-        assert aioclient_mock.mock_calls[1][2]['Password'] == '123456'
-        assert aioclient_mock.mock_calls[1][2]['fun'] == 15
-        assert aioclient_mock.mock_calls[1][2]['token'] == '654321'
-
-    @patch('homeassistant.components.device_tracker._LOGGER.error')
-    def test_setup_platform_error_webservice(self, mock_error, aioclient_mock):
-        """Setup a platform with api error."""
-        aioclient_mock.get(
-            "http://{}/common_page/login.html".format(self.host),
-            cookies={'sessionToken': '654321'}
-        )
-        aioclient_mock.post(
-            "http://{}/xml/getter.xml".format(self.host),
-            content=b'successful',
-            status=404
-        )
-
-        with assert_setup_component(1, DOMAIN):
-            assert setup_component(
-                self.hass, DOMAIN, {DOMAIN: {
-                    CONF_PLATFORM: 'upc_connect',
-                    CONF_HOST: self.host,
-                    CONF_PASSWORD: '123456'
-                }})
-
-        assert len(aioclient_mock.mock_calls) == 2
-        assert aioclient_mock.mock_calls[1][2]['Password'] == '123456'
-        assert aioclient_mock.mock_calls[1][2]['fun'] == 15
-        assert aioclient_mock.mock_calls[1][2]['token'] == '654321'
-
-        assert 'Error setting up platform' in \
-            str(mock_error.call_args_list[-1])
+        assert len(aioclient_mock.mock_calls) == 1
 
     @patch('homeassistant.components.device_tracker._LOGGER.error')
     def test_setup_platform_timeout_webservice(self, mock_error,
@@ -106,10 +73,7 @@ class TestUPCConnect(object):
         """Setup a platform with api timeout."""
         aioclient_mock.get(
             "http://{}/common_page/login.html".format(self.host),
-            cookies={'sessionToken': '654321'}
-        )
-        aioclient_mock.post(
-            "http://{}/xml/getter.xml".format(self.host),
+            cookies={'sessionToken': '654321'},
             content=b'successful',
             exc=asyncio.TimeoutError()
         )
@@ -118,14 +82,10 @@ class TestUPCConnect(object):
             assert setup_component(
                 self.hass, DOMAIN, {DOMAIN: {
                     CONF_PLATFORM: 'upc_connect',
-                    CONF_HOST: self.host,
-                    CONF_PASSWORD: '123456'
+                    CONF_HOST: self.host
                 }})
 
-        assert len(aioclient_mock.mock_calls) == 2
-        assert aioclient_mock.mock_calls[1][2]['Password'] == '123456'
-        assert aioclient_mock.mock_calls[1][2]['fun'] == 15
-        assert aioclient_mock.mock_calls[1][2]['token'] == '654321'
+        assert len(aioclient_mock.mock_calls) == 1
 
         assert 'Error setting up platform' in \
             str(mock_error.call_args_list[-1])
@@ -147,8 +107,7 @@ class TestUPCConnect(object):
             assert setup_component(
                 self.hass, DOMAIN, {DOMAIN: {
                     CONF_PLATFORM: 'upc_connect',
-                    CONF_HOST: self.host,
-                    CONF_PASSWORD: '123456'
+                    CONF_HOST: self.host
                 }})
 
         assert len(aioclient_mock.mock_calls) == 1
@@ -171,14 +130,11 @@ class TestUPCConnect(object):
         scanner = run_coroutine_threadsafe(platform.async_get_scanner(
             self.hass, {DOMAIN: {
                     CONF_PLATFORM: 'upc_connect',
-                    CONF_HOST: self.host,
-                    CONF_PASSWORD: '123456'
+                    CONF_HOST: self.host
                 }}
             ), self.hass.loop).result()
 
-        assert aioclient_mock.mock_calls[1][2]['Password'] == '123456'
-        assert aioclient_mock.mock_calls[1][2]['fun'] == 15
-        assert aioclient_mock.mock_calls[1][2]['token'] == '654321'
+        assert len(aioclient_mock.mock_calls) == 1
 
         aioclient_mock.clear_requests()
         aioclient_mock.post(
@@ -211,14 +167,11 @@ class TestUPCConnect(object):
         scanner = run_coroutine_threadsafe(platform.async_get_scanner(
             self.hass, {DOMAIN: {
                     CONF_PLATFORM: 'upc_connect',
-                    CONF_HOST: self.host,
-                    CONF_PASSWORD: '123456'
+                    CONF_HOST: self.host
                 }}
             ), self.hass.loop).result()
 
-        assert aioclient_mock.mock_calls[1][2]['Password'] == '123456'
-        assert aioclient_mock.mock_calls[1][2]['fun'] == 15
-        assert aioclient_mock.mock_calls[1][2]['token'] == '654321'
+        assert len(aioclient_mock.mock_calls) == 1
 
         aioclient_mock.clear_requests()
         aioclient_mock.get(
@@ -235,8 +188,8 @@ class TestUPCConnect(object):
         mac_list = run_coroutine_threadsafe(
             scanner.async_scan_devices(), self.hass.loop).result()
 
-        assert len(aioclient_mock.mock_calls) == 3
-        assert aioclient_mock.mock_calls[1][2]['fun'] == 15
+        assert len(aioclient_mock.mock_calls) == 2
+        assert aioclient_mock.mock_calls[1][2]['fun'] == 123
         assert mac_list == ['30:D3:2D:0:69:21', '5C:AA:FD:25:32:02',
                             '70:EE:50:27:A1:38']
 
@@ -255,14 +208,11 @@ class TestUPCConnect(object):
         scanner = run_coroutine_threadsafe(platform.async_get_scanner(
             self.hass, {DOMAIN: {
                     CONF_PLATFORM: 'upc_connect',
-                    CONF_HOST: self.host,
-                    CONF_PASSWORD: '123456'
+                    CONF_HOST: self.host
                 }}
             ), self.hass.loop).result()
 
-        assert aioclient_mock.mock_calls[1][2]['Password'] == '123456'
-        assert aioclient_mock.mock_calls[1][2]['fun'] == 15
-        assert aioclient_mock.mock_calls[1][2]['token'] == '654321'
+        assert len(aioclient_mock.mock_calls) == 1
 
         aioclient_mock.clear_requests()
         aioclient_mock.get(
@@ -280,7 +230,7 @@ class TestUPCConnect(object):
             scanner.async_scan_devices(), self.hass.loop).result()
 
         assert len(aioclient_mock.mock_calls) == 2
-        assert aioclient_mock.mock_calls[1][2]['fun'] == 15
+        assert aioclient_mock.mock_calls[1][2]['fun'] == 123
         assert mac_list == []
 
     def test_scan_devices_parse_error(self, aioclient_mock):
@@ -298,14 +248,11 @@ class TestUPCConnect(object):
         scanner = run_coroutine_threadsafe(platform.async_get_scanner(
             self.hass, {DOMAIN: {
                     CONF_PLATFORM: 'upc_connect',
-                    CONF_HOST: self.host,
-                    CONF_PASSWORD: '123456'
+                    CONF_HOST: self.host
                 }}
             ), self.hass.loop).result()
 
-        assert aioclient_mock.mock_calls[1][2]['Password'] == '123456'
-        assert aioclient_mock.mock_calls[1][2]['fun'] == 15
-        assert aioclient_mock.mock_calls[1][2]['token'] == '654321'
+        assert len(aioclient_mock.mock_calls) == 1
 
         aioclient_mock.clear_requests()
         aioclient_mock.post(

--- a/tests/components/device_tracker/test_upc_connect.py
+++ b/tests/components/device_tracker/test_upc_connect.py
@@ -147,8 +147,7 @@ class TestUPCConnect(object):
             scanner.async_scan_devices(), self.hass.loop).result()
 
         assert len(aioclient_mock.mock_calls) == 1
-        assert aioclient_mock.mock_calls[0][2]['fun'] == 123
-        assert scanner.token == '1235678'
+        assert aioclient_mock.mock_calls[0][2] == 'token=654321&fun=123'
         assert mac_list == ['30:D3:2D:0:69:21', '5C:AA:FD:25:32:02',
                             '70:EE:50:27:A1:38']
 
@@ -189,7 +188,7 @@ class TestUPCConnect(object):
             scanner.async_scan_devices(), self.hass.loop).result()
 
         assert len(aioclient_mock.mock_calls) == 2
-        assert aioclient_mock.mock_calls[1][2]['fun'] == 123
+        assert aioclient_mock.mock_calls[1][2] == 'token=654321&fun=123'
         assert mac_list == ['30:D3:2D:0:69:21', '5C:AA:FD:25:32:02',
                             '70:EE:50:27:A1:38']
 
@@ -230,7 +229,7 @@ class TestUPCConnect(object):
             scanner.async_scan_devices(), self.hass.loop).result()
 
         assert len(aioclient_mock.mock_calls) == 2
-        assert aioclient_mock.mock_calls[1][2]['fun'] == 123
+        assert aioclient_mock.mock_calls[1][2] == 'token=654321&fun=123'
         assert mac_list == []
 
     def test_scan_devices_parse_error(self, aioclient_mock):
@@ -265,6 +264,6 @@ class TestUPCConnect(object):
             scanner.async_scan_devices(), self.hass.loop).result()
 
         assert len(aioclient_mock.mock_calls) == 1
-        assert aioclient_mock.mock_calls[0][2]['fun'] == 123
+        assert aioclient_mock.mock_calls[0][2] == 'token=654321&fun=123'
         assert scanner.token is None
         assert mac_list == []


### PR DESCRIPTION
## Description:

This addresses two things:

1. The UPC Connect component randomly starts failing with the following error:
```
2017-06-22 17:08:48 WARNING (MainThread) [homeassistant.components.device_tracker.upc_connect] Receive http code 302
2017-06-22 17:08:48 WARNING (MainThread) [homeassistant.components.device_tracker.upc_connect] Can't read device from 192.168.0.1
```
A restart of Home Assistant sometimes fixes the issue, and sometimes doesn't.

2. The password for the router is actually not needed to retrieve the list of devices.

The fix is as follow:

1. The user agent has to stay the same between each request, which wasn't the case.
2. In the POST data sent to ``http://host/xml/getter.xml``, the ``token`` parameter has to come first, and ``fun`` second, otherwise the router returns HTTP 302 instead of the list of devices: This works: ``token=X&fun=Y``, this doesn't: ``fun=Y&token=X`` 😬.
3. I also removed the need for calling the login and logout functions, because they aren't required to query the list of devices. The router password is no longer needed. This was tested on the Virgin Media Super Hub 3.0 (Ireland). @pvizeli Could you also test on the UPC Connect router to make sure this still works on that router?

**Related issue:** fixes #8157

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#2931

## Example entry for `configuration.yaml`:
```yaml
device_tracker router:
  - platform: upc_connect
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tested against the Virgin Media Hub 3.0 (Ireland)
