### PR TITLE
Bayesian Binary Sensor

### DIFF
--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -31,26 +31,22 @@ CONF_TO_STATE = 'to_state'
 
 DEFAULT_NAME = 'BayesianBinary'
 
-NUMERIC_STATE_SCHEMA = vol.Schema(
-    {
-        CONF_PLATFORM: 'numeric_state',
-        CONF_ENTITY_ID: cv.entity_id,
-        vol.Optional(CONF_ABOVE): vol.Coerce(float),
-        vol.Optional(CONF_BELOW): vol.Coerce(float),
-        CONF_P_GIVEN_T: vol.Coerce(float),
-        vol.Optional(CONF_P_GIVEN_F): vol.Coerce(float)
-    },
-    required=True)
+NUMERIC_STATE_SCHEMA = vol.Schema({
+    CONF_PLATFORM: 'numeric_state',
+    vol.Required(CONF_ENTITY_ID): cv.entity_id,
+    vol.Optional(CONF_ABOVE): vol.Coerce(float),
+    vol.Optional(CONF_BELOW): vol.Coerce(float),
+    vol.Required(CONF_P_GIVEN_T): vol.Coerce(float),
+    vol.Optional(CONF_P_GIVEN_F): vol.Coerce(float)
+}, required=True)
 
-STATE_SCHEMA = vol.Schema(
-    {
-        CONF_PLATFORM: CONF_STATE,
-        CONF_ENTITY_ID: cv.entity_id,
-        CONF_TO_STATE: cv.string,
-        CONF_P_GIVEN_T: vol.Coerce(float),
-        vol.Optional(CONF_P_GIVEN_F): vol.Coerce(float)
-    },
-    required=True)
+STATE_SCHEMA = vol.Schema({
+    CONF_PLATFORM: CONF_STATE,
+    vol.Required(CONF_ENTITY_ID): cv.entity_id,
+    vol.Required(CONF_TO_STATE): cv.string,
+    vol.Required(CONF_P_GIVEN_T): vol.Coerce(float),
+    vol.Optional(CONF_P_GIVEN_F): vol.Coerce(float)
+}, required=True)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME):
@@ -58,7 +54,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DEVICE_CLASS): cv.string,
     vol.Required(CONF_OBSERVATIONS): vol.Schema(
         vol.All(cv.ensure_list, [vol.Any(NUMERIC_STATE_SCHEMA,
-                                         STATE_SCHEMA)])),
+                                         STATE_SCHEMA)])
+    ),
     vol.Required(CONF_PRIOR): vol.Coerce(float),
     vol.Optional(CONF_PROBABILITY_THRESHOLD):
         vol.Coerce(float),

--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -11,11 +11,11 @@ from collections import OrderedDict
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.binary_sensor import (BinarySensorDevice,
-                                                    PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_ABOVE, CONF_BELOW, CONF_DEVICE_CLASS,
-                                 CONF_ENTITY_ID, CONF_NAME, CONF_PLATFORM,
-                                 CONF_STATE, STATE_UNKNOWN)
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    CONF_ABOVE, CONF_BELOW, CONF_DEVICE_CLASS, CONF_ENTITY_ID, CONF_NAME,
+    CONF_PLATFORM, CONF_STATE, STATE_UNKNOWN)
 from homeassistant.core import callback
 from homeassistant.helpers import condition
 from homeassistant.helpers.event import async_track_state_change
@@ -54,17 +54,14 @@ STATE_SCHEMA = vol.Schema(
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME):
-    cv.string,
-    vol.Optional(CONF_DEVICE_CLASS):
-    cv.string,
-    vol.Required(CONF_OBSERVATIONS):
-    vol.Schema(
+        cv.string,
+    vol.Optional(CONF_DEVICE_CLASS): cv.string,
+    vol.Required(CONF_OBSERVATIONS): vol.Schema(
         vol.All(cv.ensure_list, [vol.Any(NUMERIC_STATE_SCHEMA,
                                          STATE_SCHEMA)])),
-    vol.Required(CONF_PRIOR):
-    vol.Coerce(float),
+    vol.Required(CONF_PRIOR): vol.Coerce(float),
     vol.Optional(CONF_PROBABILITY_THRESHOLD):
-    vol.Coerce(float),
+        vol.Coerce(float),
 })
 
 
@@ -74,7 +71,6 @@ def update_probability(prior, prob_true, prob_false):
     denominator = numerator + prob_false * (1 - prior)
 
     probability = numerator / denominator
-
     return probability
 
 
@@ -146,7 +142,6 @@ class BayesianBinarySensor(BinarySensorDevice):
         async_track_state_change(
           self.hass, entities, async_threshold_sensor_state_listener)
 
-    @callback
     def _update_current_obs(self, entity_observation, should_trigger):
         """Update current observation."""
         entity = entity_observation['entity_id']
@@ -164,7 +159,6 @@ class BayesianBinarySensor(BinarySensorDevice):
         else:
             self.current_obs.pop(entity, None)
 
-    @callback
     def _process_numeric_state(self, entity_observation):
         """Add entity to current_obs if numeric state conditions are met."""
         entity = entity_observation['entity_id']
@@ -176,7 +170,6 @@ class BayesianBinarySensor(BinarySensorDevice):
 
         self._update_current_obs(entity_observation, should_trigger)
 
-    @callback
     def _process_state(self, entity_observation):
         """Add entity to current observations if state conditions are met."""
         entity = entity_observation['entity_id']

--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -47,7 +47,7 @@ NUMERIC_STATE_SCHEMA = vol.Schema({
 })
 
 STATE_SCHEMA = vol.Schema({
-    CONF_PLATFORM: 'state',
+    CONF_PLATFORM: CONF_STATE,
     CONF_ENTITY_ID: cv.string,
     CONF_TO_STATE: cv.string,
     CONF_P_GIVEN_T: vol.Coerce(float),
@@ -61,8 +61,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     cv.string,
     vol.Required(CONF_OBSERVATIONS):
     vol.Schema(
-        vol.All(cv.ensure_list, [vol.Any(NUMERIC_STATE_SCHEMA, STATE_SCHEMA)
-                                 ])),
+        vol.All(cv.ensure_list, [vol.Any(NUMERIC_STATE_SCHEMA,
+                                         STATE_SCHEMA)])),
     vol.Required(CONF_PRIOR):
     vol.Coerce(float),
     vol.Optional(CONF_PROBABILITY_THRESHOLD):
@@ -71,6 +71,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def update_probability(prior, prob_true, prob_false):
+    """Update probability using Bayes' rule."""
     numerator = prob_true * prior
     denominator = numerator + prob_false * (1 - prior)
 
@@ -119,6 +120,7 @@ class BayesianBinarySensor(BinarySensorDevice):
 
     @asyncio.coroutine
     def async_added_to_hass(self):
+        """Call when entity about to be added to hass."""
         @callback
         # pylint: disable=invalid-name
         def async_threshold_sensor_state_listener(entity, old_state,

--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -60,8 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_OBSERVATIONS):
     vol.Schema(
         vol.All(cv.ensure_list, [vol.Any(NUMERIC_STATE_SCHEMA,
-                                         STATE_SCHEMA)])
-    ),
+                                         STATE_SCHEMA)])),
     vol.Required(CONF_PRIOR):
     vol.Coerce(float),
     vol.Optional(CONF_PROBABILITY_THRESHOLD):
@@ -148,7 +147,9 @@ class BayesianBinarySensor(BinarySensorDevice):
             async_track_state_change(self.hass, entity_id,
                                      async_threshold_sensor_state_listener)
 
+    @callback
     def _update_current_obs(self, entity_observation, should_trigger):
+        """Update current observation."""
         entity = entity_observation['entity_id']
 
         if should_trigger:
@@ -164,7 +165,9 @@ class BayesianBinarySensor(BinarySensorDevice):
         else:
             self.current_obs.pop(entity, None)
 
+    @callback
     def _process_numeric_state(self, entity_observation):
+        """Add entity to current_obs if numeric state conditions are met."""
         entity = entity_observation['entity_id']
 
         should_trigger = condition.async_numeric_state(
@@ -174,7 +177,9 @@ class BayesianBinarySensor(BinarySensorDevice):
 
         self._update_current_obs(entity_observation, should_trigger)
 
+    @callback
     def _process_state(self, entity_observation):
+        """Add entity to current observations if state conditions are met."""
         entity = entity_observation['entity_id']
 
         should_trigger = condition.state(self.hass, entity,

--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -45,7 +45,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     observations = config.get(CONF_OBSERVATIONS)
     prior = config.get(CONF_PRIOR)
     probability_threshold = config.get(CONF_PROBABILITY_THRESHOLD)
-    device_class = CONF_DEVICE_CLASS
+    device_class = config.get(CONF_DEVICE_CLASS)
 
     async_add_devices([
         BayesianBinarySensor(hass, name, prior, observations,

--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -137,7 +137,7 @@ class BayesianBinarySensor(BinarySensorDevice):
 
         entities = [obs['entity_id'] for obs in self._observations]
         async_track_state_change(
-          self.hass, entities, async_threshold_sensor_state_listener)
+            self.hass, entities, async_threshold_sensor_state_listener)
 
     def _update_current_obs(self, entity_observation, should_trigger):
         """Update current observation."""
@@ -146,7 +146,7 @@ class BayesianBinarySensor(BinarySensorDevice):
         if should_trigger:
             prob_true = entity_observation['prob_given_true']
             prob_false = entity_observation.get(
-              'prob_given_false', 1 - prob_true)
+                'prob_given_false', 1 - prob_true)
 
             self.current_obs[entity] = {
                 'prob_true': prob_true,
@@ -172,7 +172,7 @@ class BayesianBinarySensor(BinarySensorDevice):
         entity = entity_observation['entity_id']
 
         should_trigger = condition.state(
-          self.hass, entity, entity_observation.get('to_state'))
+            self.hass, entity, entity_observation.get('to_state'))
 
         self._update_current_obs(entity_observation, should_trigger)
 

--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -142,10 +142,9 @@ class BayesianBinarySensor(BinarySensorDevice):
 
             self.hass.async_add_job(self.async_update_ha_state, True)
 
-        for obs in self._observations:
-            entity_id = obs['entity_id']
-            async_track_state_change(self.hass, entity_id,
-                                     async_threshold_sensor_state_listener)
+        entities = [obs['entity_id'] for obs in self._observations]
+        async_track_state_change(
+          self.hass, entities, async_threshold_sensor_state_listener)
 
     @callback
     def _update_current_obs(self, entity_observation, should_trigger):
@@ -154,8 +153,8 @@ class BayesianBinarySensor(BinarySensorDevice):
 
         if should_trigger:
             prob_true = entity_observation['prob_given_true']
-            prob_false = entity_observation.get('prob_given_false',
-                                                1 - prob_true)
+            prob_false = entity_observation.get(
+              'prob_given_false', 1 - prob_true)
 
             self.current_obs[entity] = {
                 'prob_true': prob_true,
@@ -182,8 +181,8 @@ class BayesianBinarySensor(BinarySensorDevice):
         """Add entity to current observations if state conditions are met."""
         entity = entity_observation['entity_id']
 
-        should_trigger = condition.state(self.hass, entity,
-                                         entity_observation.get('to_state'))
+        should_trigger = condition.state(
+          self.hass, entity, entity_observation.get('to_state'))
 
         self._update_current_obs(entity_observation, should_trigger)
 

--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -1,0 +1,175 @@
+"""
+Use Bayesian Inference to trigger a binary sensor.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.bayesian_binary/
+"""
+import asyncio
+import logging
+from collections import OrderedDict
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.binary_sensor import (BinarySensorDevice,
+                                                    PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_NAME, STATE_UNKNOWN, CONF_SENSOR_CLASS,
+                                 CONF_DEVICE_CLASS)
+from homeassistant.core import callback
+from homeassistant.helpers import condition
+from homeassistant.helpers.deprecation import get_deprecated
+from homeassistant.helpers.event import async_track_state_change
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_PROBABILITY_THRESHOLD = 'probability_threshold'
+CONF_OBSERVATIONS = 'observations'
+CONF_PRIOR = 'prior'
+
+DEFAULT_NAME = 'BayesianBinary'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME):
+    cv.string,
+    vol.Required(CONF_OBSERVATIONS):
+    vol.Schema([dict]),
+    vol.Required(CONF_PRIOR):
+    vol.Coerce(float),
+    vol.Required(CONF_PROBABILITY_THRESHOLD):
+    vol.Coerce(float),
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Threshold sensor."""
+    name = config.get(CONF_NAME)
+    observations = config.get(CONF_OBSERVATIONS)
+    prior = config.get(CONF_PRIOR)
+    probability_threshold = config.get(CONF_PROBABILITY_THRESHOLD)
+    device_class = get_deprecated(config, CONF_DEVICE_CLASS, CONF_SENSOR_CLASS)
+
+    async_add_devices([
+        BayesianBinarySensor(hass, name, prior, observations,
+                             probability_threshold, device_class)
+    ], True)
+    return True
+
+
+class BayesianBinarySensor(BinarySensorDevice):
+    """Representation of a Bayesian sensor."""
+
+    def __init__(self, hass, name, prior, observations, probability_threshold,
+                 device_class):
+        """Initialize the Bayesian sensor."""
+        self._hass = hass
+        self._name = name
+        self._observations = observations
+        self._probability_threshold = probability_threshold
+        self._device_class = device_class
+        self._deviation = False
+        self.prior = prior
+        self.probability = prior
+
+        self.current_obs = OrderedDict({})
+
+        self.entity_obs = {obs['entity_id']: obs for obs in self._observations}
+
+        self.watchers = {
+            'numeric_state': self.__process_numeric_state,
+            'state': self.__process_state
+        }
+
+        @callback
+        # pylint: disable=invalid-name
+        def async_threshold_sensor_state_listener(entity, old_state,
+                                                  new_state):
+            """Handle sensor state changes."""
+            if new_state.state == STATE_UNKNOWN:
+                return
+
+            entity_obs = self.entity_obs[entity]
+            platform = entity_obs['platform']
+
+            self.watchers[platform](entity_obs)
+
+            prior = self.prior
+            for obs in self.current_obs.values():
+                prior = self.__update_probability(obs, prior)
+
+            self.probability = prior
+
+            hass.async_add_job(self.async_update_ha_state, True)
+
+        # For entity in entities
+        for trigger in self._observations:
+            entity_id = trigger['entity_id']
+            async_track_state_change(hass, entity_id,
+                                     async_threshold_sensor_state_listener)
+
+    def __process_numeric_state(self, entity_observation):
+        entity = entity_observation['entity_id']
+        if condition.async_numeric_state(self._hass, entity,
+                                         entity_observation.get('below'),
+                                         entity_observation.get('above'), None,
+                                         entity_observation):
+
+            self.current_obs[entity] = entity_observation['probability']
+
+        else:
+            self.current_obs.pop(entity, None)
+
+    def __process_state(self, entity_observation):
+        entity = entity_observation['entity_id']
+        if condition.state(self._hass, entity,
+                           entity_observation.get('to_state')):
+
+            self.current_obs[entity] = entity_observation['probability']
+
+        else:
+            self.current_obs.pop(entity, None)
+
+    def __update_probability(self, prior, observation):
+        prob_pos = observation
+        prob_neg = 1 - prob_pos
+
+        numerator = prob_pos * prior
+        denominator = numerator + prob_neg * (1 - prior)
+
+        probability = numerator / denominator
+
+        return probability
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._deviation
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def device_class(self):
+        """Return the sensor class of the sensor."""
+        return self._device_class
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return {
+            'observations': [val for val in self.current_obs.values()],
+            'probability': self.probability,
+            'probability_threshold': self._probability_threshold
+        }
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Get the latest data and updates the states."""
+        self._deviation = bool(self.probability > self._probability_threshold)

--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -101,9 +101,8 @@ class BayesianBinarySensor(BinarySensorDevice):
 
             hass.async_add_job(self.async_update_ha_state, True)
 
-        # For entity in entities
-        for trigger in self._observations:
-            entity_id = trigger['entity_id']
+        for obs in self._observations:
+            entity_id = obs['entity_id']
             async_track_state_change(hass, entity_id,
                                      async_threshold_sensor_state_listener)
 

--- a/tests/components/binary_sensor/test_bayesian.py
+++ b/tests/components/binary_sensor/test_bayesian.py
@@ -18,7 +18,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         self.hass.stop()
 
     def test_sensor_numeric_state(self):
-        """Test sensor on numeric state platform observations"""
+        """Test sensor on numeric state platform observations."""
         config = {
             'binary_sensor': {
                 'platform':
@@ -82,7 +82,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         assert state.state == 'off'
 
     def test_sensor_state(self):
-        """Test sensor on state platform observations"""
+        """Test sensor on state platform observations."""
         config = {
             'binary_sensor': {
                 'name':

--- a/tests/components/binary_sensor/test_bayesian.py
+++ b/tests/components/binary_sensor/test_bayesian.py
@@ -156,6 +156,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         assert state.state == 'off'
 
     def test_probability_updates(self):
+        """Test probability update function."""
         prob_true = [0.3, 0.6, 0.8]
         prob_false = [0.7, 0.4, 0.2]
         prior = 0.5

--- a/tests/components/binary_sensor/test_bayesian.py
+++ b/tests/components/binary_sensor/test_bayesian.py
@@ -1,0 +1,139 @@
+"""The test for the bayesian sensor platform."""
+import unittest
+
+from homeassistant.setup import setup_component
+from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
+
+from tests.common import get_test_home_assistant
+
+
+class TestBayesianBinarySensor(unittest.TestCase):
+    """Test the threshold sensor."""
+
+    def setup_method(self, method):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_sensor_numeric_state(self):
+        """Test if source is above threshold."""
+        config = {
+            'binary_sensor': {
+                'platform':
+                'bayesian',
+                'name':
+                'Test_Binary',
+                'observations': [{
+                    'platform': 'numeric_state',
+                    'entity_id': 'sensor.test_monitored',
+                    'below': 10,
+                    'above': 5,
+                    'probability': 0.8
+                }],
+                'prior':
+                0.2,
+                'probability_threshold':
+                0.4,
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.states.set('sensor.test_monitored', 4,
+                             {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_binary')
+
+        self.assertEqual([], state.attributes.get('observations'))
+        self.assertEqual(0.2, state.attributes.get('probability'))
+
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', 6)
+        self.hass.block_till_done()
+        self.hass.states.set('sensor.test_monitored', 4)
+        self.hass.block_till_done()
+        self.hass.states.set('sensor.test_monitored', 6)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_binary')
+        self.assertEqual([0.8], state.attributes.get('observations'))
+        self.assertAlmostEqual(0.5, state.attributes.get('probability'))
+
+        assert state.state == 'on'
+
+        self.hass.states.set('sensor.test_monitored', 6)
+        self.hass.block_till_done()
+        self.hass.states.set('sensor.test_monitored', 4)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_binary')
+        self.assertAlmostEqual(0.2, state.attributes.get('probability'))
+
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', 15)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_binary')
+
+        assert state.state == 'off'
+
+    def test_sensor_lower(self):
+        """Test if source is below threshold."""
+        config = {
+            'binary_sensor': {
+                'name':
+                'Test_Binary',
+                'platform':
+                'bayesian',
+                'observations': [{
+                    'platform': 'state',
+                    'entity_id': 'sensor.test_monitored',
+                    'to_state': 'off',
+                    'probability': 0.8
+                }],
+                'prior':
+                0.2,
+                'probability_threshold':
+                0.4,
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.states.set('sensor.test_monitored', 'on')
+
+        state = self.hass.states.get('binary_sensor.test_binary')
+
+        self.assertEqual([], state.attributes.get('observations'))
+        self.assertEqual(0.2, state.attributes.get('probability'))
+
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', 'off')
+        self.hass.block_till_done()
+        self.hass.states.set('sensor.test_monitored', 'on')
+        self.hass.block_till_done()
+        self.hass.states.set('sensor.test_monitored', 'off')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_binary')
+        self.assertEqual([0.8], state.attributes.get('observations'))
+        self.assertAlmostEqual(0.5, state.attributes.get('probability'))
+
+        assert state.state == 'on'
+
+        self.hass.states.set('sensor.test_monitored', 'off')
+        self.hass.block_till_done()
+        self.hass.states.set('sensor.test_monitored', 'on')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_binary')
+        self.assertAlmostEqual(0.2, state.attributes.get('probability'))
+
+        assert state.state == 'off'

--- a/tests/components/binary_sensor/test_bayesian.py
+++ b/tests/components/binary_sensor/test_bayesian.py
@@ -2,7 +2,6 @@
 import unittest
 
 from homeassistant.setup import setup_component
-from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
 
 from tests.common import get_test_home_assistant
 
@@ -19,7 +18,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         self.hass.stop()
 
     def test_sensor_numeric_state(self):
-        """Test if source is above threshold."""
+        """Test sensor on numeric state platform observations"""
         config = {
             'binary_sensor': {
                 'platform':
@@ -42,8 +41,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
 
         assert setup_component(self.hass, 'binary_sensor', config)
 
-        self.hass.states.set('sensor.test_monitored', 4,
-                             {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
+        self.hass.states.set('sensor.test_monitored', 4)
         self.hass.block_till_done()
 
         state = self.hass.states.get('binary_sensor.test_binary')
@@ -83,8 +81,8 @@ class TestBayesianBinarySensor(unittest.TestCase):
 
         assert state.state == 'off'
 
-    def test_sensor_lower(self):
-        """Test if source is below threshold."""
+    def test_sensor_state(self):
+        """Test sensor on state platform observations"""
         config = {
             'binary_sensor': {
                 'name':


### PR DESCRIPTION
## Description:
Why:

* It would be beneficial to leverage various sensor outputs in a
Bayesian manner in order to sense more complex events.

This change addresses the need by:

* `BayesianBinarySensor` class in
`./homeassistant/components/binary_sensor/bayesian.py`
* Tests in `./tests/components/binary_sensor/test_bayesian.py`

Caveats:
This is my first time in this code-base. I did try to follow conventions
that I was able to find, but I'm sure there will be some issues to
straighten out.

## Example entry for `configuration.yaml` (if applicable):
```
binary_sensor:
  name: 'currently_cooking'
  platform: 'bayesian'
  prior: 0.1
  probability_threshold: 0.7
  observations:
    - entity_id: 'switch.kitchen_lights'
      prob_given_true: 0.6
      prob_given_false: 0.2
      platform: 'state'
      to_state: 'on'
    - entity_id: 'sensor.stove_temperature'
      prob_given_true: 0.9
      platform: 'numeric_state'
      above: 100
    - entity_id: 'sensor.kitchen_motion'
      prob_given_true: 0.5
      prob_given_false: 0.2
      platform: 'state'
      to_state: 'on'

binary_sensor:
  name: 'in_bed'
  platform: 'bayesian'
  prior: 0.5
  probability_threshold: 0.95
  observations:
    - entity_id: 'sensor.living_room_motion'
      prob_given_true: 0.4
      prob_given_false: 0.2
      platform: 'state'
      to_state: 'off'
    - entity_id: 'sensor.basement_motion'
      prob_given_true: 0.5
      prob_given_false: 0.4
      platform: 'state'
      to_state: 'off'
    - entity_id: 'sensor.bedroom_motion'
      prob_given_true: 0.5
      platform: 'state'
      to_state: 'on'
    - entity_id: 'sensor.sun'
      prob_given_true: 0.7
      platform: 'state'
      to_state: 'below_horizon'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)  https://github.com/home-assistant/home-assistant.github.io/pull/3268


If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
