### PR TITLE
Fix off_delay for zwave trigger sensors

### DIFF
--- a/homeassistant/components/zwave/discovery_schemas.py
+++ b/homeassistant/components/zwave/discovery_schemas.py
@@ -28,7 +28,12 @@ DISCOVERY_SCHEMAS = [
          const.DISC_PRIMARY: {
              const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_SENSOR_BINARY],
              const.DISC_TYPE: const.TYPE_BOOL,
-             const.DISC_GENRE: const.GENRE_USER
+             const.DISC_GENRE: const.GENRE_USER,
+         },
+         'off_delay': {
+             const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_CONFIGURATION],
+             const.DISC_INDEX: [9],
+             const.DISC_OPTIONAL: True,
          }})},
     {const.DISC_COMPONENT: 'climate',
      const.DISC_GENERIC_DEVICE_CLASS: [const.GENERIC_TYPE_THERMOSTAT],

--- a/tests/components/binary_sensor/test_zwave.py
+++ b/tests/components/binary_sensor/test_zwave.py
@@ -77,7 +77,8 @@ def test_trigger_sensor_value_changed(hass, mock_openzwave):
     node = MockNode(
         manufacturer_id='013c', product_type='0002', product_id='0002')
     value = MockValue(data=False, node=node)
-    values = MockEntityValues(primary=value)
+    value_off_delay = MockValue(data=15, node=node)
+    values = MockEntityValues(primary=value, off_delay=value_off_delay)
     device = zwave.get_device(node=node, values=values, node_config={})
 
     assert not device.is_on


### PR DESCRIPTION
## Description:
Fixes an issue with  zwave binary sensor under triggersensor class.
`re_arm_sec` was always 60 seconds no matter what. This was because at discovery time the configuration parameter that dictates the off time were not yet discovered by OZW. So now this is moved inside the `update_properties` function to be set there. Also this allows the parameter to be changed at runtime.
