### PR TITLE
optimistic mode for template covers (w/o timed movement)

### DIFF
--- a/homeassistant/components/cover/template.py
+++ b/homeassistant/components/cover/template.py
@@ -266,10 +266,9 @@ class CoverTemplate(CoverDevice):
     def async_open_cover(self, **kwargs):
         """Move the cover up."""
         if self._open_script:
-            self.hass.async_add_job(self._open_script.async_run())
+            yield from self._open_script.async_run()
         elif self._position_script:
-            self.hass.async_add_job(self._position_script.async_run(
-                {"position": 100}))
+            yield from self._position_script.async_run({"position": 100})
         if self._optimistic:
             self._position = 100
             self.hass.async_add_job(self.async_update_ha_state())
@@ -278,10 +277,9 @@ class CoverTemplate(CoverDevice):
     def async_close_cover(self, **kwargs):
         """Move the cover down."""
         if self._close_script:
-            self.hass.async_add_job(self._close_script.async_run())
+            yield from self._close_script.async_run()
         elif self._position_script:
-            self.hass.async_add_job(self._position_script.async_run(
-                {"position": 0}))
+            yield from self._position_script.async_run({"position": 0})
         if self._optimistic:
             self._position = 0
             self.hass.async_add_job(self.async_update_ha_state())
@@ -296,8 +294,8 @@ class CoverTemplate(CoverDevice):
     def async_set_cover_position(self, **kwargs):
         """Set cover position."""
         self._position = kwargs[ATTR_POSITION]
-        self.hass.async_add_job(self._position_script.async_run(
-            {"position": self._position}))
+        yield from self._position_script.async_run(
+            {"position": self._position})
         if self._optimistic:
             self.hass.async_add_job(self.async_update_ha_state())
 
@@ -305,8 +303,7 @@ class CoverTemplate(CoverDevice):
     def async_open_cover_tilt(self, **kwargs):
         """Tilt the cover open."""
         self._tilt_value = 100
-        self.hass.async_add_job(self._tilt_script.async_run(
-            {"tilt": self._tilt_value}))
+        yield from self._tilt_script.async_run({"tilt": self._tilt_value})
         if self._tilt_optimistic:
             self.hass.async_add_job(self.async_update_ha_state())
 
@@ -314,8 +311,8 @@ class CoverTemplate(CoverDevice):
     def async_close_cover_tilt(self, **kwargs):
         """Tilt the cover closed."""
         self._tilt_value = 0
-        self.hass.async_add_job(self._tilt_script.async_run(
-            {"tilt": self._tilt_value}))
+        yield from self._tilt_script.async_run(
+            {"tilt": self._tilt_value})
         if self._tilt_optimistic:
             self.hass.async_add_job(self.async_update_ha_state())
 
@@ -323,8 +320,7 @@ class CoverTemplate(CoverDevice):
     def async_set_cover_tilt_position(self, **kwargs):
         """Move the cover tilt to a specific position."""
         self._tilt_value = kwargs[ATTR_TILT_POSITION]
-        self.hass.async_add_job(self._tilt_script.async_run(
-            {"tilt": self._tilt_value}))
+        yield from self._tilt_script.async_run({"tilt": self._tilt_value})
         if self._tilt_optimistic:
             self.hass.async_add_job(self.async_update_ha_state())
 

--- a/homeassistant/components/cover/template.py
+++ b/homeassistant/components/cover/template.py
@@ -174,8 +174,8 @@ class CoverTemplate(CoverDevice):
                             (not state_template and not position_template))
         self._tilt_optimistic = tilt_optimistic or not tilt_template
         self._icon = None
-        self._position = 0
-        self._tilt_value = 0
+        self._position = None
+        self._tilt_value = None
         self._entities = entity_ids
 
         if self._template is not None:

--- a/tests/components/cover/test_template.py
+++ b/tests/components/cover/test_template.py
@@ -583,7 +583,7 @@ class TestTemplateCover(unittest.TestCase):
         self.hass.block_till_done()
 
         state = self.hass.states.get('cover.test_template_cover')
-        assert state.attributes.get('current_position') == 0.0
+        assert state.attributes.get('current_position') is None
 
         cover.set_cover_position(self.hass, 42,
                                  'cover.test_template_cover')
@@ -625,7 +625,7 @@ class TestTemplateCover(unittest.TestCase):
         self.hass.block_till_done()
 
         state = self.hass.states.get('cover.test_template_cover')
-        assert state.attributes.get('current_tilt_position') == 0.0
+        assert state.attributes.get('current_tilt_position') is None
 
         cover.set_cover_tilt_position(self.hass, 42,
                                       'cover.test_template_cover')


### PR DESCRIPTION
## Description:
This pull request implements 2 new capabilities:
~~1) timed movement, allowing the template cover to emulate a proportional position by sending an open/close followed by a stop command at the appropriate time~~
2) optimistic mode allows maintaining an internal state of the cover position without relying on external factors 

This was discussed here:
https://community.home-assistant.io/t/template-cover/11141/3


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2948

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  - platform: template
    covers:
     timedcover:
        friendly_name: 'Timed Cover'
        open_cover:
          service: switch.turn_on
          entity_id: switch.open
        close_cover:
          service: switch.turn_off
          entity_id: switch.close
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

