### PR TITLE
Fix TTS options

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -280,7 +280,9 @@ class SpeechManager(object):
 
         # Options
         if provider.default_options and options:
-            options = provider.default_options.copy().update(options)
+            merged_options = provider.default_options.copy()
+            merged_options.update(options)
+            options = merged_options
         options = options or provider.default_options
         if options is not None:
             invalid_opts = [opt_name for opt_name in options.keys()


### PR DESCRIPTION
## Description:

Fix TTS options to allow default configuration overriding.

**Related issue (if applicable):** fixes #8375 

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
