### PR TITLE
Added last_update attributes to hue and fluxer components to fix http…

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -26,6 +26,7 @@ from homeassistant.const import (CONF_FILENAME, CONF_HOST, DEVICE_DEFAULT_NAME)
 from homeassistant.loader import get_component
 from homeassistant.components.emulated_hue import ATTR_EMULATED_HUE
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
 
 REQUIREMENTS = ['phue==1.0']
 
@@ -223,6 +224,7 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
                 new_lights.append(lights[light_id])
             else:
                 lights[light_id].info = info
+                lights[light_id].last_update = dt_util.now()
                 lights[light_id].schedule_update_ha_state()
 
         for lightgroup_id, info in api_groups.items():
@@ -240,6 +242,7 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
                 new_lights.append(lightgroups[lightgroup_id])
             else:
                 lightgroups[lightgroup_id].info = info
+                lightgroups[lightgroup_id].last_update = dt_util.now()
                 lightgroups[lightgroup_id].schedule_update_ha_state()
 
         if new_lights:
@@ -301,6 +304,7 @@ class HueLight(Light):
                  is_group=False):
         """Initialize the light."""
         self.light_id = light_id
+        self.last_update = None
         self.info = info
         self.bridge = bridge
         self.update_lights = update_lights
@@ -459,6 +463,9 @@ class HueLight(Light):
     def device_state_attributes(self):
         """Return the device state attributes."""
         attributes = {}
+        attributes['bridge_ip'] = self.bridge.ip
+        #attributes['bridge_name'] = self.bridge.name()
+        attributes['last_update'] = self.last_update
         if not self.allow_in_emulated_hue:
             attributes[ATTR_EMULATED_HUE] = self.allow_in_emulated_hue
         if self.is_group:

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -464,7 +464,7 @@ class HueLight(Light):
         """Return the device state attributes."""
         attributes = {}
         attributes['bridge_ip'] = self.bridge.ip
-        #attributes['bridge_name'] = self.bridge.name()
+        # attributes['bridge_name'] = self.bridge.name()
         attributes['last_update'] = self.last_update
         if not self.allow_in_emulated_hue:
             attributes[ATTR_EMULATED_HUE] = self.allow_in_emulated_hue

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -133,6 +133,7 @@ class FluxSwitch(SwitchDevice):
         self._disable_brightness_adjust = disable_brightness_adjust
         self._mode = mode
         self.unsub_tracker = None
+        self._last_update = None
 
     @property
     def name(self):
@@ -229,6 +230,9 @@ class FluxSwitch(SwitchDevice):
                          "of %s cycle complete at %s", mired, brightness,
                          round(percentage_complete * 100), time_state, now)
 
+        self._last_update = now
+        self.schedule_update_ha_state()
+
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""
         if self._start_time:
@@ -238,3 +242,11 @@ class FluxSwitch(SwitchDevice):
         else:
             sunrise = get_astral_event_date(self.hass, 'sunrise', now.date())
         return sunrise
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attributes = {}
+        attributes['lights'] = self._lights
+        attributes['last_update'] = self._last_update
+        return attributes


### PR DESCRIPTION
## Description:

This pull request adds additional attributes to the hue (bridge_ip, last_update) and fluxer (lights, last_update) component.

**Related issue (if applicable):** fixes #4005


## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: template
    sensors:
      time_between_fluxer_and_hue_update:
        value_template: '{{
as_timestamp(states.light.hue_lightstrip_monitor.attributes.last_update) | int
-
as_timestamp(states.switch.fluxer_office.attributes.last_update) | int
        }}'
        friendly_name: 'Time between fluxer and hue light update'
        unit_of_measurement: 'seconds'

light:
  - platform: hue
    host: XXX
    filename: phue1.conf
    allow_unreachable: true
    allow_hue_groups: true

switch:
- platform: flux
  lights:
    - light.hue_fido
    - light.hue_lightstrip_monitor
  name: fluxer_office
  stop_time: '23:00'
  start_colortemp: 4000
  sunset_colortemp: 3000
  stop_colortemp: 1900
  brightness: 200
  disable_brightness_adjust: false
  mode: xy

automation:
- id:              continues_fluxer_update
  alias:           Continues fluxer update after hue polling
  trigger:
    - platform:    numeric_state
      entity_id:   sensor.time_between_fluxer_and_hue_update
      above:       60
  condition:
    condition:     and
    conditions:
      - condition: state
        entity_id: light.hue_fido
        state:     'on'
  action:
    service:       switch.fluxer_office_update
    entity_id:
      - switch.fluxer_office
- id:              inital_fluxer_update
  alias:           Inital fluxer update after light turned on
  trigger:
    - platform:    state
      entity_id:   light.hue_fido
      to:          'on'
  action:
    service:       switch.fluxer_office_update
    entity_id:
      - switch.fluxer_office


```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
