### PR TITLE
Suppress exception if host is not available (fixes #8684)

### DIFF
--- a/homeassistant/components/media_player/pioneer.py
+++ b/homeassistant/components/media_player/pioneer.py
@@ -85,14 +85,13 @@ class PioneerDevice(MediaPlayerDevice):
         return None
 
     def telnet_command(self, command):
-        """Establish a telnet connection and sends `command`."""
+        """Establish a telnet connection and sends command."""
         try:
             try:
-                telnet = telnetlib.Telnet(self._host,
-                                          self._port,
-                                          self._timeout)
-            except ConnectionRefusedError:
-                _LOGGER.debug("Pioneer %s refused connection", self._name)
+                telnet = telnetlib.Telnet(
+                    self._host, self._port, self._timeout)
+            except (ConnectionRefusedError, OSError):
+                _LOGGER.warning("Pioneer %s refused connection", self._name)
                 return
             telnet.write(command.encode("ASCII") + b"\r")
             telnet.read_very_eager()  # skip response
@@ -105,8 +104,8 @@ class PioneerDevice(MediaPlayerDevice):
         """Get the latest details from the device."""
         try:
             telnet = telnetlib.Telnet(self._host, self._port, self._timeout)
-        except ConnectionRefusedError:
-            _LOGGER.debug("Pioneer %s refused connection", self._name)
+        except (ConnectionRefusedError, OSError):
+            _LOGGER.warning("Pioneer %s refused connection", self._name)
             return False
 
         pwstate = self.telnet_request(telnet, "?P", "PWR")


### PR DESCRIPTION
## Description:
Suppress exception if host is not available.

**Related issue (if applicable):** fixes #8684

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: pioneer
    host: 192.168.0.10
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

