### PR TITLE
Adding support for mapping keys to value in statsd

### DIFF
--- a/homeassistant/components/statsd.py
+++ b/homeassistant/components/statsd.py
@@ -19,6 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_ATTR = 'log_attributes'
 CONF_RATE = 'rate'
+CONF_VALUE_MAP = 'value_mapping'
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 8125
@@ -34,6 +35,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_PREFIX, default=DEFAULT_PREFIX): cv.string,
         vol.Optional(CONF_RATE, default=DEFAULT_RATE):
             vol.All(vol.Coerce(int), vol.Range(min=1)),
+        vol.Optional(CONF_VALUE_MAP, default=None): dict,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -47,6 +49,7 @@ def setup(hass, config):
     port = conf.get(CONF_PORT)
     sample_rate = conf.get(CONF_RATE)
     prefix = conf.get(CONF_PREFIX)
+    value_mapping = conf.get(CONF_VALUE_MAP)
     show_attribute_flag = conf.get(CONF_ATTR)
 
     statsd_client = statsd.StatsClient(host=host, port=port, prefix=prefix)
@@ -59,7 +62,10 @@ def setup(hass, config):
             return
 
         try:
-            _state = state_helper.state_as_number(state)
+            if value_mapping and state.state in value_mapping:
+                _state = float(value_mapping[state.state])
+            else:
+                _state = state_helper.state_as_number(state)
         except ValueError:
             # Set the state to none and continue for any numeric attributes.
             _state = None

--- a/tests/components/test_statsd.py
+++ b/tests/components/test_statsd.py
@@ -86,6 +86,7 @@ class TestStatsd(unittest.TestCase):
         config = {
             'statsd': {
                 'host': 'host',
+                'value_mapping': {'custom': 3}
             }
         }
 
@@ -98,6 +99,7 @@ class TestStatsd(unittest.TestCase):
 
         valid = {'1': 1,
                  '1.0': 1.0,
+                 'custom': 3,
                  STATE_ON: 1,
                  STATE_OFF: 0}
         for in_, out in valid.items():


### PR DESCRIPTION
## Description:
Adds the option to map values that are non-numerical to numerical ones for statsd ingesting. For example if the value for a hvac entity was set to 'cooling' you couldn't ingest that via statsd as there was no mapping for it in the state_as_number function.

**Related issue (if applicable):** 
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/3010
## Example entry for `configuration.yaml` (if applicable):
```yaml
 statsd:
   value_mapping:
     cooling: 1
     heating: 10
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
