### PR TITLE
History performance improvements for single-entity requests

### DIFF
--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -119,18 +119,36 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None,
     from sqlalchemy import and_, func
 
     with session_scope(hass=hass) as session:
-        most_recent_state_ids = session.query(
-            func.max(States.state_id).label('max_state_id')
-        ).filter(
-            (States.created >= run.start) &
-            (States.created < utc_point_in_time))
+        if entity_ids and len(entity_ids) == 1:
+            # Use an entirely different (and extremely fast) query if we only have a single entity id
+            most_recent_state_ids = session.query(
+                States.state_id.label('max_state_id')
+            ).filter(
+                (States.created < utc_point_in_time)
+            ).order_by(
+                States.created.desc())
 
-        if filters:
-            most_recent_state_ids = filters.apply(most_recent_state_ids,
-                                                  entity_ids)
+            if filters:
+                most_recent_state_ids = filters.apply(most_recent_state_ids,
+                                                      entity_ids)
 
-        most_recent_state_ids = most_recent_state_ids.group_by(
-            States.entity_id).subquery()
+            most_recent_state_ids = most_recent_state_ids.limit(1)
+
+        else:
+            # We have more than one entity to look at, so we need to do a much
+            most_recent_state_ids = session.query(
+                func.max(States.state_id).label('max_state_id')
+            ).filter(
+                (States.created >= run.start) &
+                (States.created < utc_point_in_time))
+
+            if filters:
+                most_recent_state_ids = filters.apply(most_recent_state_ids,
+                                                      entity_ids)
+
+            most_recent_state_ids = most_recent_state_ids.group_by(States.entity_id)
+
+        most_recent_state_ids = most_recent_state_ids.subquery()
 
         query = session.query(States).join(most_recent_state_ids, and_(
             States.state_id == most_recent_state_ids.c.max_state_id))

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -142,7 +142,8 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None,
                 func.max(States.state_id).label('max_state_id')
             ).filter(
                 (States.created >= run.start) &
-                (States.created < utc_point_in_time))
+                (States.created < utc_point_in_time) &
+                (~States.domain.in_(IGNORE_DOMAINS)))
 
             if filters:
                 most_recent_state_ids = filters.apply(most_recent_state_ids,

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -124,7 +124,8 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None,
             most_recent_state_ids = session.query(
                 States.state_id.label('max_state_id')
             ).filter(
-                (States.created < utc_point_in_time)
+                (States.created < utc_point_in_time) &
+                (States.entity_id.in_(entity_ids))
             ).order_by(
                 States.created.desc())
 

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -137,7 +137,9 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None,
             most_recent_state_ids = most_recent_state_ids.limit(1)
 
         else:
-            # We have more than one entity to look at, so we need to do a much
+            # We have more than one entity to look at (most commonly we want
+            # all entities,) so we need to do a search on all states since the
+            # last recorder run started.
             most_recent_state_ids = session.query(
                 func.max(States.state_id).label('max_state_id')
             ).filter(

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -120,7 +120,8 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None,
 
     with session_scope(hass=hass) as session:
         if entity_ids and len(entity_ids) == 1:
-            # Use an entirely different (and extremely fast) query if we only have a single entity id
+            # Use an entirely different (and extremely fast) query if we only
+            # have a single entity id
             most_recent_state_ids = session.query(
                 States.state_id.label('max_state_id')
             ).filter(
@@ -147,7 +148,8 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None,
                 most_recent_state_ids = filters.apply(most_recent_state_ids,
                                                       entity_ids)
 
-            most_recent_state_ids = most_recent_state_ids.group_by(States.entity_id)
+            most_recent_state_ids = most_recent_state_ids.group_by(
+                States.entity_id)
 
         most_recent_state_ids = most_recent_state_ids.subquery()
 

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -123,8 +123,7 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None,
             func.max(States.state_id).label('max_state_id')
         ).filter(
             (States.created >= run.start) &
-            (States.created < utc_point_in_time) &
-            (~States.domain.in_(IGNORE_DOMAINS)))
+            (States.created < utc_point_in_time))
 
         if filters:
             most_recent_state_ids = filters.apply(most_recent_state_ids,


### PR DESCRIPTION
## Description:
Drastically improves performance when fetching the history of a single entity. It accomplishes this by doing an entirely different query for fetching the "synthetic first datapoint" when only a single entity_id is being searched for.

There is still a ton of room for improvement when it comes to multi-entity history fetching which I am continuing to investigate, but this first change makes a massive improvement for all single entity popups.

The performance change in some of my tests shows this change to be about 300x faster (30 seconds to 0.1 seconds!) (There is no theoretical upper limit due to the issue with multi-entity queries getting worse the longer the current recorder run has been going.)

**Related issue (if applicable):** fixes n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** none

## Example entry for `configuration.yaml` (if applicable): none

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works. *(not needed; existing tests cover the code already)*
