### PR TITLE
Bumped Amcrest version

### DIFF
--- a/homeassistant/components/amcrest.py
+++ b/homeassistant/components/amcrest.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['amcrest==1.2.0']
+REQUIREMENTS = ['amcrest==1.2.1']
 DEPENDENCIES = ['ffmpeg']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -61,7 +61,7 @@ aiopvapi==1.4
 alarmdecoder==0.12.3
 
 # homeassistant.components.amcrest
-amcrest==1.2.0
+amcrest==1.2.1
 
 # homeassistant.components.media_player.anthemav
 anthemav==1.1.8


### PR DESCRIPTION
## Description:
  
   Bumping Amcrest version to fix issue https://github.com/home-assistant/home-assistant/issues/8551 which makes Amcrest data serializable to work via discovery platform. 

**Related issue (if applicable):** fixes #8551 

## Example entry for `configuration.yaml` (if applicable):
```yaml
#configuration.yaml
amcrest: !include amcrest.yaml

#amcrest.yaml
- host: !secret amcrest_driveway_host
  name: "Amcrest Driveway"
  username: !secret amcrest_driveway_username
  password: !secret amcrest_driveway_password
  port: 80
  resolution: high
  stream_source: rtsp
  sensors:
    - motion_detector

```

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

