### PR TITLE
Update aiolifx

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -33,7 +33,7 @@ import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['aiolifx==0.5.0', 'aiolifx_effects==0.1.0']
+REQUIREMENTS = ['aiolifx==0.5.2', 'aiolifx_effects==0.1.0']
 
 UDP_BROADCAST_PORT = 56700
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -49,7 +49,7 @@ aiodns==1.1.1
 aiohttp_cors==0.5.3
 
 # homeassistant.components.light.lifx
-aiolifx==0.5.0
+aiolifx==0.5.2
 
 # homeassistant.components.light.lifx
 aiolifx_effects==0.1.0


### PR DESCRIPTION
## Description:

The upcoming LIFX firmware (currently in beta test) has uncovered an aiolifx bug that makes lights completely unusable. This release is fixed.

As the firmware release is imminent, I think this should go into 0.48.2 (if one is made). I am unsure of the process for getting in there. As a start I have set a Milestone.


**Related issue (if applicable):** fixes #8284

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54