### PR TITLE
Support Windows in UPNP discovery

### DIFF
--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -71,7 +71,7 @@ class UPNPResponderThread(threading.Thread):
 
         # Note that the double newline at the end of
         # this string is required per the SSDP spec
-       resp_template = """HTTP/1.1 200 OK
+        resp_template = """HTTP/1.1 200 OK
 CACHE-CONTROL: max-age=60
 EXT:
 LOCATION: http://{0}:{1}/description.xml

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -2,7 +2,6 @@
 import threading
 import socket
 import logging
-import os
 import select
 
 from aiohttp import web

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -133,7 +133,8 @@ USN: uuid:Socket-1_0-221438K0100073::urn:schemas-upnp-org:device:basic:1
 
                 _LOGGER.error("UPNP Responder socket exception occured: %s",
                               ex.__str__)
-                # this one is used to stop the followup error of data not being initialised
+                # without the following continue, a second exception occurs
+                # because the data object has not been initialized
                 continue
 
             if "M-SEARCH" in data.decode('utf-8'):


### PR DESCRIPTION
## Description:
Windows version of python does NOT support select of pipes, only sockets.  This causes this module to fail under windows.

By refactoring the code to use a simply timeout repeat, instead of pipes, then the module will work for either linux or Windows.

Also, the receipt of SSDP messages is via the ANY ip address and not the Multicast address, thus the bind was also incorrect.


I've set the timeout to 2 seconds, but if the only reason to turn off the service is when shutting down HA, thus this could easily be lengthened to a longer timeframe to reduce the looping.

**Related issue (if applicable):** fixes #3327

