### PR TITLE
Fix from main component repo

### DIFF
--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -273,31 +273,38 @@ class TadoClimate(ClimateDevice):
             else:
                 self._device_is_active = True
 
+        overlay = False
+        overlay_data = None
+        termination = self._current_operation
+        cooling = False
+        fan_speed = CONST_MODE_OFF
+
+        if 'overlay' in data:
+            overlay_data = data['overlay']
+            overlay = overlay_data is not None
+
+        if overlay:
+            termination = overlay_data['termination']['type']
+
+            if 'setting' in overlay_data:
+                setting_data = overlay_data['setting']
+                setting = setting is not None
+
+            if setting:
+                if 'mode' in setting_data:
+                    cooling = setting_data['mode'] == 'COOL'
+
+                if 'fanSpeed' in setting_data:
+                    fan_speed = setting_data['fanSpeed']
+
         if self._device_is_active:
-            overlay = False
-            overlay_data = None
-            termination = self._current_operation
-            cooling = False
-            fan_speed = CONST_MODE_OFF
-
-            if 'overlay' in data:
-                overlay_data = data['overlay']
-                overlay = overlay_data is not None
-
-            if overlay:
-                termination = overlay_data['termination']['type']
-
-                if 'setting' in overlay_data:
-                    cooling = overlay_data['setting']['mode'] == 'COOL'
-                    fan_speed = overlay_data['setting']['fanSpeed']
-
             # If you set mode manualy to off, there will be an overlay
             # and a termination, but we want to see the mode "OFF"
-
             self._overlay_mode = termination
             self._current_operation = termination
-            self._cooling = cooling
-            self._current_fan = fan_speed
+
+        self._cooling = cooling
+        self._current_fan = fan_speed
 
     def _control_heating(self):
         """Send new target temperature to mytado."""


### PR DESCRIPTION
Handle case where 'mode' and 'fanSpeed' are missing JSON. Based on changes in commit https://github.com/wmalgadey/tado_component/commit/adfb608f86b8bf4c1c43e71b4067cbfe1de9ba85

## Description:


**Related issue (if applicable):** fixes #8606

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
