### PR TITLE
Hue light: No traceback for timeouts or refused connections to the bridge

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -115,7 +115,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if discovery_info is not None:
         if "HASS Bridge" in discovery_info.get('name', ''):
-            _LOGGER.info('Emulated hue found, will not add')
+            _LOGGER.info("Emulated hue found, will not add")
             return False
 
         host = discovery_info.get('host')
@@ -126,7 +126,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             host = _find_host_from_config(hass, filename)
 
         if host is None:
-            _LOGGER.error('No host found in configuration')
+            _LOGGER.error("No host found in configuration")
             return False
 
     # Only act if we are not already configuring this host
@@ -180,6 +180,12 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
 
         try:
             api = bridge.get_api()
+        except phue.PhueRequestTimeout:
+            _LOGGER.warning("Timeout trying to reach the bridge")
+            return
+        except ConnectionRefusedError:
+            _LOGGER.error("The bridge refused the connection")
+            return
         except socket.error:
             # socket.error when we cannot reach Hue
             _LOGGER.exception("Cannot reach the bridge")
@@ -221,8 +227,8 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
 
         for lightgroup_id, info in api_groups.items():
             if 'state' not in info:
-                _LOGGER.warning('Group info does not contain state. '
-                                'Please update your hub.')
+                _LOGGER.warning("Group info does not contain state. "
+                                "Please update your hub.")
                 skip_groups = True
                 break
 


### PR DESCRIPTION
## Description:

When the Hue bridge is stressed\*\*, some times a timeout or a `ConnectionRefusedError` happens. The exception doesn't need to be logged.

The errors are like this:
```text
2017-07-17 23:15:32 ERROR (Thread-5) [homeassistant.components.light.hue] Cannot reach the bridge
Traceback (most recent call last):
  File "/home/homeassistant/.pyenv/versions/3.5.2/envs/hass35/lib/python3.5/site-packages/homeassistant/components/light/hue.py", line 182, in update_lights
    api = bridge.get_api()
  File "/home/homeassistant/.homeassistant/deps/phue.py", line 838, in get_api
    return self.request('GET', '/api/' + self.username)
  File "/home/homeassistant/.homeassistant/deps/phue.py", line 651, in request
    connection.request(mode, address)
  File "/home/homeassistant/.pyenv/versions/3.5.2/lib/python3.5/http/client.py", line 1106, in request
    self._send_request(method, url, body, headers)
  File "/home/homeassistant/.pyenv/versions/3.5.2/lib/python3.5/http/client.py", line 1151, in _send_request
    self.endheaders(body)
  File "/home/homeassistant/.pyenv/versions/3.5.2/lib/python3.5/http/client.py", line 1102, in endheaders
    self._send_output(message_body)
  File "/home/homeassistant/.pyenv/versions/3.5.2/lib/python3.5/http/client.py", line 934, in _send_output
    self.send(msg)
  File "/home/homeassistant/.pyenv/versions/3.5.2/lib/python3.5/http/client.py", line 877, in send
    self.connect()
  File "/home/homeassistant/.pyenv/versions/3.5.2/lib/python3.5/http/client.py", line 849, in connect
    (self.host,self.port), self.timeout, self.source_address)
  File "/home/homeassistant/.pyenv/versions/3.5.2/lib/python3.5/socket.py", line 711, in create_connection
    raise err
  File "/home/homeassistant/.pyenv/versions/3.5.2/lib/python3.5/socket.py", line 702, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
```

A simple error message like `"The bridge refused the connection"` helps much more to analyse the logs.

\*\* When doing a lot of light changes (in my case, with Hyperion working as an Ambilight TV with 6 hue bulbs), the bridge goes to some overload, and sometimes doesn't answer to HA.

**Related issue (if applicable):** fixes #8003

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: hue
    host: 192.168.1.X
    allow_unreachable: true
    homebridge_hidden: true
    scan_interval: 12
```
