### PR TITLE
Block dependencies that depend on enum34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ COPY requirements_all.txt requirements_all.txt
 # Uninstall enum34 because some depenndecies install it but breaks Python 3.4+.
 # See PR #8103 for more info.
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet && \
-    pip3 uninstall -y enum34
+    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet
 
 # Copy source
 COPY . .

--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -22,7 +22,7 @@ from homeassistant.components.light import (
     Light, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['yeelight==0.3.0']
+REQUIREMENTS = ['yeelight==0.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/skybeacon.py
+++ b/homeassistant/components/sensor/skybeacon.py
@@ -16,7 +16,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_NAME, CONF_MAC, TEMP_CELSIUS, STATE_UNKNOWN, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pygatt==3.1.1']
+# REQUIREMENTS = ['pygatt==3.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,6 +39,9 @@ CONNECT_TIMEOUT = 30
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Skybeacon sensor."""
+    _LOGGER.warning("This platform has been disabled due to having a "
+                    "requirement depending on enum34.")
+    return
     name = config.get(CONF_NAME)
     mac = config.get(CONF_MAC)
     _LOGGER.debug("Setting up...")

--- a/homeassistant/components/sensor/skybeacon.py
+++ b/homeassistant/components/sensor/skybeacon.py
@@ -42,6 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     _LOGGER.warning("This platform has been disabled due to having a "
                     "requirement depending on enum34.")
     return
+    # pylint: disable=unreachable
     name = config.get(CONF_NAME)
     mac = config.get(CONF_MAC)
     _LOGGER.debug("Setting up...")
@@ -139,6 +140,7 @@ class Monitor(threading.Thread):
 
     def run(self):
         """Thread that keeps connection alive."""
+        # pylint: disable=import-error
         import pygatt
         from pygatt.backends import Characteristic
         from pygatt.exceptions import (

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -9,3 +9,6 @@ aiohttp==2.2.4
 async_timeout==1.2.1
 chardet==3.0.4
 astral==1.4
+
+# Breaks Python 3.6 and is not needed for our supported Pythons
+enum34==1000000000.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -983,7 +983,7 @@ yahoo-finance==1.4.0
 yahooweather==0.8
 
 # homeassistant.components.light.yeelight
-yeelight==0.3.0
+yeelight==0.3.2
 
 # homeassistant.components.light.yeelightsunflower
 yeelightsunflower==0.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -584,9 +584,6 @@ pyfoscam==1.2
 # homeassistant.components.ifttt
 pyfttt==0.3
 
-# homeassistant.components.sensor.skybeacon
-pygatt==3.1.1
-
 # homeassistant.components.remote.harmony
 pyharmony==1.0.16
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -88,6 +88,10 @@ URL_PIN = ('https://home-assistant.io/developers/code_review_platform/'
 
 CONSTRAINT_PATH = os.path.join(os.path.dirname(__file__),
                                '../homeassistant/package_constraints.txt')
+CONSTRAINT_BASE = """
+# Breaks Python 3.6 and is not needed for our supported Pythons
+enum34==1000000000.0.0
+"""
 
 
 def explore_module(package, explore_children):
@@ -223,7 +227,7 @@ def write_test_requirements_file(data):
 def write_constraints_file(data):
     """Write constraints to a file."""
     with open(CONSTRAINT_PATH, 'w+', newline="\n") as req_file:
-        req_file.write(data)
+        req_file.write(data + CONSTRAINT_BASE)
 
 
 def validate_requirements_file(data):

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -233,19 +233,19 @@ def write_constraints_file(data):
 def validate_requirements_file(data):
     """Validate if requirements_all.txt is up to date."""
     with open('requirements_all.txt', 'r') as req_file:
-        return data == ''.join(req_file)
+        return data == req_file.read()
 
 
 def validate_requirements_test_file(data):
     """Validate if requirements_all.txt is up to date."""
     with open('requirements_test_all.txt', 'r') as req_file:
-        return data == ''.join(req_file)
+        return data == req_file.read()
 
 
 def validate_constraints_file(data):
     """Validate if constraints is up to date."""
     with open(CONSTRAINT_PATH, 'r') as req_file:
-        return data == ''.join(req_file)
+        return data + CONSTRAINT_BASE == req_file.read()
 
 
 def main():

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands =
      py.test --timeout=30 --duration=10 --cov --cov-report= {posargs}
 deps =
      -r{toxinidir}/requirements_test_all.txt
+     -c{toxinidir}/homeassistant/package_constraints.txt
 
 [testenv:lint]
 basepython = python3
@@ -22,6 +23,7 @@ ignore_errors = True
 deps =
      -r{toxinidir}/requirements_all.txt
      -r{toxinidir}/requirements_test.txt
+     -c{toxinidir}/homeassistant/package_constraints.txt
 commands =
      flake8
      pylint homeassistant

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -29,8 +29,7 @@ COPY requirements_all.txt requirements_all.txt
 # Uninstall enum34 because some depenndecies install it but breaks Python 3.4+.
 # See PR #8103 for more info.
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet && \
-    pip3 uninstall -y enum34
+    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet
 
 # BEGIN: Development additions
 


### PR DESCRIPTION
## Description:
This blocks enum34 from being installed. It is a backport of the Python 3.4 enum module for Python 2.7-3.3. It is never needed for Home Assistant.

When installed in Python 3.6, it will blow up things that depend on enum.

This change will fail any dependency that tries to install enum34. As these dependencies have to depend on `enum-compat` instead, which will only install `enum34` when necessary.

See earlier work done in #8103

As this is very annoying, I'm planning on disabling components/platforms that currently depend on requirements that pull in enum34. Based on the current list that will only be sensor.skybeacon.

Found violating packages with `pipdeptree --reverse --packages enum34`:

  - libpurecoollink==0.2.0 [requires: enum34>=1.1.6] - PR to fix it: https://github.com/CharlesBlonde/libpurecoollink/pull/10
  - pygatt==3.1.1 [requires: enum34] - PR with fix has gone stale: https://github.com/peplin/pygatt/pull/131 - Used by sensor.skybeacon
  - yeelight==0.3.0 [requires: enum34] - fixed in 0.3.2 so upgraded in this PR

The `pygatt` and `yeelight` PRs have been submitted over a month ago and have not gotten any response. 

**Related issue (if applicable):** fixes #7733

