### PR TITLE
Fix error when updating tado status

### DIFF
--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -288,7 +288,7 @@ class TadoClimate(ClimateDevice):
 
             if 'setting' in overlay_data:
                 setting_data = overlay_data['setting']
-                setting = setting is not None
+                setting = setting_data is not None
 
             if setting:
                 if 'mode' in setting_data:


### PR DESCRIPTION
## Description:
The tado climate component uses the wrong variable when updating the current mode for a zone. This causes an exception and the current state is not updated correctly.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
