### PR TITLE
Updated pysnmp to 4.3.9

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -16,7 +16,7 @@ from homeassistant.const import CONF_HOST
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pysnmp==4.3.8']
+REQUIREMENTS = ['pysnmp==4.3.9']
 
 CONF_COMMUNITY = 'community'
 CONF_AUTHKEY = 'authkey'

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PORT, CONF_UNIT_OF_MEASUREMENT)
 
-REQUIREMENTS = ['pysnmp==4.3.8']
+REQUIREMENTS = ['pysnmp==4.3.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -684,7 +684,7 @@ pysma==0.1.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
-pysnmp==4.3.8
+pysnmp==4.3.9
 
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner


### PR DESCRIPTION
## Description:
Upgrade pysnmp to 4.3.9.  Tested using the example configuration below.

**Related issue (if applicable):** fixes #8672

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: snmp
  name: printer_toner_black
  host: 192.168.1.201
  baseoid: 1.3.6.1.2.1.43.11.1.1.9.1.1
  unit_of_measurement: "%"
```

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
