### PR TITLE
Add version sensor

### DIFF
--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -1,5 +1,5 @@
 """
-Support for displaying the current version of HOme Assistant.
+Support for displaying the current version of Home Assistant.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.version/

--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -1,0 +1,55 @@
+"""
+Support for displaying the current version of HOme Assistant.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.version/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import __version__, CONF_NAME
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "Current Version"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Version sensor platform."""
+    name = config.get(CONF_NAME)
+
+    async_add_devices([VersionSensor(name)], True)
+
+
+class VersionSensor(Entity):
+    """Representation of a Home Assistant version sensor."""
+
+    def __init__(self, name):
+        """Initialize the Version sensor."""
+        self._name = name
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Get the latest data and updates the state."""
+        self._state = __version__

--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -28,7 +28,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Version sensor platform."""
     name = config.get(CONF_NAME)
 
-    async_add_devices([VersionSensor(name)], True)
+    async_add_devices([VersionSensor(name)])
 
 
 class VersionSensor(Entity):
@@ -37,7 +37,7 @@ class VersionSensor(Entity):
     def __init__(self, name):
         """Initialize the Version sensor."""
         self._name = name
-        self._state = None
+        self._state = __version__
 
     @property
     def name(self):
@@ -45,11 +45,11 @@ class VersionSensor(Entity):
         return self._name
 
     @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
     def state(self):
         """Return the state of the sensor."""
         return self._state
-
-    @asyncio.coroutine
-    def async_update(self):
-        """Get the latest data and updates the state."""
-        self._state = __version__

--- a/tests/components/sensor/test_version.py
+++ b/tests/components/sensor/test_version.py
@@ -1,12 +1,13 @@
 """The test for the version sensor platform."""
+import asyncio
 import unittest
+from unittest.mock import patch
 
 from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 
 MOCK_VERSION = '10.0'
-MOCK_DEV_VERSION = '10.0.dev0'
 
 
 class TestVersionSensor(unittest.TestCase):
@@ -25,33 +26,26 @@ class TestVersionSensor(unittest.TestCase):
         config = {
             'sensor': {
                 'platform': 'version',
-                'name': 'test',
             }
         }
 
         assert setup_component(self.hass, 'sensor', config)
 
-        self.hass.states.set('sensor.test', MOCK_VERSION)
-        self.hass.block_till_done()
+    @asyncio.coroutine
+    def test_version(self):
+        """Test the Version sensor."""
+        config = {
+            'sensor': {
+                'platform': 'version',
+                'name': 'test',
+            }
+        }
+
+        with patch('homeassistant.const.__version__', MOCK_VERSION):
+            assert setup_component(self.hass, 'sensor', config)
+            self.hass.block_till_done()
 
         state = self.hass.states.get('sensor.test')
 
         self.assertEqual(state.state, '10.0')
 
-    def test_version_sensor_dev(self):
-        """Test the Version sensor."""
-        config = {
-            'sensor': {
-                'platform': 'version',
-                'name': 'test_dev',
-            }
-        }
-
-        assert setup_component(self.hass, 'sensor', config)
-
-        self.hass.states.set('sensor.test_dev', MOCK_DEV_VERSION)
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('sensor.test_dev')
-
-        self.assertEqual(state.state, '10.0.dev0')

--- a/tests/components/sensor/test_version.py
+++ b/tests/components/sensor/test_version.py
@@ -48,4 +48,3 @@ class TestVersionSensor(unittest.TestCase):
         state = self.hass.states.get('sensor.test')
 
         self.assertEqual(state.state, '10.0')
-

--- a/tests/components/sensor/test_version.py
+++ b/tests/components/sensor/test_version.py
@@ -1,0 +1,57 @@
+"""The test for the version sensor platform."""
+import unittest
+
+from homeassistant.setup import setup_component
+
+from tests.common import get_test_home_assistant
+
+MOCK_VERSION = '10.0'
+MOCK_DEV_VERSION = '10.0.dev0'
+
+
+class TestVersionSensor(unittest.TestCase):
+    """Test the Version sensor."""
+
+    def setup_method(self, method):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_version_sensor(self):
+        """Test the Version sensor."""
+        config = {
+            'sensor': {
+                'platform': 'version',
+                'name': 'test',
+            }
+        }
+
+        assert setup_component(self.hass, 'sensor', config)
+
+        self.hass.states.set('sensor.test', MOCK_VERSION)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('sensor.test')
+
+        self.assertEqual(state.state, '10.0')
+
+    def test_version_sensor_dev(self):
+        """Test the Version sensor."""
+        config = {
+            'sensor': {
+                'platform': 'version',
+                'name': 'test_dev',
+            }
+        }
+
+        assert setup_component(self.hass, 'sensor', config)
+
+        self.hass.states.set('sensor.test_dev', MOCK_DEV_VERSION)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('sensor.test_dev')
+
+        self.assertEqual(state.state, '10.0.dev0')


### PR DESCRIPTION
## Description:
The topic about displaying the current Home Assistant version as sensor is coming up again and again. There are [multiples solutions](https://community.home-assistant.io/t/any-way-to-show-currently-installed-version-with-sensor/3012) available to do but this sensor may be the most efficient one. 

Successor of #8224.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3163

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: version
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
