### PR TITLE
Wink discovery

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -33,6 +33,7 @@ SERVICE_IKEA_TRADFRI = 'ikea_tradfri'
 SERVICE_HASSIO = 'hassio'
 SERVICE_AXIS = 'axis'
 SERVICE_APPLE_TV = 'apple_tv'
+SERVICE_WINK = 'wink'
 
 SERVICE_HANDLERS = {
     SERVICE_HASS_IOS_APP: ('ios', None),
@@ -42,6 +43,7 @@ SERVICE_HANDLERS = {
     SERVICE_HASSIO: ('hassio', None),
     SERVICE_AXIS: ('axis', None),
     SERVICE_APPLE_TV: ('apple_tv', None),
+    SERVICE_WINK: ('wink', None),
     'philips_hue': ('light', 'hue'),
     'google_cast': ('media_player', 'cast'),
     'panasonic_viera': ('media_player', 'panasonic_viera'),

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -201,13 +201,13 @@ def setup(hass, config):
             return False
         pywink.set_bearer_token(token)
 
-    try:
+    if config.get(DOMAIN) is not None:
         client_id = config[DOMAIN].get(ATTR_CLIENT_ID)
         client_secret = config[DOMAIN].get(ATTR_CLIENT_SECRET)
         email = config[DOMAIN].get(CONF_EMAIL)
         password = config[DOMAIN].get(CONF_PASSWORD)
         local_control = config[DOMAIN].get(CONF_LOCAL_CONTROL)
-    except KeyError:
+    else:
         client_id = None
         client_secret = None
         email = None

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -201,11 +201,19 @@ def setup(hass, config):
             return False
         pywink.set_bearer_token(token)
 
-    client_id = config[DOMAIN].get(ATTR_CLIENT_ID)
-    client_secret = config[DOMAIN].get(ATTR_CLIENT_SECRET)
-    email = config[DOMAIN].get(CONF_EMAIL)
-    password = config[DOMAIN].get(CONF_PASSWORD)
-    local_control = config[DOMAIN].get(CONF_LOCAL_CONTROL)
+    try:
+        client_id = config[DOMAIN].get(ATTR_CLIENT_ID)
+        client_secret = config[DOMAIN].get(ATTR_CLIENT_SECRET)
+        email = config[DOMAIN].get(CONF_EMAIL)
+        password = config[DOMAIN].get(CONF_PASSWORD)
+        local_control = config[DOMAIN].get(CONF_LOCAL_CONTROL)
+    except KeyError:
+        client_id = None
+        client_secret = None
+        email = None
+        password = None
+        local_control = None
+        hass.data[DOMAIN]['configurator'] = True
     if None not in [client_id, client_secret]:
         _LOGGER.info("Using legacy oauth authentication")
         if not local_control:


### PR DESCRIPTION
## Description:
netdisco 1.1.0 added support for Wink discovery. This uses that new support to pop up the Wink configurator if a Wink hub v1, Wink hub v2, or Wink Relay is discovered. The configurator only supports setup of oauth. 

## Example entry for `configuration.yaml` (if applicable):
```yaml
discovery:
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
