### PR TITLE
Warn instead of raise on duplicate YAML key

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -186,8 +186,8 @@ def _ordered_dict(loader: SafeLineLoader,
         if key in seen:
             fname = getattr(loader.stream, 'name', '')
             _LOGGER.warning(
-                'YAML file {} contains duplicate key "{}". '
-                'Check lines {} and {}.'.format(fname, key, seen[key], line))
+                'YAML file % contains duplicate key "%". '
+                'Check lines % and %.', fname, key, seen[key], line)
         seen[key] = line
 
     return _add_reference(OrderedDict(nodes), loader, node)

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -185,12 +185,9 @@ def _ordered_dict(loader: SafeLineLoader,
 
         if key in seen:
             fname = getattr(loader.stream, 'name', '')
-            first_mark = yaml.Mark(fname, 0, seen[key], -1, None, None)
-            second_mark = yaml.Mark(fname, 0, line, -1, None, None)
-            raise yaml.MarkedYAMLError(
-                context="duplicate key: \"{}\"".format(key),
-                context_mark=first_mark, problem_mark=second_mark,
-            )
+            _LOGGER.warning(
+                'YAML file {} contains duplicate key "{}". '
+                'Check lines {} and {}.'.format(fname, key, seen[key], line))
         seen[key] = line
 
     return _add_reference(OrderedDict(nodes), loader, node)

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -185,9 +185,9 @@ def _ordered_dict(loader: SafeLineLoader,
 
         if key in seen:
             fname = getattr(loader.stream, 'name', '')
-            _LOGGER.warning(
-                'YAML file % contains duplicate key "%". '
-                'Check lines % and %.', fname, key, seen[key], line)
+            _LOGGER.error(
+                'YAML file %s contains duplicate key "%s". '
+                'Check lines %d and %d.', fname, key, seen[key], line)
         seen[key] = line
 
     return _add_reference(OrderedDict(nodes), loader, node)

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -15,6 +15,7 @@ from tests.common import get_test_config_dir, patch_yaml_files
 
 @pytest.fixture(autouse=True)
 def mock_credstash():
+    """Mock credstash so it doesn't connect to the internet."""
     with patch.object(yaml, 'credstash') as mock_credstash:
         mock_credstash.getSecret.return_value = None
         yield mock_credstash

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -5,10 +5,19 @@ import unittest
 import logging
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import yaml
 from homeassistant.config import YAML_CONFIG_FILE, load_yaml_config_file
 from tests.common import get_test_config_dir, patch_yaml_files
+
+
+@pytest.fixture(autouse=True)
+def mock_credstash():
+    with patch.object(yaml, 'credstash') as mock_credstash:
+        mock_credstash.getSecret.return_value = None
+        yield mock_credstash
 
 
 class TestYaml(unittest.TestCase):
@@ -29,13 +38,6 @@ class TestYaml(unittest.TestCase):
         with io.StringIO(conf) as file:
             doc = yaml.yaml.safe_load(file)
         assert doc['key'] == 'value'
-
-    def test_duplicate_key(self):
-        """Test duplicate dict keys."""
-        files = {YAML_CONFIG_FILE: 'key: thing1\nkey: thing2'}
-        with self.assertRaises(HomeAssistantError):
-            with patch_yaml_files(files):
-                load_yaml_config_file(YAML_CONFIG_FILE)
 
     def test_unhashable_key(self):
         """Test an unhasable key."""
@@ -411,3 +413,11 @@ def test_representing_yaml_loaded_data():
     with patch_yaml_files(files):
         data = load_yaml_config_file(YAML_CONFIG_FILE)
     assert yaml.dump(data) == "key:\n- 1\n- '2'\n- 3\n"
+
+
+def test_duplicate_key(caplog):
+    """Test duplicate dict keys."""
+    files = {YAML_CONFIG_FILE: 'key: thing1\nkey: thing2'}
+    with patch_yaml_files(files):
+        load_yaml_config_file(YAML_CONFIG_FILE)
+    assert 'contains duplicate key' in caplog.text


### PR DESCRIPTION
## Description:
This will print a warning instead of raising an error when a user accidentally adds a duplicate key to their configuration file.

This is a better user experience. Not starting up is very annoying, especially when launched via something like Systemd or docker.

Also mocks out credstash, as it was making requests to the server on each test.

CC @dale3h 
