### PR TITLE
Add a service call to enable (or disable) a thermostat

### DIFF
--- a/homeassistant/components/climate/demo.py
+++ b/homeassistant/components/climate/demo.py
@@ -13,11 +13,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Demo climate devices."""
     add_devices([
         DemoClimate('HeatPump', 68, TEMP_FAHRENHEIT, None, None, 77,
-                    'Auto Low', None, None, 'Auto', 'heat', None, None, None),
+                    'Auto Low', None, None, 'Auto', 'heat', None, None, None,
+                    None),
         DemoClimate('Hvac', 21, TEMP_CELSIUS, True, None, 22, 'On High',
-                    67, 54, 'Off', 'cool', False, None, None),
+                    67, 54, 'Off', 'cool', False, None, None, True),
         DemoClimate('Ecobee', None, TEMP_CELSIUS, None, None, 23, 'Auto Low',
-                    None, None, 'Auto', 'auto', None, 24, 21)
+                    None, None, 'Auto', 'auto', None, 24, 21, None)
     ])
 
 
@@ -27,7 +28,8 @@ class DemoClimate(ClimateDevice):
     def __init__(self, name, target_temperature, unit_of_measurement,
                  away, hold, current_temperature, current_fan_mode,
                  target_humidity, current_humidity, current_swing_mode,
-                 current_operation, aux, target_temp_high, target_temp_low):
+                 current_operation, aux, target_temp_high, target_temp_low,
+                 enabled):
         """Initialize the climate device."""
         self._name = name
         self._target_temperature = target_temperature
@@ -35,6 +37,7 @@ class DemoClimate(ClimateDevice):
         self._unit_of_measurement = unit_of_measurement
         self._away = away
         self._hold = hold
+        self._enabled = enabled
         self._current_temperature = current_temperature
         self._current_humidity = current_humidity
         self._current_fan_mode = current_fan_mode
@@ -108,6 +111,11 @@ class DemoClimate(ClimateDevice):
         return self._away
 
     @property
+    def is_enabled(self):
+        """Return whether the thermostat is currently enabled."""
+        return self._enabled
+
+    @property
     def current_hold_mode(self):
         """Return hold mode setting."""
         return self._hold
@@ -175,6 +183,16 @@ class DemoClimate(ClimateDevice):
     def turn_away_mode_off(self):
         """Turn away mode off."""
         self._away = False
+        self.schedule_update_ha_state()
+
+    def turn_enabled_off(self):
+        """Turn enabled off."""
+        self._enabled = False
+        self.schedule_update_ha_state()
+
+    def turn_enabled_on(self):
+        """Turn enabled on."""
+        self._enabled = True
         self.schedule_update_ha_state()
 
     def set_hold_mode(self, hold):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -87,6 +87,7 @@ class GenericThermostat(ClimateDevice):
         self.min_cycle_duration = min_cycle_duration
         self._tolerance = tolerance
         self._keep_alive = keep_alive
+        self._is_enabled = True
 
         self._active = False
         self._cur_temp = None
@@ -117,6 +118,11 @@ class GenericThermostat(ClimateDevice):
     def name(self):
         """Return the name of the thermostat."""
         return self._name
+
+    @property
+    def is_enabled(self):
+        """Return whether the thermostat is currently enabled."""
+        return self._is_enabled
 
     @property
     def temperature_unit(self):
@@ -152,6 +158,16 @@ class GenericThermostat(ClimateDevice):
         self._target_temp = temperature
         self._async_control_heating()
         yield from self.async_update_ha_state()
+
+    def turn_enabled_off(self):
+        """Turn enabled off."""
+        self._is_enabled = False
+        if self._is_device_active:
+            switch.async_turn_off(self.hass, self.heater_entity_id)
+
+    def turn_enabled_on(self):
+        """Turn enabled on."""
+        self._is_enabled = True
 
     @property
     def min_temp(self):
@@ -219,6 +235,9 @@ class GenericThermostat(ClimateDevice):
                          'Generic thermostat active.')
 
         if not self._active:
+            return
+
+        if not self._is_enabled:
             return
 
         if self.min_cycle_duration:

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -22,6 +22,18 @@ set_away_mode:
       description: New value of away mode
       example: true
 
+set_enabled:
+  description: Enable or disable a climate device
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to change
+      example: 'climate.kitchen'
+
+    enabled:
+      description: New value of enabled
+      example: true
+
 set_hold_mode:
   description: Turn hold mode for climate device
 

--- a/tests/components/climate/test_demo.py
+++ b/tests/components/climate/test_demo.py
@@ -208,6 +208,28 @@ class TestDemoClimate(unittest.TestCase):
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual('off', state.attributes.get('away_mode'))
 
+    def test_set_enabled_bad_attr(self):
+        """Test setting the enabled without required attribute."""
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual('on', state.attributes.get('enabled'))
+        climate.set_enabled(self.hass, None, ENTITY_CLIMATE)
+        self.hass.block_till_done()
+        self.assertEqual('on', state.attributes.get('enabled'))
+
+    def test_set_enabled_on(self):
+        """Test setting the enabled on/true."""
+        climate.set_enabled(self.hass, True, ENTITY_CLIMATE)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual('on', state.attributes.get('enabled'))
+
+    def test_set_enabled_off(self):
+        """Test setting the enabled mode off/false."""
+        climate.set_enabled(self.hass, False, ENTITY_CLIMATE)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual('off', state.attributes.get('enabled'))
+
     def test_set_hold_mode_home(self):
         """Test setting the hold mode home."""
         climate.set_hold_mode(self.hass, 'home', ENTITY_ECOBEE)

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -211,6 +211,30 @@ class TestClimateGenericThermostat(unittest.TestCase):
         self.assertEqual(SERVICE_TURN_OFF, call.service)
         self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
+    def test_running_when_enabled_not_set(self):
+        """Test that the switch turns off when enabled is set False."""
+        self._setup_switch(True)
+        climate.set_temperature(self.hass, 30)
+        self.hass.block_till_done()
+        climate.set_enabled(self.hass, False)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('switch', call.domain)
+        self.assertEqual(SERVICE_TURN_OFF, call.service)
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
+    def test_no_state_change_when_enabled_not_set(self):
+        """Test that the switch doesn't turn on when enabled is False."""
+        self._setup_switch(False)
+        climate.set_temperature(self.hass, 30)
+        self.hass.block_till_done()
+        climate.set_enabled(self.hass, False)
+        self.hass.block_till_done()
+        self._setup_sensor(25)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
         """Setup the test sensor."""
         self.hass.states.set(ENT_SENSOR, temp, {
@@ -320,6 +344,30 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         self.assertEqual('switch', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
         self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
+    def test_running_when_enabled_not_set(self):
+        """Test that the switch turns off when enabled is set False."""
+        self._setup_switch(True)
+        climate.set_temperature(self.hass, 30)
+        self.hass.block_till_done()
+        climate.set_enabled(self.hass, False)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('switch', call.domain)
+        self.assertEqual(SERVICE_TURN_OFF, call.service)
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
+    def test_no_state_change_when_enabled_not_set(self):
+        """Test that the switch doesn't turn on when enabled is False."""
+        self._setup_switch(False)
+        climate.set_temperature(self.hass, 30)
+        self.hass.block_till_done()
+        climate.set_enabled(self.hass, False)
+        self.hass.block_till_done()
+        self._setup_sensor(35)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
 
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
         """Setup the test sensor."""


### PR DESCRIPTION
## Description:
This commit adds a new boolean attribute, enabled, to describe whether
the thermostat is currently running. It also includes all the relevant
service calls to manipulate it, and an implementation for the demo and
generic_thermostat components.

This is at least useful for the generic thermostat module because it is
completely implemented in software so there is no way to say don't run
the switch regardless of the sensor state. A real thermostat doesn't have
this issue because normally you can just switch it off. But, having a
service call available to enable/disable any climate control could be
generally useful, especially for automation. (the example I have in mind
is to disable the thermostat when a window is opened)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
