### PR TITLE
When Sonos gets a tts source - dont't show an image

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -695,6 +695,9 @@ class SonosDevice(MediaPlayerDevice):
         if url in ('', 'NOT_IMPLEMENTED', None):
             if fallback_uri in ('', 'NOT_IMPLEMENTED', None):
                 return None
+            if fallback_uri.find('tts_proxy') > 0:
+                # If the content is a tts don't try to fetch an image from it.
+                return None
             return 'http://{host}:{port}/getaa?s=1&u={uri}'.format(
                 host=self._player.ip_address,
                 port=1400,


### PR DESCRIPTION
## Description:

When Sonos gets a tts source - dont't show an image

**Related issue (if applicable):** related #8170

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
