### PR TITLE
Added pi-hole sensor rounding

### DIFF
--- a/homeassistant/components/sensor/pi_hole.py
+++ b/homeassistant/components/sensor/pi_hole.py
@@ -104,7 +104,10 @@ class PiHoleSensor(Entity):
     @property
     def state(self):
         """Return the state of the device."""
-        return self._api.data[self._var_id]
+        try:
+            return round(self._api.data[self._var_id], 2)
+        except TypeError:
+            return self._api.data[self._var_id]
 
     # pylint: disable=no-member
     @property


### PR DESCRIPTION
## Description:
The pi-hole sensor grabs the raw API results from Pi-Hole which can have stupidly long decimals (specifically the percentage of ads blocked).  I round to two decimals and wrap in a try/except to ensure future sensors that are added will still return states (i.e. when they are non-numeric).

## Checklist:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**