### PR TITLE
RFLink: Add send_command service

### DIFF
--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -533,3 +533,16 @@ knx:
       data:
         description: KNX data to send
         example: 1
+
+rflink:
+  send_command:
+    description: Send device command through RFLink
+
+    fields:
+      device_id:
+        description: RFLink device ID
+        example: 'newkaku_0000c6c2_1'
+
+      command:
+        description: The command to be sent
+        example: 'on'


### PR DESCRIPTION
## Description:

RFLink platform doesn't provide a service to send commands to devices through RFLink. This complicates its usage in automations and template sensors/switches.

The `rflink.send_command` service provides this functionality by accepting two parameters (both are required):

| Parameter  | Description | Example |
| --- | --- | --- |
| device_id | RFLink device ID | newkaku_0000c6c2_1 |
| command | The command to be sent | on |

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

---

PS: Original PR and discussion was #8020