### PR TITLE
ubus: Make multiple instances work again

### DIFF
--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -115,8 +115,8 @@ class UbusDeviceScanner(DeviceScanner):
 
             return self.mac2name.get(device.upper(), None)
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     @_refresh_on_acccess_denied
+    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the Luci router is up to date.
 


### PR DESCRIPTION
Back in "ubus: Refresh session on Access denied (#8111)" I added the
decorator _refresh_on_acccess_denied. Somehow that stopped multiple ubus
trackers from working in parallel, and only the one first init'ed
worked.

Changing the order of the decorators fixes the issue but, I'm sorry to
say I can't figure out why. There's some magic somewhere which I'm
missing.

Signed-off-by: Anton Lundin <glance@acc.umu.se>