### PR TITLE
Do not call update() in constructor

### DIFF
--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -72,7 +72,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     add_devices([RestBinarySensor(
-        hass, rest, name, device_class, value_template)])
+        hass, rest, name, device_class, value_template)], True)
 
 
 class RestBinarySensor(BinarySensorDevice):
@@ -87,7 +87,6 @@ class RestBinarySensor(BinarySensorDevice):
         self._state = False
         self._previous_data = None
         self._value_template = value_template
-        self.update()
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -25,12 +25,14 @@ DEFAULT_METHOD = 'GET'
 DEFAULT_NAME = 'REST Sensor'
 DEFAULT_VERIFY_SSL = True
 
+METHODS = ['POST', 'GET']
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
     vol.Optional(CONF_AUTHENTICATION):
         vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
     vol.Optional(CONF_HEADERS): {cv.string: cv.string},
-    vol.Optional(CONF_METHOD, default=DEFAULT_METHOD): vol.In(['POST', 'GET']),
+    vol.Optional(CONF_METHOD, default=DEFAULT_METHOD): vol.In(METHODS),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_PAYLOAD): cv.string,
@@ -70,7 +72,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("Unable to fetch REST data")
         return False
 
-    add_devices([RestSensor(hass, rest, name, unit, value_template)])
+    add_devices([RestSensor(hass, rest, name, unit, value_template)], True)
 
 
 class RestSensor(Entity):
@@ -84,7 +86,6 @@ class RestSensor(Entity):
         self._state = STATE_UNKNOWN
         self._unit_of_measurement = unit_of_measurement
         self._value_template = value_template
-        self.update()
 
     @property
     def name(self):

--- a/tests/components/sensor/test_rest.py
+++ b/tests/components/sensor/test_rest.py
@@ -1,4 +1,4 @@
-"""The tests for the REST switch platform."""
+"""The tests for the REST sensor platform."""
 import unittest
 from unittest.mock import patch, Mock
 
@@ -15,8 +15,8 @@ from homeassistant.helpers.config_validation import template
 from tests.common import get_test_home_assistant, assert_setup_component
 
 
-class TestRestSwitchSetup(unittest.TestCase):
-    """Tests for setting up the REST switch platform."""
+class TestRestSensorSetup(unittest.TestCase):
+    """Tests for setting up the REST sensor platform."""
 
     def setUp(self):
         """Setup things to be run when tests are started."""
@@ -133,9 +133,9 @@ class TestRestSensor(unittest.TestCase):
         self.value_template = template('{{ value_json.key }}')
         self.value_template.hass = self.hass
 
-        self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
-                                      self.unit_of_measurement,
-                                      self.value_template)
+        self.sensor = rest.RestSensor(
+            self.hass, self.rest, self.name, self.unit_of_measurement,
+            self.value_template)
 
     def tearDown(self):
         """Stop everything that was started."""
@@ -151,17 +151,18 @@ class TestRestSensor(unittest.TestCase):
 
     def test_unit_of_measurement(self):
         """Test the unit of measurement."""
-        self.assertEqual(self.unit_of_measurement,
-                         self.sensor.unit_of_measurement)
+        self.assertEqual(
+            self.unit_of_measurement, self.sensor.unit_of_measurement)
 
     def test_state(self):
         """Test the initial state."""
+        self.sensor.update()
         self.assertEqual(self.initial_state, self.sensor.state)
 
     def test_update_when_value_is_none(self):
         """Test state gets updated to unknown when sensor returns no data."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(None))
+        self.rest.update = Mock(
+            'rest.RestData.update', side_effect=self.update_side_effect(None))
         self.sensor.update()
         self.assertEqual(STATE_UNKNOWN, self.sensor.state)
 
@@ -178,8 +179,8 @@ class TestRestSensor(unittest.TestCase):
         self.rest.update = Mock('rest.RestData.update',
                                 side_effect=self.update_side_effect(
                                     'plain_state'))
-        self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
-                                      self.unit_of_measurement, None)
+        self.sensor = rest.RestSensor(
+            self.hass, self.rest, self.name, self.unit_of_measurement, None)
         self.sensor.update()
         self.assertEqual('plain_state', self.sensor.state)
 
@@ -192,8 +193,8 @@ class TestRestData(unittest.TestCase):
         self.method = "GET"
         self.resource = "http://localhost"
         self.verify_ssl = True
-        self.rest = rest.RestData(self.method, self.resource, None, None, None,
-                                  self.verify_ssl)
+        self.rest = rest.RestData(
+            self.method, self.resource, None, None, None, self.verify_ssl)
 
     @requests_mock.Mocker()
     def test_update(self, mock_req):


### PR DESCRIPTION
## Description:
- Do not call update() in constructor
- Update docstrings

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: rest
    resource: http://ip.jsontest.com
    name: External IP
    value_template: '{{ value_json.ip }}'
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
