### PR TITLE
Fix radiothermostat -1 value issue

### DIFF
--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -143,7 +143,7 @@ class RadioThermostat(ClimateDevice):
             _LOGGER.error("Invalid temperature detected, retrying")
             current_temp = self.device.temp['raw']
             retry += 1
-        if retry == 5: 
+        if retry == 5:
             _LOGGER.error("Couldn't get valid reading")
             return
         self._current_temperature = current_temp

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -1,5 +1,6 @@
 """
 Support for Radio Thermostat wifi-enabled home thermostats.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.radiotherm/
 """
@@ -219,6 +220,7 @@ class RadioThermostat(ClimateDevice):
 
     def turn_away_mode_on(self):
         """Turn away on.
+        
         The RTCOA app simulates away mode by using a hold.
         """
         away_temp = None

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -138,9 +138,14 @@ class RadioThermostat(ClimateDevice):
     def update(self):
         """Update the data from the thermostat."""
         current_temp = self.device.temp['raw']
-        while current_temp == -1:
+        retry = 0
+        while current_temp == -1 and retry < 5:
             _LOGGER.error("Invalid temperature detected, retrying")
             current_temp = self.device.temp['raw']
+            retry += 1
+        if retry == 5: 
+            _LOGGER.error("Couldn't get valid reading")
+            return
         self._current_temperature = current_temp
         self._name = self.device.name['raw']
         self._fmode = self.device.fmode['human']
@@ -149,30 +154,51 @@ class RadioThermostat(ClimateDevice):
 
         if self._tmode == 'Cool':
             target_temp = self.device.t_cool['raw']
-            while target_temp == -1:
+            retry = 0
+            while target_temp == -1 and retry < 5:
                 _LOGGER.error("Invalid temperature detected, retrying")
                 target_temp = self.device.t_cool['raw']
+                retry += 1
+            if retry == 5:
+                _LOGGER.error("Couldn't get valid reading")
+                return
             self._target_temperature = target_temp
             self._current_operation = STATE_COOL
         elif self._tmode == 'Heat':
             target_temp = self.device.t_heat['raw']
-            while target_temp == -1:
+            retry = 0
+            while target_temp == -1 and retry < 5:
                 _LOGGER.error("Invalid temperature detected, retrying")
                 target_temp = self.device.t_heat['raw']
+                retry += 1
+            if retry == 5:
+                _LOGGER.error("Couldn't get valid reading")
+                return
             self._target_temperature = target_temp
             self._current_operation = STATE_HEAT
         elif self._tmode == 'Auto':
             if self._tstate == 'Cool':
                 target_temp = self.device.t_cool['raw']
-                while target_temp == -1:
+                retry = 0
+                while target_temp == -1 and retry < 5:
                     _LOGGER.error("Invalid temperature detected, retrying")
                     target_temp = self.device.t_cool['raw']
+                    retry += 1
+                if retry == 5:
+                    _LOGGER.error("Couldn't get valid reading")
+                    return
                 self._target_temperature = target_temp
             elif self._tstate == 'Heat':
                 target_temp = self.device.t_heat['raw']
-                while target_temp == -1:
+                retry = 0
+                while target_temp == -1 and retry < 5:
                     _LOGGER.error("Invalid temperature detected, retrying")
                     target_temp = self.device.t_heat['raw']
+                    retry += 1
+                if retry == 5:
+                    _LOGGER.error("Couldn't get valid reading")
+                    return
+                self._target_temperature = target_temp
                 self._target_temperature = target_temp
             self._current_operation = STATE_AUTO
         else:

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -220,7 +220,7 @@ class RadioThermostat(ClimateDevice):
 
     def turn_away_mode_on(self):
         """Turn away on.
-        
+
         The RTCOA app simulates away mode by using a hold.
         """
         away_temp = None

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -136,69 +136,52 @@ class RadioThermostat(ClimateDevice):
         return self._away
 
     def update(self):
-        """Update the data from the thermostat."""
+        """Update and validate the data from the thermostat."""
         current_temp = self.device.temp['raw']
-        retry = 0
-        while current_temp == -1 and retry < 5:
-            _LOGGER.error("Invalid temperature detected, retrying")
-            current_temp = self.device.temp['raw']
-            retry += 1
-        if retry == 5:
-            _LOGGER.error("Couldn't get valid reading")
+        if current_temp == -1:
+            _LOGGER.error("Couldn't get valid temperature reading")
             return
         self._current_temperature = current_temp
         self._name = self.device.name['raw']
-        self._fmode = self.device.fmode['human']
-        self._tmode = self.device.tmode['human']
-        self._tstate = self.device.tstate['human']
+        try:
+            self._fmode = self.device.fmode['human']
+        except AttributeError:
+            _LOGGER.error("Couldn't get valid fan mode reading")
+        try:
+            self._tmode = self.device.tmode['human']
+        except AttributeError:
+            _LOGGER.error("Couldn't get valid thermostat mode reading")
+        try:
+            self._tstate = self.device.tstate['human']
+        except AttributeError:
+            _LOGGER.error("Couldn't get valid thermostat state reading")
 
         if self._tmode == 'Cool':
             target_temp = self.device.t_cool['raw']
-            retry = 0
-            while target_temp == -1 and retry < 5:
-                _LOGGER.error("Invalid temperature detected, retrying")
-                target_temp = self.device.t_cool['raw']
-                retry += 1
-            if retry == 5:
-                _LOGGER.error("Couldn't get valid reading")
+            if target_temp == -1:
+                _LOGGER.error("Couldn't get target reading")
                 return
             self._target_temperature = target_temp
             self._current_operation = STATE_COOL
         elif self._tmode == 'Heat':
             target_temp = self.device.t_heat['raw']
-            retry = 0
-            while target_temp == -1 and retry < 5:
-                _LOGGER.error("Invalid temperature detected, retrying")
-                target_temp = self.device.t_heat['raw']
-                retry += 1
-            if retry == 5:
-                _LOGGER.error("Couldn't get valid reading")
+            if target_temp == -1:
+                _LOGGER.error("Couldn't get valid target reading")
                 return
             self._target_temperature = target_temp
             self._current_operation = STATE_HEAT
         elif self._tmode == 'Auto':
             if self._tstate == 'Cool':
                 target_temp = self.device.t_cool['raw']
-                retry = 0
-                while target_temp == -1 and retry < 5:
-                    _LOGGER.error("Invalid temperature detected, retrying")
-                    target_temp = self.device.t_cool['raw']
-                    retry += 1
-                if retry == 5:
-                    _LOGGER.error("Couldn't get valid reading")
+                if target_temp == -1:
+                    _LOGGER.error("Couldn't get valid target reading")
                     return
                 self._target_temperature = target_temp
             elif self._tstate == 'Heat':
                 target_temp = self.device.t_heat['raw']
-                retry = 0
-                while target_temp == -1 and retry < 5:
-                    _LOGGER.error("Invalid temperature detected, retrying")
-                    target_temp = self.device.t_heat['raw']
-                    retry += 1
-                if retry == 5:
-                    _LOGGER.error("Couldn't get valid reading")
+                if target_temp == -1:
+                    _LOGGER.error("Couldn't get valid target reading")
                     return
-                self._target_temperature = target_temp
                 self._target_temperature = target_temp
             self._current_operation = STATE_AUTO
         else:

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -1,6 +1,5 @@
 """
 Support for Radio Thermostat wifi-enabled home thermostats.
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.radiotherm/
 """
@@ -137,23 +136,43 @@ class RadioThermostat(ClimateDevice):
 
     def update(self):
         """Update the data from the thermostat."""
-        self._current_temperature = self.device.temp['raw']
+        current_temp = self.device.temp['raw']
+        while current_temp == -1:
+            _LOGGER.error("Invalid temperature detected, retrying")
+            current_temp = self.device.temp['raw']
+        self._current_temperature = current_temp
         self._name = self.device.name['raw']
         self._fmode = self.device.fmode['human']
         self._tmode = self.device.tmode['human']
         self._tstate = self.device.tstate['human']
 
         if self._tmode == 'Cool':
-            self._target_temperature = self.device.t_cool['raw']
+            target_temp = self.device.t_cool['raw']
+            while target_temp == -1:
+                _LOGGER.error("Invalid temperature detected, retrying")
+                target_temp = self.device.t_cool['raw']
+            self._target_temperature = target_temp
             self._current_operation = STATE_COOL
         elif self._tmode == 'Heat':
-            self._target_temperature = self.device.t_heat['raw']
+            target_temp = self.device.t_heat['raw']
+            while target_temp == -1:
+                _LOGGER.error("Invalid temperature detected, retrying")
+                target_temp = self.device.t_heat['raw']
+            self._target_temperature = target_temp
             self._current_operation = STATE_HEAT
         elif self._tmode == 'Auto':
             if self._tstate == 'Cool':
-                self._target_temperature = self.device.t_cool['raw']
+                target_temp = self.device.t_cool['raw']
+                while target_temp == -1:
+                    _LOGGER.error("Invalid temperature detected, retrying")
+                    target_temp = self.device.t_cool['raw']
+                self._target_temperature = target_temp
             elif self._tstate == 'Heat':
-                self._target_temperature = self.device.t_heat['raw']
+                target_temp = self.device.t_heat['raw']
+                while target_temp == -1:
+                    _LOGGER.error("Invalid temperature detected, retrying")
+                    target_temp = self.device.t_heat['raw']
+                self._target_temperature = target_temp
             self._current_operation = STATE_AUTO
         else:
             self._current_operation = STATE_IDLE
@@ -200,7 +219,6 @@ class RadioThermostat(ClimateDevice):
 
     def turn_away_mode_on(self):
         """Turn away on.
-
         The RTCOA app simulates away mode by using a hold.
         """
         away_temp = None


### PR DESCRIPTION
## Description: Fixed issue where Radio Thermostat will sometimes return a current temperature or set temperature value of -1

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
