### PR TITLE
Check if /dev/input/by-id exists

### DIFF
--- a/homeassistant/components/keyboard_remote.py
+++ b/homeassistant/components/keyboard_remote.py
@@ -94,19 +94,24 @@ class KeyboardRemote(threading.Thread):
         if self.dev is not None:
             _LOGGER.debug("Keyboard connected, %s", self.device_id)
         else:
-            id_folder = '/dev/input/by-id/'
-            device_names = [InputDevice(file_name).name
-                            for file_name in list_devices()]
             _LOGGER.debug(
                 'Keyboard not connected, %s.\n\
-                Check /dev/input/event* permissions.\
-                Possible device names are:\n %s.\n \
-                Possible device descriptors are %s:\n %s',
-                self.device_id,
-                device_names,
-                id_folder,
-                os.listdir(id_folder)
+                Check /dev/input/event* permissions.',
+                self.device_id
                 )
+
+            id_folder = '/dev/input/by-id/'
+
+            if os.path.isdir(id_folder):
+                device_names = [InputDevice(file_name).name
+                                for file_name in list_devices()]
+                _LOGGER.debug(
+                    'Possible device names are:\n %s.\n \
+                    Possible device descriptors are %s:\n %s',
+                    device_names,
+                    id_folder,
+                    os.listdir(id_folder)
+                    )
 
         threading.Thread.__init__(self)
         self.stopped = threading.Event()


### PR DESCRIPTION
## Description:

If the input device is not connected when starting hass, keyboard_remote tries to access `/dev/input/by-id`, which may not exist. This PR adds a check to only access the by-id folder if it exists.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
