### PR TITLE
Allow usage of colorlog 3.0.1

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -13,7 +13,7 @@ from homeassistant import bootstrap, loader, setup, config as config_util
 import homeassistant.util.yaml as yaml
 from homeassistant.exceptions import HomeAssistantError
 
-REQUIREMENTS = ('colorlog>2.1,<3',)
+REQUIREMENTS = ('colorlog==3.0.1',)
 if system() == 'Windows':  # Ensure colorama installed for colorlog on Windows
     REQUIREMENTS += ('colorama<=1',)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -137,7 +137,7 @@ ciscosparkapi==0.4.2
 coinmarketcap==3.0.1
 
 # homeassistant.scripts.check_config
-colorlog>2.1,<3
+colorlog==3.0.1
 
 # homeassistant.components.alarm_control_panel.concord232
 # homeassistant.components.binary_sensor.concord232


### PR DESCRIPTION
## Description:
- `parse_colors` was not removed with 3.x.x

Tested with

```bash
$ hass --script check_config
```
Would be nice if someone could give it a try on Windows. Thanks.