### PR TITLE
Make gzips reproducible by excluding timestamp

### DIFF
--- a/script/build_frontend
+++ b/script/build_frontend
@@ -24,7 +24,7 @@ cp build/service_worker.js ..
 cd ..
 
 # Pack frontend
-gzip -f -k -9 *.html *.js ./panels/*.html
+gzip -f -n -k -9 *.html *.js ./panels/*.html
 cd ../../../..
 
 # Generate the MD5 hash of the new frontend


### PR DESCRIPTION
## Description:
Currently, gzip includes the timestamp in the file header, resulting in a different binary every time `script/build_frontend` is run. This change removes the timestamp from the gzip output, making the zip process reproducible.

See: https://wiki.debian.org/ReproducibleBuilds/TimestampsInGzipHeaders
