### PR TITLE
Added rounding to Google Wifi

### DIFF
--- a/homeassistant/components/sensor/google_wifi.py
+++ b/homeassistant/components/sensor/google_wifi.py
@@ -186,7 +186,7 @@ class GoogleWifiAPI(object):
                             sensor_value == '0.0.0.0'):
                         sensor_value = 'Latest'
                     elif attr_key == ATTR_UPTIME:
-                        sensor_value /= 3600 * 24
+                        sensor_value = round(sensor_value / (3600 * 24), 2)
                     elif attr_key == ATTR_LAST_RESTART:
                         last_restart = (
                             dt.now() - timedelta(seconds=sensor_value))


### PR DESCRIPTION
## Description:
This is annoying:
![image](https://user-images.githubusercontent.com/1395685/29004282-d4d72146-7a92-11e7-8722-39376cb878c3.png)

So I round it.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

