### PR TITLE
Fixed pi-hole rounding

### DIFF
--- a/homeassistant/components/sensor/google_wifi.py
+++ b/homeassistant/components/sensor/google_wifi.py
@@ -1,0 +1,170 @@
+"""
+Support for retreiving status info from Google Wifi/OnHub routers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.google_wifi/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+import requests
+
+import homeassistant.util.dt as dt
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME, CONF_HOST, CONF_MONITORED_CONDITIONS,
+    STATE_UNKNOWN)
+
+_LOGGER = logging.getLogger(__name__)
+
+ENDPOINT = '/api/v1/status'
+
+ATTR_CURRENT_VERSION = 'current_version'
+ATTR_NEW_VERSION = 'new_version'
+ATTR_UPTIME = 'uptime'
+ATTR_LAST_RESTART = 'last_restart'
+ATTR_LOCAL_IP = 'local_ip'
+ATTR_STATUS = 'status'
+
+DEFAULT_NAME = 'google_wifi'
+DEFAULT_HOST = 'testwifi.here'
+
+MONITORED_CONDITIONS = {
+    ATTR_CURRENT_VERSION: ['Current Version',
+                           None, 'mdi:network-question',
+                           ['software', 'softwareVersion']],
+    ATTR_NEW_VERSION: ['New Version',
+                       None, 'mdi:update',
+                       ['software', 'updateNewVersion']],
+    ATTR_UPTIME: ['Uptime',
+                  'days', 'mdi:timelapse',
+                  ['system', 'uptime']],
+    ATTR_LAST_RESTART: ['Last Network Restart',
+                        None, 'mdi:restart',
+                        None],
+    ATTR_LOCAL_IP: ['Local IP Address',
+                    None, 'mdi:access-point-network',
+                    ['wan', 'localIpAddress']],
+    ATTR_STATUS: ['Status',
+                  None, 'mdi:google',
+                  ['wan', 'online']]
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=MONITORED_CONDITIONS):
+        vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Google Wifi sensor."""
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+
+    api = GoogleWifiAPI(host)
+
+    sensors = [GoogleWifiSensor(hass, api, name, condition)
+               for condition in config[CONF_MONITORED_CONDITIONS]]
+
+    add_devices(sensors, True)
+
+
+class GoogleWifiSensor(Entity):
+    """Representation of a Google Wifi sensor."""
+
+    def __init__(self, hass, api, name, variable):
+        """Initialize a Pi-Hole sensor."""
+        self._hass = hass
+        self._api = api
+        self._name = name
+
+        variable_info = MONITORED_CONDITIONS[variable]
+        self._var_name = variable
+        self._var_units = variable_info[1]
+        self._var_icon = variable_info[2]
+        self._var_key = variable_info[3]
+        self._uptime_keys = MONITORED_CONDITIONS[ATTR_UPTIME][3]
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return "{}_{}".format(self._name, self._var_name)
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._var_icon
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._var_units
+
+    @property
+    def availiable(self):
+        """Return availiability of goole wifi api."""
+        return self._api.availiable
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        if self._var_name == ATTR_LAST_RESTART and self.availiable:
+            uptime = self._api.data[self._uptime_keys[0]][self._uptime_keys[1]]
+            last_restart = dt.now() - timedelta(seconds=uptime)
+            return last_restart.strftime("%Y-%m-%d %H:%M:%S")
+
+        if self.availiable:
+            if (not self._api.data['wan']['ipAddress'] and
+                    self._var_name == ATTR_LOCAL_IP):
+                state_data = STATE_UNKNOWN
+            else:
+                state_data = self._api.data[self._var_key[0]][self._var_key[1]]
+
+            if self._var_name == ATTR_UPTIME:
+                return round(state_data / (24 * 3600), 2)
+            elif self._var_name == ATTR_STATUS:
+                if state_data:
+                    return "Online"
+                return "Offline"
+            elif self._var_name == ATTR_NEW_VERSION:
+                if state_data == '0.0.0.0':
+                    return "Latest"
+            return state_data
+
+        return STATE_UNKNOWN
+
+    def update(self):
+        """Get the latest data from the Google Wifi API."""
+        self._api.update()
+
+
+class GoogleWifiAPI(object):
+    """Get the latest data and update the states."""
+
+    def __init__(self, host):
+        """Initialize the data object."""
+        uri = 'http://'
+        resource = "{}{}{}".format(uri, host, ENDPOINT)
+
+        self._request = requests.Request('GET', resource).prepare()
+        self.data = None
+        self.availiable = True
+        self.update()
+
+    def update(self):
+        """Get the latest data from the router."""
+        try:
+            with requests.Session() as sess:
+                response = sess.send(
+                    self._request, timeout=10)
+            self.data = response.json()
+            self.availiable = True
+        except ValueError:
+            _LOGGER.error("Unable to fetch data from Google Wifi")
+            self.availiable = False
+            self.data = None

--- a/homeassistant/components/sensor/pi_hole.py
+++ b/homeassistant/components/sensor/pi_hole.py
@@ -104,7 +104,10 @@ class PiHoleSensor(Entity):
     @property
     def state(self):
         """Return the state of the device."""
-        return self._api.data[self._var_id]
+        try:
+            return round(self._api.data[self._var_id])
+        except TypeError:
+            return self._api.data[self._var_id]
 
     # pylint: disable=no-member
     @property

--- a/homeassistant/components/sensor/pi_hole.py
+++ b/homeassistant/components/sensor/pi_hole.py
@@ -105,7 +105,7 @@ class PiHoleSensor(Entity):
     def state(self):
         """Return the state of the device."""
         try:
-            return round(self._api.data[self._var_id])
+            return round(self._api.data[self._var_id], 2)
         except TypeError:
             return self._api.data[self._var_id]
 

--- a/tests/components/sensor/test_google_wifi.py
+++ b/tests/components/sensor/test_google_wifi.py
@@ -1,0 +1,200 @@
+"""The tests for the Google Wifi platform."""
+import unittest
+from unittest.mock import patch, Mock
+from datetime import datetime
+import requests_mock
+
+from homeassistant.setup import setup_component
+import homeassistant.components.sensor.google_wifi as google_wifi
+from homeassistant.const import STATE_UNKNOWN
+
+from tests.common import get_test_home_assistant, assert_setup_component
+
+NAME = 'foo'
+
+MOCK_DATA = ('{"software": {"softwareVersion":"initial",'
+             '"updateNewVersion":"initial"},'
+             '"system": {"uptime":86400},'
+             '"wan": {"localIpAddress":"initial", "online":true,'
+             '"ipAddress":true}}')
+
+MOCK_DATA_NEXT = ('{"software": {"softwareVersion":"next",'
+                  '"updateNewVersion":"0.0.0.0"},'
+                  '"system": {"uptime":172800},'
+                  '"wan": {"localIpAddress":"next", "online":false,'
+                  '"ipAddress":false}}')
+
+
+class TestGoogleWifiSetup(unittest.TestCase):
+    """Tests for setting up the Google Wifi switch platform."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @requests_mock.Mocker()
+    def test_setup_minimum(self, mock_req):
+        """Test setup with minimum configuration."""
+        resource = '{}{}{}'.format('http://',
+                                   google_wifi.DEFAULT_HOST,
+                                   google_wifi.ENDPOINT)
+        mock_req.get(resource, status_code=200)
+        self.assertTrue(setup_component(self.hass, 'sensor', {
+            'sensor': {
+                'platform': 'google_wifi'
+            }
+        }))
+
+    @requests_mock.Mocker()
+    def test_setup_get(self, mock_req):
+        """Test setup with full configuration."""
+        resource = '{}{}{}'.format('http://',
+                                   'localhost',
+                                   google_wifi.ENDPOINT)
+        mock_req.get(resource, status_code=200)
+        self.assertTrue(setup_component(self.hass, 'sensor', {
+            'sensor': {
+                'platform': 'google_wifi',
+                'host': 'localhost',
+                'name': 'Test Wifi',
+                'monitored_conditions': ['current_version',
+                                         'new_version',
+                                         'uptime',
+                                         'last_restart',
+                                         'local_ip',
+                                         'status']
+            }
+        }))
+        assert_setup_component(6, 'sensor')
+
+
+class TestGoogleWifiSensor(unittest.TestCase):
+    """Tests for Google Wifi sensor platform."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        resource = '{}{}{}'.format('http://',
+                                   'localhost',
+                                   google_wifi.ENDPOINT)
+        with requests_mock.Mocker() as mock_req:
+            mock_req.get(resource, text=MOCK_DATA, status_code=200)
+            self.api = google_wifi.GoogleWifiAPI("localhost")
+        self.name = NAME
+        self.sensor_dict = dict()
+        for condition, cond_list in google_wifi.MONITORED_CONDITIONS.items():
+            sensor = google_wifi.GoogleWifiSensor(self.hass, self.api,
+                                                  self.name, condition)
+            name = '{}_{}'.format(self.name, condition)
+            units = cond_list[1]
+            icon = cond_list[2]
+            self.sensor_dict[name] = {'sensor': sensor,
+                                      'units': units,
+                                      'icon': icon}
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_name(self):
+        """Test the name."""
+        for name in self.sensor_dict:
+            sensor = self.sensor_dict[name]['sensor']
+            self.assertEqual(name, sensor.name)
+
+    def test_unit_of_measurement(self):
+        """Test the unit of measurement."""
+        for name in self.sensor_dict:
+            sensor = self.sensor_dict[name]['sensor']
+            self.assertEqual(self.sensor_dict[name]['units'],
+                             sensor.unit_of_measurement)
+
+    def test_icon(self):
+        """Test the icon."""
+        for name in self.sensor_dict:
+            sensor = self.sensor_dict[name]['sensor']
+            self.assertEqual(self.sensor_dict[name]['icon'], sensor.icon)
+
+    @requests_mock.Mocker()
+    def test_state(self, mock_req):
+        """Test the initial state."""
+        resource = '{}{}{}'.format('http://',
+                                   'localhost',
+                                   google_wifi.ENDPOINT)
+        mock_req.get(resource, text=MOCK_DATA, status_code=200)
+        now = datetime(1970, month=1, day=1)
+        with patch('homeassistant.util.dt.now', return_value=now):
+            for name in self.sensor_dict:
+                sensor = self.sensor_dict[name]['sensor']
+                sensor.update()
+                if name == '{}_{}'.format(self.name,
+                                          google_wifi.ATTR_LAST_RESTART):
+                    self.assertEqual('1969-12-31 00:00:00', sensor.state)
+                elif name == '{}_{}'.format(self.name,
+                                            google_wifi.ATTR_UPTIME):
+                    self.assertEqual(1, sensor.state)
+                elif name == '{}_{}'.format(self.name,
+                                            google_wifi.ATTR_STATUS):
+                    self.assertEqual('Online', sensor.state)
+                else:
+                    self.assertEqual('initial', sensor.state)
+
+    @requests_mock.Mocker()
+    def test_update_when_value_is_none(self, mock_req):
+        """Test state gets updated to unknown when sensor returns no data."""
+        resource = '{}{}{}'.format('http://',
+                                   'localhost',
+                                   google_wifi.ENDPOINT)
+        mock_req.get(resource, text=None, status_code=200)
+        for name in self.sensor_dict:
+            sensor = self.sensor_dict[name]['sensor']
+            sensor.update()
+            self.assertEqual(STATE_UNKNOWN, sensor.state)
+
+    @requests_mock.Mocker()
+    def test_update_when_value_changed(self, mock_req):
+        """Test state gets updated when sensor returns a new status."""
+        resource = '{}{}{}'.format('http://',
+                                   'localhost',
+                                   google_wifi.ENDPOINT)
+        mock_req.get(resource, text=MOCK_DATA_NEXT, status_code=200)
+        now = datetime(1970, month=1, day=1)
+        with patch('homeassistant.util.dt.now', return_value=now):
+            for name in self.sensor_dict:
+                sensor = self.sensor_dict[name]['sensor']
+                sensor.update()
+                if name == '{}_{}'.format(self.name,
+                                          google_wifi.ATTR_LAST_RESTART):
+                    self.assertEqual('1969-12-30 00:00:00', sensor.state)
+                elif name == '{}_{}'.format(self.name,
+                                            google_wifi.ATTR_UPTIME):
+                    self.assertEqual(2, sensor.state)
+                elif name == '{}_{}'.format(self.name,
+                                            google_wifi.ATTR_STATUS):
+                    self.assertEqual('Offline', sensor.state)
+                elif name == '{}_{}'.format(self.name,
+                                            google_wifi.ATTR_NEW_VERSION):
+                    self.assertEqual('Latest', sensor.state)
+                elif name == '{}_{}'.format(self.name,
+                                            google_wifi.ATTR_LOCAL_IP):
+                    self.assertEqual(STATE_UNKNOWN, sensor.state)
+                else:
+                    self.assertEqual('next', sensor.state)
+
+    def test_update_when_unavailiable(self):
+        """Test state updates when Google Wifi unavailiable."""
+        self.api.update = Mock('google_wifi.GoogleWifiAPI.update',
+                               side_effect=self.update_side_effect())
+        for name in self.sensor_dict:
+            sensor = self.sensor_dict[name]['sensor']
+            sensor.update()
+            self.assertEqual(STATE_UNKNOWN, sensor.state)
+
+    def update_side_effect(self):
+        """Mock representation of update function."""
+        self.api.data = None
+        self.api.availiable = False


### PR DESCRIPTION
## Description:
The `ads_percentage_blocked_today` sensor in pi-hole reports the raw value from the API which can have a stupid amount of decimals.  I round the result to two decimals and added a try/except in case more sensors (possible non-numeric) are added in the future.

EDIT - had an open PR mixed in with this branch by accident... will fix and re-open

## Checklist:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
