### PR TITLE
Expose all components on hass [Concept]

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -13,6 +13,7 @@ import csv
 import voluptuous as vol
 
 from homeassistant.core import callback
+from homeassistant.loader import bind_hass
 from homeassistant.components import group
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (
@@ -165,6 +166,7 @@ def turn_on(hass, entity_id=None, transition=None, brightness=None,
 
 
 @callback
+@bind_hass
 def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
                   brightness_pct=None, rgb_color=None, xy_color=None,
                   color_temp=None, kelvin=None, white_value=None,

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
     EVENT_SERVICE_EXECUTED, EVENT_SERVICE_REGISTERED, EVENT_STATE_CHANGED,
     EVENT_TIME_CHANGED, MATCH_ALL, EVENT_HOMEASSISTANT_CLOSE,
     EVENT_SERVICE_REMOVED, __version__)
+from homeassistant.loader import Components
 from homeassistant.exceptions import (
     HomeAssistantError, InvalidEntityFormatError)
 from homeassistant.util.async import (
@@ -128,6 +129,7 @@ class HomeAssistant(object):
         self.services = ServiceRegistry(self)
         self.states = StateMachine(self.bus, self.loop)
         self.config = Config()  # type: Config
+        self.components = Components(self)
         # This is a dictionary that any component can store any data on.
         self.data = {}
         self.state = CoreState.not_running

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -206,6 +206,7 @@ class ComponentWrapper:
 
 def bind_hass(func):
     """Decorator to indicate that first argument is hass."""
+    # pylint: disable=protected-access
     func.__bind_hass = True
     return func
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -10,6 +10,7 @@ call get_component('switch.your_platform'). In both cases the config directory
 is checked to see if it contains a user provided version. If not available it
 will check the built-in components and platforms.
 """
+import functools as ft
 import importlib
 import logging
 import os
@@ -168,6 +169,45 @@ def get_component(comp_name) -> Optional[ModuleType]:
     _LOGGER.error("Unable to find component %s", comp_name)
 
     return None
+
+
+class Components:
+    """Helper to load components."""
+
+    def __init__(self, hass):
+        """Initialize the Components class."""
+        self._hass = hass
+
+    def __getattr__(self, comp_name):
+        """Fetch a component."""
+        component = ComponentWrapper(self._hass, get_component(comp_name))
+        setattr(self, comp_name, component)
+        return component
+
+
+class ComponentWrapper:
+    """Class to wrap a component and auto fill in hass argument."""
+
+    def __init__(self, hass, component):
+        """Initialize the component wrapper."""
+        self._hass = hass
+        self._component = component
+
+    def __getattr__(self, attr):
+        """Fetch an attribute."""
+        value = getattr(self._component, attr)
+
+        if hasattr(value, '__bind_hass'):
+            value = ft.partial(value, self._hass)
+
+        setattr(self, attr, value)
+        return value
+
+
+def bind_hass(func):
+    """Decorator to indicate that first argument is hass."""
+    func.__bind_hass = True
+    return func
 
 
 def load_order_component(comp_name: str) -> OrderedSet:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -180,9 +180,12 @@ class Components:
 
     def __getattr__(self, comp_name):
         """Fetch a component."""
-        component = ComponentWrapper(self._hass, get_component(comp_name))
-        setattr(self, comp_name, component)
-        return component
+        component = get_component(comp_name)
+        if component is None:
+            raise ImportError('Unable to load {}'.format(comp_name))
+        wrapped = ComponentWrapper(self._hass, component)
+        setattr(self, comp_name, wrapped)
+        return wrapped
 
 
 class ComponentWrapper:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -3,6 +3,8 @@
 import asyncio
 import unittest
 
+import pytest
+
 import homeassistant.loader as loader
 import homeassistant.components.http as http
 
@@ -63,6 +65,13 @@ def test_component_loader(hass):
     components = loader.Components(hass)
     assert components.http.CONFIG_SCHEMA is http.CONFIG_SCHEMA
     assert hass.components.http.CONFIG_SCHEMA is http.CONFIG_SCHEMA
+
+
+def test_component_loader_non_existing(hass):
+    """Test loading components."""
+    components = loader.Components(hass)
+    with pytest.raises(ImportError):
+        components.non_existing
 
 
 @asyncio.coroutine


### PR DESCRIPTION
This PR is the idea of @pvizeli. I thought it was so great that I felt like putting it in code to see how the concept would look.

The idea origins from two concerns:

1. Components adding their objects to `hass`. This was brought up for intents in #8434 by @andrey-git 
2. It is not clear what the best approach is currently to import components. It's actually `get_component('light')` with  `from homeassistant.loader import get_component`. It is not `from homeassistant.components import light`. The latter is bad as it will not take custom components into consideration.

For components we're going to introduce a new object on hass: `hass.components`. You can fetch any component from this object and it will be correctly resolved. So `hass.components.light` will use `get_component('light')` under the hood.

As extra benefit, we're introducing a new decorator called `bind_hass`. This decorator can be used on any method that you want to expose as a component. When that method is invoked from a component fetched from `hass.components`, it will automatically supply `hass` as first argument.

Before:

```python
from homeassistant.components import light

@asyncio.coroutine
def async_setup(hass, config):
    light.turn_on(hass, 'light.example')
```

After:

```python
@asyncio.coroutine
def async_setup(hass, config):
    hass.components.light.turn_on('light.example')
```

As an extra bonus, this will also set us up for killing `get_component` in the future. It's design is flawed because it doesn't depend on `hass` and thus prevents running two Home Assistant instances with different configuration directories in 1 Python process (and thus running tests in parallel!).

*Note*: Components like http and intent will still have to be imported normally because they provide classes that need to be extended.