### PR TITLE
Fix TP-Link device tracker regression since 0.49

### DIFF
--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -391,7 +391,8 @@ class Tplink5DeviceScanner(TplinkDeviceScanner):
                 "Cache-Control": "no-cache"
             }
 
-            password_md5 = hashlib.md5(self.password.encode('utf')).hexdigest().upper()
+            password_md5 = hashlib.md5(
+                self.password.encode('utf')).hexdigest().upper()
 
             # create a session to handle cookie easier
             session = requests.session()

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -391,7 +391,7 @@ class Tplink5DeviceScanner(TplinkDeviceScanner):
                 "Cache-Control": "no-cache"
             }
 
-            password_md5 = hashlib.md5(self.password).hexdigest().upper()
+            password_md5 = hashlib.md5(self.password.encode('utf')).hexdigest().upper()
 
             # create a session to handle cookie easier
             session = requests.session()


### PR DESCRIPTION
## Description:
Fix TP-Link device tracker regression since 0.49

This regression was introduced by #8322.

Because all backends are attempted, and the broken one is first in line, this breaks other routers than the addition from the PR as well.

Fix is to utf encode the password like the other TP-Link backends do.

Traceback generated by the regression:
```
INFO:homeassistant.components.device_tracker:Setting up device_tracker.tplink
INFO:homeassistant.components.device_tracker.tplink:Loading wireless clients...
ERROR:homeassistant.components.device_tracker:Error setting up platform tplink
Traceback (most recent call last):
  File "/home/maikel/projects/home-assistant/homeassistant/components/device_tracker/__init__.py", line 151, in async_setup_platform
    platform.get_scanner, hass, {DOMAIN: p_config})
  File "/usr/lib64/python3.6/asyncio/futures.py", line 331, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib64/python3.6/asyncio/tasks.py", line 244, in _wakeup
    future.result()
  File "/usr/lib64/python3.6/asyncio/futures.py", line 244, in result
    raise self._exception
  File "/usr/lib64/python3.6/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/maikel/projects/home-assistant/homeassistant/components/device_tracker/tplink.py", line 39, in get_scanner
    scanner = cls(config[DOMAIN])
  File "/home/maikel/projects/home-assistant/homeassistant/components/device_tracker/tplink.py", line 63, in __init__
    self.success_init = self._update_info()
  File "/home/maikel/projects/home-assistant/homeassistant/util/__init__.py", line 303, in wrapper
    result = method(*args, **kwargs)
  File "/home/maikel/projects/home-assistant/homeassistant/components/device_tracker/tplink.py", line 394, in _update_info
    password_md5 = hashlib.md5(self.password).hexdigest().upper()
TypeError: Unicode-objects must be encoded before hashing
```

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
