### PR TITLE
Fix octoprint errors when printer is off/disconnected

### DIFF
--- a/homeassistant/components/octoprint.py
+++ b/homeassistant/components/octoprint.py
@@ -23,7 +23,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_API_KEY): cv.string,
         vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_NUMBER_OF_TOOLS, default=None): cv.positive_int,
+        vol.Optional(CONF_NUMBER_OF_TOOLS, default=0): cv.positive_int,
         vol.Optional(CONF_BED, default=False): cv.boolean
     }),
 }, extra=vol.ALLOW_EXTRA)
@@ -36,11 +36,10 @@ def setup(hass, config):
     number_of_tools = config[DOMAIN][CONF_NUMBER_OF_TOOLS]
     bed = config[DOMAIN][CONF_BED]
 
-    hass.data[DOMAIN] = {"api": None, CONF_NUMBER_OF_TOOLS: number_of_tools,
-                         CONF_BED: bed}
+    hass.data[DOMAIN] = {"api": None}
 
     try:
-        octoprint_api = OctoPrintAPI(base_url, api_key)
+        octoprint_api = OctoPrintAPI(base_url, api_key, bed, number_of_tools)
         hass.data[DOMAIN]["api"] = octoprint_api
         octoprint_api.get('printer')
         octoprint_api.get('job')
@@ -53,7 +52,7 @@ def setup(hass, config):
 class OctoPrintAPI(object):
     """Simple JSON wrapper for OctoPrint's API."""
 
-    def __init__(self, api_url, key):
+    def __init__(self, api_url, key, bed, number_of_tools):
         """Initialize OctoPrint API and set headers needed later."""
         self.api_url = api_url
         self.headers = {'content-type': CONTENT_TYPE_JSON,
@@ -65,13 +64,23 @@ class OctoPrintAPI(object):
         self.available = False
         self.printer_error_logged = False
         self.job_error_logged = False
+        self.bed = bed
+        self.number_of_tools = number_of_tools
+        _LOGGER.error(str(bed) + " " + str(number_of_tools))
 
     def get_tools(self):
-        """Get the dynamic list of tools that temperature is monitored on."""
-        tools = self.printer_last_reading[0].get('temperature')
-        if tools is not None:
-            return tools.keys()
-        return None
+        """Get the list of tools that temperature is monitored on."""
+        tools = []
+        if self.number_of_tools > 0:
+            for tool_number in range(0, self.number_of_tools):
+                tools.append("tool" + str(tool_number))
+        if self.bed:
+            tools.append('bed')
+        if not self.bed and self.number_of_tools == 0:
+            temps = self.printer_last_reading[0].get('temperature')
+            if temps is not None:
+                tools = temps.keys()
+        return tools
 
     def get(self, endpoint):
         """Send a get request, and return the response as a dict."""

--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -54,7 +54,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 'If you do not want to have your printer on <br />'
                 ' at all times, and you would like to monitor <br /> '
                 'temperatures, please add <br />'
-                'bed and/or number\_of\_tools to your config.',
+                'bed and/or number&#95of&#95tools to your config <br />'
+                'and restart.',
                 title=NOTIFICATION_TITLE,
                 notification_id=NOTIFICATION_ID)
 


### PR DESCRIPTION
## Description:
Currently OctoPrint temperature sensors are dynamically added to HASS via the OctoPrint API. If the user wants temperature to be reported, all temperatures are returned. However, if the printer is powered off during HASS startup there is no way to know which sensors to create because the OctoPrint API doesn't respond. This PR will still dynamically add temperature sensors, but will only do so if the user doesn't have those sensors defined in the main OctoPrint config. 

Two new config options will be added.
`number_of_tools` (int) - The number of non-bed temperature sensors. ex. Print head. Defaults to None which causes the sensors to be loaded dynamically if the printer is on/connected to OctoPrint.
`bed` (boolean) - If the bed is heated set to True, defaults to false.

**Related issue (if applicable):** fixes #8978 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3211

## Example entry for `configuration.yaml` (if applicable):
```yaml
octoprint:
  host: 127.0.0.1
  api_key: !secret octoprint_api_key
  number_of_tools: 1
  bed: True
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

I have done very limited testing as my printer isn't in a good state to do much with. Requesting testing from @cmsimike and @nunofgs. If either of you could test please try with the new config options and without both with your printer attached and disconnected.

The easiest way to test would be to drop the two changed files in this PR into YOUR_HA_CONFIG_FOLDER/custom_components/octoprint.py and YOUR_HA_CONFIG_FOLDER/custom_components/sensor/octoprint.py this should override the current octoprint files. Of course remember to delete them when you are done.
