### PR TITLE
Add Intent component

### DIFF
--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -218,10 +218,12 @@ class AlexaResponse(object):
         self.session_attributes = {}
         self.should_end_session = True
         self.variables = {}
-        for key, value in intent_info.get('slots', {}).items():
-            if 'value' in value:
-                underscored_key = key.replace('.', '_')
-                self.variables[underscored_key] = value['value']
+        # Intent is None if request was a LaunchRequest or SessionEndedRequest
+        if intent_info is not None:
+            for key, value in intent_info.get('slots', {}).items():
+                if 'value' in value:
+                    underscored_key = key.replace('.', '_')
+                    self.variables[underscored_key] = value['value']
 
     def add_card(self, card_type, title, content):
         """Add a card to the response."""

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -110,7 +110,7 @@ def async_setup(hass, config):
 
 
 def _create_matcher(utterance):
-    """Creates a regex that matches the utterance."""
+    """Create a regex that matches the utterance."""
     parts = re.split(r'({\w+})', utterance)
     group_matcher = re.compile(r'{(\w+)}')
 

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -31,7 +31,7 @@ SERVICE_PROCESS_SCHEMA = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({
-    vol.Optional('intents', default={}): vol.Schema({
+    vol.Optional('intents'): vol.Schema({
         cv.string: vol.All(cv.ensure_list, [cv.string])
     })
 })}, extra=vol.ALLOW_EXTRA)
@@ -47,7 +47,7 @@ def async_setup(hass, config):
 
     intents = {
         intent: [_create_matcher(sentence) for sentence in sentences]
-        for intent, sentences in config['intents'].items()
+        for intent, sentences in config.get('intents', {}).items()
     }
 
     @asyncio.coroutine

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -14,12 +14,10 @@ import voluptuous as vol
 from homeassistant import core
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON)
-import homeassistant.helpers.config_validation as cv
-from homeassistant import loader
+from homeassistant.helpers import intent, config_validation as cv
 
 
 REQUIREMENTS = ['fuzzywuzzy==0.15.0']
-DEPENDENCIES = ['intent']
 
 ATTR_TEXT = 'text'
 DOMAIN = 'conversation'
@@ -66,7 +64,7 @@ def async_setup(hass, config):
                 if not match:
                     continue
 
-                yield from loader.get_component('intent').async_handle(
+                yield from intent.async_handle(
                     hass, DOMAIN, intent_type,
                     {key: {'value': value} for key, value
                      in match.groupdict().items()}, text)

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -18,6 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 
 REQUIREMENTS = ['fuzzywuzzy==0.15.0']
+DEPENDENCIES = ['intent']
 
 ATTR_TEXT = 'text'
 DOMAIN = 'conversation'

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -12,6 +12,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.config import find_config_file, load_yaml_config_file
 from homeassistant.const import CONF_NAME, EVENT_THEMES_UPDATED
 from homeassistant.core import callback
+from homeassistant.loader import bind_hass
 from homeassistant.components import api
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.auth import is_trusted_ip
@@ -75,6 +76,7 @@ SERVICE_SET_THEME_SCHEMA = vol.Schema({
 })
 
 
+@bind_hass
 def register_built_in_panel(hass, component_name, sidebar_title=None,
                             sidebar_icon=None, url_path=None, config=None):
     """Register a built-in panel."""
@@ -96,6 +98,7 @@ def register_built_in_panel(hass, component_name, sidebar_title=None,
                    sidebar_icon, url_path, url, config)
 
 
+@bind_hass
 def register_panel(hass, component_name, path, md5=None, sidebar_title=None,
                    sidebar_icon=None, url_path=None, url=None, config=None):
     """Register a panel for the frontend.

--- a/homeassistant/components/intent.py
+++ b/homeassistant/components/intent.py
@@ -1,0 +1,172 @@
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+
+
+DOMAIN = 'intent'
+_LOGGER = logging.getLogger(__name__)
+
+SLOT_SCHEMA = vol.Schema({
+    vol.Optional('type'): str,
+})
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Setup intent."""
+    hass.intent = IntentRegistry(hass)
+    return True
+
+
+class IntentError(HomeAssistantError):
+    """Base class for intent related errors."""
+
+    pass
+
+
+class UnknownIntent(IntentError):
+    """When the intent is not registered."""
+
+    pass
+
+
+class InvalidSlotInfo(IntentError):
+    """When the slot data is invalid."""
+
+    pass
+
+
+class IntentHandleError(IntentError):
+    """Error while handling intent."""
+
+    pass
+
+
+class IntentHandler:
+    """Intent handler registration."""
+
+    intent_type = None
+    slot_schema = None
+    _slot_schema = None
+    platforms = None
+
+    @callback
+    def async_can_handle(self, intent):
+        """Test if an intent can be handled."""
+        return self.platforms is None or intent.platform in self.platforms
+
+    @callback
+    def async_validate_slots(self, slots):
+        """Validate slot information."""
+        if self.slot_schema is None:
+            return slots
+
+        if self._slot_schema is None:
+            self._slot_schema = vol.Schema({
+                key: SLOT_SCHEMA.extend({'value': validator})
+                for key, validator in self.slot_schema.items()})
+
+        return self._slot_schema(slots)
+
+    @asyncio.coroutine
+    def async_handle(self, intent):
+        """Handle the intent."""
+        raise NotImplementedError()
+
+    def __repr__(self):
+        return '<{} - {}>'.format(self.__class__.__name__, self.intent_type)
+
+
+class Intent:
+    """Hold the intent."""
+
+    __slots__ = ['hass', 'platform', 'intent_type', 'slots', 'text_input']
+
+    def __init__(self, hass, platform, intent_type, slots, text_input):
+        """Initialize an intent."""
+        self.hass = hass
+        self.platform = platform
+        self.intent_type = intent_type
+        self.slots = slots
+        self.text_input = text_input
+
+    @callback
+    def create_response(self):
+        """Create a response."""
+        return IntentResponse(self)
+
+
+class IntentResponse:
+    """Response to an intent."""
+
+    def __init__(self, intent):
+        """Initialize an IntentResponse."""
+        self.intent = intent
+        self.speech = {}
+        self.card = {}
+
+    @callback
+    def async_set_speech(self, speech, speech_type='plain', extra_data=None):
+        """Set speech response."""
+        self.speech[speech_type] = {
+            'speech': speech,
+            'extra_data': extra_data,
+        }
+
+    @callback
+    def async_set_card(self, title, content, card_type='simple'):
+        """Set speech response."""
+        self.card[card_type] = {
+            'title': title,
+            'content': content,
+        }
+
+    @callback
+    def as_dict(self):
+        """Return a dictionary representation of an intent response."""
+        return {
+            'speech': self.speech,
+            'card': self.card,
+        }
+
+
+class IntentRegistry:
+    """Registry of intent handlers."""
+
+    def __init__(self, hass):
+        """Initialize intent registry."""
+        self.hass = hass
+        self.intents = {}
+
+    @callback
+    def async_register(self, handler):
+        """Register an intent."""
+        if handler.intent_type in self.intents:
+            _LOGGER.warning('Intent %s is being overwritten by %s.',
+                            handler.intent_type, handler)
+            return
+
+        self.intents[handler.intent_type] = handler
+
+    @asyncio.coroutine
+    def async_handle(self, platform, intent_type, slots=None, text_input=None):
+        """Handle an intent."""
+        handler = self.intents.get(intent_type)
+
+        if handler is None:
+            raise UnknownIntent()
+
+        intent = Intent(self.hass, platform, intent_type, slots or {},
+                        text_input)
+
+        try:
+            result = yield from handler.async_handle(intent)
+            return result
+        except vol.Invalid as err:
+            raise InvalidSlotInfo from err
+        except Exception as err:
+            raise IntentHandleError from err

--- a/homeassistant/components/intent.py
+++ b/homeassistant/components/intent.py
@@ -1,3 +1,4 @@
+"""Module to coordinate user intentions."""
 import asyncio
 import logging
 
@@ -78,6 +79,7 @@ class IntentHandler:
         raise NotImplementedError()
 
     def __repr__(self):
+        """String representation of intent handler."""
         return '<{} - {}>'.format(self.__class__.__name__, self.intent_type)
 
 

--- a/homeassistant/components/intent.py
+++ b/homeassistant/components/intent.py
@@ -169,6 +169,7 @@ class IntentRegistry:
                         text_input)
 
         try:
+            _LOGGER.info("Triggering intent handler %s", handler)
             result = yield from handler.async_handle(intent)
             return result
         except vol.Invalid as err:

--- a/homeassistant/components/intent.py
+++ b/homeassistant/components/intent.py
@@ -12,8 +12,7 @@ DOMAIN = 'intent'
 _LOGGER = logging.getLogger(__name__)
 
 SLOT_SCHEMA = vol.Schema({
-    vol.Optional('type'): str,
-})
+}, extra=vol.ALLOW_EXTRA)
 
 SPEECH_TYPE_PLAIN = 'plain'
 SPEECH_TYPE_SSML = 'ssml'

--- a/homeassistant/components/intent.py
+++ b/homeassistant/components/intent.py
@@ -15,6 +15,9 @@ SLOT_SCHEMA = vol.Schema({
     vol.Optional('type'): str,
 })
 
+SPEECH_TYPE_PLAIN = 'plain'
+SPEECH_TYPE_SSML = 'ssml'
+
 
 @asyncio.coroutine
 def async_setup(hass, config):

--- a/homeassistant/components/intent_script.py
+++ b/homeassistant/components/intent_script.py
@@ -1,0 +1,89 @@
+"""Handle intents with scripts."""
+import asyncio
+import copy
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.intent import IntentHandler
+from homeassistant.helpers import template, script, config_validation as cv
+
+DOMAIN = 'intent_script'
+DEPENDENCIES = ['intent']
+
+CONF_INTENTS = 'intents'
+CONF_SPEECH = 'speech'
+
+CONF_ACTION = 'action'
+CONF_CARD = 'card'
+CONF_TYPE = 'type'
+CONF_TITLE = 'title'
+CONF_CONTENT = 'content'
+CONF_TEXT = 'text'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: {
+        cv.string: {
+            vol.Optional(CONF_ACTION): cv.SCRIPT_SCHEMA,
+            vol.Optional(CONF_CARD): {
+                vol.Optional(CONF_TYPE, default='simple'): cv.string,
+                vol.Required(CONF_TITLE): cv.template,
+                vol.Required(CONF_CONTENT): cv.template,
+            },
+            vol.Optional(CONF_SPEECH): {
+                vol.Optional(CONF_TYPE, default='plain'): cv.string,
+                vol.Required(CONF_TEXT): cv.template,
+            }
+        }
+    }
+}, extra=vol.ALLOW_EXTRA)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Activate Alexa component."""
+    intents = copy.deepcopy(config[DOMAIN])
+    template.attach(hass, intents)
+
+    for intent_type, conf in intents.items():
+        if CONF_ACTION in conf:
+            conf[CONF_ACTION] = script.Script(
+                hass, conf[CONF_ACTION],
+                "Intent Script {}".format(intent_type))
+        hass.intent.async_register(ScriptIntentHandler(intent_type, conf))
+
+    return True
+
+
+class ScriptIntentHandler(IntentHandler):
+
+    def __init__(self, intent_type, config):
+        self.intent_type = intent_type
+        self.config = config
+
+    @asyncio.coroutine
+    def async_handle(self, intent):
+        """Handle the intent."""
+        speech = self.config.get(CONF_SPEECH)
+        card = self.config.get(CONF_CARD)
+        action = self.config.get(CONF_ACTION)
+        slots = {key: value['value'] for key, value in intent.slots.items()}
+
+        if action is not None:
+            yield from action.async_run(slots)
+
+        response = intent.create_response()
+
+        if speech is not None:
+            response.async_set_speech(speech[CONF_TEXT].async_render(slots),
+                                      speech[CONF_TYPE])
+
+        if card is not None:
+            response.async_set_card(
+                card[CONF_TITLE].async_render(slots),
+                card[CONF_CONTENT].async_render(slots),
+                card[CONF_TYPE])
+
+        return response

--- a/homeassistant/components/intent_script.py
+++ b/homeassistant/components/intent_script.py
@@ -58,8 +58,10 @@ def async_setup(hass, config):
 
 
 class ScriptIntentHandler(IntentHandler):
+    """Respond to an intent with a script."""
 
     def __init__(self, intent_type, config):
+        """Initialize the script intent handler."""
         self.intent_type = intent_type
         self.config = config
 

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -1,3 +1,4 @@
+"""Component to manage a shoppling list."""
 import asyncio
 import logging
 

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -1,0 +1,62 @@
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.intent import IntentHandler
+import homeassistant.helpers.config_validation as cv
+
+
+DOMAIN = 'shopping_list'
+DEPENDENCIES = ['intent']
+_LOGGER = logging.getLogger(__name__)
+CONFIG_SCHEMA = vol.Schema({DOMAIN: {}}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Initialize the shopping list."""
+    hass.data[DOMAIN] = []
+    hass.intent.async_register(AddItemIntent())
+    hass.intent.async_register(ListTopItemsIntent())
+    return True
+
+
+class AddItemIntent(IntentHandler):
+    """Handle AddItem intents."""
+
+    intent_type = 'ShoppingListAddItem'
+    slot_schema = {
+        'item': cv.string
+    }
+
+    @asyncio.coroutine
+    def async_handle(self, intent):
+        """Handle the intent."""
+        print(intent.slots)
+        slots = self.async_validate_slots(intent.slots)
+        item = slots['item']['value']
+        intent.hass.data[DOMAIN].append(item)
+
+        response = intent.create_response()
+        response.async_set_speech(
+            "I've added {} to your shopping list".format(item))
+        return response
+
+
+class ListTopItemsIntent(IntentHandler):
+    """Handle AddItem intents."""
+
+    intent_type = 'ShoppingListLastItems'
+    slot_schema = {
+        'item': cv.string
+    }
+
+    @asyncio.coroutine
+    def async_handle(self, intent):
+        """Handle the intent."""
+        response = intent.create_response()
+        response.async_set_speech(
+            "These are the top 5 items in your shopping list: {}".format(
+                ', '.join(reversed(intent.hass.data[DOMAIN][-5:]))))
+        return response

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -4,14 +4,17 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 from homeassistant.components.intent import IntentHandler
+from homeassistant.components.http import HomeAssistantView
 import homeassistant.helpers.config_validation as cv
 
 
 DOMAIN = 'shopping_list'
-DEPENDENCIES = ['intent']
+DEPENDENCIES = ['intent', 'http']
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = vol.Schema({DOMAIN: {}}, extra=vol.ALLOW_EXTRA)
+EVENT = 'shopping_list_updated'
 
 
 @asyncio.coroutine
@@ -20,6 +23,7 @@ def async_setup(hass, config):
     hass.data[DOMAIN] = []
     hass.intent.async_register(AddItemIntent())
     hass.intent.async_register(ListTopItemsIntent())
+    hass.http.register_view(ShoppingListView)
     return True
 
 
@@ -34,7 +38,6 @@ class AddItemIntent(IntentHandler):
     @asyncio.coroutine
     def async_handle(self, intent):
         """Handle the intent."""
-        print(intent.slots)
         slots = self.async_validate_slots(intent.slots)
         item = slots['item']['value']
         intent.hass.data[DOMAIN].append(item)
@@ -42,6 +45,7 @@ class AddItemIntent(IntentHandler):
         response = intent.create_response()
         response.async_set_speech(
             "I've added {} to your shopping list".format(item))
+        intent.hass.bus.async_fire(EVENT)
         return response
 
 
@@ -60,4 +64,16 @@ class ListTopItemsIntent(IntentHandler):
         response.async_set_speech(
             "These are the top 5 items in your shopping list: {}".format(
                 ', '.join(reversed(intent.hass.data[DOMAIN][-5:]))))
+        intent.hass.bus.async_fire(EVENT)
         return response
+
+
+class ShoppingListView(HomeAssistantView):
+    """View to retrieve shopping list content."""
+    url = '/api/shopping_list'
+    name = "api:shopping_list"
+
+    @callback
+    def get(self, request):
+        """Retrieve if API is running."""
+        return self.json(request.app['hass'].data[DOMAIN])

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -15,8 +15,8 @@ DEPENDENCIES = ['http']
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = vol.Schema({DOMAIN: {}}, extra=vol.ALLOW_EXTRA)
 EVENT = 'shopping_list_updated'
-INTENT_ADD_ITEM = 'ShoppingListAddItem'
-INTENT_LAST_ITEMS = 'ShoppingListLastItems'
+INTENT_ADD_ITEM = 'HassShoppingListAddItem'
+INTENT_LAST_ITEMS = 'HassShoppingListLastItems'
 
 
 @asyncio.coroutine

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -32,6 +32,8 @@ def async_setup(hass, config):
     hass.components.conversation.async_register(INTENT_LAST_ITEMS, [
         'What is on my shopping list'
     ])
+    hass.components.frontend.register_built_in_panel(
+        'shopping-list', 'Shopping List', 'mdi:cart')
     return True
 
 

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -15,6 +15,8 @@ DEPENDENCIES = ['http']
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = vol.Schema({DOMAIN: {}}, extra=vol.ALLOW_EXTRA)
 EVENT = 'shopping_list_updated'
+INTENT_ADD_ITEM = 'ShoppingListAddItem'
+INTENT_LAST_ITEMS = 'ShoppingListLastItems'
 
 
 @asyncio.coroutine
@@ -24,13 +26,19 @@ def async_setup(hass, config):
     intent.async_register(hass, AddItemIntent())
     intent.async_register(hass, ListTopItemsIntent())
     hass.http.register_view(ShoppingListView)
+    hass.components.conversation.async_register(INTENT_ADD_ITEM, [
+        'Add {item} to my shopping list',
+    ])
+    hass.components.conversation.async_register(INTENT_LAST_ITEMS, [
+        'What is on my shopping list'
+    ])
     return True
 
 
 class AddItemIntent(intent.IntentHandler):
     """Handle AddItem intents."""
 
-    intent_type = 'ShoppingListAddItem'
+    intent_type = INTENT_ADD_ITEM
     slot_schema = {
         'item': cv.string
     }
@@ -52,7 +60,7 @@ class AddItemIntent(intent.IntentHandler):
 class ListTopItemsIntent(intent.IntentHandler):
     """Handle AddItem intents."""
 
-    intent_type = 'ShoppingListLastItems'
+    intent_type = INTENT_LAST_ITEMS
     slot_schema = {
         'item': cv.string
     }

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -70,6 +70,7 @@ class ListTopItemsIntent(IntentHandler):
 
 class ShoppingListView(HomeAssistantView):
     """View to retrieve shopping list content."""
+
     url = '/api/shopping_list'
     name = "api:shopping_list"
 

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -5,30 +5,24 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/snips/
 """
 import asyncio
-import copy
 import json
 import logging
 import voluptuous as vol
-from homeassistant.helpers import template, script, config_validation as cv
+from homeassistant.helpers import config_validation as cv
 import homeassistant.loader as loader
+from homeassistant.components.intent import IntentError
 
 DOMAIN = 'snips'
-DEPENDENCIES = ['mqtt']
+DEPENDENCIES = ['mqtt', 'intent']
 CONF_INTENTS = 'intents'
 CONF_ACTION = 'action'
 
 INTENT_TOPIC = 'hermes/nlu/intentParsed'
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: {
-        CONF_INTENTS: {
-            cv.string: {
-                vol.Optional(CONF_ACTION): cv.SCRIPT_SCHEMA,
-            }
-        }
-    }
+    DOMAIN: {}
 }, extra=vol.ALLOW_EXTRA)
 
 INTENT_SCHEMA = vol.Schema({
@@ -50,73 +44,34 @@ INTENT_SCHEMA = vol.Schema({
 def async_setup(hass, config):
     """Activate Snips component."""
     mqtt = loader.get_component('mqtt')
-    intents = config[DOMAIN].get(CONF_INTENTS, {})
-    handler = IntentHandler(hass, intents)
 
     @asyncio.coroutine
     def message_received(topic, payload, qos):
         """Handle new messages on MQTT."""
-        LOGGER.debug("New intent: %s", payload)
-        yield from handler.handle_intent(payload)
+        _LOGGER.debug("New intent: %s", payload)
+
+        try:
+            request = json.loads(payload)
+        except TypeError:
+            _LOGGER.error('Received invalid JSON: %s', payload)
+            return
+
+        try:
+            request = INTENT_SCHEMA(request)
+        except vol.Invalid as err:
+            _LOGGER.error('Intent has invalid schema: %s. %s', err, request)
+            return
+
+        intent = request['intent']['intentName'].split('__')[-1]
+        slots = {slot['slotName']: {'value': slot['value']['value']}
+                 for slot in request.get('slots', [])}
+
+        try:
+            yield from hass.intent.async_handle(
+                DOMAIN, intent, slots, request['input'])
+        except IntentError:
+            _LOGGER.exception("Error while handling intent.")
 
     yield from mqtt.async_subscribe(hass, INTENT_TOPIC, message_received)
 
     return True
-
-
-class IntentHandler(object):
-    """Help handling intents."""
-
-    def __init__(self, hass, intents):
-        """Initialize the intent handler."""
-        self.hass = hass
-        intents = copy.deepcopy(intents)
-        template.attach(hass, intents)
-
-        for name, intent in intents.items():
-            if CONF_ACTION in intent:
-                intent[CONF_ACTION] = script.Script(
-                    hass, intent[CONF_ACTION], "Snips intent {}".format(name))
-
-        self.intents = intents
-
-    @asyncio.coroutine
-    def handle_intent(self, payload):
-        """Handle an intent."""
-        try:
-            response = json.loads(payload)
-        except TypeError:
-            LOGGER.error('Received invalid JSON: %s', payload)
-            return
-
-        try:
-            response = INTENT_SCHEMA(response)
-        except vol.Invalid as err:
-            LOGGER.error('Intent has invalid schema: %s. %s', err, response)
-            return
-
-        intent = response['intent']['intentName'].split('__')[-1]
-        config = self.intents.get(intent)
-
-        if config is None:
-            LOGGER.warning("Received unknown intent %s. %s", intent, response)
-            return
-
-        action = config.get(CONF_ACTION)
-
-        if action is not None:
-            slots = self.parse_slots(response)
-            yield from action.async_run(slots)
-
-    # pylint: disable=no-self-use
-    def parse_slots(self, response):
-        """Parse the intent slots."""
-        parameters = {}
-
-        for slot in response.get('slots', []):
-            key = slot['slotName']
-            value = slot['value']['value']
-            if value is not None:
-                parameters[key] = value
-
-        return parameters

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -9,7 +9,6 @@ import json
 import logging
 import voluptuous as vol
 from homeassistant.helpers import intent, config_validation as cv
-from homeassistant import loader
 
 DOMAIN = 'snips'
 DEPENDENCIES = ['mqtt']
@@ -42,8 +41,6 @@ INTENT_SCHEMA = vol.Schema({
 @asyncio.coroutine
 def async_setup(hass, config):
     """Activate Snips component."""
-    mqtt = loader.get_component('mqtt')
-
     @asyncio.coroutine
     def message_received(topic, payload, qos):
         """Handle new messages on MQTT."""
@@ -71,6 +68,7 @@ def async_setup(hass, config):
         except intent.IntentError:
             _LOGGER.exception("Error while handling intent.")
 
-    yield from mqtt.async_subscribe(hass, INTENT_TOPIC, message_received)
+    yield from hass.components.mqtt.async_subscribe(
+        INTENT_TOPIC, message_received)
 
     return True

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -8,7 +8,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 
 
-DOMAIN = 'intent'
+DATA_KEY = 'intent'
 _LOGGER = logging.getLogger(__name__)
 
 SLOT_SCHEMA = vol.Schema({
@@ -21,9 +21,9 @@ SPEECH_TYPE_SSML = 'ssml'
 @callback
 def async_register(hass, handler):
     """Register an intent with Home Assistant."""
-    intents = hass.data.get(DOMAIN)
+    intents = hass.data.get(DATA_KEY)
     if intents is None:
-        intents = hass.data[DOMAIN] = {}
+        intents = hass.data[DATA_KEY] = {}
 
     if handler.intent_type in intents:
         _LOGGER.warning('Intent %s is being overwritten by %s.',
@@ -35,7 +35,7 @@ def async_register(hass, handler):
 @asyncio.coroutine
 def async_handle(hass, platform, intent_type, slots=None, text_input=None):
     """Handle an intent."""
-    handler = hass.data.get(DOMAIN, {}).get(intent_type)
+    handler = hass.data.get(DATA_KEY, {}).get(intent_type)
 
     if handler is None:
         raise UnknownIntent()
@@ -50,12 +50,6 @@ def async_handle(hass, platform, intent_type, slots=None, text_input=None):
         raise InvalidSlotInfo from err
     except Exception as err:
         raise IntentHandleError from err
-
-
-@asyncio.coroutine
-def async_setup(hass, config):
-    """Setup intent."""
-    return True
 
 
 class IntentError(HomeAssistantError):

--- a/tests/common.py
+++ b/tests/common.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
     STATE_ON, STATE_OFF, DEVICE_DEFAULT_NAME, EVENT_TIME_CHANGED,
     EVENT_STATE_CHANGED, EVENT_PLATFORM_DISCOVERED, ATTR_SERVICE,
     ATTR_DISCOVERED, SERVER_PORT, EVENT_HOMEASSISTANT_CLOSE)
-from homeassistant.components import mqtt, recorder
+from homeassistant.components import mqtt, recorder, intent
 from homeassistant.components.http.auth import auth_middleware
 from homeassistant.components.http.const import (
     KEY_USE_X_FORWARDED_FOR, KEY_BANS_ENABLED, KEY_TRUSTED_NETWORKS)
@@ -191,6 +191,28 @@ def async_mock_service(hass, domain, service):
 
 
 mock_service = threadsafe_callback_factory(async_mock_service)
+
+
+@asyncio.coroutine
+def async_mock_intent(hass, intent_typ):
+    """Set up a fake intent handler."""
+    if 'intent' not in hass.config.components:
+        yield from async_setup_component(hass, 'intent', {'intent': {}})
+
+    intents = []
+
+    class ScriptIntentHandler(intent.IntentHandler):
+        intent_type = intent_typ
+
+        @asyncio.coroutine
+        def async_handle(self, intent):
+            """Handle the intent."""
+            intents.append(intent)
+            return intent.create_response()
+
+    hass.intent.async_register(ScriptIntentHandler())
+
+    return intents
 
 
 @ha.callback

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -47,50 +47,52 @@ def alexa_client(loop, hass, test_client):
                     "uid": "uuid"
                 }
             },
-            "intents": {
-                "WhereAreWeIntent": {
-                    "speech": {
-                        "type": "plaintext",
-                        "text":
-                        """
-                            {%- if is_state("device_tracker.paulus", "home")
-                                   and is_state("device_tracker.anne_therese",
-                                                "home") -%}
-                                You are both home, you silly
-                            {%- else -%}
-                                Anne Therese is at {{
-                                    states("device_tracker.anne_therese")
-                                }} and Paulus is at {{
-                                    states("device_tracker.paulus")
-                                }}
-                            {% endif %}
-                        """,
-                    }
+        }
+    }))
+    assert loop.run_until_complete(async_setup_component(hass, 'intent_script', {
+        'intent_script': {
+            "WhereAreWeIntent": {
+                "speech": {
+                    "type": "plain",
+                    "text":
+                    """
+                        {%- if is_state("device_tracker.paulus", "home")
+                               and is_state("device_tracker.anne_therese",
+                                            "home") -%}
+                            You are both home, you silly
+                        {%- else -%}
+                            Anne Therese is at {{
+                                states("device_tracker.anne_therese")
+                            }} and Paulus is at {{
+                                states("device_tracker.paulus")
+                            }}
+                        {% endif %}
+                    """,
+                }
+            },
+            "GetZodiacHoroscopeIntent": {
+                "speech": {
+                    "type": "plain",
+                    "text": "You told us your sign is {{ ZodiacSign }}.",
+                }
+            },
+            "AMAZON.PlaybackAction<object@MusicCreativeWork>": {
+                "speech": {
+                    "type": "plain",
+                    "text": "Playing {{ object_byArtist_name }}.",
+                }
+            },
+            "CallServiceIntent": {
+                "speech": {
+                    "type": "plain",
+                    "text": "Service called",
                 },
-                "GetZodiacHoroscopeIntent": {
-                    "speech": {
-                        "type": "plaintext",
-                        "text": "You told us your sign is {{ ZodiacSign }}.",
-                    }
-                },
-                "AMAZON.PlaybackAction<object@MusicCreativeWork>": {
-                    "speech": {
-                        "type": "plaintext",
-                        "text": "Playing {{ object_byArtist_name }}.",
-                    }
-                },
-                "CallServiceIntent": {
-                    "speech": {
-                        "type": "plaintext",
-                        "text": "Service called",
+                "action": {
+                    "service": "test.alexa",
+                    "data_template": {
+                        "hello": "{{ ZodiacSign }}"
                     },
-                    "action": {
-                        "service": "test.alexa",
-                        "data_template": {
-                            "hello": "{{ ZodiacSign }}"
-                        },
-                        "entity_id": "switch.test",
-                    }
+                    "entity_id": "switch.test",
                 }
             }
         }

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -49,54 +49,55 @@ def alexa_client(loop, hass, test_client):
             },
         }
     }))
-    assert loop.run_until_complete(async_setup_component(hass, 'intent_script', {
-        'intent_script': {
-            "WhereAreWeIntent": {
-                "speech": {
-                    "type": "plain",
-                    "text":
-                    """
-                        {%- if is_state("device_tracker.paulus", "home")
-                               and is_state("device_tracker.anne_therese",
-                                            "home") -%}
-                            You are both home, you silly
-                        {%- else -%}
-                            Anne Therese is at {{
-                                states("device_tracker.anne_therese")
-                            }} and Paulus is at {{
-                                states("device_tracker.paulus")
-                            }}
-                        {% endif %}
-                    """,
-                }
-            },
-            "GetZodiacHoroscopeIntent": {
-                "speech": {
-                    "type": "plain",
-                    "text": "You told us your sign is {{ ZodiacSign }}.",
-                }
-            },
-            "AMAZON.PlaybackAction<object@MusicCreativeWork>": {
-                "speech": {
-                    "type": "plain",
-                    "text": "Playing {{ object_byArtist_name }}.",
-                }
-            },
-            "CallServiceIntent": {
-                "speech": {
-                    "type": "plain",
-                    "text": "Service called",
+    assert loop.run_until_complete(async_setup_component(
+        hass, 'intent_script', {
+            'intent_script': {
+                "WhereAreWeIntent": {
+                    "speech": {
+                        "type": "plain",
+                        "text":
+                        """
+                            {%- if is_state("device_tracker.paulus", "home")
+                                   and is_state("device_tracker.anne_therese",
+                                                "home") -%}
+                                You are both home, you silly
+                            {%- else -%}
+                                Anne Therese is at {{
+                                    states("device_tracker.anne_therese")
+                                }} and Paulus is at {{
+                                    states("device_tracker.paulus")
+                                }}
+                            {% endif %}
+                        """,
+                    }
                 },
-                "action": {
-                    "service": "test.alexa",
-                    "data_template": {
-                        "hello": "{{ ZodiacSign }}"
+                "GetZodiacHoroscopeIntent": {
+                    "speech": {
+                        "type": "plain",
+                        "text": "You told us your sign is {{ ZodiacSign }}.",
+                    }
+                },
+                "AMAZON.PlaybackAction<object@MusicCreativeWork>": {
+                    "speech": {
+                        "type": "plain",
+                        "text": "Playing {{ object_byArtist_name }}.",
+                    }
+                },
+                "CallServiceIntent": {
+                    "speech": {
+                        "type": "plain",
+                        "text": "Service called",
                     },
-                    "entity_id": "switch.test",
+                    "action": {
+                        "service": "test.alexa",
+                        "data_template": {
+                            "hello": "{{ ZodiacSign }}"
+                        },
+                        "entity_id": "switch.test",
+                    }
                 }
             }
-        }
-    }))
+        }))
     return loop.run_until_complete(test_client(hass.http.app))
 
 

--- a/tests/components/test_apiai.py
+++ b/tests/components/test_apiai.py
@@ -57,14 +57,15 @@ def setUpModule():
 
     hass.services.register("test", "apiai", mock_service)
 
-    setup.setup_component(hass, apiai.DOMAIN, {
-        # Key is here to verify we allow other keys in config too
-        "homeassistant": {},
-        "apiai": {
-            "intents": {
-                "WhereAreWeIntent": {
-                    "speech":
-                    """
+    assert setup.setup_component(hass, apiai.DOMAIN, {
+        "apiai": {},
+    })
+    assert setup.setup_component(hass, "intent_script", {
+        "intent_script": {
+            "WhereAreWeIntent": {
+                "speech": {
+                    "type": "plain",
+                    "text": """
                         {%- if is_state("device_tracker.paulus", "home")
                                and is_state("device_tracker.anne_therese",
                                             "home") -%}
@@ -77,19 +78,25 @@ def setUpModule():
                             }}
                         {% endif %}
                     """,
+                }
+            },
+            "GetZodiacHoroscopeIntent": {
+                "speech": {
+                    "type": "plain",
+                    "text": "You told us your sign is {{ ZodiacSign }}.",
+                }
+            },
+            "CallServiceIntent": {
+                "speech": {
+                    "type": "plain",
+                    "text": "Service called",
                 },
-                "GetZodiacHoroscopeIntent": {
-                    "speech": "You told us your sign is {{ ZodiacSign }}.",
-                },
-                "CallServiceIntent": {
-                    "speech": "Service called",
-                    "action": {
-                        "service": "test.apiai",
-                        "data_template": {
-                            "hello": "{{ ZodiacSign }}"
-                        },
-                        "entity_id": "switch.test",
-                    }
+                "action": {
+                    "service": "test.apiai",
+                    "data_template": {
+                        "hello": "{{ ZodiacSign }}"
+                    },
+                    "entity_id": "switch.test",
                 }
             }
         }
@@ -509,5 +516,4 @@ class TestApiai(unittest.TestCase):
         self.assertEqual(200, req.status_code)
         text = req.json().get("speech")
         self.assertEqual(
-            "Intent 'unknown' is not yet configured within Home Assistant.",
-            text)
+            "This intent is not yet configured within Home Assistant.", text)

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -122,7 +122,7 @@ class TestConversation(unittest.TestCase):
 @asyncio.coroutine
 def test_calling_intent(hass):
     """Test calling an intent from a conversation."""
-    intents = yield from async_mock_intent(hass, 'OrderBeer')
+    intents = async_mock_intent(hass, 'OrderBeer')
 
     result = yield from async_setup_component(hass, 'conversation', {
         'conversation': {

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -1,16 +1,17 @@
 """The tests for the Conversation component."""
 # pylint: disable=protected-access
+import asyncio
 import unittest
 from unittest.mock import patch
 
 from homeassistant.core import callback
-from homeassistant.setup import setup_component
+from homeassistant.setup import setup_component, async_setup_component
 import homeassistant.components as core_components
 from homeassistant.components import conversation
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.util.async import run_coroutine_threadsafe
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import get_test_home_assistant, async_mock_intent
 
 
 class TestConversation(unittest.TestCase):
@@ -25,10 +26,9 @@ class TestConversation(unittest.TestCase):
         self.assertTrue(run_coroutine_threadsafe(
             core_components.async_setup(self.hass, {}), self.hass.loop
         ).result())
-        with assert_setup_component(0):
-            self.assertTrue(setup_component(self.hass, conversation.DOMAIN, {
-                conversation.DOMAIN: {}
-            }))
+        self.assertTrue(setup_component(self.hass, conversation.DOMAIN, {
+            conversation.DOMAIN: {}
+        }))
 
     # pylint: disable=invalid-name
     def tearDown(self):
@@ -119,44 +119,31 @@ class TestConversation(unittest.TestCase):
         self.assertFalse(mock_call.called)
 
 
-class TestConfiguration(unittest.TestCase):
-    """Test the conversation configuration component."""
+@asyncio.coroutine
+def test_calling_intent(hass):
+    """Test calling an intent from a conversation."""
+    intents = yield from async_mock_intent(hass, 'OrderBeer')
 
-    # pylint: disable=invalid-name
-    def setUp(self):
-        """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.assertTrue(setup_component(self.hass, conversation.DOMAIN, {
-            conversation.DOMAIN: {
-                'test_2': {
-                    'sentence': 'switch boolean',
-                    'action': {
-                        'service': 'input_boolean.toggle'
-                    }
-                }
+    result = yield from async_setup_component(hass, 'conversation', {
+        'conversation': {
+            'intents': {
+                'OrderBeer': [
+                    'I would like the {type} beer'
+                ]
             }
-        }))
+        }
+    })
+    assert result
 
-    # pylint: disable=invalid-name
-    def tearDown(self):
-        """Stop everything that was started."""
-        self.hass.stop()
+    yield from hass.services.async_call(
+        'conversation', 'process', {
+            conversation.ATTR_TEXT: 'I would like the Grolsch beer'
+        })
+    yield from hass.async_block_till_done()
 
-    def test_custom(self):
-        """Setup and perform good turn on requests."""
-        calls = []
-
-        @callback
-        def record_call(service):
-            """Recorder for a call."""
-            calls.append(service)
-
-        self.hass.services.register('input_boolean', 'toggle', record_call)
-
-        event_data = {conversation.ATTR_TEXT: 'switch boolean'}
-        self.assertTrue(self.hass.services.call(
-            conversation.DOMAIN, 'process', event_data, True))
-
-        call = calls[-1]
-        self.assertEqual('input_boolean', call.domain)
-        self.assertEqual('toggle', call.service)
+    assert len(intents) == 1
+    intent = intents[0]
+    assert intent.platform == 'conversation'
+    assert intent.intent_type == 'OrderBeer'
+    assert intent.slots == {'type': {'value': 'Grolsch'}}
+    assert intent.text_input == 'I would like the Grolsch beer'

--- a/tests/components/test_demo.py
+++ b/tests/components/test_demo.py
@@ -24,6 +24,7 @@ def minimize_demo_platforms(hass):
 
 @pytest.fixture(autouse=True)
 def demo_cleanup(hass):
+    """Clean up device tracker demo file."""
     yield
     try:
         os.remove(hass.config.path(device_tracker.YAML_DEVICES))

--- a/tests/components/test_demo.py
+++ b/tests/components/test_demo.py
@@ -1,52 +1,61 @@
 """The tests for the Demo component."""
+import asyncio
 import json
 import os
-import unittest
 
-from homeassistant.setup import setup_component
+import pytest
+
+from homeassistant.setup import async_setup_component
 from homeassistant.components import demo, device_tracker
 from homeassistant.remote import JSONEncoder
 
-from tests.common import mock_http_component, get_test_home_assistant
+
+@pytest.fixture
+def minimize_demo_platforms(hass):
+    """Cleanup demo component for tests."""
+    orig = demo.COMPONENTS_WITH_DEMO_PLATFORM
+    demo.COMPONENTS_WITH_DEMO_PLATFORM = [
+        'switch', 'light', 'media_player']
+
+    yield
+
+    demo.COMPONENTS_WITH_DEMO_PLATFORM = orig
 
 
-class TestDemo(unittest.TestCase):
-    """Test the Demo component."""
+@pytest.fixture(autouse=True)
+def demo_cleanup(hass):
+    yield
+    try:
+        os.remove(hass.config.path(device_tracker.YAML_DEVICES))
+    except FileNotFoundError:
+        pass
 
-    def setUp(self):  # pylint: disable=invalid-name
-        """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        mock_http_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
-        """Stop everything that was started."""
-        self.hass.stop()
+@asyncio.coroutine
+def test_if_demo_state_shows_by_default(hass, minimize_demo_platforms):
+    """Test if demo state shows if we give no configuration."""
+    yield from async_setup_component(hass, demo.DOMAIN, {demo.DOMAIN: {}})
 
-        try:
-            os.remove(self.hass.config.path(device_tracker.YAML_DEVICES))
-        except FileNotFoundError:
-            pass
+    assert hass.states.get('a.Demo_Mode') is not None
 
-    def test_if_demo_state_shows_by_default(self):
-        """Test if demo state shows if we give no configuration."""
-        setup_component(self.hass, demo.DOMAIN, {demo.DOMAIN: {}})
 
-        self.assertIsNotNone(self.hass.states.get('a.Demo_Mode'))
+@asyncio.coroutine
+def test_hiding_demo_state(hass, minimize_demo_platforms):
+    """Test if you can hide the demo card."""
+    yield from async_setup_component(hass, demo.DOMAIN, {
+        demo.DOMAIN: {'hide_demo_state': 1}})
 
-    def test_hiding_demo_state(self):
-        """Test if you can hide the demo card."""
-        setup_component(self.hass, demo.DOMAIN, {
-            demo.DOMAIN: {'hide_demo_state': 1}})
+    assert hass.states.get('a.Demo_Mode') is None
 
-        self.assertIsNone(self.hass.states.get('a.Demo_Mode'))
 
-    def test_all_entities_can_be_loaded_over_json(self):
-        """Test if you can hide the demo card."""
-        setup_component(self.hass, demo.DOMAIN, {
-            demo.DOMAIN: {'hide_demo_state': 1}})
+@asyncio.coroutine
+def test_all_entities_can_be_loaded_over_json(hass):
+    """Test if you can hide the demo card."""
+    yield from async_setup_component(hass, demo.DOMAIN, {
+        demo.DOMAIN: {'hide_demo_state': 1}})
 
-        try:
-            json.dumps(self.hass.states.all(), cls=JSONEncoder)
-        except Exception:
-            self.fail('Unable to convert all demo entities to JSON. '
-                      'Wrong data in state machine!')
+    try:
+        json.dumps(hass.states.async_all(), cls=JSONEncoder)
+    except Exception:
+        pytest.fail('Unable to convert all demo entities to JSON. '
+                    'Wrong data in state machine!')

--- a/tests/components/test_intent_script.py
+++ b/tests/components/test_intent_script.py
@@ -1,0 +1,43 @@
+import asyncio
+
+from homeassistant.bootstrap import async_setup_component
+
+from tests.common import async_mock_service
+
+
+@asyncio.coroutine
+def test_intent_script(hass):
+    """Test intent scripts work."""
+    calls = async_mock_service(hass, 'test', 'service')
+
+    yield from async_setup_component(hass, 'intent_script', {
+        'intent_script': {
+            'HelloWorld': {
+                'action': {
+                    'service': 'test.service',
+                    'data_template': {
+                        'hello': '{{ name }}'
+                    }
+                },
+                'card': {
+                    'title': 'Hello {{ name }}',
+                    'content': 'Content for {{ name }}',
+                },
+                'speech': {
+                    'text': 'Good morning {{ name }}'
+                }
+            }
+        }
+    })
+
+    response = yield from hass.intent.async_handle(
+        'test', 'HelloWorld', {'name': {'value': 'Paulus'}}
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data['hello'] == 'Paulus'
+
+    assert response.speech['plain']['speech'] == 'Good morning Paulus'
+
+    assert response.card['simple']['title'] == 'Hello Paulus'
+    assert response.card['simple']['content'] == 'Content for Paulus'

--- a/tests/components/test_intent_script.py
+++ b/tests/components/test_intent_script.py
@@ -1,3 +1,4 @@
+"""Test intent_script component."""
 import asyncio
 
 from homeassistant.bootstrap import async_setup_component

--- a/tests/components/test_intent_script.py
+++ b/tests/components/test_intent_script.py
@@ -2,6 +2,7 @@
 import asyncio
 
 from homeassistant.bootstrap import async_setup_component
+from homeassistant.helpers import intent
 
 from tests.common import async_mock_service
 
@@ -31,8 +32,8 @@ def test_intent_script(hass):
         }
     })
 
-    response = yield from hass.intent.async_handle(
-        'test', 'HelloWorld', {'name': {'value': 'Paulus'}}
+    response = yield from intent.async_handle(
+        hass, 'test', 'HelloWorld', {'name': {'value': 'Paulus'}}
     )
 
     assert len(calls) == 1

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -1,3 +1,4 @@
+"""Test shopping list component"""
 import asyncio
 
 from homeassistant.bootstrap import async_setup_component
@@ -5,6 +6,7 @@ from homeassistant.bootstrap import async_setup_component
 
 @asyncio.coroutine
 def test_add_item(hass):
+    """Test adding an item intent."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
     response = yield from hass.intent.async_handle(
@@ -16,7 +18,8 @@ def test_add_item(hass):
 
 
 @asyncio.coroutine
-def test_recent_items(hass):
+def test_recent_items_intent(hass):
+    """Test recent items."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
     yield from hass.intent.async_handle(

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -1,0 +1,37 @@
+import asyncio
+
+from homeassistant.bootstrap import async_setup_component
+
+
+@asyncio.coroutine
+def test_add_item(hass):
+    yield from async_setup_component(hass, 'shopping_list', {})
+
+    response = yield from hass.intent.async_handle(
+        'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
+    )
+
+    assert response.speech['plain']['speech'] == \
+        "I've added beer to your shopping list"
+
+
+@asyncio.coroutine
+def test_recent_items(hass):
+    yield from async_setup_component(hass, 'shopping_list', {})
+
+    yield from hass.intent.async_handle(
+        'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
+    )
+    yield from hass.intent.async_handle(
+        'test', 'ShoppingListAddItem', {'item': {'value': 'wine'}}
+    )
+    yield from hass.intent.async_handle(
+        'test', 'ShoppingListAddItem', {'item': {'value': 'soda'}}
+    )
+
+    response = yield from hass.intent.async_handle(
+        'test', 'ShoppingListLastItems'
+    )
+
+    assert response.speech['plain']['speech'] == \
+        "These are the top 5 items in your shopping list: soda, wine, beer"

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -2,6 +2,7 @@
 import asyncio
 
 from homeassistant.bootstrap import async_setup_component
+from homeassistant.helpers import intent
 
 
 @asyncio.coroutine
@@ -9,8 +10,8 @@ def test_add_item(hass):
     """Test adding an item intent."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
-    response = yield from hass.intent.async_handle(
-        'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
+    response = yield from intent.async_handle(
+        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
     )
 
     assert response.speech['plain']['speech'] == \
@@ -22,18 +23,18 @@ def test_recent_items_intent(hass):
     """Test recent items."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
-    yield from hass.intent.async_handle(
-        'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
+    yield from intent.async_handle(
+        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
     )
-    yield from hass.intent.async_handle(
-        'test', 'ShoppingListAddItem', {'item': {'value': 'wine'}}
+    yield from intent.async_handle(
+        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'wine'}}
     )
-    yield from hass.intent.async_handle(
-        'test', 'ShoppingListAddItem', {'item': {'value': 'soda'}}
+    yield from intent.async_handle(
+        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'soda'}}
     )
 
-    response = yield from hass.intent.async_handle(
-        'test', 'ShoppingListLastItems'
+    response = yield from intent.async_handle(
+        hass, 'test', 'ShoppingListLastItems'
     )
 
     assert response.speech['plain']['speech'] == \
@@ -45,11 +46,11 @@ def test_api(hass, test_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
-    yield from hass.intent.async_handle(
-        'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
+    yield from intent.async_handle(
+        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
     )
-    yield from hass.intent.async_handle(
-        'test', 'ShoppingListAddItem', {'item': {'value': 'wine'}}
+    yield from intent.async_handle(
+        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'wine'}}
     )
 
     client = yield from test_client(hass.http.app)

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -38,3 +38,23 @@ def test_recent_items_intent(hass):
 
     assert response.speech['plain']['speech'] == \
         "These are the top 5 items in your shopping list: soda, wine, beer"
+
+
+@asyncio.coroutine
+def test_api(hass, test_client):
+    """Test the API."""
+    yield from async_setup_component(hass, 'shopping_list', {})
+
+    yield from hass.intent.async_handle(
+        'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
+    )
+    yield from hass.intent.async_handle(
+        'test', 'ShoppingListAddItem', {'item': {'value': 'wine'}}
+    )
+
+    client = yield from test_client(hass.http.app)
+    resp = yield from client.get('/api/shopping_list')
+
+    assert resp.status == 200
+    data = yield from resp.json()
+    assert data == ['beer', 'wine']

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -11,7 +11,7 @@ def test_add_item(hass):
     yield from async_setup_component(hass, 'shopping_list', {})
 
     response = yield from intent.async_handle(
-        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'beer'}}
     )
 
     assert response.speech['plain']['speech'] == \
@@ -24,17 +24,17 @@ def test_recent_items_intent(hass):
     yield from async_setup_component(hass, 'shopping_list', {})
 
     yield from intent.async_handle(
-        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'beer'}}
     )
     yield from intent.async_handle(
-        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'wine'}}
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'wine'}}
     )
     yield from intent.async_handle(
-        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'soda'}}
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'soda'}}
     )
 
     response = yield from intent.async_handle(
-        hass, 'test', 'ShoppingListLastItems'
+        hass, 'test', 'HassShoppingListLastItems'
     )
 
     assert response.speech['plain']['speech'] == \
@@ -47,10 +47,10 @@ def test_api(hass, test_client):
     yield from async_setup_component(hass, 'shopping_list', {})
 
     yield from intent.async_handle(
-        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'beer'}}
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'beer'}}
     )
     yield from intent.async_handle(
-        hass, 'test', 'ShoppingListAddItem', {'item': {'value': 'wine'}}
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'wine'}}
     )
 
     client = yield from test_client(hass.http.app)

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -1,4 +1,4 @@
-"""Test shopping list component"""
+"""Test shopping list component."""
 import asyncio
 
 from homeassistant.bootstrap import async_setup_component

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -30,14 +30,16 @@ def test_snips_call_action(hass, mqtt_mock):
     calls = async_mock_service(hass, 'test', 'service')
 
     result = yield from async_setup_component(hass, "snips", {
-        "snips": {
-            "intents": {
-                "Lights": {
-                    "action": {
-                        "service": "test.service",
-                        "data_template": {
-                            "color": "{{ light_color }}"
-                        }
+        "snips": {},
+    })
+    assert result
+    result = yield from async_setup_component(hass, "intent_script", {
+        "intent_script": {
+            "Lights": {
+                "action": {
+                    "service": "test.service",
+                    "data_template": {
+                        "color": "{{ light_color }}"
                     }
                 }
             }

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -2,7 +2,7 @@
 import asyncio
 
 from homeassistant.bootstrap import async_setup_component
-from tests.common import async_fire_mqtt_message, async_mock_service
+from tests.common import async_fire_mqtt_message, async_mock_intent
 
 EXAMPLE_MSG = """
 {
@@ -16,7 +16,7 @@ EXAMPLE_MSG = """
             "slotName": "light_color",
             "value": {
                 "kind": "Custom",
-                "value": "blue"
+                "value": "green"
             }
         }
     ]
@@ -27,29 +27,19 @@ EXAMPLE_MSG = """
 @asyncio.coroutine
 def test_snips_call_action(hass, mqtt_mock):
     """Test calling action via Snips."""
-    calls = async_mock_service(hass, 'test', 'service')
-
     result = yield from async_setup_component(hass, "snips", {
         "snips": {},
     })
     assert result
-    result = yield from async_setup_component(hass, "intent_script", {
-        "intent_script": {
-            "Lights": {
-                "action": {
-                    "service": "test.service",
-                    "data_template": {
-                        "color": "{{ light_color }}"
-                    }
-                }
-            }
-        }
-    })
-    assert result
+
+    intents = yield from async_mock_intent(hass, 'Lights')
 
     async_fire_mqtt_message(hass, 'hermes/nlu/intentParsed',
                             EXAMPLE_MSG)
     yield from hass.async_block_till_done()
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.data.get('color') == 'blue'
+    assert len(intents) == 1
+    intent = intents[0]
+    assert intent.platform == 'snips'
+    assert intent.intent_type == 'Lights'
+    assert intent.slots == {'light_color': {'value': 'green'}}
+    assert intent.text_input == 'turn the lights green'

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -32,7 +32,7 @@ def test_snips_call_action(hass, mqtt_mock):
     })
     assert result
 
-    intents = yield from async_mock_intent(hass, 'Lights')
+    intents = async_mock_intent(hass, 'Lights')
 
     async_fire_mqtt_message(hass, 'hermes/nlu/intentParsed',
                             EXAMPLE_MSG)


### PR DESCRIPTION
## Description:

![intents 3](https://user-images.githubusercontent.com/1444314/28244893-d0658fea-69ac-11e7-9871-4e246c206357.png)

[Google Draw version](https://docs.google.com/drawings/d/1i9AsOQNCBCaeM14QwEglZizV0lZiWKHZgroZc9izB0E/edit?usp=sharing)

Intents represent a users intent to do an action. Although it is very similar to a service, it is not the same. Services are meant for home control.

Now that we have API.ai, Alexa and Snips, I noticed a lot of repeating pieces of code. All three work with intents and expect some sort of response. This can be either voice or a card.

The goal is to make it trivial in Home Assistant to handle intents from different services and hook them into your components. Bonus goal is to auto-configure the conversation component with sentences that your component supports so that we get a voice assistant up and running fairly easy.

The `intent` helper abstracts the handling of the intents away from these components and makes it available as a general interface. This makes it easy for other components to offer intent handling.

The first use case for intents will be a new `intent_script` component. This is basically the functionality that Alexa and Snips offer today, abstracted into a component. Both Alexa and Snips have been updated to use this new structure.

As a second use case I have included an example shopping list component that can be controlled by your voice. Demo of shopping list in action: https://twitter.com/balloob/status/886764069335605249

Breaks config for Alexa, Snips, API.AI, Conversation. Config from Alexa, Snips and API.AI have been moved to new component `intent_script`. Conversation component new config:

```yaml
intent_script:
  LightKitchen:
    action:
      service: light.turn_on
      data:
        entity_id: light.kitchen

shopping_list:

conversation:
  intents:
    ShoppingListAddItem:
      - Add {item} to my shopping list
    LightKitchen:
      - Brighten up the kitchen
```


To do:

 - [x] Fix Alexa tests
 - [x] Verify Alexa still works
 - [ ] Fire events on event bus `intent_received` and `intent_handled` (? - we don't do this for HTTP either)

Future:

 - [x] Update api.ai component
 - [x] Include a panel for the shopping list
 - [ ] Persist shopping list between restarts
 - [x] Update conversation to use intents
 - [ ] Add default intents for turning things on/off to conversation component
 - [x] Allow any component to register conversation sentences that turn into intents

## Feedback welcome :-)

**Related issue (if applicable):** fixes #8394 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
intent_script:
  LightKitchen:
    action:
      service: light.turn_on
      data:
        entity_id: light.kitchen

shopping_list:

conversation:
  intents:
    ShoppingListAddItem:
      - Add {item} to my shopping list
    LightKitchen:
      - Brighten up the kitchen
```

## Checklist:

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
