### PR TITLE
LIFX: assume default features for unknown products

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -159,12 +159,18 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
 def lifxwhite(device):
     """Return whether this is a white-only bulb."""
-    return not aiolifx().products.features_map[device.product]["color"]
+    features = aiolifx().products.features_map.get(device.product, None)
+    if features:
+        return not features["color"]
+    return False
 
 
 def lifxmultizone(device):
     """Return whether this is a multizone bulb/strip."""
-    return aiolifx().products.features_map[device.product]["multizone"]
+    features = aiolifx().products.features_map.get(device.product, None)
+    if features:
+        return features["multizone"]
+    return False
 
 
 def find_hsbk(**kwargs):


### PR DESCRIPTION
## Description:

This makes the detection work for prototypes as well.

Reported in frawau/aiolifx#21 by @cmsimike

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] <s>New dependencies are only imported inside functions that use them ([example][ex-import]).</s>
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54