### PR TITLE
Enhance python_script to support "_getitem_"

### DIFF
--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -65,6 +65,7 @@ def execute(hass, filename, source, data=None):
     from RestrictedPython import compile_restricted_exec
     from RestrictedPython.Guards import safe_builtins, full_write_guard
     from RestrictedPython.Utilities import utility_builtins
+    from RestrictedPython.Eval import default_guarded_getitem
 
     compiled = compile_restricted_exec(source, filename=filename)
 
@@ -99,6 +100,7 @@ def execute(hass, filename, source, data=None):
         '_getattr_': protected_getattr,
         '_write_': full_write_guard,
         '_getiter_': iter,
+        '_getitem_': default_guarded_getitem
     }
     logger = logging.getLogger('{}.{}'.format(__name__, filename))
     local = {

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -138,6 +138,23 @@ hass.async_stop()
 
 
 @asyncio.coroutine
+def test_using_complex_structures(hass, caplog):
+    """Test that dicts and lists work."""
+
+    caplog.set_level(logging.INFO)
+    source = """
+mydict = {"a": 1, "b": 2}
+mylist = [1, 2, 3, 4]
+logger.info('Logging from inside script: %s %s' % (mydict["a"], mylist[2]))
+    """
+
+    hass.async_add_job(execute, hass, 'test.py', source, {})
+    yield from hass.async_block_till_done()
+
+    assert "Logging from inside script: 1 3" in caplog.text
+
+
+@asyncio.coroutine
 def test_accessing_forbidden_methods(hass, caplog):
     """Test compile error logs error."""
     caplog.set_level(logging.ERROR)

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -140,7 +140,6 @@ hass.async_stop()
 @asyncio.coroutine
 def test_using_complex_structures(hass, caplog):
     """Test that dicts and lists work."""
-
     caplog.set_level(logging.INFO)
     source = """
 mydict = {"a": 1, "b": 2}


### PR DESCRIPTION
In order to use dict / list structures in python scripts we need
_getitem_ allowed in the RestrictedPython environment. There is a
default_guarded_getitem included with RestrictedPython, which is a
pass through used in the Eval code paths.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
