### PR TITLE
Lutron Caseta Cover SerenaHoneycombShades Support

### DIFF
--- a/homeassistant/components/cover/lutron_caseta.py
+++ b/homeassistant/components/cover/lutron_caseta.py
@@ -23,7 +23,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Lutron Caseta Serena shades as a cover device."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
-    cover_devices = bridge.get_devices_by_types(["SerenaRollerShade"])
+    cover_devices = bridge.get_devices_by_types(["SerenaRollerShade",
+                                                 "SerenaHoneycombShade"])
     for cover_device in cover_devices:
         dev = LutronCasetaCover(cover_device, bridge)
         devs.append(dev)


### PR DESCRIPTION
## Description:
Adds support for the Lutron Caseta SerenaHoneycombShades in the cover component. This expands supported Lutron shades to Serena Honeycomb and Roller Shades.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) - **N/A**

If the code communicates with devices, web services, or third-party tools:

  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

**Note: Non-checked items aren't applicable to this change**