### PR TITLE
Upgrade libnacl to 1.5.2

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -21,7 +21,7 @@ from homeassistant.components import zone as zone_comp
 from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 
 DEPENDENCIES = ['mqtt']
-REQUIREMENTS = ['libnacl==1.5.1']
+REQUIREMENTS = ['libnacl==1.5.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -353,7 +353,7 @@ keyring>=9.3,<10.0
 knxip==0.5
 
 # homeassistant.components.device_tracker.owntracks
-libnacl==1.5.1
+libnacl==1.5.2
 
 # homeassistant.components.dyson
 libpurecoollink==0.2.0


### PR DESCRIPTION
## 1.5.2
- Add Support for AEAD AES and chacha20poly1305

Tested with the following configuration:

``` yaml
device_tracker:
  - platform: owntracks
    secret: xyz
```