### PR TITLE
Fix is_allowed_path for symlinks

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 from distutils.version import LooseVersion  # pylint: disable=import-error
 import logging
 import os
-import pathlib
 import re
 import shutil
 import sys
@@ -379,7 +378,7 @@ def async_process_ha_core_config(hass, config):
     hac.whitelist_external_dirs = {hass.config.path('www')}
     if CONF_WHITELIST_EXTERNAL_DIRS in config:
         hac.whitelist_external_dirs.update(set(
-            pathlib.Path(ext_dir).resolve() for ext_dir
+            os.path.abspath(ext_dir) for ext_dir
             in config[CONF_WHITELIST_EXTERNAL_DIRS]))
 
     # Customize

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -377,8 +377,10 @@ def async_process_ha_core_config(hass, config):
     # init whitelist external dir
     hac.whitelist_external_dirs = set((hass.config.path('www'),))
     if CONF_WHITELIST_EXTERNAL_DIRS in config:
-        hac.whitelist_external_dirs.update(
-            set(config[CONF_WHITELIST_EXTERNAL_DIRS]))
+        dirs = config[CONF_WHITELIST_EXTERNAL_DIRS]
+        import pathlib
+        dirs = map(lambda d: pathlib.Path(d).resolve(), dirs)
+        hac.whitelist_external_dirs.update(set(dirs))
 
     # Customize
     cust_exact = dict(config[CONF_CUSTOMIZE])

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -376,11 +376,11 @@ def async_process_ha_core_config(hass, config):
         set_time_zone(config.get(CONF_TIME_ZONE))
 
     # init whitelist external dir
-    hac.whitelist_external_dirs = set((hass.config.path('www'),))
+    hac.whitelist_external_dirs = {hass.config.path('www')}
     if CONF_WHITELIST_EXTERNAL_DIRS in config:
-        dirs = config[CONF_WHITELIST_EXTERNAL_DIRS]
-        dirs = map(lambda d: pathlib.Path(d).resolve(), dirs)
-        hac.whitelist_external_dirs.update(set(dirs))
+        hac.whitelist_external_dirs.update(set(
+            pathlib.Path(ext_dir).resolve() for ext_dir
+            in config[CONF_WHITELIST_EXTERNAL_DIRS]))
 
     # Customize
     cust_exact = dict(config[CONF_CUSTOMIZE])

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from distutils.version import LooseVersion  # pylint: disable=import-error
 import logging
 import os
+import pathlib
 import re
 import shutil
 import sys
@@ -378,7 +379,6 @@ def async_process_ha_core_config(hass, config):
     hac.whitelist_external_dirs = set((hass.config.path('www'),))
     if CONF_WHITELIST_EXTERNAL_DIRS in config:
         dirs = config[CONF_WHITELIST_EXTERNAL_DIRS]
-        import pathlib
         dirs = map(lambda d: pathlib.Path(d).resolve(), dirs)
         hac.whitelist_external_dirs.update(set(dirs))
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1081,13 +1081,13 @@ class Config(object):
         """Check if the path is valid for access from outside."""
         parent = pathlib.Path(path).parent
         try:
-            parent = parent.resolve()  # pylint: disable=no-member
+            parent = os.path.abspath(parent)  # pylint: disable=no-member
         except (FileNotFoundError, RuntimeError, PermissionError):
             return False
 
         for whitelisted_path in self.whitelist_external_dirs:
             try:
-                parent.relative_to(whitelisted_path)
+                pathlib.Path(parent).relative_to(whitelisted_path)
                 return True
             except ValueError:
                 pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,6 @@
 # pylint: disable=protected-access
 import asyncio
 import os
-import pathlib
 import unittest
 import unittest.mock as mock
 from collections import OrderedDict
@@ -398,7 +397,7 @@ class TestConfig(unittest.TestCase):
         assert self.hass.config.time_zone.zone == 'America/New_York'
         assert len(self.hass.config.whitelist_external_dirs) == 2
 
-        expected_path = pathlib.Path('/tmp').resolve()
+        expected_path = os.path.abspath('/tmp')
         assert expected_path in self.hass.config.whitelist_external_dirs
 
     def test_loading_configuration_temperature_unit(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 import asyncio
 import os
+import pathlib
 import unittest
 import unittest.mock as mock
 from collections import OrderedDict
@@ -397,7 +398,6 @@ class TestConfig(unittest.TestCase):
         assert self.hass.config.time_zone.zone == 'America/New_York'
         assert len(self.hass.config.whitelist_external_dirs) == 2
 
-        import pathlib
         expected_path = pathlib.Path('/tmp').resolve()
         assert expected_path in self.hass.config.whitelist_external_dirs
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -396,7 +396,10 @@ class TestConfig(unittest.TestCase):
         assert self.hass.config.units.name == CONF_UNIT_SYSTEM_IMPERIAL
         assert self.hass.config.time_zone.zone == 'America/New_York'
         assert len(self.hass.config.whitelist_external_dirs) == 2
-        assert '/tmp' in self.hass.config.whitelist_external_dirs
+
+        import pathlib
+        expected_path = pathlib.Path('/tmp').resolve()
+        assert expected_path in self.hass.config.whitelist_external_dirs
 
     def test_loading_configuration_temperature_unit(self):
         """Test backward compatibility when loading core config."""


### PR DESCRIPTION
Whitelisted directories that are symlinked fail the `is_allowed_path` check because the configured directories are not `Path#resolve`d while those evaluated in `is_allowed_path are`. This change solves the problem by using `os.path.abspath`, as recommended by @pvizeli.

- _init whitelist external dir_: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/config.py#L373-L377
- `is_allowed_path`: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/core.py#L1078-L1093