### PR TITLE
Fix #9010 - Swiss Public Transportation shows departure time in the past

### DIFF
--- a/homeassistant/components/sensor/swiss_public_transport.py
+++ b/homeassistant/components/sensor/swiss_public_transport.py
@@ -136,7 +136,7 @@ class PublicTransportData(object):
             'fields[]=connections/from/departureTimestamp/&' +
             'fields[]=connections/',
             timeout=10)
-        connections = response.json()['connections'][:2]
+        connections = response.json()['connections'][1:3]
 
         try:
             self.times = [


### PR DESCRIPTION
## Description:
http://transport.opendata.ch/ changed their API and now also returns the previous departure.

**Related issue (if applicable):** fixes #9010 

