### PR TITLE
Fix TypeError with new Tradfri observe feature.

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -43,6 +43,12 @@ def async_setup_platform(hass, config, add_devices, discovery_info=None):
     devices_command = gateway.get_devices()
     devices_commands = yield from api(devices_command)
     devices = yield from api(*devices_commands)
+
+    try:
+        devices = iter(devices)
+    except TypeError:
+        devices = [devices]
+
     lights = [dev for dev in devices if dev.has_light_control]
     add_devices(TradfriLight(light, api) for light in lights)
 
@@ -51,6 +57,12 @@ def async_setup_platform(hass, config, add_devices, discovery_info=None):
         groups_command = gateway.get_groups()
         groups_commands = yield from api(groups_command)
         groups = yield from api(*groups_commands)
+
+        try:
+            groups = iter(groups)
+        except TypeError:
+            groups = [groups]
+
         add_devices(TradfriGroup(group, api) for group in groups)
 
 


### PR DESCRIPTION
## Description:
A TypeError occurs in the new Tradfri observe feature, when only one device or group is detected.

In `devices = yield from api(*devices_commands)`, if devices_commands only contains one item, pytradfri returns just a single object, not a iterable/list.

The same applies for `groups = yield from api(*groups_commands)`

This seems intentional at pytradfri's side: https://github.com/ggravlingen/pytradfri/blob/2.1.1/pytradfri/api/aiocoap_api.py#L124 , so that's why I've not raised a issue/PR there.

The new observe feature for Tradfri is awesome btw, big ups to all involved, I'm looking forward to see it land in stable releases :)

## Checklist (or what's left of it after stripping non applicable parts):

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
