### PR TITLE
Support for Plex servers with enforced SSL

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -82,8 +82,17 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
     if file_config:
         # Setup a configured PlexServer
-        host, token = file_config.popitem()
-        token = token['token']
+        host, host_config = file_config.popitem()
+        token = host_config['token']
+        try:
+            has_ssl = host_config['ssl']
+        except KeyError:
+            has_ssl = False
+        try:
+            verify_ssl = host_config['verify']
+        except KeyError:
+            verify_ssl = True
+
     # Via discovery
     elif discovery_info is not None:
         # Parse discovery data
@@ -95,19 +104,27 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         if host in _CONFIGURING:
             return
         token = None
+        has_ssl = False
+        verify_ssl = True
     else:
         return
 
-    setup_plexserver(host, token, hass, config, add_devices_callback)
+    setup_plexserver(host, token, has_ssl, verify_ssl, hass, config, add_devices_callback)
 
 
-def setup_plexserver(host, token, hass, config, add_devices_callback):
+def setup_plexserver(host, token, has_ssl, verify_ssl, hass, config, add_devices_callback):
     """Set up a plexserver based on host parameter."""
     import plexapi.server
     import plexapi.exceptions
 
+    cert_session = None
+    http_prefix = 'https' if has_ssl else 'http'
+    if has_ssl and (verify_ssl is False):
+        _LOGGER.info("Ignoring SSL verification")
+        cert_session = requests.Session()
+        cert_session.verify = False
     try:
-        plexserver = plexapi.server.PlexServer('http://%s' % host, token)
+        plexserver = plexapi.server.PlexServer('%s://%s' % (http_prefix, host), token, cert_session)
         _LOGGER.info("Discovery configuration done (no token needed)")
     except (plexapi.exceptions.BadRequest, plexapi.exceptions.Unauthorized,
             plexapi.exceptions.NotFound) as error:
@@ -126,11 +143,13 @@ def setup_plexserver(host, token, hass, config, add_devices_callback):
     # Save config
     if not config_from_file(
             hass.config.path(PLEX_CONFIG_FILE), {host: {
-                'token': token
+                'token': token,
+                'ssl': has_ssl,
+                'verify': verify_ssl,
             }}):
         _LOGGER.error("Failed to save configuration file")
 
-    _LOGGER.info('Connected to: http://%s', host)
+    _LOGGER.info('Connected to: %s://%s', http_prefix, host)
 
     plex_clients = {}
     plex_sessions = {}
@@ -217,7 +236,11 @@ def request_configuration(host, hass, config, add_devices_callback):
     def plex_configuration_callback(data):
         """Handle configuration changes."""
         setup_plexserver(
-            host, data.get('token'), hass, config, add_devices_callback)
+                host, data.get('token'),
+                True if data.get('has_ssl') else False,
+                False if data.get('do_not_verify') else True,
+                hass, config, add_devices_callback
+            )
 
     _CONFIGURING[host] = configurator.request_config(
         hass,
@@ -229,6 +252,16 @@ def request_configuration(host, hass, config, add_devices_callback):
         fields=[{
             'id': 'token',
             'name': 'X-Plex-Token',
+            'type': ''
+        },
+        {
+            'id': 'has_ssl',
+            'name': 'Use SSL',
+            'type': ''
+        },
+        {
+            'id': 'do_not_verify_ssl',
+            'name': 'Do not verify SSL',
             'type': ''
         }])
 

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -109,10 +109,14 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     else:
         return
 
-    setup_plexserver(host, token, has_ssl, verify_ssl, hass, config, add_devices_callback)
+    setup_plexserver(
+            host, token, has_ssl, verify_ssl,
+            hass, config, add_devices_callback
+        )
 
 
-def setup_plexserver(host, token, has_ssl, verify_ssl, hass, config, add_devices_callback):
+def setup_plexserver(
+        host, token, has_ssl, verify_ssl, hass, config, add_devices_callback):
     """Set up a plexserver based on host parameter."""
     import plexapi.server
     import plexapi.exceptions
@@ -124,7 +128,10 @@ def setup_plexserver(host, token, has_ssl, verify_ssl, hass, config, add_devices
         cert_session = requests.Session()
         cert_session.verify = False
     try:
-        plexserver = plexapi.server.PlexServer('%s://%s' % (http_prefix, host), token, cert_session)
+        plexserver = plexapi.server.PlexServer(
+                '%s://%s' % (http_prefix, host),
+                token, cert_session
+            )
         _LOGGER.info("Discovery configuration done (no token needed)")
     except (plexapi.exceptions.BadRequest, plexapi.exceptions.Unauthorized,
             plexapi.exceptions.NotFound) as error:
@@ -253,13 +260,11 @@ def request_configuration(host, hass, config, add_devices_callback):
             'id': 'token',
             'name': 'X-Plex-Token',
             'type': ''
-        },
-        {
+        },{
             'id': 'has_ssl',
             'name': 'Use SSL',
             'type': ''
-        },
-        {
+        },{
             'id': 'do_not_verify_ssl',
             'name': 'Do not verify SSL',
             'type': ''

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -260,11 +260,11 @@ def request_configuration(host, hass, config, add_devices_callback):
             'id': 'token',
             'name': 'X-Plex-Token',
             'type': ''
-        },{
+        }, {
             'id': 'has_ssl',
             'name': 'Use SSL',
             'type': ''
-        },{
+        }, {
             'id': 'do_not_verify_ssl',
             'name': 'Do not verify SSL',
             'type': ''

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -110,9 +110,9 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         return
 
     setup_plexserver(
-            host, token, has_ssl, verify_ssl,
-            hass, config, add_devices_callback
-        )
+        host, token, has_ssl, verify_ssl,
+        hass, config, add_devices_callback
+    )
 
 
 def setup_plexserver(
@@ -129,9 +129,9 @@ def setup_plexserver(
         cert_session.verify = False
     try:
         plexserver = plexapi.server.PlexServer(
-                '%s://%s' % (http_prefix, host),
-                token, cert_session
-            )
+            '%s://%s' % (http_prefix, host),
+            token, cert_session
+        )
         _LOGGER.info("Discovery configuration done (no token needed)")
     except (plexapi.exceptions.BadRequest, plexapi.exceptions.Unauthorized,
             plexapi.exceptions.NotFound) as error:
@@ -243,11 +243,11 @@ def request_configuration(host, hass, config, add_devices_callback):
     def plex_configuration_callback(data):
         """Handle configuration changes."""
         setup_plexserver(
-                host, data.get('token'),
-                cv.boolean(data.get('has_ssl')),
-                cv.boolean(data.get('do_not_verify')),
-                hass, config, add_devices_callback
-            )
+            host, data.get('token'),
+            cv.boolean(data.get('has_ssl')),
+            cv.boolean(data.get('do_not_verify')),
+            hass, config, add_devices_callback
+        )
 
     _CONFIGURING[host] = configurator.request_config(
         hass,

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -244,8 +244,8 @@ def request_configuration(host, hass, config, add_devices_callback):
         """Handle configuration changes."""
         setup_plexserver(
                 host, data.get('token'),
-                True if data.get('has_ssl') else False,
-                False if data.get('do_not_verify') else True,
+                cv.boolean(data.get('has_ssl')),
+                cv.boolean(data.get('do_not_verify')),
                 hass, config, add_devices_callback
             )
 


### PR DESCRIPTION
## Description:

This PR introduces support for Plex servers that enforce SSL. Such servers may not have signed SSL certificates available for their local domain, causing connection failures for API requests.

The `plex.conf` file format was updated to enable SSL connections and invalid certificate credentials, toggleable by the user. Safe defaults are in place: no SSL, and certificate validation enabled.

@Hellowlol may want to take a look at this PR.

**Related issue:** fixes #7602

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#2932

## Example entry for `plex.conf`:
From this:
```yaml
{"x.x.x.x:32400": {"token": "..."}}
```
To this:
```yaml
{"x.x.x.x:32400": {"token": "...", "ssl": true, "verify": false}}
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [X] ~~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  - [X] ~~New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  - [X] ~~New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
  - [X] ~~New files were added to `.coveragerc`.~~
