### PR TITLE
Implement trv-on-off config param which causes the state of the TRV to either be reported as on or off

### DIFF
--- a/homeassistant/components/climate/maxcube.py
+++ b/homeassistant/components/climate/maxcube.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/maxcube/
 import socket
 import logging
 
-from homeassistant.components.climate import ClimateDevice, STATE_AUTO
+from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate import STATE_AUTO, STATE_ON, STATE_OFF
 from homeassistant.components.maxcube import MAXCUBE_HANDLE
 from homeassistant.const import TEMP_CELSIUS, ATTR_TEMPERATURE
 from homeassistant.const import STATE_UNKNOWN
@@ -18,8 +19,10 @@ STATE_MANUAL = 'manual'
 STATE_BOOST = 'boost'
 STATE_VACATION = 'vacation'
 
-
 def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Get config"""
+    trv_on_off = hass.data["maxcube_trv_on_off"]
+
     """Iterate through all MAX! Devices and add thermostats."""
     cube = hass.data[MAXCUBE_HANDLE].cube
 
@@ -30,7 +33,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             cube.room_by_id(device.room_id).name, device.name)
 
         if cube.is_thermostat(device) or cube.is_wallthermostat(device):
-            devices.append(MaxCubeClimate(hass, name, device.rf_address))
+            devices.append(
+                MaxCubeClimate(hass, name, device.rf_address, trv_on_off)
+            )
 
     if devices:
         add_devices(devices)
@@ -39,13 +44,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class MaxCubeClimate(ClimateDevice):
     """MAX! Cube ClimateDevice."""
 
-    def __init__(self, hass, name, rf_address):
+    def __init__(self, hass, name, rf_address, trv_on_off):
         """Initialize MAX! Cube ClimateDevice."""
         self._name = name
         self._unit_of_measurement = TEMP_CELSIUS
         self._operation_list = [STATE_AUTO, STATE_MANUAL, STATE_BOOST,
                                 STATE_VACATION]
         self._rf_address = rf_address
+        self._trv_on_off = trv_on_off
         self._cubehandle = hass.data[MAXCUBE_HANDLE]
 
     @property
@@ -85,8 +91,16 @@ class MaxCubeClimate(ClimateDevice):
 
     @property
     def current_operation(self):
-        """Return current operation (auto, manual, boost, vacation)."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
+
+        """If we are only interested in whether the TRV is off or on"""
+        if self._trv_on_off and hasattr(device, 'valve_position'):
+            if device.valve_position is 0:
+                return STATE_OFF
+
+            return STATE_ON
+
+        """Return current operation (auto, manual, boost, vacation)."""
         return self.map_mode_max_hass(device.mode)
 
     @property

--- a/homeassistant/components/climate/maxcube.py
+++ b/homeassistant/components/climate/maxcube.py
@@ -20,7 +20,9 @@ STATE_BOOST = 'boost'
 STATE_VACATION = 'vacation'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Get config"""
+    """Set up the Max! Cube Platform."""
+
+    """Get config."""
     trv_on_off = hass.data["maxcube_trv_on_off"]
 
     """Iterate through all MAX! Devices and add thermostats."""
@@ -91,9 +93,10 @@ class MaxCubeClimate(ClimateDevice):
 
     @property
     def current_operation(self):
+        """Return the current operation."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
 
-        """If we are only interested in whether the TRV is off or on"""
+        """If we are only interested in whether the TRV is off or on."""
         if self._trv_on_off and hasattr(device, 'valve_position'):
             if device.valve_position is 0:
                 return STATE_OFF

--- a/homeassistant/components/climate/maxcube.py
+++ b/homeassistant/components/climate/maxcube.py
@@ -20,8 +20,6 @@ STATE_BOOST = 'boost'
 STATE_VACATION = 'vacation'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the Max! Cube Platform."""
-
     """Get config."""
     trv_on_off = hass.data["maxcube_trv_on_off"]
 

--- a/homeassistant/components/climate/maxcube.py
+++ b/homeassistant/components/climate/maxcube.py
@@ -23,7 +23,6 @@ STATE_VACATION = 'vacation'
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Get config."""
     trv_on_off = hass.data["maxcube_trv_on_off"]
-
     """Iterate through all MAX! Devices and add thermostats."""
     cube = hass.data[MAXCUBE_HANDLE].cube
 
@@ -94,14 +93,12 @@ class MaxCubeClimate(ClimateDevice):
     def current_operation(self):
         """Return the current operation."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
-
         """If we are only interested in whether the TRV is off or on."""
         if self._trv_on_off and hasattr(device, 'valve_position'):
             if device.valve_position is 0:
                 return STATE_OFF
 
             return STATE_ON
-
         """Return current operation (auto, manual, boost, vacation)."""
         return self.map_mode_max_hass(device.mode)
 

--- a/homeassistant/components/climate/maxcube.py
+++ b/homeassistant/components/climate/maxcube.py
@@ -19,6 +19,7 @@ STATE_MANUAL = 'manual'
 STATE_BOOST = 'boost'
 STATE_VACATION = 'vacation'
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Get config."""
     trv_on_off = hass.data["maxcube_trv_on_off"]

--- a/homeassistant/components/maxcube.py
+++ b/homeassistant/components/maxcube.py
@@ -34,8 +34,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 def setup(hass, config):
-    """Set up the Max! Cube."""
-
     """Establish connection to MAX! Cube."""
     from maxcube.connection import MaxCubeConnection
     from maxcube.cube import MaxCube

--- a/homeassistant/components/maxcube.py
+++ b/homeassistant/components/maxcube.py
@@ -34,6 +34,8 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 def setup(hass, config):
+    """Set up the Max! Cube."""
+
     """Establish connection to MAX! Cube."""
     from maxcube.connection import MaxCubeConnection
     from maxcube.cube import MaxCube

--- a/homeassistant/components/maxcube.py
+++ b/homeassistant/components/maxcube.py
@@ -33,6 +33,7 @@ CONFIG_SCHEMA = vol.Schema({
     }),
 }, extra=vol.ALLOW_EXTRA)
 
+
 def setup(hass, config):
     """Establish connection to MAX! Cube."""
     from maxcube.connection import MaxCubeConnection

--- a/homeassistant/components/maxcube.py
+++ b/homeassistant/components/maxcube.py
@@ -23,14 +23,15 @@ DEFAULT_PORT = 62910
 DOMAIN = 'maxcube'
 
 MAXCUBE_HANDLE = 'maxcube'
+CONF_TRV_ON_OFF = 'trv_on_off'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_TRV_ON_OFF, default=False): cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
-
 
 def setup(hass, config):
     """Establish connection to MAX! Cube."""
@@ -39,6 +40,7 @@ def setup(hass, config):
 
     host = config.get(DOMAIN).get(CONF_HOST)
     port = config.get(DOMAIN).get(CONF_PORT)
+    trv_on_off = config.get(DOMAIN).get(CONF_TRV_ON_OFF)
 
     try:
         cube = MaxCube(MaxCubeConnection(host, port))
@@ -48,6 +50,7 @@ def setup(hass, config):
         return False
 
     hass.data[MAXCUBE_HANDLE] = MaxCubeHandle(cube)
+    hass.data["maxcube_trv_on_off"] = trv_on_off
 
     load_platform(hass, 'climate', DOMAIN)
     load_platform(hass, 'binary_sensor', DOMAIN)


### PR DESCRIPTION
## Description:

This value, based on the valve's actuator position, will be useful to some people who need to trigger an action (e.g. fire up the boiler) when a radiator is turned on.

I'm not particularly happy with how the config is carried over but I cannot fathom how to do it any differently. This is the only component I can see which sets itself up in /components/ and then has its main functionality in /components/climate/. Any suggestions and I'm happy to change it.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#2998

## Example entry for `configuration.yaml` (if applicable):
```yaml
maxcube:
   host: 192.168.0.20
   trv_on_off: True
```