### PR TITLE
Fix Arlo Q not working with 0.48.1

### DIFF
--- a/homeassistant/components/camera/arlo.py
+++ b/homeassistant/components/camera/arlo.py
@@ -49,7 +49,6 @@ class ArloCam(Camera):
         """Initialize an Arlo camera."""
         super().__init__()
         self._camera = camera
-        self._base_stn = hass.data[DATA_ARLO].base_stations[0]
         self._name = self._camera.name
         self._motion_status = False
         self._ffmpeg = hass.data[DATA_FFMPEG]
@@ -103,7 +102,16 @@ class ArloCam(Camera):
 
     def set_base_station_mode(self, mode):
         """Set the mode in the base station."""
-        self._base_stn.mode = mode
+        # Get the list of base stations identified by library
+        base_stations = has.data[DATA_ARLO].base_stations
+
+        # Some Arlo cameras does not have basestation
+        # So check if there is base station detected first
+        # if yes, then choose the primary base station
+        # Set the mode on the chosen base station
+        if base_stations:
+            primary_base_station = base_stations[0]
+            primary_base_station.mode = mode
 
     def enable_motion_detection(self):
         """Enable the Motion detection in base station (Arm)."""

--- a/homeassistant/components/camera/arlo.py
+++ b/homeassistant/components/camera/arlo.py
@@ -103,7 +103,7 @@ class ArloCam(Camera):
     def set_base_station_mode(self, mode):
         """Set the mode in the base station."""
         # Get the list of base stations identified by library
-        base_stations = has.data[DATA_ARLO].base_stations
+        base_stations = self.hass.data[DATA_ARLO].base_stations
 
         # Some Arlo cameras does not have basestation
         # So check if there is base station detected first


### PR DESCRIPTION
## Description:
This change will re-enable the functionality for Arlo Q cameras. 

When we added the code to enable/disable motion detection, we assumed that base station will be present for all arlo type of cameras. But found recently that Arlo Q cameras does not have base station. So, removed the base_station dependency in the init code.  Line 52 in the init code was the cause of Arlo Q not working which has been removed now.

Instead added code in enable/disable motion detection code to first check if base station is detected by library. If base station is detected then it will use it to enable the motion detection. If not detected, even if service was called, it will not do anything (For example, if some one has only Arlo Q cameras, then base station will not be detected, then even if they run the 'enable_motion_detection' service, it will not do anything).  This change will also make sure that Enable/Disable motion detection service continues to work for Arlo and Arlo Pro cameras which have base station.  Tested with the Arlo cameras that I have at my home.

Enabling/disabling the motion detection for Arlo Q cameras (assuming it has that capability) will not work for this type of camera yet.  It has to be added by someone who has that camera, as I don't know the protocol nor have that camera to do that.

**Related issue (if applicable):** fixes #8412 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
