### PR TITLE
python-insteonplm module version bump

### DIFF
--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 
-REQUIREMENTS = ['insteonplm==0.7.4']
+REQUIREMENTS = ['insteonplm==0.7.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -334,7 +334,7 @@ influxdb==3.0.0
 insteonlocal==0.52
 
 # homeassistant.components.insteon_plm
-insteonplm==0.7.4
+insteonplm==0.7.5
 
 # homeassistant.components.verisure
 jsonpath==0.75


### PR DESCRIPTION
Requiring python-insteonplm v0.7.5 (up from 0.7.4) now

## Description:

Simple point release on python-insteonplm package requirement.