### PR TITLE
fix for a bug introduced with media support in #8413

### DIFF
--- a/homeassistant/components/notify/twitter.py
+++ b/homeassistant/components/notify/twitter.py
@@ -60,10 +60,13 @@ class TwitterNotificationService(BaseNotificationService):
     def send_message(self, message="", **kwargs):
         """Tweet a message, optionally with media."""
         data = kwargs.get(ATTR_DATA)
-        media = data.get(ATTR_MEDIA)
-        if not self.hass.config.is_allowed_path(media):
-            _LOGGER.warning("'%s' is not in a whitelisted area.", media)
-            return
+
+        media = None
+        if data:
+            media = data.get(ATTR_MEDIA)
+            if not self.hass.config.is_allowed_path(media):
+                _LOGGER.warning("'%s' is not in a whitelisted area.", media)
+                return
 
         media_id = self.upload_media(media)
 


### PR DESCRIPTION
fix for a bug introduced with media support in #8413

`data` may be `None` if twitter data property not present in configuration
```
  File "./homeassistant/components/notify/twitter.py", line 63, in send_message
    media = data.get(ATTR_MEDIA)
```