### PR TITLE
Fix Dyson sensors

### DIFF
--- a/homeassistant/components/dyson.py
+++ b/homeassistant/components/dyson.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_TIMEOUT, \
     CONF_DEVICES
 
-REQUIREMENTS = ['libpurecoollink==0.2.0']
+REQUIREMENTS = ['libpurecoollink==0.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fan/dyson.py
+++ b/homeassistant/components/fan/dyson.py
@@ -83,8 +83,8 @@ class DysonPureCoolLinkDevice(FanEntity):
 
     def on_message(self, message):
         """Called when new messages received from the fan."""
-        from libpurecoollink.dyson import DysonState
-        if isinstance(message, DysonState):
+        from libpurecoollink.dyson_pure_state import DysonPureCoolState
+        if isinstance(message, DysonPureCoolState):
             _LOGGER.debug("Message received for fan device %s : %s", self.name,
                           message)
             self.schedule_update_ha_state()

--- a/homeassistant/components/sensor/dyson.py
+++ b/homeassistant/components/sensor/dyson.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/sensor.dyson/
 import logging
 import asyncio
 
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import TEMP_CELSIUS, STATE_OFF
 from homeassistant.components.dyson import DYSON_DEVICES
 
 from homeassistant.helpers.entity import Entity
@@ -128,6 +128,8 @@ class DysonHumiditySensor(DysonSensor):
     def state(self):
         """Return Dust value."""
         if self._device.environmental_state:
+            if self._device.environmental_state.humidity == 0:
+                return STATE_OFF
             return self._device.environmental_state.humidity
         return None
 
@@ -151,6 +153,8 @@ class DysonTemperatureSensor(DysonSensor):
         """Return Dust value."""
         if self._device.environmental_state:
             temperature_kelvin = self._device.environmental_state.temperature
+            if temperature_kelvin == 0:
+                return STATE_OFF
             if self._unit == TEMP_CELSIUS:
                 return float("{0:.1f}".format(temperature_kelvin - 273.15))
             return float("{0:.1f}".format(temperature_kelvin * 9 / 5 - 459.67))
@@ -172,7 +176,7 @@ class DysonAirQualitySensor(DysonSensor):
 
     @property
     def state(self):
-        """Return Air QUality value."""
+        """Return Air Quality value."""
         if self._device.environmental_state:
             return self._device.environmental_state.volatil_organic_compounds
         return None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -353,7 +353,7 @@ knxip==0.5
 libnacl==1.5.2
 
 # homeassistant.components.dyson
-libpurecoollink==0.2.0
+libpurecoollink==0.4.1
 
 # homeassistant.components.device_tracker.mikrotik
 librouteros==1.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -62,7 +62,7 @@ holidays==0.8.1
 influxdb==3.0.0
 
 # homeassistant.components.dyson
-libpurecoollink==0.2.0
+libpurecoollink==0.4.1
 
 # homeassistant.components.media_player.soundtouch
 libsoundtouch==0.7.2

--- a/tests/components/fan/test_dyson.py
+++ b/tests/components/fan/test_dyson.py
@@ -6,10 +6,10 @@ from homeassistant.components.dyson import DYSON_DEVICES
 from homeassistant.components.fan import dyson
 from tests.common import get_test_home_assistant
 from libpurecoollink.const import FanSpeed, FanMode, NightMode, Oscillation
-from libpurecoollink.dyson import DysonState
+from libpurecoollink.dyson_pure_state import DysonPureCoolState
 
 
-class MockDysonState(DysonState):
+class MockDysonState(DysonPureCoolState):
     """Mock Dyson state."""
 
     def __init__(self):


### PR DESCRIPTION
## Description:

Fix Dyson sensors if devices are configured without standby monitoring.
It also upgrade libpurecoolink library to remove unused enum34 dependency (PR #8698 )

**Related issue (if applicable):** fixes #8569 

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
