### PR TITLE
Change units from KW to W

### DIFF
--- a/homeassistant/components/sensor/efergy.py
+++ b/homeassistant/components/sensor/efergy.py
@@ -33,11 +33,11 @@ CONF_CURRENT_VALUES = 'current_values'
 DEFAULT_PERIOD = 'year'
 
 SENSOR_TYPES = {
-    CONF_INSTANT: ['Energy Usage', 'kW'],
+    CONF_INSTANT: ['Energy Usage', 'W'],
     CONF_AMOUNT: ['Energy Consumed', 'kWh'],
     CONF_BUDGET: ['Energy Budget', None],
     CONF_COST: ['Energy Cost', None],
-    CONF_CURRENT_VALUES: ['Per-Device Usage', 'kW']
+    CONF_CURRENT_VALUES: ['Per-Device Usage', 'W']
 }
 
 TYPES_SCHEMA = vol.In(SENSOR_TYPES)
@@ -120,7 +120,7 @@ class EfergySensor(Entity):
             if self.type == 'instant_readings':
                 url_string = _RESOURCE + 'getInstant?token=' + self.app_token
                 response = get(url_string, timeout=10)
-                self._state = response.json()['reading'] / 1000
+                self._state = response.json()['reading']
             elif self.type == 'amount':
                 url_string = _RESOURCE + 'getEnergy?token=' + self.app_token \
                     + '&offset=' + self.utc_offset + '&period=' \
@@ -144,7 +144,7 @@ class EfergySensor(Entity):
                 for sensor in response.json():
                     if self.sid == sensor['sid']:
                         measurement = next(iter(sensor['data'][0].values()))
-                        self._state = measurement / 1000
+                        self._state = measurement
             else:
                 self._state = 'Unknown'
         except (RequestException, ValueError, KeyError):

--- a/tests/components/sensor/test_efergy.py
+++ b/tests/components/sensor/test_efergy.py
@@ -85,13 +85,13 @@ class TestEfergySensor(unittest.TestCase):
               'sensor': ONE_SENSOR_CONFIG})
         self.assertEqual('38.21',
                          self.hass.states.get('sensor.energy_consumed').state)
-        self.assertEqual('1.58',
+        self.assertEqual('1580',
                          self.hass.states.get('sensor.energy_usage').state)
         self.assertEqual('ok',
                          self.hass.states.get('sensor.energy_budget').state)
         self.assertEqual('5.27',
                          self.hass.states.get('sensor.energy_cost').state)
-        self.assertEqual('1.628',
+        self.assertEqual('1628',
                          self.hass.states.get('sensor.efergy_728386').state)
 
     @requests_mock.Mocker()
@@ -100,9 +100,9 @@ class TestEfergySensor(unittest.TestCase):
         mock_responses(mock)
         assert setup_component(self.hass, 'sensor', {
               'sensor': MULTI_SENSOR_CONFIG})
-        self.assertEqual('0.218',
+        self.assertEqual('218',
                          self.hass.states.get('sensor.efergy_728386').state)
-        self.assertEqual('1.808',
+        self.assertEqual('1808',
                          self.hass.states.get('sensor.efergy_0').state)
-        self.assertEqual('0.312',
+        self.assertEqual('312',
                          self.hass.states.get('sensor.efergy_728387').state)


### PR DESCRIPTION
Change power unit from kW to W to be consistent with other energy sensors.

## Description:
The SI unit for power is W. Inconsistent use of kW and W messes up exporting values to Influx/Prometheus endpoint for instance. Billing is usually done by kWh which makes sense to keep as a unit though.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
