### PR TITLE
Extended Dlib image_processing to save images to directories and bugfixes

### DIFF
--- a/homeassistant/components/image_processing/dlib_face_detect.py
+++ b/homeassistant/components/image_processing/dlib_face_detect.py
@@ -6,26 +6,55 @@ https://home-assistant.io/components/image_processing.dlib_face_detect/
 """
 import logging
 import io
+import os
+import time
 
-from homeassistant.core import split_entity_id
+import voluptuous as vol
+
+from homeassistant.core import split_entity_id, callback
 # pylint: disable=unused-import
+from homeassistant.components.image_processing.dlib_face_identify import (
+    keep_image)
 from homeassistant.components.image_processing import PLATFORM_SCHEMA  # noqa
 from homeassistant.components.image_processing import (
-    CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)
+    ATTR_ENTITY_ID, CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)
 from homeassistant.components.image_processing.microsoft_face_identify import (
-    ImageProcessingFaceEntity)
+    ATTR_TOTAL_FACES, ImageProcessingFaceEntity)
+import homeassistant.helpers.config_validation as cv
+
 
 REQUIREMENTS = ['face_recognition==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
+EVENT_DETECT_FACE = 'image_processing.detect_face'
+
+CONF_WITH_FACES = 'keep_faces'
+CONF_WITHOUT_FACES = 'keep_no_faces'
+
+DEFAULT_FACES_DIR = 'dlib_faces'
+DEFAULT_WITHOUT_FACES_DIR = 'dlib_nofaces'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_WITH_FACES, default=False): cv.boolean,
+    vol.Optional(CONF_WITHOUT_FACES, default=False): cv.boolean,
+})
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Dlib Face detection platform."""
+    with_faces_dir = hass.config.path(DEFAULT_FACES_DIR)
+    without_faces_dir = hass.config.path(DEFAULT_WITHOUT_FACES_DIR)
+
     entities = []
     for camera in config[CONF_SOURCE]:
         entities.append(DlibFaceDetectEntity(
-            camera[CONF_ENTITY_ID], camera.get(CONF_NAME)
+            camera[CONF_ENTITY_ID],
+            config[CONF_WITH_FACES],
+            config[CONF_WITHOUT_FACES],
+            with_faces_dir,
+            without_faces_dir,
+            camera.get(CONF_NAME)
         ))
 
     add_devices(entities)
@@ -34,11 +63,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class DlibFaceDetectEntity(ImageProcessingFaceEntity):
     """Dlib Face API entity for identify."""
 
-    def __init__(self, camera_entity, name=None):
+    def __init__(self, camera_entity, save_faces, save_without_faces,
+                 with_faces_dir, without_faces_dir, name=None):
         """Initialize Dlib face entity."""
         super().__init__()
 
         self._camera = camera_entity
+        self._save_faces = save_faces
+        self._save_without_faces = save_without_faces
+        self._with_faces_dir = with_faces_dir
+        self._without_faces_dir = without_faces_dir
+        self.total_faces = 0
 
         if name:
             self._name = name
@@ -56,6 +91,27 @@ class DlibFaceDetectEntity(ImageProcessingFaceEntity):
         """Return the name of the entity."""
         return self._name
 
+    @property
+    def state_attributes(self):
+        """Return device specific state attributes."""
+        attr = {
+            ATTR_TOTAL_FACES: self.total_faces,
+        }
+
+        return attr
+
+    @callback
+    def async_process_faces(self, faces, total):
+        """Send event with detected faces and store data."""
+        # pylint: disable=unused-variable
+        for face in faces:
+            event = {ATTR_ENTITY_ID: self.entity_id}
+            self.hass.async_add_job(
+                self.hass.bus.async_fire, EVENT_DETECT_FACE, event
+            )
+
+        self.total_faces = total
+
     def process_image(self, image):
         """Process image."""
         # pylint: disable=import-error
@@ -67,5 +123,17 @@ class DlibFaceDetectEntity(ImageProcessingFaceEntity):
 
         image = face_recognition.load_image_file(fak_file)
         face_locations = face_recognition.face_locations(image)
+
+        timestamp = time.strftime('%b-%d-%Y_%H:%M:%S', time.localtime())
+        filename = "{0}_{1}.jpg".format(self.camera_entity, timestamp)
+
+        if face_locations:
+            if self._save_faces:
+                keep_image(fak_file,
+                           os.path.join(self._with_faces_dir, filename))
+        else:
+            if self._save_without_faces:
+                keep_image(fak_file,
+                           os.path.join(self._without_faces_dir, filename))
 
         self.process_faces(face_locations, len(face_locations))

--- a/homeassistant/components/image_processing/dlib_face_identify.py
+++ b/homeassistant/components/image_processing/dlib_face_identify.py
@@ -149,7 +149,7 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
                                        self._known_faces_dir,
                                        filename))
 
-                if self._save_unknown_faces:
+                if self._save_unknown_faces and not result[0]:
                     keep_image(fak_file,
                                os.path.join(self._unknown_faces_dir, filename))
 

--- a/homeassistant/components/image_processing/dlib_face_identify.py
+++ b/homeassistant/components/image_processing/dlib_face_identify.py
@@ -6,6 +6,8 @@ https://home-assistant.io/components/image_processing.dlib_face_identify/
 """
 import logging
 import io
+import os
+import time
 
 import voluptuous as vol
 
@@ -13,7 +15,7 @@ from homeassistant.core import split_entity_id
 from homeassistant.components.image_processing import (
     PLATFORM_SCHEMA, CONF_SOURCE, CONF_ENTITY_ID, CONF_NAME)
 from homeassistant.components.image_processing.microsoft_face_identify import (
-    ImageProcessingFaceEntity)
+    ATTR_TOTAL_FACES, ATTR_FACES, ImageProcessingFaceEntity)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['face_recognition==0.2.0']
@@ -22,18 +24,45 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_NAME = 'name'
 CONF_FACES = 'faces'
+CONF_KNOWN_FACES = 'keep_known_faces'
+CONF_UNKNOWN_FACES = 'keep_unknown_faces'
+
+DEFAULT_KNOWN_FACES_DIR = 'dlib_known_faces'
+DEFAULT_UNKNOWN_FACES_DIR = 'dlib_unknown_faces'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_FACES): {cv.string: cv.isfile},
+    vol.Optional(CONF_KNOWN_FACES, default=False): cv.boolean,
+    vol.Optional(CONF_UNKNOWN_FACES, default=False): cv.boolean,
 })
+
+
+def keep_image(image, filename):
+    """Save image for troubleshooting."""
+    directory = os.path.dirname(filename)
+
+    if not os.path.isdir(directory):
+        os.mkdir(directory)
+
+    with open(filename, 'wb') as fdb:
+        fdb.write(image.getvalue())
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Dlib Face detection platform."""
+    known_faces_dir = hass.config.path(DEFAULT_KNOWN_FACES_DIR)
+    unknown_faces_dir = hass.config.path(DEFAULT_UNKNOWN_FACES_DIR)
+
     entities = []
     for camera in config[CONF_SOURCE]:
         entities.append(DlibFaceIdentifyEntity(
-            camera[CONF_ENTITY_ID], config[CONF_FACES], camera.get(CONF_NAME)
+            camera[CONF_ENTITY_ID],
+            config[CONF_FACES],
+            config[CONF_KNOWN_FACES],
+            config[CONF_UNKNOWN_FACES],
+            known_faces_dir,
+            unknown_faces_dir,
+            camera.get(CONF_NAME),
         ))
 
     add_devices(entities)
@@ -42,13 +71,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
     """Dlib Face API entity for identify."""
 
-    def __init__(self, camera_entity, faces, name=None):
+    def __init__(self, camera_entity, faces, save_known, save_unknown,
+                 known_faces_dir, unknown_faces_dir, name=None):
         """Initialize Dlib face identify entry."""
         # pylint: disable=import-error
         import face_recognition
         super().__init__()
 
         self._camera = camera_entity
+        self._save_known_faces = save_known
+        self._save_unknown_faces = save_unknown
+        self._known_faces_dir = known_faces_dir
+        self._unknown_faces_dir = unknown_faces_dir
 
         if name:
             self._name = name
@@ -58,8 +92,12 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
 
         self._faces = {}
         for face_name, face_file in faces.items():
-            image = face_recognition.load_image_file(face_file)
-            self._faces[face_name] = face_recognition.face_encodings(image)[0]
+            try:
+                image = face_recognition.load_image_file(face_file)
+                self._faces[face_name] = \
+                    face_recognition.face_encodings(image)[0]
+            except IndexError as err:
+                _LOGGER.error("Failed to parse %s. Error: %s", face_file, err)
 
     @property
     def camera_entity(self):
@@ -70,6 +108,16 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
     def name(self):
         """Return the name of the entity."""
         return self._name
+
+    @property
+    def state_attributes(self):
+        """Return device specific state attributes."""
+        attr = {
+            ATTR_FACES: [face['name'] for face in self.faces],
+            ATTR_TOTAL_FACES: self.total_faces,
+        }
+
+        return attr
 
     def process_image(self, image):
         """Process image."""
@@ -83,6 +131,9 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
         image = face_recognition.load_image_file(fak_file)
         unknowns = face_recognition.face_encodings(image)
 
+        timestamp = time.strftime('%b-%d-%Y_%H:%M:%S', time.localtime())
+        filename = "{0}_{1}.jpg".format(self.camera_entity, timestamp)
+
         found = []
         for unknown_face in unknowns:
             for name, face in self._faces.items():
@@ -91,5 +142,15 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
                     found.append({
                         ATTR_NAME: name
                     })
+
+                    if self._save_known_faces:
+                        keep_image(fak_file,
+                                   os.path.join(
+                                       self._known_faces_dir,
+                                       filename))
+
+                if self._save_unknown_faces:
+                    keep_image(fak_file,
+                               os.path.join(self._unknown_faces_dir, filename))
 
         self.process_faces(found, len(unknowns))


### PR DESCRIPTION
## Description:
 During the `image_processing.dlib*` configuration process I found a little bit complicated to understand if the component was working or not. 
 So the idea of this PR is to make the process a little more comprehensive by allowing the user some options to save the images captures by Dlib to a directory to determine how accurate the `face_recognition` is. 

This PR also fixes the issue reported at https://github.com/home-assistant/home-assistant/issues/8493 since dlib behaves a little bit different than `microsoft_face_recognition`.  

This also allows `dlib_face_identify` to show the name of the face detected instead showing the meta object on the frontend. 

- Fixed traceback AttributeError: 'tuple' object has no attribute 'update' (fixes #8493)
- Introduced ability to debug picture when a face is or not detected.
- Treats exception when image cannot be parsed
- Modified state_attributes to return the face_name attribute instead object

**Related issue (if applicable):** fixes #8493

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>  **wip**


## Example entry for `configuration.yaml` (if applicable):
```yaml
#configuration.yaml
image_processing: !include image_processing.yaml
automation: !include automations.yaml
android_ip_webcam:
  - host: 192.168.169.121
    scan_interval: 3

#image_processing.yaml
- platform: dlib_face_detect
  keep_faces: True
  keep_no_faces: True
  source:
    - entity_id: camera.ip_webcam
      name: "detect face"

- platform: dlib_face_identify
  keep_known_faces: True
  keep_unknown_faces: True
  source:
    - entity_id: camera.ip_webcam
      name: "Identify mmello"
  faces:
    mmello: /home/hass/.homeassistant/faces/mmello.png
    mmello-fail: /home/hass/.homeassistant/faces/mmello-fail.jpg

#automation.yaml
- alias: mmello detected
  trigger:
    platform: event
    event_type: image_processing.detect_face
    event_data:
      entity_id: image_processing.identify_mmello
      name: mmello
  action:
    service: homeassistant.turn_on
    entity_id: switch.kitchen_light
```
![image](https://user-images.githubusercontent.com/809840/28256201-eda97fb2-6a8d-11e7-9ff2-c5de0d064a0f.png)

![image](https://user-images.githubusercontent.com/809840/28256190-d776fc42-6a8d-11e7-9d59-84e47b175651.png)

When enabled, the options above will save the images on the directories  {CONFIGURATION_HASS}/:
```bash
(ha-py36) ↪ ls -lad dlib_*
drwxrwxr-x. 2 mdemello mdemello 12288 Jul 17 01:23 dlib_faces/
drwxrwxr-x. 2 mdemello mdemello  4096 Jul 17 01:23 dlib_known_faces/
drwxrwxr-x. 2 mdemello mdemello 12288 Jul 17 01:23 dlib_nofaces/
drwxrwxr-x. 2 mdemello mdemello 12288 Jul 17 01:23 dlib_unknown_faces/

(ha-py36) ↪ ls -la dlib_known_faces/ | head
total 1296
drwxrwxr-x. 2 mdemello mdemello  4096 Jul 17 01:23 .
drwxrwxr-x. 9 mdemello mdemello  4096 Jul 17 01:23 ..
-rw-rw-r--. 1 mdemello mdemello 16673 Jul 17 00:36 camera.ip_webcam_Jul-17-2017_00:36:14.jpg
-rw-rw-r--. 1 mdemello mdemello 18964 Jul 17 00:36 camera.ip_webcam_Jul-17-2017_00:36:36.jpg
-rw-rw-r--. 1 mdemello mdemello 18681 Jul 17 00:36 camera.ip_webcam_Jul-17-2017_00:36:47.jpg
-rw-rw-r--. 1 mdemello mdemello 18046 Jul 17 00:36 camera.ip_webcam_Jul-17-2017_00:36:58.jpg
-rw-rw-r--. 1 mdemello mdemello 17850 Jul 17 00:37 camera.ip_webcam_Jul-17-2017_00:37:09.jpg
-rw-rw-r--. 1 mdemello mdemello 16434 Jul 17 00:37 camera.ip_webcam_Jul-17-2017_00:37:42.jpg
-rw-rw-r--. 1 mdemello mdemello 16771 Jul 17 00:38 camera.ip_webcam_Jul-17-2017_00:38:04.jpg
```
## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) **WIP**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
