### PR TITLE
Report Harmony remote off if state is unknown

### DIFF
--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -174,7 +174,7 @@ class HarmonyRemote(remote.RemoteDevice):
     @property
     def is_on(self):
         """Return False if PowerOff is the current activity, otherwise True."""
-        return self._current_activity != 'PowerOff'
+        return self._current_activity not in [None, 'PowerOff']
 
     def update(self):
         """Return current activity."""


### PR DESCRIPTION
## Description:
I have automations for when my Harmony remote turns off. During startup, the remote would initially report as on until the state was actually known, which meant if it was off, it would trigger my on->off automation.

Instead, behave as most components and report as off until the state is known.