### PR TITLE
WIP: Add state to Service in core

### DIFF
--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -150,10 +150,10 @@ def async_setup(hass, config):
 
     hass.services.async_register(
         ha.DOMAIN, SERVICE_TURN_OFF, async_handle_turn_service,
-        state_to_set=STATE_OFF)
+        state=STATE_OFF)
     hass.services.async_register(
         ha.DOMAIN, SERVICE_TURN_ON, async_handle_turn_service,
-        state_to_set=STATE_ON)
+        state=STATE_ON)
     hass.services.async_register(
         ha.DOMAIN, SERVICE_TOGGLE, async_handle_turn_service)
 

--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.service import extract_entity_ids
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE,
     SERVICE_HOMEASSISTANT_STOP, SERVICE_HOMEASSISTANT_RESTART,
-    RESTART_EXIT_CODE)
+    RESTART_EXIT_CODE, STATE_OFF, STATE_ON)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -149,9 +149,11 @@ def async_setup(hass, config):
         yield from asyncio.wait(tasks, loop=hass.loop)
 
     hass.services.async_register(
-        ha.DOMAIN, SERVICE_TURN_OFF, async_handle_turn_service)
+        ha.DOMAIN, SERVICE_TURN_OFF, async_handle_turn_service,
+        state_to_set=STATE_OFF)
     hass.services.async_register(
-        ha.DOMAIN, SERVICE_TURN_ON, async_handle_turn_service)
+        ha.DOMAIN, SERVICE_TURN_ON, async_handle_turn_service,
+        state_to_set=STATE_ON)
     hass.services.async_register(
         ha.DOMAIN, SERVICE_TOGGLE, async_handle_turn_service)
 

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -157,7 +157,7 @@ def async_setup(hass, config):
         hass.services.async_register(
             DOMAIN, service, async_alarm_service_handler,
             descriptions.get(service), schema=ALARM_SERVICE_SCHEMA,
-            state_to_set=SERVICE_TO_METHOD[service]['state'])
+            state=SERVICE_TO_METHOD[service]['state'])
 
     return True
 

--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -138,10 +138,12 @@ def async_setup(hass, config):
     # Setup service calls
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_OFF, async_handle_alert_service,
-        descriptions.get(SERVICE_TURN_OFF), schema=ALERT_SERVICE_SCHEMA)
+        descriptions.get(SERVICE_TURN_OFF), schema=ALERT_SERVICE_SCHEMA,
+        state_to_set=STATE_OFF)
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_ON, async_handle_alert_service,
-        descriptions.get(SERVICE_TURN_ON), schema=ALERT_SERVICE_SCHEMA)
+        descriptions.get(SERVICE_TURN_ON), schema=ALERT_SERVICE_SCHEMA,
+        state_to_set=STATE_ON)
     hass.services.async_register(
         DOMAIN, SERVICE_TOGGLE, async_handle_alert_service,
         descriptions.get(SERVICE_TOGGLE), schema=ALERT_SERVICE_SCHEMA)

--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -139,11 +139,11 @@ def async_setup(hass, config):
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_OFF, async_handle_alert_service,
         descriptions.get(SERVICE_TURN_OFF), schema=ALERT_SERVICE_SCHEMA,
-        state_to_set=STATE_OFF)
+        state=STATE_OFF)
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_ON, async_handle_alert_service,
         descriptions.get(SERVICE_TURN_ON), schema=ALERT_SERVICE_SCHEMA,
-        state_to_set=STATE_ON)
+        state=STATE_ON)
     hass.services.async_register(
         DOMAIN, SERVICE_TOGGLE, async_handle_alert_service,
         descriptions.get(SERVICE_TOGGLE), schema=ALERT_SERVICE_SCHEMA)

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -349,7 +349,7 @@ class APITemplateView(HomeAssistantView):
 def async_services_json(hass):
     """Generate services data to JSONify."""
     return [{"domain": key, "services": value}
-            for key, value in hass.services.async_services().items()]
+            for key, value in hass.services.async_services_json().items()]
 
 
 def async_events_json(hass):

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -17,7 +17,8 @@ from homeassistant.loader import bind_hass
 from homeassistant import config as conf_util
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_PLATFORM, STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF,
-    SERVICE_TOGGLE, SERVICE_RELOAD, EVENT_HOMEASSISTANT_START, CONF_ID)
+    SERVICE_TOGGLE, SERVICE_RELOAD, EVENT_HOMEASSISTANT_START, CONF_ID,
+    STATE_OFF)
 from homeassistant.components import logbook
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import extract_domain_configs, script, condition
@@ -226,10 +227,12 @@ def async_setup(hass, config):
         DOMAIN, SERVICE_TOGGLE, toggle_service_handler,
         descriptions.get(SERVICE_TOGGLE), schema=SERVICE_SCHEMA)
 
-    for service in (SERVICE_TURN_ON, SERVICE_TURN_OFF):
+    for service, state in [
+            (SERVICE_TURN_ON, STATE_ON), (SERVICE_TURN_OFF, STATE_OFF)]:
         hass.services.async_register(
             DOMAIN, service, turn_onoff_service_handler,
-            descriptions.get(service), schema=SERVICE_SCHEMA)
+            descriptions.get(service), schema=SERVICE_SCHEMA,
+            state_to_set=state)
 
     return True
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -232,7 +232,7 @@ def async_setup(hass, config):
         hass.services.async_register(
             DOMAIN, service, turn_onoff_service_handler,
             descriptions.get(service), schema=SERVICE_SCHEMA,
-            state_to_set=state)
+            state=state)
 
     return True
 

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -199,7 +199,7 @@ def async_setup(hass, config):
         hass.services.async_register(
             DOMAIN, service_name, async_handle_cover_service,
             descriptions.get(service_name), schema=schema,
-            state_to_set=SERVICE_TO_METHOD[service_name].get('state'))
+            state=SERVICE_TO_METHOD[service_name].get('state'))
 
     return True
 

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -72,8 +72,9 @@ COVER_SET_COVER_TILT_POSITION_SCHEMA = COVER_SERVICE_SCHEMA.extend({
 })
 
 SERVICE_TO_METHOD = {
-    SERVICE_OPEN_COVER: {'method': 'async_open_cover'},
-    SERVICE_CLOSE_COVER: {'method': 'async_close_cover'},
+    SERVICE_OPEN_COVER: {'method': 'async_open_cover', 'state': STATE_OPEN},
+    SERVICE_CLOSE_COVER: {
+        'method': 'async_close_cover', 'state': STATE_CLOSED},
     SERVICE_SET_COVER_POSITION: {
         'method': 'async_set_cover_position',
         'schema': COVER_SET_COVER_POSITION_SCHEMA},
@@ -197,7 +198,8 @@ def async_setup(hass, config):
             'schema', COVER_SERVICE_SCHEMA)
         hass.services.async_register(
             DOMAIN, service_name, async_handle_cover_service,
-            descriptions.get(service_name), schema=schema)
+            descriptions.get(service_name), schema=schema,
+            state_to_set=SERVICE_TO_METHOD[service_name].get('state'))
 
     return True
 

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -245,7 +245,7 @@ def async_setup(hass, config: dict):
         hass.services.async_register(
             DOMAIN, service_name, async_handle_fan_service,
             descriptions.get(service_name), schema=schema,
-            state_to_set=SERVICE_TO_METHOD[service_name].get('state'))
+            state=SERVICE_TO_METHOD[service_name].get('state'))
 
     return True
 

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.components import group
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (SERVICE_TURN_ON, SERVICE_TOGGLE,
                                  SERVICE_TURN_OFF, ATTR_ENTITY_ID,
-                                 STATE_UNKNOWN)
+                                 STATE_OFF, STATE_ON, STATE_UNKNOWN)
 from homeassistant.loader import bind_hass
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
@@ -64,12 +64,12 @@ PROP_TO_ATTR = {
 }  # type: dict
 
 FAN_SET_SPEED_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_SPEED): cv.string
 })  # type: dict
 
 FAN_TURN_ON_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Optional(ATTR_SPEED): cv.string
 })  # type: dict
 
@@ -78,27 +78,29 @@ FAN_TURN_OFF_SCHEMA = vol.Schema({
 })  # type: dict
 
 FAN_OSCILLATE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_OSCILLATING): cv.boolean
 })  # type: dict
 
 FAN_TOGGLE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_ids
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
 })
 
 FAN_SET_DIRECTION_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Optional(ATTR_DIRECTION): cv.string
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_DIRECTION): cv.string
 })  # type: dict
 
 SERVICE_TO_METHOD = {
     SERVICE_TURN_ON: {
         'method': 'async_turn_on',
         'schema': FAN_TURN_ON_SCHEMA,
+        'state': STATE_ON,
     },
     SERVICE_TURN_OFF: {
         'method': 'async_turn_off',
         'schema': FAN_TURN_OFF_SCHEMA,
+        'state': STATE_OFF,
     },
     SERVICE_TOGGLE: {
         'method': 'async_toggle',
@@ -242,7 +244,8 @@ def async_setup(hass, config: dict):
         schema = SERVICE_TO_METHOD[service_name].get('schema')
         hass.services.async_register(
             DOMAIN, service_name, async_handle_fan_service,
-            descriptions.get(service_name), schema=schema)
+            descriptions.get(service_name), schema=schema,
+            state_to_set=SERVICE_TO_METHOD[service_name].get('state'))
 
     return True
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -306,12 +306,12 @@ def async_setup(hass, config):
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_ON, async_handle_light_service,
         descriptions.get(SERVICE_TURN_ON), schema=LIGHT_TURN_ON_SCHEMA,
-        state_to_set=STATE_ON)
+        state=STATE_ON)
 
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_OFF, async_handle_light_service,
         descriptions.get(SERVICE_TURN_OFF), schema=LIGHT_TURN_OFF_SCHEMA,
-        state_to_set=STATE_OFF)
+        state=STATE_OFF)
 
     hass.services.async_register(
         DOMAIN, SERVICE_TOGGLE, async_handle_light_service,

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.loader import bind_hass
 from homeassistant.components import group
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (
-    STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE,
+    STATE_OFF, STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE,
     ATTR_ENTITY_ID)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
@@ -305,11 +305,13 @@ def async_setup(hass, config):
 
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_ON, async_handle_light_service,
-        descriptions.get(SERVICE_TURN_ON), schema=LIGHT_TURN_ON_SCHEMA)
+        descriptions.get(SERVICE_TURN_ON), schema=LIGHT_TURN_ON_SCHEMA,
+        state_to_set=STATE_ON)
 
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_OFF, async_handle_light_service,
-        descriptions.get(SERVICE_TURN_OFF), schema=LIGHT_TURN_OFF_SCHEMA)
+        descriptions.get(SERVICE_TURN_OFF), schema=LIGHT_TURN_OFF_SCHEMA,
+        state_to_set=STATE_OFF)
 
     hass.services.async_register(
         DOMAIN, SERVICE_TOGGLE, async_handle_light_service,

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -465,7 +465,7 @@ class ActiveConnection:
         msg = GET_SERVICES_MESSAGE_SCHEMA(msg)
 
         self.to_write.put_nowait(result_message(
-            msg['id'], self.hass.services.async_services()))
+            msg['id'], self.hass.services.async_services_json()))
 
     def handle_get_config(self, msg):
         """Handle get config command.

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -749,9 +749,9 @@ class Service(object):
     """Representation of a callable service."""
 
     __slots__ = ['func', 'description', 'fields', 'schema',
-                 'is_callback', 'is_coroutinefunction', 'state_to_set']
+                 'is_callback', 'is_coroutinefunction', 'state']
 
-    def __init__(self, func, description, fields, schema, state_to_set=None):
+    def __init__(self, func, description, fields, schema, state=None):
         """Initialize a service."""
         self.func = func
         self.description = description or ''
@@ -759,7 +759,7 @@ class Service(object):
         self.schema = schema
         self.is_callback = is_callback(func)
         self.is_coroutinefunction = asyncio.iscoroutinefunction(func)
-        self.state_to_set = state_to_set
+        self.state = state
 
     def as_dict(self):
         """Return dictionary representation of this service."""
@@ -850,7 +850,7 @@ class ServiceRegistry(object):
         return service.lower() in self._services.get(domain.lower(), [])
 
     def register(self, domain, service, service_func, description=None,
-                 schema=None, state_to_set=None):
+                 schema=None, state=None):
         """
         Register a service.
 
@@ -859,7 +859,7 @@ class ServiceRegistry(object):
 
         Schema is called to coerce and validate the service data.
 
-        Use state_to_set to know what state the service sets.
+        Use state to know what state the service sets.
         """
         run_callback_threadsafe(
             self._hass.loop,
@@ -869,7 +869,7 @@ class ServiceRegistry(object):
 
     @callback
     def async_register(self, domain, service, service_func, description=None,
-                       schema=None, state_to_set=None):
+                       schema=None, state=None):
         """
         Register a service.
 
@@ -878,7 +878,7 @@ class ServiceRegistry(object):
 
         Schema is called to coerce and validate the service data.
 
-        Use state_to_set to know what state the service sets.
+        Use state to know what state the service sets.
 
         This method must be run in the event loop.
         """
@@ -887,7 +887,7 @@ class ServiceRegistry(object):
         description = description or {}
         service_obj = Service(service_func, description.get('description'),
                               description.get('fields', {}), schema,
-                              state_to_set)
+                              state)
 
         if domain in self._services:
             self._services[domain][service] = service_obj

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -768,6 +768,14 @@ class Service(object):
             'fields': self.fields,
         }
 
+    def can_call(self, service_data):
+        """Return True if service can be called with service_data."""
+        try:
+            self.schema(service_data)
+            return True
+        except vol.Invalid:
+            return False
+
 
 class ServiceCall(object):
     """Representation of a call to a service."""

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -824,14 +824,18 @@ class ServiceRegistry(object):
         ).result()
 
     @callback
-    def async_services(self):
+    def async_services(self, domain=None):
         """Return read only dict with per domain a dict with service instances.
 
         This method must be run in the event loop.
         """
-        return MappingProxyType({
+        all_services = MappingProxyType({
             domain: MappingProxyType(services)
             for domain, services in self._services.items()})
+        if domain is not None:
+            return all_services.get(domain)
+        else:
+            return all_services
 
     @callback
     def async_services_json(self):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -825,23 +825,6 @@ class ServiceRegistry(object):
 
     @callback
     def async_services(self):
-        """Return dictionary with per domain a dict of available services.
-
-        This method must be run in the event loop.
-        """
-        return {domain: {key: value.as_dict() for key, value
-                         in self._services[domain].items()}
-                for domain in self._services}
-
-    @property
-    def full_services(self):
-        """Return dict with per domain a dict with the service instances."""
-        return run_callback_threadsafe(
-            self._hass.loop, self.async_full_services,
-        ).result()
-
-    @callback
-    def async_full_services(self):
         """Return read only dict with per domain a dict with service instances.
 
         This method must be run in the event loop.
@@ -849,6 +832,16 @@ class ServiceRegistry(object):
         return MappingProxyType({
             domain: MappingProxyType(services)
             for domain, services in self._services.items()})
+
+    @callback
+    def async_services_json(self):
+        """Return dictionary with per domain a dict of JSONified services.
+
+        This method must be run in the event loop.
+        """
+        return {domain: {key: value.as_dict() for key, value
+                         in self._services[domain].items()}
+                for domain in self._services}
 
     def has_service(self, domain, service):
         """Test if specified service exists.

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -834,13 +834,13 @@ class ServiceRegistry(object):
 
     @callback
     def async_full_services(self):
-        """Return dict with per domain a dict with the service instances.
+        """Return read only dict with per domain a dict with service instances.
 
         This method must be run in the event loop.
         """
-        return {domain: {key: value for key, value
-                         in self._services[domain].items()}
-                for domain in self._services}
+        return MappingProxyType({
+            domain: MappingProxyType(services)
+            for domain, services in self._services.items()})
 
     def has_service(self, domain, service):
         """Test if specified service exists.
@@ -886,8 +886,7 @@ class ServiceRegistry(object):
         service = service.lower()
         description = description or {}
         service_obj = Service(service_func, description.get('description'),
-                              description.get('fields', {}), schema,
-                              state)
+                              description.get('fields', {}), schema, state)
 
         if domain in self._services:
             self._services[domain][service] = service_obj

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -749,9 +749,9 @@ class Service(object):
     """Representation of a callable service."""
 
     __slots__ = ['func', 'description', 'fields', 'schema',
-                 'is_callback', 'is_coroutinefunction']
+                 'is_callback', 'is_coroutinefunction', 'state_to_set']
 
-    def __init__(self, func, description, fields, schema):
+    def __init__(self, func, description, fields, schema, state_to_set=None):
         """Initialize a service."""
         self.func = func
         self.description = description or ''
@@ -759,6 +759,7 @@ class Service(object):
         self.schema = schema
         self.is_callback = is_callback(func)
         self.is_coroutinefunction = asyncio.iscoroutinefunction(func)
+        self.state_to_set = state_to_set
 
     def as_dict(self):
         """Return dictionary representation of this service."""
@@ -809,18 +810,35 @@ class ServiceRegistry(object):
 
     @property
     def services(self):
-        """Return dictionary with per domain a list of available services."""
+        """Return dictionary with per domain a dict of available services."""
         return run_callback_threadsafe(
             self._hass.loop, self.async_services,
         ).result()
 
     @callback
     def async_services(self):
-        """Return dictionary with per domain a list of available services.
+        """Return dictionary with per domain a dict of available services.
 
         This method must be run in the event loop.
         """
         return {domain: {key: value.as_dict() for key, value
+                         in self._services[domain].items()}
+                for domain in self._services}
+
+    @property
+    def full_services(self):
+        """Return dict with per domain a dict with the service instances."""
+        return run_callback_threadsafe(
+            self._hass.loop, self.async_full_services,
+        ).result()
+
+    @callback
+    def async_full_services(self):
+        """Return dict with per domain a dict with the service instances.
+
+        This method must be run in the event loop.
+        """
+        return {domain: {key: value for key, value
                          in self._services[domain].items()}
                 for domain in self._services}
 
@@ -832,7 +850,7 @@ class ServiceRegistry(object):
         return service.lower() in self._services.get(domain.lower(), [])
 
     def register(self, domain, service, service_func, description=None,
-                 schema=None):
+                 schema=None, state_to_set=None):
         """
         Register a service.
 
@@ -840,6 +858,8 @@ class ServiceRegistry(object):
         the service and a key 'fields' to describe the fields.
 
         Schema is called to coerce and validate the service data.
+
+        Use state_to_set to know what state the service sets.
         """
         run_callback_threadsafe(
             self._hass.loop,
@@ -849,7 +869,7 @@ class ServiceRegistry(object):
 
     @callback
     def async_register(self, domain, service, service_func, description=None,
-                       schema=None):
+                       schema=None, state_to_set=None):
         """
         Register a service.
 
@@ -858,13 +878,16 @@ class ServiceRegistry(object):
 
         Schema is called to coerce and validate the service data.
 
+        Use state_to_set to know what state the service sets.
+
         This method must be run in the event loop.
         """
         domain = domain.lower()
         service = service.lower()
         description = description or {}
         service_obj = Service(service_func, description.get('description'),
-                              description.get('fields', {}), schema)
+                              description.get('fields', {}), schema,
+                              state_to_set)
 
         if domain in self._services:
             self._services[domain][service] = service_obj

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -118,7 +118,7 @@ def async_get_state_services(hass, domain, state):
 
     This function must be run in the event loop.
     """
-    domain_services = hass.services.async_full_services().get(domain)
+    domain_services = hass.services.async_services().get(domain)
 
     if not domain_services:
         _LOGGER.warning("No services found for domain %s", domain)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -122,7 +122,7 @@ def async_get_state_services(hass, domain, state):
 
     if not domain_services:
         _LOGGER.warning("No services found for domain %s", domain)
-        return
+        return None
 
     services = defaultdict(dict)
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -146,6 +146,7 @@ def async_get_state_services(hass, domain, state):
             # voluptuous modifies the value before returning it, so make a copy
             valid_attrs = schema(dict(state.attributes))
         except vol.Invalid:
+            services.pop(service_name, None)
             continue
         if valid_attrs:
             services[service_name]['attrs'] = valid_attrs

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1,14 +1,13 @@
 """Service calling related helpers."""
 import asyncio
 import logging
-from collections import defaultdict
 # pylint: disable=unused-import
 from typing import Optional  # NOQA
 
 import voluptuous as vol
 
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import callback, HomeAssistant  # NOQA
+from homeassistant.core import callback, HomeAssistant, ServiceCall  # NOQA
 from homeassistant.exceptions import TemplateError
 from homeassistant.loader import get_component
 import homeassistant.helpers.config_validation as cv
@@ -124,12 +123,12 @@ def async_get_state_services(hass, domain, state):
         _LOGGER.warning("No services found for domain %s", domain)
         return None
 
-    services = defaultdict(dict)
+    services = {}
 
     for service_name, service_obj in domain_services.items():
         if (service_obj.state is not None and
                 service_obj.state == state.state):
-            services[service_name]['state'] = state.state
+            services[service_name] = ServiceCall(domain, service_name)
         if (service_obj.schema is None or
                 # service with no state to set must require attributes
                 # to be able to change state attributes
@@ -149,6 +148,7 @@ def async_get_state_services(hass, domain, state):
             services.pop(service_name, None)
             continue
         if valid_attrs:
-            services[service_name]['attrs'] = valid_attrs
+            services[service_name] = ServiceCall(
+                domain, service_name, valid_attrs)
 
-    return dict(services)
+    return services

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -138,10 +138,13 @@ def async_get_state_services(hass, domain, state):
                     for key in service_obj.schema.schema) and
                 service_name not in services):
             continue
-        service_obj.schema.extra = vol.REMOVE_EXTRA
+        # make a copy to be able to modify schema
+        schema = service_obj.schema.extend({})
+        # remove extra state attributes not in schema
+        schema.extra = vol.REMOVE_EXTRA
         try:
             # voluptuous modifies the value before returning it, so make a copy
-            valid_attrs = service_obj.schema(dict(state.attributes))
+            valid_attrs = schema(dict(state.attributes))
         except vol.Invalid:
             continue
         if valid_attrs:

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -127,8 +127,8 @@ def async_get_state_services(hass, domain, state):
     services = defaultdict(dict)
 
     for service_name, service_obj in domain_services.items():
-        if (service_obj.state_to_set is not None and
-                service_obj.state_to_set == state.state):
+        if (service_obj.state is not None and
+                service_obj.state == state.state):
             services[service_name]['state'] = state.state
         if (service_obj.schema is None or
                 # service with no state to set must require attributes

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -147,4 +147,4 @@ def async_get_state_services(hass, domain, state):
         if valid_attrs:
             services[service_name]['attrs'] = valid_attrs
 
-    return services
+    return dict(services)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -118,7 +118,7 @@ def async_get_state_services(hass, domain, state):
 
     This function must be run in the event loop.
     """
-    domain_services = hass.services.async_services().get(domain)
+    domain_services = hass.services.async_services(domain)
 
     if not domain_services:
         _LOGGER.warning("No services found for domain %s", domain)

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -154,13 +154,13 @@ def async_reproduce_state(hass, states, blocking=False):
                 "reproduce_state: Unable to reproduce state %s", state)
             continue
 
-        for service, service_info in services.items():
+        for service, service_call in services.items():
             # We group service calls for entities by service call
             # json used to create a hashable version of dict
             # with maybe lists in it
             key = (
                 service_domain, service,
-                json.dumps(service_info.get('attrs', {}), sort_keys=True))
+                json.dumps(dict(service_call.data), sort_keys=True))
             to_call[key].append(state.entity_id)
 
     domain_tasks = {}

--- a/tests/common.py
+++ b/tests/common.py
@@ -174,7 +174,7 @@ def get_test_instance_port():
 
 
 @ha.callback
-def async_mock_service(hass, domain, service, schema=None):
+def async_mock_service(hass, domain, service, schema=None, state_to_set=None):
     """Set up a fake service & return a calls log list to this service."""
     calls = []
 
@@ -184,7 +184,8 @@ def async_mock_service(hass, domain, service, schema=None):
         calls.append(call)
 
     hass.services.async_register(
-        domain, service, mock_service_log, schema=schema)
+        domain, service, mock_service_log, schema=schema,
+        state_to_set=state_to_set)
 
     return calls
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -174,7 +174,7 @@ def get_test_instance_port():
 
 
 @ha.callback
-def async_mock_service(hass, domain, service, schema=None, state_to_set=None):
+def async_mock_service(hass, domain, service, schema=None, state=None):
     """Set up a fake service & return a calls log list to this service."""
     calls = []
 
@@ -185,7 +185,7 @@ def async_mock_service(hass, domain, service, schema=None, state_to_set=None):
 
     hass.services.async_register(
         domain, service, mock_service_log, schema=schema,
-        state_to_set=state_to_set)
+        state=state)
 
     return calls
 

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -261,7 +261,7 @@ def test_api_get_services(hass, mock_api_client):
     """Test if we can get a dict describing current services."""
     resp = yield from mock_api_client.get(const.URL_API_SERVICES)
     data = yield from resp.json()
-    local_services = hass.services.async_services()
+    local_services = hass.services.async_services_json()
 
     for serv_domain in data:
         local = local_services.pop(serv_domain["domain"])

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -260,7 +260,7 @@ def test_get_services(hass, websocket_client):
     assert msg['id'] == 5
     assert msg['type'] == wapi.TYPE_RESULT
     assert msg['success']
-    assert msg['result'] == hass.services.async_services()
+    assert msg['result'] == hass.services.async_services_json()
 
 
 @asyncio.coroutine

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -155,8 +155,7 @@ def test_get_state_services(hass):
     services = service.async_get_state_services(hass, domain, state)
 
     assert SERVICE_TURN_ON in services
-    assert services[SERVICE_TURN_ON]['state'] == 'on'
-    assert services[SERVICE_TURN_ON]['attrs'] == state_attrs
+    assert services[SERVICE_TURN_ON].data == state_attrs
 
 
 @asyncio.coroutine
@@ -184,8 +183,7 @@ def test_get_state_services_no_schema(hass):
     services = service.async_get_state_services(hass, domain, state)
 
     assert SERVICE_TURN_ON in services
-    assert services[SERVICE_TURN_ON]['state'] == 'on'
-    assert 'attrs' not in services[SERVICE_TURN_ON]
+    assert not services[SERVICE_TURN_ON].data
 
 
 @asyncio.coroutine
@@ -230,5 +228,4 @@ def test_get_state_services_no_attributes(hass):
     services = service.async_get_state_services(hass, domain, state)
 
     assert SERVICE_TURN_ON in services
-    assert services[SERVICE_TURN_ON]['state'] == 'on'
-    assert 'attrs' not in services[SERVICE_TURN_ON]
+    assert not services[SERVICE_TURN_ON].data

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -214,9 +214,7 @@ def test_get_state_services_not_valid(hass):
 
     services = service.async_get_state_services(hass, domain, state)
 
-    assert SERVICE_TURN_ON in services
-    assert services[SERVICE_TURN_ON]['state'] == 'on'
-    assert 'attrs' not in services[SERVICE_TURN_ON]
+    assert SERVICE_TURN_ON not in services
 
 
 @asyncio.coroutine

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -177,7 +177,7 @@ def test_get_state_services_no_domain(hass, caplog):
 def test_get_state_services_no_schema(hass):
     """Test async_get_state_services with no schema for service."""
     domain = 'light'
-    async_mock_service(hass, domain, SERVICE_TURN_ON, state_to_set='on')
+    async_mock_service(hass, domain, SERVICE_TURN_ON, state='on')
     state_attrs = {'transition': 999, 'brightness': 100}
     state = ha.State('light.test', 'on', state_attrs)
 

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -75,7 +75,7 @@ def test_get_changed_since(hass):
 def test_reproduce_with_no_entity(hass):
     """Test reproduce_state with no entity."""
     calls = async_mock_service(
-        hass, 'light', SERVICE_TURN_ON, state_to_set='on')
+        hass, 'light', SERVICE_TURN_ON, state='on')
 
     yield from state.async_reproduce_state(hass, ha.State('light.test', 'on'))
     yield from hass.async_block_till_done()
@@ -107,7 +107,7 @@ def test_reproduce_group(hass):
 def test_reproduce_turn_on(hass):
     """Test reproduce_state with SERVICE_TURN_ON."""
     calls = async_mock_service(
-        hass, 'light', SERVICE_TURN_ON, state_to_set='on')
+        hass, 'light', SERVICE_TURN_ON, state='on')
     hass.states.async_set('light.test', 'off')
 
     yield from state.async_reproduce_state(hass, ha.State('light.test', 'on'))
@@ -124,7 +124,7 @@ def test_reproduce_turn_on(hass):
 def test_reproduce_turn_off(hass):
     """Test reproduce_state with SERVICE_TURN_OFF."""
     calls = async_mock_service(
-        hass, 'light', SERVICE_TURN_OFF, state_to_set='off')
+        hass, 'light', SERVICE_TURN_OFF, state='off')
     hass.states.async_set('light.test', 'on')
 
     yield from state.async_reproduce_state(hass, ha.State('light.test', 'off'))
@@ -187,7 +187,7 @@ def test_reproduce_media_data(hass):
 def test_reproduce_media_play(hass):
     """Test reproduce_state with SERVICE_MEDIA_PLAY."""
     calls = async_mock_service(
-        hass, 'media_player', SERVICE_MEDIA_PLAY, state_to_set='playing')
+        hass, 'media_player', SERVICE_MEDIA_PLAY, state='playing')
     hass.states.async_set('media_player.test', 'off')
 
     yield from state.async_reproduce_state(
@@ -205,7 +205,7 @@ def test_reproduce_media_play(hass):
 def test_reproduce_media_pause(hass):
     """Test reproduce_state with SERVICE_MEDIA_PAUSE."""
     calls = async_mock_service(
-        hass, 'media_player', SERVICE_MEDIA_PAUSE, state_to_set='paused')
+        hass, 'media_player', SERVICE_MEDIA_PAUSE, state='paused')
     hass.states.async_set('media_player.test', 'playing')
 
     yield from state.async_reproduce_state(

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -1,26 +1,25 @@
 """Test state helpers."""
 import asyncio
 from datetime import timedelta
-import unittest
 from unittest.mock import patch
+
+import pytest
+import voluptuous as vol
 
 import homeassistant.core as ha
 import homeassistant.components as core_components
-from homeassistant.const import (SERVICE_TURN_ON, SERVICE_TURN_OFF)
-from homeassistant.util.async import run_coroutine_threadsafe
+from homeassistant.const import SERVICE_TURN_ON, SERVICE_TURN_OFF
 from homeassistant.util import dt as dt_util
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import state
 from homeassistant.const import (
-    STATE_OPEN, STATE_CLOSED,
-    STATE_LOCKED, STATE_UNLOCKED,
-    STATE_ON, STATE_OFF,
-    STATE_HOME, STATE_NOT_HOME)
+    STATE_OPEN, STATE_CLOSED, STATE_LOCKED, STATE_UNLOCKED, STATE_ON,
+    STATE_OFF, STATE_HOME, STATE_NOT_HOME)
 from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA, SERVICE_MEDIA_PLAY, SERVICE_MEDIA_PAUSE)
-from homeassistant.components.sun import (STATE_ABOVE_HORIZON,
-                                          STATE_BELOW_HORIZON)
-
-from tests.common import get_test_home_assistant, mock_service
+from homeassistant.components.sun import (
+    STATE_ABOVE_HORIZON, STATE_BELOW_HORIZON)
+from tests.common import async_mock_service
 
 
 @asyncio.coroutine
@@ -49,241 +48,237 @@ def test_async_track_states(hass):
         sorted(states, key=lambda state: state.entity_id)
 
 
-class TestStateHelpers(unittest.TestCase):
-    """Test the Home Assistant event helpers."""
+@asyncio.coroutine
+def test_get_changed_since(hass):
+    """Test get_changed_since."""
+    point1 = dt_util.utcnow()
+    point2 = point1 + timedelta(seconds=5)
+    point3 = point2 + timedelta(seconds=5)
 
-    def setUp(self):     # pylint: disable=invalid-name
-        """Run when tests are started."""
-        self.hass = get_test_home_assistant()
-        run_coroutine_threadsafe(core_components.async_setup(
-            self.hass, {}), self.hass.loop).result()
+    with patch('homeassistant.core.dt_util.utcnow', return_value=point1):
+        hass.states.async_set('light.test', 'on')
+        state1 = hass.states.get('light.test')
 
-    def tearDown(self):  # pylint: disable=invalid-name
-        """Stop when tests are finished."""
-        self.hass.stop()
+    with patch('homeassistant.core.dt_util.utcnow', return_value=point2):
+        hass.states.async_set('light.test2', 'on')
+        state2 = hass.states.get('light.test2')
 
-    def test_get_changed_since(self):
-        """Test get_changed_since."""
-        point1 = dt_util.utcnow()
-        point2 = point1 + timedelta(seconds=5)
-        point3 = point2 + timedelta(seconds=5)
+    with patch('homeassistant.core.dt_util.utcnow', return_value=point3):
+        hass.states.async_set('light.test3', 'on')
+        state3 = hass.states.get('light.test3')
 
-        with patch('homeassistant.core.dt_util.utcnow', return_value=point1):
-            self.hass.states.set('light.test', 'on')
-            state1 = self.hass.states.get('light.test')
+    assert state.get_changed_since(
+        [state1, state2, state3], point2) == [state2, state3]
 
-        with patch('homeassistant.core.dt_util.utcnow', return_value=point2):
-            self.hass.states.set('light.test2', 'on')
-            state2 = self.hass.states.get('light.test2')
 
-        with patch('homeassistant.core.dt_util.utcnow', return_value=point3):
-            self.hass.states.set('light.test3', 'on')
-            state3 = self.hass.states.get('light.test3')
+@asyncio.coroutine
+def test_reproduce_with_no_entity(hass):
+    """Test reproduce_state with no entity."""
+    calls = async_mock_service(
+        hass, 'light', SERVICE_TURN_ON, state_to_set='on')
 
-        self.assertEqual(
-            [state2, state3],
-            state.get_changed_since([state1, state2, state3], point2))
+    yield from state.async_reproduce_state(hass, ha.State('light.test', 'on'))
+    yield from hass.async_block_till_done()
 
-    def test_reproduce_with_no_entity(self):
-        """Test reproduce_state with no entity."""
-        calls = mock_service(self.hass, 'light', SERVICE_TURN_ON)
+    assert len(calls) == 0
+    assert hass.states.get('light.test') is None
 
-        state.reproduce_state(self.hass, ha.State('light.test', 'on'))
 
-        self.hass.block_till_done()
+@asyncio.coroutine
+def test_reproduce_group(hass):
+    """Test reproduce_state with group."""
+    res = yield from core_components.async_setup(hass, {})
+    assert res
+    light_calls = async_mock_service(hass, 'light', SERVICE_TURN_ON)
+    hass.states.async_set(
+        'group.test', 'off', {'entity_id': ['light.test1', 'light.test2']})
 
-        self.assertTrue(len(calls) == 0)
-        self.assertEqual(None, self.hass.states.get('light.test'))
+    yield from state.async_reproduce_state(hass, ha.State('group.test', 'on'))
+    yield from hass.async_block_till_done()
 
-    def test_reproduce_turn_on(self):
-        """Test reproduce_state with SERVICE_TURN_ON."""
-        calls = mock_service(self.hass, 'light', SERVICE_TURN_ON)
+    assert len(light_calls) == 1
+    last_call = light_calls[-1]
+    assert last_call.domain == 'light'
+    assert last_call.service == SERVICE_TURN_ON
+    assert last_call.data.get('entity_id') == ['light.test1', 'light.test2']
 
-        self.hass.states.set('light.test', 'off')
 
-        state.reproduce_state(self.hass, ha.State('light.test', 'on'))
+@asyncio.coroutine
+def test_reproduce_turn_on(hass):
+    """Test reproduce_state with SERVICE_TURN_ON."""
+    calls = async_mock_service(
+        hass, 'light', SERVICE_TURN_ON, state_to_set='on')
+    hass.states.async_set('light.test', 'off')
 
-        self.hass.block_till_done()
+    yield from state.async_reproduce_state(hass, ha.State('light.test', 'on'))
+    yield from hass.async_block_till_done()
 
-        self.assertTrue(len(calls) > 0)
-        last_call = calls[-1]
-        self.assertEqual('light', last_call.domain)
-        self.assertEqual(SERVICE_TURN_ON, last_call.service)
-        self.assertEqual(['light.test'], last_call.data.get('entity_id'))
+    assert len(calls) > 0
+    last_call = calls[-1]
+    assert last_call.domain == 'light'
+    assert last_call.service == SERVICE_TURN_ON
+    assert last_call.data.get('entity_id') == ['light.test']
 
-    def test_reproduce_turn_off(self):
-        """Test reproduce_state with SERVICE_TURN_OFF."""
-        calls = mock_service(self.hass, 'light', SERVICE_TURN_OFF)
 
-        self.hass.states.set('light.test', 'on')
+@asyncio.coroutine
+def test_reproduce_turn_off(hass):
+    """Test reproduce_state with SERVICE_TURN_OFF."""
+    calls = async_mock_service(
+        hass, 'light', SERVICE_TURN_OFF, state_to_set='off')
+    hass.states.async_set('light.test', 'on')
 
-        state.reproduce_state(self.hass, ha.State('light.test', 'off'))
+    yield from state.async_reproduce_state(hass, ha.State('light.test', 'off'))
+    yield from hass.async_block_till_done()
 
-        self.hass.block_till_done()
+    assert len(calls) > 0
+    last_call = calls[-1]
+    assert last_call.domain == 'light'
+    assert last_call.service == SERVICE_TURN_OFF
+    assert last_call.data.get('entity_id') == ['light.test']
 
-        self.assertTrue(len(calls) > 0)
-        last_call = calls[-1]
-        self.assertEqual('light', last_call.domain)
-        self.assertEqual(SERVICE_TURN_OFF, last_call.service)
-        self.assertEqual(['light.test'], last_call.data.get('entity_id'))
 
-    def test_reproduce_complex_data(self):
-        """Test reproduce_state with complex service data."""
-        calls = mock_service(self.hass, 'light', SERVICE_TURN_ON)
+@asyncio.coroutine
+def test_reproduce_state_attributes(hass):
+    """Test reproduce_state with state attributes."""
+    schema = vol.Schema({
+        'entity_id': cv.entity_ids, 'transition': 999, 'brightness': 100})
+    calls = async_mock_service(hass, 'light', SERVICE_TURN_ON, schema, 'on')
+    hass.states.async_set('light.test', 'off')
 
-        self.hass.states.set('light.test', 'off')
+    state_attrs = {'transition': 999, 'brightness': 100}
+    yield from state.async_reproduce_state(
+        hass, ha.State('light.test', 'on', state_attrs))
+    yield from hass.async_block_till_done()
 
-        complex_data = ['hello', {'11': '22'}]
+    assert len(calls) > 0
+    last_call = calls[-1]
+    assert last_call.domain == 'light'
+    assert last_call.service == SERVICE_TURN_ON
+    assert last_call.data.get('transition') == 999
+    assert last_call.data.get('brightness') == 100
 
-        state.reproduce_state(self.hass, ha.State('light.test', 'on', {
-            'complex': complex_data
-        }))
 
-        self.hass.block_till_done()
+@asyncio.coroutine
+def test_reproduce_media_data(hass):
+    """Test reproduce_state with SERVICE_PLAY_MEDIA."""
+    schema = vol.Schema({
+        'entity_id': cv.entity_ids,
+        vol.Required('media_content_type'): str,
+        vol.Required('media_content_id'): str})
+    calls = async_mock_service(
+        hass, 'media_player', SERVICE_PLAY_MEDIA, schema)
+    hass.states.async_set('media_player.test', 'off')
 
-        self.assertTrue(len(calls) > 0)
-        last_call = calls[-1]
-        self.assertEqual('light', last_call.domain)
-        self.assertEqual(SERVICE_TURN_ON, last_call.service)
-        self.assertEqual(complex_data, last_call.data.get('complex'))
+    media_attributes = {
+        'media_content_type': 'movie', 'media_content_id': 'batman'}
+    yield from state.async_reproduce_state(
+        hass, ha.State('media_player.test', 'None', media_attributes))
+    yield from hass.async_block_till_done()
 
-    def test_reproduce_media_data(self):
-        """Test reproduce_state with SERVICE_PLAY_MEDIA."""
-        calls = mock_service(self.hass, 'media_player', SERVICE_PLAY_MEDIA)
+    assert len(calls) > 0
+    last_call = calls[-1]
+    assert last_call.domain == 'media_player'
+    assert last_call.service == SERVICE_PLAY_MEDIA
+    assert last_call.data.get('media_content_type') == 'movie'
+    assert last_call.data.get('media_content_id') == 'batman'
 
-        self.hass.states.set('media_player.test', 'off')
 
-        media_attributes = {'media_content_type': 'movie',
-                            'media_content_id': 'batman'}
+@asyncio.coroutine
+def test_reproduce_media_play(hass):
+    """Test reproduce_state with SERVICE_MEDIA_PLAY."""
+    calls = async_mock_service(
+        hass, 'media_player', SERVICE_MEDIA_PLAY, state_to_set='playing')
+    hass.states.async_set('media_player.test', 'off')
 
-        state.reproduce_state(self.hass, ha.State('media_player.test', 'None',
-                                                  media_attributes))
+    yield from state.async_reproduce_state(
+        hass, ha.State('media_player.test', 'playing'))
+    yield from hass.async_block_till_done()
 
-        self.hass.block_till_done()
+    assert len(calls) > 0
+    last_call = calls[-1]
+    assert last_call.domain == 'media_player'
+    assert last_call.service == SERVICE_MEDIA_PLAY
+    assert last_call.data.get('entity_id') == ['media_player.test']
 
-        self.assertTrue(len(calls) > 0)
-        last_call = calls[-1]
-        self.assertEqual('media_player', last_call.domain)
-        self.assertEqual(SERVICE_PLAY_MEDIA, last_call.service)
-        self.assertEqual('movie', last_call.data.get('media_content_type'))
-        self.assertEqual('batman', last_call.data.get('media_content_id'))
 
-    def test_reproduce_media_play(self):
-        """Test reproduce_state with SERVICE_MEDIA_PLAY."""
-        calls = mock_service(self.hass, 'media_player', SERVICE_MEDIA_PLAY)
+@asyncio.coroutine
+def test_reproduce_media_pause(hass):
+    """Test reproduce_state with SERVICE_MEDIA_PAUSE."""
+    calls = async_mock_service(
+        hass, 'media_player', SERVICE_MEDIA_PAUSE, state_to_set='paused')
+    hass.states.async_set('media_player.test', 'playing')
 
-        self.hass.states.set('media_player.test', 'off')
+    yield from state.async_reproduce_state(
+        hass, ha.State('media_player.test', 'paused'))
+    yield from hass.async_block_till_done()
 
-        state.reproduce_state(
-            self.hass, ha.State('media_player.test', 'playing'))
+    assert len(calls) > 0
+    last_call = calls[-1]
+    assert last_call.domain == 'media_player'
+    assert last_call.service == SERVICE_MEDIA_PAUSE
+    assert last_call.data.get('entity_id') == ['media_player.test']
 
-        self.hass.block_till_done()
 
-        self.assertTrue(len(calls) > 0)
-        last_call = calls[-1]
-        self.assertEqual('media_player', last_call.domain)
-        self.assertEqual(SERVICE_MEDIA_PLAY, last_call.service)
-        self.assertEqual(['media_player.test'],
-                         last_call.data.get('entity_id'))
+@asyncio.coroutine
+def test_reproduce_bad_state(hass):
+    """Test reproduce_state with bad state."""
+    calls = async_mock_service(hass, 'light', SERVICE_TURN_ON)
+    hass.states.async_set('light.test', 'off')
 
-    def test_reproduce_media_pause(self):
-        """Test reproduce_state with SERVICE_MEDIA_PAUSE."""
-        calls = mock_service(self.hass, 'media_player', SERVICE_MEDIA_PAUSE)
+    yield from state.async_reproduce_state(hass, ha.State('light.test', 'bad'))
+    yield from hass.async_block_till_done()
 
-        self.hass.states.set('media_player.test', 'playing')
+    assert len(calls) == 0
+    assert hass.states.get('light.test').state == 'off'
 
-        state.reproduce_state(
-            self.hass, ha.State('media_player.test', 'paused'))
 
-        self.hass.block_till_done()
+@asyncio.coroutine
+def test_reproduce_entities_same(hass):
+    """Test reproduce_state with two entities with same domain and data."""
+    schema = vol.Schema({
+        'entity_id': cv.entity_ids, 'transition': int, 'brightness': int})
+    light_calls = async_mock_service(
+        hass, 'light', SERVICE_TURN_ON, schema, 'on')
+    hass.states.async_set('light.test1', 'off')
+    hass.states.async_set('light.test2', 'off')
 
-        self.assertTrue(len(calls) > 0)
-        last_call = calls[-1]
-        self.assertEqual('media_player', last_call.domain)
-        self.assertEqual(SERVICE_MEDIA_PAUSE, last_call.service)
-        self.assertEqual(['media_player.test'],
-                         last_call.data.get('entity_id'))
+    yield from state.async_reproduce_state(hass, [
+        ha.State('light.test1', 'on', {'brightness': 95}),
+        ha.State('light.test2', 'on', {'brightness': 95})])
+    yield from hass.async_block_till_done()
 
-    def test_reproduce_bad_state(self):
-        """Test reproduce_state with bad state."""
-        calls = mock_service(self.hass, 'light', SERVICE_TURN_ON)
+    assert len(light_calls) == 1
+    last_call = light_calls[-1]
+    assert last_call.domain == 'light'
+    assert last_call.service == SERVICE_TURN_ON
+    assert last_call.data.get('entity_id') == ['light.test1', 'light.test2']
+    assert last_call.data.get('brightness') == 95
 
-        self.hass.states.set('light.test', 'off')
 
-        state.reproduce_state(self.hass, ha.State('light.test', 'bad'))
+def test_as_number_states():
+    """Test state_as_number with states."""
+    zero_states = (STATE_OFF, STATE_CLOSED, STATE_UNLOCKED,
+                   STATE_BELOW_HORIZON, STATE_NOT_HOME)
+    one_states = (STATE_ON, STATE_OPEN, STATE_LOCKED, STATE_ABOVE_HORIZON,
+                  STATE_HOME)
+    for _state in zero_states:
+        assert state.state_as_number(ha.State('domain.test', _state, {})) == 0
+    for _state in one_states:
+        assert state.state_as_number(ha.State('domain.test', _state, {})) == 1
 
-        self.hass.block_till_done()
 
-        self.assertTrue(len(calls) == 0)
-        self.assertEqual('off', self.hass.states.get('light.test').state)
+def test_as_number_coercion():
+    """Test state_as_number with number."""
+    for _state in ('0', '0.0', 0, 0.0):
+        assert state.state_as_number(
+            ha.State('domain.test', _state, {})) == 0.0
+    for _state in ('1', '1.0', 1, 1.0):
+        assert state.state_as_number(
+            ha.State('domain.test', _state, {})) == 1.0
 
-    def test_reproduce_group(self):
-        """Test reproduce_state with group."""
-        light_calls = mock_service(self.hass, 'light', SERVICE_TURN_ON)
 
-        self.hass.states.set('group.test', 'off', {
-            'entity_id': ['light.test1', 'light.test2']})
-
-        state.reproduce_state(self.hass, ha.State('group.test', 'on'))
-
-        self.hass.block_till_done()
-
-        self.assertEqual(1, len(light_calls))
-        last_call = light_calls[-1]
-        self.assertEqual('light', last_call.domain)
-        self.assertEqual(SERVICE_TURN_ON, last_call.service)
-        self.assertEqual(['light.test1', 'light.test2'],
-                         last_call.data.get('entity_id'))
-
-    def test_reproduce_group_same_data(self):
-        """Test reproduce_state with group with same domain and data."""
-        light_calls = mock_service(self.hass, 'light', SERVICE_TURN_ON)
-
-        self.hass.states.set('light.test1', 'off')
-        self.hass.states.set('light.test2', 'off')
-
-        state.reproduce_state(self.hass, [
-            ha.State('light.test1', 'on', {'brightness': 95}),
-            ha.State('light.test2', 'on', {'brightness': 95})])
-
-        self.hass.block_till_done()
-
-        self.assertEqual(1, len(light_calls))
-        last_call = light_calls[-1]
-        self.assertEqual('light', last_call.domain)
-        self.assertEqual(SERVICE_TURN_ON, last_call.service)
-        self.assertEqual(['light.test1', 'light.test2'],
-                         last_call.data.get('entity_id'))
-        self.assertEqual(95, last_call.data.get('brightness'))
-
-    def test_as_number_states(self):
-        """Test state_as_number with states."""
-        zero_states = (STATE_OFF, STATE_CLOSED, STATE_UNLOCKED,
-                       STATE_BELOW_HORIZON, STATE_NOT_HOME)
-        one_states = (STATE_ON, STATE_OPEN, STATE_LOCKED, STATE_ABOVE_HORIZON,
-                      STATE_HOME)
-        for _state in zero_states:
-            self.assertEqual(0, state.state_as_number(
-                ha.State('domain.test', _state, {})))
-        for _state in one_states:
-            self.assertEqual(1, state.state_as_number(
-                ha.State('domain.test', _state, {})))
-
-    def test_as_number_coercion(self):
-        """Test state_as_number with number."""
-        for _state in ('0', '0.0', 0, 0.0):
-            self.assertEqual(
-                0.0, state.state_as_number(
-                    ha.State('domain.test', _state, {})))
-        for _state in ('1', '1.0', 1, 1.0):
-            self.assertEqual(
-                1.0, state.state_as_number(
-                    ha.State('domain.test', _state, {})))
-
-    def test_as_number_invalid_cases(self):
-        """Test state_as_number with invalid cases."""
-        for _state in ('', 'foo', 'foo.bar', None, False, True, object,
-                       object()):
-            self.assertRaises(ValueError,
-                              state.state_as_number,
-                              ha.State('domain.test', _state, {}))
+def test_as_number_invalid_cases():
+    """Test state_as_number with invalid cases."""
+    for _state in ('', 'foo', 'foo.bar', None, False, True, object, object()):
+        with pytest.raises(ValueError):
+            state.state_as_number(ha.State('domain.test', _state, {}))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     ATTR_NOW, EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP,
     EVENT_HOMEASSISTANT_CLOSE, EVENT_SERVICE_REGISTERED, EVENT_SERVICE_REMOVED)
 
-from tests.common import get_test_home_assistant
+from tests.common import async_mock_service, get_test_home_assistant
 
 PST = pytz.timezone('America/Los_Angeles')
 
@@ -648,16 +648,9 @@ class TestServiceRegistry(unittest.TestCase):
     def test_services(self):
         """Test services."""
         expected = {
-            'test_domain': {'test_service': {'description': '', 'fields': {}}}
-        }
-        self.assertEqual(expected, self.services.services)
-
-    def test_full_services(self):
-        """Test full services."""
-        expected = {
             'test_domain': {'test_service': self.services._services[
                 'test_domain']['test_service']}}
-        self.assertEqual(expected, self.services.full_services)
+        self.assertEqual(expected, self.services.services)
 
     def test_call_with_blocking_done_in_time(self):
         """Test call with blocking."""
@@ -967,3 +960,14 @@ def test_track_task_functions(loop):
         assert hass._track_task
     finally:
         yield from hass.async_stop()
+
+
+@asyncio.coroutine
+def test_services_json(hass):
+    """Test async_services_json."""
+    expected = {
+        'test_domain': {'test_service': {'description': '', 'fields': {}}}
+    }
+    async_mock_service(hass, 'test_domain', 'test_service')
+    services_json = hass.services.async_services_json()
+    assert services_json == expected

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -971,3 +971,14 @@ def test_services_json(hass):
     async_mock_service(hass, 'test_domain', 'test_service')
     services_json = hass.services.async_services_json()
     assert services_json == expected
+
+
+@asyncio.coroutine
+def test_get_domain_services(hass):
+    """Test get services for domain."""
+    async_mock_service(hass, 'test_domain', 'test_service')
+    expected = {'test_service': hass.services._services[
+        'test_domain']['test_service']}
+
+    services = hass.services.async_services('test_domain')
+    assert services == expected

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -652,6 +652,13 @@ class TestServiceRegistry(unittest.TestCase):
         }
         self.assertEqual(expected, self.services.services)
 
+    def test_full_services(self):
+        """Test full services."""
+        expected = {
+            'test_domain': {'test_service': self.services._services[
+                'test_domain']['test_service']}}
+        self.assertEqual(expected, self.services.full_services)
+
     def test_call_with_blocking_done_in_time(self):
         """Test call with blocking."""
         calls = []


### PR DESCRIPTION
## Description:

**NOT FINISHED**: I'd like to get some input before I continue adding states to all  relevant services.

The aim is to be able to find all services required to be called to achieve a certain state including state attributes.

This is today useful in scenes and in the future could be useful to be able to put the home in different states automatically based on machine learned state data.

* Add `state_to_set` keyword argument to Service class.
* Add `state_to_set` keyword argument to register method in `ServiceRegistry`.
* Add `full_services` property in `ServiceRegistry` to get services including service object.
* Add `async_get_services` in service helper to get all services per domain that can be used to set a certain state. Only add services to return value that have valid attributes if service does not set a state but sets state attibutes.
* Update logic in state helper `async_reproduce_state`.
* Add `schema` and `state_to_set` to mock_service.
* Add test for new core `full_services` property.
* Replace state helper tests with pytest versions.
* Add tests for service helper.
* Update components service state.
* Update alarm_control_panel service state.
* Update alert service state. Need to look into required attributes in combination with service state.
* Update automation service state.
* Update cover service state.
* Fix fan service schema and update service state.
* Update service state for light.
* Not finished: register states with all relevant services.

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.