### PR TITLE
Disable roombapy

### DIFF
--- a/homeassistant/components/vacuum/roomba.py
+++ b/homeassistant/components/vacuum/roomba.py
@@ -69,6 +69,7 @@ SUPPORT_ROOMBA_CARPET_BOOST = SUPPORT_ROOMBA | SUPPORT_FAN_SPEED
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the iRobot Roomba vacuum cleaner platform."""
+    # pylint: disable=import-error
     from roomba import Roomba
     if PLATFORM not in hass.data:
         hass.data[PLATFORM] = {}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -838,7 +838,7 @@ rflink==0.0.34
 ring_doorbell==0.1.4
 
 # homeassistant.components.vacuum.roomba
-roombapy==1.3.0
+# roombapy==1.3.0
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.6

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -29,7 +29,8 @@ COMMENT_REQUIREMENTS = (
     'blinkt',
     'smbus-cffi',
     'envirophat',
-    'i2csense'
+    'i2csense',
+    'roombapy'
 )
 
 TEST_REQUIREMENTS = (


### PR DESCRIPTION
## Description:

This component try to install openzwave 3 and that Fails with our openzwave Version:
![unbenannt](https://user-images.githubusercontent.com/15338540/29203617-7b2253da-7e72-11e7-9b5b-b2e5d90b8927.PNG)

Maybe @pschmitt can fix that in a next release and we can enable it agen. But for the moment it will not work with hassio and official docker image.
