### PR TITLE
Upgrade sphinx-autodoc-typehints to 1.2.1

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
 Sphinx==1.6.3
-sphinx-autodoc-typehints==1.2.0
+sphinx-autodoc-typehints==1.2.1
 sphinx-autodoc-annotation==1.0.post1


### PR DESCRIPTION
## 1.2.1

* Fixed `ValueError` when `getargspec()` encounters a built-in function
* Fixed `AttributeError` when `Any` is combined with another type in a `Union`
  (thanks Davis Kirkendall)