### PR TITLE
Wemo multi take2

### DIFF
--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -74,7 +74,7 @@ class WemoSwitch(SwitchDevice):
     @property
     def should_poll(self):
         """No polling needed with subscriptions."""
-        if self._model_name == 'Insight':
+        if self._model_name in ['Insight', 'DLI emulated Belkin Socket']:
             return True
         return False
 

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -26,7 +26,8 @@ WEMO_MODEL_DISPATCH = {
     'Sensor':  'binary_sensor',
     'Socket':  'switch',
     'LightSwitch': 'switch',
-    'CoffeeMaker': 'switch'
+    'CoffeeMaker': 'switch',
+    'DLI emulated Belkin Socket': 'switch'
 }
 
 SUBSCRIPTION_REGISTRY = None

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -86,15 +86,22 @@ def setup(hass, config):
                    for address in config.get(DOMAIN, {}).get(CONF_STATIC, []))
 
     for address, device in devices:
-        port = pywemo.ouimeaux_device.probe_wemo(address)
-        if not port:
-            _LOGGER.warning('Unable to probe wemo at %s', address)
-            continue
-        _LOGGER.info('Adding wemo at %s:%i', address, port)
-
-        url = 'http://%s:%i/setup.xml' % (address, port)
+        # statically configured wemos need to be probed to get information
+        # about the device
         if device is None:
+            port = pywemo.ouimeaux_device.probe_wemo(address)
+            if not port:
+                _LOGGER.warning('Unable to probe wemo at %s', address)
+                continue
+            _LOGGER.info('Adding wemo at %s:%i', address, port)
+
+            url = 'http://%s:%i/setup.xml' % (address, port)
+
             device = pywemo.discovery.device_from_description(url, None)
+        else:
+            _LOGGER.info('Adding wemo at %s', device.basicevent.hostname)
+
+            url = 'http://%s/setup.xml' % (device.basicevent.hostname)
 
         discovery_info = {
             'model_name': device.model_name,


### PR DESCRIPTION
## Description:
The newest digital loggers web based switches https://www.digital-loggers.com/pro.html present themselves as a emulated wemo device. they offer all 8 ports on a single IP with each socket on a different tcp port.

This is a different approach to supporting the same functionality as in #8307 it does not require any changes in pywemo. however with this approach the DLI devices can not be reprobed I do feel that there is still a lot of value for the change in https://github.com/pavoni/pywemo/pull/78 as it will provide an extra safety valve

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>


## Checklist:



If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**