### PR TITLE
Allow get local ip to work without internet

### DIFF
--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -99,7 +99,10 @@ def get_local_ip():
 
         return sock.getsockname()[0]
     except socket.error:
-        return socket.gethostbyname(socket.gethostname())
+        try:
+            return socket.gethostbyname(socket.gethostname())
+        except socket.gaierror:
+            return '127.0.0.1'
     finally:
         sock.close()
 


### PR DESCRIPTION
`get_local_ip` would fail if there was no internet connection. Now it is defaulting to `127.0.0.1`.

This allows using the HTTP component without an internet connection.
