### PR TITLE
Honor PEP8 naming convention

### DIFF
--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 from homeassistant.const import (
-    ATTR_FRIENDLY_NAME, __version__ as CURRENT_VERSION)
+    ATTR_FRIENDLY_NAME, __version__ as current_version)
 from homeassistant.helpers import event
 
 REQUIREMENTS = ['distro==1.0.4']
@@ -75,7 +75,7 @@ def _load_uuid(hass, filename=UPDATER_UUID_FILE):
 @asyncio.coroutine
 def async_setup(hass, config):
     """Set up the updater component."""
-    if 'dev' in CURRENT_VERSION:
+    if 'dev' in current_version:
         # This component only makes sense in release versions
         _LOGGER.warning("Running on 'dev', only analytics will be submitted")
 
@@ -90,24 +90,23 @@ def async_setup(hass, config):
     @asyncio.coroutine
     def check_new_version(now):
         """Check if a new version is available and report if one is."""
-        result = yield from get_newest_version(hass, huuid,
-                                               include_components)
+        result = yield from get_newest_version(hass, huuid, include_components)
 
         if result is None:
             return
 
         newest, releasenotes = result
 
-        if newest is None or 'dev' in CURRENT_VERSION:
+        if newest is None or 'dev' in current_version:
             return
 
-        if StrictVersion(newest) > StrictVersion(CURRENT_VERSION):
+        if StrictVersion(newest) > StrictVersion(current_version):
             _LOGGER.info("The latest available version is %s", newest)
             hass.states.async_set(
                 ENTITY_ID, newest, {ATTR_FRIENDLY_NAME: 'Update Available',
                                     ATTR_RELEASE_NOTES: releasenotes}
             )
-        elif StrictVersion(newest) == StrictVersion(CURRENT_VERSION):
+        elif StrictVersion(newest) == StrictVersion(current_version):
             _LOGGER.info(
                 "You are on the latest version (%s) of Home Assistant", newest)
 
@@ -125,12 +124,12 @@ def get_system_info(hass, include_components):
     """Return info about the system."""
     info_object = {
         'arch': platform.machine(),
-        'dev': 'dev' in CURRENT_VERSION,
+        'dev': 'dev' in current_version,
         'docker': False,
         'os_name': platform.system(),
         'python_version': platform.python_version(),
         'timezone': dt_util.DEFAULT_TIME_ZONE.zone,
-        'version': CURRENT_VERSION,
+        'version': current_version,
         'virtualenv': os.environ.get('VIRTUAL_ENV') is not None,
     }
 
@@ -182,7 +181,7 @@ def get_newest_version(hass, huuid, include_components):
 
     try:
         res = RESPONSE_SCHEMA(res)
-        return (res['version'], res['release-notes'])
+        return res['version'], res['release-notes']
     except vol.Invalid:
-        _LOGGER.error('Got unexpected response: %s', res)
+        _LOGGER.error("Got unexpected response: %s", res)
         return None

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -47,7 +47,7 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: {
 }}, extra=vol.ALLOW_EXTRA)
 
 RESPONSE_SCHEMA = vol.Schema({
-    vol.Required('version'): str,
+    vol.Required('version'): cv.string,
     vol.Required('release-notes'): cv.url,
 })
 

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -40,8 +40,8 @@ def mock_get_uuid():
 
 @asyncio.coroutine
 @freeze_time("Mar 15th, 2017")
-def test_new_version_shows_entity_after_hour(hass, mock_get_uuid,
-                                             mock_get_newest_version):
+def test_new_version_shows_entity_after_hour(
+        hass, mock_get_uuid, mock_get_newest_version):
     """Test if new entity is created if new version is available."""
     mock_get_uuid.return_value = MOCK_HUUID
     mock_get_newest_version.return_value = mock_coro((NEW_VERSION, ''))
@@ -50,7 +50,7 @@ def test_new_version_shows_entity_after_hour(hass, mock_get_uuid,
         hass, updater.DOMAIN, {updater.DOMAIN: {}})
     assert res, 'Updater failed to setup'
 
-    with patch('homeassistant.components.updater.CURRENT_VERSION',
+    with patch('homeassistant.components.updater.current_version',
                MOCK_VERSION):
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
         yield from hass.async_block_till_done()
@@ -60,8 +60,8 @@ def test_new_version_shows_entity_after_hour(hass, mock_get_uuid,
 
 @asyncio.coroutine
 @freeze_time("Mar 15th, 2017")
-def test_same_version_not_show_entity(hass, mock_get_uuid,
-                                      mock_get_newest_version):
+def test_same_version_not_show_entity(
+        hass, mock_get_uuid, mock_get_newest_version):
     """Test if new entity is created if new version is available."""
     mock_get_uuid.return_value = MOCK_HUUID
     mock_get_newest_version.return_value = mock_coro((MOCK_VERSION, ''))
@@ -70,7 +70,7 @@ def test_same_version_not_show_entity(hass, mock_get_uuid,
         hass, updater.DOMAIN, {updater.DOMAIN: {}})
     assert res, 'Updater failed to setup'
 
-    with patch('homeassistant.components.updater.CURRENT_VERSION',
+    with patch('homeassistant.components.updater.current_version',
                MOCK_VERSION):
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
         yield from hass.async_block_till_done()
@@ -91,7 +91,7 @@ def test_disable_reporting(hass, mock_get_uuid, mock_get_newest_version):
         }})
     assert res, 'Updater failed to setup'
 
-    with patch('homeassistant.components.updater.CURRENT_VERSION',
+    with patch('homeassistant.components.updater.current_version',
                MOCK_VERSION):
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
         yield from hass.async_block_till_done()


### PR DESCRIPTION
## Description:
- Honor PEP8 naming convention
- Remove redundant parentheses
- Align quoting

## Example entry for `configuration.yaml` (if applicable):
```yaml
updater:
```
## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
