### PR TITLE
directv: extended discovery via REST api, bug fix 

### DIFF
--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.directv/
 """
 import voluptuous as vol
+import requests
 
 from homeassistant.components.media_player import (
     MEDIA_TYPE_TVSHOW, MEDIA_TYPE_VIDEO, SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA,
@@ -53,7 +54,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         name = 'DirecTV_' + discovery_info.get('serial', '')
 
         # attempt to discover additional RVU units
-        import requests
         try:
             resp = requests.get(
                 'http://%s:%d/info/getLocations' % (host, DEFAULT_PORT)).json()

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -47,7 +47,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         hosts.append([
             'DirecTV_' + discovery_info.get('serial', ''),
-            host, DEFAULT_PORT
+            host, DEFAULT_PORT, DEFAULT_DEVICE
         ])
 
     elif CONF_HOST in config:


### PR DESCRIPTION
## Description:

See commit messages for better details.

DirecTV RVU clients are now detected and configured if the discovery component is used.

**Related issue (if applicable):** 
- Probably can close home-assistant/netdisco#42 as a wont-fix or not-a-bug
- Fixes #9003

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3128

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
 - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
- [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
