### PR TITLE
Upgrade TwitterAPI to 2.4.6

### DIFF
--- a/homeassistant/components/notify/twitter.py
+++ b/homeassistant/components/notify/twitter.py
@@ -16,7 +16,7 @@ from homeassistant.components.notify import (
     ATTR_DATA, PLATFORM_SCHEMA, BaseNotificationService)
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_USERNAME
 
-REQUIREMENTS = ['TwitterAPI==2.4.5']
+REQUIREMENTS = ['TwitterAPI==2.4.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -36,7 +36,7 @@ PyMata==2.14
 SoCo==0.12
 
 # homeassistant.components.notify.twitter
-TwitterAPI==2.4.5
+TwitterAPI==2.4.6
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.4.0


### PR DESCRIPTION
## 2.4.6
-  Added direct message endpoints.

Tested with the following configuration:

``` yaml
notify:
  - platform: twitter
    name: twitter
    consumer_key: !secret twitter_consumer_key
    consumer_secret: !secret twitter_consumer_secret
    access_token: !secret twitter_access_token
    access_token_secret: !secret twitter_token_secret
```

Message sent with "Call Service"

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}! Update of TwitterAPI for @home_assistant"
}
```

:smile: -> [:m:](https://twitter.com/fabaff/status/887272204035031040)
