### PR TITLE
buienradar dates tz-aware

### DIFF
--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -23,10 +23,11 @@ from homeassistant.helpers.event import (
     async_track_point_in_utc_time)
 from homeassistant.util import dt as dt_util
 
-REQUIREMENTS = ['buienradar==0.7']
+REQUIREMENTS = ['buienradar==0.8']
 
 _LOGGER = logging.getLogger(__name__)
 
+MEASURED_LABEL = 'Measured'
 TIMEFRAME_LABEL = 'Timeframe'
 # Schedule next call after (minutes):
 SCHEDULE_OK = 10
@@ -40,7 +41,7 @@ SENSOR_TYPES = {
     'symbol': ['Symbol', None, None],
     'humidity': ['Humidity', '%', 'mdi:water-percent'],
     'temperature': ['Temperature', TEMP_CELSIUS, 'mdi:thermometer'],
-    'groundtemperature': ['Ground Temperature', TEMP_CELSIUS,
+    'groundtemperature': ['Ground temperature', TEMP_CELSIUS,
                           'mdi:thermometer'],
     'windspeed': ['Wind speed', 'm/s', 'mdi:weather-windy'],
     'windforce': ['Wind force', 'Bft', 'mdi:weather-windy'],
@@ -205,10 +206,16 @@ class BrSensor(Entity):
 
             return result
 
-        return {
+        result = {
             ATTR_ATTRIBUTION: self._attribution,
             SENSOR_TYPES['stationname'][0]: self._stationname,
         }
+        if self._measured is not None:
+            # convert datetime (Europe/Amsterdam) into local datetime
+            local_dt = dt_util.as_local(self._measured)
+            result[MEASURED_LABEL] = local_dt.strftime("%c")
+
+        return result
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/weather/buienradar.py
+++ b/homeassistant/components/weather/buienradar.py
@@ -16,7 +16,7 @@ from homeassistant.components.sensor.buienradar import (
     BrData)
 import voluptuous as vol
 
-REQUIREMENTS = ['buienradar==0.7']
+REQUIREMENTS = ['buienradar==0.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -124,7 +124,7 @@ broadlink==0.5
 
 # homeassistant.components.sensor.buienradar
 # homeassistant.components.weather.buienradar
-buienradar==0.7
+buienradar==0.8
 
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2


### PR DESCRIPTION
## Description:

**Sensor:**
Attribution of a Buienradar sensor will now show the actual datetime of measurement at the weatherstation. (this might be up to 10-20 minutes before the update was detected over the buienradar API.)

**Weather**:
Forecasted data are now timezone aware and is attributed to noon dutch time (Europe/Amsterdam) and not at midnight. This will allow someone to correctly show buienradar weather forecast when not running in Europe/Amsterdam timezone.

**No updated documentation**
**No config changes**

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
