### PR TITLE
added ONVIF rtsp stream authentication

### DIFF
--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -74,8 +74,7 @@ class ONVIFCamera(Camera):
             self._input = self._input.replace(
                 'rtsp://', 'rtsp://{}:{}@'.format(
                     config.get(CONF_USERNAME),
-                    config.get(CONF_PASSWORD))
-                , 1)
+                    config.get(CONF_PASSWORD)), 1)
         _LOGGER.debug("ONVIF Camera Using the following URL for %s: %s",
                       self._name, self._input)
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -71,9 +71,11 @@ class ONVIFCamera(Camera):
         )
         self._input = media.GetStreamUri().Uri
         if config.get(CONF_STREAM_AUTH):
-            self._input = self._input.replace('rtsp://',
-                'rtsp://{}:{}@'.format(config.get(CONF_USERNAME),
-                config.get(CONF_PASSWORD)), 1)
+            self._input = self._input.replace(
+                'rtsp://', 'rtsp://{}:{}@'.format(
+                    config.get(CONF_USERNAME),
+                    config.get(CONF_PASSWORD))
+                , 1)
         _LOGGER.debug("ONVIF Camera Using the following URL for %s: %s",
                       self._name, self._input)
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -72,7 +72,7 @@ class ONVIFCamera(Camera):
         self._input = media.GetStreamUri().Uri
         if config.get(CONF_STREAM_AUTH):
             self._input=self._input.replace('rtsp://', 'rtsp://{}:{}@'.format(
-            config.get(CONF_USERNAME),config.get(CONF_PASSWORD)),1)
+                config.get(CONF_USERNAME), config.get(CONF_PASSWORD)), 1)
         _LOGGER.debug("ONVIF Camera Using the following URL for %s: %s",
                       self._name, self._input)
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -1,6 +1,5 @@
 """
 Support for ONVIF Cameras with FFmpeg as decoder.
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.onvif/
 """
@@ -31,6 +30,8 @@ DEFAULT_NAME = 'ONVIF Camera'
 DEFAULT_PORT = 5000
 DEFAULT_USERNAME = 'admin'
 DEFAULT_PASSWORD = '888888'
+CONF_STREAM_AUTH = 'stream_auth'
+DEFAULT_STREAM_AUTH = False
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -38,6 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_STREAM_AUTH, default=DEFAULT_STREAM_AUTH): cv.boolean,
 })
 
 
@@ -68,6 +70,9 @@ class ONVIFCamera(Camera):
             '{}/wsdl/media.wsdl'.format(os.path.dirname(onvif.__file__))
         )
         self._input = media.GetStreamUri().Uri
+        if config.get(CONF_STREAM_AUTH):
+            self._input=self._input.replace('rtsp://','rtsp://{}:{}@'.format(config.get(
+            CONF_USERNAME),config.get(CONF_PASSWORD)),1)
         _LOGGER.debug("ONVIF Camera Using the following URL for %s: %s",
                       self._name, self._input)
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -71,7 +71,7 @@ class ONVIFCamera(Camera):
         )
         self._input = media.GetStreamUri().Uri
         if config.get(CONF_STREAM_AUTH):
-            self._input=self._input.replace('rtsp://', 'rtsp://{}:{}@'.format(
+            self._input = self._input.replace('rtsp://', 'rtsp://{}:{}@'.format(
                 config.get(CONF_USERNAME), config.get(CONF_PASSWORD)), 1)
         _LOGGER.debug("ONVIF Camera Using the following URL for %s: %s",
                       self._name, self._input)

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -71,8 +71,9 @@ class ONVIFCamera(Camera):
         )
         self._input = media.GetStreamUri().Uri
         if config.get(CONF_STREAM_AUTH):
-            self._input = self._input.replace('rtsp://', 'rtsp://{}:{}@'.format(
-                config.get(CONF_USERNAME), config.get(CONF_PASSWORD)), 1)
+            self._input = self._input.replace('rtsp://',
+                'rtsp://{}:{}@'.format(config.get(CONF_USERNAME),
+                config.get(CONF_PASSWORD)), 1)
         _LOGGER.debug("ONVIF Camera Using the following URL for %s: %s",
                       self._name, self._input)
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -1,5 +1,6 @@
 """
 Support for ONVIF Cameras with FFmpeg as decoder.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.onvif/
 """

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -71,8 +71,8 @@ class ONVIFCamera(Camera):
         )
         self._input = media.GetStreamUri().Uri
         if config.get(CONF_STREAM_AUTH):
-            self._input=self._input.replace('rtsp://','rtsp://{}:{}@'.format(config.get(
-            CONF_USERNAME),config.get(CONF_PASSWORD)),1)
+            self._input=self._input.replace('rtsp://','rtsp://{}:{}@'.format(
+            config.get(CONF_USERNAME),config.get(CONF_PASSWORD)),1)
         _LOGGER.debug("ONVIF Camera Using the following URL for %s: %s",
                       self._name, self._input)
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -71,7 +71,7 @@ class ONVIFCamera(Camera):
         )
         self._input = media.GetStreamUri().Uri
         if config.get(CONF_STREAM_AUTH):
-            self._input=self._input.replace('rtsp://','rtsp://{}:{}@'.format(
+            self._input=self._input.replace('rtsp://', 'rtsp://{}:{}@'.format(
             config.get(CONF_USERNAME),config.get(CONF_PASSWORD)),1)
         _LOGGER.debug("ONVIF Camera Using the following URL for %s: %s",
                       self._name, self._input)


### PR DESCRIPTION
## Description:
Added extra optional boolean to enable the username and password to be passed through to the RTSP stream URL, this is required by some cameras.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3051

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
