### PR TITLE
Added additional attributes to OwnTracks device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -353,12 +353,20 @@ def _parse_see_args(topic, data):
     kwargs = {
         'dev_id': dev_id,
         'host_name': host_name,
-        'gps': (data[WAYPOINT_LAT_KEY], data[WAYPOINT_LON_KEY])
+        'gps': (data[WAYPOINT_LAT_KEY], data[WAYPOINT_LON_KEY]),
+        'attributes':{}
     }
     if 'acc' in data:
         kwargs['gps_accuracy'] = data['acc']
     if 'batt' in data:
         kwargs['battery'] = data['batt']
+    if 'vel' in data:
+        kwargs['attributes']['velocity'] = data['vel']
+    if 'tid' in data:
+        kwargs['attributes']['tid'] = data['tid']
+    if 'addr' in data:
+        kwargs['attributes']['address'] = data['addr']
+
     return dev_id, kwargs
 
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -354,7 +354,7 @@ def _parse_see_args(topic, data):
         'dev_id': dev_id,
         'host_name': host_name,
         'gps': (data[WAYPOINT_LAT_KEY], data[WAYPOINT_LON_KEY]),
-        'attributes':{}
+        'attributes': {}
     }
     if 'acc' in data:
         kwargs['gps_accuracy'] = data['acc']


### PR DESCRIPTION
## Description:
Adds three relevant attributes to OwnTracks devices
* vel: Current speed of the device
* tid: Tracker ID of the device to distinguish it from other devices of the same user 
* addr: Can be used by OwnTracks recorder to provide reverse geocoding for the lat/lon coordinates  

![image](https://user-images.githubusercontent.com/782356/28249500-46f294d2-6a57-11e7-9293-4f6ed2f4705b.png)

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
