### PR TITLE
Persist shopping list + clear completed

### DIFF
--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -1,6 +1,8 @@
 """Component to manage a shoppling list."""
 import asyncio
+import json
 import logging
+import os
 import uuid
 
 import voluptuous as vol
@@ -23,43 +25,55 @@ ITEM_UPDATE_SCHEMA = vol.Schema({
     'complete': bool,
     'name': str,
 })
+PERSISTENCE = '.shopping_list.json'
 
 
 @asyncio.coroutine
 def async_setup(hass, config):
     """Initialize the shopping list."""
-    hass.data[DOMAIN] = ShoppingData([])
+    data = hass.data[DOMAIN] = ShoppingData(hass)
+    yield from data.async_load()
+
     intent.async_register(hass, AddItemIntent())
     intent.async_register(hass, ListTopItemsIntent())
+
     hass.http.register_view(ShoppingListView)
     hass.http.register_view(UpdateShoppingListItemView)
+    hass.http.register_view(ClearCompletedItemsView)
+
     hass.components.conversation.async_register(INTENT_ADD_ITEM, [
         'Add {item} to my shopping list',
     ])
     hass.components.conversation.async_register(INTENT_LAST_ITEMS, [
         'What is on my shopping list'
     ])
+
     hass.components.frontend.register_built_in_panel(
         'shopping-list', 'Shopping List', 'mdi:cart')
+
     return True
 
 
 class ShoppingData:
     """Class to hold shopping list data."""
 
-    def __init__(self, items):
+    def __init__(self, hass):
         """Initialize the shopping list."""
-        self.items = items
+        self.hass = hass
+        self.items = []
 
-    def add(self, name):
+    @callback
+    def async_add(self, name):
         """Add a shopping list item."""
         self.items.append({
             'name': name,
             'id': uuid.uuid4().hex,
             'complete': False
         })
+        self.hass.async_add_job(self.save)
 
-    def update(self, item_id, info):
+    @callback
+    def async_update(self, item_id, info):
         """Update a shopping list item."""
         item = next((itm for itm in self.items if itm['id'] == item_id), None)
 
@@ -68,11 +82,33 @@ class ShoppingData:
 
         info = ITEM_UPDATE_SCHEMA(info)
         item.update(info)
+        self.hass.async_add_job(self.save)
         return item
 
-    def clear_completed(self):
+    @callback
+    def async_clear_completed(self):
         """Clear completed items."""
         self.items = [itm for itm in self.items if not itm['complete']]
+        self.hass.async_add_job(self.save)
+
+    @asyncio.coroutine
+    def async_load(self):
+        """Load items."""
+        def load():
+            """Load the items synchronously."""
+            path = self.hass.config.path(PERSISTENCE)
+            if not os.path.isfile(path):
+                return []
+            with open(path) as file:
+                return json.loads(file.read())
+
+        items = yield from self.hass.async_add_job(load)
+        self.items = items
+
+    def save(self):
+        """Save the items."""
+        with open(self.hass.config.path(PERSISTENCE), 'wt') as file:
+            file.write(json.dumps(self.items, sort_keys=True, indent=4))
 
 
 class AddItemIntent(intent.IntentHandler):
@@ -88,7 +124,7 @@ class AddItemIntent(intent.IntentHandler):
         """Handle the intent."""
         slots = self.async_validate_slots(intent_obj.slots)
         item = slots['item']['value']
-        intent_obj.hass.data[DOMAIN].add(item)
+        intent_obj.hass.data[DOMAIN].async_add(item)
 
         response = intent_obj.create_response()
         response.async_set_speech(
@@ -137,8 +173,8 @@ class ShoppingListView(http.HomeAssistantView):
 class UpdateShoppingListItemView(http.HomeAssistantView):
     """View to retrieve shopping list content."""
 
-    url = '/api/shopping_list/{item_id}'
-    name = "api:shopping_list:id"
+    url = '/api/shopping_list/item/{item_id}'
+    name = "api:shopping_list:item:id"
 
     @callback
     def post(self, request, item_id):
@@ -146,10 +182,25 @@ class UpdateShoppingListItemView(http.HomeAssistantView):
         data = yield from request.json()
 
         try:
-            item = request.app['hass'].data[DOMAIN].update(item_id, data)
+            item = request.app['hass'].data[DOMAIN].async_update(item_id, data)
             request.app['hass'].bus.async_fire(EVENT)
             return self.json(item)
         except KeyError:
             return self.json_message('Item not found', HTTP_NOT_FOUND)
         except vol.Invalid:
             return self.json_message('Item not found', HTTP_BAD_REQUEST)
+
+
+class ClearCompletedItemsView(http.HomeAssistantView):
+    """View to retrieve shopping list content."""
+
+    url = '/api/shopping_list/clear_completed'
+    name = "api:shopping_list:clear_completed"
+
+    @callback
+    def post(self, request):
+        """Retrieve if API is running."""
+        hass = request.app['hass']
+        hass.data[DOMAIN].async_clear_completed()
+        hass.bus.async_fire(EVENT)
+        return self.json_message('Cleared completed items.')


### PR DESCRIPTION
## Description:
This adds persistence and clear completed functionality to the shopping list.

## Example entry for `configuration.yaml` (if applicable):
```yaml
shopping_list:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
