### PR TITLE
Upgrade aiohttp to 2.2.5

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ pip>=8.0.3
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.2.4
+aiohttp==2.2.5
 async_timeout==1.2.1
 chardet==3.0.4
 astral==1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ pip>=8.0.3
 jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.2.4
+aiohttp==2.2.5
 async_timeout==1.2.1
 chardet==3.0.4
 astral==1.4

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     'jinja2>=2.9.5',
     'voluptuous==0.10.5',
     'typing>=3,<4',
-    'aiohttp==2.2.4',
+    'aiohttp==2.2.5',
     'async_timeout==1.2.1',
     'chardet==3.0.4',
     'astral==1.4',


### PR DESCRIPTION
## 2.2.5
- Don't raise deprecation warning on loop.run_until_complete(client.close())

Tested with: 

```yaml
http:
```