### PR TITLE
Is_allowed_path raise for None path

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1079,6 +1079,9 @@ class Config(object):
 
     def is_allowed_path(self, path: str) -> bool:
         """Check if the path is valid for access from outside."""
+        if path is None:
+            return False
+
         parent = pathlib.Path(path).parent
         try:
             parent = parent.resolve()  # pylint: disable=no-member

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1079,8 +1079,7 @@ class Config(object):
 
     def is_allowed_path(self, path: str) -> bool:
         """Check if the path is valid for access from outside."""
-        if path is None:
-            return False
+        assert path is not None
 
         parent = pathlib.Path(path).parent
         try:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -833,7 +833,7 @@ class TestConfig(unittest.TestCase):
             for path in unvalid:
                 assert not self.config.is_allowed_path(path)
 
-            with self.assertRaises(ValueError):
+            with self.assertRaises(AssertionError):
                 self.config.is_allowed_path(None)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -833,7 +833,7 @@ class TestConfig(unittest.TestCase):
             for path in unvalid:
                 assert not self.config.is_allowed_path(path)
 
-             with self.assertRaises(ValueError):
+            with self.assertRaises(ValueError):
                 self.config.is_allowed_path(None)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -829,6 +829,7 @@ class TestConfig(unittest.TestCase):
                 "/root/secure_file",
                 "/var/../etc/passwd",
                 test_file,
+                None,
             ]
             for path in unvalid:
                 assert not self.config.is_allowed_path(path)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -829,10 +829,12 @@ class TestConfig(unittest.TestCase):
                 "/root/secure_file",
                 "/var/../etc/passwd",
                 test_file,
-                None,
             ]
             for path in unvalid:
                 assert not self.config.is_allowed_path(path)
+
+             with self.assertRaises(ValueError):
+                self.config.is_allowed_path(None)
 
 
 @patch('homeassistant.core.monotonic')


### PR DESCRIPTION
## Description:
Is allowed path return False for None path

**Related issue (if applicable):** fixes #8948
Alternative fix: https://github.com/home-assistant/home-assistant/compare/dev...pushbullet?quick_pull=1
But I think it is better to fix it in the is_allowed_path function

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
