### PR TITLE
Pilight switch: restore last state after restart

### DIFF
--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -129,10 +129,6 @@ class PilightSwitch(SwitchDevice):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Call when entity about to be added to hass."""
-        if self.entity_id is None:
-            self.entity_id = generate_entity_id(
-                ENTITY_ID_FORMAT, self._name, hass=self._hass)
-
         state = yield from async_get_last_state(self._hass, self.entity_id)
         if state:
             self._state = state.state == STATE_ON

--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -18,9 +18,6 @@ from homeassistant.helpers.restore_state import async_get_last_state
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = 'switch'
-ENTITY_ID_FORMAT = DOMAIN + '.{}'
-
 CONF_OFF_CODE = 'off_code'
 CONF_OFF_CODE_RECIEVE = 'off_code_receive'
 CONF_ON_CODE = 'on_code'
@@ -141,6 +138,11 @@ class PilightSwitch(SwitchDevice):
     def should_poll(self):
         """No polling needed, state set when correct code is received."""
         return False
+
+    @property 
+    def assumed_state(self): 
+        """Return True if unable to access real state of the entity.""" 
+        return True 
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -16,7 +16,6 @@ from homeassistant.const import (CONF_NAME, CONF_ID, CONF_SWITCHES, CONF_STATE,
                                  CONF_PROTOCOL, STATE_ON)
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.restore_state import async_get_last_state
-from homeassistant.util.async import run_coroutine_threadsafe
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -139,10 +139,10 @@ class PilightSwitch(SwitchDevice):
         """No polling needed, state set when correct code is received."""
         return False
 
-    @property 
-    def assumed_state(self): 
-        """Return True if unable to access real state of the entity.""" 
-        return True 
+    @property
+    def assumed_state(self):
+        """Return True if unable to access real state of the entity."""
+        return True
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -14,7 +14,6 @@ import homeassistant.components.pilight as pilight
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_NAME, CONF_ID, CONF_SWITCHES, CONF_STATE,
                                  CONF_PROTOCOL, STATE_ON)
-from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.restore_state import async_get_last_state
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Description:

This uses the restore_state helper to set the last known state to
pilight switches when the devices are initialized after a HA
restart.

Without this HA forget the state on every restart and needs to be told
the state by retoggling the switches. This can cause unwanted effects
as a switch toggling may emit an RF signal.


## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
