### PR TITLE
Upgrade pyasn1 to 0.3.1 and pyasn1-modules to 0.0.10

### DIFF
--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -15,8 +15,8 @@ from homeassistant.const import CONF_PASSWORD, CONF_SENDER, CONF_RECIPIENT
 
 REQUIREMENTS = ['sleekxmpp==1.3.2',
                 'dnspython3==1.15.0',
-                'pyasn1==0.2.3',
-                'pyasn1-modules==0.0.9']
+                'pyasn1==0.3.1',
+                'pyasn1-modules==0.0.10']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -526,10 +526,10 @@ pyalarmdotcom==0.3.0
 pyarlo==0.0.4
 
 # homeassistant.components.notify.xmpp
-pyasn1-modules==0.0.9
+pyasn1-modules==0.0.10
 
 # homeassistant.components.notify.xmpp
-pyasn1==0.2.3
+pyasn1==0.3.1
 
 # homeassistant.components.apple_tv
 pyatv==0.3.4


### PR DESCRIPTION
## 0.3.1
Changelog: https://github.com/etingof/pyasn1/blob/master/CHANGES.rst#revision-031-released-26-07-2017

**Related issue (if applicable):** fixes #8231 (perhaps, unable to verify)

Tested with the following configuration:

``` yaml
notify:
  - platform: xmpp
    name: jabber
    sender: !secret xmpp_sender
    password: !secret xmpp_password
    recipient: !secret xmpp_recipient
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```