### PR TITLE
Telegram callbacks: fix `chat_id` for a callback query from a chat group (#8461)

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -581,6 +581,8 @@ class BaseTelegramBotEntity:
             data[ATTR_FROM_LAST] = msg_data['from']['last_name']
         if 'chat' in msg_data:
             data[ATTR_CHAT_ID] = msg_data['chat']['id']
+        elif ATTR_MESSAGE in msg_data and 'chat' in msg_data[ATTR_MESSAGE]:
+            data[ATTR_CHAT_ID] = msg_data[ATTR_MESSAGE]['chat']['id']
 
         return True, data
 


### PR DESCRIPTION
## Description:

When receiving a `telegram_callback` from a chat group, the `chat_id` is not attached to the event data. This fixes it.

`chat_id` should be present at : `{{ trigger.event.data.chat_id }}` but it isn't. 
(It's also present in: `{{ trigger.event.data.message.chat.id }}`)

**Related issue (if applicable):** fixes #8461

## Example entry for `configuration.yaml` (if applicable):
```yaml
telegram_bot:
  platform: polling
  api_key: !secret telegram_bot_api_key
  allowed_chat_ids:
    - !secret telegram_bot_chat_id_1
    - !secret telegram_bot_chat_id_2
    - !secret telegram_bot_group_1

automation:
- alias: 'Telegram bot for winner'
  trigger:
    platform: event
    event_type: telegram_command
    event_data:
      command: '/word'
      args:
      - 'test'
  action:
    service: telegram_bot.send_message
    data_template:
      title: 'Random Word'
      target: '{{ trigger.event.data.chat_id }}'
      message: 'This random words winner is {{ trigger.event.data.from_first }} with {{ trigger.event.data.text }}. Use /win to claim your prize. DEBUG: ```{{ trigger.event.data }}```'
      inline_keyboard: [[["Click here for winner prize!", "/win"]]]

- alias: Telegram bot for win
  trigger:
    platform: event
    event_type: telegram_callback
    event_data:
      data: /win
  action:
    - service: telegram_bot.send_photo
      data_template:
        target: '{{ trigger.event.data.chat_id }}'
        # WORKS NOW: target: '{{ trigger.event.data.message.chat.id }}'
        url: http://www.popular-mag.com/wp-content/uploads/a7545babeea20443bc592608c9a02643-1487887103.gif
        caption: Dick pic
```
