### PR TITLE
bump python-mirobo requirement to support newer firmwares and more

### DIFF
--- a/homeassistant/components/switch/xiaomi_vacuum.py
+++ b/homeassistant/components/switch/xiaomi_vacuum.py
@@ -22,7 +22,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-mirobo==0.0.8']
+REQUIREMENTS = ['python-mirobo==0.1.1']
 
 
 # pylint: disable=unused-argument

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -710,7 +710,7 @@ python-juicenet==0.0.5
 # python-lirc==1.2.3
 
 # homeassistant.components.switch.xiaomi_vacuum
-python-mirobo==0.0.8
+python-mirobo==0.1.1
 
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5


### PR DESCRIPTION
## Description:
This commit just bumps to the new upstream version of python-mirobo to support xiaomi vacuums with newer firmware images (and upcoming remote controls).


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
