### PR TITLE
Added Lutron Caseta Scene Support

### DIFF
--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -28,6 +28,10 @@ CONFIG_SCHEMA = vol.Schema({
     })
 }, extra=vol.ALLOW_EXTRA)
 
+LUTRON_CASETA_COMPONENTS = [
+    'light', 'switch', 'cover', 'scene'
+]
+
 
 def setup(hass, base_config):
     """Set up the Lutron component."""
@@ -44,7 +48,7 @@ def setup(hass, base_config):
 
     _LOGGER.info("Connected to Lutron smartbridge at %s", config[CONF_HOST])
 
-    for component in ('light', 'switch', 'cover'):
+    for component in LUTRON_CASETA_COMPONENTS:
         discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     return True

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pylutron-caseta==0.2.6']
+REQUIREMENTS = ['pylutron-caseta==0.2.7']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/scene/lutron_caseta.py
+++ b/homeassistant/components/scene/lutron_caseta.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/scene.lutron_caseta/
 import logging
 
 from homeassistant.components.scene import Scene
-from homeassistant.components.lutron_caseta import (LUTRON_CASETA_SMARTBRIDGE)
+from homeassistant.components.lutron_caseta import LUTRON_CASETA_SMARTBRIDGE
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/scene/lutron_caseta.py
+++ b/homeassistant/components/scene/lutron_caseta.py
@@ -4,15 +4,15 @@ Support for Lutron Caseta scenes.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/scene.lutron_caseta/
 """
-import asyncio
 import logging
 
 from homeassistant.components.scene import Scene
-from homeassistant.components.lutron_caseta import (LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice)
+from homeassistant.components.lutron_caseta import (LUTRON_CASETA_SMARTBRIDGE)
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['lutron_caseta']
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Lutron Caseta lights."""
@@ -24,6 +24,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         devs.append(dev)
 
     add_devices(devs, True)
+
 
 class LutronCasetaScene(Scene):
     """Representation of a Lutron Caseta scene."""

--- a/homeassistant/components/scene/lutron_caseta.py
+++ b/homeassistant/components/scene/lutron_caseta.py
@@ -1,0 +1,54 @@
+"""
+Support for Lutron Caseta scenes.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/scene.lutron_caseta/
+"""
+import asyncio
+import logging
+
+from homeassistant.components.scene import Scene
+from homeassistant.components.lutron_caseta import (LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['lutron_caseta']
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Lutron Caseta lights."""
+    devs = []
+    bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
+    scenes = bridge.get_scenes()
+    for scene in scenes:
+        dev = LutronCasetaScene(scenes[scene], bridge)
+        devs.append(dev)
+
+    add_devices(devs, True)
+
+class LutronCasetaScene(Scene):
+    """Representation of a Lutron Caseta scene."""
+
+    def __init__(self, scene, bridge):
+        """Initialize the Lutron Caseta scene."""
+        self._scene_name = scene["name"]
+        self._scene_id = scene["scene_id"]
+        self._bridge = bridge
+
+    @property
+    def name(self):
+        """Return the name of the scene."""
+        return self._scene_name
+
+    @property
+    def should_poll(self):
+        """Return that polling is not necessary."""
+        return False
+
+    @property
+    def is_on(self):
+        """There is no way of detecting if a scene is active (yet)."""
+        return False
+
+    def activate(self, **kwargs):
+        """Activate the scene."""
+        self._bridge.activate_scene(self._scene_id)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -623,7 +623,7 @@ pylitejet==0.1
 pyloopenergy==0.0.17
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.2.6
+pylutron-caseta==0.2.7
 
 # homeassistant.components.lutron
 pylutron==0.1.0


### PR DESCRIPTION
## Description:
Added support to pull scenes present in Lutron Caseta SmartBridge into Home Assistant. Scenes can now be triggered directly from Home Assistant.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io/pull/3081

## Example entry for `configuration.yaml` (if applicable):
Configuration is the same as the rest of the Lutron Caseta component. No extra config is needed:
```
lutron_caseta:
  host: <ip_of_smartbridge>

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`. **N/A**

[ex-requir]: https://github.com/kfcook/home-assistant/blob/lutron-caseta-scene-support/homeassistant/components/lutron_caseta.py#L17
