### PR TITLE
Fixes Fitbit sensor to report battery level for the expected device

### DIFF
--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -433,9 +433,8 @@ class FitbitSensor(Entity):
 
     def update(self):
         """Get the latest data from the Fitbit API and update the states."""
-        if self.resource_type == 'devices/battery':
-            response = self.client.get_devices()
-            self._state = response[0].get('battery')
+        if self.resource_type == 'devices/battery' and self.extra:
+            self._state = self.extra.get('battery')
         else:
             container = self.resource_type.replace("/", "-")
             response = self.client.time_series(self.resource_type, period='7d')


### PR DESCRIPTION
## Description:
Fixes Fitbit sensor to report battery level for the expected device. The old version was returning always the battery level from the first registered device while this one reports the expected value. 

## Example entry for `configuration.yaml` (if applicable):
```yaml
#configuration.yaml
sensor:
 - platform: fitbit
   monitored_resources:
    - "activities/steps"
    - "devices/battery"
```
**Before**
![image](https://camo.githubusercontent.com/a3e64b7080d9665c65453c96927a4a78efdb27e3/68747470733a2f2f636f6d6d756e6974792d686f6d652d617373697374616e742d6173736574732e73332e616d617a6f6e6177732e636f6d2f6f726967696e616c2f32582f622f623235393466616561653637663633346362636562353135313238353366313934376666623361642e706e67)

**Now**
![image](https://user-images.githubusercontent.com/809840/28609713-cc2db54c-71b3-11e7-979d-31cd25045ecd.png)

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.