### PR TITLE
Added Time Remaining and Time Elapsed sensors for octoprint

### DIFF
--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -25,6 +25,8 @@ SENSOR_TYPES = {
     'Temperatures': ['printer', 'temperature', '*', TEMP_CELSIUS],
     'Current State': ['printer', 'state', 'text', None],
     'Job Percentage': ['job', 'progress', 'completion', '%'],
+    'Time Remaining': ['job', 'progress', 'printTimeLeft', 'seconds'],
+    'Time Elapsed': ['job', 'progress', 'printTime', 'seconds'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
## Description:
Added Time Remaining and Time Elapsed to OctoPrint sensors. Both sensors report in seconds.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: octoprint
    monitored_conditions:
      - 'Time Remaining'
      - 'Time Elapsed'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
