### PR TITLE
Change level

### DIFF
--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -152,7 +152,7 @@ class StatisticsSensor(Entity):
                 self.stdev = round(statistics.stdev(self.states), 2)
                 self.variance = round(statistics.variance(self.states), 2)
             except statistics.StatisticsError as err:
-                _LOGGER.warning(err)
+                _LOGGER.error(err)
                 self.mean = self.median = STATE_UNKNOWN
                 self.stdev = self.variance = STATE_UNKNOWN
             if self.states:


### PR DESCRIPTION
## Description:
Change from `warning` to `error`.

**Related issue (if applicable):** [23813](https://community.home-assistant.io/t/statistics-sensor-does-not-work/23813)

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: statistics
    entity_id: sensor.cpu
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
