### PR TITLE
Add transition support to light.zha

### DIFF
--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -72,8 +72,9 @@ class Light(zha.Entity, light.Light):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        duration = kwargs.get(light.ATTR_TRANSITION, DEFAULT_DURATION)
-        duration = duration * 10 # tenths of s
+        duration = kwargs.get(
+            light.ATTR_TRANSITION, DEFAULT_DURATION)
+        duration = duration * 10  # tenths of s
         if light.ATTR_COLOR_TEMP in kwargs:
             temperature = kwargs[light.ATTR_COLOR_TEMP]
             yield from self._endpoint.light_color.move_to_color_temp(

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -72,8 +72,7 @@ class Light(zha.Entity, light.Light):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        duration = kwargs.get(
-            light.ATTR_TRANSITION, DEFAULT_DURATION)
+        duration = kwargs.get(light.ATTR_TRANSITION, DEFAULT_DURATION)
         duration = duration * 10  # tenths of s
         if light.ATTR_COLOR_TEMP in kwargs:
             temperature = kwargs[light.ATTR_COLOR_TEMP]
@@ -96,7 +95,8 @@ class Light(zha.Entity, light.Light):
             )
 
         if self._brightness is not None:
-            brightness = kwargs.get(light.ATTR_BRIGHTNESS, self._brightness or 255)
+            brightness = kwargs.get(
+                light.ATTR_BRIGHTNESS, self._brightness or 255)
             self._brightness = brightness
             # Move to level with on/off:
             yield from self._endpoint.level.move_to_level_with_on_off(

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -17,6 +17,7 @@ DEPENDENCIES = ['zha']
 
 DEFAULT_DURATION = 0.5
 
+
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Zigbee Home Automation lights."""

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -9,11 +9,13 @@ import logging
 
 from homeassistant.components import light, zha
 from homeassistant.util.color import color_RGB_to_xy
+from homeassistant.const import STATE_UNKNOWN
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['zha']
 
+DEFAULT_DURATION = 0.5
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
@@ -48,6 +50,7 @@ class Light(zha.Entity, light.Light):
         import bellows.zigbee.zcl.clusters as zcl_clusters
         if zcl_clusters.general.LevelControl.cluster_id in self._in_clusters:
             self._supported_features |= light.SUPPORT_BRIGHTNESS
+            self._supported_features |= light.SUPPORT_TRANSITION
             self._brightness = 0
         if zcl_clusters.lighting.Color.cluster_id in self._in_clusters:
             # Not sure all color lights necessarily support this directly
@@ -62,14 +65,15 @@ class Light(zha.Entity, light.Light):
     @property
     def is_on(self) -> bool:
         """Return true if entity is on."""
-        if self._state == 'unknown':
+        if self._state == STATE_UNKNOWN:
             return False
         return bool(self._state)
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        duration = 5  # tenths of s
+        duration = kwargs.get(light.ATTR_TRANSITION, DEFAULT_DURATION)
+        duration = duration * 10 # tenths of s
         if light.ATTR_COLOR_TEMP in kwargs:
             temperature = kwargs[light.ATTR_COLOR_TEMP]
             yield from self._endpoint.light_color.move_to_color_temp(
@@ -91,7 +95,7 @@ class Light(zha.Entity, light.Light):
             )
 
         if self._brightness is not None:
-            brightness = kwargs.get('brightness', self._brightness or 255)
+            brightness = kwargs.get(light.ATTR_BRIGHTNESS, self._brightness or 255)
             self._brightness = brightness
             # Move to level with on/off:
             yield from self._endpoint.level.move_to_level_with_on_off(


### PR DESCRIPTION
## Description:
Use the transition attribute when turning on ZHA lights instead of a static 0.5 seconds. Also, use more constants in the ZHA light component.