### PR TITLE
Add nuki lock'n'go and unlatch services and add attributes

### DIFF
--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -79,10 +79,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         path.join(path.dirname(__file__), 'services.yaml'))
 
     hass.services.register(
-        NUKI_DATA, SERVICE_LOCK_N_GO, service_handler,
+        DOMAIN, SERVICE_LOCK_N_GO, service_handler,
         descriptions.get(SERVICE_LOCK_N_GO), schema=LOCK_N_GO_SERVICE_SCHEMA)
     hass.services.register(
-        NUKI_DATA, SERVICE_UNLATCH, service_handler,
+        DOMAIN, SERVICE_UNLATCH, service_handler,
         descriptions.get(SERVICE_UNLATCH), schema=UNLATCH_SERVICE_SCHEMA)
 
 

--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -5,20 +5,31 @@ For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/lock.nuki/
 """
 from datetime import timedelta
+from os import path
+import asyncio
 import logging
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.lock import (LockDevice, PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_TOKEN)
+from homeassistant.config import load_yaml_config_file
+from homeassistant.const import (
+    ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, CONF_TOKEN)
+from homeassistant.helpers.service import extract_entity_ids
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pynuki==1.2.2']
+REQUIREMENTS = ['pynuki==1.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PORT = 8080
+
+ATTR_BATTERY_CRITICAL = 'battery_critical'
+ATTR_NUKI_ID = 'nuki_id'
+ATTR_UNLATCH = 'unlatch'
+DOMAIN = 'nuki'
+SERVICE_LOCK_N_GO = 'nuki_lock_n_go'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -26,6 +37,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_TOKEN): cv.string
 })
 
+LOCK_N_GO_SERVICE_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_UNLATCH, default=False): cv.boolean
+})
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=30)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=5)
@@ -36,17 +51,50 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Nuki lock platform."""
     from pynuki import NukiBridge
     bridge = NukiBridge(config.get(CONF_HOST), config.get(CONF_TOKEN))
-    add_devices([NukiLock(lock) for lock in bridge.locks])
+    add_devices([NukiLock(lock, hass) for lock in bridge.locks])
+
+    def lock_n_go(service):
+        """Service handler for nuki.lock_n_go."""
+        unlatch = service.data.get(ATTR_UNLATCH, False)
+        entity_ids = extract_entity_ids(hass, service)
+        all_locks = hass.data[DOMAIN]['lock']
+        target_locks = []
+        if entity_ids is None:
+            target_locks = all_locks
+        else:
+            for lock in all_locks:
+                if lock.entity_id in entity_ids:
+                    target_locks.append(lock)
+        for lock in target_locks:
+            lock.lock_n_go(unlatch=unlatch)
+
+    descriptions = load_yaml_config_file(
+        path.join(path.dirname(__file__), 'services.yaml'))
+
+    hass.services.register(
+        DOMAIN, SERVICE_LOCK_N_GO, lock_n_go,
+        descriptions.get(SERVICE_LOCK_N_GO), schema=LOCK_N_GO_SERVICE_SCHEMA)
 
 
 class NukiLock(LockDevice):
     """Representation of a Nuki lock."""
 
-    def __init__(self, nuki_lock):
+    def __init__(self, nuki_lock, hass):
         """Initialize the lock."""
+        self.hass = hass
         self._nuki_lock = nuki_lock
         self._locked = nuki_lock.is_locked
         self._name = nuki_lock.name
+        self._battery_critical = nuki_lock.battery_critical
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Callback when entity is added to hass."""
+        if not DOMAIN in self.hass.data:
+            self.hass.data[DOMAIN] = {}
+        if not 'lock' in self.hass.data[DOMAIN]:
+            self.hass.data[DOMAIN]['lock'] = []
+        self.hass.data[DOMAIN]['lock'].append(self)
 
     @property
     def name(self):
@@ -58,12 +106,21 @@ class NukiLock(LockDevice):
         """Return true if lock is locked."""
         return self._locked
 
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        data = {
+            ATTR_BATTERY_CRITICAL: self._battery_critical,
+            ATTR_NUKI_ID: self._nuki_lock.nuki_id}
+        return data
+
     @Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):
         """Update the nuki lock properties."""
         self._nuki_lock.update(aggressive=False)
         self._name = self._nuki_lock.name
         self._locked = self._nuki_lock.is_locked
+        self._battery_critical = self._nuki_lock.battery_critical
 
     def lock(self, **kwargs):
         """Lock the device."""
@@ -72,3 +129,11 @@ class NukiLock(LockDevice):
     def unlock(self, **kwargs):
         """Unlock the device."""
         self._nuki_lock.unlock()
+
+    def lock_n_go(self, **kwargs):
+        """Lock and go.
+
+        This will first unlock the door, then wait for 20 seconds (or another
+        amount of time depending on the lock settings) and relock.
+        """
+        self._nuki_lock.lock_n_go(kwargs)

--- a/homeassistant/components/lock/services.yaml
+++ b/homeassistant/components/lock/services.yaml
@@ -31,6 +31,14 @@ nuki_lock_n_go:
       description: Whether to unlatch the lock
       example: false
 
+nuki_unlatch:
+  description: "Unlatch"
+
+  fields:
+    entity_id:
+      description: Entity id of the Nuki lock
+      example: 'lock.front_door'
+
 lock:
   description: Lock all or specified locks
 

--- a/homeassistant/components/lock/services.yaml
+++ b/homeassistant/components/lock/services.yaml
@@ -20,6 +20,17 @@ get_usercode:
       description: Code slot to retrive a code from
       example: 1
 
+nuki_lock_n_go:
+  description: "Lock 'n' Go"
+
+  fields:
+    entity_id:
+      description: Entity id of the Nuki lock
+      example: 'lock.front_door'
+    unlatch:
+      description: Whether to unlatch the lock
+      example: false
+
 lock:
   description: Lock all or specified locks
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -651,7 +651,7 @@ pynetgear==0.3.3
 pynetio==0.1.6
 
 # homeassistant.components.lock.nuki
-pynuki==1.2.2
+pynuki==1.3.0
 
 # homeassistant.components.sensor.nut
 pynut2==2.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -651,7 +651,7 @@ pynetgear==0.3.3
 pynetio==0.1.6
 
 # homeassistant.components.lock.nuki
-pynuki==1.3.0
+pynuki==1.3.1
 
 # homeassistant.components.sensor.nut
 pynut2==2.1.2


### PR DESCRIPTION
## Description:
The Nuki locks have a Lock'n'go feature which consists in unlocking, waiting for a certain amount of time (20 seconds by default) then locking again.
https://nuki.io/en/support/smart-lock/sl-features/locking-with-the-smart-lock/

Also there is an unlatch function which will effectively open the door.

**TL;DR**
- Add 2 new services: `nuki.nuki_lock_n_go` and `nuki.nuki_unlatch`
- Add 2 new attributes: `battery_critical` and `nuki_id`

**Related issue (if applicable):** Fixes #5988

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3078

## Example entry for `configuration.yaml` (if applicable):
```yaml
lock:
  - platform: nuki
    host: 192.168.10.13
    token: XXXXXXX
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
