### PR TITLE
Fix Z-Wave barrier discovery for new API

### DIFF
--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -345,6 +345,9 @@ INDEX_ALARM_TYPE = 0
 INDEX_ALARM_LEVEL = 1
 INDEX_ALARM_ACCESS_CONTROL = 9
 
+# https://github.com/OpenZWave/open-zwave/blob/de1c0e60edf1d1bee81f1ae54b1f58e66c6fd8ed/cpp/src/command_classes/BarrierOperator.cpp#L69
+INDEX_BARRIER_OPERATOR_LABEL = 1
+
 # https://github.com/OpenZWave/open-zwave/blob/67f180eb565f0054f517ff395c71ecd706f6a837/cpp/src/command_classes/DoorLock.cpp#L77
 INDEX_DOOR_LOCK_LOCK = 0
 

--- a/homeassistant/components/zwave/discovery_schemas.py
+++ b/homeassistant/components/zwave/discovery_schemas.py
@@ -92,7 +92,7 @@ DISCOVERY_SCHEMAS = [
              const.DISC_INDEX: [const.INDEX_SWITCH_MULTILEVEL_DIM],
              const.DISC_OPTIONAL: True,
          }})},
-    {const.DISC_COMPONENT: 'cover',  # Garage Door
+    {const.DISC_COMPONENT: 'cover',  # Garage Door Switch
      const.DISC_GENERIC_DEVICE_CLASS: [
          const.GENERIC_TYPE_SWITCH_MULTILEVEL,
          const.GENERIC_TYPE_ENTRY_CONTROL],
@@ -105,10 +105,24 @@ DISCOVERY_SCHEMAS = [
          const.SPECIFIC_TYPE_SECURE_DOOR],
      const.DISC_VALUES: dict(DEFAULT_VALUES_SCHEMA, **{
          const.DISC_PRIMARY: {
-             const.DISC_COMMAND_CLASS: [
-                 const.COMMAND_CLASS_BARRIER_OPERATOR,
-                 const.COMMAND_CLASS_SWITCH_BINARY],
+             const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_SWITCH_BINARY],
              const.DISC_GENRE: const.GENRE_USER,
+         }})},
+    {const.DISC_COMPONENT: 'cover',  # Garage Door Barrier
+     const.DISC_GENERIC_DEVICE_CLASS: [
+         const.GENERIC_TYPE_SWITCH_MULTILEVEL,
+         const.GENERIC_TYPE_ENTRY_CONTROL],
+     const.DISC_SPECIFIC_DEVICE_CLASS: [
+         const.SPECIFIC_TYPE_CLASS_A_MOTOR_CONTROL,
+         const.SPECIFIC_TYPE_CLASS_B_MOTOR_CONTROL,
+         const.SPECIFIC_TYPE_CLASS_C_MOTOR_CONTROL,
+         const.SPECIFIC_TYPE_MOTOR_MULTIPOSITION,
+         const.SPECIFIC_TYPE_SECURE_BARRIER_ADDON,
+         const.SPECIFIC_TYPE_SECURE_DOOR],
+     const.DISC_VALUES: dict(DEFAULT_VALUES_SCHEMA, **{
+         const.DISC_PRIMARY: {
+             const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_BARRIER_OPERATOR],
+             const.DISC_INDEX: [const.INDEX_BARRIER_OPERATOR_LABEL],
          }})},
     {const.DISC_COMPONENT: 'fan',
      const.DISC_GENERIC_DEVICE_CLASS: [

--- a/tests/components/cover/test_zwave.py
+++ b/tests/components/cover/test_zwave.py
@@ -32,16 +32,30 @@ def test_get_device_detects_rollershutter(hass, mock_openzwave):
     assert isinstance(device, zwave.ZwaveRollershutter)
 
 
-def test_get_device_detects_garagedoor(hass, mock_openzwave):
+def test_get_device_detects_garagedoor_switch(hass, mock_openzwave):
     """Test device returns garage door."""
     node = MockNode()
-    value = MockValue(data=0, node=node,
+    value = MockValue(data=False, node=node,
+                      command_class=const.COMMAND_CLASS_SWITCH_BINARY)
+    values = MockEntityValues(primary=value, node=node)
+
+    device = zwave.get_device(hass=hass, node=node, values=values,
+                              node_config={})
+    assert isinstance(device, zwave.ZwaveGarageDoorSwitch)
+    assert device.device_class == "garage"
+    assert device.supported_features == SUPPORT_OPEN | SUPPORT_CLOSE
+
+
+def test_get_device_detects_garagedoor_barrier(hass, mock_openzwave):
+    """Test device returns garage door."""
+    node = MockNode()
+    value = MockValue(data="Closed", node=node,
                       command_class=const.COMMAND_CLASS_BARRIER_OPERATOR)
     values = MockEntityValues(primary=value, node=node)
 
     device = zwave.get_device(hass=hass, node=node, values=values,
                               node_config={})
-    assert isinstance(device, zwave.ZwaveGarageDoor)
+    assert isinstance(device, zwave.ZwaveGarageDoorBarrier)
     assert device.device_class == "garage"
     assert device.supported_features == SUPPORT_OPEN | SUPPORT_CLOSE
 
@@ -158,7 +172,39 @@ def test_roller_reverse_open_close(hass, mock_openzwave):
     assert value_id == close_value.value_id
 
 
-def test_garage_value_changed(hass, mock_openzwave):
+def test_switch_garage_value_changed(hass, mock_openzwave):
+    """Test position changed."""
+    node = MockNode()
+    value = MockValue(data=False, node=node,
+                      command_class=const.COMMAND_CLASS_SWITCH_BINARY)
+    values = MockEntityValues(primary=value, node=node)
+    device = zwave.get_device(hass=hass, node=node, values=values,
+                              node_config={})
+
+    assert device.is_closed
+
+    value.data = True
+    value_changed(value)
+    assert not device.is_closed
+
+
+def test_switch_garage_commands(hass, mock_openzwave):
+    """Test position changed."""
+    node = MockNode()
+    value = MockValue(data=False, node=node,
+                      command_class=const.COMMAND_CLASS_SWITCH_BINARY)
+    values = MockEntityValues(primary=value, node=node)
+    device = zwave.get_device(hass=hass, node=node, values=values,
+                              node_config={})
+
+    assert value.data is False
+    device.open_cover()
+    assert value.data is True
+    device.close_cover()
+    assert value.data is False
+
+
+def test_barrier_garage_value_changed(hass, mock_openzwave):
     """Test position changed."""
     node = MockNode()
     value = MockValue(data="Closed", node=node,
@@ -190,7 +236,7 @@ def test_garage_value_changed(hass, mock_openzwave):
     assert device.is_closing
 
 
-def test_garage_commands(hass, mock_openzwave):
+def test_barrier_garage_commands(hass, mock_openzwave):
     """Test position changed."""
     node = MockNode()
     value = MockValue(data="Closed", node=node,


### PR DESCRIPTION
## Description:
I got updated to the latest openzwave, and after #8574 there are some problems with zwave cover discovery. This PR broke support for covers that expose themselves as binary switches. The discovery schema also needs to be updated so that the barrier class is controlling the right value.

CC @firstof9 (Can you test this to make sure it still works on your system?)