### PR TITLE
Changes Pi-hole graphs from stacked bar to line

### DIFF
--- a/homeassistant/components/sensor/pi_hole.py
+++ b/homeassistant/components/sensor/pi_hole.py
@@ -36,21 +36,21 @@ SCAN_INTERVAL = timedelta(minutes=5)
 
 MONITORED_CONDITIONS = {
     'dns_queries_today': ['DNS Queries Today',
-                          None, 'mdi:comment-question-outline'],
+                          'queries', 'mdi:comment-question-outline'],
     'ads_blocked_today': ['Ads Blocked Today',
-                          None, 'mdi:close-octagon-outline'],
+                          'ads', 'mdi:close-octagon-outline'],
     'ads_percentage_today': ['Ads Percentage Blocked Today',
                              '%', 'mdi:close-octagon-outline'],
     'domains_being_blocked': ['Domains Blocked',
-                              None, 'mdi:block-helper'],
+                              'domains', 'mdi:block-helper'],
     'queries_cached': ['DNS Queries Cached',
-                       None, 'mdi:comment-question-outline'],
+                       'queries', 'mdi:comment-question-outline'],
     'queries_forwarded': ['DNS Queries Forwarded',
-                          None, 'mdi:comment-question-outline'],
+                          'queries', 'mdi:comment-question-outline'],
     'unique_clients': ['DNS Unique Clients',
-                       None, 'mdi:account-outline'],
+                       'clients', 'mdi:account-outline'],
     'unique_domains': ['DNS Unique Domains',
-                       None, 'mdi:domain'],
+                       'domains', 'mdi:domain'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
## Description:
Currently, Pi-hole sensors don't specific any units of measurement; as a result, their graphs show up as stacked bar charts:

<img width="366" alt="screen shot 2017-08-08 at 1 30 11 pm" src="https://user-images.githubusercontent.com/47216/29090823-14007a00-7c3e-11e7-84b2-94aa0c7b30b0.png">

Given that all Pi-hole sensors are numeric in nature, it would be better to provide units and, as a result, get line graphs instead:

<img width="366" alt="screen shot 2017-08-08 at 1 30 53 pm" src="https://user-images.githubusercontent.com/47216/29090855-23f822a0-7c3e-11e7-8e34-b254fcb7227a.png">

This PR assigns units of measurement to each sensor that the Pi-hole platform produces.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: pi_hole
    host: 192.168.1.100
    monitored_conditions:
      - ads_blocked_today
      - ads_percentage_today
      - dns_queries_today
      - domains_being_blocked
      - queries_cached
      - queries_forwarded
      - unique_clients
      - unique_domains
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
