### PR TITLE
New component: London air quality

### DIFF
--- a/homeassistant/components/sensor/london_air.py
+++ b/homeassistant/components/sensor/london_air.py
@@ -1,0 +1,201 @@
+"""
+Sensor for checking the status of London air.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.london_air/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+import requests
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+_LOGGER = logging.getLogger(__name__)
+
+LOCATIONS = 'locations'
+SCAN_INTERVAL = timedelta(minutes=30)
+AUTHORITIES = [
+    'Barking and Dagenham',
+    'Bexley',
+    'Brent',
+    'Camden',
+    'City of London',
+    'Croydon',
+    'Ealing',
+    'Enfield',
+    'Greenwich',
+    'Hackney',
+    'Hammersmith and Fulham',
+    'Haringey',
+    'Harrow',
+    'Havering',
+    'Hillingdon',
+    'Islington',
+    'Kensington and Chelsea',
+    'Kingston',
+    'Lambeth',
+    'Lewisham',
+    'Merton',
+    'Redbridge',
+    'Richmond',
+    'Southwark',
+    'Sutton',
+    'Tower Hamlets',
+    'Wandsworth',
+    'Westminster']
+URL = 'http://api.erg.kcl.ac.uk/AirQuality/Hourly/MonitoringIndex/GroupName=London/Json'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(LOCATIONS):
+        vol.All(cv.ensure_list, [vol.In(list(AUTHORITIES))]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Tube sensor."""
+    data = APIData()
+    data.update()
+    sensors = []
+    for name in config.get(LOCATIONS):
+        sensors.append(AirSensor(name, data))
+
+    add_devices(sensors, True)
+
+
+class APIData(object):
+    """Get the latest data for all authorities."""
+
+    def __init__(self):
+        """Initialize the AirData object."""
+        self.data = None
+
+    # Update only once in scan interval.
+    @Throttle(SCAN_INTERVAL)
+    def update(self):
+        """Get the latest data from TFL."""
+        response = requests.get(URL)
+        if response.status_code != 200:
+            _LOGGER.warning("Invalid response from API")
+        else:
+            self.data = parse_api_response(response.json())
+
+
+class AirSensor(Entity):
+    """Single authority air sensor"""
+
+    ICON = 'mdi:cloud-outline'
+
+    def __init__(self, name, APIdata):
+        """Initialize the sensor."""
+        self._name = name
+        self._APIdata = APIdata
+        self._site_data = None
+        self._state = None
+        self._updated = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def site_data(self):
+        """Return the dict of sites data."""
+        return self._site_data
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self.ICON
+
+    @property
+    def device_state_attributes(self):
+        """Return other details about the sensor state."""
+        attrs = {}
+        attrs['updated'] = self._updated
+        attrs['sites'] = len(self._site_data)
+        attrs['data'] = self._site_data
+        return attrs
+
+    def update(self):
+        """Update the sensor."""
+        self._APIdata.update()
+        self._site_data = self._APIdata.data[self._name]
+        self._updated = self._site_data[0]['updated']
+        sites_status = []
+        for site in self._site_data:
+            if site['pollutants_status'] != 'no_species_data':
+                sites_status.append(site['pollutants_status'])
+        if sites_status:
+            self._state = max(set(sites_status), key=sites_status.count)
+        else:
+            self._state = 'no_species_data'
+
+def parse_api_response(response):
+    """Take in the API response. API can return dict or list of data so need to check. """
+    data = dict.fromkeys(AUTHORITIES)     # Holds all data
+    for authority in AUTHORITIES:
+        for entry in response['HourlyAirQualityIndex']['LocalAuthority']:   # Loop over entries
+            if entry['@LocalAuthorityName'] == authority:
+                authority_data = []
+
+                if isinstance(entry['Site'], dict):
+                    entry_sites_data = [entry['Site']]
+                else:
+                    entry_sites_data = entry['Site']
+
+                for site in entry_sites_data:
+                    site_data = {}
+                    species_data = []
+
+                    site_data['updated']   = site['@BulletinDate']
+                    site_data['latitude']  = site['@Latitude']
+                    site_data['longitude'] = site['@Longitude']
+                    site_data['site_code'] = site['@SiteCode']
+                    site_data['site_name'] = site['@SiteName'].split("-")[-1].lstrip()
+                    site_data['site_type'] = site['@SiteType']
+
+                    if isinstance(site['Species'], dict):
+                        species_data = [site['Species']]
+                    else:
+                        species_data = site['Species']
+
+                    parsed_species_data = []
+                    quality_list = []
+                    for species in species_data:
+                        if species['@AirQualityBand'] != 'No data':
+                            species_dict = {}
+                            species_dict['description'] = species['@SpeciesDescription']
+                            species_dict['code'] = species['@SpeciesCode']
+                            species_dict['quality'] = species['@AirQualityBand']
+                            species_dict['index'] = species['@AirQualityIndex']
+                            species_dict['summary'] = species_dict['code'] + ' is ' + species_dict['quality']
+                            parsed_species_data.append(species_dict)
+                            quality_list.append(species_dict['quality'])
+
+                    if not parsed_species_data:      # if no valid species data
+                        parsed_species_data.append('no_species_data')
+                    site_data['pollutants'] = parsed_species_data
+
+                    if quality_list:
+                        site_data['pollutants_status'] = max(set(quality_list), key=quality_list.count)
+                        site_data['number_of_pollutants'] = len(quality_list)
+                    else:
+                        site_data['pollutants_status'] = 'no_species_data'
+                        site_data['number_of_pollutants'] = 0
+
+                    authority_data.append(site_data)
+
+                data[authority] = authority_data
+
+    return data

--- a/tests/components/sensor/test_london_air.py
+++ b/tests/components/sensor/test_london_air.py
@@ -1,0 +1,44 @@
+"""The tests for the tube_state platform."""
+import unittest
+import requests_mock
+
+from homeassistant.components.sensor.london_air import LOCATIONS, URL
+from homeassistant.setup import setup_component
+from tests.common import load_fixture, get_test_home_assistant
+
+VALID_CONFIG = {
+    'platform': 'london_air',
+    LOCATIONS: [
+        'Merton',
+        'Westminster',
+    ]
+}
+
+
+class TestLondonAirSensor(unittest.TestCase):
+    """Test the tube_state platform."""
+
+    def setUp(self):
+        """Initialize values for this testcase class."""
+        self.hass = get_test_home_assistant()
+        self.config = VALID_CONFIG
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @requests_mock.Mocker()
+    def test_setup(self, mock_req):
+        """Test for operational tube_state sensor with proper attributes."""
+        mock_req.get(URL, text=load_fixture('london_air.json'))
+        self.assertTrue(
+            setup_component(self.hass, 'sensor', {'sensor': self.config}))
+
+        state = self.hass.states.get('sensor.merton')
+        assert state.state == 'Low'
+        assert state.attributes.get('updated') == '2017-08-03 03:00:00'
+        assert state.attributes.get('sites') == 2
+        assert state.attributes.get('data')[0]['site_code'] == 'ME2'
+
+        state = self.hass.states.get('sensor.westminster')
+        assert state.state == 'Low'

--- a/tests/fixtures/london_air.json
+++ b/tests/fixtures/london_air.json
@@ -1,0 +1,2909 @@
+{
+  "HourlyAirQualityIndex": {
+    "@GroupName": "London",
+    "@TimeToLive": "38",
+    "LocalAuthority": [
+      {
+        "@LocalAuthorityCode": "1",
+        "@LocalAuthorityName": "Barking and Dagenham",
+        "@LaCentreLatitude": "51.538435",
+        "@LaCentreLongitude": "0.11467",
+        "@LaCentreLatitudeWGS84": "6717095.01808",
+        "@LaCentreLongitudeWGS84": "12765.0060093",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BG1",
+            "@SiteName": "Barking and Dagenham - Rush Green",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.563752",
+            "@Longitude": "0.177891",
+            "@LatitudeWGS84": "6721627.34498",
+            "@LongitudeWGS84": "19802.7355367",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "SO2",
+                "@SpeciesDescription": "Sulphur Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BG2",
+            "@SiteName": "Barking and Dagenham - Scrattons Farm",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.529389",
+            "@Longitude": "0.132857",
+            "@LatitudeWGS84": "6715476.18683",
+            "@LongitudeWGS84": "14789.5735883",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "2",
+        "@LocalAuthorityName": "Barnet",
+        "@LaCentreLatitude": "51.652929",
+        "@LaCentreLongitude": "-0.199606",
+        "@LaCentreLatitudeWGS84": "6737612.214325",
+        "@LaCentreLongitudeWGS84": "-22220.038279"
+      },
+      {
+        "@LocalAuthorityCode": "3",
+        "@LocalAuthorityName": "Bexley",
+        "@LaCentreLatitude": "51.441355",
+        "@LaCentreLongitude": "0.14861",
+        "@LaCentreLatitudeWGS84": "6699738.789844",
+        "@LaCentreLongitudeWGS84": "16543.189527",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BQ7",
+            "@SiteName": "Bexley - Belvedere West",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.4946486813055",
+            "@Longitude": "0.137279111232178",
+            "@LatitudeWGS84": "6709278.28804",
+            "@LongitudeWGS84": "14951.9364255",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BQ8",
+            "@SiteName": "Bexley - Belvedere West FDMS",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.4946486813055",
+            "@Longitude": "0.137279111232178",
+            "@LatitudeWGS84": "6709278.28804",
+            "@LongitudeWGS84": "14951.9364255",
+            "Species": {
+              "@SpeciesCode": "PM10",
+              "@SpeciesDescription": "PM10 Particulate",
+              "@AirQualityIndex": "0",
+              "@AirQualityBand": "No data",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BX0",
+            "@SiteName": "Bexley - Belvedere FDMS",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.4906102082147",
+            "@Longitude": "0.158914493927518",
+            "@LatitudeWGS84": "6708546.55118",
+            "@LongitudeWGS84": "17686.6633362",
+            "Species": {
+              "@SpeciesCode": "PM10",
+              "@SpeciesDescription": "PM10 Particulate",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Trigger"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BX1",
+            "@SiteName": "Bexley - Slade Green",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.4659832746662",
+            "@Longitude": "0.184877126994369",
+            "@LatitudeWGS84": "6704140.10457",
+            "@LongitudeWGS84": "20577.2727637",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "2",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "SO2",
+                "@SpeciesDescription": "Sulphur Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BX2",
+            "@SiteName": "Bexley - Belvedere",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.4906102082147",
+            "@Longitude": "0.158914493927518",
+            "@LatitudeWGS84": "6708546.55118",
+            "@LongitudeWGS84": "17686.6633362",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BX9",
+            "@SiteName": "Bexley - Slade Green FDMS",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.4659832746662",
+            "@Longitude": "0.184877126994369",
+            "@LatitudeWGS84": "6704140.10457",
+            "@LongitudeWGS84": "20577.2727637",
+            "Species": {
+              "@SpeciesCode": "PM25",
+              "@SpeciesDescription": "PM2.5 Particulate",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Trigger"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "GB0",
+            "@SiteName": "Greenwich and Bexley - Falconwood FDMS",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.4563",
+            "@Longitude": "0.085606",
+            "@LatitudeWGS84": "6702408.29265",
+            "@LongitudeWGS84": "9529.61632885",
+            "Species": {
+              "@SpeciesCode": "PM25",
+              "@SpeciesDescription": "PM2.5 Particulate",
+              "@AirQualityIndex": "2",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Trigger"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "GB6",
+            "@SiteName": "Greenwich and Bexley - Falconwood",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.4563",
+            "@Longitude": "0.085606",
+            "@LatitudeWGS84": "6702408.29265",
+            "@LongitudeWGS84": "9529.61632885",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "2",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "4",
+        "@LocalAuthorityName": "Brent",
+        "@LaCentreLatitude": "51.552255",
+        "@LaCentreLongitude": "-0.30262",
+        "@LaCentreLatitudeWGS84": "6719568.804179",
+        "@LaCentreLongitudeWGS84": "-33687.504304",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BT4",
+            "@SiteName": "Brent - Ikea",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.552476",
+            "@Longitude": "-0.258089",
+            "@LatitudeWGS84": "6719608.36938",
+            "@LongitudeWGS84": "-28730.3360593",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BT5",
+            "@SiteName": "Brent - Neasden Lane",
+            "@SiteType": "Industrial",
+            "@Latitude": "51.552656",
+            "@Longitude": "-0.248774",
+            "@LatitudeWGS84": "6719640.59457",
+            "@LongitudeWGS84": "-27693.3950026",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BT6",
+            "@SiteName": "Brent - John Keble Primary School",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.537799",
+            "@Longitude": "-0.247793",
+            "@LatitudeWGS84": "6716981.19188",
+            "@LongitudeWGS84": "-27584.1905821",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BT8",
+            "@SiteName": "Brent - Ark Franklin Academy",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.5324054617809",
+            "@Longitude": "-0.217718908639377",
+            "@LatitudeWGS84": "6716981.19188",
+            "@LongitudeWGS84": "-27584.1905821",
+            "Species": {
+              "@SpeciesCode": "PM10",
+              "@SpeciesDescription": "PM10 Particulate",
+              "@AirQualityIndex": "0",
+              "@AirQualityBand": "No data",
+              "@IndexSource": "Measurement"
+            }
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "5",
+        "@LocalAuthorityName": "Bromley",
+        "@LaCentreLatitude": "51.405683",
+        "@LaCentreLongitude": "0.01435",
+        "@LaCentreLatitudeWGS84": "6693370.521916",
+        "@LaCentreLongitudeWGS84": "1597.434693"
+      },
+      {
+        "@LocalAuthorityCode": "6",
+        "@LocalAuthorityName": "Camden",
+        "@LaCentreLatitude": "51.551706",
+        "@LaCentreLongitude": "-0.158825",
+        "@LaCentreLatitudeWGS84": "6719470.518604",
+        "@LaCentreLongitudeWGS84": "-17680.318125",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "BL0",
+            "@SiteName": "Camden - Bloomsbury",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.522287",
+            "@Longitude": "-0.125848",
+            "@LatitudeWGS84": "6714205.47041",
+            "@LongitudeWGS84": "-14009.3352774",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "SO2",
+                "@SpeciesDescription": "Sulphur Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "CD1",
+            "@SiteName": "Camden - Swiss Cottage",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.544219",
+            "@Longitude": "-0.175284",
+            "@LatitudeWGS84": "6718130.26521",
+            "@LongitudeWGS84": "-19512.5256242",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "CD9",
+            "@SiteName": "Camden - Euston Road",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.5277066194645",
+            "@Longitude": "-0.129053205282516",
+            "@LatitudeWGS84": "6715175.15109",
+            "@LongitudeWGS84": "-14366.1370973",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "IM1",
+            "@SiteName": "Camden - Holborn (inmidtown)",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.5173675146177",
+            "@Longitude": "-0.1201947113171",
+            "@LatitudeWGS84": "6713325.37384719",
+            "@LongitudeWGS84": "-13380.0140598641",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "7",
+        "@LocalAuthorityName": "City of London",
+        "@LaCentreLatitude": "51.51333",
+        "@LaCentreLongitude": "-0.088947",
+        "@LaCentreLatitudeWGS84": "6712603.132989",
+        "@LaCentreLongitudeWGS84": "-9901.534748",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "CT2",
+            "@SiteName": "City of London - Farringdon Street",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.5145253362314",
+            "@Longitude": "-0.104515626337876",
+            "@LatitudeWGS84": "6712816.9511",
+            "@LongitudeWGS84": "-11634.6263039",
+            "Species": {
+              "@SpeciesCode": "PM25",
+              "@SpeciesDescription": "PM2.5 Particulate",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Trigger"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "CT3",
+            "@SiteName": "City of London - Sir John Cass School",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.513847178423",
+            "@Longitude": "-0.077765681752",
+            "@LatitudeWGS84": "6712695.6436",
+            "@LongitudeWGS84": "-8656.83609382",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "CT4",
+            "@SiteName": "City of London - Beech Street",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.520225273171",
+            "@Longitude": "-0.0961060474176381",
+            "@LatitudeWGS84": "6713836.61564",
+            "@LongitudeWGS84": "-10698.4762607",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "CT6",
+            "@SiteName": "City of London - Walbrook Wharf",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.510499",
+            "@Longitude": "-0.091634",
+            "@LatitudeWGS84": "6712096.7547",
+            "@LongitudeWGS84": "-10200.6502194",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "0",
+              "@AirQualityBand": "No data",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "CT8",
+            "@SiteName": "City of London - Upper Thames Street",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.5095436853913",
+            "@Longitude": "-0.0873571979556188",
+            "@LatitudeWGS84": "6711925.88559",
+            "@LongitudeWGS84": "-9724.55879355",
+            "Species": {
+              "@SpeciesCode": "PM10",
+              "@SpeciesDescription": "PM10 Particulate",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Trigger"
+            }
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "8",
+        "@LocalAuthorityName": "Croydon",
+        "@LaCentreLatitude": "51.372361",
+        "@LaCentreLongitude": "-0.100401",
+        "@LaCentreLatitudeWGS84": "6687426.268766",
+        "@LaCentreLongitudeWGS84": "-11176.588195",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "CR5",
+            "@SiteName": "Croydon - Norbury",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.411349",
+            "@Longitude": "-0.12311",
+            "@LatitudeWGS84": "6694381.70052",
+            "@LongitudeWGS84": "-13704.5425116",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "CR7",
+            "@SiteName": "Croydon - Purley Way A23",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.3622305655403",
+            "@Longitude": "-0.117604507351392",
+            "@LatitudeWGS84": "6685619.97595951",
+            "@LongitudeWGS84": "-13091.6738733508",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "CR8",
+            "@SiteName": "Croydon - Norbury Manor",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.410039",
+            "@Longitude": "-0.127523",
+            "@LatitudeWGS84": "6694147.90117935",
+            "@LongitudeWGS84": "-14195.7954244306",
+            "Species": {
+              "@SpeciesCode": "PM25",
+              "@SpeciesDescription": "PM2.5 Particulate",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Trigger"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "CR9",
+            "@SiteName": "Croydon - Park Lane",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.3739530635378",
+            "@Longitude": "-0.0967638468323854",
+            "@LatitudeWGS84": "6687714.0876655",
+            "@LongitudeWGS84": "-10771.7986892368",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "9",
+        "@LocalAuthorityName": "Ealing",
+        "@LaCentreLatitude": "51.513351",
+        "@LaCentreLongitude": "-0.304214",
+        "@LaCentreLatitudeWGS84": "6712606.889356",
+        "@LaCentreLongitudeWGS84": "-33864.947572",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "EA6",
+            "@SiteName": "Ealing - Hanger Lane Gyratory",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.53085",
+            "@Longitude": "-0.292488",
+            "@LatitudeWGS84": "6715737.619",
+            "@LongitudeWGS84": "-32559.6152231",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "EA8",
+            "@SiteName": "Ealing - Horn Lane",
+            "@SiteType": "Industrial",
+            "@Latitude": "51.518948",
+            "@Longitude": "-0.265617",
+            "@LatitudeWGS84": "6713608.11252",
+            "@LongitudeWGS84": "-29568.349186",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "EI1",
+            "@SiteName": "Ealing - Western Avenue",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.5236078191481",
+            "@Longitude": "-0.265502631799754",
+            "@LatitudeWGS84": "6714441.78131",
+            "@LongitudeWGS84": "-29555.6177762",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "EI8",
+            "@SiteName": "Ealing - Horn Lane TEOM",
+            "@SiteType": "Industrial",
+            "@Latitude": "51.5189160348806",
+            "@Longitude": "-0.265652052386222",
+            "@LatitudeWGS84": "6713608.11252",
+            "@LongitudeWGS84": "-29568.349186",
+            "Species": {
+              "@SpeciesCode": "PM10",
+              "@SpeciesDescription": "PM10 Particulate",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Trigger"
+            }
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "10",
+        "@LocalAuthorityName": "Enfield",
+        "@LaCentreLatitude": "51.652096",
+        "@LaCentreLongitude": "-0.081533",
+        "@LaCentreLatitudeWGS84": "6737462.75468",
+        "@LaCentreLongitudeWGS84": "-9076.212043",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "EN1",
+            "@SiteName": "Enfield - Bush Hill Park",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.6450367266602",
+            "@Longitude": "-0.0661800662229116",
+            "@LatitudeWGS84": "6736196.26651",
+            "@LongitudeWGS84": "-7367.1312726",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "0",
+              "@AirQualityBand": "No data",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "EN4",
+            "@SiteName": "Enfield - Derby Road",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.614864007",
+            "@Longitude": "-0.0507658363689",
+            "@LatitudeWGS84": "6730785.26900193",
+            "@LongitudeWGS84": "-5651.2270542806",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "SO2",
+                "@SpeciesDescription": "Sulphur Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "EN5",
+            "@SiteName": "Enfield - Bowes Primary School",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.613865",
+            "@Longitude": "-0.125338",
+            "@LatitudeWGS84": "6730606.17452",
+            "@LongitudeWGS84": "-13952.562337",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "EN7",
+            "@SiteName": "Enfield - Prince of Wales School",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.66864334727",
+            "@Longitude": "-0.02200720557",
+            "@LatitudeWGS84": "6740432.24987404",
+            "@LongitudeWGS84": "-2449.83091783529",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "11",
+        "@LocalAuthorityName": "Greenwich",
+        "@LaCentreLatitude": "51.47879",
+        "@LaCentreLongitude": "-0.010677",
+        "@LaCentreLatitudeWGS84": "6706427.144723",
+        "@LaCentreLongitudeWGS84": "-1188.558203",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "GN0",
+            "@SiteName": "Greenwich - A206 Burrage Grove",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.490532",
+            "@Longitude": "0.074003",
+            "@LatitudeWGS84": "6708526.16964",
+            "@LongitudeWGS84": "8237.97627717",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "GN3",
+            "@SiteName": "Greenwich - Plumstead High Street",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.486957",
+            "@Longitude": "0.095111",
+            "@LatitudeWGS84": "6707887.0378",
+            "@LongitudeWGS84": "10587.7080888",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "GN4",
+            "@SiteName": "Greenwich - Fiveways Sidcup Rd A20",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.4346627060562",
+            "@Longitude": "0.0642224671704697",
+            "@LatitudeWGS84": "6702412.5486",
+            "@LongitudeWGS84": "4535.53633525",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "GR4",
+            "@SiteName": "Greenwich - Eltham",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.45258",
+            "@Longitude": "0.070766",
+            "@LatitudeWGS84": "6701743.73787",
+            "@LongitudeWGS84": "7877.63508548",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "2",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "SO2",
+                "@SpeciesDescription": "Sulphur Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "GR7",
+            "@SiteName": "Greenwich - Blackheath",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.472504",
+            "@Longitude": "-0.012381",
+            "@LatitudeWGS84": "6705303.66805",
+            "@LongitudeWGS84": "-1378.24661551",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "GR8",
+            "@SiteName": "Greenwich - Woolwich Flyover",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.486884",
+            "@Longitude": "0.017901",
+            "@LatitudeWGS84": "6707873.98752",
+            "@LongitudeWGS84": "1992.73020469",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "GR9",
+            "@SiteName": "Greenwich - Westhorne Avenue",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.456357",
+            "@Longitude": "0.040725",
+            "@LatitudeWGS84": "6702418.47577",
+            "@LongitudeWGS84": "4533.48626256",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "12",
+        "@LocalAuthorityName": "Hackney",
+        "@LaCentreLatitude": "51.545787",
+        "@LaCentreLongitude": "-0.055418",
+        "@LaCentreLatitudeWGS84": "6718410.935789",
+        "@LaCentreLongitudeWGS84": "-6169.103541",
+        "Site": {
+          "@BulletinDate": "2017-08-03 03:00:00",
+          "@SiteCode": "HK6",
+          "@SiteName": "Hackney - Old Street",
+          "@SiteType": "Roadside",
+          "@Latitude": "51.526454",
+          "@Longitude": "-0.08491",
+          "@LatitudeWGS84": "6714951.02162",
+          "@LongitudeWGS84": "-9452.13796326",
+          "Species": [
+            {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            },
+            {
+              "@SpeciesCode": "O3",
+              "@SpeciesDescription": "Ozone",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            },
+            {
+              "@SpeciesCode": "PM10",
+              "@SpeciesDescription": "PM10 Particulate",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Trigger"
+            }
+          ]
+        }
+      },
+      {
+        "@LocalAuthorityCode": "13",
+        "@LocalAuthorityName": "Hammersmith and Fulham",
+        "@LaCentreLatitude": "51.486674",
+        "@LaCentreLongitude": "-0.212088",
+        "@LaCentreLatitudeWGS84": "6707836.445728",
+        "@LaCentreLongitudeWGS84": "-23609.528163",
+        "Site": {
+          "@BulletinDate": "2017-08-03 03:00:00",
+          "@SiteCode": "HF4",
+          "@SiteName": "Hammersmith and Fulham - Shepherds Bush",
+          "@SiteType": "Roadside",
+          "@Latitude": "51.5045625671557",
+          "@Longitude": "-0.224670007031603",
+          "@LatitudeWGS84": "6711035.01276",
+          "@LongitudeWGS84": "-25010.1507793",
+          "Species": [
+            {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            },
+            {
+              "@SpeciesCode": "PM10",
+              "@SpeciesDescription": "PM10 Particulate",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Trigger"
+            }
+          ]
+        }
+      },
+      {
+        "@LocalAuthorityCode": "14",
+        "@LocalAuthorityName": "Haringey",
+        "@LaCentreLatitude": "51.577629",
+        "@LaCentreLongitude": "-0.091721",
+        "@LaCentreLatitudeWGS84": "6724112.718777",
+        "@LaCentreLongitudeWGS84": "-10210.335015",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "HG1",
+            "@SiteName": "Haringey - Haringey Town Hall",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.599302",
+            "@Longitude": "-0.068218",
+            "@LatitudeWGS84": "6727995.87648",
+            "@LongitudeWGS84": "-7593.99302294",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "HG4",
+            "@SiteName": "Haringey  - Priory Park South",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.5839769007709",
+            "@Longitude": "-0.125400278484885",
+            "@LatitudeWGS84": "6725249.88218781",
+            "@LongitudeWGS84": "-13959.4951462721",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "2",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "15",
+        "@LocalAuthorityName": "Harrow",
+        "@LaCentreLatitude": "51.578809",
+        "@LaCentreLongitude": "-0.33376",
+        "@LaCentreLatitudeWGS84": "6724324.092044",
+        "@LaCentreLongitudeWGS84": "-37153.993247",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "HR1",
+            "@SiteName": "Harrow - Stanmore",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.617327",
+            "@Longitude": "-0.298775",
+            "@LatitudeWGS84": "6731226.83276",
+            "@LongitudeWGS84": "-33259.4808618",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "HR2",
+            "@SiteName": "Harrow - Pinner Road",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.588417",
+            "@Longitude": "-0.362989",
+            "@LatitudeWGS84": "6726045.37632",
+            "@LongitudeWGS84": "-40407.7506436",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "16",
+        "@LocalAuthorityName": "Havering",
+        "@LaCentreLatitude": "51.577924",
+        "@LaCentreLongitude": "0.212083",
+        "@LaCentreLatitudeWGS84": "6724165.561579",
+        "@LaCentreLongitudeWGS84": "23608.971566",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "HV1",
+            "@SiteName": "Havering - Rainham",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.520787459334",
+            "@Longitude": "0.205460705694044",
+            "@LatitudeWGS84": "6713943.19288",
+            "@LongitudeWGS84": "22876.155358",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "HV3",
+            "@SiteName": "Havering - Romford",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.572976",
+            "@Longitude": "0.179079",
+            "@LatitudeWGS84": "6723279.28089",
+            "@LongitudeWGS84": "19934.9830918",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "17",
+        "@LocalAuthorityName": "Hillingdon",
+        "@LaCentreLatitude": "51.533411",
+        "@LaCentreLongitude": "-0.452568",
+        "@LaCentreLatitudeWGS84": "6716195.906043",
+        "@LaCentreLongitudeWGS84": "-50379.639309",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "HI0",
+            "@SiteName": "Hillingdon - Keats Way",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.496309",
+            "@Longitude": "-0.460826",
+            "@LatitudeWGS84": "6709559.07689",
+            "@LongitudeWGS84": "-51298.9156643",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "LH0",
+            "@SiteName": "Hillingdon - Harlington",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.48878",
+            "@Longitude": "-0.441627",
+            "@LatitudeWGS84": "6708212.94408",
+            "@LongitudeWGS84": "-49161.6927606",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "18",
+        "@LocalAuthorityName": "Hounslow",
+        "@LaCentreLatitude": "51.467586",
+        "@LaCentreLongitude": "-0.361799",
+        "@LaCentreLatitudeWGS84": "6704424.797578",
+        "@LaCentreLongitudeWGS84": "-40275.28045"
+      },
+      {
+        "@LocalAuthorityCode": "19",
+        "@LocalAuthorityName": "Islington",
+        "@LaCentreLatitude": "51.534961",
+        "@LaCentreLongitude": "-0.103742",
+        "@LaCentreLatitudeWGS84": "6716473.288702",
+        "@LaCentreLongitudeWGS84": "-11548.506614",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "IS2",
+            "@SiteName": "Islington - Holloway Road",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.555378",
+            "@Longitude": "-0.116146",
+            "@LatitudeWGS84": "6720127.92666",
+            "@LongitudeWGS84": "-12929.3135777",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "IS6",
+            "@SiteName": "Islington - Arsenal",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.557895",
+            "@Longitude": "-0.106989",
+            "@LatitudeWGS84": "6720578.5826",
+            "@LongitudeWGS84": "-11909.9610005",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "20",
+        "@LocalAuthorityName": "Kensington and Chelsea",
+        "@LaCentreLatitude": "51.501886",
+        "@LaCentreLongitude": "-0.190895",
+        "@LaCentreLatitudeWGS84": "6710556.349032",
+        "@LaCentreLongitudeWGS84": "-21250.334195",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "KC1",
+            "@SiteName": "Kensington and Chelsea - North Ken",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.5210467476039",
+            "@Longitude": "-0.213492139585065",
+            "@LatitudeWGS84": "6713983.58013",
+            "@LongitudeWGS84": "-23765.836267",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "2",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "SO2",
+                "@SpeciesDescription": "Sulphur Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "KC2",
+            "@SiteName": "Kensington and Chelsea - Cromwell Road",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.49550391",
+            "@Longitude": "-0.178809464",
+            "@LatitudeWGS84": "6709415.12178",
+            "@LongitudeWGS84": "-19904.9784815",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "2",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "KC3",
+            "@SiteName": "Kensington and Chelsea - Knightsbridge",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.49913951",
+            "@Longitude": "-0.164337605",
+            "@LatitudeWGS84": "6710065.20988",
+            "@LongitudeWGS84": "-18293.9785068",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "KC4",
+            "@SiteName": "Kensington and Chelsea - Kings Road",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.48743685",
+            "@Longitude": "-0.168397129",
+            "@LatitudeWGS84": "6707972.82158",
+            "@LongitudeWGS84": "-18745.8826513",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "KC5",
+            "@SiteName": "Kensington and Chelsea - Earls Court Rd",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.49019756",
+            "@Longitude": "-0.190863311",
+            "@LatitudeWGS84": "6708466.37696",
+            "@LongitudeWGS84": "-21246.8065916",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "KC7",
+            "@SiteName": "Kensington and Chelsea - North Ken FDMS",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.52106551",
+            "@Longitude": "-0.21344617",
+            "@LatitudeWGS84": "6713986.93682",
+            "@LongitudeWGS84": "-23760.7189562",
+            "Species": {
+              "@SpeciesCode": "PM10",
+              "@SpeciesDescription": "PM10 Particulate",
+              "@AirQualityIndex": "0",
+              "@AirQualityBand": "No data",
+              "@IndexSource": "Measurement"
+            }
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "21",
+        "@LocalAuthorityName": "Kingston",
+        "@LaCentreLatitude": "51.412317",
+        "@LaCentreLongitude": "-0.300443",
+        "@LaCentreLatitudeWGS84": "6694554.466476",
+        "@LaCentreLongitudeWGS84": "-33445.161772",
+        "Site": {
+          "@BulletinDate": "2017-08-03 03:00:00",
+          "@SiteCode": "KT4",
+          "@SiteName": "Kingston Upon Thames - Tolworth Broadway",
+          "@SiteType": "Roadside",
+          "@Latitude": "51.379312",
+          "@Longitude": "-0.281259",
+          "@LatitudeWGS84": "6688665.88821522",
+          "@LongitudeWGS84": "-31309.6086610253",
+          "Species": [
+            {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            },
+            {
+              "@SpeciesCode": "PM10",
+              "@SpeciesDescription": "PM10 Particulate",
+              "@AirQualityIndex": "0",
+              "@AirQualityBand": "No data",
+              "@IndexSource": "Measurement"
+            }
+          ]
+        }
+      },
+      {
+        "@LocalAuthorityCode": "22",
+        "@LocalAuthorityName": "Lambeth",
+        "@LaCentreLatitude": "51.489112",
+        "@LaCentreLongitude": "-0.11067",
+        "@LaCentreLatitudeWGS84": "6708272.298688",
+        "@LaCentreLongitudeWGS84": "-12319.728046",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "LB4",
+            "@SiteName": "Lambeth - Brixton Road",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.464113541162",
+            "@Longitude": "-0.11458102695123",
+            "@LatitudeWGS84": "6703810.46654",
+            "@LongitudeWGS84": "-12751.5363509",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "LB5",
+            "@SiteName": "Lambeth - Bondway Interchange",
+            "@SiteType": "Industrial",
+            "@Latitude": "51.4854867739729",
+            "@Longitude": "-0.124545234819213",
+            "@LatitudeWGS84": "6707629.96897",
+            "@LongitudeWGS84": "-13860.2784792",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "SO2",
+                "@SpeciesDescription": "Sulphur Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "LB6",
+            "@SiteName": "Lambeth - Streatham Green",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.4282131429499",
+            "@Longitude": "-0.13186863879576",
+            "@LatitudeWGS84": "6697392.0894",
+            "@LongitudeWGS84": "-14679.5497223",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "23",
+        "@LocalAuthorityName": "Lewisham",
+        "@LaCentreLatitude": "51.456879",
+        "@LaCentreLongitude": "-0.015964",
+        "@LaCentreLatitudeWGS84": "6702511.73226",
+        "@LaCentreLongitudeWGS84": "-1777.104351",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "LW1",
+            "@SiteName": "Lewisham - Catford",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.445468",
+            "@Longitude": "-0.020266",
+            "@LatitudeWGS84": "6700473.37417",
+            "@LongitudeWGS84": "-2256.00080042",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "LW2",
+            "@SiteName": "Lewisham - New Cross",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.474954",
+            "@Longitude": "-0.039641",
+            "@LatitudeWGS84": "6705741.5303",
+            "@LongitudeWGS84": "-4412.81593454",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "LW4",
+            "@SiteName": "Lewisham - Loampit Vale",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.4646910611736",
+            "@Longitude": "-0.016068243204",
+            "@LatitudeWGS84": "6703907.50224776",
+            "@LongitudeWGS84": "-1788.70865141176",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "24",
+        "@LocalAuthorityName": "Merton",
+        "@LaCentreLatitude": "51.415672",
+        "@LaCentreLongitude": "-0.191814",
+        "@LaCentreLatitudeWGS84": "6695153.285882",
+        "@LaCentreLongitudeWGS84": "-21352.636807",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "ME2",
+            "@SiteName": "Merton - Merton Road",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.4161384794862",
+            "@Longitude": "-0.192230805042824",
+            "@LatitudeWGS84": "6695236.54926",
+            "@LongitudeWGS84": "-21399.0353321",
+            "Species": {
+              "@SpeciesCode": "PM10",
+              "@SpeciesDescription": "PM10 Particulate",
+              "@AirQualityIndex": "2",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Trigger"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "ME9",
+            "@SiteName": "Merton - Morden Civic Centre 2",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.40162",
+            "@Longitude": "-0.19589212",
+            "@LatitudeWGS84": "6692543.79001",
+            "@LongitudeWGS84": "-21810.7165116",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "25",
+        "@LocalAuthorityName": "Newham",
+        "@LaCentreLatitude": "51.525516",
+        "@LaCentreLongitude": "0.035216",
+        "@LaCentreLatitudeWGS84": "6714783.190603",
+        "@LaCentreLongitudeWGS84": "3920.227188"
+      },
+      {
+        "@LocalAuthorityCode": "26",
+        "@LocalAuthorityName": "Redbridge",
+        "@LaCentreLatitude": "51.58861",
+        "@LaCentreLongitude": "0.082398",
+        "@LaCentreLatitudeWGS84": "6726079.956218",
+        "@LaCentreLongitudeWGS84": "9172.503402",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "RB4",
+            "@SiteName": "Redbridge - Gardner Close",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.57661",
+            "@Longitude": "0.030858",
+            "@LatitudeWGS84": "6723930.18984",
+            "@LongitudeWGS84": "3435.0968469",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "RB7",
+            "@SiteName": "Redbridge - Ley Street",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.5694843315237",
+            "@Longitude": "0.0829074748964946",
+            "@LatitudeWGS84": "6722606.75352",
+            "@LongitudeWGS84": "9108.2720562",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "2",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "27",
+        "@LocalAuthorityName": "Richmond",
+        "@LaCentreLatitude": "51.461342",
+        "@LaCentreLongitude": "-0.303547",
+        "@LaCentreLatitudeWGS84": "6703309.100938",
+        "@LaCentreLongitudeWGS84": "-33790.697472",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "RHG",
+            "@SiteName": "Richmond Upon Thames - Chertsey Road",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.4531422511004",
+            "@Longitude": "-0.341218138106469",
+            "@LatitudeWGS84": "",
+            "@LongitudeWGS84": "",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "RI1",
+            "@SiteName": "Richmond Upon Thames - Castelnau",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.480189",
+            "@Longitude": "-0.237335",
+            "@LatitudeWGS84": "6706677.20458",
+            "@LongitudeWGS84": "-26420.0113474",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "RI2",
+            "@SiteName": "Richmond Upon Thames - Barnes Wetlands",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.476168",
+            "@Longitude": "-0.230427",
+            "@LatitudeWGS84": "6705958.50423",
+            "@LongitudeWGS84": "-25651.016305",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "2",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "TD0",
+            "@SiteName": "Richmond Upon Thames - Ntl Physical  Lab",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.4243043441456",
+            "@Longitude": "-0.345714576446947",
+            "@LatitudeWGS84": "6696103.27675",
+            "@LongitudeWGS84": "-37808.8858115",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "TD5",
+            "@SiteName": "Richmond Upon Thames - Bushy Park",
+            "@SiteType": "Suburban",
+            "@Latitude": "51.4252560360937",
+            "@Longitude": "-0.345608290872898",
+            "@LatitudeWGS84": "6696694.23761",
+            "@LongitudeWGS84": "-38484.7706099",
+            "Species": [
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "28",
+        "@LocalAuthorityName": "Southwark",
+        "@LaCentreLatitude": "51.501725",
+        "@LaCentreLongitude": "-0.097993",
+        "@LaCentreLatitudeWGS84": "6710527.557503",
+        "@LaCentreLongitudeWGS84": "-10908.530861",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "SK5",
+            "@SiteName": "Southwark - A2 Old Kent Road",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.4804994936467",
+            "@Longitude": "-0.0595528932573422",
+            "@LatitudeWGS84": "6706732.70383",
+            "@LongitudeWGS84": "-6629.39775267",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "SK6",
+            "@SiteName": "Southwark - Elephant and Castle",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.4931557048667",
+            "@Longitude": "-0.101527038274853",
+            "@LatitudeWGS84": "6709004.43394458",
+            "@LongitudeWGS84": "-11305.3848459833",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "29",
+        "@LocalAuthorityName": "Sutton",
+        "@LaCentreLatitude": "51.360448",
+        "@LaCentreLongitude": "-0.191691",
+        "@LaCentreLatitudeWGS84": "6685302.179467",
+        "@LaCentreLongitudeWGS84": "-21338.94451",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "ST4",
+            "@SiteName": "Sutton - Wallington",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.3586596124998",
+            "@Longitude": "-0.149723946604927",
+            "@LatitudeWGS84": "6684987.88329",
+            "@LongitudeWGS84": "-16663.3032574",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "ST5",
+            "@SiteName": "Sutton - Beddington Lane north",
+            "@SiteType": "Industrial",
+            "@Latitude": "51.389286904505",
+            "@Longitude": "-0.141661524779893",
+            "@LatitudeWGS84": "6690449.76537",
+            "@LongitudeWGS84": "-15766.2908005",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "ST6",
+            "@SiteName": "Sutton - Worcester Park",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.377923",
+            "@Longitude": "-0.240414",
+            "@LatitudeWGS84": "6688418.16328",
+            "@LongitudeWGS84": "-26762.7640596",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "ST8",
+            "@SiteName": "Sutton - Beddington Lane",
+            "@SiteType": "Industrial",
+            "@Latitude": "51.3835652277943",
+            "@Longitude": "-0.1364178614733",
+            "@LatitudeWGS84": "6689424.4883013",
+            "@LongitudeWGS84": "-15185.9668743151",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "30",
+        "@LocalAuthorityName": "Tower Hamlets",
+        "@LaCentreLatitude": "51.523244",
+        "@LaCentreLongitude": "-0.027208",
+        "@LaCentreLatitudeWGS84": "6714376.688877",
+        "@LaCentreLongitudeWGS84": "-3028.780706",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "TH2",
+            "@SiteName": "Tower Hamlets - Mile End Road",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.5225294860844",
+            "@Longitude": "-0.0421550991900347",
+            "@LatitudeWGS84": "6714255.02857",
+            "@LongitudeWGS84": "-4688.33167425",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "TH4",
+            "@SiteName": "Tower Hamlets - Blackwall",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.5150461674013",
+            "@Longitude": "-0.00841849265642741",
+            "@LatitudeWGS84": "6712915.63292",
+            "@LongitudeWGS84": "-933.636569283",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "31",
+        "@LocalAuthorityName": "Waltham Forest",
+        "@LaCentreLatitude": "51.588638",
+        "@LaCentreLongitude": "-0.011762",
+        "@LaCentreLatitudeWGS84": "6726084.973003",
+        "@LaCentreLongitudeWGS84": "-1309.339851"
+      },
+      {
+        "@LocalAuthorityCode": "32",
+        "@LocalAuthorityName": "Wandsworth",
+        "@LaCentreLatitude": "51.45679",
+        "@LaCentreLongitude": "-0.192679",
+        "@LaCentreLatitudeWGS84": "6702495.832131",
+        "@LaCentreLongitudeWGS84": "-21448.928167",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "WA2",
+            "@SiteName": "Wandsworth - Wandsworth Town Hall",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.456962",
+            "@Longitude": "-0.191074",
+            "@LatitudeWGS84": "6702526.5605",
+            "@LongitudeWGS84": "-21270.2603838",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "WA7",
+            "@SiteName": "Wandsworth - Putney High Street",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.463429",
+            "@Longitude": "-0.215871",
+            "@LatitudeWGS84": "6703681.99537",
+            "@LongitudeWGS84": "-24030.649797",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "WA8",
+            "@SiteName": "Wandsworth - Putney High Street Facade",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.4637206047191",
+            "@Longitude": "-0.215890144123119",
+            "@LatitudeWGS84": "6703734.09916",
+            "@LongitudeWGS84": "-24032.7809111",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "0",
+              "@AirQualityBand": "No data",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "WA9",
+            "@SiteName": "Wandsworth - Putney",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.4650325059122",
+            "@Longitude": "-0.215824580947572",
+            "@LatitudeWGS84": "6703968.51315",
+            "@LongitudeWGS84": "-24025.4824518",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "WAA",
+            "@SiteName": "Wandsworth - Battersea",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.4794395281222",
+            "@Longitude": "-0.141786953606306",
+            "@LatitudeWGS84": "6706543.24163182",
+            "@LongitudeWGS84": "-15783.6514765835",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "WAB",
+            "@SiteName": "Wandsworth - Tooting High Street",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.429331",
+            "@Longitude": "-0.166524",
+            "@LatitudeWGS84": "6697591.67537674",
+            "@LongitudeWGS84": "-18537.3668848591",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "WAC",
+            "@SiteName": "Wandsworth - Lavender Hill (Clapham Jct)",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.4636903568111",
+            "@Longitude": "-0.166713485994806",
+            "@LatitudeWGS84": "",
+            "@LongitudeWGS84": "",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@LocalAuthorityCode": "33",
+        "@LocalAuthorityName": "Westminster",
+        "@LaCentreLatitude": "51.509645",
+        "@LaCentreLongitude": "-0.158586",
+        "@LaCentreLatitudeWGS84": "6711944.006712",
+        "@LaCentreLongitudeWGS84": "-17653.712767",
+        "Site": [
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "MY1",
+            "@SiteName": "Westminster - Marylebone Road",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.52254",
+            "@Longitude": "-0.15459",
+            "@LatitudeWGS84": "6714250.73471",
+            "@LongitudeWGS84": "-17208.8800817",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "SO2",
+                "@SpeciesDescription": "Sulphur Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "MY7",
+            "@SiteName": "Westminster - Marylebone Road FDMS",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.52254",
+            "@Longitude": "-0.15459",
+            "@LatitudeWGS84": "6714250.73471",
+            "@LongitudeWGS84": "-17208.8800817",
+            "Species": [
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "PM25",
+                "@SpeciesDescription": "PM2.5 Particulate",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "NB1",
+            "@SiteName": "Westminster - Strand (Northbank BID)",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.511998",
+            "@Longitude": "-0.116715",
+            "@LatitudeWGS84": "6712364.87549212",
+            "@LongitudeWGS84": "-12992.6543679369",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "0",
+              "@AirQualityBand": "No data",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "WM0",
+            "@SiteName": "Westminster - Horseferry Road",
+            "@SiteType": "Urban Background",
+            "@Latitude": "51.494681",
+            "@Longitude": "-0.131938",
+            "@LatitudeWGS84": "6709267.98298",
+            "@LongitudeWGS84": "-14687.2709763",
+            "Species": [
+              {
+                "@SpeciesCode": "NO2",
+                "@SpeciesDescription": "Nitrogen Dioxide",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "O3",
+                "@SpeciesDescription": "Ozone",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              },
+              {
+                "@SpeciesCode": "PM10",
+                "@SpeciesDescription": "PM10 Particulate",
+                "@AirQualityIndex": "1",
+                "@AirQualityBand": "Low",
+                "@IndexSource": "Trigger"
+              },
+              {
+                "@SpeciesCode": "SO2",
+                "@SpeciesDescription": "Sulphur Dioxide",
+                "@AirQualityIndex": "0",
+                "@AirQualityBand": "No data",
+                "@IndexSource": "Measurement"
+              }
+            ]
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "WM6",
+            "@SiteName": "Westminster - Oxford Street",
+            "@SiteType": "Kerbside",
+            "@Latitude": "51.5139287404213",
+            "@Longitude": "-0.152792701881935",
+            "@LatitudeWGS84": "6712710.23315",
+            "@LongitudeWGS84": "-17008.8057704",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          },
+          {
+            "@BulletinDate": "2017-08-03 03:00:00",
+            "@SiteCode": "WM9",
+            "@SiteName": "Westminster - Victoria (Victoria BID)",
+            "@SiteType": "Roadside",
+            "@Latitude": "51.4977331829735",
+            "@Longitude": "-0.14424140916201",
+            "@LatitudeWGS84": "6709818.70995547",
+            "@LongitudeWGS84": "-16057.0573104942",
+            "Species": {
+              "@SpeciesCode": "NO2",
+              "@SpeciesDescription": "Nitrogen Dioxide",
+              "@AirQualityIndex": "1",
+              "@AirQualityBand": "Low",
+              "@IndexSource": "Measurement"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description:
The london_air component queries the London air quality data feed provided by Kings College London. A single sensor will be added for each location (local authority district or borough) specified in the configuration file. The state of each sensor is the overall air quality in that borough. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/pull/3132) <3132>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: london_air
    locations:
      - Barking and Dagenham
      - Bexley
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ x] Tests have been added to verify that the new code works.
