### PR TITLE
InfluxDB component improvements

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -149,7 +149,8 @@ def setup(hass, config):
             _state = state.state
             _state_key = "state"
 
-        measurement = component_config.get(state.entity_id).get(CONF_OVERRIDE_MEASUREMENT)
+        measurement = component_config.get(state.entity_id).get(
+            CONF_OVERRIDE_MEASUREMENT)
         if measurement in (None, ''):
             if override_measurement:
                 measurement = override_measurement

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -25,6 +25,7 @@ CONF_DB_NAME = 'database'
 CONF_TAGS = 'tags'
 CONF_DEFAULT_MEASUREMENT = 'default_measurement'
 CONF_OVERRIDE_MEASUREMENT = 'override_measurement'
+CONF_INFLUXDB_MEASUREMENT = 'influxdb_measurement'
 CONF_TAGS_ATTRIBUTES = "tags_attributes"
 
 DEFAULT_DATABASE = 'home_assistant'
@@ -131,15 +132,17 @@ def setup(hass, config):
             _state = state.state
             _state_key = "state"
 
-        if override_measurement:
-            measurement = override_measurement
-        else:
-            measurement = state.attributes.get('unit_of_measurement')
-            if measurement in (None, ''):
-                if default_measurement:
-                    measurement = default_measurement
-                else:
-                    measurement = state.entity_id
+        measurement = state.attributes.get(CONF_INFLUXDB_MEASUREMENT)
+        if measurement in (None, ''):
+            if override_measurement:
+                measurement = override_measurement
+            else:
+                measurement = state.attributes.get('unit_of_measurement')
+                if measurement in (None, ''):
+                    if default_measurement:
+                        measurement = default_measurement
+                    else:
+                        measurement = state.entity_id
 
         json_body = [
             {
@@ -158,7 +161,7 @@ def setup(hass, config):
         for key, value in state.attributes.items():
             if key in tags_attributes:
                 json_body[0]['tags'][key] = value
-            elif key != 'unit_of_measurement':
+            elif not (key in ['unit_of_measurement', CONF_INFLUXDB_MEASUREMENT]):
                 # If the key is already in fields
                 if key in json_body[0]['fields']:
                     key = key + "_"

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_PORT, CONF_SSL, CONF_VERIFY_SSL, CONF_USERNAME, CONF_PASSWORD,
     CONF_EXCLUDE, CONF_INCLUDE, CONF_DOMAINS, CONF_ENTITIES)
 from homeassistant.helpers import state as state_helper
+from homeassistant.helpers.entity_values import EntityValues
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['influxdb==3.0.0']
@@ -25,13 +26,19 @@ CONF_DB_NAME = 'database'
 CONF_TAGS = 'tags'
 CONF_DEFAULT_MEASUREMENT = 'default_measurement'
 CONF_OVERRIDE_MEASUREMENT = 'override_measurement'
-CONF_INFLUXDB_MEASUREMENT = 'influxdb_measurement'
 CONF_TAGS_ATTRIBUTES = 'tags_attributes'
+CONF_COMPONENT_CONFIG = 'component_config'
+CONF_COMPONENT_CONFIG_GLOB = 'component_config_glob'
+CONF_COMPONENT_CONFIG_DOMAIN = 'component_config_domain'
 
 DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_VERIFY_SSL = True
 DOMAIN = 'influxdb'
 TIMEOUT = 5
+
+COMPONENT_CONFIG_SCHEMA_ENTRY = vol.Schema({
+    vol.Optional(CONF_OVERRIDE_MEASUREMENT): cv.string,
+})
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -58,6 +65,12 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_TAGS_ATTRIBUTES, default=[]):
             vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+        vol.Optional(CONF_COMPONENT_CONFIG, default={}):
+            vol.Schema({cv.entity_id: COMPONENT_CONFIG_SCHEMA_ENTRY}),
+        vol.Optional(CONF_COMPONENT_CONFIG_GLOB, default={}):
+            vol.Schema({cv.string: COMPONENT_CONFIG_SCHEMA_ENTRY}),
+        vol.Optional(CONF_COMPONENT_CONFIG_DOMAIN, default={}):
+            vol.Schema({cv.string: COMPONENT_CONFIG_SCHEMA_ENTRY}),
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -102,6 +115,10 @@ def setup(hass, config):
     tags_attributes = conf.get(CONF_TAGS_ATTRIBUTES)
     default_measurement = conf.get(CONF_DEFAULT_MEASUREMENT)
     override_measurement = conf.get(CONF_OVERRIDE_MEASUREMENT)
+    component_config = EntityValues(
+        conf[CONF_COMPONENT_CONFIG],
+        conf[CONF_COMPONENT_CONFIG_DOMAIN],
+        conf[CONF_COMPONENT_CONFIG_GLOB])
 
     try:
         influx = InfluxDBClient(**kwargs)
@@ -132,9 +149,7 @@ def setup(hass, config):
             _state = state.state
             _state_key = "state"
 
-        # This optional attribute can be set by user in `customize` section.
-        # If set, it takes precedence over other measurement name overrides.
-        measurement = state.attributes.get(CONF_INFLUXDB_MEASUREMENT)
+        measurement = component_config.get(state.entity_id).get(CONF_OVERRIDE_MEASUREMENT)
         if measurement in (None, ''):
             if override_measurement:
                 measurement = override_measurement
@@ -163,7 +178,7 @@ def setup(hass, config):
         for key, value in state.attributes.items():
             if key in tags_attributes:
                 json_body[0]['tags'][key] = value
-            elif key not in ['unit_of_measurement', CONF_INFLUXDB_MEASUREMENT]:
+            elif key != 'unit_of_measurement':
                 # If the key is already in fields
                 if key in json_body[0]['fields']:
                     key = key + "_"

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -25,7 +25,7 @@ CONF_DB_NAME = 'database'
 CONF_TAGS = 'tags'
 CONF_DEFAULT_MEASUREMENT = 'default_measurement'
 CONF_OVERRIDE_MEASUREMENT = 'override_measurement'
-CONF_BLACKLIST_DOMAINS = "blacklist_domains"
+CONF_TAGS_ATTRIBUTES = "tags_attributes"
 
 DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_VERIFY_SSL = True
@@ -54,6 +54,8 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_OVERRIDE_MEASUREMENT): cv.string,
         vol.Optional(CONF_TAGS, default={}):
             vol.Schema({cv.string: cv.string}),
+        vol.Optional(CONF_TAGS_ATTRIBUTES, default=[]):
+            vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
@@ -96,6 +98,7 @@ def setup(hass, config):
     blacklist_e = set(exclude.get(CONF_ENTITIES, []))
     blacklist_d = set(exclude.get(CONF_DOMAINS, []))
     tags = conf.get(CONF_TAGS)
+    tags_attributes = conf.get(CONF_TAGS_ATTRIBUTES)
     default_measurement = conf.get(CONF_DEFAULT_MEASUREMENT)
     override_measurement = conf.get(CONF_OVERRIDE_MEASUREMENT)
 
@@ -153,7 +156,9 @@ def setup(hass, config):
         ]
 
         for key, value in state.attributes.items():
-            if key != 'unit_of_measurement':
+            if key in tags_attributes:
+                json_body[0]['tags'][key] = value
+            elif key != 'unit_of_measurement':
                 # If the key is already in fields
                 if key in json_body[0]['fields']:
                     key = key + "_"

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -26,7 +26,7 @@ CONF_TAGS = 'tags'
 CONF_DEFAULT_MEASUREMENT = 'default_measurement'
 CONF_OVERRIDE_MEASUREMENT = 'override_measurement'
 CONF_INFLUXDB_MEASUREMENT = 'influxdb_measurement'
-CONF_TAGS_ATTRIBUTES = "tags_attributes"
+CONF_TAGS_ATTRIBUTES = 'tags_attributes'
 
 DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_VERIFY_SSL = True
@@ -132,6 +132,8 @@ def setup(hass, config):
             _state = state.state
             _state_key = "state"
 
+        # This optional attribute can be set by user in `customize` section.
+        # If set, it takes precedence over other measurement name overrides.
         measurement = state.attributes.get(CONF_INFLUXDB_MEASUREMENT)
         if measurement in (None, ''):
             if override_measurement:
@@ -161,7 +163,7 @@ def setup(hass, config):
         for key, value in state.attributes.items():
             if key in tags_attributes:
                 json_body[0]['tags'][key] = value
-            elif not (key in ['unit_of_measurement', CONF_INFLUXDB_MEASUREMENT]):
+            elif key not in ['unit_of_measurement', CONF_INFLUXDB_MEASUREMENT]:
                 # If the key is already in fields
                 if key in json_body[0]['fields']:
                     key = key + "_"

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -129,7 +129,8 @@ class TestInfluxDB(unittest.TestCase):
                 'multi_periods': '0.120.240.2023873'
             }
             state = mock.MagicMock(
-                state=in_, domain='fake', object_id='entity', attributes=attrs)
+                state=in_, domain='fake', entity_id='fake.entity-id',
+                object_id='entity', attributes=attrs)
             event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
             if isinstance(out, str):
                 body = [{
@@ -198,11 +199,11 @@ class TestInfluxDB(unittest.TestCase):
             else:
                 attrs = {}
             state = mock.MagicMock(
-                state=1, domain='fake', entity_id='entity-id',
+                state=1, domain='fake', entity_id='fake.entity-id',
                 object_id='entity', attributes=attrs)
             event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
             body = [{
-                'measurement': 'entity-id',
+                'measurement': 'fake.entity-id',
                 'tags': {
                     'domain': 'fake',
                     'entity_id': 'entity',
@@ -227,8 +228,8 @@ class TestInfluxDB(unittest.TestCase):
         self._setup()
 
         state = mock.MagicMock(
-            state=1, domain='fake', entity_id='entity-id', object_id='entity',
-            attributes={})
+            state=1, domain='fake', entity_id='fake.entity-id',
+            object_id='entity', attributes={})
         event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
         mock_client.return_value.write_points.side_effect = \
             influx_client.exceptions.InfluxDBClientError('foo')
@@ -240,11 +241,11 @@ class TestInfluxDB(unittest.TestCase):
 
         for state_state in (1, 'unknown', '', 'unavailable'):
             state = mock.MagicMock(
-                state=state_state, domain='fake', entity_id='entity-id',
+                state=state_state, domain='fake', entity_id='fake.entity-id',
                 object_id='entity', attributes={})
             event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
             body = [{
-                'measurement': 'entity-id',
+                'measurement': 'fake.entity-id',
                 'tags': {
                     'domain': 'fake',
                     'entity_id': 'entity',
@@ -442,7 +443,8 @@ class TestInfluxDB(unittest.TestCase):
                 'invalid_attribute': ['value1', 'value2']
             }
             state = mock.MagicMock(
-                state=in_, domain='fake', object_id='entity', attributes=attrs)
+                state=in_, domain='fake', entity_id='fake.entity-id',
+                object_id='entity', attributes=attrs)
             event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
             if isinstance(out, str):
                 body = [{

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -425,7 +425,7 @@ class TestInfluxDB(unittest.TestCase):
             mock_client.return_value.write_points.reset_mock()
 
     def test_event_listener_invalid_type(self, mock_client):
-        """Test the event listener when an attirbute has an invalid type."""
+        """Test the event listener when an attribute has an invalid type."""
         self._setup()
 
         valid = {
@@ -533,7 +533,7 @@ class TestInfluxDB(unittest.TestCase):
             mock_client.return_value.write_points.reset_mock()
 
     def test_event_listener_tags_attributes(self, mock_client):
-        """Test the event listener against a whitelist."""
+        """Test the event listener when some attributes should be tags."""
         config = {
             'influxdb': {
                 'host': 'host',
@@ -578,7 +578,7 @@ class TestInfluxDB(unittest.TestCase):
         mock_client.return_value.write_points.reset_mock()
 
     def test_event_listener_component_override_measurement(self, mock_client):
-        """Test the event listener with a default measurement."""
+        """Test the event listener with overrided measurements."""
         config = {
             'influxdb': {
                 'host': 'host',


### PR DESCRIPTION
## Description:

This PR includes two improvements to InfluxDB component:

1. Allows reporting some state attributes as tags to InfluxDB. Some state attributes should really be tags in InfluxDB. E.g. it is helpful to be able to group by friendly_name, or add a custom attribute like "location" and group by that. Graphs in Grafana are much easier to read when friendly names are used, and not node ids.  This commit adds an optional setting to InfluxDB config: 'tags_attributes'. Any attribute on this list will be reported as tag and not as field to InfluxDB. 

2. Allow overriding InfluxDB measurement for each reported item separately. Bundling all items with the same "unit of measurement" together does not always makes sense. For example, both "relatively humidity" and "battery level" are reported as "%", but I'd rather see them as separate measurements in InfluxDB. This commit allows for 'influxdb_measurement' attribute. When set on node, it will take precedence over the global 'override_measurement' and component-specific 'unit_of_measurement'.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3054

## Example entry for `configuration.yaml`:
```yaml

influxdb:
  tags_attributes: [friendly_name, location]

homeassistant:
  customize:
    sensor.master_bedroom_temperature:
      location: 'Master bedroom'
      influxdb_measurement: temperature

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
