### PR TITLE
Added media_helper service

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -304,7 +304,7 @@ omit =
     homeassistant/components/lock/nuki.py
     homeassistant/components/lock/lockitron.py
     homeassistant/components/lock/sesame.py
-    homeassistant/components/media_helper.py
+    homeassistant/components/media_extractor.py
     homeassistant/components/media_player/anthemav.py
     homeassistant/components/media_player/aquostv.py
     homeassistant/components/media_player/braviatv.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -304,6 +304,7 @@ omit =
     homeassistant/components/lock/nuki.py
     homeassistant/components/lock/lockitron.py
     homeassistant/components/lock/sesame.py
+    homeassistant/components/media_helper.py
     homeassistant/components/media_player/anthemav.py
     homeassistant/components/media_player/aquostv.py
     homeassistant/components/media_player/braviatv.py

--- a/homeassistant/components/media_extractor.py
+++ b/homeassistant/components/media_extractor.py
@@ -13,7 +13,7 @@ from homeassistant.components.media_player import (
 from homeassistant.config import load_yaml_config_file
 
 
-DOMAIN = 'media_helper'
+DOMAIN = 'media_extractor'
 DEPENDENCIES = ['media_player']
 REQUIREMENTS = ['youtube_dl==2017.7.2']
 
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def setup(hass, config):
-    """Set up the media_helper service."""
+    """Set up the media_extractor service."""
     descriptions = load_yaml_config_file(
         os.path.join(os.path.dirname(__file__),
                      'media_player', 'services.yaml'))
@@ -75,7 +75,7 @@ def get_media_stream_url(media_url):
         raise YDException()
 
     if 'entries' in all_media_streams:
-        _LOGGER.warning("Playlists is not supported, "
+        _LOGGER.warning("Playlists are not supported, "
                         "looking for the first video")
         try:
             selected_stream = next(all_media_streams['entries'])

--- a/homeassistant/components/media_helper.py
+++ b/homeassistant/components/media_helper.py
@@ -27,7 +27,7 @@ def setup(hass, config):
                      'media_player', 'services.yaml'))
 
     def play_media(call):
-        """Get stream url and send it to the media_player.play_media service."""
+        """Get stream url and send it to the media_player.play_media."""
         media_url = call.data.get(ATTR_MEDIA_CONTENT_ID)
 
         try:

--- a/homeassistant/components/media_helper.py
+++ b/homeassistant/components/media_helper.py
@@ -1,0 +1,101 @@
+"""
+Decorator service for the media_player.play_media service.
+
+Extracts stream url and sends it to the media_player.play_media
+service.
+"""
+import logging
+import os
+
+from homeassistant.components.media_player import (
+    ATTR_MEDIA_CONTENT_ID, DOMAIN as MEDIA_PLAYER_DOMAIN,
+    MEDIA_PLAYER_PLAY_MEDIA_SCHEMA, SERVICE_PLAY_MEDIA)
+from homeassistant.config import load_yaml_config_file
+
+
+DOMAIN = 'media_helper'
+DEPENDENCIES = ['media_player']
+REQUIREMENTS = ['youtube_dl==2017.7.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup(hass, config):
+    """Set up the media_helper service."""
+    descriptions = load_yaml_config_file(
+        os.path.join(os.path.dirname(__file__),
+                     'media_player', 'services.yaml'))
+
+    def play_media(call):
+        """Get stream url and send it to the media_player.play_media service."""
+        media_url = call.data.get(ATTR_MEDIA_CONTENT_ID)
+
+        try:
+            stream_url = get_media_stream_url(media_url)
+        except YDException:
+            _LOGGER.error("Could not retrieve data for the url: %s",
+                          media_url)
+            return
+        else:
+            data = {k: v for k, v in call.data.items()
+                    if k != ATTR_MEDIA_CONTENT_ID}
+            data[ATTR_MEDIA_CONTENT_ID] = stream_url
+
+            hass.async_add_job(
+                hass.services.async_call(
+                    MEDIA_PLAYER_DOMAIN, SERVICE_PLAY_MEDIA, data)
+            )
+
+    hass.services.register(DOMAIN,
+                           SERVICE_PLAY_MEDIA,
+                           play_media,
+                           description=descriptions[SERVICE_PLAY_MEDIA],
+                           schema=MEDIA_PLAYER_PLAY_MEDIA_SCHEMA)
+
+    return True
+
+
+class YDException(Exception):
+    """General service exception."""
+
+    pass
+
+
+def get_media_stream_url(media_url):
+    """Extract stream url from the media url."""
+    from youtube_dl import YoutubeDL
+    from youtube_dl.utils import DownloadError, ExtractorError
+
+    ydl = YoutubeDL({'quiet': True, 'logger': _LOGGER})
+
+    try:
+        all_media_streams = ydl.extract_info(media_url, process=False)
+    except DownloadError:
+        # This exception will be logged by youtube-dl itself
+        raise YDException()
+
+    if 'entries' in all_media_streams:
+        _LOGGER.warning("Playlists is not supported, "
+                        "looking for the first video")
+        try:
+            selected_stream = next(all_media_streams['entries'])
+        except StopIteration:
+            _LOGGER.error("Playlist is empty")
+            raise YDException()
+    else:
+        selected_stream = all_media_streams
+
+    try:
+        media_info = ydl.process_ie_result(selected_stream, download=False)
+    except (ExtractorError, DownloadError):
+        # This exception will be logged by youtube-dl itself
+        raise YDException()
+
+    format_selector = ydl.build_format_selector('best')
+
+    try:
+        best_quality_stream = next(format_selector(media_info))
+    except (KeyError, StopIteration):
+        best_quality_stream = media_info
+
+    return best_quality_stream['url']

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -944,6 +944,9 @@ yeelight==0.3.0
 # homeassistant.components.light.yeelightsunflower
 yeelightsunflower==0.0.8
 
+# homeassistant.components.media_helper
+youtube_dl==2017.7.2
+
 # homeassistant.components.light.zengge
 zengge==0.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -944,7 +944,7 @@ yeelight==0.3.0
 # homeassistant.components.light.yeelightsunflower
 yeelightsunflower==0.0.8
 
-# homeassistant.components.media_helper
+# homeassistant.components.media_extractor
 youtube_dl==2017.7.2
 
 # homeassistant.components.light.zengge


### PR DESCRIPTION
## Description:

This service is just a decorator for the media_player.play_media service. It extracts media stream url from media_content_id and sends it to the media_player.play_media service. It adds support for [these](https://rg3.github.io/youtube-dl/supportedsites.html)  web sites.

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_extractor:
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) 

### Documentation is the same as for the the media_player.play_media service

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
