### PR TITLE
Added support for default value when environment variable is missing

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -202,7 +202,7 @@ def _env_var_yaml(loader: SafeLineLoader,
     """Load environment variables and embed it into the configuration YAML."""
     args = node.value.split()
 
-    """Check for a default value"""
+    # Check for a default value
     if len(args) > 1:
         return os.getenv(args[0], ' '.join(args[1:]))
     elif args[0] in os.environ:

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -200,8 +200,13 @@ def _construct_seq(loader: SafeLineLoader, node: yaml.nodes.Node):
 def _env_var_yaml(loader: SafeLineLoader,
                   node: yaml.nodes.Node):
     """Load environment variables and embed it into the configuration YAML."""
-    if node.value in os.environ:
-        return os.environ[node.value]
+    args = node.value.split()
+
+    """Check for a default value"""
+    if len(args) > 1:
+        return os.getenv(args[0], ' '.join(args[1:]))
+    elif args[0] in os.environ:
+        return os.environ[args[0]]
     else:
         _LOGGER.error("Environment variable %s not defined.", node.value)
         raise HomeAssistantError(node.value)

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -59,6 +59,13 @@ class TestYaml(unittest.TestCase):
         assert doc['password'] == "secret_password"
         del os.environ["PASSWORD"]
 
+    def test_environment_variable_default(self):
+        """Test config file with default value for environment variable."""
+        conf = "password: !env_var PASSWORD secret_password"
+        with io.StringIO(conf) as file:
+            doc = yaml.yaml.safe_load(file)
+        assert doc['password'] == "secret_password"
+
     def test_invalid_enviroment_variable(self):
         """Test config file with no enviroment variable sat."""
         conf = "password: !env_var PASSWORD"


### PR DESCRIPTION
## Description:
When using the !env_var tag in a configuration file, you can supply a default value for missing Environment Variables like this:

```yaml
password: !env_var PASSWORD default_password
```

Excluding a default value will continue to function as before.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#2982