### PR TITLE
LIFX: make broadcast address configurable

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -43,9 +43,11 @@ MESSAGE_RETRIES = 8
 UNAVAILABLE_GRACE = 90
 
 CONF_SERVER = 'server'
+CONF_BROADCAST = 'broadcast'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SERVER, default='0.0.0.0'): cv.string,
+    vol.Optional(CONF_BROADCAST, default='255.255.255.255'): cv.string,
 })
 
 SERVICE_LIFX_SET_STATE = 'lifx_set_state'
@@ -125,7 +127,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     lifx_discovery = aiolifx.LifxDiscovery(
         hass.loop,
         lifx_manager,
-        discovery_interval=DISCOVERY_INTERVAL)
+        discovery_interval=DISCOVERY_INTERVAL,
+        broadcast_ip=config.get(CONF_BROADCAST))
 
     coro = hass.loop.create_datagram_endpoint(
         lambda: lifx_discovery, local_addr=(server_addr, UDP_BROADCAST_PORT))


### PR DESCRIPTION
## Description:

This configuration variable was removed when migrating from liffylights to aiolifx. I thought the setting was unnecessary because it was not present in aiolifx but in fact it is needed in some setups. Thus, I got it added to aiolifx and now it is back in HA as well.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2967

## Example entry for `configuration.yaml`:
```yaml
light:
  platform: lifx
  broadcast: 10.0.2.255
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.