### PR TITLE
Fix zwave power_consumption attribute

### DIFF
--- a/homeassistant/components/zwave/util.py
+++ b/homeassistant/components/zwave/util.py
@@ -54,9 +54,12 @@ def check_value_schema(value, schema):
                       value.instance, schema[const.DISC_INSTANCE])
         return False
     if const.DISC_SCHEMAS in schema:
+        found = False
         for schema_item in schema[const.DISC_SCHEMAS]:
-            if not check_value_schema(value, schema_item):
-                return False
+            found = found or check_value_schema(value, schema_item)
+        if not found:
+            return False
+
     return True
 
 

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -3,6 +3,9 @@ import asyncio
 from collections import OrderedDict
 from datetime import datetime
 
+import unittest
+from unittest.mock import patch, MagicMock
+
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
 from homeassistant.components import zwave
@@ -12,8 +15,6 @@ from homeassistant.components.zwave import (
 from homeassistant.setup import setup_component
 
 import pytest
-import unittest
-from unittest.mock import patch, MagicMock
 
 from tests.common import (
     get_test_home_assistant, async_fire_time_changed)
@@ -310,6 +311,50 @@ def test_value_discovery_existing_entity(hass, mock_openzwave):
         'temperature'] == 22.0
     assert hass.states.get('climate.mock_node_mock_value').attributes[
         'current_temperature'] == 23.5
+
+
+@asyncio.coroutine
+def test_power_schemes(hass, mock_openzwave):
+    """Test power attribute."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch('pydispatch.dispatcher.connect', new=mock_connect):
+        yield from async_setup_component(hass, 'zwave', {'zwave': {
+            'new_entity_ids': True,
+            }})
+
+    assert len(mock_receivers) == 1
+
+    node = MockNode(node_id=11, generic=const.GENERIC_TYPE_SWITCH_BINARY)
+    switch = MockValue(
+        data=True, node=node, index=12, instance=13,
+        command_class=const.COMMAND_CLASS_SWITCH_BINARY,
+        genre=const.GENRE_USER, type=const.TYPE_BOOL)
+    hass.async_add_job(mock_receivers[0], node, switch)
+
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get('switch.mock_node_mock_value').state == 'on'
+    assert 'power_consumption' not in hass.states.get(
+        'switch.mock_node_mock_value').attributes
+
+    def mock_update(self):
+        self.hass.async_add_job(self.async_update_ha_state)
+
+    with patch.object(zwave.node_entity.ZWaveBaseEntity,
+                      'maybe_schedule_update', new=mock_update):
+        power = MockValue(
+            data=23.5, node=node, index=const.INDEX_SENSOR_MULTILEVEL_POWER,
+            instance=13, command_class=const.COMMAND_CLASS_SENSOR_MULTILEVEL)
+        hass.async_add_job(mock_receivers[0], node, power)
+        yield from hass.async_block_till_done()
+
+    assert hass.states.get('switch.mock_node_mock_value').attributes[
+        'power_consumption'] == 23.5
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

Fix zwave power_consumption attribute that was broken by #7853
Fixes #8591

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
