### PR TITLE
LIFX: support for multizone

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -155,6 +155,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     return True
 
 
+def lifxwhite(device):
+    """Return whether this is a white-only bulb."""
+    return not aiolifx().products.features_map[device.product]["color"]
+
+
 def find_hsbk(**kwargs):
     """Find the desired color from a number of possible inputs."""
     hue, saturation, brightness, kelvin = [None]*4
@@ -381,14 +386,7 @@ class LIFXLight(Light):
         self.device = device
         self.effects_conductor = effects_conductor
         self.registered = True
-        self.product = device.product
         self.postponed_update = None
-
-    @property
-    def lifxwhite(self):
-        """Return whether this is a white-only bulb."""
-        # https://lan.developer.lifx.com/docs/lifx-products
-        return self.product in [10, 11, 18]
 
     @property
     def available(self):
@@ -433,7 +431,7 @@ class LIFXLight(Light):
     def min_mireds(self):
         """Return the coldest color_temp that this light supports."""
         # The 3 LIFX "White" products supported a limited temperature range
-        if self.lifxwhite:
+        if lifxwhite(self.device):
             kelvin = 6500
         else:
             kelvin = 9000
@@ -443,7 +441,7 @@ class LIFXLight(Light):
     def max_mireds(self):
         """Return the warmest color_temp that this light supports."""
         # The 3 LIFX "White" products supported a limited temperature range
-        if self.lifxwhite:
+        if lifxwhite(self.device):
             kelvin = 2700
         else:
             kelvin = 2500
@@ -468,7 +466,7 @@ class LIFXLight(Light):
         features = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP |
                     SUPPORT_TRANSITION | SUPPORT_EFFECT)
 
-        if not self.lifxwhite:
+        if not lifxwhite(self.device):
             features |= SUPPORT_RGB_COLOR | SUPPORT_XY_COLOR
 
         return features
@@ -476,7 +474,7 @@ class LIFXLight(Light):
     @property
     def effect_list(self):
         """Return the list of supported effects for this light."""
-        if self.lifxwhite:
+        if lifxwhite(self.device):
             return [
                 SERVICE_EFFECT_PULSE,
                 SERVICE_EFFECT_STOP,

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -112,11 +112,21 @@ LIFX_EFFECT_STOP_SCHEMA = vol.Schema({
 })
 
 
+def aiolifx():
+    """Return the aiolifx module."""
+    import aiolifx as aiolifx_module
+    return aiolifx_module
+
+
+def aiolifx_effects():
+    """Return the aiolifx_effects module."""
+    import aiolifx_effects as aiolifx_effects_module
+    return aiolifx_effects_module
+
+
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the LIFX platform."""
-    import aiolifx
-
     if sys.platform == 'win32':
         _LOGGER.warning("The lifx platform is known to not work on Windows. "
                         "Consider using the lifx_legacy platform instead")
@@ -124,7 +134,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     server_addr = config.get(CONF_SERVER)
 
     lifx_manager = LIFXManager(hass, async_add_devices)
-    lifx_discovery = aiolifx.LifxDiscovery(
+    lifx_discovery = aiolifx().LifxDiscovery(
         hass.loop,
         lifx_manager,
         discovery_interval=DISCOVERY_INTERVAL,
@@ -187,11 +197,10 @@ class LIFXManager(object):
 
     def __init__(self, hass, async_add_devices):
         """Initialize the light."""
-        import aiolifx_effects
         self.entities = {}
         self.hass = hass
         self.async_add_devices = async_add_devices
-        self.effects_conductor = aiolifx_effects.Conductor(loop=hass.loop)
+        self.effects_conductor = aiolifx_effects().Conductor(loop=hass.loop)
 
         descriptions = load_yaml_config_file(
             path.join(path.dirname(__file__), 'services.yaml'))
@@ -245,11 +254,10 @@ class LIFXManager(object):
     @asyncio.coroutine
     def start_effect(self, entities, service, **kwargs):
         """Start a light effect on entities."""
-        import aiolifx_effects
         devices = list(map(lambda l: l.device, entities))
 
         if service == SERVICE_EFFECT_PULSE:
-            effect = aiolifx_effects.EffectPulse(
+            effect = aiolifx_effects().EffectPulse(
                 power_on=kwargs.get(ATTR_POWER_ON),
                 period=kwargs.get(ATTR_PERIOD),
                 cycles=kwargs.get(ATTR_CYCLES),
@@ -264,7 +272,7 @@ class LIFXManager(object):
             if ATTR_BRIGHTNESS in kwargs:
                 brightness = convert_8_to_16(kwargs[ATTR_BRIGHTNESS])
 
-            effect = aiolifx_effects.EffectColorloop(
+            effect = aiolifx_effects().EffectColorloop(
                 power_on=kwargs.get(ATTR_POWER_ON),
                 period=kwargs.get(ATTR_PERIOD),
                 change=kwargs.get(ATTR_CHANGE),

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -117,6 +117,10 @@ lifx_set_state:
       description: Automatic infrared level (0..255) when light brightness is low
       example: 255
 
+    zones:
+      description: List of zone numbers to affect (8 per LIFX Z, starts at 0)
+      example: '[0,5]'
+
     transition:
       description: Duration in seconds it takes to get to the final state
       example: 10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -52,7 +52,7 @@ aiohttp_cors==0.5.3
 aiolifx==0.5.2
 
 # homeassistant.components.light.lifx
-aiolifx_effects==0.1.0
+aiolifx_effects==0.1.1
 
 # homeassistant.components.scene.hunterdouglas_powerview
 aiopvapi==1.4


### PR DESCRIPTION
## Description:

Support multizone lights like the LIFX Z strip. This is available through `lifx_set_state` and allows setting each zone to a different color/brightness. Unfortunately, I do not see a way to make this work with scenes.

This implementation also fixes an issue where adjusting the brightness in the UI would make all zones the same color.

The first commits rearrange things, making it quite simple to add the multizone support in the final commit.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2804

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  red_white_blue:
    sequence:
      - service: light.lifx_set_state
        data:
          entity_id: light.z
          color_name: 'red'
          brightness_pct: 80
          transition: 10
          zones: [0,3,6]
      - service: light.lifx_set_state
        data:
          entity_id: light.z
          kelvin: 5600
          brightness_pct: 60
          transition: 10
          zones: [1,4,7]
      - service: light.lifx_set_state
        data:
          entity_id: light.z
          color_name: 'blue'
          brightness_pct: 80
          transition: 10
          zones: [2,5]
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running`script/gen_requirements_all.py`.
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54