### PR TITLE
Exclude 'TAXI' product (fixes #8401)

### DIFF
--- a/homeassistant/components/sensor/uber.py
+++ b/homeassistant/components/sensor/uber.py
@@ -59,7 +59,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
            (product_id not in wanted_product_ids):
             continue
         dev.append(UberSensor('time', timeandpriceest, product_id, product))
-        if product.get('price_details') is not None:
+
+        if product.get('price_details') is not None \
+                and product['display_name'] != 'TAXI':
             dev.append(UberSensor(
                 'price', timeandpriceest, product_id, product))
 


### PR DESCRIPTION
## Description:
San Francisco has a product 'TAXI' with no price details which lead to a TypeError for the price sensor. 

**Related issue (if applicable):** fixes #8401

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
# Paris
  - platform: uber
    server_token: !secret uber_api
    start_latitude: 48.8459759
    start_longitude: 2.3707804
    end_latitude: 48.8630169
    end_longitude: 2.3763798
# San Francisco
  - platform: uber
    server_token: !secret uber_api
    start_longitude: -122.420443
    start_latitude: 37.780248
    end_longitude: -122.393289
    end_latitude: 37.795833
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
