### PR TITLE
Handle manual edits to emulated_hue_ids.json

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -193,7 +193,7 @@ class Config(object):
             if entity_id == ent_id:
                 return number
 
-        number = str(len(self.numbers) + 1)
+        number = str(max(int(k) for k in self.numbers) + 1)
         self.numbers[number] = entity_id
         self._save_numbers_json()
         return number


### PR DESCRIPTION
## Description:
I've added and removed a few entities from my setup since starting to use the `emulated_hue` component. I wanted to remove all references to some of the old stuff, so I manually edited the `emulated_hue_ids.json` file. This resulted in new entities not being properly added.

With this change, new emulated hue numbers are based off the highest currently numbered entity, not purely off the number of entities in the file. This appears to be the way Hue itself does things.