### PR TITLE
Citybikes: Allow None as result for empty slots

### DIFF
--- a/homeassistant/components/sensor/citybikes.py
+++ b/homeassistant/components/sensor/citybikes.py
@@ -82,7 +82,7 @@ NETWORKS_RESPONSE_SCHEMA = vol.Schema({
 
 STATION_SCHEMA = vol.Schema({
     vol.Required(ATTR_FREE_BIKES): cv.positive_int,
-    vol.Required(ATTR_EMPTY_SLOTS): cv.positive_int,
+    vol.Required(ATTR_EMPTY_SLOTS): vol.Any(cv.positive_int, None),
     vol.Required(ATTR_LATITUDE): cv.latitude,
     vol.Required(ATTR_LONGITUDE): cv.latitude,
     vol.Required(ATTR_ID): cv.string,


### PR DESCRIPTION
The citibykes API returns "null" as value for empty_slots on some
stations (see #8527). This causes the component to not process the data.

This is fixed by accepting None as valid data. The row in the frontend
is left empty if "null" was returned by the service.

fixes #8527

## Description:


**Related issue (if applicable):** fixes #8527 


## Example entry for `configuration.yaml` (if applicable):
```yaml
sensors:
  - platform: citybikes
    name: Bikes Test
    latitude: 51.0488256
    longitude: 13.7226159
    radius: 300
```

## Checklist:


If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
