### PR TITLE
Fix check for running inside venv

### DIFF
--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -1,15 +1,17 @@
 """Home Assistant command line scripts."""
 import argparse
 import importlib
+import logging
 import os
 import sys
-import logging
+
 from typing import List
 
+from homeassistant.bootstrap import mount_local_lib_path
 from homeassistant.config import get_default_config_dir
 from homeassistant.const import CONSTRAINT_FILE
-from homeassistant.util.package import install_package, is_virtual_env
-from homeassistant.bootstrap import mount_local_lib_path
+from homeassistant.util.package import (
+    install_package, running_under_virtualenv)
 
 
 def run(args: List) -> int:
@@ -41,7 +43,7 @@ def run(args: List) -> int:
 
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     for req in getattr(script, 'REQUIREMENTS', []):
-        if is_virtual_env():
+        if running_under_virtualenv():
             returncode = install_package(req, constraints=os.path.join(
                 os.path.dirname(__file__), os.pardir, CONSTRAINT_FILE))
         else:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -77,7 +77,7 @@ def _async_process_requirements(hass: core.HomeAssistant, name: str,
 
     def pip_install(mod):
         """Install packages."""
-        if pkg_util.is_virtual_env():
+        if pkg_util.running_under_virtualenv():
             return pkg_util.install_package(
                 mod, constraints=os.path.join(
                     os.path.dirname(__file__), CONSTRAINT_FILE))

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -2,11 +2,12 @@
 import asyncio
 import logging
 import os
+from subprocess import PIPE, Popen
 import sys
 import threading
-from subprocess import Popen, PIPE
 from urllib.parse import urlparse
 
+from pip.locations import running_under_virtualenv
 from typing import Optional
 
 import pkg_resources
@@ -36,7 +37,7 @@ def install_package(package: str, upgrade: bool=True,
         if constraints is not None:
             args += ['--constraint', constraints]
         if target:
-            assert not is_virtual_env()
+            assert not running_under_virtualenv()
             # This only works if not running in venv
             args += ['--user']
             env['PYTHONUSERBASE'] = os.path.abspath(target)
@@ -68,11 +69,6 @@ def check_package_exists(package: str) -> bool:
 
     env = pkg_resources.Environment()
     return any(dist in req for dist in env[req.project_name])
-
-
-def is_virtual_env() -> bool:
-    """Return true if environment is a virtual environment."""
-    return hasattr(sys, 'real_prefix')
 
 
 def _get_user_site(deps_dir: str) -> tuple:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -204,13 +204,14 @@ class TestSetup:
         assert 'comp' not in self.hass.config.components
 
     @mock.patch('homeassistant.setup.os.path.dirname')
-    @mock.patch('homeassistant.util.package.sys')
+    @mock.patch('homeassistant.util.package.running_under_virtualenv',
+                return_value=True)
     @mock.patch('homeassistant.util.package.install_package',
                 return_value=True)
     def test_requirement_installed_in_venv(
-            self, mock_install, mock_sys, mock_dirname):
+            self, mock_install, mock_venv, mock_dirname):
         """Test requirement installed in virtual environment."""
-        mock_sys.real_prefix = 'pythonpath'
+        mock_venv.return_value = True
         mock_dirname.return_value = 'ha_package_path'
         self.hass.config.skip_pip = False
         loader.set_component(
@@ -222,11 +223,12 @@ class TestSetup:
             constraints=os.path.join('ha_package_path', CONSTRAINT_FILE))
 
     @mock.patch('homeassistant.setup.os.path.dirname')
-    @mock.patch('homeassistant.util.package.sys', spec=object())
+    @mock.patch('homeassistant.util.package.running_under_virtualenv',
+                return_value=False)
     @mock.patch('homeassistant.util.package.install_package',
                 return_value=True)
     def test_requirement_installed_in_deps(
-            self, mock_install, mock_sys, mock_dirname):
+            self, mock_install, mock_venv, mock_dirname):
         """Test requirement installed in deps directory."""
         mock_dirname.return_value = 'ha_package_path'
         self.hass.config.skip_pip = False


### PR DESCRIPTION
## Description:
* Import and use the function for checking if venv is active from pip instead of defining it ourselves.
* Fix tests.

**Related issue (if applicable):**
Issue reported by @andrey-git in #7801 

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.