### PR TITLE
Fix STATION_SCHEMA validation on longitude

### DIFF
--- a/homeassistant/components/sensor/citybikes.py
+++ b/homeassistant/components/sensor/citybikes.py
@@ -84,7 +84,7 @@ STATION_SCHEMA = vol.Schema({
     vol.Required(ATTR_FREE_BIKES): cv.positive_int,
     vol.Required(ATTR_EMPTY_SLOTS): vol.Any(cv.positive_int, None),
     vol.Required(ATTR_LATITUDE): cv.latitude,
-    vol.Required(ATTR_LONGITUDE): cv.latitude,
+    vol.Required(ATTR_LONGITUDE): cv.longitude,
     vol.Required(ATTR_ID): cv.string,
     vol.Required(ATTR_NAME): cv.string,
     vol.Required(ATTR_TIMESTAMP): cv.string,


### PR DESCRIPTION
## Description:

If you are beyond longitude -90 or +90, the citybikes component won't work for you ;)

## Example entry for `configuration.yaml` (if applicable):
```yaml

sensor bikes:
  - platform: citybikes
    radius: 500
    latitude: 25.01
    longitude: 121.5
```

## Checklist:

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
