### PR TITLE
Add Soundtouch support for playing an HTTP url

### DIFF
--- a/homeassistant/components/media_player/soundtouch.py
+++ b/homeassistant/components/media_player/soundtouch.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/media_player.soundtouch/
 import logging
 
 from os import path
+import re
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -20,7 +21,7 @@ from homeassistant.const import (CONF_HOST, CONF_NAME, STATE_OFF, CONF_PORT,
                                  STATE_PAUSED, STATE_PLAYING,
                                  STATE_UNAVAILABLE)
 
-REQUIREMENTS = ['libsoundtouch==0.6.2']
+REQUIREMENTS = ['libsoundtouch==0.7.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -305,15 +306,22 @@ class SoundTouchDevice(MediaPlayerDevice):
 
     def play_media(self, media_type, media_id, **kwargs):
         """Play a piece of media."""
-        _LOGGER.info("Starting media with media_id:" + str(media_id))
-        presets = self._device.presets()
-        preset = next([preset for preset in presets if
-                       preset.preset_id == str(media_id)].__iter__(), None)
-        if preset is not None:
-            _LOGGER.info("Playing preset: " + preset.name)
-            self._device.select_preset(preset)
+        _LOGGER.debug("Starting media with media_id: " + str(media_id))
+        if re.match(r'http://', str(media_id)):
+            # URL
+            _LOGGER.debug("Playing URL %s", str(media_id))
+            self._device.play_url(str(media_id))
         else:
-            _LOGGER.warning("Unable to find preset with id " + str(media_id))
+            # Preset
+            presets = self._device.presets()
+            preset = next([preset for preset in presets if
+                           preset.preset_id == str(media_id)].__iter__(), None)
+            if preset is not None:
+                _LOGGER.debug("Playing preset: " + preset.name)
+                self._device.select_preset(preset)
+            else:
+                _LOGGER.warning(
+                    "Unable to find preset with id " + str(media_id))
 
     def create_zone(self, slaves):
         """

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -353,7 +353,7 @@ libpurecoollink==0.1.5
 librouteros==1.0.2
 
 # homeassistant.components.media_player.soundtouch
-libsoundtouch==0.6.2
+libsoundtouch==0.7.2
 
 # homeassistant.components.light.lifx_legacy
 liffylights==0.9.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -65,7 +65,7 @@ influxdb==3.0.0
 libpurecoollink==0.1.5
 
 # homeassistant.components.media_player.soundtouch
-libsoundtouch==0.6.2
+libsoundtouch==0.7.2
 
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi

--- a/tests/components/media_player/test_soundtouch.py
+++ b/tests/components/media_player/test_soundtouch.py
@@ -584,6 +584,24 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         self.assertEqual(mocked_presets.call_count, 2)
         self.assertEqual(mocked_select_preset.call_count, 1)
 
+    @mock.patch('libsoundtouch.device.SoundTouchDevice.play_url')
+    @mock.patch('libsoundtouch.device.SoundTouchDevice.volume')
+    @mock.patch('libsoundtouch.device.SoundTouchDevice.status')
+    @mock.patch('libsoundtouch.soundtouch_device',
+                side_effect=_mock_soundtouch_device)
+    def test_play_media_url(self, mocked_sountouch_device, mocked_status,
+                            mocked_volume, mocked_play_url):
+        """Test play preset 1."""
+        soundtouch.setup_platform(self.hass,
+                                  default_component(),
+                                  mock.MagicMock())
+        all_devices = self.hass.data[soundtouch.DATA_SOUNDTOUCH]
+        self.assertEqual(mocked_sountouch_device.call_count, 1)
+        self.assertEqual(mocked_status.call_count, 1)
+        self.assertEqual(mocked_volume.call_count, 1)
+        all_devices[0].play_media('MUSIC', "http://fqdn/file.mp3")
+        mocked_play_url.assert_called_with("http://fqdn/file.mp3")
+
     @mock.patch('libsoundtouch.device.SoundTouchDevice.create_zone')
     @mock.patch('libsoundtouch.device.SoundTouchDevice.volume')
     @mock.patch('libsoundtouch.device.SoundTouchDevice.status')


### PR DESCRIPTION
## Description:

Allow Bose Soundtouch media player to play HTTP URL.

It allows using TTS services like google_say or Amazon Polly.

Warning: Only HTTP is supported (not HTTPS). It is a device limitation and a new firmware with this feature should be available this summer.

**Related issue (if applicable):** fixes #8267 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2943

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
