### PR TITLE
Sabnzbd: do not assume discovery info is a dict

### DIFF
--- a/homeassistant/components/sensor/sabnzbd.py
+++ b/homeassistant/components/sensor/sabnzbd.py
@@ -130,15 +130,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the SABnzbd platform."""
     from pysabnzbd import SabnzbdApi
 
-    host = config.get(CONF_HOST) or discovery_info.get(CONF_HOST)
-    port = config.get(CONF_PORT) or discovery_info.get(CONF_PORT)
-    name = config.get(CONF_NAME, DEFAULT_NAME)
-    use_ssl = DEFAULT_SSL
-
-    if config.get(CONF_SSL):
-        use_ssl = True
-    elif discovery_info.get('properties', {}).get('https', '0') == '1':
-        use_ssl = True
+    if discovery_info is not None:
+        host = discovery_info.get(CONF_HOST)
+        port = discovery_info.get(CONF_PORT)
+        name = DEFAULT_NAME
+        use_ssl = discovery_info.get('properties', {}).get('https', '0') == '1'
+    else:
+        host = config.get(CONF_HOST)
+        port = config.get(CONF_PORT)
+        name = config.get(CONF_NAME, DEFAULT_NAME)
+        use_ssl = config.get(CONF_SSL)
 
     uri_scheme = 'https://' if use_ssl else 'http://'
     base_url = "{}{}:{}/".format(uri_scheme, host, port)


### PR DESCRIPTION
## Description:
#8634 assumed that discovery info was an empty dict when omitted. This is not the case, it's `None`. This patch removes that assumption.

**Related issue (if applicable):** fixes #8941

Would love to get feedback if this patch works @ViperRNMC / @Hellowlol 