### PR TITLE
Fix issues with latest Motion firmware

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -82,7 +82,7 @@ def setup(hass, config):
                                 config)
 
     def get_model_from_uuid(uuid):
-        """Determine Wemo model from UUID"""
+        """Determine Wemo model from UUID."""
         if uuid is None:
             return None
         elif uuid.startswith('uuid:Socket'):

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -101,7 +101,7 @@ def setup(hass, config):
             return 'CoffeeMaker'
         else:
             return None
-        
+
     discovery.listen(hass, SERVICE_WEMO, discovery_dispatch)
 
     _LOGGER.info("Scanning for WeMo devices.")

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -15,8 +15,6 @@ from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-from pywemo.ouimeaux_device.api.xsd import device as deviceParser
-
 REQUIREMENTS = ['pywemo==0.4.19']
 
 DOMAIN = 'wemo'
@@ -52,7 +50,8 @@ CONFIG_SCHEMA = vol.Schema({
 def setup(hass, config):
     """Set up for WeMo devices."""
     import pywemo
-
+    from pywemo.ouimeaux_device.api.xsd import device as deviceParser
+    
     global SUBSCRIPTION_REGISTRY
     SUBSCRIPTION_REGISTRY = pywemo.SubscriptionRegistry()
     SUBSCRIPTION_REGISTRY.start()

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -51,7 +51,7 @@ def setup(hass, config):
     """Set up for WeMo devices."""
     import pywemo
     from pywemo.ouimeaux_device.api.xsd import device as deviceParser
-    
+
     global SUBSCRIPTION_REGISTRY
     SUBSCRIPTION_REGISTRY = pywemo.SubscriptionRegistry()
     SUBSCRIPTION_REGISTRY.start()

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/wemo/
 import logging
 
 import voluptuous as vol
-
 import requests
 
 from homeassistant.components.discovery import SERVICE_WEMO
@@ -83,7 +82,7 @@ def setup(hass, config):
                                 config)
 
     def get_model_from_uuid(uuid):
-        """ Tries to determine which device it is based on the uuid. """
+        """Determine Wemo model from UUID"""
         if uuid is None:
             return None
         elif uuid.startswith('uuid:Socket'):
@@ -102,8 +101,7 @@ def setup(hass, config):
             return 'CoffeeMaker'
         else:
             return None
-
-
+        
     discovery.listen(hass, SERVICE_WEMO, discovery_dispatch)
 
     _LOGGER.info("Scanning for WeMo devices.")
@@ -127,7 +125,8 @@ def setup(hass, config):
         xml = requests.get(url, timeout=10)
         uuid = deviceParser.parseString(xml.content).device.UDN
 
-        _LOGGER.debug("Device UUID is %s, this makes it a %s", uuid, get_model_from_uuid(uuid))
+        _LOGGER.debug("Device UUID is %s, this makes it a %s ",
+                      uuid, get_model_from_uuid(uuid))
 
         discovery_info = {
             'model_name': get_model_from_uuid(uuid),

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -8,11 +8,15 @@ import logging
 
 import voluptuous as vol
 
+import requests
+
 from homeassistant.components.discovery import SERVICE_WEMO
 from homeassistant.helpers import discovery
 from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
+from pywemo.ouimeaux_device.api.xsd import device as deviceParser
 
 REQUIREMENTS = ['pywemo==0.4.19']
 
@@ -24,8 +28,10 @@ WEMO_MODEL_DISPATCH = {
     'Insight': 'switch',
     'Maker':   'switch',
     'Sensor':  'binary_sensor',
+    'Motion':  'binary_sensor',
     'Socket':  'switch',
     'LightSwitch': 'switch',
+    'Switch': 'switch',
     'CoffeeMaker': 'switch'
 }
 
@@ -76,6 +82,28 @@ def setup(hass, config):
         discovery.load_platform(hass, component, DOMAIN, discovery_info,
                                 config)
 
+    def get_model_from_uuid(uuid):
+        """ Tries to determine which device it is based on the uuid. """
+        if uuid is None:
+            return None
+        elif uuid.startswith('uuid:Socket'):
+            return 'Switch'
+        elif uuid.startswith('uuid:Lightswitch'):
+            return 'LightSwitch'
+        elif uuid.startswith('uuid:Insight'):
+            return 'Insight'
+        elif uuid.startswith('uuid:Sensor'):
+            return 'Motion'
+        elif uuid.startswith('uuid:Maker'):
+            return 'Maker'
+        elif uuid.startswith('uuid:Bridge'):
+            return 'Bridge'
+        elif uuid.startswith('uuid:CoffeeMaker'):
+            return 'CoffeeMaker'
+        else:
+            return None
+
+
     discovery.listen(hass, SERVICE_WEMO, discovery_dispatch)
 
     _LOGGER.info("Scanning for WeMo devices.")
@@ -96,8 +124,13 @@ def setup(hass, config):
         if device is None:
             device = pywemo.discovery.device_from_description(url, None)
 
+        xml = requests.get(url, timeout=10)
+        uuid = deviceParser.parseString(xml.content).device.UDN
+
+        _LOGGER.debug("Device UUID is %s, this makes it a %s", uuid, get_model_from_uuid(uuid))
+
         discovery_info = {
-            'model_name': device.model_name,
+            'model_name': get_model_from_uuid(uuid),
             'serial': device.serialnumber,
             'mac_address': device.mac,
             'ssdp_description': url,


### PR DESCRIPTION
## Description:
The latest firmware for Wemo Motion sometimes sets the model name to "Socket". The UUID string is always correct, so this PR moves detection over to use that. I fully understand it probably needs better code, my Python is pretty bad...

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**