### PR TITLE
Remove code in wink.py overwriting hass.data configurator

### DIFF
--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -103,7 +103,7 @@ def _read_config_file(file_path):
 
 def _request_app_setup(hass, config):
     """Assist user with configuring the Wink dev application."""
-    hass.data['configurator'] = True
+    hass.data[DOMAIN]['configurator'] = True
     configurator = get_component('configurator')
 
     # pylint: disable=unused-argument
@@ -151,7 +151,7 @@ def _request_app_setup(hass, config):
 
 def _request_oauth_completion(hass, config):
     """Request user complete Wink OAuth2 flow."""
-    hass.data['configurator'] = True
+    hass.data[DOMAIN]['configurator'] = True
     configurator = get_component('configurator')
     if DOMAIN in hass.data[DOMAIN]['configuring']:
         configurator.notify_errors(


### PR DESCRIPTION
## Description:
Fix configurator bug introduced with #8208 

Wink was setting hass.data['configurator'] to a boolean when it should have been setting hass.data[DOMAIN]['configurator'] to a boolean.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
