### PR TITLE
directv: add configuration glue for Genie slaves

### DIFF
--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -12,11 +12,12 @@ from homeassistant.components.media_player import (
     SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK, SUPPORT_PLAY,
     MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, STATE_OFF, STATE_PLAYING, CONF_PORT)
+    CONF_DEVICE, CONF_HOST, CONF_NAME, STATE_OFF, STATE_PLAYING, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['directpy==0.1']
 
+DEFAULT_DEVICE = '0'
 DEFAULT_NAME = 'DirecTV Receiver'
 DEFAULT_PORT = 8080
 
@@ -30,6 +31,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_DEVICE, default=DEFAULT_DEVICE): cv.string,
 })
 
 
@@ -50,7 +52,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     elif CONF_HOST in config:
         hosts.append([
-            config.get(CONF_NAME), config.get(CONF_HOST), config.get(CONF_PORT)
+            config.get(CONF_NAME), config.get(CONF_HOST),
+            config.get(CONF_PORT), config.get(CONF_DEVICE)
         ])
 
     dtvs = []
@@ -67,10 +70,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class DirecTvDevice(MediaPlayerDevice):
     """Representation of a DirecTV reciever on the network."""
 
-    def __init__(self, name, host, port):
+    def __init__(self, name, host, port, device):
         """Initialize the device."""
         from DirectPy import DIRECTV
-        self.dtv = DIRECTV(host, port)
+        self.dtv = DIRECTV(host, port, device)
         self._name = name
         self._is_standby = True
         self._current = None


### PR DESCRIPTION
## Description:
```
DirectPy, the third party library used for controlling directv boxes,
has the ability to accept an ID in order to act as a remote for Genie
slaves instead of just the master directv box. This commit adds glue
such that one can configure home assistant to interface with these slave
genie boxes.

Signed-off-by: Nicholas Sielicki <sielicki@yandex.com>
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3096

## Example entry for `configuration.yaml` (if applicable):
See [here](https://github.com/home-assistant/home-assistant.github.io/pull/3096/files#diff-a18cceff645069e77fc9c682aa0d5324R57)

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
