### PR TITLE
Remove some more usage of run_in_executor

### DIFF
--- a/tests/components/binary_sensor/test_zwave.py
+++ b/tests/components/binary_sensor/test_zwave.py
@@ -83,15 +83,13 @@ def test_trigger_sensor_value_changed(hass, mock_openzwave):
     assert not device.is_on
 
     value.data = True
-    yield from hass.loop.run_in_executor(None, value_changed, value)
-    yield from hass.async_block_till_done()
+    yield from hass.async_add_job(value_changed, value)
     assert device.invalidate_after is None
 
     device.hass = hass
 
     value.data = True
-    yield from hass.loop.run_in_executor(None, value_changed, value)
-    yield from hass.async_block_till_done()
+    yield from hass.async_add_job(value_changed, value)
     assert device.is_on
 
     test_time = device.invalidate_after - datetime.timedelta(seconds=1)

--- a/tests/components/camera/test_generic.py
+++ b/tests/components/camera/test_generic.py
@@ -2,7 +2,7 @@
 import asyncio
 from unittest import mock
 
-from homeassistant.setup import setup_component, async_setup_component
+from homeassistant.setup import async_setup_component
 
 
 @asyncio.coroutine
@@ -10,18 +10,14 @@ def test_fetching_url(aioclient_mock, hass, test_client):
     """Test that it fetches the given url."""
     aioclient_mock.get('http://example.com', text='hello world')
 
-    def setup_platform():
-        """Setup the platform."""
-        assert setup_component(hass, 'camera', {
-            'camera': {
-                'name': 'config_test',
-                'platform': 'generic',
-                'still_image_url': 'http://example.com',
-                'username': 'user',
-                'password': 'pass'
-            }})
-
-    yield from hass.loop.run_in_executor(None, setup_platform)
+    yield from async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'generic',
+            'still_image_url': 'http://example.com',
+            'username': 'user',
+            'password': 'pass'
+        }})
 
     client = yield from test_client(hass.http.app)
 
@@ -44,18 +40,14 @@ def test_limit_refetch(aioclient_mock, hass, test_client):
     aioclient_mock.get('http://example.com/15a', text='hello planet')
     aioclient_mock.get('http://example.com/20a', status=404)
 
-    def setup_platform():
-        """Setup the platform."""
-        assert setup_component(hass, 'camera', {
-            'camera': {
-                'name': 'config_test',
-                'platform': 'generic',
-                'still_image_url':
-                'http://example.com/{{ states.sensor.temp.state + "a" }}',
-                'limit_refetch_to_url_change': True,
-            }})
-
-    yield from hass.loop.run_in_executor(None, setup_platform)
+    yield from async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'generic',
+            'still_image_url':
+            'http://example.com/{{ states.sensor.temp.state + "a" }}',
+            'limit_refetch_to_url_change': True,
+        }})
 
     client = yield from test_client(hass.http.app)
 

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -12,7 +12,6 @@ from homeassistant.setup import async_setup_component
 @asyncio.coroutine
 def test_loading_file(hass, test_client):
     """Test that it loads image from disk."""
-
     with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
             mock.patch('os.access', mock.Mock(return_value=True)):
         yield from async_setup_component(hass, 'camera', {

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -6,27 +6,21 @@ from unittest import mock
 # https://bugs.python.org/issue23004
 from mock_open import MockOpen
 
-from homeassistant.setup import setup_component, async_setup_component
-
-from tests.common import mock_http_component
-import logging
+from homeassistant.setup import async_setup_component
 
 
 @asyncio.coroutine
 def test_loading_file(hass, test_client):
     """Test that it loads image from disk."""
-    @mock.patch('os.path.isfile', mock.Mock(return_value=True))
-    @mock.patch('os.access', mock.Mock(return_value=True))
-    def setup_platform():
-        """Setup platform inside callback."""
-        assert setup_component(hass, 'camera', {
+
+    with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
+            mock.patch('os.access', mock.Mock(return_value=True)):
+        yield from async_setup_component(hass, 'camera', {
             'camera': {
                 'name': 'config_test',
                 'platform': 'local_file',
                 'file_path': 'mock.file',
             }})
-
-    yield from hass.loop.run_in_executor(None, setup_platform)
 
     client = yield from test_client(hass.http.app)
 
@@ -45,26 +39,18 @@ def test_loading_file(hass, test_client):
 @asyncio.coroutine
 def test_file_not_readable(hass, caplog):
     """Test a warning is shown setup when file is not readable."""
-    mock_http_component(hass)
-
-    @mock.patch('os.path.isfile', mock.Mock(return_value=True))
-    @mock.patch('os.access', mock.Mock(return_value=False))
-    def run_test():
-
-        caplog.set_level(
-            logging.WARNING, logger='requests.packages.urllib3.connectionpool')
-
-        assert setup_component(hass, 'camera', {
+    with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
+            mock.patch('os.access', mock.Mock(return_value=False)):
+        yield from async_setup_component(hass, 'camera', {
             'camera': {
                 'name': 'config_test',
                 'platform': 'local_file',
                 'file_path': 'mock.file',
             }})
-        assert 'Could not read' in caplog.text
-        assert 'config_test' in caplog.text
-        assert 'mock.file' in caplog.text
 
-    yield from hass.loop.run_in_executor(None, run_test)
+    assert 'Could not read' in caplog.text
+    assert 'config_test' in caplog.text
+    assert 'mock.file' in caplog.text
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:
Found some more usages of run_in_executor. Replaced them with either `hass.async_add_job` or made them no longer necessary.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
