### PR TITLE
Upgrade pyhomematic to 0.1.30

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['pyhomematic==0.1.29']
+REQUIREMENTS = ['pyhomematic==0.1.30']
 
 DOMAIN = 'homematic'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -590,7 +590,7 @@ pyharmony==1.0.16
 pyhik==0.1.3
 
 # homeassistant.components.homematic
-pyhomematic==0.1.29
+pyhomematic==0.1.30
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==1.2.0


### PR DESCRIPTION
## Description:
- Added HM-LC-Sw1-PCB @cgeidt
- Added support for HmIP-FSM and HmIP-BSM @Munsio
- Added FRQUENCY parameter for some powermeters @buxit

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
