### PR TITLE
Remove deprecated substitute interfaces

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -14,7 +14,6 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (STATE_ON, STATE_OFF)
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
-from homeassistant.helpers.deprecation import deprecated_substitute
 
 DOMAIN = 'binary_sensor'
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -66,7 +65,6 @@ class BinarySensorDevice(Entity):
         return STATE_ON if self.is_on else STATE_OFF
 
     @property
-    @deprecated_substitute('sensor_class')
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
         return None

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -21,7 +21,6 @@ from homeassistant.loader import bind_hass
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
-from homeassistant.helpers.deprecation import deprecated_substitute
 from homeassistant.components.http import HomeAssistantView, KEY_AUTHENTICATED
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -589,7 +588,6 @@ class MediaPlayerDevice(Entity):
         return None
 
     @property
-    @deprecated_substitute('supported_media_commands')
     def supported_features(self):
         """Flag media player features that are supported."""
         return 0


### PR DESCRIPTION
## Description:
This PR removes the deprecated substitute interfaces from media_player and binary_sensor. These would only have been used by custom components and have been issuing warnings since 0.39.