### PR TITLE
Feature alexa launch request

### DIFF
--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -128,19 +128,13 @@ class AlexaIntentsView(http.HomeAssistantView):
         alexa_intent_info = req.get('intent')
         alexa_response = AlexaResponse(hass, alexa_intent_info)
 
-        if req_type == 'LaunchRequest':
-            alexa_response.add_speech(
-                SpeechType.plaintext,
-                "Hello, and welcome to the future. How may I help?")
-            return self.json(alexa_response)
-
-        if req_type != 'IntentRequest':
+        if req_type != 'IntentRequest' and req_type != 'LaunchRequest':
             _LOGGER.warning('Received unsupported request: %s', req_type)
             return self.json_message(
                 'Received unsupported request: {}'.format(req_type),
                 HTTP_BAD_REQUEST)
 
-        intent_name = alexa_intent_info['name']
+        intent_name = 'LaunchRequest' if req_type == 'LaunchRequest' else alexa_intent_info['name']
 
         try:
             intent_response = yield from intent.async_handle(

--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -135,7 +135,9 @@ class AlexaIntentsView(http.HomeAssistantView):
                 HTTP_BAD_REQUEST)
 
         if req_type == 'LaunchRequest':
-            intent_name = data.get('session', {}).get('application', {}).get('applicationId')
+            intent_name = data.get('session', {})       \
+                              .get('application', {})   \
+                              .get('applicationId')
         else:
             intent_name = alexa_intent_info['name']
 

--- a/homeassistant/components/alexa.py
+++ b/homeassistant/components/alexa.py
@@ -134,7 +134,10 @@ class AlexaIntentsView(http.HomeAssistantView):
                 'Received unsupported request: {}'.format(req_type),
                 HTTP_BAD_REQUEST)
 
-        intent_name = 'LaunchRequest' if req_type == 'LaunchRequest' else alexa_intent_info['name']
+        if req_type == 'LaunchRequest':
+            intent_name = data.get('session', {}).get('application', {}).get('applicationId')
+        else:
+            intent_name = alexa_intent_info['name']
 
         try:
             intent_response = yield from intent.async_handle(

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -182,6 +182,7 @@ def test_intent_launch_request_not_configured(alexa_client):
                                         {}).get("text")
     assert text == "This intent is not yet configured within Home Assistant."
 
+
 @asyncio.coroutine
 def test_intent_request_with_slots(alexa_client):
     """Test a request with slots."""

--- a/tests/components/test_alexa.py
+++ b/tests/components/test_alexa.py
@@ -100,6 +100,12 @@ def alexa_client(loop, hass, test_client):
                         },
                         "entity_id": "switch.test",
                     }
+                },
+                APPLICATION_ID: {
+                    "speech": {
+                        "type": "plain",
+                        "text": "LaunchRequest has been received.",
+                    }
                 }
             }
         }))
@@ -140,9 +146,41 @@ def test_intent_launch_request(alexa_client):
     }
     req = yield from _intent_req(alexa_client, data)
     assert req.status == 200
-    resp = yield from req.json()
-    assert "outputSpeech" in resp["response"]
+    data = yield from req.json()
+    text = data.get("response", {}).get("outputSpeech",
+                                        {}).get("text")
+    assert text == "LaunchRequest has been received."
 
+
+@asyncio.coroutine
+def test_intent_launch_request_not_configured(alexa_client):
+    """Test the launch of a request."""
+    data = {
+        "version": "1.0",
+        "session": {
+            "new": True,
+            "sessionId": SESSION_ID,
+            "application": {
+                "applicationId":
+                    'amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00000'
+            },
+            "attributes": {},
+            "user": {
+                "userId": "amzn1.account.AM3B00000000000000000000000"
+            }
+        },
+        "request": {
+            "type": "LaunchRequest",
+            "requestId": REQUEST_ID,
+            "timestamp": "2015-05-13T12:34:56Z"
+        }
+    }
+    req = yield from _intent_req(alexa_client, data)
+    assert req.status == 200
+    data = yield from req.json()
+    text = data.get("response", {}).get("outputSpeech",
+                                        {}).get("text")
+    assert text == "This intent is not yet configured within Home Assistant."
 
 @asyncio.coroutine
 def test_intent_request_with_slots(alexa_client):


### PR DESCRIPTION
## Description:
Add intent script support for the LaunchRequest skill request type.  This allows you to create skills that will respond in cases like "Alexa, Red Alert!".

Note: New to python, so may have made some coding standard violations.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3104

## Example entry for `configuration.yaml` (if applicable):
```yaml
intent_script:
  amzn1.ask.skill.08888888-7777-6666-5555-444444444444:
    action:
      service: script.turn_on
      entity_id: script.red_alert
    speech:
      type: plain
      text: OK
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
