### PR TITLE
Fix media_position for cast component

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -234,18 +234,13 @@ class CastDevice(MediaPlayerDevice):
     @property
     def media_position(self):
         """Position of current playing media in seconds."""
-        if self.media_status is None or self.media_status_received is None or \
+        if self.media_status is None or \
                 not (self.media_status.player_is_playing or
+                     self.media_status.player_is_paused or
                      self.media_status.player_is_idle):
             return None
 
-        position = self.media_status.current_time
-
-        if self.media_status.player_is_playing:
-            position += (dt_util.utcnow() -
-                         self.media_status_received).total_seconds()
-
-        return position
+        return self.media_status.current_time
 
     @property
     def media_position_updated_at(self):


### PR DESCRIPTION
## Description:
Make media_position available during state paused.

Also, don't adjust for media_position_updated_at. I.e. do as vlc, sonos etc so that returned position is the position at the time of media_position_updated_at, not now.

**Related issue (if applicable):** fixes #7896

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
