### PR TITLE
added invert_state optional parameter

### DIFF
--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -97,13 +97,11 @@ class RPiGPIOCover(CoverDevice):
     def update(self):
         """Update the state of the cover."""
         self._state = rpi_gpio.read_input(self._state_pin)
-        if self._state_invert:
-            self._state = not self._state
 
     @property
     def is_closed(self):
         """Return true if cover is closed."""
-        return self._state
+        return self._state != self._state_invert
 
     def _trigger(self):
         """Trigger the cover."""

--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -25,10 +25,12 @@ CONF_RELAY_TIME = 'relay_time'
 CONF_STATE_PIN = 'state_pin'
 CONF_STATE_PULL_MODE = 'state_pull_mode'
 CONF_STATE_INVERT = 'state_invert'
+CONF_RELAY_INVERT = 'relay_invert'
 
 DEFAULT_RELAY_TIME = .2
 DEFAULT_STATE_PULL_MODE = 'UP'
 DEFAULT_STATE_INVERT = False
+DEFAULT_RELAY_INVERT = False
 DEPENDENCIES = ['rpi_gpio']
 
 _COVERS_SCHEMA = vol.All(
@@ -48,6 +50,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         cv.string,
     vol.Optional(CONF_RELAY_TIME, default=DEFAULT_RELAY_TIME): cv.positive_int,
     vol.Optional(CONF_STATE_INVERT, default=DEFAULT_STATE_INVERT): cv.boolean,
+    vol.Optional(CONF_RELAY_INVERT, default=DEFAULT_RELAY_INVERT): cv.boolean,
 })
 
 
@@ -57,13 +60,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     relay_time = config.get(CONF_RELAY_TIME)
     state_pull_mode = config.get(CONF_STATE_PULL_MODE)
     state_invert = config.get(CONF_STATE_INVERT)
+    relay_invert = config.get(CONF_RELAY_INVERT)
     covers = []
     covers_conf = config.get(CONF_COVERS)
 
     for cover in covers_conf:
         covers.append(RPiGPIOCover(
             cover[CONF_NAME], cover[CONF_RELAY_PIN], cover[CONF_STATE_PIN],
-            state_pull_mode, relay_time, state_invert))
+            state_pull_mode, relay_time, state_invert, relay_invert))
     add_devices(covers)
 
 
@@ -71,7 +75,7 @@ class RPiGPIOCover(CoverDevice):
     """Representation of a Raspberry GPIO cover."""
 
     def __init__(self, name, relay_pin, state_pin, state_pull_mode,
-                 relay_time, state_invert):
+                 relay_time, state_invert, relay_invert):
         """Initialize the cover."""
         self._name = name
         self._state = False
@@ -80,9 +84,10 @@ class RPiGPIOCover(CoverDevice):
         self._state_pull_mode = state_pull_mode
         self._relay_time = relay_time
         self._state_invert = state_invert
+        self._relay_invert = relay_invert
         rpi_gpio.setup_output(self._relay_pin)
         rpi_gpio.setup_input(self._state_pin, self._state_pull_mode)
-        rpi_gpio.write_output(self._relay_pin, True)
+        rpi_gpio.write_output(self._relay_pin, True != self._relay_invert)
 
     @property
     def unique_id(self):
@@ -105,9 +110,9 @@ class RPiGPIOCover(CoverDevice):
 
     def _trigger(self):
         """Trigger the cover."""
-        rpi_gpio.write_output(self._relay_pin, False)
+        rpi_gpio.write_output(self._relay_pin, False != self._relay_invert)
         sleep(self._relay_time)
-        rpi_gpio.write_output(self._relay_pin, True)
+        rpi_gpio.write_output(self._relay_pin, True != self._relay_invert)
 
     def close_cover(self):
         """Close the cover."""

--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -24,13 +24,13 @@ CONF_RELAY_PIN = 'relay_pin'
 CONF_RELAY_TIME = 'relay_time'
 CONF_STATE_PIN = 'state_pin'
 CONF_STATE_PULL_MODE = 'state_pull_mode'
-CONF_STATE_INVERT = 'state_invert'
-CONF_RELAY_INVERT = 'relay_invert'
+CONF_INVERT_STATE = 'invert_state'
+CONF_INVERT_RELAY = 'invert_relay'
 
 DEFAULT_RELAY_TIME = .2
 DEFAULT_STATE_PULL_MODE = 'UP'
-DEFAULT_STATE_INVERT = False
-DEFAULT_RELAY_INVERT = False
+DEFAULT_INVERT_STATE = False
+DEFAULT_INVERT_RELAY = False
 DEPENDENCIES = ['rpi_gpio']
 
 _COVERS_SCHEMA = vol.All(
@@ -49,8 +49,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_STATE_PULL_MODE, default=DEFAULT_STATE_PULL_MODE):
         cv.string,
     vol.Optional(CONF_RELAY_TIME, default=DEFAULT_RELAY_TIME): cv.positive_int,
-    vol.Optional(CONF_STATE_INVERT, default=DEFAULT_STATE_INVERT): cv.boolean,
-    vol.Optional(CONF_RELAY_INVERT, default=DEFAULT_RELAY_INVERT): cv.boolean,
+    vol.Optional(CONF_INVERT_STATE, default=DEFAULT_INVERT_STATE): cv.boolean,
+    vol.Optional(CONF_INVERT_RELAY, default=DEFAULT_INVERT_RELAY): cv.boolean,
 })
 
 
@@ -59,15 +59,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the RPi cover platform."""
     relay_time = config.get(CONF_RELAY_TIME)
     state_pull_mode = config.get(CONF_STATE_PULL_MODE)
-    state_invert = config.get(CONF_STATE_INVERT)
-    relay_invert = config.get(CONF_RELAY_INVERT)
+    invert_state = config.get(CONF_INVERT_STATE)
+    invert_relay = config.get(CONF_INVERT_RELAY)
     covers = []
     covers_conf = config.get(CONF_COVERS)
 
     for cover in covers_conf:
         covers.append(RPiGPIOCover(
             cover[CONF_NAME], cover[CONF_RELAY_PIN], cover[CONF_STATE_PIN],
-            state_pull_mode, relay_time, state_invert, relay_invert))
+            state_pull_mode, relay_time, invert_state, invert_relay))
     add_devices(covers)
 
 
@@ -75,7 +75,7 @@ class RPiGPIOCover(CoverDevice):
     """Representation of a Raspberry GPIO cover."""
 
     def __init__(self, name, relay_pin, state_pin, state_pull_mode,
-                 relay_time, state_invert, relay_invert):
+                 relay_time, invert_state, invert_relay):
         """Initialize the cover."""
         self._name = name
         self._state = False
@@ -83,11 +83,11 @@ class RPiGPIOCover(CoverDevice):
         self._state_pin = state_pin
         self._state_pull_mode = state_pull_mode
         self._relay_time = relay_time
-        self._state_invert = state_invert
-        self._relay_invert = relay_invert
+        self._invert_state = invert_state
+        self._invert_relay = invert_relay
         rpi_gpio.setup_output(self._relay_pin)
         rpi_gpio.setup_input(self._state_pin, self._state_pull_mode)
-        rpi_gpio.write_output(self._relay_pin, not self._relay_invert)
+        rpi_gpio.write_output(self._relay_pin, not self._invert_relay)
 
     @property
     def unique_id(self):
@@ -106,13 +106,13 @@ class RPiGPIOCover(CoverDevice):
     @property
     def is_closed(self):
         """Return true if cover is closed."""
-        return self._state != self._state_invert
+        return self._state != self._invert_state
 
     def _trigger(self):
         """Trigger the cover."""
-        rpi_gpio.write_output(self._relay_pin, self._relay_invert)
+        rpi_gpio.write_output(self._relay_pin, self._invert_relay)
         sleep(self._relay_time)
-        rpi_gpio.write_output(self._relay_pin, not self._relay_invert)
+        rpi_gpio.write_output(self._relay_pin, not self._invert_relay)
 
     def close_cover(self):
         """Close the cover."""

--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -87,7 +87,7 @@ class RPiGPIOCover(CoverDevice):
         self._relay_invert = relay_invert
         rpi_gpio.setup_output(self._relay_pin)
         rpi_gpio.setup_input(self._state_pin, self._state_pull_mode)
-        rpi_gpio.write_output(self._relay_pin, True != self._relay_invert)
+        rpi_gpio.write_output(self._relay_pin, not self._relay_invert)
 
     @property
     def unique_id(self):
@@ -110,9 +110,9 @@ class RPiGPIOCover(CoverDevice):
 
     def _trigger(self):
         """Trigger the cover."""
-        rpi_gpio.write_output(self._relay_pin, False != self._relay_invert)
+        rpi_gpio.write_output(self._relay_pin, self._relay_invert)
         sleep(self._relay_time)
-        rpi_gpio.write_output(self._relay_pin, True != self._relay_invert)
+        rpi_gpio.write_output(self._relay_pin, not self._relay_invert)
 
     def close_cover(self):
         """Close the cover."""

--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -97,7 +97,7 @@ class RPiGPIOCover(CoverDevice):
     def update(self):
         """Update the state of the cover."""
         self._state = rpi_gpio.read_input(self._state_pin)
-        if (self._state_invert):
+        if self._state_invert:
             self._state = not self._state
 
     @property


### PR DESCRIPTION
## Description:
Added a new configuration variable to the Raspberry Pi Cover component that allows the state pin to be interpreted as 0 = closed.

This is in response to two feature requests:
https://community.home-assistant.io/t/invert-logic-cover-rpi-gpio/4147
https://community.home-assistant.io/t/add-invert-logic-to-raspberry-pi-cover-state/9532

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#3086

## Example entry for `configuration.yaml`:
```yaml
cover:
  - platform: rpi_gpio
    state_invert: true
    covers:
      - name: garage door 1
        relay_pin: 25
        state_pin: 21
      - name: garage door 2
        relay_pin: 24
        state_pin: 20
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
