### PR TITLE
Support changing the bulb color for tplink smartbulbs, fixes #8766

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -94,7 +94,6 @@ class TPLinkSmartBulb(Light):
             self.smartbulb.brightness = brightness_to_percentage(brightness)
         if ATTR_RGB_COLOR in kwargs:
             rgb = kwargs.get(ATTR_RGB_COLOR)
-            self._rgb = rgb
             self.smartbulb.hsv = rgb_to_hsv(rgb)
 
 

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -59,7 +59,7 @@ def hsv_to_rgb(hsv: Tuple[float, float, float]) -> Tuple[int, int, int]:
 class TPLinkSmartBulb(Light):
     """Representation of a TPLink Smart Bulb."""
 
-    def __init__(self, smartbulb: SmartBulb, name):
+    def __init__(self, smartbulb: 'SmartBulb', name):
         """Initialize the bulb."""
         self.smartbulb = smartbulb
 

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -59,9 +59,9 @@ def hsv_to_rgb(hsv: Tuple[float, float, float]) -> Tuple[int, int, int]:
 class TPLinkSmartBulb(Light):
     """Representation of a TPLink Smart Bulb."""
 
-    def __init__(self, smartbulb, name):
+    def __init__(self, smartbulb: SmartBulb, name):
         """Initialize the bulb."""
-        self.smartbulb = smartbulb  # type: SmartBulb
+        self.smartbulb = smartbulb
 
         # Use the name set on the device if not set
         if name is None:

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -44,16 +44,16 @@ def brightness_from_percentage(percent):
     return (percent*255.0)/100.0
 
 
-def rgb_to_hsv(rgb: Tuple[float, float, float]) -> Tuple[float, float, float]:
+def rgb_to_hsv(rgb: Tuple[float, float, float]) -> Tuple[int, int, int]:
     """Convert RGB tuple (values 0-255) to HSV (degrees, %, %)."""
     h, s, v = colorsys.rgb_to_hsv(rgb[0]/255, rgb[1]/255, rgb[2]/255)
     return int(h * 360), int(s * 100), int(v * 100)
 
 
-def hsv_to_rgb(hsv: Tuple[float, float, float]) -> Tuple[float, float, float]:
+def hsv_to_rgb(hsv: Tuple[float, float, float]) -> Tuple[int, int, int]:
     """Convert HSV tuple (degrees, %, %) to RGB (values 0-255)."""
     r, g, b = colorsys.hsv_to_rgb(hsv[0]/360, hsv[1]/100, hsv[2]/100)
-    return r * 255, g * 255, b * 255
+    return int(r * 255), int(g * 255), int(b * 255)
 
 
 class TPLinkSmartBulb(Light):

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -15,9 +15,7 @@ from homeassistant.util.color import \
 from homeassistant.util.color import (
     color_temperature_kelvin_to_mired as kelvin_to_mired)
 
-from typing import Tuple, TYPE_CHECKING
-if TYPE_CHECKING:
-    from pyHS100 import SmartBulb
+from typing import Tuple
 
 REQUIREMENTS = ['pyHS100==0.2.4.2']
 
@@ -95,8 +93,6 @@ class TPLinkSmartBulb(Light):
         if ATTR_RGB_COLOR in kwargs:
             rgb = kwargs.get(ATTR_RGB_COLOR)
             self.smartbulb.hsv = rgb_to_hsv(rgb)
-
-
 
     def turn_off(self):
         """Turn the light off."""

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -42,12 +42,16 @@ def brightness_from_percentage(percent):
     return (percent*255.0)/100.0
 
 
+# Travis-CI runs too old astroid https://github.com/PyCQA/pylint/issues/1212
+# pylint: disable=invalid-sequence-index
 def rgb_to_hsv(rgb: Tuple[float, float, float]) -> Tuple[int, int, int]:
     """Convert RGB tuple (values 0-255) to HSV (degrees, %, %)."""
     hue, sat, value = colorsys.rgb_to_hsv(rgb[0]/255, rgb[1]/255, rgb[2]/255)
     return int(hue * 360), int(sat * 100), int(value * 100)
 
 
+# Travis-CI runs too old astroid https://github.com/PyCQA/pylint/issues/1212
+# pylint: disable=invalid-sequence-index
 def hsv_to_rgb(hsv: Tuple[float, float, float]) -> Tuple[int, int, int]:
     """Convert HSV tuple (degrees, %, %) to RGB (values 0-255)."""
     red, green, blue = colorsys.hsv_to_rgb(hsv[0]/360, hsv[1]/100, hsv[2]/100)

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -46,14 +46,14 @@ def brightness_from_percentage(percent):
 
 def rgb_to_hsv(rgb: Tuple[float, float, float]) -> Tuple[int, int, int]:
     """Convert RGB tuple (values 0-255) to HSV (degrees, %, %)."""
-    h, s, v = colorsys.rgb_to_hsv(rgb[0]/255, rgb[1]/255, rgb[2]/255)
-    return int(h * 360), int(s * 100), int(v * 100)
+    hue, sat, value = colorsys.rgb_to_hsv(rgb[0]/255, rgb[1]/255, rgb[2]/255)
+    return int(hue * 360), int(sat * 100), int(value * 100)
 
 
 def hsv_to_rgb(hsv: Tuple[float, float, float]) -> Tuple[int, int, int]:
     """Convert HSV tuple (degrees, %, %) to RGB (values 0-255)."""
-    r, g, b = colorsys.hsv_to_rgb(hsv[0]/360, hsv[1]/100, hsv[2]/100)
-    return int(r * 255), int(g * 255), int(b * 255)
+    red, green, blue = colorsys.hsv_to_rgb(hsv[0]/360, hsv[1]/100, hsv[2]/100)
+    return int(red * 255), int(green * 255), int(blue * 255)
 
 
 class TPLinkSmartBulb(Light):

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -47,7 +47,7 @@ def brightness_from_percentage(percent):
 def rgb_to_hsv(rgb: Tuple[float, float, float]) -> Tuple[float, float, float]:
     """Convert RGB tuple (values 0-255) to HSV (degrees, %, %)."""
     h, s, v = colorsys.rgb_to_hsv(rgb[0]/255, rgb[1]/255, rgb[2]/255)
-    return h * 360, s * 100, v * 100
+    return int(h * 360), int(s * 100), int(v * 100)
 
 
 def hsv_to_rgb(hsv: Tuple[float, float, float]) -> Tuple[float, float, float]:

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/light.tplink/
 """
 import logging
+import colorsys
 from homeassistant.const import (CONF_HOST, CONF_NAME)
 from homeassistant.components.light import (
     Light, ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_KELVIN, ATTR_RGB_COLOR,
@@ -13,7 +14,6 @@ from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 from homeassistant.util.color import (
     color_temperature_kelvin_to_mired as kelvin_to_mired)
-import colorsys
 
 from typing import Tuple, TYPE_CHECKING
 if TYPE_CHECKING:
@@ -113,6 +113,7 @@ class TPLinkSmartBulb(Light):
 
     @property
     def rgb_color(self):
+        """Return the color in RGB."""
         return self._rgb
 
     @property

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -78,7 +78,7 @@ class TPLinkSmartBulb(Light):
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness or 255)
             self.smartbulb.brightness = brightness_to_percentage(brightness)
-        if ATTR_RGB_COLOR:
+        if ATTR_RGB_COLOR in kwargs:
             rgb = kwargs.get(ATTR_RGB_COLOR)
             self._rgb = rgb
             self.smartbulb.hsv = color_RGB_to_hsv(rgb[0], rgb[1], rgb[2])

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -7,12 +7,17 @@ https://home-assistant.io/components/light.tplink/
 import logging
 from homeassistant.const import (CONF_HOST, CONF_NAME)
 from homeassistant.components.light import (
-    Light, ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_KELVIN,
-    SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP)
+    Light, ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_KELVIN, ATTR_RGB_COLOR,
+    SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR)
 from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
-from homeassistant.util.color import \
-    color_temperature_kelvin_to_mired as kelvin_to_mired
+from homeassistant.util.color import (
+    color_RGB_to_hsv, color_hsv_to_RGB,
+    color_temperature_kelvin_to_mired as kelvin_to_mired)
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from pyHS100 import SmartBulb
 
 REQUIREMENTS = ['pyHS100==0.2.4.2']
 
@@ -44,7 +49,7 @@ class TPLinkSmartBulb(Light):
 
     def __init__(self, smartbulb, name):
         """Initialize the bulb."""
-        self.smartbulb = smartbulb
+        self.smartbulb = smartbulb  # type: SmartBulb
 
         # Use the name set on the device if not set
         if name is None:
@@ -55,6 +60,7 @@ class TPLinkSmartBulb(Light):
         self._state = None
         self._color_temp = None
         self._brightness = None
+        self._rgb = None
         _LOGGER.debug("Setting up TP-Link Smart Bulb")
 
     @property
@@ -72,6 +78,11 @@ class TPLinkSmartBulb(Light):
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness or 255)
             self.smartbulb.brightness = brightness_to_percentage(brightness)
+        if ATTR_RGB_COLOR:
+            rgb = kwargs.get(ATTR_RGB_COLOR)
+            self._rgb = rgb
+            self.smartbulb.hsv = color_RGB_to_hsv(rgb[0], rgb[1], rgb[2])
+
         self.smartbulb.state = self.smartbulb.BULB_STATE_ON
 
     def turn_off(self):
@@ -87,6 +98,10 @@ class TPLinkSmartBulb(Light):
     def brightness(self):
         """Return the brightness of this light between 0..255."""
         return self._brightness
+
+    @property
+    def rgb_color(self):
+        return self._rgb
 
     @property
     def is_on(self):
@@ -106,10 +121,15 @@ class TPLinkSmartBulb(Light):
                         self.smartbulb.color_temp != 0):
                     self._color_temp = kelvin_to_mired(
                         self.smartbulb.color_temp)
+                h, s, v = self.smartbulb.hsv
+                self._rgb = color_hsv_to_RGB(h, s, v)
         except (SmartPlugException, OSError) as ex:
             _LOGGER.warning('Could not read state for %s: %s', self.name, ex)
 
     @property
     def supported_features(self):
         """Flag supported features."""
+        supported_features = SUPPORT_TPLINK
+        if self.smartbulb.is_color:
+            supported_features += SUPPORT_RGB_COLOR
         return SUPPORT_TPLINK

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -15,7 +15,7 @@ from homeassistant.util.color import (
     color_temperature_kelvin_to_mired as kelvin_to_mired)
 import colorsys
 
-from typing import TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING
 if TYPE_CHECKING:
     from pyHS100 import SmartBulb
 
@@ -44,12 +44,14 @@ def brightness_from_percentage(percent):
     return (percent*255.0)/100.0
 
 
-def rgb_to_hsv(rgb):
+def rgb_to_hsv(rgb: Tuple[float, float, float]) -> Tuple[float, float, float]:
+    """Convert RGB tuple (values 0-255) to HSV (degrees, %, %)."""
     h, s, v = colorsys.rgb_to_hsv(rgb[0]/255, rgb[1]/255, rgb[2]/255)
     return h * 360, s * 100, v * 100
 
 
-def hsv_to_rgb(hsv):
+def hsv_to_rgb(hsv: Tuple[float, float, float]) -> Tuple[float, float, float]:
+    """Convert HSV tuple (degrees, %, %) to RGB (values 0-255)."""
     r, g, b = colorsys.hsv_to_rgb(hsv[0]/360, hsv[1]/100, hsv[2]/100)
     return r * 255, g * 255, b * 255
 

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -132,4 +132,4 @@ class TPLinkSmartBulb(Light):
         supported_features = SUPPORT_TPLINK
         if self.smartbulb.is_color:
             supported_features += SUPPORT_RGB_COLOR
-        return SUPPORT_TPLINK
+        return supported_features

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -82,6 +82,8 @@ class TPLinkSmartBulb(Light):
 
     def turn_on(self, **kwargs):
         """Turn the light on."""
+        self.smartbulb.state = self.smartbulb.BULB_STATE_ON
+
         if ATTR_COLOR_TEMP in kwargs:
             self.smartbulb.color_temp = \
                 mired_to_kelvin(kwargs[ATTR_COLOR_TEMP])
@@ -95,7 +97,7 @@ class TPLinkSmartBulb(Light):
             self._rgb = rgb
             self.smartbulb.hsv = rgb_to_hsv(rgb)
 
-        self.smartbulb.state = self.smartbulb.BULB_STATE_ON
+
 
     def turn_off(self):
         """Turn the light off."""


### PR DESCRIPTION
## Description:
Adds support for changing the color of the bulb, note that this has not been tested by me as I don't own the corresponding hardware.

**Related issue (if applicable):** fixes #8766

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
