### PR TITLE
Temporary fix for the client_id generation (fixes #8315)

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -315,7 +315,7 @@ def async_setup(hass, config):
         client_cert = conf.get(CONF_CLIENT_CERT)
         tls_insecure = conf.get(CONF_TLS_INSECURE)
         protocol = conf[CONF_PROTOCOL]
-        
+
         # hbmqtt requires a client id to be set.
         if client_id is None:
             client_id = 'home-assistant'

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -300,7 +300,7 @@ def async_setup(hass, config):
     import random
     client_id = conf.get(
         CONF_CLIENT_ID, 'home-assistant-{}'.format(random.randrange(0, 1000)))
-    #client_id = conf.get(CONF_CLIENT_ID)
+    # client_id = conf.get(CONF_CLIENT_ID)
     keepalive = conf.get(CONF_KEEPALIVE)
 
     # Only setup if embedded config passed in or no broker specified

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -296,11 +296,7 @@ def async_setup(hass, config):
     if conf is None:
         conf = CONFIG_SCHEMA({DOMAIN: {}})[DOMAIN]
 
-    # Remove the generation of the client_id after it's fixed in HBMQTT
-    import random
-    client_id = conf.get(
-        CONF_CLIENT_ID, 'home-assistant-{}'.format(random.randrange(0, 1000)))
-    # client_id = conf.get(CONF_CLIENT_ID)
+    client_id = conf.get(CONF_CLIENT_ID)
     keepalive = conf.get(CONF_KEEPALIVE)
 
     # Only setup if embedded config passed in or no broker specified
@@ -319,6 +315,10 @@ def async_setup(hass, config):
         client_cert = conf.get(CONF_CLIENT_CERT)
         tls_insecure = conf.get(CONF_TLS_INSECURE)
         protocol = conf[CONF_PROTOCOL]
+        
+        # hbmqtt requires a client id to be set.
+        if client_id is None:
+            client_id = 'home-assistant'
     elif broker_config:
         # If no broker passed in, auto config to internal server
         broker, port, username, password, certificate, protocol = broker_config

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -296,7 +296,11 @@ def async_setup(hass, config):
     if conf is None:
         conf = CONFIG_SCHEMA({DOMAIN: {}})[DOMAIN]
 
-    client_id = conf.get(CONF_CLIENT_ID)
+    # Remove the generation of the client_id after it's fixed in HBMQTT
+    import random
+    client_id = conf.get(
+        CONF_CLIENT_ID, 'home-assistant-{}'.format(random.randrange(0, 1000)))
+    #client_id = conf.get(CONF_CLIENT_ID)
     keepalive = conf.get(CONF_KEEPALIVE)
 
     # Only setup if embedded config passed in or no broker specified


### PR DESCRIPTION
## Description:
MQTT 3.1.1 delegates the [generation of a client ID](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718031) to the server. With `paho-mqtt-1.3.0` and the embedded MQTT server it only works if `client_id` is provided.

This temporary fix allows to run the embedded MQTT server without setting a `client_id`.

**Related issue (if applicable):** fixes #8315

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt:
```
## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
