### PR TITLE
Yahoo Weather update, supports forecast for more days

### DIFF
--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -25,7 +25,7 @@ ATTRIBUTION = "Weather details provided by Yahoo! Inc."
 ATTR_FORECAST_TEMP_LOW = 'templow'
 
 CONF_WOEID = 'woeid'
-CONF_FORECAST = 'forecast'
+CONF_FORECAST_DAYS = 'forecast_days'
 
 DEFAULT_NAME = 'Yweather'
 
@@ -48,9 +48,7 @@ CONDITION_CLASSES = {
     'exceptional': [0, 1, 2, 3, 4, 25, 36],
 }
 
-_CONDITION_CLASSES_MAX = 50
-
-CONDITION_CLASSES_LIST = [str(x) for x in range(0, _CONDITION_CLASSES_MAX)]
+CONDITION_CLASSES_LIST = [str(x) for x in range(0, 50)]
 
 for cond, condlst in CONDITION_CLASSES.items():
     for condi in condlst:
@@ -59,7 +57,7 @@ for cond, condlst in CONDITION_CLASSES.items():
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_WOEID, default=None): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_FORECAST, default=5):
+    vol.Optional(CONF_FORECAST_DAYS, default=5):
         vol.All(vol.Coerce(int), vol.Range(min=0, max=10)),
 })
 
@@ -70,7 +68,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     unit = hass.config.units.temperature_unit
     woeid = config.get(CONF_WOEID)
-    forecast = config.get(CONF_FORECAST)
+    forecast = config.get(CONF_FORECAST_DAYS)
     name = config.get(CONF_NAME)
 
     yunit = UNIT_C if unit == TEMP_CELSIUS else UNIT_F

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -53,8 +53,8 @@ CONDITION_CLASSES_LIST = [str(x) for x in range(0, 50)]
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_WOEID, default=None): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_FORECAST, default=0):
-        vol.All(vol.Coerce(int), vol.Range(min=0, max=5)),
+    vol.Optional(CONF_FORECAST, default=5):
+    vol.All(vol.Coerce(int), vol.Range(min=0, max=5)),
 })
 
 DEGREE_TO_TEXT = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW', 'N']
@@ -161,7 +161,7 @@ class YahooWeatherWeather(WeatherEntity):
         """Return the forecast array."""
         return [{'datetime':v['date'], ATTR_FORECAST_TEMP:int(v['high']), 'templow': int(v['low']),
                  'condition': CONDITION_CLASSES_LIST[int(v['code'])]}
-                for v in self._data.yahoo.Forecast]
+                for v in self._data.yahoo.Forecast[:self._forecast]]
 
     def update(self):
         """Get the latest data from Yahoo! and updates the states."""

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -57,7 +57,7 @@ for cond, condlst in CONDITION_CLASSES.items():
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_WOEID, default=None): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_FORECAST_DAYS, default=5):
+    vol.Optional(CONF_FORECAST_DAYS, default=0):
         vol.All(vol.Coerce(int), vol.Range(min=0, max=10)),
 })
 

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -63,6 +63,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(vol.Coerce(int), vol.Range(min=0, max=10)),
 })
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Yahoo! weather platform."""
     from yahooweather import get_woeid, UNIT_C, UNIT_F

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -78,7 +78,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if not yahoo_api.update():
         _LOGGER.critical("Can't retrieve weather data from Yahoo!")
         return False
-    
+
     # create condition helper
     if DATA_CONDITION not in hass.data:
         hass.data[DATA_CONDITION] = [str(x) for x in range(0, 50)]
@@ -160,7 +160,7 @@ class YahooWeatherWeather(WeatherEntity):
                     ATTR_FORECAST_TIME: v['date'],
                     ATTR_FORECAST_TEMP:int(v['high']),
                     ATTR_FORECAST_TEMP_LOW: int(v['low']),
-                    ATTR_FORECAST_CONDITION: hass.data[DATA_CONDITION][
+                    ATTR_FORECAST_CONDITION: self.hass.data[DATA_CONDITION][
                         int(v['code'])]
                 } for v in self._data.yahoo.Forecast[]]
         except (ValueError, IndexError):

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -25,7 +25,7 @@ ATTRIBUTION = "Weather details provided by Yahoo! Inc."
 ATTR_FORECAST_TEMP_LOW = 'templow'
 
 CONF_WOEID = 'woeid'
-CONF_FORECAST_DAYS = 'forecast_days'
+CONF_FORECAST = 'forecast'
 
 DEFAULT_NAME = 'Yweather'
 
@@ -57,7 +57,7 @@ for cond, condlst in CONDITION_CLASSES.items():
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_WOEID, default=None): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_FORECAST_DAYS, default=0):
+    vol.Optional(CONF_FORECAST, default=0):
         vol.All(vol.Coerce(int), vol.Range(min=0, max=10)),
 })
 
@@ -68,7 +68,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     unit = hass.config.units.temperature_unit
     woeid = config.get(CONF_WOEID)
-    forecast = config.get(CONF_FORECAST_DAYS)
+    forecast = config.get(CONF_FORECAST)
     name = config.get(CONF_NAME)
 
     yunit = UNIT_C if unit == TEMP_CELSIUS else UNIT_F

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -160,9 +160,9 @@ class YahooWeatherWeather(WeatherEntity):
                     ATTR_FORECAST_TIME: v['date'],
                     ATTR_FORECAST_TEMP:int(v['high']),
                     ATTR_FORECAST_TEMP_LOW: int(v['low']),
-                    ATTR_FORECAST_CONDITION: self.hass.data[DATA_CONDITION][
-                        int(v['code'])]
-                } for v in self._data.yahoo.Forecast[]]
+                    ATTR_FORECAST_CONDITION: 
+                        self.hass.data[DATA_CONDITION][int(v['code'])]
+                } for v in self._data.yahoo.Forecast]
         except (ValueError, IndexError):
             return STATE_UNKNOWN
 

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -11,7 +11,8 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.weather import (
-    WeatherEntity, PLATFORM_SCHEMA, ATTR_FORECAST, ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME)
+    WeatherEntity, PLATFORM_SCHEMA,
+    ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME)
 from homeassistant.const import (TEMP_CELSIUS, CONF_NAME)
 
 REQUIREMENTS = ["yahooweather==0.8"]
@@ -21,7 +22,6 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_FORECAST_CONDITION = 'condition'
 ATTRIBUTION = "Weather details provided by Yahoo! Inc."
 
-ATTR_FORECAST_TIME = 'datetime'
 ATTR_FORECAST_TEMP_LOW = 'templow'
 
 CONF_WOEID = 'woeid'
@@ -161,9 +161,14 @@ class YahooWeatherWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        return [{ATTR_FORECAST_TIME: v['date'], ATTR_FORECAST_TEMP:int(v['high']), ATTR_FORECAST_TEMP_LOW: int(v['low']),
-                 ATTR_FORECAST_CONDITION: CONDITION_CLASSES_LIST[int(v['code'])]}
-                for v in self._data.yahoo.Forecast[:self._forecast]]
+        return [
+            {
+                ATTR_FORECAST_TIME: v['date'],
+                ATTR_FORECAST_TEMP:int(v['high']),
+                ATTR_FORECAST_TEMP_LOW: int(v['low']),
+                ATTR_FORECAST_CONDITION: CONDITION_CLASSES_LIST[
+                    int(v['code'])]
+            } for v in self._data.yahoo.Forecast[:self._forecast]]
 
     def update(self):
         """Get the latest data from Yahoo! and updates the states."""

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -13,7 +13,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.weather import (
     WeatherEntity, PLATFORM_SCHEMA,
     ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME)
-from homeassistant.const import (TEMP_CELSIUS, CONF_NAME)
+from homeassistant.const import (TEMP_CELSIUS, CONF_NAME, STATE_UNKNOWN)
 
 REQUIREMENTS = ["yahooweather==0.8"]
 
@@ -116,7 +116,7 @@ class YahooWeatherWeather(WeatherEntity):
         try:
             return CONDITION_CLASSES_LIST[int(self._data.yahoo.Now['code'])]
         except (ValueError, IndexError):
-            return ''
+            return STATE_UNKNOWN
 
     @property
     def temperature(self):
@@ -150,7 +150,7 @@ class YahooWeatherWeather(WeatherEntity):
 
     @property
     def wind_bearing(self):
-        """Return the wind speed."""
+        """Return the wind direction."""
         return self._data.yahoo.Wind['direction']
 
     @property
@@ -161,7 +161,7 @@ class YahooWeatherWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        if not self._forecast:
+        if self._forecast == 0:
             return []
         try:
             return [

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.weather import (
-    WeatherEntity, PLATFORM_SCHEMA, ATTR_FORECAST_TEMP)
+    WeatherEntity, PLATFORM_SCHEMA, ATTR_FORECAST, ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME)
 from homeassistant.const import (TEMP_CELSIUS, CONF_NAME)
 
 REQUIREMENTS = ["yahooweather==0.8"]
@@ -21,11 +21,11 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_FORECAST_CONDITION = 'condition'
 ATTRIBUTION = "Weather details provided by Yahoo! Inc."
 
-ATTR_FORECAST_DATE = 'datetime'
-ATTR_FORECAST_TEMP = 'temperature'
+ATTR_FORECAST_TIME = 'datetime'
+ATTR_FORECAST_TEMP_LOW = 'templow'
 
-CONF_FORECAST = 'forecast'
 CONF_WOEID = 'woeid'
+CONF_FORECAST = 'forecast'
 
 DEFAULT_NAME = 'Yweather'
 
@@ -94,8 +94,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     add_devices([YahooWeatherWeather(yahoo_api, name, forecast)], True)
 
+
 def _windtostring(degree):
     return DEGREE_TO_TEXT[int((int(degree) + 22.5) / 45)]
+
 
 class YahooWeatherWeather(WeatherEntity):
     """Representation of Yahoo! weather data."""
@@ -159,8 +161,8 @@ class YahooWeatherWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        return [{'datetime':v['date'], ATTR_FORECAST_TEMP:int(v['high']), 'templow': int(v['low']),
-                 'condition': CONDITION_CLASSES_LIST[int(v['code'])]}
+        return [{ATTR_FORECAST_TIME: v['date'], ATTR_FORECAST_TEMP:int(v['high']), ATTR_FORECAST_TEMP_LOW: int(v['low']),
+                 ATTR_FORECAST_CONDITION: CONDITION_CLASSES_LIST[int(v['code'])]}
                 for v in self._data.yahoo.Forecast[:self._forecast]]
 
     def update(self):

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -55,7 +55,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_WOEID, default=None): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_FORECAST, default=0):
-        vol.All(vol.Coerce(int), vol.Range(min=0, max=10)),
+        vol.All(vol.Coerce(int), vol.Range(min=0, max=5)),
 })
 
 

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -160,16 +160,19 @@ class YahooWeatherWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        if self._forecast == None:
+        if not self._forecast:
             return []
-        return [
-            {
-                ATTR_FORECAST_TIME: v['date'],
-                ATTR_FORECAST_TEMP:int(v['high']),
-                ATTR_FORECAST_TEMP_LOW: int(v['low']),
-                ATTR_FORECAST_CONDITION: CONDITION_CLASSES_LIST[
-                    int(v['code'])]
-            } for v in self._data.yahoo.Forecast[:self._forecast]]
+        try:
+            return [
+                {
+                    ATTR_FORECAST_TIME: v['date'],
+                    ATTR_FORECAST_TEMP:int(v['high']),
+                    ATTR_FORECAST_TEMP_LOW: int(v['low']),
+                    ATTR_FORECAST_CONDITION: CONDITION_CLASSES_LIST[
+                        int(v['code'])]
+                } for v in self._data.yahoo.Forecast[:self._forecast]]
+        except (ValueError, IndexError):
+            return []
 
     def update(self):
         """Get the latest data from Yahoo! and updates the states."""

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -160,7 +160,7 @@ class YahooWeatherWeather(WeatherEntity):
                     ATTR_FORECAST_TIME: v['date'],
                     ATTR_FORECAST_TEMP:int(v['high']),
                     ATTR_FORECAST_TEMP_LOW: int(v['low']),
-                    ATTR_FORECAST_CONDITION: 
+                    ATTR_FORECAST_CONDITION:
                         self.hass.data[DATA_CONDITION][int(v['code'])]
                 } for v in self._data.yahoo.Forecast]
         except (ValueError, IndexError):


### PR DESCRIPTION
## Description:


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3047

Works perfectly with home-assistant/home-assistant-polymer#352 updated weather panel.

## Example entry for `configuration.yaml` (if applicable):
```yaml
weather:
  - platform: yweather
    name: weather_today
```

**Breaking change**
`forecast` is now every time present and the options was removed.

## Checklist:

  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

Tested on my device with `hass --debug`.
