### PR TITLE
REST binary sensor value_template optional

### DIFF
--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -107,6 +107,8 @@ class RestBinarySensor(BinarySensorDevice):
         if self.rest.data is None:
             return False
 
+        response = self.rest.data
+
         if self._value_template is not None:
             response = self._value_template.\
                 async_render_with_possible_json_value(self.rest.data, False)


### PR DESCRIPTION
## Description
According to the documentation, the `value_template` for the REST
binary_sensor is not required. However, if you don't provide this when
setting up a binary sensor, the component fails. Looks like a variable
was not being set, which I've now included.

This should make the REST binary sensor act the same way as the REST
sensor now.

#### Example entry for `configuration.yaml`:
```yaml
binary_sensor:
  - platform: rest
    resource: http://IP_ADDRESS/ENDPOINT
    method: POST
```