### PR TITLE
Fix typo (sending USERNAME instead of PASSWORD) introduced in #7963

### DIFF
--- a/homeassistant/components/lutron.py
+++ b/homeassistant/components/lutron.py
@@ -41,7 +41,7 @@ def setup(hass, base_config):
 
     config = base_config.get(DOMAIN)
     hass.data[LUTRON_CONTROLLER] = Lutron(
-        config[CONF_HOST], config[CONF_USERNAME], config[CONF_USERNAME])
+        config[CONF_HOST], config[CONF_USERNAME], config[CONF_PASSWORD])
 
     hass.data[LUTRON_CONTROLLER].load_xml_db()
     hass.data[LUTRON_CONTROLLER].connect()


### PR DESCRIPTION
## Description:
In the configuration check cleanup in #7963, the username was accidentally sent twice.

**Related issue (if applicable):** fixes #8165