### PR TITLE
Define the turn on/off action for media player Kodi with scripts

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -596,7 +596,8 @@ class KodiDevice(MediaPlayerDevice):
         if self._turn_on_action == 'script':
             _LOGGER.info('Turn on script %s', self._script_on)
             yield from self.hass.async_add_job(
-                partial(self.hass.services.call, *self._script_on.split('.')))
+                partial(self.hass.services.call,
+                        *self._script_on.split('.')))
         elif self._turn_on_action == WAKE_ON_LAN:
             if self._mac:
                 service_data = {'mac': self._mac}
@@ -630,7 +631,8 @@ class KodiDevice(MediaPlayerDevice):
         elif self._turn_off_action == 'script':
             _LOGGER.info('Turn off script %s', self._script_off)
             yield from self.hass.async_add_job(
-                partial(self.hass.services.call, *self._script_on.split('.')))
+                partial(self.hass.services.call,
+                        *self._script_off.split('.')))
         else:
             _LOGGER.warning("turn_off requested but turn_off_action is none")
 


### PR DESCRIPTION
## Description:

Support for generic Home Assistant **script sequences** to be defined as `turn_on_action` and `turn_off_action` parameters for the **media player Kodi**.

## Example entry for `configuration.yaml`:

```yaml
media_player:
- platform: kodi
  host: 192.168.1.XX
  turn_on_action:
    - service: wake_on_lan.send_magic_packet
      data:
        mac: B8:27:EB:BD:A4:28
        broadcast_address: 192.168.255.255
    - service: persistent_notification.create
      data:
        message: 'Turn on Kodi with Wake On LAN'
  turn_off_action:
    service: python_script.turn_off_kodi
```

For the old way of defining the `turn_off_action` (`quit`, `hibernate`, `suspend`, `reboot`, and `shutdown`), a conversion to the script method is performed, and a deprecation warning is logged.

```yaml
# Equivalent to `turn_off_action: quit`
  turn_off_action:
    service: media_player.kodi_call_method
    data:
      entity_id: media_player.kodi
      method: Application.Quit
```

~~Add **turn_on** and **turn_off** actions to the **media player Kodi** to be able to:~~
~~- Wake on LAN a device with `media_player/turn_on`.~~
~~- Run a `script` or a `python_script` with `media_player/turn_on` or `media_player/turn_off`.~~


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2951


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

## More info

This PR is related to the previous work of @Tadly  in #8240, but with the new approach discussed there, with a new component `wake_on_lan` (proposed in #8397) which is called from Kodi.

~~Because it relies on the `wake_on_lan` component, which is not merged at this time, it can't work now (_ImportErrors_). If #8397 is not accepted, I will change this accordingly.~~

**The final approach has been to add the `turn_on_action` and `turn_off_action` as generic script sequences, deprecating the old turn off options list.**
