### PR TITLE
Marrantz SR5006 & SR5006 treated as AVR-X device | Fixed Mapping of M…

### DIFF
--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_ON, CONF_ZONE)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['denonavr==0.5.1']
+REQUIREMENTS = ['denonavr==0.5.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -148,7 +148,7 @@ datapoint==0.4.3
 # decora==0.6
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.5.1
+denonavr==0.5.2
 
 # homeassistant.components.media_player.directv
 directpy==0.1


### PR DESCRIPTION
…edia Player and AUX input functions

## Description:
- Marrantz SR5006 & SR5006 treated as AVR-X device
- Fixed Mapping of Media Player and AUX input functions

**Related issue (if applicable):** fixes #6011 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
