### PR TITLE
Update pyHik to catch XML errors

### DIFF
--- a/homeassistant/components/binary_sensor/hikvision.py
+++ b/homeassistant/components/binary_sensor/hikvision.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_SSL, EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_START,
     ATTR_LAST_TRIP_TIME, CONF_CUSTOMIZE)
 
-REQUIREMENTS = ['pyhik==0.1.2']
+REQUIREMENTS = ['pyhik==0.1.3']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_IGNORED = 'ignored'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -570,7 +570,7 @@ pygatt==3.1.1
 pyharmony==1.0.16
 
 # homeassistant.components.binary_sensor.hikvision
-pyhik==0.1.2
+pyhik==0.1.3
 
 # homeassistant.components.homematic
 pyhomematic==0.1.28


### PR DESCRIPTION
## Description:
Bump pyHik version to properly handle blank XML sections in the camera events processing.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
