### PR TITLE
Add scripts editor backend

### DIFF
--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.util.yaml import load_yaml, dump
 
 DOMAIN = 'config'
 DEPENDENCIES = ['http']
-SECTIONS = ('core', 'group', 'hassbian', 'automation')
+SECTIONS = ('core', 'group', 'hassbian', 'automation', 'script')
 ON_DEMAND = ('zwave')
 
 

--- a/homeassistant/components/config/script.py
+++ b/homeassistant/components/config/script.py
@@ -1,0 +1,19 @@
+"""Provide configuration end points for Groups."""
+import asyncio
+
+from homeassistant.components.config import EditKeyBasedConfigView
+from homeassistant.components.script import SCRIPT_ENTRY_SCHEMA, async_reload
+import homeassistant.helpers.config_validation as cv
+
+
+CONFIG_PATH = 'scripts.yaml'
+
+
+@asyncio.coroutine
+def async_setup(hass):
+    """Set up the Group config API."""
+    hass.http.register_view(EditKeyBasedConfigView(
+        'script', 'config', CONFIG_PATH, cv.slug, SCRIPT_ENTRY_SCHEMA,
+        post_write_hook=async_reload
+    ))
+    return True

--- a/homeassistant/components/config/script.py
+++ b/homeassistant/components/config/script.py
@@ -1,4 +1,4 @@
-"""Provide configuration end points for Groups."""
+"""Provide configuration end points for scripts."""
 import asyncio
 
 from homeassistant.components.config import EditKeyBasedConfigView
@@ -11,7 +11,7 @@ CONFIG_PATH = 'scripts.yaml'
 
 @asyncio.coroutine
 def async_setup(hass):
-    """Set up the Group config API."""
+    """Set up the script config API."""
     hass.http.register_view(EditKeyBasedConfigView(
         'script', 'config', CONFIG_PATH, cv.slug, SCRIPT_ENTRY_SCHEMA,
         post_write_hook=async_reload

--- a/homeassistant/components/script.py
+++ b/homeassistant/components/script.py
@@ -39,13 +39,13 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 GROUP_NAME_ALL_SCRIPTS = 'all scripts'
 
-_SCRIPT_ENTRY_SCHEMA = vol.Schema({
+SCRIPT_ENTRY_SCHEMA = vol.Schema({
     CONF_ALIAS: cv.string,
     vol.Required(CONF_SEQUENCE): cv.SCRIPT_SCHEMA,
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({cv.slug: _SCRIPT_ENTRY_SCHEMA})
+    DOMAIN: vol.Schema({cv.slug: SCRIPT_ENTRY_SCHEMA})
 }, extra=vol.ALLOW_EXTRA)
 
 SCRIPT_SERVICE_SCHEMA = vol.Schema(dict)
@@ -86,6 +86,15 @@ def turn_off(hass, entity_id):
 def toggle(hass, entity_id):
     """Toggle the script."""
     hass.services.call(DOMAIN, SERVICE_TOGGLE, {ATTR_ENTITY_ID: entity_id})
+
+
+@bind_hass
+def async_reload(hass):
+    """Reload the automation from config.
+
+    Returns a coroutine object.
+    """
+    return hass.services.async_call(DOMAIN, SERVICE_RELOAD)
 
 
 @asyncio.coroutine

--- a/homeassistant/components/script.py
+++ b/homeassistant/components/script.py
@@ -63,12 +63,6 @@ def is_on(hass, entity_id):
 
 
 @bind_hass
-def reload(hass):
-    """Reload script component."""
-    hass.services.call(DOMAIN, SERVICE_RELOAD)
-
-
-@bind_hass
 def turn_on(hass, entity_id, variables=None):
     """Turn script on."""
     _, object_id = split_entity_id(entity_id)
@@ -89,8 +83,14 @@ def toggle(hass, entity_id):
 
 
 @bind_hass
+def reload(hass):
+    """Reload script component."""
+    hass.services.call(DOMAIN, SERVICE_RELOAD)
+
+
+@bind_hass
 def async_reload(hass):
-    """Reload the automation from config.
+    """Reload the scripts from config.
 
     Returns a coroutine object.
     """

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -108,6 +108,7 @@ tts:
 
 group: !include groups.yaml
 automation: !include automations.yaml
+script: !include scripts.yaml
 """
 
 
@@ -173,11 +174,14 @@ def create_default_config(config_dir, detect_location=True):
         CONFIG_PATH as GROUP_CONFIG_PATH)
     from homeassistant.components.config.automation import (
         CONFIG_PATH as AUTOMATION_CONFIG_PATH)
+    from homeassistant.components.config.script import (
+        CONFIG_PATH as SCRIPT_CONFIG_PATH)
 
     config_path = os.path.join(config_dir, YAML_CONFIG_FILE)
     version_path = os.path.join(config_dir, VERSION_FILE)
     group_yaml_path = os.path.join(config_dir, GROUP_CONFIG_PATH)
     automation_yaml_path = os.path.join(config_dir, AUTOMATION_CONFIG_PATH)
+    script_yaml_path = os.path.join(config_dir, SCRIPT_CONFIG_PATH)
 
     info = {attr: default for attr, default, _, _ in DEFAULT_CORE_CONFIG}
 
@@ -216,11 +220,14 @@ def create_default_config(config_dir, detect_location=True):
         with open(version_path, 'wt') as version_file:
             version_file.write(__version__)
 
-        with open(group_yaml_path, 'w'):
+        with open(group_yaml_path, 'wt'):
             pass
 
         with open(automation_yaml_path, 'wt') as fil:
             fil.write('[]')
+
+        with open(script_yaml_path, 'wt'):
+            pass
 
         return config_path
 


### PR DESCRIPTION
## Description:
Add the backend for a script editor. Not introducing any new pieces of code as I was able to completely piece this one together from existing pieces! (frontend + backend)

Demo: https://www.youtube.com/watch?v=_Rntpcj1CGA&feature=youtu.be

Polymer PR: https://github.com/home-assistant/home-assistant-polymer/pull/393

## Example entry for `configuration.yaml` (if applicable):
```yaml
script: !include scripts.yaml
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
