### PR TITLE
Nello.io lock support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -326,6 +326,7 @@ omit =
     homeassistant/components/light/yeelightsunflower.py
     homeassistant/components/light/zengge.py
     homeassistant/components/lirc.py
+    homeassistant/components/lock/nello.py
     homeassistant/components/lock/nuki.py
     homeassistant/components/lock/lockitron.py
     homeassistant/components/lock/sesame.py

--- a/homeassistant/components/lock/nello.py
+++ b/homeassistant/components/lock/nello.py
@@ -99,6 +99,7 @@ class NelloLock(LockDevice):
         """Unlock the device."""
         # Optimistically assume the door has been opened
         self._locked = False
-        self._nello_lock.open_door()
+        if not self._nello_lock.open_door():
+            _LOGGER.error("Failed to unlock")
         # Reset the state to locked
         self._locked = True

--- a/homeassistant/components/lock/nello.py
+++ b/homeassistant/components/lock/nello.py
@@ -42,9 +42,7 @@ class NelloLock(LockDevice):
         """Initialize the lock."""
         self._nello_lock = nello_lock
         self._device_attrs = None
-        self._address = None
         self._activity = None
-        self._locked = True
         self._name = None
 
     @property
@@ -55,7 +53,7 @@ class NelloLock(LockDevice):
     @property
     def is_locked(self):
         """Return true if lock is locked."""
-        return self._locked
+        return True
 
     @property
     def device_state_attributes(self):
@@ -97,9 +95,5 @@ class NelloLock(LockDevice):
 
     def unlock(self, **kwargs):
         """Unlock the device."""
-        # Optimistically assume the door has been opened
-        self._locked = False
         if not self._nello_lock.open_door():
             _LOGGER.error("Failed to unlock")
-        # Reset the state to locked
-        self._locked = True

--- a/homeassistant/components/lock/nello.py
+++ b/homeassistant/components/lock/nello.py
@@ -1,0 +1,104 @@
+"""
+Nello.io lock platform.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/lock.nello/
+"""
+from itertools import filterfalse
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.lock import (LockDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_PASSWORD, CONF_USERNAME)
+
+REQUIREMENTS = ['pynello==1.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_ADDRESS = 'address'
+ATTR_LOCATION_ID = 'location_id'
+EVENT_DOOR_BELL = 'nello_bell_ring'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Nello lock platform."""
+    from pynello import Nello
+    nello = Nello(config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
+    add_devices([NelloLock(lock) for lock in nello.locations], True)
+
+
+class NelloLock(LockDevice):
+    """Representation of a Nello lock."""
+
+    def __init__(self, nello_lock):
+        """Initialize the lock."""
+        self._nello_lock = nello_lock
+        self._device_attrs = None
+        self._address = None
+        self._activity = None
+        self._locked = True
+        self._name = None
+
+    @property
+    def name(self):
+        """Return the name of the lock."""
+        return self._name
+
+    @property
+    def is_locked(self):
+        """Return true if lock is locked."""
+        return self._locked
+
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        return self._device_attrs
+
+    def update(self):
+        """Update the nello lock properties."""
+        self._nello_lock.update()
+        # Location identifiers
+        location_id = self._nello_lock.location_id
+        short_id = self._nello_lock.short_id
+        address = self._nello_lock.address
+        self._name = 'Nello {}'.format(short_id)
+        self._device_attrs = {
+            ATTR_ADDRESS: address,
+            ATTR_LOCATION_ID: location_id
+        }
+        # Process recent activity
+        activity = self._nello_lock.activity
+        if self._activity:
+            # Filter out old events
+            new_activity = list(
+                filterfalse(lambda x: x in self._activity, activity))
+            if new_activity:
+                for act in new_activity:
+                    activity_type = act.get('type')
+                    if activity_type == 'bell.ring.denied':
+                        event_data = {
+                            'address': address,
+                            'date': act.get('date'),
+                            'description': act.get('description'),
+                            'location_id': location_id,
+                            'short_id': short_id
+                        }
+                        self.hass.bus.fire(EVENT_DOOR_BELL, event_data)
+        # Save the activity history so that we don't trigger an event twice
+        self._activity = activity
+
+    def unlock(self, **kwargs):
+        """Unlock the device."""
+        # Optimistically assume the door has been opened
+        self._locked = False
+        self._nello_lock.open_door()
+        # Reset the state to locked
+        self._locked = True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -651,6 +651,9 @@ pymyq==0.0.8
 # homeassistant.components.mysensors
 pymysensors==0.10.0
 
+# homeassistant.components.lock.nello
+pynello==1.5
+
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3.3
 


### PR DESCRIPTION
## Description:
[Nello.io](https://www.nello.io) are cloud-based intercom solutions that allow to buzz open the door in apartment buildings and receive notifications when someone rings the bell.
This here presents a new `lock` device that does not implement the `lock` function ;)
It also fires a `nello_bell_ring` event when the bell has been rung.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3173

## Example entry for `configuration.yaml` (if applicable):
```yaml
lock:
  - platform: nello
    username: mail@example.com
    password: !secret nello_password
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.