### PR TITLE
Fix KeyError (fixes #3721, fixes #7241)

### DIFF
--- a/homeassistant/components/sensor/uber.py
+++ b/homeassistant/components/sensor/uber.py
@@ -9,10 +9,10 @@ from datetime import timedelta
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['uber_rides==0.4.1']
 
@@ -35,8 +35,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_START_LONGITUDE): cv.longitude,
     vol.Optional(CONF_END_LATITUDE): cv.latitude,
     vol.Optional(CONF_END_LONGITUDE): cv.longitude,
-    vol.Optional(CONF_PRODUCT_IDS):
-        vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_PRODUCT_IDS): vol.All(cv.ensure_list, [cv.string]),
 })
 
 
@@ -57,11 +56,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
            (product_id not in wanted_product_ids):
             continue
         dev.append(UberSensor('time', timeandpriceest, product_id, product))
-        if (product.get('price_details') is not None) and \
-           product['price_details']['estimate'] != 'Metered':
+        if product.get('price_details') is not None:
             dev.append(UberSensor(
                 'price', timeandpriceest, product_id, product))
-    add_devices(dev)
+
+    add_devices(dev, True)
 
 
 class UberSensor(Entity):
@@ -73,8 +72,8 @@ class UberSensor(Entity):
         self._product_id = product_id
         self._product = product
         self._sensortype = sensorType
-        self._name = '{} {}'.format(self._product['display_name'],
-                                    self._sensortype)
+        self._name = '{} {}'.format(
+            self._product['display_name'], self._sensortype)
         if self._sensortype == 'time':
             self._unit_of_measurement = 'min'
             time_estimate = self._product.get('time_estimate_seconds', 0)
@@ -90,7 +89,6 @@ class UberSensor(Entity):
                 self._state = int(price_details.get(statekey, 0))
             else:
                 self._state = 0
-        self.update()
 
     @property
     def name(self):
@@ -214,8 +212,8 @@ class UberEstimate(object):
                 if product.get('price_details') is None:
                     price_details = {}
                 price_details['estimate'] = price.get('estimate', '0')
-                price_details['high_estimate'] = price.get('high_estimate',
-                                                           '0')
+                price_details['high_estimate'] = price.get(
+                    'high_estimate', '0')
                 price_details['low_estimate'] = price.get('low_estimate', '0')
                 price_details['currency_code'] = price.get('currency_code')
                 surge_multiplier = price.get('surge_multiplier', '0')


### PR DESCRIPTION
## Description:
'Metered' doesn't seem to be used any more and the KeyError for 'estimate' prevents the sensors from loading.

**Related issue (if applicable):** fixes #3721, #7241

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
# Melborne
  - platform: uber
    server_token: !secret uber_api
    start_latitude: -37.8136
    start_longitude: 144.9631
# Paris
  - platform: uber
    server_token: !secret uber_api
    start_latitude: 48.8459759
    start_longitude: 2.3707804
#    end_latitude: 48.8630169
#    end_longitude: 2.3763798
# Los Angeles
  - platform: uber
    server_token: !secret uber_api
    start_latitude: 34.0418343
    start_longitude: -118.2550553
#    end_latitude: 34.0182377
#    end_longitude: -118.2856994
# New York
  - platform: uber
    server_token: !secret uber_api
    start_latitude: 40.7274342
    start_longitude: -73.9937903
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
