### PR TITLE
History query and schema optimizations for huge performance boost

### DIFF
--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -106,7 +106,7 @@ def state_changes_during_period(hass, start_time, end_time=None,
             query = query.filter_by(entity_id=entity_id.lower())
 
         states = execute(
-            query.order_by(States.entity_id, States.last_updated))
+            query.order_by(States.last_updated))
 
     return states_to_json(hass, states, start_time, entity_id)
 

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -132,10 +132,10 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None,
             most_recent_state_ids = session.query(
                 States.state_id.label('max_state_id')
             ).filter(
-                (States.created < utc_point_in_time) &
+                (States.last_updated < utc_point_in_time) &
                 (States.entity_id.in_(entity_ids))
             ).order_by(
-                States.created.desc())
+                States.last_updated.desc())
 
             most_recent_state_ids = most_recent_state_ids.limit(1)
 
@@ -148,8 +148,8 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None,
                 States.entity_id.label('max_entity_id'),
                 func.max(States.last_updated).label('max_last_updated')
             ).filter(
-                (States.created >= run.start) &
-                (States.created < utc_point_in_time)
+                (States.last_updated >= run.start) &
+                (States.last_updated < utc_point_in_time)
             )
 
             if entity_ids:

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -97,7 +97,7 @@ def state_changes_during_period(hass, start_time, end_time=None,
     with session_scope(hass=hass) as session:
         query = session.query(States).filter(
             (States.last_changed == States.last_updated) &
-            (States.last_changed > start_time))
+            (States.last_updated > start_time))
 
         if end_time is not None:
             query = query.filter(States.last_updated < end_time)

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -200,10 +200,16 @@ def states_to_json(hass, states, start_time, entity_id, filters=None):
     entity_ids = [entity_id] if entity_id is not None else None
 
     # Get the states at the start time
+    timer_start = time.perf_counter()
     for state in get_states(hass, start_time, entity_ids, filters=filters):
         state.last_changed = start_time
         state.last_updated = start_time
         result[state.entity_id].append(state)
+
+    if _LOGGER.isEnabledFor(logging.DEBUG):
+        elapsed = time.perf_counter() - timer_start
+        _LOGGER.debug(
+            'getting %d first datapoints took %fs', len(result), elapsed)
 
     # Append all changes to it
     for ent_id, group in groupby(states, lambda state: state.entity_id):

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -30,7 +30,7 @@ def migrate_schema(instance):
             new_version = version + 1
             _LOGGER.info("Upgrading recorder db schema to version %s",
                          new_version)
-            _apply_update(instance.engine, new_version)
+            _apply_update(instance.engine, new_version, current_version)
             session.add(SchemaChanges(schema_version=new_version))
 
             _LOGGER.info("Upgrade to version %s done", new_version)
@@ -50,11 +50,71 @@ def _create_index(engine, table_name, index_name):
     # Look up the index object by name from the table is the the models
     index = next(idx for idx in table.indexes if idx.name == index_name)
     _LOGGER.debug("Creating %s index", index_name)
+    _LOGGER.info("Adding index `%s` to database. Note: this can take several "
+                 "minutes on large databases and slow computers. Please "
+                 "be patient!", index_name)
     index.create(engine)
     _LOGGER.debug("Finished creating %s", index_name)
 
 
-def _apply_update(engine, new_version):
+def _drop_index(engine, table_name, index_name):
+    """Drop an index from a specified table.
+
+    There is no universal way to do something like `DROP INDEX IF EXISTS`
+    so we will simply execute the DROP command and ignore any exceptions
+
+    WARNING: Due to some engines (MySQL at least) being unable to use bind
+    parameters in a DROP INDEX statement (at least via SQLAlchemy), the query
+    string here is generated from the method parameters without sanitizing.
+    DO NOT USE THIS FUNCTION IN ANY OPERATION THAT TAKES USER INPUT.
+    """
+    from sqlalchemy import text
+    from sqlalchemy.exc import SQLAlchemyError
+
+    _LOGGER.debug("Dropping index %s from table %s", index_name, table_name)
+    success = False
+
+    # Engines like DB2/Oracle
+    try:
+        engine.execute(text("DROP INDEX {index}".format(
+            index=index_name)))
+    except SQLAlchemyError:
+        pass
+    else:
+        success = True
+
+    # Engines like SQLite, SQL Server
+    if not success:
+        try:
+            engine.execute(text("DROP INDEX {table}.{index}".format(
+                index=index_name,
+                table=table_name)))
+        except SQLAlchemyError:
+            pass
+        else:
+            success = True
+
+    if not success:
+        # Engines like MySQL, MS Access
+        try:
+            engine.execute(text("DROP INDEX {index} ON {table}".format(
+                index=index_name,
+                table=table_name)))
+        except SQLAlchemyError:
+            pass
+        else:
+            success = True
+
+    if success:
+        _LOGGER.debug("Finished dropping index %s from table %s",
+                      index_name, table_name)
+    else:
+        _LOGGER.warning("Failed to drop index %s from table %s. Schema "
+                        "Migration will continue; this is not a "
+                        "critical operation.", index_name, table_name)
+
+
+def _apply_update(engine, new_version, old_version):
     """Perform operations to bring schema up to date."""
     if new_version == 1:
         _create_index(engine, "events", "ix_events_time_fired")
@@ -63,9 +123,26 @@ def _apply_update(engine, new_version):
         _create_index(engine, "recorder_runs", "ix_recorder_runs_start_end")
         # Create indexes for states
         _create_index(engine, "states", "ix_states_last_updated")
-        _create_index(engine, "states", "ix_states_entity_id_created")
     elif new_version == 3:
-        _create_index(engine, "states", "ix_states_created_domain")
+        # There used to be a new index here, but it was removed in version 4.
+        pass
+    elif new_version == 4:
+        # Queries were rewritten in this schema release. Most indexes from
+        # earlier versions of the schema are no longer needed.
+
+        if old_version == 3:
+            # Remove index that was added in version 3
+            _drop_index(engine, "states", "ix_states_created_domain")
+        if old_version == 2:
+            # Remove index that was added in version 2
+            _drop_index(engine, "states", "ix_states_entity_id_created")
+
+        # Remove indexes that were added in version 0
+        _drop_index(engine, "states", "states__state_changes")
+        _drop_index(engine, "states", "states__significant_changes")
+        _drop_index(engine, "states", "ix_states_entity_id_created")
+
+        _create_index(engine, "states", "ix_states_entity_id_last_updated")
     else:
         raise ValueError("No schema migration defined for version {}"
                          .format(new_version))

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -16,7 +16,7 @@ from homeassistant.remote import JSONEncoder
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,14 +70,11 @@ class States(Base):   # type: ignore
                           index=True)
     created = Column(DateTime(timezone=True), default=datetime.utcnow)
 
-    __table_args__ = (Index('states__state_changes',
-                            'last_changed', 'last_updated', 'entity_id'),
-                      Index('states__significant_changes',
-                            'domain', 'last_updated', 'entity_id'),
-                      Index('ix_states_entity_id_created',
-                            'entity_id', 'created'),
-                      Index('ix_states_created_domain',
-                            'created', 'domain'),)
+    __table_args__ = (
+        # Used for fetching the state of entities at a specific time
+        # (get_states in history.py)
+        Index(
+            'ix_states_entity_id_last_updated', 'entity_id', 'last_updated'),)
 
     @staticmethod
     def from_event(event):

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -16,12 +16,12 @@ def purge_old_data(instance, purge_days):
 
     with session_scope(session=instance.get_session()) as session:
         deleted_rows = session.query(States) \
-                              .filter((States.created < purge_before)) \
+                              .filter((States.last_updated < purge_before)) \
                               .delete(synchronize_session=False)
         _LOGGER.debug("Deleted %s states", deleted_rows)
 
         deleted_rows = session.query(Events) \
-                              .filter((Events.created < purge_before)) \
+                              .filter((Events.time_fired < purge_before)) \
                               .delete(synchronize_session=False)
         _LOGGER.debug("Deleted %s events", deleted_rows)
 

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -58,10 +58,19 @@ def execute(qry):
 
     for tryno in range(0, RETRIES):
         try:
-            return [
+            timer_start = time.perf_counter()
+            result = [
                 row for row in
                 (row.to_native() for row in qry)
                 if row is not None]
+
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                elapsed = time.perf_counter() - timer_start
+                _LOGGER.debug('converting %d rows to native objects took %fs',
+                              len(result),
+                              elapsed)
+
+            return result
         except SQLAlchemyError as err:
             _LOGGER.error("Error executing query: %s", err)
 

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -37,7 +37,7 @@ def test_schema_update_calls(hass):
         yield from wait_connection_ready(hass)
 
     update.assert_has_calls([
-        call(hass.data[DATA_INSTANCE].engine, version+1) for version
+        call(hass.data[DATA_INSTANCE].engine, version+1, 0) for version
         in range(0, SCHEMA_VERSION)])
 
 
@@ -64,4 +64,4 @@ def test_schema_migrate(hass):
 def test_invalid_update():
     """Test that an invalid new version raises an exception."""
     with pytest.raises(ValueError):
-        migration._apply_update(None, -1)
+        migration._apply_update(None, -1, 0)


### PR DESCRIPTION
## Description:
This is the culmination of all of my optimization research. It changes nearly all of the queries that touch the `states` table.

The end result of all of this is that every query I have tested executes in well under 1 second, even on a RPi using MySQL with 6 million rows and around 300 entities. This is true even when you're getting an unrealistically huge date range! (The bottleneck for history requests is now entirely inside Python, specifically the process that converts db rows to native objects.)

The user-facing end result of all of this is that the history page should load very fast now. It is still ~7 seconds on my overly large database because of the aforementioned bottleneck in the code, but it has nothing to do with the database anymore! It should also make using a history sensor FAR more efficient as well. I haven't done any specific performance tests there, but it is now benefiting from the same query optimizations as everything else (and since it is only fetching a small time period, the history page bottleneck should be of no concern to it.)

Here is the technical summary of the changes:

`get_significant_updates` and `state_changes_during_period`: The primary ORDER BY on `entity_id` was removed. This sorting made it impossible to use an index due to the fact that it is range filtering on the second sort dimension. As it turns out, we `groupby()` the rows in python when doing the json conversion anyway, so it's entirely not needed! (The latter function also had a typo in it, which must have been causing its own performance issues as it was range filtering between two different columns.)

`get_states`: This is the big one.

- The query has been significantly rewritten to properly utilize an index for the innermost (and most costly) GROUP BY clause.
- There is also a _very slight_ functional change to this query: instead of picking the highest `state_id`, we pick the highest `last_updated` entry. This is more appropriate because `state_id` does not guarantee the same ordering that the events fired.
- Also, we were doing the range filter by `created` before, which has a similar problem: this is just the time that the db row was _written_, not when the event was fired.
- The changes to use `last_updated` for everything is also what enables an efficient index to be used, because we are no longer using an aggregate function on a different column than we are filtering by!
- The domain and entity_id filters were moved to the outermost query as that result set will be very small and the filesort in that case is just fine.

`purge.py`: I changed the purge script to filter by `last_updated` for the same reasons mentioned above, and it allows this DELETE operation to use an index whereas before it could not.

`Schema Migration`: The db schema has been updated:

- I removed all of the superfluous indexes (some are no longer necessary, and others were actually pointless even before the query changes.) To do this, I needed to write a new function in the migrate script to drop the indexes. Sadly, this is messy, but it should be entirely functional on most db engines people use.
- I added one new index for `(entity_id, last_updated)`. Nearly every history query uses either this index or the already-existing `last_updated` index.

`Misc`: I added some DEBUG logging across the board that I think we should leave in, as it would help track down where the performance bottleneck is on any user's system. I also added an INFO level log message to the Migration script that informs the user that a new index is being created which could take quite some time. On my RPi3 with a way-too-big database, it takes 15 minutes!

**I recommend tagging this as a breaking change:** The deleted indexes could cause problems for users that might be querying the hass database directly. Pretty much anyone using the `created` column should just switch over to the `last_updated` column which will perform much better (and it will *probably* be more appropriate for what they're doing anyway.)

**Related issue (if applicable): n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable): n/a

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

