### PR TITLE
Update to pyenvisalink 2.2, and remove range validation on zonedump i…

### DIFF
--- a/homeassistant/components/envisalink.py
+++ b/homeassistant/components/envisalink.py
@@ -74,7 +74,8 @@ CONFIG_SCHEMA = vol.Schema({
             vol.All(vol.Coerce(int), vol.Range(min=3, max=4)),
         vol.Optional(CONF_EVL_KEEPALIVE, default=DEFAULT_KEEPALIVE):
             vol.All(vol.Coerce(int), vol.Range(min=15)),
-        vol.Optional(CONF_ZONEDUMP_INTERVAL, default=DEFAULT_ZONEDUMP_INTERVAL): vol.Coerce(int),
+        vol.Optional(CONF_ZONEDUMP_INTERVAL, 
+            default=DEFAULT_ZONEDUMP_INTERVAL): vol.Coerce(int),
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/envisalink.py
+++ b/homeassistant/components/envisalink.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-REQUIREMENTS = ['pyenvisalink==2.1']
+REQUIREMENTS = ['pyenvisalink==2.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,9 +74,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.All(vol.Coerce(int), vol.Range(min=3, max=4)),
         vol.Optional(CONF_EVL_KEEPALIVE, default=DEFAULT_KEEPALIVE):
             vol.All(vol.Coerce(int), vol.Range(min=15)),
-        vol.Optional(CONF_ZONEDUMP_INTERVAL,
-                     default=DEFAULT_ZONEDUMP_INTERVAL):
-            vol.All(vol.Coerce(int), vol.Range(min=15)),
+        vol.Optional(CONF_ZONEDUMP_INTERVAL): vol.Coerce(int),
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/envisalink.py
+++ b/homeassistant/components/envisalink.py
@@ -74,7 +74,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.All(vol.Coerce(int), vol.Range(min=3, max=4)),
         vol.Optional(CONF_EVL_KEEPALIVE, default=DEFAULT_KEEPALIVE):
             vol.All(vol.Coerce(int), vol.Range(min=15)),
-        vol.Optional(CONF_ZONEDUMP_INTERVAL): vol.Coerce(int),
+        vol.Optional(CONF_ZONEDUMP_INTERVAL, default=DEFAULT_ZONEDUMP_INTERVAL): vol.Coerce(int),
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/envisalink.py
+++ b/homeassistant/components/envisalink.py
@@ -74,7 +74,8 @@ CONFIG_SCHEMA = vol.Schema({
             vol.All(vol.Coerce(int), vol.Range(min=3, max=4)),
         vol.Optional(CONF_EVL_KEEPALIVE, default=DEFAULT_KEEPALIVE):
             vol.All(vol.Coerce(int), vol.Range(min=15)),
-        vol.Optional(CONF_ZONEDUMP_INTERVAL, 
+        vol.Optional(
+            CONF_ZONEDUMP_INTERVAL,
             default=DEFAULT_ZONEDUMP_INTERVAL): vol.Coerce(int),
     }),
 }, extra=vol.ALLOW_EXTRA)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -576,7 +576,7 @@ pyeight==0.0.7
 pyemby==1.4
 
 # homeassistant.components.envisalink
-pyenvisalink==2.1
+pyenvisalink==2.2
 
 # homeassistant.components.sensor.fido
 pyfido==1.0.1


### PR DESCRIPTION
…nterval.

## Description:
Bumping pyenvisalink library, as a small bug was fixed on that end of things.  Also, a user wished me to remove some range validation on one of my configuration parameters, as it was not necessary for anyone using a DSC panel.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
