### PR TITLE
Explicit entity ids

### DIFF
--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -208,14 +208,14 @@ class BrSensor(Entity):
 
             return result
 
-        result =  {
+        result = {
             ATTR_ATTRIBUTION: self._attribution,
             SENSOR_TYPES['stationname'][0]: self._stationname,
         }
         if self._measured is not None:
             # convert datetime (Europe/Amsterdam) into local datetime
-            dt = dt_util.as_local(self._measured)
-            result[MEASURED_LABEL] = dt.strftime("%c")
+            local_dt = dt_util.as_local(self._measured)
+            result[MEASURED_LABEL] = local_dt.strftime("%c")
 
         return result
 

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -13,7 +13,7 @@ import aiohttp
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.sensor import PLATFORM_SCHEMA, ENTITY_ID_FORMAT
 from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_LATITUDE, CONF_LONGITUDE,
     CONF_MONITORED_CONDITIONS, CONF_NAME, TEMP_CELSIUS)
@@ -23,10 +23,11 @@ from homeassistant.helpers.event import (
     async_track_point_in_utc_time)
 from homeassistant.util import dt as dt_util
 
-REQUIREMENTS = ['buienradar==0.7']
+REQUIREMENTS = ['buienradar==0.8']
 
 _LOGGER = logging.getLogger(__name__)
 
+MEASURED_LABEL = 'Measured'
 TIMEFRAME_LABEL = 'Timeframe'
 # Schedule next call after (minutes):
 SCHEDULE_OK = 10
@@ -40,12 +41,12 @@ SENSOR_TYPES = {
     'symbol': ['Symbol', None, None],
     'humidity': ['Humidity', '%', 'mdi:water-percent'],
     'temperature': ['Temperature', TEMP_CELSIUS, 'mdi:thermometer'],
-    'groundtemperature': ['Ground Temperature', TEMP_CELSIUS,
+    'groundtemperature': ['Ground temperature', TEMP_CELSIUS,
                           'mdi:thermometer'],
     'windspeed': ['Wind speed', 'm/s', 'mdi:weather-windy'],
     'windforce': ['Wind force', 'Bft', 'mdi:weather-windy'],
     'winddirection': ['Wind direction', None, 'mdi:compass-outline'],
-    'windazimuth': ['Wind direction azimuth', '°', 'mdi:compass-outline'],
+    'windazimuth': ['Wind azimuth', '°', 'mdi:compass-outline'],
     'pressure': ['Pressure', 'hPa', 'mdi:gauge'],
     'visibility': ['Visibility', 'm', None],
     'windgust': ['Wind gust', 'm/s', 'mdi:weather-windy'],
@@ -110,9 +111,11 @@ class BrSensor(Entity):
         from buienradar.buienradar import (PRECIPITATION_FORECAST)
 
         self.client_name = client_name
-        self._name = SENSOR_TYPES[sensor_type][0]
         self.type = sensor_type
+        e_id = '{}_{}'.format(self.client_name, self.type)
+        self.entity_id = ENTITY_ID_FORMAT.format(e_id)
         self._state = None
+        self._name = SENSOR_TYPES[sensor_type][0]
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
         self._entity_picture = None
         self._attribution = None
@@ -171,7 +174,7 @@ class BrSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return '{} {}'.format(self.client_name, self._name)
+        return self._name
 
     @property
     def state(self):
@@ -205,10 +208,16 @@ class BrSensor(Entity):
 
             return result
 
-        return {
+        result =  {
             ATTR_ATTRIBUTION: self._attribution,
             SENSOR_TYPES['stationname'][0]: self._stationname,
         }
+        if self._measured is not None:
+            # convert datetime (Europe/Amsterdam) into local datetime
+            dt = dt_util.as_local(self._measured)
+            result[MEASURED_LABEL] = dt.strftime("%c")
+
+        return result
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/weather/buienradar.py
+++ b/homeassistant/components/weather/buienradar.py
@@ -16,7 +16,7 @@ from homeassistant.components.sensor.buienradar import (
     BrData)
 import voluptuous as vol
 
-REQUIREMENTS = ['buienradar==0.7']
+REQUIREMENTS = ['buienradar==0.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -124,7 +124,7 @@ broadlink==0.5
 
 # homeassistant.components.sensor.buienradar
 # homeassistant.components.weather.buienradar
-buienradar==0.7
+buienradar==0.8
 
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2


### PR DESCRIPTION
## Description:

Buienradar sensor
============

**1:  Entity_id set explicit (Breaking Change)**
    Before the buienradar sensors were not explicitly setting the sensor's entity_id, so the entity_id was derived by homeassustant from the sensor's display/friendly name.
    This caused some subtle differences between the monitored_condition users have to configure in the config and the resulting sensors/entity_ids in homeassitant, causing confusion.

Entity_ids are now set as follows:
   
    **name** (_Optional_): 
    You can specify a name of the component, but do not have to. 
    If you specify a name, the sensors will get an entity_id of 'sensor.[name]_[monitored_condition], 
    for example: 'sensor.lopik_temperature' or 'sensor.weather_groundtemperature'; 
   
    if no name is specified the sensors will be called sensor.br_[monitored_condition], 
    for example 'sensor.br_temperature' or 'sensor.br_winddirection'
   
   
**Breaking Change:**
For the monitored_conditions shown below the sensor's entity_id will change:
   
* monitored_condition: grountemperature
   previous entity_id: 'sensor.[name]_ground_temperature' or 'sensor.br_ground_temperature'
   new entity_id: 'sensor.[name]_groundtemperature' or 'sensor.br_groundtemperature'
* monitored_condition: windspeed
   previous entity_id: 'sensor.[name]_wind_speed' or 'sensor.br_wind_speed'
   new entity_id: 'sensor.[name]_windspeed' or 'sensor.br_windspeed'
* monitored_condition: windforce
   previous entity_id: 'sensor.[name]_wind_force' or 'sensor.br_wind_force'
   new entity_id: 'sensor.[name]_windforce' or 'sensor.br_windforce'
* monitored_condition: winddirection
   previous entity_id: 'sensor.[name]_wind_direction' or 'sensor.br_wind_direction'
   new entity_id: 'sensor.[name]_winddirection' or 'sensor.br_winddirection'
* monitored_condition: windazimuth
   previous entity_id: 'sensor.[name]_wind_direction_azimuth' or 'sensor.br_wind_direction_azimuth'
   new entity_id: 'sensor.[name]_windazimuth' or 'sensor.br_windazimuth'
* monitored_condition: windgust
   previous entity_id: 'sensor.[name]_wind_gust' or 'sensor.br_wind_gust'
   new entity_id: 'sensor.[name]_windgust' or 'sensor.br_windgust'
  
**2:  Attribution of a Buienradar sensor will now show the actual datetime of measurement at the weatherstation.**
    (this might be up to 10-20 minutes before the update was detected over the buienradar API.)
    
Buienradar weather
==================
Forecasted temperatures are now shown at noon (dutch time (Europe/Amsterdam)) and not at midnight, and take timezone into account.


**Related issue (if applicable):** 
none

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3114

## Example entry for `configuration.yaml` (if applicable):

unchanged / see docu

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
