### PR TITLE
Fix for Neato D3 state obtaining

### DIFF
--- a/homeassistant/components/sensor/neato.py
+++ b/homeassistant/components/sensor/neato.py
@@ -105,7 +105,7 @@ class NeatoConnectedSensor(Entity):
                 self._status_state = ERRORS.get(self._state['error'])
         if self.type == SENSOR_TYPE_BATTERY:
             self._battery_state = self._state['details']['charge']
-        if self._mapdata is None:
+        if not self._mapdata.get(self.robot.serial, {}).get('maps', []):
             return
         self.clean_time_start = (
             (self._mapdata[self.robot.serial]['maps'][0]['start_at']

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -72,7 +72,7 @@ class NeatoConnectedSwitch(ToggleEntity):
                 self._clean_state = STATE_ON
             else:
                 self._clean_state = STATE_OFF
-            _LOGGER.debug("Schedule state: %s", self._schedule_state)
+            _LOGGER.debug("Clean state: %s", self._clean_state)
         if self.type == SWITCH_TYPE_SCHEDULE:
             _LOGGER.debug("State: %s", self._state)
             if self.robot.schedule_enabled:


### PR DESCRIPTION
## Description:
Fix error that occurred when getting state of Neato D3 Connected

**Related issue (if applicable):** fixes #8831 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
