### PR TITLE
Make 'monitored_conditions' optional

### DIFF
--- a/tests/components/sensor/test_sonarr.py
+++ b/tests/components/sensor/test_sonarr.py
@@ -1,4 +1,4 @@
-"""The tests for the sonarr platform."""
+"""The tests for the Sonarr platform."""
 import unittest
 import time
 from datetime import datetime
@@ -561,7 +561,7 @@ class TestSonarrSetup(unittest.TestCase):
     # pylint: disable=invalid-name
     DEVICES = []
 
-    def add_devices(self, devices):
+    def add_devices(self, devices, update):
         """Mock add devices."""
         for device in devices:
             self.DEVICES.append(device)


### PR DESCRIPTION
## Description:
- Do not call update() in constructor
- Make `monitored_conditions` optional
- Update ordering

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3142

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: sonarr
    api_key: !secret sonarr_api
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
