### PR TITLE
Allow all panel urls

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -8,8 +8,7 @@ import os
 from aiohttp import web
 
 from homeassistant.core import callback
-from homeassistant.const import HTTP_NOT_FOUND
-from homeassistant.components import api, group
+from homeassistant.components import api
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.auth import is_trusted_ip
 from homeassistant.components.http.const import KEY_DEVELOPMENT

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -138,6 +138,8 @@ def register_panel(hass, component_name, path, md5=None, sidebar_title=None,
     if index_view:
         hass.http.app.router.add_route(
             'get', '/{}'.format(url_path), index_view.get)
+        hass.http.app.router.add_route(
+            'get', '/{}/{{extra:.+}}'.format(url_path), index_view.get)
 
 
 def add_manifest_json_key(key, val):
@@ -172,8 +174,10 @@ def setup(hass, config):
     # Now register their urls.
     if DATA_PANELS in hass.data:
         for url_path in hass.data[DATA_PANELS]:
-            hass.http.app.router.add_route('get', '/{}'.format(url_path),
-                                           index_view.get)
+            hass.http.app.router.add_route(
+                'get', '/{}'.format(url_path), index_view.get)
+            hass.http.app.router.add_route(
+                'get', '/{}/{{extra:.+}}'.format(url_path), index_view.get)
     else:
         hass.data[DATA_PANELS] = {}
 
@@ -212,7 +216,7 @@ class IndexView(HomeAssistantView):
     url = '/'
     name = 'frontend:index'
     requires_auth = False
-    extra_urls = ['/states', '/states/{entity_id}']
+    extra_urls = ['/states', '/states/{extra}']
 
     def __init__(self):
         """Initialize the frontend view."""
@@ -225,16 +229,9 @@ class IndexView(HomeAssistantView):
         )
 
     @asyncio.coroutine
-    def get(self, request, entity_id=None):
+    def get(self, request, extra=None):
         """Serve the index view."""
         hass = request.app['hass']
-
-        if entity_id is not None:
-            state = hass.states.get(entity_id)
-
-            if (not state or state.domain != 'group' or
-                    not state.attributes.get(group.ATTR_VIEW)):
-                return self.json_message('Entity not found', HTTP_NOT_FOUND)
 
         if request.app[KEY_DEVELOPMENT]:
             core_url = '/static/home-assistant-polymer/build/core.js'

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -61,9 +61,5 @@ def test_states_routes(hass, mock_http_client):
     resp = yield from mock_http_client.get('/states')
     assert resp.status == 200
 
-    resp = yield from mock_http_client.get('/states/group.non_existing')
-    assert resp.status == 404
-
-    hass.states.async_set('group.existing', 'on', {'view': True})
     resp = yield from mock_http_client.get('/states/group.existing')
     assert resp.status == 200


### PR DESCRIPTION
## Description:
This will allow all panel urls to show the UI. This helps with the improved routing changes in https://github.com/home-assistant/home-assistant-polymer/pull/328 . We can now get `/config/z-wave` and `/hassio/store`

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
