### PR TITLE
Cleanup old device_tracker stuff

### DIFF
--- a/homeassistant/components/device_tracker/actiontec.py
+++ b/homeassistant/components/device_tracker/actiontec.py
@@ -7,9 +7,7 @@ https://home-assistant.io/components/device_tracker.actiontec/
 import logging
 import re
 import telnetlib
-import threading
 from collections import namedtuple
-from datetime import timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -17,9 +15,6 @@ import homeassistant.util.dt as dt_util
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.util import Throttle
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,7 +49,6 @@ class ActiontecDeviceScanner(DeviceScanner):
         self.host = config[CONF_HOST]
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
-        self.lock = threading.Lock()
         self.last_results = []
         data = self.get_actiontec_data()
         self.success_init = data is not None
@@ -74,7 +68,6 @@ class ActiontecDeviceScanner(DeviceScanner):
                 return client.ip
         return None
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the router is up to date.
 
@@ -84,16 +77,15 @@ class ActiontecDeviceScanner(DeviceScanner):
         if not self.success_init:
             return False
 
-        with self.lock:
-            now = dt_util.now()
-            actiontec_data = self.get_actiontec_data()
-            if not actiontec_data:
-                return False
-            self.last_results = [Device(data['mac'], name, now)
-                                 for name, data in actiontec_data.items()
-                                 if data['timevalid'] > -60]
-            _LOGGER.info("Scan successful")
-            return True
+        now = dt_util.now()
+        actiontec_data = self.get_actiontec_data()
+        if not actiontec_data:
+            return False
+        self.last_results = [Device(data['mac'], name, now)
+                             for name, data in actiontec_data.items()
+                             if data['timevalid'] > -60]
+        _LOGGER.info("Scan successful")
+        return True
 
     def get_actiontec_data(self):
         """Retrieve data from Actiontec MI424WR and return parsed result."""

--- a/homeassistant/components/device_tracker/cisco_ios.py
+++ b/homeassistant/components/device_tracker/cisco_ios.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.cisco_ios/
 """
 import logging
-from datetime import timedelta
 
 import voluptuous as vol
 

--- a/homeassistant/components/device_tracker/cisco_ios.py
+++ b/homeassistant/components/device_tracker/cisco_ios.py
@@ -14,9 +14,6 @@ from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, \
     CONF_PORT
-from homeassistant.util import Throttle
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,7 +62,6 @@ class CiscoDeviceScanner(DeviceScanner):
 
         return self.last_results
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """
         Ensure the information from the Cisco router is up to date.

--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.fritz/
 """
 import logging
-from datetime import timedelta
 
 import voluptuous as vol
 
@@ -13,11 +12,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.util import Throttle
 
 REQUIREMENTS = ['fritzconnection==0.6.3']
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,7 +84,6 @@ class FritzBoxScanner(DeviceScanner):
             return None
         return ret
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Retrieve latest information from the FRITZ!Box."""
         if not self.success_init:

--- a/homeassistant/components/device_tracker/linksys_ap.py
+++ b/homeassistant/components/device_tracker/linksys_ap.py
@@ -6,8 +6,6 @@ https://home-assistant.io/components/device_tracker.linksys_ap/
 """
 import base64
 import logging
-import threading
-from datetime import timedelta
 
 import requests
 import voluptuous as vol
@@ -16,9 +14,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import DOMAIN, PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL)
-from homeassistant.util import Throttle
 
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 INTERFACES = 2
 DEFAULT_TIMEOUT = 10
 
@@ -51,8 +47,6 @@ class LinksysAPDeviceScanner(object):
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
         self.verify_ssl = config[CONF_VERIFY_SSL]
-
-        self.lock = threading.Lock()
         self.last_results = []
 
         # Check if the access point is accessible
@@ -76,24 +70,22 @@ class LinksysAPDeviceScanner(object):
         """
         return None
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Check for connected devices."""
         from bs4 import BeautifulSoup as BS
 
-        with self.lock:
-            _LOGGER.info("Checking Linksys AP")
+        _LOGGER.info("Checking Linksys AP")
 
-            self.last_results = []
-            for interface in range(INTERFACES):
-                request = self._make_request(interface)
-                self.last_results.extend(
-                    [x.find_all('td')[1].text
-                     for x in BS(request.content, "html.parser")
-                     .find_all(class_='section-row')]
-                )
+        self.last_results = []
+        for interface in range(INTERFACES):
+            request = self._make_request(interface)
+            self.last_results.extend(
+                [x.find_all('td')[1].text
+                 for x in BS(request.content, "html.parser")
+                 .find_all(class_='section-row')]
+            )
 
-            return True
+        return True
 
     def _make_request(self, unit=0):
         # No, the '&&' is not a typo - this is expected by the web interface.

--- a/homeassistant/components/device_tracker/netgear.py
+++ b/homeassistant/components/device_tracker/netgear.py
@@ -5,8 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.netgear/
 """
 import logging
-import threading
-from datetime import timedelta
 
 import voluptuous as vol
 
@@ -15,13 +13,10 @@ from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT)
-from homeassistant.util import Throttle
 
 REQUIREMENTS = ['pynetgear==0.3.3']
 
 _LOGGER = logging.getLogger(__name__)
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 DEFAULT_HOST = 'routerlogin.net'
 DEFAULT_USER = 'admin'
@@ -56,8 +51,6 @@ class NetgearDeviceScanner(DeviceScanner):
         import pynetgear
 
         self.last_results = []
-        self.lock = threading.Lock()
-
         self._api = pynetgear.Netgear(password, host, username, port)
 
         _LOGGER.info("Logging in")
@@ -85,7 +78,6 @@ class NetgearDeviceScanner(DeviceScanner):
         except StopIteration:
             return None
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Retrieve latest information from the Netgear router.
 
@@ -94,12 +86,11 @@ class NetgearDeviceScanner(DeviceScanner):
         if not self.success_init:
             return
 
-        with self.lock:
-            _LOGGER.info("Scanning")
+        _LOGGER.info("Scanning")
 
-            results = self._api.get_attached_devices()
+        results = self._api.get_attached_devices()
 
-            if results is None:
-                _LOGGER.warning("Error scanning devices")
+        if results is None:
+            _LOGGER.warning("Error scanning devices")
 
-            self.last_results = results or []
+        self.last_results = results or []

--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -4,6 +4,7 @@ Support for scanning a network with nmap.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.nmap_tracker/
 """
+from datetime import timedelta
 import logging
 import re
 import subprocess

--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -8,7 +8,6 @@ import logging
 import re
 import subprocess
 from collections import namedtuple
-from datetime import timedelta
 
 import voluptuous as vol
 
@@ -17,7 +16,6 @@ import homeassistant.util.dt as dt_util
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOSTS
-from homeassistant.util import Throttle
 
 REQUIREMENTS = ['python-nmap==0.6.1']
 
@@ -28,8 +26,6 @@ CONF_EXCLUDE = 'exclude'
 CONF_HOME_INTERVAL = 'home_interval'
 CONF_OPTIONS = 'scan_options'
 DEFAULT_OPTIONS = '-F --host-timeout 5s'
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -97,7 +93,6 @@ class NmapDeviceScanner(DeviceScanner):
             return filter_named[0]
         return None
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Scan the network for devices.
 

--- a/homeassistant/components/device_tracker/sky_hub.py
+++ b/homeassistant/components/device_tracker/sky_hub.py
@@ -6,8 +6,6 @@ https://home-assistant.io/components/device_tracker.sky_hub/
 """
 import logging
 import re
-import threading
-from datetime import timedelta
 
 import requests
 import voluptuous as vol
@@ -16,12 +14,9 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
-from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 _MAC_REGEX = re.compile(r'(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})')
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string
@@ -43,11 +38,7 @@ class SkyHubDeviceScanner(DeviceScanner):
         """Initialise the scanner."""
         _LOGGER.info("Initialising Sky Hub")
         self.host = config.get(CONF_HOST, '192.168.1.254')
-
-        self.lock = threading.Lock()
-
         self.last_results = {}
-
         self.url = 'http://{}/'.format(self.host)
 
         # Test the router is accessible
@@ -62,17 +53,15 @@ class SkyHubDeviceScanner(DeviceScanner):
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
-        with self.lock:
-            # If not initialised and not already scanned and not found.
-            if device not in self.last_results:
-                self._update_info()
+        # If not initialised and not already scanned and not found.
+        if device not in self.last_results:
+            self._update_info()
 
-                if not self.last_results:
-                    return None
+            if not self.last_results:
+                return None
 
-            return self.last_results.get(device)
+        return self.last_results.get(device)
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the Sky Hub is up to date.
 
@@ -81,18 +70,17 @@ class SkyHubDeviceScanner(DeviceScanner):
         if not self.success_init:
             return False
 
-        with self.lock:
-            _LOGGER.info("Scanning")
+        _LOGGER.info("Scanning")
 
-            data = _get_skyhub_data(self.url)
+        data = _get_skyhub_data(self.url)
 
-            if not data:
-                _LOGGER.warning('Error scanning devices')
-                return False
+        if not data:
+            _LOGGER.warning('Error scanning devices')
+            return False
 
-            self.last_results = data
+        self.last_results = data
 
-            return True
+        return True
 
 
 def _get_skyhub_data(url):

--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -6,8 +6,6 @@ https://home-assistant.io/components/device_tracker.snmp/
 """
 import binascii
 import logging
-import threading
-from datetime import timedelta
 
 import voluptuous as vol
 
@@ -15,7 +13,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
-from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,8 +24,6 @@ CONF_PRIVKEY = 'privkey'
 CONF_BASEOID = 'baseoid'
 
 DEFAULT_COMMUNITY = 'public'
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -68,9 +63,6 @@ class SnmpScanner(DeviceScanner):
                 privProtocol=cfg.usmAesCfb128Protocol
             )
         self.baseoid = cmdgen.MibVariable(config[CONF_BASEOID])
-
-        self.lock = threading.Lock()
-
         self.last_results = []
 
         # Test the router is accessible
@@ -90,7 +82,6 @@ class SnmpScanner(DeviceScanner):
         # We have no names
         return None
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the device is up to date.
 
@@ -99,13 +90,12 @@ class SnmpScanner(DeviceScanner):
         if not self.success_init:
             return False
 
-        with self.lock:
-            data = self.get_snmp_data()
-            if not data:
-                return False
+        data = self.get_snmp_data()
+        if not data:
+            return False
 
-            self.last_results = data
-            return True
+        self.last_results = data
+        return True
 
     def get_snmp_data(self):
         """Fetch MAC addresses from access point via SNMP."""

--- a/homeassistant/components/device_tracker/swisscom.py
+++ b/homeassistant/components/device_tracker/swisscom.py
@@ -5,8 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.swisscom/
 """
 import logging
-import threading
-from datetime import timedelta
 
 import requests
 import voluptuous as vol
@@ -16,8 +14,6 @@ from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
 from homeassistant.util import Throttle
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,9 +37,6 @@ class SwisscomDeviceScanner(DeviceScanner):
     def __init__(self, config):
         """Initialize the scanner."""
         self.host = config[CONF_HOST]
-
-        self.lock = threading.Lock()
-
         self.last_results = {}
 
         # Test the router is accessible.
@@ -64,7 +57,6 @@ class SwisscomDeviceScanner(DeviceScanner):
                 return client['host']
         return None
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the Swisscom router is up to date.
 
@@ -73,16 +65,15 @@ class SwisscomDeviceScanner(DeviceScanner):
         if not self.success_init:
             return False
 
-        with self.lock:
-            _LOGGER.info("Loading data from Swisscom Internet Box")
-            data = self.get_swisscom_data()
-            if not data:
-                return False
+        _LOGGER.info("Loading data from Swisscom Internet Box")
+        data = self.get_swisscom_data()
+        if not data:
+            return False
 
-            active_clients = [client for client in data.values() if
-                              client['status']]
-            self.last_results = active_clients
-            return True
+        active_clients = [client for client in data.values() if
+                          client['status']]
+        self.last_results = active_clients
+        return True
 
     def get_swisscom_data(self):
         """Retrieve data from Swisscom and return parsed result."""

--- a/homeassistant/components/device_tracker/swisscom.py
+++ b/homeassistant/components/device_tracker/swisscom.py
@@ -13,7 +13,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
-from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/device_tracker/thomson.py
+++ b/homeassistant/components/device_tracker/thomson.py
@@ -7,8 +7,6 @@ https://home-assistant.io/components/device_tracker.thomson/
 import logging
 import re
 import telnetlib
-import threading
-from datetime import timedelta
 
 import voluptuous as vol
 
@@ -16,9 +14,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.util import Throttle
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,9 +49,6 @@ class ThomsonDeviceScanner(DeviceScanner):
         self.host = config[CONF_HOST]
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
-
-        self.lock = threading.Lock()
-
         self.last_results = {}
 
         # Test the router is accessible.
@@ -77,7 +69,6 @@ class ThomsonDeviceScanner(DeviceScanner):
                 return client['host']
         return None
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the THOMSON router is up to date.
 
@@ -86,17 +77,16 @@ class ThomsonDeviceScanner(DeviceScanner):
         if not self.success_init:
             return False
 
-        with self.lock:
-            _LOGGER.info("Checking ARP")
-            data = self.get_thomson_data()
-            if not data:
-                return False
+        _LOGGER.info("Checking ARP")
+        data = self.get_thomson_data()
+        if not data:
+            return False
 
-            # Flag C stands for CONNECTED
-            active_clients = [client for client in data.values() if
-                              client['status'].find('C') != -1]
-            self.last_results = active_clients
-            return True
+        # Flag C stands for CONNECTED
+        active_clients = [client for client in data.values() if
+                          client['status'].find('C') != -1]
+        self.last_results = active_clients
+        return True
 
     def get_thomson_data(self):
         """Retrieve data from THOMSON and return parsed result."""

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -8,8 +8,7 @@ import base64
 import hashlib
 import logging
 import re
-import threading
-from datetime import timedelta, datetime
+from datetime import datetime
 
 import requests
 import voluptuous as vol
@@ -18,9 +17,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.util import Throttle
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +55,6 @@ class TplinkDeviceScanner(DeviceScanner):
         self.password = password
 
         self.last_results = {}
-        self.lock = threading.Lock()
         self.success_init = self._update_info()
 
     def scan_devices(self):
@@ -72,28 +67,26 @@ class TplinkDeviceScanner(DeviceScanner):
         """Get firmware doesn't save the name of the wireless device."""
         return None
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the TP-Link router is up to date.
 
         Return boolean if scanning successful.
         """
-        with self.lock:
-            _LOGGER.info("Loading wireless clients...")
+        _LOGGER.info("Loading wireless clients...")
 
-            url = 'http://{}/userRpm/WlanStationRpm.htm'.format(self.host)
-            referer = 'http://{}'.format(self.host)
-            page = requests.get(
-                url, auth=(self.username, self.password),
-                headers={'referer': referer}, timeout=4)
+        url = 'http://{}/userRpm/WlanStationRpm.htm'.format(self.host)
+        referer = 'http://{}'.format(self.host)
+        page = requests.get(
+            url, auth=(self.username, self.password),
+            headers={'referer': referer}, timeout=4)
 
-            result = self.parse_macs.findall(page.text)
+        result = self.parse_macs.findall(page.text)
 
-            if result:
-                self.last_results = [mac.replace("-", ":") for mac in result]
-                return True
+        if result:
+            self.last_results = [mac.replace("-", ":") for mac in result]
+            return True
 
-            return False
+        return False
 
 
 class Tplink2DeviceScanner(TplinkDeviceScanner):
@@ -109,47 +102,45 @@ class Tplink2DeviceScanner(TplinkDeviceScanner):
         """Get firmware doesn't save the name of the wireless device."""
         return self.last_results.get(device)
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the TP-Link router is up to date.
 
         Return boolean if scanning successful.
         """
-        with self.lock:
-            _LOGGER.info("Loading wireless clients...")
+        _LOGGER.info("Loading wireless clients...")
 
-            url = 'http://{}/data/map_access_wireless_client_grid.json' \
-                .format(self.host)
-            referer = 'http://{}'.format(self.host)
+        url = 'http://{}/data/map_access_wireless_client_grid.json' \
+            .format(self.host)
+        referer = 'http://{}'.format(self.host)
 
-            # Router uses Authorization cookie instead of header
-            # Let's create the cookie
-            username_password = '{}:{}'.format(self.username, self.password)
-            b64_encoded_username_password = base64.b64encode(
-                username_password.encode('ascii')
-            ).decode('ascii')
-            cookie = 'Authorization=Basic {}' \
-                .format(b64_encoded_username_password)
+        # Router uses Authorization cookie instead of header
+        # Let's create the cookie
+        username_password = '{}:{}'.format(self.username, self.password)
+        b64_encoded_username_password = base64.b64encode(
+            username_password.encode('ascii')
+        ).decode('ascii')
+        cookie = 'Authorization=Basic {}' \
+            .format(b64_encoded_username_password)
 
-            response = requests.post(
-                url, headers={'referer': referer, 'cookie': cookie},
-                timeout=4)
+        response = requests.post(
+            url, headers={'referer': referer, 'cookie': cookie},
+            timeout=4)
 
-            try:
-                result = response.json().get('data')
-            except ValueError:
-                _LOGGER.error("Router didn't respond with JSON. "
-                              "Check if credentials are correct.")
-                return False
-
-            if result:
-                self.last_results = {
-                    device['mac_addr'].replace('-', ':'): device['name']
-                    for device in result
-                    }
-                return True
-
+        try:
+            result = response.json().get('data')
+        except ValueError:
+            _LOGGER.error("Router didn't respond with JSON. "
+                          "Check if credentials are correct.")
             return False
+
+        if result:
+            self.last_results = {
+                device['mac_addr'].replace('-', ':'): device['name']
+                for device in result
+                }
+            return True
+
+        return False
 
 
 class Tplink3DeviceScanner(TplinkDeviceScanner):
@@ -202,70 +193,67 @@ class Tplink3DeviceScanner(TplinkDeviceScanner):
                           response.text)
             return False
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the TP-Link router is up to date.
 
         Return boolean if scanning successful.
         """
-        with self.lock:
-            if (self.stok == '') or (self.sysauth == ''):
-                self._get_auth_tokens()
+        if (self.stok == '') or (self.sysauth == ''):
+            self._get_auth_tokens()
 
-            _LOGGER.info("Loading wireless clients...")
+        _LOGGER.info("Loading wireless clients...")
 
-            url = ('http://{}/cgi-bin/luci/;stok={}/admin/wireless?'
-                   'form=statistics').format(self.host, self.stok)
-            referer = 'http://{}/webpages/index.html'.format(self.host)
+        url = ('http://{}/cgi-bin/luci/;stok={}/admin/wireless?'
+               'form=statistics').format(self.host, self.stok)
+        referer = 'http://{}/webpages/index.html'.format(self.host)
 
-            response = requests.post(url,
-                                     params={'operation': 'load'},
-                                     headers={'referer': referer},
-                                     cookies={'sysauth': self.sysauth},
-                                     timeout=5)
+        response = requests.post(url,
+                                 params={'operation': 'load'},
+                                 headers={'referer': referer},
+                                 cookies={'sysauth': self.sysauth},
+                                 timeout=5)
 
-            try:
-                json_response = response.json()
+        try:
+            json_response = response.json()
 
-                if json_response.get('success'):
-                    result = response.json().get('data')
-                else:
-                    if json_response.get('errorcode') == 'timeout':
-                        _LOGGER.info("Token timed out. Relogging on next scan")
-                        self.stok = ''
-                        self.sysauth = ''
-                        return False
-                    _LOGGER.error(
-                        "An unknown error happened while fetching data")
+            if json_response.get('success'):
+                result = response.json().get('data')
+            else:
+                if json_response.get('errorcode') == 'timeout':
+                    _LOGGER.info("Token timed out. Relogging on next scan")
+                    self.stok = ''
+                    self.sysauth = ''
                     return False
-            except ValueError:
-                _LOGGER.error("Router didn't respond with JSON. "
-                              "Check if credentials are correct")
+                _LOGGER.error(
+                    "An unknown error happened while fetching data")
                 return False
-
-            if result:
-                self.last_results = {
-                    device['mac'].replace('-', ':'): device['mac']
-                    for device in result
-                    }
-                return True
-
+        except ValueError:
+            _LOGGER.error("Router didn't respond with JSON. "
+                          "Check if credentials are correct")
             return False
 
+        if result:
+            self.last_results = {
+                device['mac'].replace('-', ':'): device['mac']
+                for device in result
+                }
+            return True
+
+        return False
+
     def _log_out(self):
-        with self.lock:
-            _LOGGER.info("Logging out of router admin interface...")
+        _LOGGER.info("Logging out of router admin interface...")
 
-            url = ('http://{}/cgi-bin/luci/;stok={}/admin/system?'
-                   'form=logout').format(self.host, self.stok)
-            referer = 'http://{}/webpages/index.html'.format(self.host)
+        url = ('http://{}/cgi-bin/luci/;stok={}/admin/system?'
+               'form=logout').format(self.host, self.stok)
+        referer = 'http://{}/webpages/index.html'.format(self.host)
 
-            requests.post(url,
-                          params={'operation': 'write'},
-                          headers={'referer': referer},
-                          cookies={'sysauth': self.sysauth})
-            self.stok = ''
-            self.sysauth = ''
+        requests.post(url,
+                      params={'operation': 'write'},
+                      headers={'referer': referer},
+                      cookies={'sysauth': self.sysauth})
+        self.stok = ''
+        self.sysauth = ''
 
 
 class Tplink4DeviceScanner(TplinkDeviceScanner):
@@ -318,38 +306,36 @@ class Tplink4DeviceScanner(TplinkDeviceScanner):
             _LOGGER.error("Couldn't fetch auth tokens")
             return False
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the TP-Link router is up to date.
 
         Return boolean if scanning successful.
         """
-        with self.lock:
-            if (self.credentials == '') or (self.token == ''):
-                self._get_auth_tokens()
+        if (self.credentials == '') or (self.token == ''):
+            self._get_auth_tokens()
 
-            _LOGGER.info("Loading wireless clients...")
+        _LOGGER.info("Loading wireless clients...")
 
-            mac_results = []
+        mac_results = []
 
-            # Check both the 2.4GHz and 5GHz client list URLs
-            for clients_url in ('WlanStationRpm.htm', 'WlanStationRpm_5g.htm'):
-                url = 'http://{}/{}/userRpm/{}' \
-                    .format(self.host, self.token, clients_url)
-                referer = 'http://{}'.format(self.host)
-                cookie = 'Authorization=Basic {}'.format(self.credentials)
+        # Check both the 2.4GHz and 5GHz client list URLs
+        for clients_url in ('WlanStationRpm.htm', 'WlanStationRpm_5g.htm'):
+            url = 'http://{}/{}/userRpm/{}' \
+                .format(self.host, self.token, clients_url)
+            referer = 'http://{}'.format(self.host)
+            cookie = 'Authorization=Basic {}'.format(self.credentials)
 
-                page = requests.get(url, headers={
-                    'cookie': cookie,
-                    'referer': referer
-                })
-                mac_results.extend(self.parse_macs.findall(page.text))
+            page = requests.get(url, headers={
+                'cookie': cookie,
+                'referer': referer
+            })
+            mac_results.extend(self.parse_macs.findall(page.text))
 
-            if not mac_results:
-                return False
+        if not mac_results:
+            return False
 
-            self.last_results = [mac.replace("-", ":") for mac in mac_results]
-            return True
+        self.last_results = [mac.replace("-", ":") for mac in mac_results]
+        return True
 
 
 class Tplink5DeviceScanner(TplinkDeviceScanner):
@@ -365,69 +351,67 @@ class Tplink5DeviceScanner(TplinkDeviceScanner):
         """Get firmware doesn't save the name of the wireless device."""
         return None
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the TP-Link AP is up to date.
 
         Return boolean if scanning successful.
         """
-        with self.lock:
-            _LOGGER.info("Loading wireless clients...")
+        _LOGGER.info("Loading wireless clients...")
 
-            base_url = 'http://{}'.format(self.host)
+        base_url = 'http://{}'.format(self.host)
 
-            header = {
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12;"
-                              " rv:53.0) Gecko/20100101 Firefox/53.0",
-                "Accept": "application/json, text/javascript, */*; q=0.01",
-                "Accept-Language": "Accept-Language: en-US,en;q=0.5",
-                "Accept-Encoding": "gzip, deflate",
-                "Content-Type": "application/x-www-form-urlencoded; "
-                                "charset=UTF-8",
-                "X-Requested-With": "XMLHttpRequest",
-                "Referer": "http://" + self.host + "/",
-                "Connection": "keep-alive",
-                "Pragma": "no-cache",
-                "Cache-Control": "no-cache"
-            }
+        header = {
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12;"
+                          " rv:53.0) Gecko/20100101 Firefox/53.0",
+            "Accept": "application/json, text/javascript, */*; q=0.01",
+            "Accept-Language": "Accept-Language: en-US,en;q=0.5",
+            "Accept-Encoding": "gzip, deflate",
+            "Content-Type": "application/x-www-form-urlencoded; "
+                            "charset=UTF-8",
+            "X-Requested-With": "XMLHttpRequest",
+            "Referer": "http://" + self.host + "/",
+            "Connection": "keep-alive",
+            "Pragma": "no-cache",
+            "Cache-Control": "no-cache"
+        }
 
-            password_md5 = hashlib.md5(
-                self.password.encode('utf')).hexdigest().upper()
+        password_md5 = hashlib.md5(
+            self.password.encode('utf')).hexdigest().upper()
 
-            # create a session to handle cookie easier
-            session = requests.session()
-            session.get(base_url, headers=header)
+        # create a session to handle cookie easier
+        session = requests.session()
+        session.get(base_url, headers=header)
 
-            login_data = {"username": self.username, "password": password_md5}
-            session.post(base_url, login_data, headers=header)
+        login_data = {"username": self.username, "password": password_md5}
+        session.post(base_url, login_data, headers=header)
 
-            # a timestamp is required to be sent as get parameter
-            timestamp = int(datetime.now().timestamp() * 1e3)
+        # a timestamp is required to be sent as get parameter
+        timestamp = int(datetime.now().timestamp() * 1e3)
 
-            client_list_url = '{}/data/monitor.client.client.json'.format(
-                base_url)
+        client_list_url = '{}/data/monitor.client.client.json'.format(
+            base_url)
 
-            get_params = {
-                'operation': 'load',
-                '_': timestamp
-            }
+        get_params = {
+            'operation': 'load',
+            '_': timestamp
+        }
 
-            response = session.get(client_list_url,
-                                   headers=header,
-                                   params=get_params)
-            session.close()
-            try:
-                list_of_devices = response.json()
-            except ValueError:
-                _LOGGER.error("AP didn't respond with JSON. "
-                              "Check if credentials are correct.")
-                return False
-
-            if list_of_devices:
-                self.last_results = {
-                    device['MAC'].replace('-', ':'): device['DeviceName']
-                    for device in list_of_devices['data']
-                    }
-                return True
-
+        response = session.get(client_list_url,
+                               headers=header,
+                               params=get_params)
+        session.close()
+        try:
+            list_of_devices = response.json()
+        except ValueError:
+            _LOGGER.error("AP didn't respond with JSON. "
+                          "Check if credentials are correct.")
             return False
+
+        if list_of_devices:
+            self.last_results = {
+                device['MAC'].replace('-', ':'): device['DeviceName']
+                for device in list_of_devices['data']
+                }
+            return True
+
+        return False

--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -7,8 +7,6 @@ https://home-assistant.io/components/device_tracker.ubus/
 import json
 import logging
 import re
-import threading
-from datetime import timedelta
 
 import requests
 import voluptuous as vol
@@ -17,11 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.util import Throttle
 from homeassistant.exceptions import HomeAssistantError
-
-# Return cached results if last scan was less then this time ago.
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,7 +64,6 @@ class UbusDeviceScanner(DeviceScanner):
         self.password = config[CONF_PASSWORD]
 
         self.parse_api_pattern = re.compile(r"(?P<param>\w*) = (?P<value>.*);")
-        self.lock = threading.Lock()
         self.last_results = {}
         self.url = 'http://{}/ubus'.format(host)
 
@@ -89,34 +82,32 @@ class UbusDeviceScanner(DeviceScanner):
     @_refresh_on_acccess_denied
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
-        with self.lock:
-            if self.leasefile is None:
-                result = _req_json_rpc(
-                    self.url, self.session_id, 'call', 'uci', 'get',
-                    config="dhcp", type="dnsmasq")
-                if result:
-                    values = result["values"].values()
-                    self.leasefile = next(iter(values))["leasefile"]
-                else:
-                    return
+        if self.leasefile is None:
+            result = _req_json_rpc(
+                self.url, self.session_id, 'call', 'uci', 'get',
+                config="dhcp", type="dnsmasq")
+            if result:
+                values = result["values"].values()
+                self.leasefile = next(iter(values))["leasefile"]
+            else:
+                return
 
-            if self.mac2name is None:
-                result = _req_json_rpc(
-                    self.url, self.session_id, 'call', 'file', 'read',
-                    path=self.leasefile)
-                if result:
-                    self.mac2name = dict()
-                    for line in result["data"].splitlines():
-                        hosts = line.split(" ")
-                        self.mac2name[hosts[1].upper()] = hosts[3]
-                else:
-                    # Error, handled in the _req_json_rpc
-                    return
+        if self.mac2name is None:
+            result = _req_json_rpc(
+                self.url, self.session_id, 'call', 'file', 'read',
+                path=self.leasefile)
+            if result:
+                self.mac2name = dict()
+                for line in result["data"].splitlines():
+                    hosts = line.split(" ")
+                    self.mac2name[hosts[1].upper()] = hosts[3]
+            else:
+                # Error, handled in the _req_json_rpc
+                return
 
-            return self.mac2name.get(device.upper(), None)
+        return self.mac2name.get(device.upper(), None)
 
     @_refresh_on_acccess_denied
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the information from the Luci router is up to date.
 
@@ -125,25 +116,24 @@ class UbusDeviceScanner(DeviceScanner):
         if not self.success_init:
             return False
 
-        with self.lock:
-            _LOGGER.info("Checking ARP")
+        _LOGGER.info("Checking ARP")
 
-            if not self.hostapd:
-                hostapd = _req_json_rpc(
-                    self.url, self.session_id, 'list', 'hostapd.*', '')
-                self.hostapd.extend(hostapd.keys())
+        if not self.hostapd:
+            hostapd = _req_json_rpc(
+                self.url, self.session_id, 'list', 'hostapd.*', '')
+            self.hostapd.extend(hostapd.keys())
 
-            self.last_results = []
-            results = 0
-            for hostapd in self.hostapd:
-                result = _req_json_rpc(
-                    self.url, self.session_id, 'call', hostapd, 'get_clients')
+        self.last_results = []
+        results = 0
+        for hostapd in self.hostapd:
+            result = _req_json_rpc(
+                self.url, self.session_id, 'call', hostapd, 'get_clients')
 
-                if result:
-                    results = results + 1
-                    self.last_results.extend(result['clients'].keys())
+            if result:
+                results = results + 1
+                self.last_results.extend(result['clients'].keys())
 
-            return bool(results)
+        return bool(results)
 
 
 def _req_json_rpc(url, session_id, rpcmethod, subsystem, method, **params):

--- a/homeassistant/components/device_tracker/volvooncall.py
+++ b/homeassistant/components/device_tracker/volvooncall.py
@@ -9,8 +9,7 @@ import logging
 from homeassistant.util import slugify
 from homeassistant.helpers.dispatcher import (
     dispatcher_connect, dispatcher_send)
-from homeassistant.components.volvooncall import (
-    DATA_KEY, SIGNAL_VEHICLE_SEEN)
+from homeassistant.components.volvooncall import DATA_KEY, SIGNAL_VEHICLE_SEEN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/device_tracker/xiaomi.py
+++ b/homeassistant/components/device_tracker/xiaomi.py
@@ -5,8 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.xiaomi/
 """
 import logging
-import threading
-from datetime import timedelta
 
 import requests
 import voluptuous as vol
@@ -15,11 +13,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -47,8 +42,6 @@ class XiaomiDeviceScanner(DeviceScanner):
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
 
-        self.lock = threading.Lock()
-
         self.last_results = {}
         self.token = _get_token(self.host, self.username, self.password)
 
@@ -62,21 +55,19 @@ class XiaomiDeviceScanner(DeviceScanner):
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
-        with self.lock:
-            if self.mac2name is None:
-                result = self._retrieve_list_with_retry()
-                if result:
-                    hosts = [x for x in result
-                             if 'mac' in x and 'name' in x]
-                    mac2name_list = [
-                        (x['mac'].upper(), x['name']) for x in hosts]
-                    self.mac2name = dict(mac2name_list)
-                else:
-                    # Error, handled in the _retrieve_list_with_retry
-                    return
-            return self.mac2name.get(device.upper(), None)
+        if self.mac2name is None:
+            result = self._retrieve_list_with_retry()
+            if result:
+                hosts = [x for x in result
+                         if 'mac' in x and 'name' in x]
+                mac2name_list = [
+                    (x['mac'].upper(), x['name']) for x in hosts]
+                self.mac2name = dict(mac2name_list)
+            else:
+                # Error, handled in the _retrieve_list_with_retry
+                return
+        return self.mac2name.get(device.upper(), None)
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
     def _update_info(self):
         """Ensure the informations from the router are up to date.
 
@@ -85,12 +76,11 @@ class XiaomiDeviceScanner(DeviceScanner):
         if not self.success_init:
             return False
 
-        with self.lock:
-            result = self._retrieve_list_with_retry()
-            if result:
-                self._store_result(result)
-                return True
-            return False
+        result = self._retrieve_list_with_retry()
+        if result:
+            self._store_result(result)
+            return True
+        return False
 
     def _retrieve_list_with_retry(self):
         """Retrieve the device list with a retry if token is invalid.


### PR DESCRIPTION
## Description:

With latest migration to async we do now a lot stuff more on device_tracker component. So it is not possible that 2 scan running parallel so we can remove threads locks and all throttle that are for <= 10sec (default scan time). The component protect now the platform.

So we can now remove 200 lines that will be handle with 10 lines on device_tracker.