### PR TITLE
Adds support for all "shade" hardware

### DIFF
--- a/homeassistant/components/cover/lutron_caseta.py
+++ b/homeassistant/components/cover/lutron_caseta.py
@@ -19,14 +19,17 @@ DEPENDENCIES = ['lutron_caseta']
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the Lutron Caseta Serena shades as a cover device."""
+    """Set up the Lutron Caseta shades as a cover device."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
-    cover_devices = bridge.get_devices_by_types(["SerenaRollerShade",
-                                                 "SerenaHoneycombShade"])
-    for cover_device in cover_devices:
-        dev = LutronCasetaCover(cover_device, bridge)
-        devs.append(dev)
+    all_devices = bridge.get_devices()
+    for device_id in all_devices:
+        dev = all_devices[device_id]
+        _type = dev['type']
+        # generically identify all shades where type contains shade
+        if 'shade' in _type.lower():
+            cover_dev = LutronCasetaCover(dev, bridge)
+            devs.append(cover_dev)
 
     add_devices(devs, True)
 

--- a/homeassistant/components/cover/lutron_caseta.py
+++ b/homeassistant/components/cover/lutron_caseta.py
@@ -26,7 +26,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for device_id in all_devices:
         dev = all_devices[device_id]
         _type = dev['type']
-        # generically identify all shades where type contains shade
+        # Generically identify all shades where type contains 'shade'
         if 'shade' in _type.lower():
             cover_dev = LutronCasetaCover(dev, bridge)
             devs.append(cover_dev)


### PR DESCRIPTION
## Description:
Looks like the Lutron Caseta shades all come with different "type" identifiers.  It appears that the types always has the word shade in it.  This PR will look for the sub-string "shade" in the "type" identifier and if found, add the device as a cover device.

**Related issue (if applicable):** NA

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io NA

## Example entry for `configuration.yaml` (if applicable):  No changes to configuration

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
