### PR TITLE
Fix media_extractor for some sites

### DIFF
--- a/homeassistant/components/media_extractor.py
+++ b/homeassistant/components/media_extractor.py
@@ -125,24 +125,13 @@ class MediaExtractor:
         else:
             selected_media = all_media
 
-        try:
-            media_info = ydl.process_ie_result(selected_media,
-                                               download=False)
-        except (ExtractorError, DownloadError):
-            # This exception will be logged by youtube-dl itself
-            raise MEDownloadException()
-
         def stream_selector(query):
             """Find stream url that matches query."""
             try:
-                format_selector = ydl.build_format_selector(query)
-            except (SyntaxError, ValueError, AttributeError) as ex:
-                _LOGGER.error(ex)
-                raise MEQueryException()
-
-            try:
-                requested_stream = next(format_selector(media_info))
-            except (KeyError, StopIteration):
+                ydl.params['format'] = query
+                requested_stream = ydl.process_ie_result(selected_media,
+                                                         download=False)
+            except (ExtractorError, DownloadError):
                 _LOGGER.error("Could not extract stream for the query: %s",
                               query)
                 raise MEQueryException()


### PR DESCRIPTION
Result of [discussion](https://github.com/home-assistant/home-assistant/pull/8795):

- Support audio sites with `format=best` (default format)
- Support sites with only 1 format in results