### PR TITLE
Improvements (configuration and validation)

### DIFF
--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -5,20 +5,21 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.yr/
 """
 import asyncio
-from datetime import timedelta
 import logging
+
+from datetime import timedelta
 from random import randrange
 from xml.parsers.expat import ExpatError
 
-import async_timeout
 import aiohttp
+import async_timeout
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_ELEVATION, CONF_MONITORED_CONDITIONS,
-    ATTR_ATTRIBUTION)
+    ATTR_ATTRIBUTION, CONF_NAME)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
@@ -32,7 +33,6 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ATTRIBUTION = "Weather forecast from yr.no, delivered by the Norwegian " \
                    "Meteorological Institute and the NRK."
 
-# Sensor types are defined like so:
 SENSOR_TYPES = {
     'symbol': ['Symbol', None],
     'precipitation': ['Precipitation', 'mm'],
@@ -52,35 +52,42 @@ SENSOR_TYPES = {
 
 CONF_FORECAST = 'forecast'
 
+DEFAULT_FORECAST = 0
+DEFAULT_NAME = 'yr'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=['symbol']): vol.All(
-        cv.ensure_list, vol.Length(min=1), [vol.In(SENSOR_TYPES.keys())]),
+    vol.Optional(CONF_ELEVATION): vol.Coerce(int),
+    vol.Optional(CONF_FORECAST, default=DEFAULT_FORECAST): vol.Coerce(int),
     vol.Optional(CONF_LATITUDE): cv.latitude,
     vol.Optional(CONF_LONGITUDE): cv.longitude,
-    vol.Optional(CONF_ELEVATION): vol.Coerce(int),
-    vol.Optional(CONF_FORECAST): vol.Coerce(int)
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=['symbol']):
+        vol.All(cv.ensure_list, vol.Length(min=1), [vol.In(SENSOR_TYPES)]),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Yr.no sensor."""
+    elevation = config.get(CONF_ELEVATION, hass.config.elevation or 0)
+    forecast = config.get(CONF_FORECAST)
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    elevation = config.get(CONF_ELEVATION, hass.config.elevation or 0)
-    forecast = config.get(CONF_FORECAST, 0)
+    name = config.get(CONF_NAME)
 
     if None in (latitude, longitude):
         _LOGGER.error("Latitude or longitude not set in Home Assistant config")
         return False
 
-    coordinates = {'lat': str(latitude),
-                   'lon': str(longitude),
-                   'msl': str(elevation)}
+    coordinates = {
+        'lat': str(latitude),
+        'lon': str(longitude),
+        'msl': str(elevation),
+    }
 
     dev = []
     for sensor_type in config[CONF_MONITORED_CONDITIONS]:
-        dev.append(YrSensor(sensor_type))
+        dev.append(YrSensor(name, sensor_type))
     async_add_devices(dev)
 
     weather = YrData(hass, coordinates, forecast, dev)
@@ -94,9 +101,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class YrSensor(Entity):
     """Representation of an Yr.no sensor."""
 
-    def __init__(self, sensor_type):
+    def __init__(self, name, sensor_type):
         """Initialize the sensor."""
-        self.client_name = 'yr'
+        self.client_name = name
         self._name = SENSOR_TYPES[sensor_type][0]
         self.type = sensor_type
         self._state = None
@@ -159,7 +166,7 @@ class YrData(object):
 
         def try_again(err: str):
             """Retry in 15 minutes."""
-            _LOGGER.warning('Retrying in 15 minutes: %s', err)
+            _LOGGER.warning("Retrying in 15 minutes: %s", err)
             self._nextrun = None
             nxt = dt_util.utcnow() + timedelta(minutes=15)
             if nxt.minute >= 15:


### PR DESCRIPTION
## Description:
- Set default in validation
- Ordering
- Allow the users to set  name for the sensors (analog the other platforms)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3121

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: yr
    name: Weather
    monitored_conditions:
      - temperature
      - symbol
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
