### PR TITLE
HomeMatic dependency upgrade + IP Wall Thermostat support

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['pyhomematic==0.1.28']
+REQUIREMENTS = ['pyhomematic==0.1.29']
 
 DOMAIN = 'homematic'
 
@@ -68,7 +68,7 @@ HM_DEVICE_TYPES = {
         'FillingLevel', 'ValveDrive', 'EcoLogic'],
     DISCOVER_CLIMATE: [
         'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2',
-        'MAXWallThermostat', 'IPThermostat'],
+        'MAXWallThermostat', 'IPThermostat', 'IPThermostatWall'],
     DISCOVER_BINARY_SENSORS: [
         'ShutterContact', 'Smoke', 'SmokeV2', 'Motion', 'MotionV2',
         'RemoteMotion', 'WeatherSensor', 'TiltSensor', 'IPShutterContact',

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -577,7 +577,7 @@ pyharmony==1.0.16
 pyhik==0.1.3
 
 # homeassistant.components.homematic
-pyhomematic==0.1.28
+pyhomematic==0.1.29
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==1.2.0


### PR DESCRIPTION
## Description:
This PR upgrades the dependency and adds support for the HmIP-STHD Wall Thermostat.
The pyhomematic upgrade fixes the BC-PB-2-WM device and adds HM-LC-Ja1PBU-FM to the list of supported covers.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
