### PR TITLE
Add max_age to statistics sensor

### DIFF
--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -44,9 +44,8 @@ ICON = 'mdi:calculator'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_SAMPLING_SIZE,
-                 default=DEFAULT_SIZE): vol.All(vol.Coerce(int),
-                                                vol.Range(min=1)),
+    vol.Optional(CONF_SAMPLING_SIZE, default=DEFAULT_SIZE):
+        vol.All(vol.Coerce(int), vol.Range(min=1)),
     vol.Optional(CONF_MAX_AGE): cv.time_period
 })
 

--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -44,7 +44,9 @@ ICON = 'mdi:calculator'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_SAMPLING_SIZE, default=DEFAULT_SIZE): vol.All(vol.Coerce(int), vol.Range(min=1)),
+    vol.Optional(CONF_SAMPLING_SIZE,
+                 default=DEFAULT_SIZE): vol.All(vol.Coerce(int),
+                                                vol.Range(min=1)),
     vol.Optional(CONF_MAX_AGE): cv.time_period
 })
 

--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -44,7 +44,7 @@ ICON = 'mdi:calculator'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_SAMPLING_SIZE, default=DEFAULT_SIZE): cv.positive_int,
+    vol.Optional(CONF_SAMPLING_SIZE, default=DEFAULT_SIZE): vol.All(vol.Coerce(int), vol.Range(min=1)),
     vol.Optional(CONF_MAX_AGE): cv.time_period
 })
 
@@ -79,15 +79,9 @@ class StatisticsSensor(Entity):
         self._sampling_size = sampling_size
         self._max_age = max_age
         self._unit_of_measurement = None
-        if self._sampling_size == 0:
-            self.states = deque()
-        else:
-            self.states = deque(maxlen=self._sampling_size)
+        self.states = deque(maxlen=self._sampling_size)
         if self._max_age is not None:
-            if self._sampling_size == 0:
-                self.ages = deque()
-            else:
-                self.ages = deque(maxlen=self._sampling_size)
+            self.ages = deque(maxlen=self._sampling_size)
 
         self.median = self.mean = self.variance = self.stdev = 0
         self.min = self.max = self.total = self.count = 0
@@ -144,8 +138,7 @@ class StatisticsSensor(Entity):
                 ATTR_MAX_VALUE: self.max,
                 ATTR_MEDIAN: self.median,
                 ATTR_MIN_VALUE: self.min,
-                ATTR_SAMPLING_SIZE: 'unlimited' if self._sampling_size is
-                                    0 else self._sampling_size,
+                ATTR_SAMPLING_SIZE: self._sampling_size,
                 ATTR_STANDARD_DEVIATION: self.stdev,
                 ATTR_TOTAL: self.total,
                 ATTR_VARIANCE: self.variance,

--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +35,8 @@ ATTR_SAMPLING_SIZE = 'sampling_size'
 ATTR_TOTAL = 'total'
 
 CONF_SAMPLING_SIZE = 'sampling_size'
+CONF_MAX_AGE = 'max_age'
+
 DEFAULT_NAME = 'Stats'
 DEFAULT_SIZE = 20
 ICON = 'mdi:calculator'
@@ -42,6 +45,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_SAMPLING_SIZE, default=DEFAULT_SIZE): cv.positive_int,
+    vol.Optional(CONF_MAX_AGE): cv.time_period
 })
 
 
@@ -51,16 +55,18 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     entity_id = config.get(CONF_ENTITY_ID)
     name = config.get(CONF_NAME)
     sampling_size = config.get(CONF_SAMPLING_SIZE)
+    max_age = config.get(CONF_MAX_AGE, None)
 
     async_add_devices(
-        [StatisticsSensor(hass, entity_id, name, sampling_size)], True)
+        [StatisticsSensor(hass, entity_id, name, sampling_size, max_age)],
+        True)
     return True
 
 
 class StatisticsSensor(Entity):
     """Representation of a Statistics sensor."""
 
-    def __init__(self, hass, entity_id, name, sampling_size):
+    def __init__(self, hass, entity_id, name, sampling_size, max_age):
         """Initialize the Statistics sensor."""
         self._hass = hass
         self._entity_id = entity_id
@@ -71,11 +77,18 @@ class StatisticsSensor(Entity):
         else:
             self._name = '{} {}'.format(name, ATTR_COUNT)
         self._sampling_size = sampling_size
+        self._max_age = max_age
         self._unit_of_measurement = None
         if self._sampling_size == 0:
             self.states = deque()
         else:
             self.states = deque(maxlen=self._sampling_size)
+        if self._max_age is not None:
+            if self._sampling_size == 0:
+                self.ages = deque()
+            else:
+                self.ages = deque(maxlen=self._sampling_size)
+
         self.median = self.mean = self.variance = self.stdev = 0
         self.min = self.max = self.total = self.count = 0
         self.average_change = self.change = 0
@@ -89,6 +102,9 @@ class StatisticsSensor(Entity):
 
             try:
                 self.states.append(float(new_state.state))
+                if self._max_age is not None:
+                    now = dt_util.utcnow()
+                    self.ages.append(now)
                 self.count = self.count + 1
             except ValueError:
                 self.count = self.count + 1
@@ -142,9 +158,20 @@ class StatisticsSensor(Entity):
         """Return the icon to use in the frontend, if any."""
         return ICON
 
+    def _purge_old(self):
+        """Remove states which are older than self._max_age."""
+        now = dt_util.utcnow()
+
+        while (len(self.ages) > 0) and (now - self.ages[0]) > self._max_age:
+            self.ages.popleft()
+            self.states.popleft()
+
     @asyncio.coroutine
     def async_update(self):
         """Get the latest data and updates the states."""
+        if self._max_age is not None:
+            self._purge_old()
+
         if not self.is_binary:
             try:
                 self.mean = round(statistics.mean(self.states), 2)

--- a/tests/components/sensor/test_statistics.py
+++ b/tests/components/sensor/test_statistics.py
@@ -4,7 +4,10 @@ import statistics
 
 from homeassistant.setup import setup_component
 from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
+from homeassistant.util import dt as dt_util
 from tests.common import get_test_home_assistant
+from unittest.mock import patch
+from datetime import datetime, timedelta
 
 
 class TestStatisticsSensor(unittest.TestCase):
@@ -99,4 +102,36 @@ class TestStatisticsSensor(unittest.TestCase):
         state = self.hass.states.get('sensor.test_mean')
 
         self.assertEqual(3.8, state.attributes.get('min_value'))
+        self.assertEqual(14, state.attributes.get('max_value'))
+
+    def test_max_age(self):
+        """Test value deprecation."""
+        mock_data = {
+            'return_time': datetime(2017, 8, 2, 12, 23, tzinfo=dt_util.UTC),
+        }
+
+        def mock_now():
+            return mock_data['return_time']
+
+        with patch('homeassistant.components.sensor.statistics.dt_util.utcnow',
+                   new=mock_now):
+            assert setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'statistics',
+                    'name': 'test',
+                    'entity_id': 'sensor.test_monitored',
+                    'max_age': {'minutes': 3}
+                }
+            })
+
+            for value in self.values:
+                self.hass.states.set('sensor.test_monitored', value,
+                                     {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
+                self.hass.block_till_done()
+                # insert the next value one minute later
+                mock_data['return_time'] += timedelta(minutes=1)
+
+            state = self.hass.states.get('sensor.test_mean')
+
+        self.assertEqual(6, state.attributes.get('min_value'))
         self.assertEqual(14, state.attributes.get('max_value'))


### PR DESCRIPTION
## Description:

This adds a max_age configuration option to the statistics sensor. If the option is set, the sensor will track when a certain measurement was taken and will purge measurements when they grow older than max_age.

This can be useful to have the sensor display something like the average over the last 30 minutes or so.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3125

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: statistics
    entity_id: sensor.cpu
    max_age: 
      minutes: 30
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
