### PR TITLE
Added continue-on-errors, added value template

### DIFF
--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -13,7 +13,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PORT, CONF_UNIT_OF_MEASUREMENT)
+    CONF_HOST, CONF_NAME, CONF_PORT, CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN,
+    CONF_VALUE_TEMPLATE)
 
 REQUIREMENTS = ['pysnmp==4.3.9']
 
@@ -22,6 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 CONF_BASEOID = 'baseoid'
 CONF_COMMUNITY = 'community'
 CONF_VERSION = 'version'
+CONF_ACCEPT_ERRORS = 'accept_errors'
+CONF_DEFAULT_VALUE = 'default_value'
 
 DEFAULT_COMMUNITY = 'public'
 DEFAULT_HOST = 'localhost'
@@ -45,6 +48,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_VERSION, default=DEFAULT_VERSION):
         vol.In(SNMP_VERSIONS),
+    vol.Optional(CONF_ACCEPT_ERRORS, default=False): cv.boolean,
+    vol.Optional(CONF_DEFAULT_VALUE): cv.string,
+    vol.Optional(CONF_VALUE_TEMPLATE): cv.template
 })
 
 
@@ -61,6 +67,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     baseoid = config.get(CONF_BASEOID)
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
     version = config.get(CONF_VERSION)
+    accept_errors = config.get(CONF_ACCEPT_ERRORS)
+    default_value = config.get(CONF_DEFAULT_VALUE)
+    value_template = config.get(CONF_VALUE_TEMPLATE)
+
+    if value_template is not None:
+        value_template.hass = hass
 
     errindication, _, _, _ = next(
         getCmd(SnmpEngine(),
@@ -69,23 +81,24 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                ContextData(),
                ObjectType(ObjectIdentity(baseoid))))
 
-    if errindication:
+    if errindication and not accept_errors:
         _LOGGER.error("Please check the details in the configuration file")
         return False
     else:
-        data = SnmpData(host, port, community, baseoid, version)
-        add_devices([SnmpSensor(data, name, unit)], True)
+        data = SnmpData(host, port, community, baseoid, version, accept_errors, default_value)
+        add_devices([SnmpSensor(data, name, unit, value_template)], True)
 
 
 class SnmpSensor(Entity):
     """Representation of a SNMP sensor."""
 
-    def __init__(self, data, name, unit_of_measurement):
+    def __init__(self, data, name, unit_of_measurement, value_template):
         """Initialize the sensor."""
         self.data = data
         self._name = name
         self._state = None
         self._unit_of_measurement = unit_of_measurement
+        self._value_template = value_template
 
     @property
     def name(self):
@@ -105,19 +118,29 @@ class SnmpSensor(Entity):
     def update(self):
         """Get the latest data and updates the states."""
         self.data.update()
-        self._state = self.data.value
+        value = self.data.value
+
+        if value is None:
+            value = STATE_UNKNOWN
+        elif self._value_template is not None:
+            value = self._value_template.render_with_possible_json_value(
+                value, STATE_UNKNOWN)
+
+        self._state = value
 
 
 class SnmpData(object):
     """Get the latest data and update the states."""
 
-    def __init__(self, host, port, community, baseoid, version):
+    def __init__(self, host, port, community, baseoid, version, accept_errors, default_value):
         """Initialize the data object."""
         self._host = host
         self._port = port
         self._community = community
         self._baseoid = baseoid
         self._version = SNMP_VERSIONS[version]
+        self._accept_errors = accept_errors
+        self._default_value = default_value
         self.value = None
 
     def update(self):
@@ -133,11 +156,14 @@ class SnmpData(object):
                    ObjectType(ObjectIdentity(self._baseoid)))
             )
 
-        if errindication:
+        if errindication and not self._accept_errors:
             _LOGGER.error("SNMP error: %s", errindication)
-        elif errstatus:
+        elif errstatus and not self._accept_errors:
             _LOGGER.error("SNMP error: %s at %s", errstatus.prettyPrint(),
                           errindex and restable[-1][int(errindex) - 1] or '?')
+        elif (errindication or errstatus) and self._accept_errors:
+            self.value = self._default_value
         else:
             for resrow in restable:
-                self.value = resrow[-1]
+                self.value = str(resrow[-1])
+

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -86,7 +86,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
     else:
         data = SnmpData(
-            host, port, community, baseoid,version, accept_errors,
+            host, port, community, baseoid, version, accept_errors,
             default_value)
         add_devices([SnmpSensor(data, name, unit, value_template)], True)
 
@@ -170,4 +170,3 @@ class SnmpData(object):
         else:
             for resrow in restable:
                 self.value = str(resrow[-1])
-

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -85,14 +85,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("Please check the details in the configuration file")
         return False
     else:
-        data = SnmpData(host, port, community, baseoid, version, accept_errors, default_value)
+        data = SnmpData(
+            host, port, community, baseoid,version, accept_errors,
+            default_value)
         add_devices([SnmpSensor(data, name, unit, value_template)], True)
 
 
 class SnmpSensor(Entity):
     """Representation of a SNMP sensor."""
 
-    def __init__(self, data, name, unit_of_measurement, value_template):
+    def __init__(self, data, name, unit_of_measurement,
+                 value_template):
         """Initialize the sensor."""
         self.data = data
         self._name = name
@@ -132,7 +135,8 @@ class SnmpSensor(Entity):
 class SnmpData(object):
     """Get the latest data and update the states."""
 
-    def __init__(self, host, port, community, baseoid, version, accept_errors, default_value):
+    def __init__(self, host, port, community, baseoid, version, accept_errors,
+                 default_value):
         """Initialize the data object."""
         self._host = host
         self._port = port


### PR DESCRIPTION
## Description:

Annoyed by the fact that my printer had to be on when I started Home Assistant, I added functionality to
- allow the sensor to start and keep working even if the remote host becomes unreachable
- specify an optional default value in case the remote host is unreachable
- process the value with a template

The new configuration options are:
- **value_template** (*Optional*): Defines a template to parse the value.
- **accept_errors** (*Optional*): Determines whether the sensor should start and keep working even if the SNMP host is unreachable or not responding. This allows the sensor to be initialized properly even if, for example, your printer is not on when you start Home Assistant. Defaults to `false`.
- **default_value** (*Optional*): Determines what value the sensor should take if `accept_errors` is set and the host is unreachable or not responding. If not set, the sensor will have value `unknown` in case of errors.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3175

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
sensor:
  - platform: snmp
    name: 'Printer uptime'
    host: 192.168.2.21
    baseoid: 1.3.6.1.2.1.1.3.0
    accept_errors: true
    unit_of_measurement: 'minutes'
    value_template: '{{((value | int) / 6000) | int}}'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
