### PR TITLE
Update roombapy to 1.3.1 to avoid installing all the mapping dependencies

### DIFF
--- a/homeassistant/components/vacuum/roomba.py
+++ b/homeassistant/components/vacuum/roomba.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 
 
-REQUIREMENTS = ['roombapy==1.3.0']
+REQUIREMENTS = ['roombapy==1.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -838,7 +838,7 @@ rflink==0.0.34
 ring_doorbell==0.1.4
 
 # homeassistant.components.vacuum.roomba
-roombapy==1.3.0
+roombapy==1.3.1
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.6


### PR DESCRIPTION
Bump `roombapy` to 1.3.1. This new version does not explicitly depends upon opencv-python and numpy, both will only be installed if requesting the `mapping` extra.
These dependencies are only required for the mapping feature to work, but `vacuum.roomba` does not support this yet.

Fixes https://github.com/home-assistant/home-assistant/pull/8924