### PR TITLE
Automatic device tracker remove password

### DIFF
--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -128,17 +128,8 @@ def async_setup_scanner(hass, config, async_see, discovery_info=None):
                 refresh_token)
             yield from initialize_data(session)
             return True
-        except aioautomatic.exceptions.BadRequestError as err:
-            if str(err) == 'err_invalid_refresh_token':
-                _LOGGER.error("Stored refresh token was invalid.")
-                yield from hass.async_add_job(
-                    _write_refresh_token_to_file, hass, filename, None)
-            else:
-                _LOGGER.error(str(err))
-                return False
         except aioautomatic.exceptions.AutomaticError as err:
             _LOGGER.error(str(err))
-            return False
 
     configurator = hass.components.configurator
     request_id = configurator.async_request_config(

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -17,8 +17,7 @@ from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, ATTR_ATTRIBUTES, ATTR_DEV_ID, ATTR_HOST_NAME, ATTR_MAC,
     ATTR_GPS, ATTR_GPS_ACCURACY)
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.const import (
-    CONF_USERNAME, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -51,8 +50,6 @@ DATA_REFRESH_TOKEN = 'refresh_token'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_CLIENT_ID): cv.string,
     vol.Required(CONF_SECRET): cv.string,
-    vol.Inclusive(CONF_USERNAME, 'auth'): cv.string,
-    vol.Inclusive(CONF_PASSWORD, 'auth'): cv.string,
     vol.Optional(CONF_CURRENT_LOCATION, default=False): cv.boolean,
     vol.Optional(CONF_DEVICES, default=None): vol.All(
         cv.ensure_list, [cv.string])
@@ -139,16 +136,6 @@ def async_setup_scanner(hass, config, async_see, discovery_info=None):
             else:
                 _LOGGER.error(str(err))
                 return False
-        except aioautomatic.exceptions.AutomaticError as err:
-            _LOGGER.error(str(err))
-            return False
-
-    if CONF_USERNAME in config:
-        try:
-            session = yield from client.create_session_from_password(
-                scope, config[CONF_USERNAME], config[CONF_PASSWORD])
-            yield from initialize_data(session)
-            return True
         except aioautomatic.exceptions.AutomaticError as err:
             _LOGGER.error(str(err))
             return False

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 
-REQUIREMENTS = ['aioautomatic==0.5.0']
+REQUIREMENTS = ['aioautomatic==0.6.0']
 DEPENDENCIES = ['http']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,7 +39,7 @@ SoCo==0.12
 TwitterAPI==2.4.6
 
 # homeassistant.components.device_tracker.automatic
-aioautomatic==0.5.0
+aioautomatic==0.6.0
 
 # homeassistant.components.sensor.dnsip
 aiodns==1.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -27,7 +27,7 @@ PyJWT==1.5.2
 SoCo==0.12
 
 # homeassistant.components.device_tracker.automatic
-aioautomatic==0.5.0
+aioautomatic==0.6.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/device_tracker/test_automatic.py
+++ b/tests/components/device_tracker/test_automatic.py
@@ -12,40 +12,58 @@ from tests.common import mock_http_component
 _LOGGER = logging.getLogger(__name__)
 
 
-@patch('aioautomatic.Client.create_session_from_password')
-def test_invalid_credentials(mock_create_session, hass):
+@patch('aioautomatic.Client.create_session_from_refresh_token')
+@patch('json.load')
+@patch('json.dump')
+@patch('os.makedirs')
+@patch('os.path.isfile', return_value=True)
+@patch('homeassistant.components.device_tracker.automatic.open', create=True)
+def test_invalid_credentials(
+        mock_open, mock_isfile, mock_makedirs, mock_json_dump, mock_json_load,
+        mock_create_session, hass):
     """Test with invalid credentials."""
     mock_http_component(hass)
+
+    mock_json_load.return_value = {'refresh_token': 'bad_token'}
 
     @asyncio.coroutine
     def get_session(*args, **kwargs):
         """Return the test session."""
-        raise aioautomatic.exceptions.ForbiddenError()
+        raise aioautomatic.exceptions.BadRequestError(
+            'err_invalid_refresh_token')
 
     mock_create_session.side_effect = get_session
 
     config = {
         'platform': 'automatic',
-        'username': 'bad_username',
-        'password': 'bad_password',
         'client_id': 'client_id',
         'secret': 'client_secret',
         'devices': None,
     }
-    result = hass.loop.run_until_complete(
+    hass.loop.run_until_complete(
         async_setup_scanner(hass, config, None))
-    assert not result
+    assert mock_create_session.called
+    assert len(mock_create_session.mock_calls) == 1
+    assert mock_create_session.mock_calls[0][1][0] == 'bad_token'
+    assert mock_json_dump.called
+    assert len(mock_json_dump.mock_calls) == 1
+    assert mock_json_dump.mock_calls[0][1][0] == {'refresh_token': None}
 
 
-@patch('aioautomatic.Client.create_session_from_password')
+@patch('aioautomatic.Client.create_session_from_refresh_token')
 @patch('aioautomatic.Client.ws_connect')
+@patch('json.load')
 @patch('json.dump')
 @patch('os.makedirs')
+@patch('os.path.isfile', return_value=True)
 @patch('homeassistant.components.device_tracker.automatic.open', create=True)
-def test_valid_credentials(mock_open, mock_os_makedirs, mock_json_dump,
-                           mock_ws_connect, mock_create_session, hass):
+def test_valid_credentials(
+        mock_open, mock_isfile, mock_makedirs, mock_json_dump, mock_json_load,
+        mock_ws_connect, mock_create_session, hass):
     """Test with valid credentials."""
     mock_http_component(hass)
+
+    mock_json_load.return_value = {'refresh_token': 'good_token'}
 
     session = MagicMock()
     vehicle = MagicMock()
@@ -102,6 +120,11 @@ def test_valid_credentials(mock_open, mock_os_makedirs, mock_json_dump,
     hass.async_block_till_done()
 
     assert result
+
+    assert mock_create_session.called
+    assert len(mock_create_session.mock_calls) == 1
+    assert mock_create_session.mock_calls[0][1][0] == 'good_token'
+
     assert mock_see.called
     assert len(mock_see.mock_calls) == 2
     assert mock_see.mock_calls[0][2]['dev_id'] == 'mock_id'

--- a/tests/components/device_tracker/test_automatic.py
+++ b/tests/components/device_tracker/test_automatic.py
@@ -45,9 +45,6 @@ def test_invalid_credentials(
     assert mock_create_session.called
     assert len(mock_create_session.mock_calls) == 1
     assert mock_create_session.mock_calls[0][1][0] == 'bad_token'
-    assert mock_json_dump.called
-    assert len(mock_json_dump.mock_calls) == 1
-    assert mock_json_dump.mock_calls[0][1][0] == {'refresh_token': None}
 
 
 @patch('aioautomatic.Client.create_session_from_refresh_token')


### PR DESCRIPTION
## Description:
This PR removes password authentication from the automatic device tracker. It has been disabled from the Automatic API.

**Breaking Change:**
Automatic has disabled password authentication on their API. Home Assistant will now use OAuth2 to authenticate accounts. The following steps must be taken to transition your setup:
1) Log in to your Automatic developer account. In the Automatic Developer Apps Manager, specify the OAuth Redirect URL in the developer page. This should be configured to `<home-assistant-url>/api/automatic/callback`. (Example: `http://hassio.local:8123/api/automatic/callback`) Note that this URL only needs to be accessible from the browser you use to perform the authentication.
2) Remove username/password from your automatic device tracker configuration in configuration.yaml.
3) If you have authorized your account for `scope:current_location`, add `current_location: true` to your automatic device tracker configuration in configuration.yaml.
4) When you restart home assistant, click on the Automatic Configure link in the Configurator card, and follow the instructions to authorize Home Assistant.

NOTE: Automatic's API is currently not correctly authorizing with refresh tokens, so Step 4 currently needs to be performed after every restart.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3187