### PR TITLE
fix DeviceException handling when updating xiaomi vacuum

### DIFF
--- a/homeassistant/components/vacuum/xiaomi.py
+++ b/homeassistant/components/vacuum/xiaomi.py
@@ -335,7 +335,7 @@ class MiroboVacuum(VacuumDevice):
     @asyncio.coroutine
     def async_update(self):
         """Fetch state from the device."""
-        from mirobo import VacuumException
+        from mirobo import DeviceException
         try:
             state = yield from self.hass.async_add_job(self._vacuum.status)
             _LOGGER.debug("Got new state from the vacuum: %s", state.data)
@@ -345,6 +345,6 @@ class MiroboVacuum(VacuumDevice):
         except OSError as exc:
             _LOGGER.error("Got OSError while fetching the state: %s", exc)
             # self._available = False
-        except VacuumException as exc:
+        except DeviceException as exc:
             _LOGGER.warning("Got exception while fetching the state: %s", exc)
             # self._available = False

--- a/homeassistant/components/vacuum/xiaomi.py
+++ b/homeassistant/components/vacuum/xiaomi.py
@@ -220,12 +220,12 @@ class MiroboVacuum(VacuumDevice):
     @asyncio.coroutine
     def _try_command(self, mask_error, func, *args, **kwargs):
         """Call a vacuum command handling error messages."""
-        from mirobo import VacuumException
+        from mirobo import DeviceException, VacuumException
         try:
             yield from self.hass.async_add_job(partial(func, *args, **kwargs))
             return True
-        except VacuumException as ex:
-            _LOGGER.error(mask_error, ex)
+        except (DeviceException, VacuumException) as exc:
+            _LOGGER.error(mask_error, exc)
             return False
 
     @asyncio.coroutine


### PR DESCRIPTION
## Description:

Fix the error handling when updating the botvac status, changing `VacuumException` for `DeviceException`.