### PR TITLE
MQTT Switch: add availability_topic for online/offline status

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -58,6 +58,7 @@ CONF_WILL_MESSAGE = 'will_message'
 
 CONF_STATE_TOPIC = 'state_topic'
 CONF_COMMAND_TOPIC = 'command_topic'
+CONF_AVAILABILITY_TOPIC = 'availability_topic'
 CONF_QOS = 'qos'
 CONF_RETAIN = 'retain'
 

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -83,13 +83,13 @@ class MqttSwitch(SwitchDevice):
 
     @asyncio.coroutine
     def async_added_to_hass(self):
-        """Subscribe to MQTT state events.
+        """Subscribe to MQTT events.
 
         This method is a coroutine.
         """
         @callback
         def state_message_received(topic, payload, qos):
-            """Handle new MQTT messages."""
+            """Handle new MQTT state messages."""
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(
                     payload)
@@ -100,13 +100,9 @@ class MqttSwitch(SwitchDevice):
 
             self.hass.async_add_job(self.async_update_ha_state())
 
-        """Subscribe to MQTT availability events.
-
-        This method is a coroutine.
-        """
         @callback
         def availability_message_received(topic, payload, qos):
-            """Handle new MQTT messages."""
+            """Handle new MQTT availability messages."""
             if payload == self._payload_on:
                 self._available = True
             elif payload == self._payload_off:

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -11,7 +11,8 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.components.mqtt import (
-    CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN)
+    CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_AVAILABILITY_TOPIC, CONF_QOS,
+    CONF_RETAIN)
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_OFF,
@@ -50,6 +51,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_COMMAND_TOPIC),
+        config.get(CONF_AVAILABILITY_TOPIC),
         config.get(CONF_QOS),
         config.get(CONF_RETAIN),
         config.get(CONF_PAYLOAD_ON),
@@ -62,13 +64,16 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class MqttSwitch(SwitchDevice):
     """Representation of a switch that can be toggled using MQTT."""
 
-    def __init__(self, name, state_topic, command_topic, qos, retain,
-                 payload_on, payload_off, optimistic, value_template):
+    def __init__(self, name, state_topic, command_topic, availability_topic,
+                 qos, retain, payload_on, payload_off, optimistic,
+                 value_template):
         """Initialize the MQTT switch."""
         self._state = False
         self._name = name
         self._state_topic = state_topic
         self._command_topic = command_topic
+        self._availability_topic = availability_topic
+        self._available = True if availability_topic is None else False
         self._qos = qos
         self._retain = retain
         self._payload_on = payload_on
@@ -78,12 +83,12 @@ class MqttSwitch(SwitchDevice):
 
     @asyncio.coroutine
     def async_added_to_hass(self):
-        """Subscribe to MQTT events.
+        """Subscribe to MQTT state events.
 
         This method is a coroutine.
         """
         @callback
-        def message_received(topic, payload, qos):
+        def state_message_received(topic, payload, qos):
             """Handle new MQTT messages."""
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(
@@ -95,12 +100,32 @@ class MqttSwitch(SwitchDevice):
 
             self.hass.async_add_job(self.async_update_ha_state())
 
+        """Subscribe to MQTT availability events.
+
+        This method is a coroutine.
+        """
+        @callback
+        def availability_message_received(topic, payload, qos):
+            """Handle new MQTT messages."""
+            if payload == self._payload_on:
+                self._available = True
+            elif payload == self._payload_off:
+                self._available = False
+
+            self.hass.async_add_job(self.async_update_ha_state())
+
         if self._state_topic is None:
             # Force into optimistic mode.
             self._optimistic = True
         else:
             yield from mqtt.async_subscribe(
-                self.hass, self._state_topic, message_received, self._qos)
+                self.hass, self._state_topic, state_message_received,
+                self._qos)
+
+        if self._availability_topic is not None:
+            yield from mqtt.async_subscribe(
+                self.hass, self._availability_topic,
+                availability_message_received, self._qos)
 
     @property
     def should_poll(self):
@@ -111,6 +136,11 @@ class MqttSwitch(SwitchDevice):
     def name(self):
         """Return the name of the switch."""
         return self._name
+
+    @property
+    def available(self) -> bool:
+        """Return if switch is available."""
+        return self._available
 
     @property
     def is_on(self):


### PR DESCRIPTION
## Description:
Some MQTT devices (for example, those with Espurna firmware) publish a message to a topic when the device is online, and have specified a last will message to the same topic for when going offline. This PR allows using those to set the switch to "unavailable" on the front end when it is offline.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3034

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: mqtt
    name: super_mqtt_switch
    command_topic: "/super_mqtt_switch/relay/0"
    state_topic: "/super_mqtt_switch/relay/0"
    availability_topic: "/super_mqtt_switch/status"
    payload_on:  "1"
    payload_off: "0"
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
