### PR TITLE
Do not call update() in constructor

### DIFF
--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -4,18 +4,18 @@ Support for custom shell commands to retrieve values.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.command_line/
 """
-from datetime import timedelta
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, DEVICE_CLASSES_SCHEMA, PLATFORM_SCHEMA)
 from homeassistant.components.sensor.command_line import CommandSensorData
 from homeassistant.const import (
     CONF_PAYLOAD_OFF, CONF_PAYLOAD_ON, CONF_NAME, CONF_VALUE_TEMPLATE,
     CONF_COMMAND, CONF_DEVICE_CLASS)
-import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     add_devices([CommandBinarySensor(
         hass, data, name, device_class, payload_on, payload_off,
-        value_template)])
+        value_template)], True)
 
 
 class CommandBinarySensor(BinarySensorDevice):
@@ -67,7 +67,6 @@ class CommandBinarySensor(BinarySensorDevice):
         self._payload_on = payload_on
         self._payload_off = payload_off
         self._value_template = value_template
-        self.update()
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -4,18 +4,18 @@ Allows to configure custom shell commands to turn a value for a sensor.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.command_line/
 """
-from datetime import timedelta
 import logging
 import subprocess
+from datetime import timedelta
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_NAME, CONF_VALUE_TEMPLATE, CONF_UNIT_OF_MEASUREMENT, CONF_COMMAND,
     STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
-import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         value_template.hass = hass
     data = CommandSensorData(command)
 
-    add_devices([CommandSensor(hass, data, name, unit, value_template)])
+    add_devices([CommandSensor(hass, data, name, unit, value_template)], True)
 
 
 class CommandSensor(Entity):
@@ -53,10 +53,9 @@ class CommandSensor(Entity):
         self._hass = hass
         self.data = data
         self._name = name
-        self._state = STATE_UNKNOWN
+        self._state = None
         self._unit_of_measurement = unit_of_measurement
         self._value_template = value_template
-        self.update()
 
     @property
     def name(self):

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -9,12 +9,13 @@ import subprocess
 
 import voluptuous as vol
 
-from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA,
-                                             ENTITY_ID_FORMAT)
+import homeassistant.helpers.config_validation as cv
+
+from homeassistant.components.switch import (
+    SwitchDevice, PLATFORM_SCHEMA, ENTITY_ID_FORMAT)
 from homeassistant.const import (
     CONF_FRIENDLY_NAME, CONF_SWITCHES, CONF_VALUE_TEMPLATE, CONF_COMMAND_OFF,
     CONF_COMMAND_ON, CONF_COMMAND_STATE)
-import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,30 +81,30 @@ class CommandSwitch(SwitchDevice):
     @staticmethod
     def _switch(command):
         """Execute the actual commands."""
-        _LOGGER.info('Running command: %s', command)
+        _LOGGER.info("Running command: %s", command)
 
         success = (subprocess.call(command, shell=True) == 0)
 
         if not success:
-            _LOGGER.error('Command failed: %s', command)
+            _LOGGER.error("Command failed: %s", command)
 
         return success
 
     @staticmethod
     def _query_state_value(command):
         """Execute state command for return value."""
-        _LOGGER.info('Running state command: %s', command)
+        _LOGGER.info("Running state command: %s", command)
 
         try:
             return_value = subprocess.check_output(command, shell=True)
             return return_value.strip().decode('utf-8')
         except subprocess.CalledProcessError:
-            _LOGGER.error('Command failed: %s', command)
+            _LOGGER.error("Command failed: %s", command)
 
     @staticmethod
     def _query_state_code(command):
         """Execute state command for return code."""
-        _LOGGER.info('Running state command: %s', command)
+        _LOGGER.info("Running state command: %s", command)
         return subprocess.call(command, shell=True) == 0
 
     @property
@@ -129,7 +130,7 @@ class CommandSwitch(SwitchDevice):
     def _query_state(self):
         """Query for state."""
         if not self._command_state:
-            _LOGGER.error('No state command specified')
+            _LOGGER.error("No state command specified")
             return
         if self._value_template:
             return CommandSwitch._query_state_value(self._command_state)
@@ -142,7 +143,7 @@ class CommandSwitch(SwitchDevice):
             if self._value_template:
                 payload = self._value_template.render_with_possible_json_value(
                     payload)
-            self._state = (payload.lower() == "true")
+            self._state = (payload.lower() == 'true')
 
     def turn_on(self, **kwargs):
         """Turn the device on."""

--- a/tests/components/binary_sensor/test_command_line.py
+++ b/tests/components/binary_sensor/test_command_line.py
@@ -29,7 +29,7 @@ class TestCommandSensorBinarySensor(unittest.TestCase):
 
         devices = []
 
-        def add_dev_callback(devs):
+        def add_dev_callback(devs, update):
             """Add callback to add devices."""
             for dev in devs:
                 devices.append(dev)
@@ -38,6 +38,7 @@ class TestCommandSensorBinarySensor(unittest.TestCase):
 
         self.assertEqual(1, len(devices))
         entity = devices[0]
+        entity.update()
         self.assertEqual('Test', entity.name)
         self.assertEqual(STATE_ON, entity.state)
 
@@ -58,7 +59,7 @@ class TestCommandSensorBinarySensor(unittest.TestCase):
         entity = command_line.CommandBinarySensor(
             self.hass, data, 'test', None, '1.0', '0',
             template.Template('{{ value | multiply(0.1) }}', self.hass))
-
+        entity.update()
         self.assertEqual(STATE_ON, entity.state)
 
     def test_sensor_off(self):
@@ -67,5 +68,5 @@ class TestCommandSensorBinarySensor(unittest.TestCase):
 
         entity = command_line.CommandBinarySensor(
             self.hass, data, 'test', None, '1', '0', None)
-
+        entity.update()
         self.assertEqual(STATE_OFF, entity.state)

--- a/tests/components/sensor/test_command_line.py
+++ b/tests/components/sensor/test_command_line.py
@@ -26,7 +26,7 @@ class TestCommandSensorSensor(unittest.TestCase):
                   }
         devices = []
 
-        def add_dev_callback(devs):
+        def add_dev_callback(devs, update):
             """Add callback to add devices."""
             for dev in devs:
                 devices.append(dev)
@@ -35,6 +35,7 @@ class TestCommandSensorSensor(unittest.TestCase):
 
         self.assertEqual(1, len(devices))
         entity = devices[0]
+        entity.update()
         self.assertEqual('Test', entity.name)
         self.assertEqual('in', entity.unit_of_measurement)
         self.assertEqual('5', entity.state)
@@ -57,6 +58,7 @@ class TestCommandSensorSensor(unittest.TestCase):
             self.hass, data, 'test', 'in',
             Template('{{ value | multiply(0.1) }}', self.hass))
 
+        entity.update()
         self.assertEqual(5, float(entity.state))
 
     def test_bad_command(self):


### PR DESCRIPTION
## Description:
- Do not call update() in constructor.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: command_line
    name: CPU Temperature
    command: "cat /sys/class/thermal/thermal_zone0/temp"
    unit_of_measurement: "°C"
    value_template: '{{ value | multiply(0.001) }}'
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
