### PR TITLE
Make themes API work even when themes are not defined.

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -212,17 +212,20 @@ def setup(hass, config):
         register_built_in_panel(hass, panel)
 
     themes = config.get(DOMAIN, {}).get(ATTR_THEMES)
-    if themes:
-        setup_themes(hass, themes)
+    setup_themes(hass, themes)
 
     return True
 
 
 def setup_themes(hass, themes):
     """Set up themes data and services."""
-    hass.data[DATA_THEMES] = themes
-    hass.data[DATA_DEFAULT_THEME] = DEFAULT_THEME
     hass.http.register_view(ThemesView)
+    hass.data[DATA_DEFAULT_THEME] = DEFAULT_THEME
+    if themes is None:
+        hass.data[DATA_THEMES] = {}
+        return
+
+    hass.data[DATA_THEMES] = themes
 
     @callback
     def update_theme_and_fire_event():

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -133,3 +133,13 @@ def test_themes_reload_themes(hass, mock_http_client_with_themes):
         json = yield from resp.json()
         assert json['themes'] == {'sad': {'primary-color': 'blue'}}
         assert json['default_theme'] == 'default'
+
+
+@asyncio.coroutine
+def test_missing_themes(mock_http_client):
+    """Test that themes API works when themes are not defined."""
+    resp = yield from mock_http_client.get('/api/themes')
+    assert resp.status == 200
+    json = yield from resp.json()
+    assert json['default_theme'] == 'default'
+    assert json['themes'] == {}


### PR DESCRIPTION
## Description:

Make themes API work even when themes are not defined.


If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
