### PR TITLE
Closes #7749. Bumped phue library dependency to v1.0

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -27,7 +27,7 @@ from homeassistant.loader import get_component
 from homeassistant.components.emulated_hue import ATTR_EMULATED_HUE
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['phue==0.9']
+REQUIREMENTS = ['phue==1.0']
 
 # Track previously setup bridges
 _CONFIGURED_BRIDGES = {}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -49,7 +49,7 @@ aiodns==1.1.1
 aiohttp_cors==0.5.3
 
 # homeassistant.components.light.lifx
-aiolifx==0.5.2
+aiolifx==0.5.0
 
 # homeassistant.components.light.lifx
 aiolifx_effects==0.1.0
@@ -68,13 +68,13 @@ amcrest==1.2.0
 anthemav==1.1.8
 
 # homeassistant.components.apcupsd
-apcaccess==0.0.13
+apcaccess==0.0.10
 
 # homeassistant.components.notify.apns
 apns2==0.1.1
 
 # homeassistant.components.light.avion
-# avion==0.7
+# avion==0.6
 
 # homeassistant.components.axis
 axis==8
@@ -118,8 +118,7 @@ boto3==1.4.3
 broadlink==0.3
 
 # homeassistant.components.sensor.buienradar
-# homeassistant.components.weather.buienradar
-buienradar==0.7
+buienradar==0.6
 
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2
@@ -148,13 +147,13 @@ datapoint==0.4.3
 # decora==0.6
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.5.2
+denonavr==0.5.1
 
 # homeassistant.components.media_player.directv
 directpy==0.1
 
 # homeassistant.components.notify.discord
-discord.py==0.16.8
+discord.py==0.16.0
 
 # homeassistant.components.updater
 distro==1.0.4
@@ -192,7 +191,7 @@ evohomeclient==0.2.5
 
 # homeassistant.components.image_processing.dlib_face_detect
 # homeassistant.components.image_processing.dlib_face_identify
-# face_recognition==0.2.0
+# face_recognition==0.1.14
 
 # homeassistant.components.sensor.fastdotcom
 fastdotcom==0.0.1
@@ -310,6 +309,9 @@ https://github.com/soldag/pyflic/archive/0.4.zip#pyflic==0.4
 # homeassistant.components.light.osramlightify
 https://github.com/tfriedel/python-lightify/archive/1bb1db0e7bd5b14304d7bb267e2398cd5160df46.zip#lightify==1.0.5
 
+# homeassistant.components.tado
+https://github.com/wmalgadey/PyTado/archive/0.2.1.zip#PyTado==0.2.1
+
 # homeassistant.components.media_player.lg_netcast
 https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 
@@ -342,19 +344,19 @@ jsonrpc-websocket==0.5
 keyring>=9.3,<10.0
 
 # homeassistant.components.knx
-knxip==0.4
+knxip==0.3.3
 
 # homeassistant.components.device_tracker.owntracks
 libnacl==1.5.1
 
 # homeassistant.components.dyson
-libpurecoollink==0.2.0
+libpurecoollink==0.1.5
 
 # homeassistant.components.device_tracker.mikrotik
 librouteros==1.0.2
 
 # homeassistant.components.media_player.soundtouch
-libsoundtouch==0.7.2
+libsoundtouch==0.6.2
 
 # homeassistant.components.light.lifx_legacy
 liffylights==0.9.4
@@ -364,10 +366,6 @@ limitlessled==1.0.8
 
 # homeassistant.components.media_player.liveboxplaytv
 liveboxplaytv==1.4.9
-
-# homeassistant.components.lametric
-# homeassistant.components.notify.lametric
-lmnotify==0.0.4
 
 # homeassistant.components.sensor.lyft
 lyft_rides==0.1.0b0
@@ -489,6 +487,9 @@ pushbullet.py==0.10.0
 # homeassistant.components.notify.pushetta
 pushetta==1.0.15
 
+# homeassistant.components.sensor.waqi
+pwaqi==3.0
+
 # homeassistant.components.light.rpi_gpio_pwm
 pwmled==1.1.1
 
@@ -516,8 +517,8 @@ pyasn1-modules==0.0.9
 # homeassistant.components.notify.xmpp
 pyasn1==0.2.3
 
-# homeassistant.components.apple_tv
-pyatv==0.3.2
+# homeassistant.components.media_player.apple_tv
+pyatv==0.2.1
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox
@@ -551,7 +552,7 @@ pyebox==0.1.0
 pyeight==0.0.7
 
 # homeassistant.components.media_player.emby
-pyemby==1.4
+pyemby==1.3
 
 # homeassistant.components.envisalink
 pyenvisalink==2.1
@@ -572,7 +573,7 @@ pygatt==3.1.1
 pyharmony==1.0.16
 
 # homeassistant.components.binary_sensor.hikvision
-pyhik==0.1.3
+pyhik==0.1.2
 
 # homeassistant.components.homematic
 pyhomematic==0.1.28
@@ -621,7 +622,7 @@ pymailgunner==1.4
 pymochad==0.1.1
 
 # homeassistant.components.modbus
-pymodbus==1.3.1
+pymodbus==1.3.0rc1
 
 # homeassistant.components.cover.myq
 pymyq==0.0.8
@@ -645,12 +646,9 @@ pynut2==2.1.2
 # homeassistant.components.binary_sensor.nx584
 pynx584==0.4
 
-# homeassistant.components.sensor.otp
-pyotp==2.2.6
-
 # homeassistant.components.sensor.openweathermap
 # homeassistant.components.weather.openweathermap
-pyowm==2.7.1
+pyowm==2.6.1
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.4
@@ -709,9 +707,6 @@ python-juicenet==0.0.5
 # homeassistant.components.lirc
 # python-lirc==1.2.3
 
-# homeassistant.components.switch.xiaomi_vacuum
-python-mirobo==0.0.8
-
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5
 
@@ -736,9 +731,6 @@ python-roku==3.1.3
 
 # homeassistant.components.sensor.synologydsm
 python-synology==0.1.0
-
-# homeassistant.components.tado
-python-tado==0.2.2
 
 # homeassistant.components.telegram_bot
 python-telegram-bot==6.1.0
@@ -769,9 +761,6 @@ pyunifi==2.13
 
 # homeassistant.components.vera
 pyvera==0.2.33
-
-# homeassistant.components.velux
-pyvlx==0.1.3
 
 # homeassistant.components.notify.html5
 pywebpush==1.0.5
@@ -891,7 +880,7 @@ thingspeak==0.4.1
 tikteck==0.4
 
 # homeassistant.components.alarm_control_panel.totalconnect
-total_connect_client==0.11
+total_connect_client==0.7
 
 # homeassistant.components.sensor.transmission
 # homeassistant.components.switch.transmission
@@ -913,7 +902,7 @@ uvcclient==0.10.0
 volvooncall==0.3.3
 
 # homeassistant.components.verisure
-vsure==1.3.7
+vsure==1.3.6
 
 # homeassistant.components.sensor.vasttrafik
 vtjp==0.1.14
@@ -923,9 +912,6 @@ vtjp==0.1.14
 # homeassistant.components.media_player.webostv
 # homeassistant.components.switch.wake_on_lan
 wakeonlan==0.2.2
-
-# homeassistant.components.sensor.waqi
-waqiasync==1.0.0
 
 # homeassistant.components.media_player.gpmdp
 websocket-client==0.37.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -62,10 +62,10 @@ holidays==0.8.1
 influxdb==3.0.0
 
 # homeassistant.components.dyson
-libpurecoollink==0.2.0
+libpurecoollink==0.1.5
 
 # homeassistant.components.media_player.soundtouch
-libsoundtouch==0.7.2
+libsoundtouch==0.6.2
 
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #7749

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
