### PR TITLE
Fix Kodi reconnection after websocket disconnect

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -353,7 +353,7 @@ class KodiDevice(MediaPlayerDevice):
         self._properties = {}
         self._item = {}
         self._app_properties = {}
-        self.hass.async_add_job(self.async_update_ha_state())
+        self.hass.async_add_job(self._ws_server.close())
 
     @asyncio.coroutine
     def _get_players(self):
@@ -402,6 +402,8 @@ class KodiDevice(MediaPlayerDevice):
                 # Kodi abruptly ends ws connection when exiting. We will try
                 # to reconnect on the next poll.
                 pass
+            # Update HA state after Kodi disconnects
+            self.hass.async_add_job(self.async_update_ha_state())
 
         # Create a task instead of adding a tracking job, since this task will
         # run until the websocket connection is closed.


### PR DESCRIPTION
## Description:
This PR fixes the reconnection of Kodi after it is closed. If we receive the quit message from Kodi we immediately end our websocket connection and update the HA state, so that hass knows to start polling Kodi again.