### PR TITLE
Do not overwrite a custom hyperion light name with the hostname of the server.

### DIFF
--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -62,7 +62,7 @@ class Hyperion(Light):
 
     @property
     def name(self):
-        """Return the hostname of the server."""
+        """Return the name of the light."""
         return self._name
 
     @property
@@ -114,7 +114,8 @@ class Hyperion(Light):
         """Get the hostname of the remote."""
         response = self.json_request({'command': 'serverinfo'})
         if response:
-            self._name = response['info']['hostname']
+            if self._name == self._host:
+                self._name = response['info']['hostname']
             return True
         return False
 


### PR DESCRIPTION
- Revert part of change in pull request #2634 that overwrites a custom hyperion light name with the hostname of the server.
- Correct the docstring in the name() method.

## Description:

Fixes the use of a custom name in a hyperion light. If a custom name is not specified then the default name is used which is "Hyperion".

### Caveat:

I'm extremely new to the Home Assistant code base so may be missing something important.

It is not clear to me whether using the hostname returned by the `serverinfo` command is useful anyway. Presumably the use case is if the server is specified as an IP address then this fetches a more meaningful name, however since the default name is specified as `Hyperion` and not the value of `_host` the reverted change may be incorrect and instead the whole `setup()` method could be removed. 

**Related issue:** fixes #8390
