### PR TITLE
Sets spotify media_type to music

### DIFF
--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -313,3 +313,8 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         if self._user is not None and self._user['product'] == 'premium':
             return SUPPORT_SPOTIFY
         return None
+    
+    @property
+    def media_content_type(self):
+        """Returns the media type."""
+        return MEDIA_TYPE_MUSIC

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -316,5 +316,5 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
 
     @property
     def media_content_type(self):
-        """Returns the media type."""
+        """Return the media type."""
         return MEDIA_TYPE_MUSIC

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -313,7 +313,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         if self._user is not None and self._user['product'] == 'premium':
             return SUPPORT_SPOTIFY
         return None
-    
+
     @property
     def media_content_type(self):
         """Returns the media type."""


### PR DESCRIPTION
## Description:
This PR sets the Spotify Media Player to MEDIA_TYPE_MUSIC (always).
Before this change, the spotify component looks like this:
![image](https://user-images.githubusercontent.com/13683094/27957712-f416ef80-631f-11e7-8f91-8ee0a0b2bce0.png)

After the change, it looks like this:
![image](https://user-images.githubusercontent.com/13683094/27957591-62b58ce0-631f-11e7-8515-2ed09c4e77f3.png)

Notice how the component now shows the Artist as well.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
No new docs needed

## Example entry for `configuration.yaml` (if applicable):
No config changes

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

I'm not sure if the height of the card is dependent on the media type as well.
