### PR TITLE
Honeywell fixes and improvements

### DIFF
--- a/homeassistant/components/climate/honeywell.py
+++ b/homeassistant/components/climate/honeywell.py
@@ -13,11 +13,12 @@ import voluptuous as vol
 
 from homeassistant.components.climate import (
     ClimateDevice, PLATFORM_SCHEMA, ATTR_FAN_MODE, ATTR_FAN_LIST,
-    ATTR_OPERATION_MODE, ATTR_OPERATION_LIST)
+    ATTR_OPERATION_MODE, ATTR_OPERATION_LIST, ENTITY_ID_FORMAT)
 from homeassistant.const import (
     CONF_PASSWORD, CONF_USERNAME, TEMP_CELSIUS, TEMP_FAHRENHEIT,
     ATTR_TEMPERATURE)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import async_generate_entity_id
 
 REQUIREMENTS = ['evohomeclient==0.2.5',
                 'somecomfort==0.4.1']
@@ -61,10 +62,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if region == 'us':
         return _setup_us(username, password, config, add_devices)
 
-    return _setup_round(username, password, config, add_devices)
+    return _setup_round(hass, username, password, config, add_devices)
 
 
-def _setup_round(username, password, config, add_devices):
+def _setup_round(hass, username, password, config, add_devices):
     """Set up the rounding function."""
     from evohomeclient import EvohomeClient
 
@@ -75,7 +76,7 @@ def _setup_round(username, password, config, add_devices):
         zones = evo_api.temperatures(force_refresh=True)
         for i, zone in enumerate(zones):
             add_devices(
-                [RoundThermostat(evo_api, zone['id'], i == 0, away_temp)]
+                [RoundThermostat(hass, evo_api, zone['id'], i == 0, away_temp)]
             )
     except socket.error:
         _LOGGER.error(
@@ -115,8 +116,9 @@ def _setup_us(username, password, config, add_devices):
 class RoundThermostat(ClimateDevice):
     """Representation of a Honeywell Round Connected thermostat."""
 
-    def __init__(self, device, zone_id, master, away_temp):
+    def __init__(self, hass, device, zone_id, master, away_temp):
         """Initialize the thermostat."""
+        self.hass = hass
         self.device = device
         self._current_temperature = None
         self._target_temperature = None
@@ -209,6 +211,24 @@ class RoundThermostat(ClimateDevice):
         else:
             self._name = data['name']
             self._is_dhw = False
+
+        if self.entity_id is None:
+            self.entity_id = async_generate_entity_id(
+                ENTITY_ID_FORMAT, self.name, hass=self.hass)
+
+        # The underlying library doesn't expose the thermostat's mode
+        # but we can pull it out of the big dictionary of information.
+
+        device_data = list(
+            filter(lambda x: x['name'] == self.name,
+                   self.device.full_data['devices']))
+
+        if device_data:
+            self.device.system_mode = (
+                device_data[0]['thermostat']
+                           ['changeableValues']['mode'])
+
+        self.hass.async_add_job(self.async_update_ha_state())
 
 
 class HoneywellUSThermostat(ClimateDevice):

--- a/tests/components/climate/test_honeywell.py
+++ b/tests/components/climate/test_honeywell.py
@@ -195,8 +195,8 @@ class TestHoneywell(unittest.TestCase):
             mock.call(force_refresh=True)
         )
         mock_round.assert_has_calls([
-            mock.call(mock_evo.return_value, 'foo', True, 20.0),
-            mock.call(mock_evo.return_value, 'bar', False, 20.0),
+            mock.call(hass, mock_evo.return_value, 'foo', True, 20.0),
+            mock.call(hass, mock_evo.return_value, 'bar', False, 20.0),
         ])
         self.assertEqual(2, add_devices.call_count)
 
@@ -220,8 +220,8 @@ class TestHoneywell(unittest.TestCase):
         add_devices = mock.MagicMock()
         self.assertTrue(honeywell.setup_platform(hass, config, add_devices))
         mock_round.assert_has_calls([
-            mock.call(mock_evo.return_value, 'foo', True, 16),
-            mock.call(mock_evo.return_value, 'bar', False, 16),
+            mock.call(hass, mock_evo.return_value, 'foo', True, 16),
+            mock.call(hass, mock_evo.return_value, 'bar', False, 16),
         ])
 
     @mock.patch('evohomeclient.EvohomeClient')
@@ -272,11 +272,12 @@ class TestHoneywellRound(unittest.TestCase):
             return temps
 
         self.device = mock.MagicMock()
+        hass = mock.MagicMock()
         self.device.temperatures.side_effect = fake_temperatures
-        self.round1 = honeywell.RoundThermostat(self.device, '1',
-                                                True, 16)
-        self.round2 = honeywell.RoundThermostat(self.device, '2',
-                                                False, 17)
+        self.round1 = honeywell.RoundThermostat(hass, self.device,
+                                                '1', True, 16)
+        self.round2 = honeywell.RoundThermostat(hass, self.device,
+                                                '2', False, 17)
 
     def test_attributes(self):
         """Test the attributes."""


### PR DESCRIPTION
## Description:
Update Honeywell ClimateDevice to have a meaningful state and to raise state_changed events when the state has changed.

**Related issue (if applicable):** fixes #8688 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
