### PR TITLE
Only allow 'tls_insecure_set()' if cert is present (fixes #8329)

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -452,8 +452,8 @@ class MQTT(object):
                 certificate, certfile=client_cert,
                 keyfile=client_key, tls_version=tls_version)
 
-        if tls_insecure is not None:
-            self._mqttc.tls_insecure_set(tls_insecure)
+            if tls_insecure is not None:
+                self._mqttc.tls_insecure_set(tls_insecure)
 
         self._mqttc.on_subscribe = self._mqtt_on_subscribe
         self._mqttc.on_unsubscribe = self._mqtt_on_unsubscribe


### PR DESCRIPTION
## Description:
`tls_insecure_set()` must called after `tls_set()` but `tls_set()` is only used if `certificate:` is set. If `certificate:` is missing and `tls_insecure:` is present then the issue occurs.

The sample in the documentation was minimized.

This is a requirement from `paho-mqtt-1.3.0` (#8125).

**Related issue (if applicable):** fixes #8329

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt:
  broker: test.mosquitto.org
  port: 8883
  certificate: /home/fab/.homeassistant/mosquitto.org.crt
  tls_insecure: False
  tls_version: auto
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
