### PR TITLE
Add proxy support for telegram_bot

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -49,8 +49,6 @@ ATTR_MSG = 'message'
 ATTR_MSGID = 'id'
 ATTR_PARSER = 'parse_mode'
 ATTR_PASSWORD = 'password'
-ATTR_PROXY_URL = 'proxy_url'
-ATTR_PROXY_PARAMS = 'proxy_params'
 ATTR_REPLY_TO_MSGID = 'reply_to_message_id'
 ATTR_REPLYMARKUP = 'reply_markup'
 ATTR_SHOW_ALERT = 'show_alert'
@@ -61,6 +59,8 @@ ATTR_USER_ID = 'user_id'
 ATTR_USERNAME = 'username'
 
 CONF_ALLOWED_CHAT_IDS = 'allowed_chat_ids'
+CONF_PROXY_URL = 'proxy_url'
+CONF_PROXY_PARAMS = 'proxy_params'
 
 DOMAIN = 'telegram_bot'
 
@@ -87,8 +87,8 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ALLOWED_CHAT_IDS):
         vol.All(cv.ensure_list, [vol.Coerce(int)]),
     vol.Optional(ATTR_PARSER, default=PARSER_MD): cv.string,
-    vol.Optional(ATTR_PROXY_URL): cv.string,
-    vol.Optional(ATTR_PROXY_PARAMS): dict,
+    vol.Optional(CONF_PROXY_URL): cv.string,
+    vol.Optional(CONF_PROXY_PARAMS): dict,
 })
 
 BASE_SERVICE_SCHEMA = vol.Schema({
@@ -245,8 +245,8 @@ def async_setup(hass, config):
         p_config.get(CONF_API_KEY),
         p_config.get(CONF_ALLOWED_CHAT_IDS),
         p_config.get(ATTR_PARSER),
-        p_config.get(ATTR_PROXY_URL),
-        p_config.get(ATTR_PROXY_PARAMS)
+        p_config.get(CONF_PROXY_URL),
+        p_config.get(CONF_PROXY_PARAMS)
     )
 
     @asyncio.coroutine


### PR DESCRIPTION
## Description:

This feature was [requested by a forum user about a month ago](https://community.home-assistant.io/t/add-socks5-proxy-support-for-telegram-features/21091) (and then also requested privately to my email !!). I did this minimal change for the user and it seems that works ok, but I can't say because I'm not behind a proxy.

The config is done with new optional parameters `proxy_url` and `proxy_params` (a dict).

If approved, I'll update the doc

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
telegram_bot:
  platform: polling
  api_key: !secret telegram_bot_api_key
  allowed_chat_ids:
    - !secret telegram_bot_chatid
  proxy_url: socks5://proxy_ip:proxy_port
  proxy_params:
    username: my-username
    password: my-secret-password
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
