### PR TITLE
Adds port/SSL config options for RainMachine

### DIFF
--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -94,21 +94,25 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
         entities = []
         for program in client.programs.all().get('programs'):
-            if program.get('active'):
-                _LOGGER.debug('Adding program: %s', program)
-                entities.append(
-                    RainMachineProgram(
-                        client, program, device_name=rainmachine_device_name))
+            if not program.get('active'):
+                pass
+
+            _LOGGER.debug('Adding program: %s', program)
+            entities.append(
+                RainMachineProgram(
+                    client, program, device_name=rainmachine_device_name))
 
         for zone in client.zones.all().get('zones'):
-            if zone.get('active'):
-                _LOGGER.debug('Adding zone: %s', zone)
-                entities.append(
-                    RainMachineZone(
-                        client,
-                        zone,
-                        zone_run_time,
-                        device_name=rainmachine_device_name, ))
+            if not zone.get('active'):
+                pass
+
+            _LOGGER.debug('Adding zone: %s', zone)
+            entities.append(
+                RainMachineZone(
+                    client,
+                    zone,
+                    zone_run_time,
+                    device_name=rainmachine_device_name, ))
 
         async_add_devices(entities)
     except rm.exceptions.HTTPError as exc_info:

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -8,20 +8,21 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import (ATTR_ATTRIBUTION, ATTR_DEVICE_CLASS,
-                                 CONF_EMAIL, CONF_IP_ADDRESS, CONF_PASSWORD,
-                                 CONF_PLATFORM, CONF_SCAN_INTERVAL)
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, ATTR_DEVICE_CLASS, CONF_EMAIL, CONF_IP_ADDRESS,
+    CONF_PASSWORD, CONF_PLATFORM, CONF_PORT, CONF_SCAN_INTERVAL, CONF_SSL)
 from homeassistant.util import Throttle
 
 _LOGGER = getLogger(__name__)
-REQUIREMENTS = ['regenmaschine==0.3.2']
+REQUIREMENTS = ['regenmaschine==0.4.1']
 
 ATTR_CYCLES = 'cycles'
 ATTR_TOTAL_DURATION = 'total_duration'
 
-CONF_HIDE_DISABLED_ENTITIES = 'hide_disabled_entities'
 CONF_ZONE_RUN_TIME = 'zone_run_time'
 
+DEFAULT_PORT = 8080
+DEFAULT_SSL = True
 DEFAULT_ZONE_RUN_SECONDS = 60 * 10
 
 MIN_SCAN_TIME_LOCAL = timedelta(seconds=1)
@@ -42,10 +43,12 @@ PLATFORM_SCHEMA = vol.Schema(
             vol.Email(),  # pylint: disable=no-value-for-parameter
             vol.Required(CONF_PASSWORD):
             cv.string,
+            vol.Required(CONF_PORT):
+            cv.port,
+            vol.Required(CONF_SSL):
+            cv.boolean,
             vol.Optional(CONF_ZONE_RUN_TIME, default=DEFAULT_ZONE_RUN_SECONDS):
-            cv.positive_int,
-            vol.Optional(CONF_HIDE_DISABLED_ENTITIES, default=True):
-            cv.boolean
+            cv.positive_int
         }),
     extra=vol.ALLOW_EXTRA)
 
@@ -64,46 +67,48 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     password = config.get(CONF_PASSWORD)
     _LOGGER.debug('Password: %s', password)
 
-    hide_disabled_entities = config.get(CONF_HIDE_DISABLED_ENTITIES)
-    _LOGGER.debug('Show disabled entities: %s', hide_disabled_entities)
-
     zone_run_time = config.get(CONF_ZONE_RUN_TIME)
     _LOGGER.debug('Zone run time: %s', zone_run_time)
 
     try:
         if ip_address:
-            _LOGGER.debug('Configuring local API...')
-            auth = rm.Authenticator.create_local(ip_address, password)
+            port = config.get(CONF_PORT)
+            _LOGGER.debug('Port: %s', port)
+
+            ssl = config.get(CONF_SSL)
+            _LOGGER.debug('SSL: %s', ssl)
+
+            _LOGGER.debug('Configuring local API')
+            auth = rm.Authenticator.create_local(
+                ip_address, password, port=port, https=ssl)
         elif email_address:
-            _LOGGER.debug('Configuring remote API...')
+            _LOGGER.debug('Configuring remote API')
             auth = rm.Authenticator.create_remote(email_address, password)
 
-        _LOGGER.debug('Instantiating RainMachine client...')
+        _LOGGER.debug('Querying against: %s', auth.url)
+
+        _LOGGER.debug('Instantiating RainMachine client')
         client = rm.Client(auth)
 
         rainmachine_device_name = client.provision.device_name().get('name')
 
         entities = []
         for program in client.programs.all().get('programs'):
-            if hide_disabled_entities and program.get('active') is False:
-                continue
-
-            _LOGGER.debug('Adding program: %s', program)
-            entities.append(
-                RainMachineProgram(
-                    client, program, device_name=rainmachine_device_name))
+            if program.get('active'):
+                _LOGGER.debug('Adding program: %s', program)
+                entities.append(
+                    RainMachineProgram(
+                        client, program, device_name=rainmachine_device_name))
 
         for zone in client.zones.all().get('zones'):
-            if hide_disabled_entities and zone.get('active') is False:
-                continue
-
-            _LOGGER.debug('Adding zone: %s', zone)
-            entities.append(
-                RainMachineZone(
-                    client,
-                    zone,
-                    zone_run_time,
-                    device_name=rainmachine_device_name, ))
+            if zone.get('active'):
+                _LOGGER.debug('Adding zone: %s', zone)
+                entities.append(
+                    RainMachineZone(
+                        client,
+                        zone,
+                        zone_run_time,
+                        device_name=rainmachine_device_name, ))
 
         async_add_devices(entities)
     except rm.exceptions.HTTPError as exc_info:

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -95,7 +95,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         entities = []
         for program in client.programs.all().get('programs'):
             if not program.get('active'):
-                pass
+                continue
 
             _LOGGER.debug('Adding program: %s', program)
             entities.append(
@@ -104,7 +104,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
         for zone in client.zones.all().get('zones'):
             if not zone.get('active'):
-                pass
+                continue
 
             _LOGGER.debug('Adding zone: %s', zone)
             entities.append(

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -43,9 +43,9 @@ PLATFORM_SCHEMA = vol.Schema(
             vol.Email(),  # pylint: disable=no-value-for-parameter
             vol.Required(CONF_PASSWORD):
             cv.string,
-            vol.Required(CONF_PORT):
+            vol.Optional(CONF_PORT):
             cv.port,
-            vol.Required(CONF_SSL):
+            vol.Optional(CONF_SSL):
             cv.boolean,
             vol.Optional(CONF_ZONE_RUN_TIME, default=DEFAULT_ZONE_RUN_SECONDS):
             cv.positive_int

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -43,9 +43,9 @@ PLATFORM_SCHEMA = vol.Schema(
             vol.Email(),  # pylint: disable=no-value-for-parameter
             vol.Required(CONF_PASSWORD):
             cv.string,
-            vol.Optional(CONF_PORT):
+            vol.Optional(CONF_PORT, default=DEFAULT_PORT):
             cv.port,
-            vol.Optional(CONF_SSL):
+            vol.Optional(CONF_SSL, default=DEFAULT_SSL):
             cv.boolean,
             vol.Optional(CONF_ZONE_RUN_TIME, default=DEFAULT_ZONE_RUN_SECONDS):
             cv.positive_int

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -829,7 +829,7 @@ radiotherm==1.3
 # raspihats==2.2.1
 
 # homeassistant.components.switch.rainmachine
-regenmaschine==0.3.2
+regenmaschine==0.4.1
 
 # homeassistant.components.python_script
 restrictedpython==4.0a3


### PR DESCRIPTION
## Description:
Adds the ability to specify two more configuration options when querying a RainMachine locally:

* `port`: the TCP port used by the device for its REST API (default: 8080)
* `ssl`: whether HTTPS should be used on all requests (default: true)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/3180

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  platform: rainmachine
  ip_address: 192.168.1.100
  password: my_password
  port: 8080
  ssl: true
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
