### PR TITLE
bump python-mirobo version for more robust protocol handling

### DIFF
--- a/homeassistant/components/switch/xiaomi_vacuum.py
+++ b/homeassistant/components/switch/xiaomi_vacuum.py
@@ -22,7 +22,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-mirobo==0.1.1']
+REQUIREMENTS = ['python-mirobo==0.1.2']
 
 
 # pylint: disable=unused-argument
@@ -32,7 +32,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     name = config.get(CONF_NAME)
     token = config.get(CONF_TOKEN)
 
-    add_devices_callback([MiroboSwitch(name, host, token)])
+    add_devices_callback([MiroboSwitch(name, host, token)], True)
 
 
 class MiroboSwitch(SwitchDevice):
@@ -107,7 +107,7 @@ class MiroboSwitch(SwitchDevice):
 
     def update(self):
         """Fetch state from the device."""
-        from mirobo import VacuumException
+        from mirobo import DeviceException
         try:
             state = self.vacuum.status()
             _LOGGER.debug("got state from the vacuum: %s", state)
@@ -120,5 +120,5 @@ class MiroboSwitch(SwitchDevice):
 
             self._state = state.state_code
             self._is_on = state.is_on
-        except VacuumException as ex:
+        except DeviceException as ex:
             _LOGGER.error("Got exception while fetching the state: %s", ex)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -718,7 +718,7 @@ python-juicenet==0.0.5
 # python-lirc==1.2.3
 
 # homeassistant.components.switch.xiaomi_vacuum
-python-mirobo==0.1.1
+python-mirobo==0.1.2
 
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5


### PR DESCRIPTION
also, make the platform to update on startup

## Description:
In some cases the robot may lose a track of the message sequence and thus break the connectivity with the vacuum. The new upstream release does retries with incremented sequence numbers in case a connection fails.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
