### PR TITLE
Add support for custom stream queries for media_extractor

### DIFF
--- a/homeassistant/components/media_extractor.py
+++ b/homeassistant/components/media_extractor.py
@@ -116,9 +116,10 @@ class MediaExtractor:
         if 'entries' in all_media:
             _LOGGER.warning("Playlists are not supported, "
                             "looking for the first video")
-            try:
-                selected_media = next(all_media['entries'])
-            except StopIteration:
+            entries = list(all_media['entries'])
+            if len(entries) > 0:
+                selected_media = entries[0]
+            else:
                 _LOGGER.error("Playlist is empty")
                 raise MEDownloadException()
         else:

--- a/homeassistant/components/media_extractor.py
+++ b/homeassistant/components/media_extractor.py
@@ -21,8 +21,8 @@ DOMAIN = 'media_extractor'
 DEPENDENCIES = ['media_player']
 
 CONF_CUSTOMIZE_ENTITIES = 'customize'
-CONF_DEFAULT_STREAM_FORMAT = 'default_format'
-DEFAULT_STREAM_FORMAT = 'best'
+CONF_DEFAULT_STREAM_QUERY = 'default_query'
+DEFAULT_STREAM_QUERY = 'best'
 
 
 def setup(hass, config):
@@ -33,42 +33,7 @@ def setup(hass, config):
 
     def play_media(call):
         """Get stream URL and send it to the media_player.play_media."""
-        media_url = call.data.get(ATTR_MEDIA_CONTENT_ID)
-
-        try:
-            stream_selector = get_stream_query_selector(media_url)
-        except YDNetworkException:
-            _LOGGER.error("Could not retrieve data for the URL: %s",
-                          media_url)
-            return
-
-        media_content_type = call.data.get(ATTR_MEDIA_CONTENT_TYPE)
-        default_stream_format = config[DOMAIN].get(
-            CONF_DEFAULT_STREAM_FORMAT, DEFAULT_STREAM_FORMAT)
-        entities_config = config[DOMAIN].get(CONF_CUSTOMIZE_ENTITIES, {})
-        entities = call.data.get(ATTR_ENTITY_ID, [])
-
-        if len(entities) == 0:
-            pass
-
-        for entity_id in entities:
-            stream_format_query = entities_config.get(
-                entity_id, {}).get(media_content_type, default_stream_format)
-
-            try:
-                stream_url = stream_selector(stream_format_query)
-            except YDQueryException:
-                continue
-            else:
-                data = {k: v for k, v in call.data.items()
-                        if k != ATTR_MEDIA_CONTENT_ID and k != ATTR_ENTITY_ID}
-                data[ATTR_MEDIA_CONTENT_ID] = stream_url
-                data[ATTR_ENTITY_ID] = entity_id
-
-                hass.async_add_job(
-                    hass.services.async_call(
-                        MEDIA_PLAYER_DOMAIN, SERVICE_PLAY_MEDIA, data)
-                )
+        MediaExtractor(hass, config[DOMAIN], call.data).extract_and_send()
 
     hass.services.register(DOMAIN,
                            SERVICE_PLAY_MEDIA,
@@ -79,63 +44,135 @@ def setup(hass, config):
     return True
 
 
-class YDNetworkException(Exception):
-    """Media extractor network exception."""
+class MEDownloadException(Exception):
+    """Media extractor download exception."""
 
     pass
 
 
-class YDQueryException(Exception):
+class MEQueryException(Exception):
     """Media extractor query exception."""
 
     pass
 
 
-def get_stream_query_selector(media_url):
-    """Extract stream URL from the media URL."""
-    from youtube_dl import YoutubeDL
-    from youtube_dl.utils import DownloadError, ExtractorError
+class MediaExtractor:
+    """Class which encapsulates all extraction logic."""
 
-    ydl = YoutubeDL({'quiet': True, 'logger': _LOGGER})
+    def __init__(self, hass, component_config, call_data):
+        """Initialize media extractor."""
+        self.hass = hass
+        self.config = component_config
+        self.call_data = call_data
 
-    try:
-        all_media_streams = ydl.extract_info(media_url, process=False)
-    except DownloadError:
-        # This exception will be logged by youtube-dl itself
-        raise YDNetworkException()
+    def get_media_url(self):
+        """Return media content url."""
+        return self.call_data.get(ATTR_MEDIA_CONTENT_ID)
 
-    if 'entries' in all_media_streams:
-        _LOGGER.warning("Playlists are not supported, "
-                        "looking for the first video")
+    def get_entities(self):
+        """Return list of entities."""
+        return self.call_data.get(ATTR_ENTITY_ID, [])
+
+    def extract_and_send(self):
+        """Extract exact stream format for each entity_id and play it."""
         try:
-            selected_stream = next(all_media_streams['entries'])
-        except StopIteration:
-            _LOGGER.error("Playlist is empty")
-            raise YDNetworkException()
-    else:
-        selected_stream = all_media_streams
+            stream_selector = self.get_stream_selector()
+        except MEDownloadException:
+            _LOGGER.error("Could not retrieve data for the URL: %s",
+                          self.get_media_url())
+        else:
+            entities = self.get_entities()
 
-    try:
-        media_info = ydl.process_ie_result(selected_stream, download=False)
-    except (ExtractorError, DownloadError):
-        # This exception will be logged by youtube-dl itself
-        raise YDNetworkException()
+            if len(entities) == 0:
+                self.call_media_player_service(stream_selector, None)
 
-    def stream_query_selector(stream_format_query):
-        """Find stream url that match stream_format_query."""
+            for entity_id in entities:
+                self.call_media_player_service(stream_selector, entity_id)
+
+    def get_stream_selector(self):
+        """Return format selector for the media URL."""
+        from youtube_dl import YoutubeDL
+        from youtube_dl.utils import DownloadError, ExtractorError
+
+        ydl = YoutubeDL({'quiet': True, 'logger': _LOGGER})
+
         try:
-            format_selector = ydl.build_format_selector(stream_format_query)
-        except (SyntaxError, ValueError) as e:
-            _LOGGER.error(e)
-            raise YDQueryException()
+            all_media = ydl.extract_info(self.get_media_url(),
+                                         process=False)
+        except DownloadError:
+            # This exception will be logged by youtube-dl itself
+            raise MEDownloadException()
+
+        if 'entries' in all_media:
+            _LOGGER.warning("Playlists are not supported, "
+                            "looking for the first video")
+            try:
+                selected_media = next(all_media['entries'])
+            except StopIteration:
+                _LOGGER.error("Playlist is empty")
+                raise MEDownloadException()
+        else:
+            selected_media = all_media
 
         try:
-            queried_stream = next(format_selector(media_info))
-        except (KeyError, StopIteration):
-            _LOGGER.error("Could not extract stream for the query: %s",
-                          stream_format_query)
-            raise YDQueryException()
+            media_info = ydl.process_ie_result(selected_media,
+                                               download=False)
+        except (ExtractorError, DownloadError):
+            # This exception will be logged by youtube-dl itself
+            raise MEDownloadException()
 
-        return queried_stream['url']
+        def stream_selector(query):
+            """Find stream url that matches query."""
+            try:
+                format_selector = ydl.build_format_selector(query)
+            except (SyntaxError, ValueError, AttributeError) as ex:
+                _LOGGER.error(ex)
+                raise MEQueryException()
 
-    return stream_query_selector
+            try:
+                requested_stream = next(format_selector(media_info))
+            except (KeyError, StopIteration):
+                _LOGGER.error("Could not extract stream for the query: %s",
+                              query)
+                raise MEQueryException()
+
+            return requested_stream['url']
+
+        return stream_selector
+
+    def call_media_player_service(self, stream_selector, entity_id):
+        """Call media_player.play_media service."""
+        stream_query = self.get_stream_query_for_entity(entity_id)
+
+        try:
+            stream_url = stream_selector(stream_query)
+        except MEQueryException:
+            _LOGGER.error("Wrong query format: %s", stream_query)
+            return
+        else:
+            data = {k: v for k, v in self.call_data.items()
+                    if k != ATTR_ENTITY_ID}
+            data[ATTR_MEDIA_CONTENT_ID] = stream_url
+
+            if entity_id:
+                data[ATTR_ENTITY_ID] = entity_id
+
+            self.hass.async_add_job(
+                self.hass.services.async_call(
+                    MEDIA_PLAYER_DOMAIN, SERVICE_PLAY_MEDIA, data)
+            )
+
+    def get_stream_query_for_entity(self, entity_id):
+        """Get stream format query for entity."""
+        default_stream_query = self.config.get(CONF_DEFAULT_STREAM_QUERY,
+                                               DEFAULT_STREAM_QUERY)
+
+        if entity_id:
+            media_content_type = self.call_data.get(ATTR_MEDIA_CONTENT_TYPE)
+
+            return self.config \
+                .get(CONF_CUSTOMIZE_ENTITIES, {}) \
+                .get(entity_id, {}) \
+                .get(media_content_type, default_stream_query)
+
+        return default_stream_query

--- a/homeassistant/components/media_extractor.py
+++ b/homeassistant/components/media_extractor.py
@@ -6,12 +6,14 @@ https://home-assistant.io/components/media_extractor/
 """
 import logging
 import os
+import voluptuous as vol
 
 from homeassistant.components.media_player import (
     ATTR_ENTITY_ID, ATTR_MEDIA_CONTENT_ID, ATTR_MEDIA_CONTENT_TYPE,
     DOMAIN as MEDIA_PLAYER_DOMAIN, MEDIA_PLAYER_PLAY_MEDIA_SCHEMA,
     SERVICE_PLAY_MEDIA)
 from homeassistant.config import load_yaml_config_file
+from homeassistant.helpers import config_validation as cv
 
 REQUIREMENTS = ['youtube_dl==2017.7.9']
 
@@ -23,6 +25,14 @@ DEPENDENCIES = ['media_player']
 CONF_CUSTOMIZE_ENTITIES = 'customize'
 CONF_DEFAULT_STREAM_QUERY = 'default_query'
 DEFAULT_STREAM_QUERY = 'best'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_DEFAULT_STREAM_QUERY): cv.string,
+        vol.Optional(CONF_CUSTOMIZE_ENTITIES):
+            vol.Schema({cv.entity_id: vol.Schema({cv.string: cv.string})}),
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):


### PR DESCRIPTION
## Description:
This PR adds support for custom stream queries per device and media type to media_extractor.

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_extractor:
  default_query: worst
  customize:
    media_player.kd55x8507c:
      video: bestvideo 
      music: bestaudio
      playlist: worstaudio[ext=mp4]
```

Default query if no settings provided is  **best**.
User can override default value or set custom query per device and media type.

Examples:
 * **bestvideo** - best video only stream
 * **best** - best video + audio stream
 * **bestaudio[ext=m4a]** - best audio stream with m4a extension
 * **worst** - worst video + audio stream
 * **bestaudio[ext=m4a]/bestaudio[ext=ogg]/bestaudio** - best m4a audio, otherwise best ogg audio and only then any audio

More about format queries https://github.com/rg3/youtube-dl/blob/master/README.md#format-selection

## BUT:
My settings:
```yaml
media_extractor:
  default_query: best
  customize:
    media_player.kd55x8507c:
      video/videoonly: bestvideo
      video/best: best
      audio/best: bestaudio[ext=m4a]
```
My chromecast device (Sony Bravia with Android TV) does not support these media content types https://home-assistant.io/components/media_player/#service-media_playerplay_media
It supports media_content_type attributes like:
* video/blablabla
* audio/blablabla

My service call data is:
```json
{"entity_id": "media_player.kd55x8507c", "media_content_id": "https://www.youtube.com/watch?v=VZMfhtKa-wo", "media_content_type": "audio/best"}
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.


