### PR TITLE
Do not call update() in constructor

### DIFF
--- a/homeassistant/components/sensor/pocketcasts.py
+++ b/homeassistant/components/sensor/pocketcasts.py
@@ -10,39 +10,40 @@ from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
-from homeassistant.components.sensor import (PLATFORM_SCHEMA)
-
-_LOGGER = logging.getLogger(__name__)
+from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['pocketcasts==0.1']
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
-})
+_LOGGER = logging.getLogger(__name__)
 
 ICON = 'mdi:rss'
+
 SENSOR_NAME = 'Pocketcasts unlistened episodes'
+
 SCAN_INTERVAL = timedelta(minutes=5)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the pocketcasts platform for sensors."""
     import pocketcasts
+
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+
     try:
-        api = pocketcasts.Api(
-            config.get(CONF_USERNAME),
-            config.get(CONF_PASSWORD))
-        _LOGGER.debug('Found %d podcasts',
-                      len(api.my_podcasts()))
-        add_devices([PocketCastsSensor(api)])
-        return True
+        api = pocketcasts.Api(username, password)
+        _LOGGER.debug("Found %d podcasts", len(api.my_podcasts()))
+        add_devices([PocketCastsSensor(api)], True)
     except OSError as err:
-        _LOGGER.error('Failed to contact server '
-                      '(wrong credentials?): %s', err)
+        _LOGGER.error("Connection to server failed: %s", err)
         return False
 
 
@@ -53,15 +54,6 @@ class PocketCastsSensor(Entity):
         """Initialize the sensor."""
         self._api = api
         self._state = None
-        self.update()
-
-    def update(self):
-        """Update sensor values."""
-        try:
-            self._state = len(self._api.new_episodes_released())
-            _LOGGER.debug("Found %d new episodes", self._state)
-        except OSError as err:
-            _LOGGER.warning("Failed to contact server: %s", err)
 
     @property
     def name(self):
@@ -77,3 +69,11 @@ class PocketCastsSensor(Entity):
     def icon(self):
         """Return the icon for the sensor."""
         return ICON
+
+    def update(self):
+        """Update sensor values."""
+        try:
+            self._state = len(self._api.new_episodes_released())
+            _LOGGER.debug("Found %d new episodes", self._state)
+        except OSError as err:
+            _LOGGER.warning("Failed to contact server: %s", err)


### PR DESCRIPTION
## Description:
- Do not call update() in constructor
- Update ordering
- Update docstrings

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: pocketcasts
    username: !secret pc_username
    password: !secret pc_password
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**