### PR TITLE
mpd improvements

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -53,7 +53,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     password = config.get(CONF_PASSWORD)
 
     device = MpdDevice(host, port, password, name)
-    add_devices([device])
+    add_devices([device], True)
 
 
 class MpdDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -109,6 +109,11 @@ class MpdDevice(MediaPlayerDevice):
 
         self._update_playlists()
 
+    @property
+    def avaiable(self):
+        """True if MPD is available and connected."""
+        return self._is_connected
+
     def update(self):
         """Get the latest data and update the state."""
         import mpd
@@ -130,7 +135,7 @@ class MpdDevice(MediaPlayerDevice):
     @property
     def state(self):
         """Return the media state."""
-        if not self._status:
+        if self._status is None:
             return STATE_OFF
         elif self._status['state'] == 'play':
             return STATE_PLAYING

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -100,7 +100,7 @@ class MpdDevice(MediaPlayerDevice):
         except mpd.ConnectionError:
             pass
         self._is_connected = False
-        self._state = None
+        self._status = None
 
     def _fetch_status(self):
         """Fetch status from MPD."""

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -110,7 +110,7 @@ class MpdDevice(MediaPlayerDevice):
         self._update_playlists()
 
     @property
-    def avaiable(self):
+    def available(self):
         """True if MPD is available and connected."""
         return self._is_connected
 

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.mpd/
 """
 import logging
-import socket
 from datetime import timedelta
 
 import voluptuous as vol


### PR DESCRIPTION
## Description:

Minor changes to media_player/mpd, and clean up. It is no longer required that MPD is available during HASS startup. Internal changes only, no external changes.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) <-- **Not applicable, internal changes only.**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

Note that these items are not applicable.

From #8629, now on dev-branch.