### PR TITLE
Allow to set coordinates

### DIFF
--- a/homeassistant/components/weather/zamg.py
+++ b/homeassistant/components/weather/zamg.py
@@ -12,8 +12,8 @@ from homeassistant.components.weather import (
     WeatherEntity, ATTR_WEATHER_HUMIDITY, ATTR_WEATHER_PRESSURE,
     ATTR_WEATHER_TEMPERATURE, ATTR_WEATHER_WIND_BEARING,
     ATTR_WEATHER_WIND_SPEED, PLATFORM_SCHEMA)
-from homeassistant.const import \
-    CONF_NAME, TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.const import (
+    CONF_NAME, TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE)
 from homeassistant.helpers import config_validation as cv
 # Reuse data and API logic from the sensor implementation
 from homeassistant.components.sensor.zamg import (
@@ -24,28 +24,34 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_STATION_ID): cv.string,
+    vol.Inclusive(CONF_LATITUDE, 'coordinates',
+                  'Latitude and longitude must exist together'): cv.latitude,
+    vol.Inclusive(CONF_LONGITUDE, 'coordinates',
+                  'Latitude and longitude must exist together'): cv.longitude,
 })
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the ZAMG sensor platform."""
+    """Set up the ZAMG weather platform."""
+    name = config.get(CONF_NAME)
+    latitude = config.get(CONF_LATITUDE, hass.config.latitude)
+    longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
+
     station_id = config.get(CONF_STATION_ID) or closest_station(
-        config.get(CONF_LATITUDE),
-        config.get(CONF_LONGITUDE),
-        hass.config.config_dir)
+        latitude, longitude, hass.config.config_dir)
     if station_id not in zamg_stations(hass.config.config_dir):
         _LOGGER.error("Configured ZAMG %s (%s) is not a known station",
                       CONF_STATION_ID, station_id)
         return False
 
-    probe = ZamgData(station_id=station_id, logger=_LOGGER)
+    probe = ZamgData(station_id=station_id)
     try:
         probe.update()
-    except ValueError as err:
+    except (ValueError, TypeError) as err:
         _LOGGER.error("Received error from ZAMG: %s", err)
         return False
 
-    add_devices([ZamgWeather(probe, config.get(CONF_NAME))], True)
+    add_devices([ZamgWeather(probe, name)], True)
 
 
 class ZamgWeather(WeatherEntity):
@@ -55,10 +61,6 @@ class ZamgWeather(WeatherEntity):
         """Initialise the platform with a data instance and station name."""
         self.zamg_data = zamg_data
         self.stationname = stationname
-
-    def update(self):
-        """Update current conditions."""
-        self.zamg_data.update()
 
     @property
     def name(self):
@@ -105,3 +107,7 @@ class ZamgWeather(WeatherEntity):
     def wind_bearing(self):
         """Return the wind bearing."""
         return self.zamg_data.get_data(ATTR_WEATHER_WIND_BEARING)
+
+    def update(self):
+        """Update current conditions."""
+        self.zamg_data.update()


### PR DESCRIPTION
## Description:
- Allow to set coordinates
- Make `monitored_conditions` optional
- Do not call update() in constructor
- Fix docstrings
- Get rid of broad-except
- Relax update interval

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3144

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: zamg
    latitude: 46.9509
    longitude: 7.4463
    name: ZAMG1
weather:
  - platform: zamg
    name: ZAMG2
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
