### PR TITLE
Remove deprecated automation keywords

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -12,13 +12,11 @@ import homeassistant.util.dt as dt_util
 from homeassistant.const import MATCH_ALL, CONF_PLATFORM
 from homeassistant.helpers.event import (
     async_track_state_change, async_track_point_in_utc_time)
-from homeassistant.helpers.deprecation import get_deprecated
 import homeassistant.helpers.config_validation as cv
 
 CONF_ENTITY_ID = 'entity_id'
 CONF_FROM = 'from'
 CONF_TO = 'to'
-CONF_STATE = 'state'
 CONF_FOR = 'for'
 
 TRIGGER_SCHEMA = vol.All(
@@ -28,11 +26,9 @@ TRIGGER_SCHEMA = vol.All(
         # These are str on purpose. Want to catch YAML conversions
         CONF_FROM: str,
         CONF_TO: str,
-        CONF_STATE: str,
         CONF_FOR: vol.All(cv.time_period, cv.positive_timedelta),
     }),
-    vol.Any(cv.key_dependency(CONF_FOR, CONF_TO),
-            cv.key_dependency(CONF_FOR, CONF_STATE))
+    cv.key_dependency(CONF_FOR, CONF_TO),
 )
 
 
@@ -41,7 +37,7 @@ def async_trigger(hass, config, action):
     """Listen for state changes based on configuration."""
     entity_id = config.get(CONF_ENTITY_ID)
     from_state = config.get(CONF_FROM, MATCH_ALL)
-    to_state = get_deprecated(config, CONF_TO, CONF_STATE, MATCH_ALL)
+    to_state = config.get(CONF_TO, MATCH_ALL)
     time_delta = config.get(CONF_FOR)
     async_remove_state_for_cancel = None
     async_remove_state_for_listener = None

--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -10,7 +10,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.const import CONF_AT, CONF_PLATFORM, CONF_AFTER
+from homeassistant.const import CONF_AT, CONF_PLATFORM
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_time_change
 
@@ -23,7 +23,6 @@ _LOGGER = logging.getLogger(__name__)
 TRIGGER_SCHEMA = vol.All(vol.Schema({
     vol.Required(CONF_PLATFORM): 'time',
     CONF_AT: cv.time,
-    CONF_AFTER: cv.time,
     CONF_HOURS: vol.Any(vol.Coerce(int), vol.Coerce(str)),
     CONF_MINUTES: vol.Any(vol.Coerce(int), vol.Coerce(str)),
     CONF_SECONDS: vol.Any(vol.Coerce(int), vol.Coerce(str)),
@@ -36,11 +35,6 @@ def async_trigger(hass, config, action):
     """Listen for state changes based on configuration."""
     if CONF_AT in config:
         at_time = config.get(CONF_AT)
-        hours, minutes, seconds = at_time.hour, at_time.minute, at_time.second
-    elif CONF_AFTER in config:
-        _LOGGER.warning("'after' is deprecated for the time trigger. Please "
-                        "rename 'after' to 'at' in your configuration file.")
-        at_time = config.get(CONF_AFTER)
         hours, minutes, seconds = at_time.hour, at_time.minute, at_time.second
     else:
         hours = config.get(CONF_HOURS)

--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -26,8 +26,7 @@ TRIGGER_SCHEMA = vol.All(vol.Schema({
     CONF_HOURS: vol.Any(vol.Coerce(int), vol.Coerce(str)),
     CONF_MINUTES: vol.Any(vol.Coerce(int), vol.Coerce(str)),
     CONF_SECONDS: vol.Any(vol.Coerce(int), vol.Coerce(str)),
-}), cv.has_at_least_one_key(CONF_HOURS, CONF_MINUTES,
-                            CONF_SECONDS, CONF_AT, CONF_AFTER))
+}), cv.has_at_least_one_key(CONF_HOURS, CONF_MINUTES, CONF_SECONDS, CONF_AT))
 
 
 @asyncio.coroutine

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -130,25 +130,6 @@ class TestAutomationState(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
 
-    def test_if_fires_on_entity_change_with_state_filter(self):
-        """Test for firing on entity change with state filter."""
-        assert setup_component(self.hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'trigger': {
-                    'platform': 'state',
-                    'entity_id': 'test.entity',
-                    'state': 'world'
-                },
-                'action': {
-                    'service': 'test.automation'
-                }
-            }
-        })
-
-        self.hass.states.set('test.entity', 'world')
-        self.hass.block_till_done()
-        self.assertEqual(1, len(self.calls))
-
     def test_if_fires_on_entity_change_with_both_filters(self):
         """Test for firing if both filters are a non match."""
         assert setup_component(self.hass, automation.DOMAIN, {


### PR DESCRIPTION
## Description:

The state trigger keyword `state` and the time trigger keyword `after` were deprecated in 0.46. I think now is a good time to remove them completely.

**For those clicking through looking to fix their HA**

Find all `platform: state` TRIGGERS that use "`state:`"
Change those to "`to:`"

Do the same for `platform: time` TRIGGERS, i.e. change "`after:`"  to "`at:`"

Note: Only TRIGGERS (not conditions)! 

Example:

FROM:
```
- alias: Garage door opened
  trigger:
    - platform: state
      entity_id: cover.myq
      state: 'open'
```

TO:

```
- alias: Garage door opened
  trigger:
    - platform: state
      entity_id: cover.myq
      to: 'open'
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2997

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been <s>added</s> removed to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54