### PR TITLE
Remove km from visibility, add visibility_distance

### DIFF
--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -133,7 +133,7 @@ class MetOfficeCurrentSensor(Entity):
            not retrieved from the dp call directly.
         """
         if (self._condition == 'visibility_distance' and 
-            'visibility' in self.data.data.__dict__.keys()):
+                'visibility' in self.data.data.__dict__.keys()):
             return VISIBILTY_CLASSES.get(self.data.data.visibility.value)
         if self._condition in self.data.data.__dict__.keys():
             variable = getattr(self.data.data, self._condition)

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -4,16 +4,18 @@ Support for UK Met Office weather service.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.metoffice/
 """
-import homeassistant.helpers.config_validation as cv
 import logging
-import voluptuous as vol
 from datetime import timedelta
+
+import voluptuous as vol
+
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, TEMP_CELSIUS, STATE_UNKNOWN, CONF_NAME,
     ATTR_ATTRIBUTION, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -127,12 +129,7 @@ class MetOfficeCurrentSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        """
-           Special case for added visibility_distance
-           which is just a lookup on visibility code,
-           not retrieved from the dp call directly.
-        """
-        if (self._condition == 'visibility_distance' and 
+        if (self._condition == 'visibility_distance' and
                 'visibility' in self.data.data.__dict__.keys()):
             return VISIBILTY_CLASSES.get(self.data.data.visibility.value)
         if self._condition in self.data.data.__dict__.keys():

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -4,18 +4,16 @@ Support for UK Met Office weather service.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.metoffice/
 """
+import homeassistant.helpers.config_validation as cv
 import logging
-from datetime import timedelta
-
 import voluptuous as vol
-
+from datetime import timedelta
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, TEMP_CELSIUS, STATE_UNKNOWN, CONF_NAME,
     ATTR_ATTRIBUTION, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -130,12 +128,12 @@ class MetOfficeCurrentSensor(Entity):
     def state(self):
         """Return the state of the sensor."""
         """
-           Special case for added visibility_distance 
+           Special case for added visibility_distance
            which is just a lookup on visibility code,
            not retrieved from the dp call directly.
         """
-        if self._condition == "visibility_distance" \
-                           and 'visibility' in self.data.data.__dict__.keys():
+        if (self._condition == 'visibility_distance' and 
+            'visibility' in self.data.data.__dict__.keys()):
             return VISIBILTY_CLASSES.get(self.data.data.visibility.value)
         if self._condition in self.data.data.__dict__.keys():
             variable = getattr(self.data.data, self._condition)

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -40,6 +40,15 @@ CONDITION_CLASSES = {
     'exceptional': [],
 }
 
+VISIBILTY_CLASSES = {
+    'VP': '<1',
+    'PO': '1-4',
+    'MO': '4-10',
+    'GO': '10-20',
+    'VG': '20-40',
+    'EX': '>40'
+}
+
 SCAN_INTERVAL = timedelta(minutes=35)
 
 # Sensor types are defined like: Name, units
@@ -51,7 +60,8 @@ SENSOR_TYPES = {
     'wind_speed': ['Wind Speed', 'm/s'],
     'wind_direction': ['Wind Direction', None],
     'wind_gust': ['Wind Gust', 'm/s'],
-    'visibility': ['Visibility', 'km'],
+    'visibility': ['Visibility', None],
+    'visibility_distance': ['Visibility Distance', 'km'],
     'uv': ['UV', None],
     'precipitation': ['Probability of Precipitation', '%'],
     'humidity': ['Humidity', '%']
@@ -119,6 +129,12 @@ class MetOfficeCurrentSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
+        """
+           Special case for added visibility_distance which is just a lookup on visibility code,
+           not retrieved from the dp call directly.
+        """
+        if self._condition == "visibility_distance" and 'visibility' in self.data.data.__dict__.keys():
+            return VISIBILTY_CLASSES.get(self.data.data.visibility.value)
         if self._condition in self.data.data.__dict__.keys():
             variable = getattr(self.data.data, self._condition)
             if self._condition == "weather":

--- a/homeassistant/components/sensor/metoffice.py
+++ b/homeassistant/components/sensor/metoffice.py
@@ -130,10 +130,12 @@ class MetOfficeCurrentSensor(Entity):
     def state(self):
         """Return the state of the sensor."""
         """
-           Special case for added visibility_distance which is just a lookup on visibility code,
+           Special case for added visibility_distance 
+           which is just a lookup on visibility code,
            not retrieved from the dp call directly.
         """
-        if self._condition == "visibility_distance" and 'visibility' in self.data.data.__dict__.keys():
+        if self._condition == "visibility_distance" \
+                           and 'visibility' in self.data.data.__dict__.keys():
             return VISIBILTY_CLASSES.get(self.data.data.visibility.value)
         if self._condition in self.data.data.__dict__.keys():
             variable = getattr(self.data.data, self._condition)


### PR DESCRIPTION
## Description:
The values for visibility provided by the Met Office are not in km but are codes (VG=Very Good, etc). These then map to estimated distance ranges of [visibility](http://www.metoffice.gov.uk/guide/weather/symbols#visibility).
* Remove the "km" unit from visibility as it makes no sense.
* Add new sensor value visibility_distance which is a mapping of the 2 letter code to a range in km (as linked above). This is a new optional configuration value.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2968

## Example entry for `configuration.yaml` (if applicable):
```
  - platform: metoffice
    api_key: "APIKEY"
    monitored_conditions:
      ...
      - visibility_distance
      ....
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] ~~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  - [ ] ~~New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  - [ ] ~~New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
  - [ ] ~~New files were added to `.coveragerc`.~~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
