### PR TITLE
Tado component: local variable 'setting' referenced before assignment

### DIFF
--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -288,7 +288,7 @@ class TadoClimate(ClimateDevice):
 
             if 'setting' in overlay_data:
                 setting_data = overlay_data['setting']
-                setting = setting is not None
+                setting = setting_data is not None
 
             if setting:
                 if 'mode' in setting_data:


### PR DESCRIPTION

Fixes the following error of the tado component in HA >= 0.50:

```
2017-08-02 07:41:17 ERROR (MainThread) [homeassistant.helpers.entity] Update for climate.bathroom fails
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.4/site-packages/homeassistant/helpers/entity.py", line 225, in async_update_ha_state
    yield from self.hass.async_add_job(self.update)
  File "/usr/lib/python3.4/asyncio/futures.py", line 388, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.4/asyncio/tasks.py", line 286, in _wakeup
    value = future.result()
  File "/usr/lib/python3.4/asyncio/futures.py", line 277, in result
    raise self._exception
  File "/usr/lib/python3.4/concurrent/futures/thread.py", line 54, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.4/site-packages/homeassistant/components/climate/tado.py", line 291, in update
    setting = setting is not None
UnboundLocalError: local variable 'setting' referenced before assignment
```

Compare last post of https://github.com/wmalgadey/tado_component/issues/15


