### PR TITLE
Return a 0 temperature value when none is found

### DIFF
--- a/homeassistant/components/climate/maxcube.py
+++ b/homeassistant/components/climate/maxcube.py
@@ -10,7 +10,6 @@ import logging
 from homeassistant.components.climate import ClimateDevice, STATE_AUTO
 from homeassistant.components.maxcube import MAXCUBE_HANDLE
 from homeassistant.const import TEMP_CELSIUS, ATTR_TEMPERATURE
-from homeassistant.const import STATE_UNKNOWN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/climate/maxcube.py
+++ b/homeassistant/components/climate/maxcube.py
@@ -140,7 +140,7 @@ class MaxCubeClimate(ClimateDevice):
     def map_temperature_max_hass(temperature):
         """Map Temperature from MAX! to HASS."""
         if temperature is None:
-            return STATE_UNKNOWN
+            return 0.0
 
         return temperature
 


### PR DESCRIPTION
It's well documented that these TRVs will only return the current temperature
for a short time after the actuator has moved. This means that, usually, they will
not return the current temperature. Setting a non-value here causes errors in the logs
and for the TRV to not show on the dashboard at all.