### PR TITLE
Fixed cert_expiry sensor to delay firing on HA startup

### DIFF
--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -12,6 +12,8 @@ import ssl
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
+from datetime import timedelta
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_PORT)
 from homeassistant.helpers.entity import Entity
@@ -21,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = 'SSL Certificate Expiry'
 DEFAULT_PORT = 443
 
-SCAN_INTERVAL = datetime.timedelta(hours=12)
+SCAN_INTERVAL = timedelta(hours=12)
 
 TIMEOUT = 10.0
 
@@ -71,6 +73,7 @@ class SSLCertificate(Entity):
         """Icon to use in the frontend, if any."""
         return 'mdi:certificate'
 
+    @Throttle(timedelta(seconds=120))
     def update(self):
         """Fetch the certificate information."""
         try:

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -8,12 +8,12 @@ import datetime
 import logging
 import socket
 import ssl
+from datetime import timedelta
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
-from datetime import timedelta
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_PORT)
 from homeassistant.helpers.entity import Entity
@@ -100,6 +100,6 @@ class SSLCertificate(Entity):
             return
 
         ts_seconds = ssl.cert_time_to_seconds(cert['notAfter'])
-        timestamp = datetime.datetime.fromtimestamp(ts_seconds)
-        expiry = timestamp - datetime.datetime.today()
+        timestamp = datetime.fromtimestamp(ts_seconds)
+        expiry = timestamp - datetime.today()
         self._state = expiry.days

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -4,11 +4,10 @@ Counter for the days till a HTTPS (TLS) certificate will expire.
 For more details about this sensor please refer to the documentation at
 https://home-assistant.io/components/sensor.cert_expiry/
 """
-import datetime
 import logging
 import socket
 import ssl
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import voluptuous as vol
 

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -47,7 +47,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         add_devices([SSLCertificate(sensor_name, server_name, server_port)],
                     True)
 
-    # Wait until start event is sent to load this component.
+    # To allow checking of the HA certificate we must first be running.
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
 
 


### PR DESCRIPTION
## Description:
`cert_expiry` sensor was failing to run on startup. It would throw an error in the logs:
```
2017-07-27 18:55:30 ERROR (Thread-40) [homeassistant.components.sensor.cert_expiry] Cannot connect to bla.duckdns.org
```
I modified the code so that the component is not added until `EVENT_HOMEASSISTANT_START`, which fixes those errors. 

**Related issue (if applicable):** fixes #7481 
