### PR TITLE
Device support for different new sensors of the xiaomi aqara gateway

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi.py
+++ b/homeassistant/components/binary_sensor/xiaomi.py
@@ -25,6 +25,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             model = device['model']
             if model == 'motion':
                 devices.append(XiaomiMotionSensor(device, hass, gateway))
+            elif model == 'sensor_motion.aq2':
+                devices.append(XiaomiMotionSensor(device, hass, gateway))
             elif model == 'magnet':
                 devices.append(XiaomiDoorSensor(device, gateway))
             elif model == 'sensor_magnet.aq2':

--- a/homeassistant/components/binary_sensor/xiaomi.py
+++ b/homeassistant/components/binary_sensor/xiaomi.py
@@ -27,6 +27,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 devices.append(XiaomiMotionSensor(device, hass, gateway))
             elif model == 'magnet':
                 devices.append(XiaomiDoorSensor(device, gateway))
+            elif model == 'sensor_magnet.aq2':
+                devices.append(XiaomiDoorSensor(device, gateway))
             elif model == 'smoke':
                 devices.append(XiaomiSmokeSensor(device, gateway))
             elif model == 'natgas':

--- a/homeassistant/components/sensor/xiaomi.py
+++ b/homeassistant/components/sensor/xiaomi.py
@@ -69,7 +69,7 @@ class XiaomiSensor(XiaomiDevice):
             return False
         elif self._data_key == 'pressure' and value == 0:
             return False
-        if self._data_key in ['temperature', 'humidity']:
+        if self._data_key in ['temperature', 'humidity', 'pressure']:
             value /= 100
         elif self._data_key in ['illumination']:
             value = max(value - 300, 0)

--- a/homeassistant/components/sensor/xiaomi.py
+++ b/homeassistant/components/sensor/xiaomi.py
@@ -17,13 +17,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                             'temperature', gateway))
                 devices.append(XiaomiSensor(device, 'Humidity',
                                             'humidity', gateway))
-            if device['model'] == 'weather.v1':
+            elif device['model'] == 'weather.v1':
                 devices.append(XiaomiSensor(device, 'Temperature',
                                             'temperature', gateway))
                 devices.append(XiaomiSensor(device, 'Humidity',
                                             'humidity', gateway))
                 devices.append(XiaomiSensor(device, 'Pressure',
                                             'pressure', gateway))
+            elif device['model'] == 'sensor_motion.aq2':
+                devices.append(XiaomiSensor(device, 'Illumination',
+                                            'lux', gateway))
             elif device['model'] == 'gateway':
                 devices.append(XiaomiSensor(device, 'Illumination',
                                             'illumination', gateway))
@@ -47,6 +50,8 @@ class XiaomiSensor(XiaomiDevice):
             return '%'
         elif self._data_key == 'illumination':
             return 'lm'
+        elif self._data_key == 'lux':
+            return 'lx'
         elif self._data_key == 'pressure':
             return 'hPa'
 

--- a/homeassistant/components/switch/xiaomi.py
+++ b/homeassistant/components/switch/xiaomi.py
@@ -39,10 +39,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                                    'channel_1',
                                                    False, gateway))
             elif model == 'ctrl_ln2':
-                devices.append(XiaomiGenericSwitch(device, 'Wall Switch LN Left',
+                devices.append(XiaomiGenericSwitch(device,
+                                                   'Wall Switch LN Left',
                                                    'channel_0',
                                                    False, gateway))
-                devices.append(XiaomiGenericSwitch(device, 'Wall Switch LN Right',
+                devices.append(XiaomiGenericSwitch(device,
+                                                   'Wall Switch LN Right',
                                                    'channel_1',
                                                    False, gateway))
             elif model == '86plug':

--- a/homeassistant/components/switch/xiaomi.py
+++ b/homeassistant/components/switch/xiaomi.py
@@ -27,11 +27,22 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 devices.append(XiaomiGenericSwitch(device, 'Wall Switch',
                                                    'channel_0',
                                                    False, gateway))
+            elif model == 'ctrl_ln1':
+                devices.append(XiaomiGenericSwitch(device, 'Wall Switch LN',
+                                                   'channel_0',
+                                                   False, gateway))
             elif model == 'ctrl_neutral2':
                 devices.append(XiaomiGenericSwitch(device, 'Wall Switch Left',
                                                    'channel_0',
                                                    False, gateway))
                 devices.append(XiaomiGenericSwitch(device, 'Wall Switch Right',
+                                                   'channel_1',
+                                                   False, gateway))
+            elif model == 'ctrl_ln2':
+                devices.append(XiaomiGenericSwitch(device, 'Wall Switch LN Left',
+                                                   'channel_0',
+                                                   False, gateway))
+                devices.append(XiaomiGenericSwitch(device, 'Wall Switch LN Right',
                                                    'channel_1',
                                                    False, gateway))
             elif model == '86plug':

--- a/homeassistant/components/xiaomi.py
+++ b/homeassistant/components/xiaomi.py
@@ -9,8 +9,8 @@ from homeassistant.const import (ATTR_BATTERY_LEVEL, EVENT_HOMEASSISTANT_STOP,
 
 
 REQUIREMENTS = ['https://github.com/Danielhiversen/PyXiaomiGateway/archive/'
-                '877faec36e1bfa4177cae2a0d4f49570af083e1d.zip#'
-                'PyXiaomiGateway==0.1.0']
+                'aa9325fe6fdd62a8ef8c9ca1dce31d3292f484bb.zip#'
+                'PyXiaomiGateway==0.2.0']
 
 ATTR_GW_MAC = 'gw_mac'
 ATTR_RINGTONE_ID = 'ringtone_id'

--- a/homeassistant/components/xiaomi.py
+++ b/homeassistant/components/xiaomi.py
@@ -107,7 +107,7 @@ def setup(hass, config):
         else:
             ringtone = {'mid': ring_id, 'vol': int(ring_vol)}
 
-        gw_sid = call.data.get(ATTR_GW_SID)
+        gw_sid = call.data.get(ATTR_GW_SID).replace(":", "").lower()
 
         for (_, gateway) in hass.data[PY_XIAOMI_GATEWAY].gateways.items():
             if gateway.sid == gw_sid:
@@ -124,6 +124,7 @@ def setup(hass, config):
                           ATTR_GW_SID)
             return
 
+        gw_sid = gw_sid.replace(":", "").lower()
         for (_, gateway) in hass.data[PY_XIAOMI_GATEWAY].gateways.items():
             if gateway.sid == gw_sid:
                 ringtone = {'mid': 10000}

--- a/homeassistant/components/xiaomi.py
+++ b/homeassistant/components/xiaomi.py
@@ -12,7 +12,7 @@ REQUIREMENTS = ['https://github.com/Danielhiversen/PyXiaomiGateway/archive/'
                 '877faec36e1bfa4177cae2a0d4f49570af083e1d.zip#'
                 'PyXiaomiGateway==0.1.0']
 
-ATTR_GW_SID = 'gw_sid'
+ATTR_GW_MAC = 'gw_mac'
 ATTR_RINGTONE_ID = 'ringtone_id'
 ATTR_RINGTONE_VOL = 'ringtone_vol'
 CONF_DISCOVERY_RETRY = 'discovery_retry'
@@ -90,12 +90,13 @@ def setup(hass, config):
 
     def play_ringtone_service(call):
         """Service to play ringtone through Gateway."""
-        if call.data.get(ATTR_RINGTONE_ID) is None \
-                or call.data.get(ATTR_GW_SID) is None:
+        ring_id = call.data.get(ATTR_RINGTONE_ID)
+        gw_sid = call.data.get(ATTR_GW_MAC)
+        if ring_id is None or gw_sid is None:
             _LOGGER.error("Mandatory parameters is not specified.")
             return
 
-        ring_id = int(call.data.get(ATTR_RINGTONE_ID))
+        ring_id = int(ring_id)
         if ring_id in [9, 14-19]:
             _LOGGER.error('Specified mid: %s is not defined in gateway.',
                           ring_id)
@@ -107,7 +108,7 @@ def setup(hass, config):
         else:
             ringtone = {'mid': ring_id, 'vol': int(ring_vol)}
 
-        gw_sid = call.data.get(ATTR_GW_SID).replace(":", "").lower()
+        gw_sid = gw_sid.replace(":", "").lower()
 
         for (_, gateway) in hass.data[PY_XIAOMI_GATEWAY].gateways.items():
             if gateway.sid == gw_sid:
@@ -118,10 +119,10 @@ def setup(hass, config):
 
     def stop_ringtone_service(call):
         """Service to stop playing ringtone on Gateway."""
-        gw_sid = call.data.get(ATTR_GW_SID)
+        gw_sid = call.data.get(ATTR_GW_MAC)
         if gw_sid is None:
             _LOGGER.error("Mandatory parameter (%s) is not specified.",
-                          ATTR_GW_SID)
+                          ATTR_GW_MAC)
             return
 
         gw_sid = gw_sid.replace(":", "").lower()


### PR DESCRIPTION
## Description:

This PR adds the device support for a few new sensors of the xiaomi aqara gateway (sensor_motion.aq2, sensor_magnet.aq2, ctrl_ln1, ctrl_ln2). The sensors will be auto-discovered and doesn't need configuration. Some minor issues of the recently merged component will be fixed also.
