### PR TITLE
Eight Sleep, Catch divide by zero errors when a sleep type is 0

### DIFF
--- a/homeassistant/components/sensor/eight_sleep.py
+++ b/homeassistant/components/sensor/eight_sleep.py
@@ -197,10 +197,16 @@ class EightUserSensor(EightSleepUserEntity):
         sleep_time = sum(self._attr['breakdown'].values()) - \
             self._attr['breakdown']['awake']
         state_attr[ATTR_SLEEP_DUR] = sleep_time
-        state_attr[ATTR_LIGHT_PERC] = round((
-            self._attr['breakdown']['light'] / sleep_time) * 100, 2)
-        state_attr[ATTR_DEEP_PERC] = round((
-            self._attr['breakdown']['deep'] / sleep_time) * 100, 2)
+        try:
+            state_attr[ATTR_LIGHT_PERC] = round((
+                self._attr['breakdown']['light'] / sleep_time) * 100, 2)
+        except ZeroDivisionError:
+            state_attr[ATTR_LIGHT_PERC] = 0
+        try:
+            state_attr[ATTR_DEEP_PERC] = round((
+                self._attr['breakdown']['deep'] / sleep_time) * 100, 2)
+        except ZeroDivisionError:
+            state_attr[ATTR_DEEP_PERC] = 0
 
         if self._units == 'si':
             room_temp = round(self._attr['room_temp'], 2)


### PR DESCRIPTION
## Description:
Under certain conditions the sleep percentage reported by Eight for a given type can end up being 0.  This was resulting in ZeroDivision errors being generated.  


## Checklist:


If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
