### PR TITLE
Update simplisafe-python version

### DIFF
--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['simplisafe-python==1.0.3']
+REQUIREMENTS = ['simplisafe-python==1.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -872,7 +872,7 @@ sense-hat==2.2.0
 sharp_aquos_rc==0.3.2
 
 # homeassistant.components.alarm_control_panel.simplisafe
-simplisafe-python==1.0.3
+simplisafe-python==1.0.4
 
 # homeassistant.components.notify.slack
 slacker==0.9.50


### PR DESCRIPTION
## Description:
Prevents the error in the issue below from logging when users don't have a freeze sensor associated with their SimpliSafe account.

**Related issue (if applicable):** fixes #8727 


## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to `requirements_all.txt` by running 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
