### PR TITLE
Fix tests for Demo vacuum platform (and increase coverage)

### DIFF
--- a/homeassistant/components/vacuum/demo.py
+++ b/homeassistant/components/vacuum/demo.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/demo/
 import logging
 
 from homeassistant.components.vacuum import (
-    ATTR_CLEANED_AREA, DEFAULT_ICON, SUPPORT_BATTERY, SUPPORT_FAN_SPEED,
+    ATTR_CLEANED_AREA, SUPPORT_BATTERY, SUPPORT_FAN_SPEED,
     SUPPORT_LOCATE, SUPPORT_PAUSE, SUPPORT_RETURN_HOME, SUPPORT_SEND_COMMAND,
     SUPPORT_STATUS, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
     VacuumDevice)
@@ -32,6 +32,7 @@ DEMO_VACUUM_COMPLETE = '0_Ground_floor'
 DEMO_VACUUM_MOST = '1_First_floor'
 DEMO_VACUUM_BASIC = '2_Second_floor'
 DEMO_VACUUM_MINIMAL = '3_Third_floor'
+DEMO_VACUUM_NONE = '4_Fourth_floor'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -41,6 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         DemoVacuum(DEMO_VACUUM_MOST, SUPPORT_MOST_SERVICES),
         DemoVacuum(DEMO_VACUUM_BASIC, SUPPORT_BASIC_SERVICES),
         DemoVacuum(DEMO_VACUUM_MINIMAL, SUPPORT_MINIMAL_SERVICES),
+        DemoVacuum(DEMO_VACUUM_NONE, 0),
     ])
 
 
@@ -48,7 +50,7 @@ class DemoVacuum(VacuumDevice):
     """Representation of a demo vacuum."""
 
     # pylint: disable=no-self-use
-    def __init__(self, name, supported_features=None):
+    def __init__(self, name, supported_features):
         """Initialize the vacuum."""
         self._name = name
         self._supported_features = supported_features
@@ -66,7 +68,7 @@ class DemoVacuum(VacuumDevice):
     @property
     def icon(self):
         """Return the icon for the vacuum."""
-        return DEFAULT_ICON
+        return 'mdi:roomba'
 
     @property
     def should_poll(self):
@@ -97,9 +99,7 @@ class DemoVacuum(VacuumDevice):
     @property
     def fan_speed_list(self):
         """Return the status of the vacuum."""
-        if self.supported_features & SUPPORT_FAN_SPEED == 0:
-            return
-
+        assert self.supported_features & SUPPORT_FAN_SPEED != 0
         return FAN_SPEEDS
 
     @property
@@ -118,10 +118,7 @@ class DemoVacuum(VacuumDevice):
     @property
     def supported_features(self):
         """Flag supported features."""
-        if self._supported_features is not None:
-            return self._supported_features
-
-        return super().supported_features
+        return self._supported_features
 
     def turn_on(self, **kwargs):
         """Turn the vacuum on."""


### PR DESCRIPTION
## Description:

**Fix the tests for the _Demo vacuum_ platform**

In addition, change the default icon for this vacuum to `mdi:roomba` and increase the tests coverage to 100%.

@balloob, this should fix [the problem you commented here](https://github.com/home-assistant/home-assistant/pull/8623#issuecomment-320416302), introduced with the merge of #8623. Some `self.hass.block_till_done()` where missing.

## Example entry for `configuration.yaml` (if applicable):
```yaml
vacuum:
- platform: demo
```
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**