### PR TITLE
Try catch around database updates in recorder. Resolves 6919

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -15,6 +15,7 @@ import threading
 import time
 from datetime import timedelta, datetime
 from typing import Optional, Dict
+from sqlalchemy import exc
 
 import voluptuous as vol
 
@@ -273,18 +274,31 @@ class Recorder(threading.Thread):
                     self.queue.task_done()
                     continue
 
-            try:
-                with session_scope(session=self.get_session()) as session:
-                    dbevent = Events.from_event(event)
-                    session.add(dbevent)
+            tries = 1
+            updated = False
+            while not updated and tries <= 10:
+                if tries != 1:
+                    time.sleep(CONNECT_RETRY_WAIT)
+                try:
+                    with session_scope(session=self.get_session()) as session:
+                        dbevent = Events.from_event(event)
+                        session.add(dbevent)
 
-                    if event.event_type == EVENT_STATE_CHANGED:
-                        dbstate = States.from_event(event)
-                        dbstate.event_id = dbevent.event_id
-                        session.add(dbstate)
-            except Exception as err:
-                _LOGGER.error("Error in database connectivity: %s. "
-                              "This update is not saved", err)
+                        if event.event_type == EVENT_STATE_CHANGED:
+                            dbstate = States.from_event(event)
+                            dbstate.event_id = dbevent.event_id
+                            session.add(dbstate)
+                    updated = True
+
+                except exc.OperationalError as err:
+                    _LOGGER.error("Error in database connectivity: %s. "
+                                  "(retrying in %s seconds)", err,
+                                  CONNECT_RETRY_WAIT)
+                    tries += 1
+
+            if not updated:
+                _LOGGER.error("Error in database update. Could not save "
+                              "after %d tries. Giving up", tries)
 
             self.queue.task_done()
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -273,14 +273,17 @@ class Recorder(threading.Thread):
                     self.queue.task_done()
                     continue
 
-            with session_scope(session=self.get_session()) as session:
-                dbevent = Events.from_event(event)
-                session.add(dbevent)
+            try:
+                with session_scope(session=self.get_session()) as session:
+                    dbevent = Events.from_event(event)
+                    session.add(dbevent)
 
-                if event.event_type == EVENT_STATE_CHANGED:
-                    dbstate = States.from_event(event)
-                    dbstate.event_id = dbevent.event_id
-                    session.add(dbstate)
+                    if event.event_type == EVENT_STATE_CHANGED:
+                        dbstate = States.from_event(event)
+                        dbstate.event_id = dbevent.event_id
+                        session.add(dbstate)
+            except Exception as err:
+                _LOGGER.error("Error in database connectivity: %s. This update is not saved", err)
 
             self.queue.task_done()
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -283,7 +283,8 @@ class Recorder(threading.Thread):
                         dbstate.event_id = dbevent.event_id
                         session.add(dbstate)
             except Exception as err:
-                _LOGGER.error("Error in database connectivity: %s. This update is not saved", err)
+                _LOGGER.error("Error in database connectivity: %s. "
+                              "This update is not saved", err)
 
             self.queue.task_done()
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -15,7 +15,6 @@ import threading
 import time
 from datetime import timedelta, datetime
 from typing import Optional, Dict
-from sqlalchemy import exc
 
 import voluptuous as vol
 
@@ -159,6 +158,7 @@ class Recorder(threading.Thread):
         """Start processing events to save."""
         from .models import States, Events
         from homeassistant.components import persistent_notification
+        from sqlalchemy import exc
 
         tries = 1
         connected = False


### PR DESCRIPTION
## Description:
A short database outage or connection error with mysql causes the recorder module to stop entirely, until home-assistant is restarted. All history is lost between database hiccup and hass restart. 

Exceptions raised in the sqlalchemy cause the recorder while loop to exit prematurely. Catching these exceptions will drop a single event from the history, but allow all future events to be saved.

**Related issue (if applicable):** fixes #6919 
