### PR TITLE
Fix issue #8285

### DIFF
--- a/homeassistant/components/binary_sensor/modbus.py
+++ b/homeassistant/components/binary_sensor/modbus.py
@@ -8,7 +8,7 @@ import logging
 import voluptuous as vol
 
 import homeassistant.components.modbus as modbus
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_SLAVE
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.helpers import config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -18,7 +18,6 @@ DEPENDENCIES = ['modbus']
 
 CONF_COIL = 'coil'
 CONF_COILS = 'coils'
-CONF_SLAVE = 'slave'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COILS): [{

--- a/homeassistant/components/climate/flexit.py
+++ b/homeassistant/components/climate/flexit.py
@@ -145,4 +145,4 @@ class Flexit(ClimateDevice):
 
     def set_fan_mode(self, fan):
         """Set new fan mode."""
-        self.unit.set_fan_speed(fan)
+        self.unit.set_fan_speed(self._fan_list.index(fan))

--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 
 DOMAIN = 'modbus'
 
-REQUIREMENTS = ['pymodbus==1.3.0rc1']
+REQUIREMENTS = ['pymodbus==1.3.1']
 
 # Type of network
 CONF_BAUDRATE = 'baudrate'

--- a/homeassistant/components/sensor/modbus.py
+++ b/homeassistant/components/sensor/modbus.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 import homeassistant.components.modbus as modbus
 from homeassistant.const import (
-    CONF_NAME, CONF_OFFSET, CONF_UNIT_OF_MEASUREMENT)
+    CONF_NAME, CONF_OFFSET, CONF_UNIT_OF_MEASUREMENT, CONF_SLAVE)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -25,7 +25,6 @@ CONF_PRECISION = 'precision'
 CONF_REGISTER = 'register'
 CONF_REGISTERS = 'registers'
 CONF_SCALE = 'scale'
-CONF_SLAVE = 'slave'
 CONF_DATA_TYPE = 'data_type'
 CONF_REGISTER_TYPE = 'register_type'
 

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -8,7 +8,7 @@ import logging
 import voluptuous as vol
 
 import homeassistant.components.modbus as modbus
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_SLAVE
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers import config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -18,7 +18,6 @@ DEPENDENCIES = ['modbus']
 
 CONF_COIL = "coil"
 CONF_COILS = "coils"
-CONF_SLAVE = "slave"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COILS): [{

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -619,7 +619,7 @@ pymailgunner==1.4
 pymochad==0.1.1
 
 # homeassistant.components.modbus
-pymodbus==1.3.0rc1
+pymodbus==1.3.1
 
 # homeassistant.components.cover.myq
 pymyq==0.0.8


### PR DESCRIPTION
## Description:
- Bumped pymodbus to version 1.3.1 from version 1.3.0rc1 to fix issue #8285 
- Fixed an issue with Flexit component
- Changed all modbus components so that they use CONF_SLAVE from const.py

Only tested service write_register and modbus-sensor working correctly with this version of pymodbus

**Related issue (if applicable):** fixes #8285 

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
