### PR TITLE
Fix #8960 - Decora Wi-Fi Switch unable to set brightness

### DIFF
--- a/homeassistant/components/light/decora_wifi.py
+++ b/homeassistant/components/light/decora_wifi.py
@@ -116,8 +116,8 @@ class DecoraWifiLight(Light):
         attribs = {'power': 'ON'}
 
         if ATTR_BRIGHTNESS in kwargs:
-            min_level = self._switch.get('minLevel', 0)
-            max_level = self._switch.get('maxLevel', 100)
+            min_level = self._switch.data.get('minLevel', 0)
+            max_level = self._switch.data.get('maxLevel', 100)
             brightness = int(kwargs[ATTR_BRIGHTNESS] * max_level / 255)
             brightness = max(brightness, min_level)
             attribs['brightness'] = brightness


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #8960 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
