### PR TITLE
Update python-wink version to fix Dome water valve bug.

### DIFF
--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -65,7 +65,8 @@ class WinkToggleDevice(WinkDevice, ToggleEntity):
         attributes = super(WinkToggleDevice, self).device_state_attributes
         try:
             event = self.wink.last_event()
-            attributes["last_event"] = event
+            if event is not None:
+                attributes["last_event"] = event
         except AttributeError:
             pass
         return attributes

--- a/homeassistant/components/wink.py
+++ b/homeassistant/components/wink.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-wink==1.4.2', 'pubnubsub-handler==1.0.2']
+REQUIREMENTS = ['python-wink==1.5.1', 'pubnubsub-handler==1.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -775,7 +775,7 @@ python-velbus==2.0.11
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.4.2
+python-wink==1.5.1
 
 # homeassistant.components.zwave
 python_openzwave==0.4.0.31


### PR DESCRIPTION
## Description:
Fixed a bug in python-wink preventing the Dome main water valve from working.

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/dome-water-main-switch-via-wink/24106/2

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies have been added to `requirements_all.txt` by running 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
