### PR TITLE
Add support for file attachments in pushbullet

### DIFF
--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -91,7 +91,7 @@ class PushBulletNotificationService(BaseNotificationService):
             # Backward compatibility, notify all devices in own account
             if url:
                 self.pushbullet.push_link(title, url, body=message)
-            if filepath:
+            if self.hass.config.is_allowed_path(filepath):
                 with open(filepath, "rb") as fileh:
                     filedata = self.pushbullet.upload_file(fileh, filepath)
                     self.pushbullet.push_file(title=title, body=message,
@@ -115,7 +115,7 @@ class PushBulletNotificationService(BaseNotificationService):
                 if url:
                     self.pushbullet.push_link(
                         title, url, body=message, email=tname)
-                if filepath:
+                if self.hass.config.is_allowed_path(filepath):
                     with open(filepath, "rb") as fileh:
                         filedata = self.pushbullet.upload_file(fileh, filepath)
                         self.pushbullet.push_file(title=title, body=message,

--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -19,6 +19,7 @@ REQUIREMENTS = ['pushbullet.py==0.11.0']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_URL = 'url'
+ATTR_FILE = 'file'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
@@ -80,14 +81,21 @@ class PushBulletNotificationService(BaseNotificationService):
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
         data = kwargs.get(ATTR_DATA)
         url = None
+        filepath = None
         if data:
             url = data.get(ATTR_URL, None)
+            filepath = data.get(ATTR_FILE, None)
         refreshed = False
 
         if not targets:
             # Backward compatibility, notify all devices in own account
             if url:
                 self.pushbullet.push_link(title, url, body=message)
+            if filepath:
+                with open(filepath, "rb") as fileh:
+                    filedata = self.pushbullet.upload_file(fileh, filepath)
+                    self.pushbullet.push_file(title=title, body=message,
+                                              **filedata)
             else:
                 self.pushbullet.push_note(title, message)
             _LOGGER.info("Sent notification to self")
@@ -107,6 +115,11 @@ class PushBulletNotificationService(BaseNotificationService):
                 if url:
                     self.pushbullet.push_link(
                         title, url, body=message, email=tname)
+                if filepath:
+                    with open(filepath, "rb") as fileh:
+                        filedata = self.pushbullet.upload_file(fileh, filepath)
+                        self.pushbullet.push_file(title=title, body=message,
+                                                  **filedata)
                 else:
                     self.pushbullet.push_note(title, message, email=tname)
                 _LOGGER.info("Sent notification to email %s", tname)


### PR DESCRIPTION
## Description:
This should allow users to provide a file to be uploaded via Pushbullet. A good use case for this, is sending a picture.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
