### PR TITLE
Fix support for multiple Apple TVs

### DIFF
--- a/homeassistant/components/apple_tv.py
+++ b/homeassistant/components/apple_tv.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import discovery
 from homeassistant.components.discovery import SERVICE_APPLE_TV
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyatv==0.3.2']
+REQUIREMENTS = ['pyatv==0.3.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/remote/apple_tv.py
+++ b/homeassistant/components/remote/apple_tv.py
@@ -45,6 +45,11 @@ class AppleTVRemote(remote.RemoteDevice):
         return self._name
 
     @property
+    def unique_id(self):
+        """Return an unique ID."""
+        return self._atv.metadata.device_id
+
+    @property
     def is_on(self):
         """Return true if device is on."""
         return self._power.turned_on

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -519,7 +519,7 @@ pyasn1-modules==0.0.9
 pyasn1==0.2.3
 
 # homeassistant.components.apple_tv
-pyatv==0.3.2
+pyatv==0.3.4
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox


### PR DESCRIPTION
## Description:
A bug in pyatv generated the same device id for all devices, so when specifying multiple devices only one would be added. Remote platforms were loaded for each device however because I had missed implementing unique_id there. This PR fixes both issues.

This is a candidate for next minor release, e.g. 0.49.1, as it breaks functionality for some users.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14