### PR TITLE
Fix tradfri error spam

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -82,7 +82,6 @@ class TradfriGroup(Light):
 
     def update(self):
         """Fetch new state data for this group."""
-        _LOGGER.info('Updating tradfri group')  # FIXME: Remove after testing
         from pytradfri import RequestTimeout
         try:
             self._group.update()

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -71,7 +71,7 @@ class TradfriGroup(Light):
 
     def turn_off(self, **kwargs):
         """Instruct the group lights to turn off."""
-        return self._group.set_state(0)
+        self._group.set_state(0)
 
     def turn_on(self, **kwargs):
         """Instruct the group lights to turn on, or dim."""
@@ -158,7 +158,7 @@ class Tradfri(Light):
 
     def turn_off(self, **kwargs):
         """Instruct the light to turn off."""
-        return self._light_control.set_state(False)
+        self._light_control.set_state(False)
 
     def turn_on(self, **kwargs):
         """

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -82,7 +82,12 @@ class TradfriGroup(Light):
 
     def update(self):
         """Fetch new state data for this group."""
-        self._group.update()
+        _LOGGER.info('Updating tradfri group')  # FIXME: Remove after testing
+        from pytradfri import RequestTimeout
+        try:
+            self._group.update()
+        except RequestTimeout:
+            _LOGGER.error("Tradfri update request timed out")
 
 
 class Tradfri(Light):
@@ -181,7 +186,11 @@ class Tradfri(Light):
 
     def update(self):
         """Fetch new state data for this light."""
-        self._light.update()
+        from pytradfri import RequestTimeout
+        try:
+            self._light.update()
+        except RequestTimeout:
+            _LOGGER.error("Tradfri update request timed out")
 
         # Handle Hue lights paired with the gateway
         # hex_color is 0 when bulb is unreachable

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -86,7 +86,7 @@ class TradfriGroup(Light):
         try:
             self._group.update()
         except RequestTimeout:
-            _LOGGER.error("Tradfri update request timed out")
+            _LOGGER.warning("Tradfri update request timed out")
 
 
 class Tradfri(Light):
@@ -189,7 +189,7 @@ class Tradfri(Light):
         try:
             self._light.update()
         except RequestTimeout:
-            _LOGGER.error("Tradfri update request timed out")
+            _LOGGER.warning("Tradfri update request timed out")
 
         # Handle Hue lights paired with the gateway
         # hex_color is 0 when bulb is unreachable


### PR DESCRIPTION
## Description:
* Catch tradfri timout exception early.
* Remove not needed return statements.

**Related issue (if applicable):**
fixes #7461

## Example entry for `configuration.yaml` (if applicable):
```yaml
tradfri:
  host: 192.168.1.22
  api_key: !secret tradfri_api_key
```

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**