### PR TITLE
Bump python-telegram-bot to 7.0.1

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -24,7 +24,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import TemplateError
 from homeassistant.setup import async_prepare_setup_platform
 
-REQUIREMENTS = ['python-telegram-bot==6.1.0']
+REQUIREMENTS = ['python-telegram-bot==7.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -733,7 +733,7 @@ python-synology==0.1.0
 python-tado==0.2.2
 
 # homeassistant.components.telegram_bot
-python-telegram-bot==6.1.0
+python-telegram-bot==7.0.1
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0


### PR DESCRIPTION
## Description:

Bump python-telegram-bot to [7.0.1](https://github.com/python-telegram-bot/python-telegram-bot/releases/tag/v7.0.1) for fully support Bot API 3.2.
