### PR TITLE
Support for Wink Switch and Light groups also fix fan speed selection

### DIFF
--- a/homeassistant/components/fan/wink.py
+++ b/homeassistant/components/fan/wink.py
@@ -47,7 +47,6 @@ class WinkFanDevice(WinkDevice, FanEntity):
 
     def set_speed(self: ToggleEntity, speed: str) -> None:
         """Set the speed of the fan."""
-        _LOGGGER.info(speed)
         self.wink.set_state(True, speed)
 
     def turn_on(self: ToggleEntity, speed: str=None, **kwargs) -> None:

--- a/homeassistant/components/fan/wink.py
+++ b/homeassistant/components/fan/wink.py
@@ -9,7 +9,8 @@ import logging
 
 from homeassistant.components.fan import (FanEntity, SPEED_HIGH,
                                           SPEED_LOW, SPEED_MEDIUM,
-                                          STATE_UNKNOWN)
+                                          STATE_UNKNOWN, SUPPORT_SET_SPEED,
+                                          SUPPORT_DIRECTION)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.components.wink import WinkDevice, DOMAIN
 
@@ -19,6 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 
 SPEED_LOWEST = 'lowest'
 SPEED_AUTO = 'auto'
+
+SUPPORTED_FEATURES = SUPPORT_DIRECTION + SUPPORT_SET_SPEED
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -44,11 +47,12 @@ class WinkFanDevice(WinkDevice, FanEntity):
 
     def set_speed(self: ToggleEntity, speed: str) -> None:
         """Set the speed of the fan."""
-        self.wink.set_fan_speed(speed)
+        _LOGGGER.info(speed)
+        self.wink.set_state(True, speed)
 
     def turn_on(self: ToggleEntity, speed: str=None, **kwargs) -> None:
         """Turn on the fan."""
-        self.wink.set_state(True)
+        self.wink.set_state(True, speed)
 
     def turn_off(self: ToggleEntity, **kwargs) -> None:
         """Turn off the fan."""
@@ -96,3 +100,8 @@ class WinkFanDevice(WinkDevice, FanEntity):
         if SPEED_HIGH in wink_supported_speeds:
             supported_speeds.append(SPEED_HIGH)
         return supported_speeds
+
+    @property
+    def supported_features(self: ToggleEntity) -> int:
+        """Flag supported features."""
+        return SUPPORTED_FEATURES

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -28,6 +28,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _id = light.object_id() + light.name()
         if _id not in hass.data[DOMAIN]['unique_ids']:
             add_devices([WinkLight(light, hass)])
+    for light in pywink.get_light_groups():
+        _id = light.object_id() + light.name()
+        if _id not in hass.data[DOMAIN]['unique_ids']:
+            add_devices([WinkLight(light, hass)])
 
 
 class WinkLight(WinkDevice, Light):
@@ -101,7 +105,7 @@ class WinkLight(WinkDevice, Light):
                 xyb = color_util.color_RGB_to_xy(*rgb_color)
                 state_kwargs['color_xy'] = xyb[0], xyb[1]
                 state_kwargs['brightness'] = xyb[2]
-            elif self.wink.supports_hue_saturation():
+            if self.wink.supports_hue_saturation():
                 hsv = colorsys.rgb_to_hsv(
                     rgb_color[0], rgb_color[1], rgb_color[2])
                 state_kwargs['color_hue_saturation'] = hsv[0], hsv[1]

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -32,6 +32,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _id = sprinkler.object_id() + sprinkler.name()
         if _id not in hass.data[DOMAIN]['unique_ids']:
             add_devices([WinkToggleDevice(sprinkler, hass)])
+    for switch in pywink.get_binary_switch_groups():
+        _id = switch.object_id() + switch.name()
+        if _id not in hass.data[DOMAIN]['unique_ids']:
+            add_devices([WinkToggleDevice(switch, hass)])
 
 
 class WinkToggleDevice(WinkDevice, ToggleEntity):

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==1.2.4', 'pubnubsub-handler==1.0.2']
+REQUIREMENTS = ['python-wink==1.3.1', 'pubnubsub-handler==1.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ def setup(hass, config):
         password = config[DOMAIN][CONF_PASSWORD]
         client_id = config[DOMAIN]['client_id']
         client_secret = config[DOMAIN]['client_secret']
-        pywink.set_wink_credentials(email, password, client_id, client_secret)
+        pywink.legacy_set_wink_credentials(email, password, client_id, client_secret)
         hass.data[DOMAIN]['oath'] = {"email": email,
                                      "password": password,
                                      "client_id": client_id,

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -105,7 +105,8 @@ def setup(hass, config):
         password = config[DOMAIN][CONF_PASSWORD]
         client_id = config[DOMAIN]['client_id']
         client_secret = config[DOMAIN]['client_secret']
-        pywink.legacy_set_wink_credentials(email, password, client_id, client_secret)
+        pywink.legacy_set_wink_credentials(email, password,
+                                           client_id, client_secret)
         hass.data[DOMAIN]['oath'] = {"email": email,
                                      "password": password,
                                      "client_id": client_id,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -752,7 +752,7 @@ python-twitch==1.3.0
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.2.4
+python-wink==1.3.1
 
 # homeassistant.components.zwave
 python_openzwave==0.4.0.31


### PR DESCRIPTION
## Description:
This adds support for Wink switch and light groups. These will show up in HA as one device, but under the cover could be X number of devices. Groups are treated as whatever device has the most functionality. For example, a groups of lights with 10 bulbs that only support brightness and one bulb that support full color, will support full color. A group only containing binary switches will show up as a switch in HA. 

Using Wink groups verses HA groups will greatly increase the speed changing state, because only one external call needs made verse X number of calls.

Note: Python-wink only pulls in user created groups none of the default Wink created groups are pulled. 

**Related issue (if applicable):** fixes #8388 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
