### PR TITLE
Added support for setting/getting position of Lutron Caseta Covers

### DIFF
--- a/homeassistant/components/cover/lutron_caseta.py
+++ b/homeassistant/components/cover/lutron_caseta.py
@@ -8,10 +8,9 @@ import logging
 
 
 from homeassistant.components.cover import (
-    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE)
+    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_SET_POSITION)
 from homeassistant.components.lutron_caseta import (
     LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice)
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,12 +37,17 @@ class LutronCasetaCover(LutronCasetaDevice, CoverDevice):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_OPEN | SUPPORT_CLOSE
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
 
     @property
     def is_closed(self):
         """Return if the cover is closed."""
         return self._state["current_state"] < 1
+
+    @property
+    def current_cover_position(self):
+        """Return the current position of cover."""
+        return self._state["current_state"]
 
     def close_cover(self):
         """Close the cover."""


### PR DESCRIPTION
## Description:
Added support for setting/getting position of Lutron Caseta Covers. Previously, trying to get the position of a Lutron Caseta Cover would give an error saying the property could not be found.

## Checklist:
**All other checks are N/A for this fix**
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

