### PR TITLE
WIP: Initial support for IRC

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -80,6 +80,9 @@ omit =
     homeassistant/components/ios.py
     homeassistant/components/*/ios.py
 
+    homeassistant/components/irc.py
+    homeassistant/components/*/irc.py
+
     homeassistant/components/isy994.py
     homeassistant/components/*/isy994.py
 

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -79,6 +79,7 @@ ATTR_SOURCE_TYPE = 'source_type'
 
 SOURCE_TYPE_GPS = 'gps'
 SOURCE_TYPE_ROUTER = 'router'
+SOURCE_TYPE_OTHER = 'other'
 
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,

--- a/homeassistant/components/device_tracker/irc.py
+++ b/homeassistant/components/device_tracker/irc.py
@@ -1,0 +1,65 @@
+"""
+Support for tracking a user on IRC.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.irc/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import (
+    PLATFORM_SCHEMA, SOURCE_TYPE_OTHER)
+from homeassistant.components.irc import (
+    CONF_NETWORK, CONF_CHANNEL, DATA_IRC)
+from homeassistant.core import callback
+from homeassistant.util import slugify
+import homeassistant.helpers.config_validation as cv
+
+DEPENDENCIES = ['irc']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_USER = 'user'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_NETWORK): cv.string,
+    vol.Required(CONF_USER): cv.string,
+    vol.Required(CONF_CHANNEL): cv.string,
+})
+
+
+@asyncio.coroutine
+def async_setup_scanner(hass, config, async_see, discovery_info=None):
+    """Validate the configuration and setup monitoring of a user."""
+    network = config.get(CONF_NETWORK)
+    if network not in hass.data[DATA_IRC]:
+        _LOGGER.error('Unknown IRC network: %s', network)
+        return False
+
+    user = config.get(CONF_USER)
+    channel = config.get(CONF_CHANNEL)
+    plugin = hass.data[DATA_IRC][network]
+
+    class ChannelUserObserver:
+        """Monitor changes to a channel."""
+
+        @callback
+        @staticmethod
+        def attr_updated(attr, value):
+            """Callback when an attribute for a channel has changed."""
+            if attr != 'users':
+                return
+
+            dev_id = slugify('{0} {1}'.format(user, channel))
+            status = 'online' if user in value else 'offline'
+            hass.async_add_job(
+                async_see(dev_id=dev_id,
+                          location_name=status,
+                          source_type=SOURCE_TYPE_OTHER))
+
+    chan = plugin.get_channel(channel)
+    chan.observe(ChannelUserObserver())
+
+    return True

--- a/homeassistant/components/irc.py
+++ b/homeassistant/components/irc.py
@@ -27,6 +27,7 @@ CONF_NETWORK = 'network'
 CONF_AUTOJOIN = 'autojoin'
 CONF_ZNC = 'znc'
 CONF_REAL_NAME = 'real_name'
+CONF_ONLY_WHEN_ADDRESSED = 'only_when_addressed'
 
 EVENT_PRIVMSG = 'irc_privmsg'
 
@@ -52,6 +53,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_ZNC, default=False): cv.boolean,
         vol.Optional(CONF_WHITELIST, default=[]):
             vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_ONLY_WHEN_ADDRESSED, default=True): cv.boolean,
     })])
 }, extra=vol.ALLOW_EXTRA)
 
@@ -170,6 +172,12 @@ def make_plugin():
             # Check whitelist before firing an event
             allowed = self.config.get(CONF_WHITELIST)
             if not any(map(lambda pattern: re.match(pattern, nick), allowed)):
+                return
+
+            # Check if we must be addressed by user
+            only_when_addressed = self.config.get(CONF_ONLY_WHEN_ADDRESSED)
+            is_addressed = data.startswith('{0}:'.format(self.context.nick))
+            if only_when_addressed and not is_addressed:
                 return
 
             channel = self.get_channel(target)

--- a/homeassistant/components/irc.py
+++ b/homeassistant/components/irc.py
@@ -1,0 +1,279 @@
+"""
+Support for IRC.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/irc/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import discovery
+from homeassistant.const import (
+    CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT,
+    CONF_SSL, CONF_VERIFY_SSL)
+
+REQUIREMENTS = ['irc3==1.0.0']
+DOMAIN = 'irc'
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_CHANNEL = 'channel'
+CONF_NICK = 'nick'
+CONF_NETWORK = 'network'
+CONF_AUTOJOIN = 'autojoin'
+CONF_ZNC = 'znc'
+CONF_IGNORE_USERS = 'ignore_users'
+CONF_REAL_NAME = 'real_name'
+
+DATA_IRC = 'data_irc'
+
+ATTR_MESSAGE_COUNT = 'message_count'
+
+DEFAULT_USERNAME = 'hass'
+DEFAULT_REAL_NAME = 'Home Assistant'
+DEFAULT_PORT = 6667
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.All(cv.ensure_list, [vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_NICK): cv.string,
+        vol.Required(CONF_NETWORK): cv.string,
+        vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+        vol.Optional(CONF_REAL_NAME, default=DEFAULT_REAL_NAME): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.positive_int,
+        vol.Optional(CONF_SSL, default=False): cv.boolean,
+        vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
+        vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_AUTOJOIN, default=[]):
+            vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_ZNC, default=False): cv.boolean,
+        vol.Optional(CONF_IGNORE_USERS, default=[]):
+            vol.All(cv.ensure_list, [cv.string]),
+    })])
+}, extra=vol.ALLOW_EXTRA)
+
+
+class Observable(object):
+    """Wrapper that allows observation of attributes."""
+
+    def __init__(self):
+        """Initialize a new Observable instance."""
+        self._observers = []
+        self._do_notify = True
+
+    def enable(self):
+        """Send notification updates."""
+        self._do_notify = True
+
+    def disable(self):
+        """Do not send notification updates."""
+        self._do_notify = False
+
+    def observe(self, observer):
+        """Add observer that receives attribute updates."""
+        if observer not in self._observers:
+            self._observers.append(observer)
+
+    def manual_update(self, attr):
+        """Force notify observers of an attribute update."""
+        if self._do_notify:
+            for observer in self._observers:
+                observer.attr_updated(attr, getattr(self, attr))
+
+    def update(self, **kwargs):
+        """Make updates to attributes and notify observers."""
+        # Update all properties first...
+        for attr, value in kwargs.items():
+            setattr(self, str(attr), value)
+
+        # ...then notify observers to make sure state is consistent
+        if self._do_notify:
+            for observer in self._observers:
+                for attr, value in kwargs.items():
+                    observer.attr_updated(attr, value)
+
+
+class IRCChannel(Observable):
+    """Representation of an IRC channel."""
+
+    def __init__(self, channel):
+        """Initialize a new IRC channel."""
+        super().__init__()
+        self.channel = channel
+        self.topic = None
+        self.last_speaker = None
+        self.last_message = None
+        self.message_count = 0
+        self.users = set()
+
+
+class HAPlugin(object):
+    """Plugin to IRC3 that handles IRC commands."""
+
+    import irc3
+
+    # Matches topics when re-connecting to active ZNC session
+    TOPIC_BNC_REPLAY = irc3.rfc.raw.new(
+        'TOPIC_BNC_REPLAY',
+        (r'^(@(?P<tags>\S+) )?:(?P<mask>\S+) 332 '
+         r'(?P<nick>\S+) (?P<channel>\S+) :(?P<data>.+)'))
+
+    # All users currently in a channel (matches NAMES command)
+    NAME_LIST = irc3.rfc.raw.new(
+        'NAME_LIST',
+        (r'^(@(?P<tags>\S+) )?:(?P<mask>\S+) 353 '
+         r'(?P<nick>\S+) @ (?P<channel>\S+) :(?P<users>.+)'))
+
+    def __init__(self, context):
+        """Initialize a new HAPlugin instance."""
+        self.context = context
+        self.config = context.config.get('hass_config')
+        self._channels = {}
+
+    def server_ready(self):
+        """Triggered after the server sent the MOTD."""
+        _LOGGER.info('Connected IRC network %s', self.config.get(CONF_NETWORK))
+
+    @staticmethod
+    def connection_lost():
+        """Triggered when connection is lost."""
+        _LOGGER.error('Failed to connect to IRC server')
+
+    def get_channel(self, channel):
+        """Return internal channel object."""
+        if channel not in self._channels:
+            self._channels[channel] = IRCChannel(channel)
+        return self._channels[channel]
+
+    @irc3.event(irc3.rfc.PRIVMSG)
+    def on_privmsg(self, mask=None, target=None, data=None, **kw):
+        """Handle PRIVMSG commands."""
+        # Do not trigger updates for znc playback
+        self._znc_toggle(mask, target, data)
+
+        nick = mask.split('!')[0]
+
+        # Ignore messages from blacklisted users
+        if nick in self.config.get(CONF_IGNORE_USERS):
+            return
+
+        self._update_channel(target, last_speaker=nick, last_message=data)
+
+    def _znc_toggle(self, mask, channel, data):
+        if channel not in self._channels:
+            return
+
+        if self.config.get(CONF_ZNC) and mask == '***!znc@znc.in':
+            if data == 'Buffer Playback...':
+                self._channels[channel].disable()
+            elif data == 'Playback Complete.':
+                self._channels[channel].enable()
+
+    @irc3.event(irc3.rfc.TOPIC)
+    @irc3.event(TOPIC_BNC_REPLAY)
+    def on_topic(self, channel=None, data=None, **kw):
+        """Handle TOPIC commands."""
+        self._update_channel(channel, update_counter=False, topic=data)
+
+    def _update_channel(self, channel, update_counter=True, **kwargs):
+        if channel in self._channels:
+            obj = self._channels[channel]
+            if update_counter:
+                obj.message_count += 1
+            obj.update(**kwargs)
+
+    @irc3.event(NAME_LIST)
+    def on_names(self, channel=None, users=None, **kwargs):
+        """Handle NAMES commands."""
+        if channel not in self._channels:
+            return
+
+        chan = self._channels[channel]
+        chan.users.clear()
+        for user in users.split(' '):
+            if user.startswith('@') or user.startswith('+'):
+                user = user[1:]
+            chan.users.add(user)
+        chan.manual_update('users')
+
+    # These two should update user list for channel
+    @irc3.event(irc3.rfc.JOIN_PART_QUIT)
+    def on_user_event(self, mask=None, event=None, channel=None, **kwargs):
+        """Handle JOIN, PART and QUIT commands."""
+        if channel not in self._channels:
+            return
+
+        nick = mask.split('!')[0]
+        chan = self._channels[channel]
+        if event == 'JOIN':
+            chan.users.add(nick)
+        else:
+            chan.users.remove(nick)
+        chan.manual_update('users')
+
+    @irc3.event(irc3.rfc.KICK)
+    def on_user_kick(self, channel, target, **kwargs):
+        """Handle KICK commands."""
+        if channel not in self._channels:
+            return
+
+        chan = self._channels[channel]
+        chan.users.remove(target)
+        chan.manual_update('users')
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Setup the IRC component."""
+    import irc3
+
+    hass.data[DATA_IRC] = {}
+
+    @asyncio.coroutine
+    def async_setup_irc_server(hass, config):
+        """Setup a new IRC server."""
+        irc_config = {
+            'loop': hass.loop,
+            'nick': config.get(CONF_NICK),
+            'host': config.get(CONF_HOST),
+            'port': config.get(CONF_PORT),
+            'username': config.get(CONF_USERNAME),
+            'realname': config.get(CONF_REAL_NAME),
+            'hass_config': config,
+            'autojoins': config.get(CONF_AUTOJOIN),
+            'ssl': config.get(CONF_SSL),
+            'includes': ['irc3.plugins.core', __name__]
+        }
+
+        if CONF_PASSWORD in config:
+            irc_config.update({'password': config.get(CONF_PASSWORD)})
+
+        if not config.get(CONF_VERIFY_SSL):
+            irc_config.update({'ssl_verify': 'CERT_NONE'})
+
+        import irc3
+        bot = irc3.IrcBot.from_config(irc_config)
+        network = config.get(CONF_NETWORK)
+        plugin_path = '{0}.{1}'.format(__name__, HAPlugin.__name__)
+        hass.data[DATA_IRC][network] = bot.get_plugin(plugin_path)
+        bot.run(forever=False)
+
+        hass.async_add_job(discovery.async_load_platform(
+            hass, 'notify', DOMAIN, {
+                CONF_NETWORK: network
+            }, config))
+
+    # Plugins must have an attribute which is not possible to add globally
+    # since Home Assistant installs dependencies on-the-fly. This adds it in
+    # runtime instead (sort of a hack).
+    global HAPlugin  # pylint: disable=invalid-name,global-variable-undefined
+    HAPlugin = irc3.plugin(HAPlugin)
+
+    tasks = [async_setup_irc_server(hass, conf) for conf in config[DOMAIN]]
+    if tasks:
+        yield from asyncio.wait(tasks, loop=hass.loop)
+
+    return True

--- a/homeassistant/components/notify/irc.py
+++ b/homeassistant/components/notify/irc.py
@@ -1,0 +1,54 @@
+"""
+IRC platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.irc/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.notify import (
+    ATTR_TARGET, PLATFORM_SCHEMA, BaseNotificationService)
+from homeassistant.components.irc import CONF_NETWORK, DATA_IRC
+import homeassistant.helpers.config_validation as cv
+
+DEPENDENCIES = ['irc']
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_NETWORK): cv.string,
+})
+
+
+# pylint: disable=unused-variable
+def get_service(hass, config, discovery_info=None):
+    """Get the IRC notification service."""
+    if discovery_info is None:
+        return
+
+    network = discovery_info.get(CONF_NETWORK)
+    if network not in hass.data[DATA_IRC]:
+        _LOGGER.error('Unknown IRC network: %s', network)
+        return None
+
+    plugin = hass.data[DATA_IRC][network]
+    return IRCNotificationService(plugin)
+
+
+class IRCNotificationService(BaseNotificationService):
+    """Implement the notification service for IRC."""
+
+    def __init__(self, plugin):
+        """Initialize the service."""
+        self.plugin = plugin
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to a user."""
+        if kwargs.get(ATTR_TARGET) is None:
+            _LOGGER.error('No target specified')
+            return
+
+        for target in kwargs.get(ATTR_TARGET):
+            self.plugin.context.privmsg(target, message)

--- a/homeassistant/components/sensor/irc.py
+++ b/homeassistant/components/sensor/irc.py
@@ -10,9 +10,10 @@ import logging
 import voluptuous as vol
 
 from homeassistant.core import callback
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.components.irc import (
-    CONF_NETWORK, CONF_CHANNEL, DATA_IRC, ATTR_MESSAGE_COUNT)
+    CONF_NETWORK, CONF_CHANNEL, DATA_IRC)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
@@ -73,17 +74,18 @@ class IrcSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        value = getattr(self._channel, self._attribute)
-        if isinstance(value, set) or isinstance(value, list):
-            return ', '.join(value)
-        return value
+        if self._attribute == 'topic':
+            return self._channel.topic
+        elif self._attribute == 'last_speaker':
+            return self._channel.last_speaker
+        elif self._attribute == 'users':
+            return len(self._channel.users)
+        return STATE_UNKNOWN
 
     @callback
     def attr_updated(self, attr, value):
         """Callback when an attribute for a channel has changed."""
-        print("update 1")
         if attr == self._attribute:
-            print("update 2")
             self.hass.async_add_job(self.async_update_ha_state())
 
     @property
@@ -91,5 +93,4 @@ class IrcSensor(Entity):
         """Return the state attributes."""
         return {
             ATTR_CHANNEL: self._channel.channel,
-            ATTR_MESSAGE_COUNT: self._channel.message_count
         }

--- a/homeassistant/components/sensor/irc.py
+++ b/homeassistant/components/sensor/irc.py
@@ -1,0 +1,95 @@
+"""
+Support for IRC sensors.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/sensor.irc/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.irc import (
+    CONF_NETWORK, CONF_CHANNEL, DATA_IRC, ATTR_MESSAGE_COUNT)
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['irc']
+
+CONF_ATTRIBUTE = 'attribute'
+
+ATTR_CHANNEL = 'channel'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_CHANNEL): cv.string,
+    vol.Required(CONF_NETWORK): cv.string,
+    vol.Required(CONF_ATTRIBUTE): cv.string,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the IRC sensor."""
+    network = config.get(CONF_NETWORK)
+    if network not in hass.data[DATA_IRC]:
+        _LOGGER.error('Unknown IRC network: %s', network)
+        return False
+
+    network = config.get(CONF_NETWORK)
+    channel = config.get(CONF_CHANNEL)
+    attribute = config.get(CONF_ATTRIBUTE)
+    plugin = hass.data[DATA_IRC][network]
+
+    async_add_devices([IrcSensor(plugin.get_channel(channel), attribute)])
+
+
+class IrcSensor(Entity):
+    """Representation of an IRC sensor."""
+
+    def __init__(self, channel, attribute):
+        """Initialize the sensor."""
+        self._channel = channel
+        self._attribute = attribute
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Handle when an entity is about to be added to Home Assistant."""
+        self._channel.observe(self)
+
+    @property
+    def should_poll(self):
+        """No polling needed for IRC sensor."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{0} {1}'.format(self._channel.channel, self._attribute)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        value = getattr(self._channel, self._attribute)
+        if isinstance(value, set) or isinstance(value, list):
+            return ', '.join(value)
+        return value
+
+    @callback
+    def attr_updated(self, attr, value):
+        """Callback when an attribute for a channel has changed."""
+        print("update 1")
+        if attr == self._attribute:
+            print("update 2")
+            self.hass.async_add_job(self.async_update_ha_state())
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_CHANNEL: self._channel.channel,
+            ATTR_MESSAGE_COUNT: self._channel.message_count
+        }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -327,6 +327,9 @@ insteonlocal==0.52
 # homeassistant.components.insteon_plm
 insteonplm==0.7.4
 
+# homeassistant.components.irc
+irc3==1.0.0
+
 # homeassistant.components.verisure
 jsonpath==0.75
 


### PR DESCRIPTION
## Description:
This PR adds support for Internet Relay Chat (IRC) in Home Assistant. Short summary of what is supported:

* Multiple IRC networks
* Sensors displaying topic, last speaker, or user count in a channel
* Notify platform for sending messages to a channel or user
* Device tracker that can tell if a user is in a channel or not
* Compatible with some quirks in znc (especially log replay)

Most useful settings can be specified for each server, like nick, username, hostname, password, SSL, etc. I have mostly tested this using ZNC (attaching to my already running bouncer) but it works fine as stand-alone as well. So you can use Home Assistant as an IRC bot if you like.

I am currently quite satisfied with the feature set for an initial release, but there are more features that can be added in the future (raw message, nickserv, changing modes for users, actions like kick, etc). Error management is something I feel needs to be improved before merging as it's hard to know what went wrong if it doesn't work. Feel free to try it out, come with feedback and wish for features.

Marking this PR as WIP until I've worked out the quirks regarding error management. Maybe I find some other issues as well.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
Setting up a new connection looks like this:
```yaml
irc:
  - host: irc.quakenet.org
    port: 6667
    nick: admin
    ssl: true
    verify_ssl: false
    real_name: Spiderman
    username: batman
    password: mysupersecretandsecurepassword  # specify user:password if you use znc
    network: quakenet
    znc: true
    autojoin:
      - '#hass'
      - '#otherchannel'
    whitelist:
      - robin
      - alfred.*  # regexp allowed
    only_when_addressed: true
```
Only ``host``, ``nick`` and ``network`` are required (the other are optional or have default values) but I have included all settings for clarity. Try to be as restrictive as possible with the whitelist as all messages from the listed users will be sent as events on the event bus. So you might flood it with lots of events if your IRC network is busy. If ``only_when_addressed`` is set to ``true``, an event will only by fired if the bot is addressed, i.e. message line starts with "<nick>:". This can be quite useful when creating a bot.

**You must add "" or '' around a channel as # otherwise make the rest of the line into a comment!**

To add a new sensor, add this:
```yaml
sensor:
  - platform: irc
    network: quakenet
    channel: '#hass'
    attribute: last_speaker
```
This will create a sensor displaying the last message someone said in #hass. Note that the ``network`` (quakenet) must match ``network`` in the server description. The same principal is used for other platforms as well.

Supported values for ``attribute`` is: topic, last_speaker, users (you can probably figure out what they do).

To add a device tracker, simply add this:
```yaml
device_tracker:
  - platform: irc
    network: quakenet
    user: ballob
    channel: '#hass'
```
This will setup a device tracker that changes state to "online" or "offline" depending on if ballob is in #hass on quakenet or not. It works just like any other device tracker.

The notify platform is loaded automatically by the ``irc`` component, so you do not have to care about that. To send a message, just use ``notify.notify``:
```yaml
service: notify.notify
data:
  target: '#hass'
  message: Hello!
  data:
    network: quakenet
```
If ``network`` is not specified, the message will be broadcasted on all your networks. So it's safe to leave out if you only have one network, otherwise you should probably include it.

How to put this to good use? Lets create a very, very simple IRC bot. It will listen to what is said in #hass from users specified in the whitelist and if it matches an entity, it will display the state of that entity.

Now, lets define an automation. It will trigger every time a whitelisted users says something. Some simple jinja script checks if the specified entity exists and replies with a message containing the state (or "Unknown entity" if the entity does not exist):
```yaml
automation:
  - alias: Print entity states to IRC
    trigger:
      - platform: event
        event_type: irc_privmsg
        # event_data:
        #   channel: '#hass'
    action:
      service: notify.notify
      data_template:
        target: >
          {{ trigger.event.data['channel'] }}
        message: >
          {% set message = trigger.event.data['last_message'] %}
          {% set entity_id = message.split(' ')[1] %}
          {% set state = states(entity_id) %}

          {% if state != 'unknown' %}
            State: {{ state }}
          {% else %}
            Unknown entity: {{ entity_id }}
          {% endif %}
```
Just address the bot with some entity in the channel (e.g. ``mybot: sensor.outside``) and it will print its state. Neat! This is of course very simple, but it shows some of it's potential. Combine with ``python_script`` and it should be quite flexible.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
