### PR TITLE
 Extends Pi-hole sensor to support the new monitored conditions

### DIFF
--- a/homeassistant/components/sensor/pi_hole.py
+++ b/homeassistant/components/sensor/pi_hole.py
@@ -36,11 +36,21 @@ SCAN_INTERVAL = timedelta(minutes=5)
 
 MONITORED_CONDITIONS = {
     'dns_queries_today': ['DNS Queries Today',
-                          None, 'mdi:network-question'],
+                          None, 'mdi:comment-question-outline'],
     'ads_blocked_today': ['Ads Blocked Today',
                           None, 'mdi:close-octagon-outline'],
     'ads_percentage_today': ['Ads Percentage Blocked Today',
                              '%', 'mdi:close-octagon-outline'],
+    'domains_being_blocked': ['Domains Blocked',
+                              None, 'mdi:block-helper'],
+    'queries_cached': ['DNS Queries Cached',
+                       None, 'mdi:comment-question-outline'],
+    'queries_forwarded': ['DNS Queries Forwarded',
+                          None, 'mdi:comment-question-outline'],
+    'unique_clients': ['DNS Unique Clients',
+                       None, 'mdi:account-outline'],
+    'unique_domains': ['DNS Unique Domains',
+                       None, 'mdi:domain'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
## Description:

 Extends Pi-hole sensor to support the new monitored conditions
  - domains_being_blocked
  - queries_cached
  - queries_forwarded
  - unique_clients
  - unique_domains

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3011

![image](https://user-images.githubusercontent.com/809840/28352767-4ffba14c-6c26-11e7-93da-10fb25827345.png)

## Example entry for `configuration.yaml` (if applicable):
```yaml
#configuration.yaml
 - platform: pi_hole
   host: 192.168.0.1
   monitored_conditions:
    - dns_queries_today
    - ads_blocked_today
    - ads_percentage_today
    - domains_being_blocked
    - queries_cached
    - queries_forwarded
    - unique_clients
    - unique_domains
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.