### PR TITLE
Wrap state objects in templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -229,6 +229,8 @@ class InvalidtemplateState(object):
 class TemplateState(State):
     """Class to represent a state object in a template."""
 
+    # Inheritance is done so functions that check against State keep working
+    # pylint: disable=super-init-not-called
     def __init__(self, state):
         """Initialize template state."""
         self._state = state
@@ -250,6 +252,7 @@ class TemplateState(State):
             return getattr(object.__getattribute__(self, '_state'), name)
 
     def __repr__(self):
+        """Representation of Template State."""
         rep = object.__getattribute__(self, '_state').__repr__()
         return '<template ' + rep[1:]
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -214,18 +214,6 @@ class DomainStates(object):
             key=lambda state: state.entity_id))
 
 
-class InvalidtemplateState(object):
-    """Class that is an invalid template state."""
-
-    def __getattr__(self, name):
-        """Return invalid state."""
-        return '<invalid state>'
-
-    def __str__(self):
-        """String representation."""
-        return '<invalid state>'
-
-
 class TemplateState(State):
     """Class to represent a state object in a template."""
 
@@ -259,7 +247,7 @@ class TemplateState(State):
 
 def _wrap_state(state):
     """Helper function to wrap a state."""
-    return InvalidtemplateState() if state is None else TemplateState(state)
+    return None if state is None else TemplateState(state)
 
 
 class LocationMethods(object):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -182,8 +182,10 @@ class AllStates(object):
 
     def __iter__(self):
         """Return all states."""
-        return iter(sorted(self._hass.states.async_all(),
-                           key=lambda state: state.entity_id))
+        return iter(
+            _wrap_state(state) for state in
+            sorted(self._hass.states.async_all(),
+                   key=lambda state: state.entity_id))
 
     def __call__(self, entity_id):
         """Return the states."""
@@ -236,7 +238,9 @@ class TemplateState(State):
         """Return the state concatenated with the unit if available."""
         state = object.__getattribute__(self, '_state')
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        return "{} {}".format(state.state, unit) if unit is not None else state
+        if unit is None:
+            return state.state
+        return "{} {}".format(state.state, unit)
 
     def __getattribute__(self, name):
         """Return an attribute of the state."""

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -215,12 +215,16 @@ class DomainStates(object):
 class InvalidtemplateState(object):
     """Class that is an invalid template state."""
 
-    def __getattr(self, name):
+    def __getattr__(self, name):
         """Return invalid state."""
         return '<invalid state>'
 
+    def __str__(self):
+        """String representation."""
+        return '<invalid state>'
 
-class TemplateState(object):
+
+class TemplateState(State):
     """Class to represent a state object in a template."""
 
     def __init__(self, state):
@@ -230,13 +234,20 @@ class TemplateState(object):
     @property
     def state_with_unit(self):
         """Return the state concatenated with the unit if available."""
-        state = self._state
+        state = object.__getattribute__(self, '_state')
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         return "{} {}".format(state.state, unit) if unit is not None else state
 
-    def __getattr__(self, name):
+    def __getattribute__(self, name):
         """Return an attribute of the state."""
-        return getattr(self._state, name)
+        if name in TemplateState.__dict__:
+            return object.__getattribute__(self, name)
+        else:
+            return getattr(object.__getattribute__(self, '_state'), name)
+
+    def __repr__(self):
+        rep = object.__getattribute__(self, '_state').__repr__()
+        return '<template ' + rep[1:]
 
 
 def _wrap_state(state):

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -760,17 +760,25 @@ def test_state_with_unit(hass):
     hass.states.async_set('sensor.test', '23', {
         'unit_of_measurement': 'beers',
     })
+    hass.states.async_set('sensor.test2', 'wow')
 
-    tpl = template.Template('{{ states.sensor.test.state_with_unit }}',
-                            hass)
+    tpl = template.Template(
+        '{{ states.sensor.test.state_with_unit }}', hass)
 
     assert tpl.async_render() == '23 beers'
 
+    tpl = template.Template(
+        '{{ states.sensor.test2.state_with_unit }}', hass)
 
-@asyncio.coroutine
-def test_invalid_state(hass):
-    """Test rendering an invalid state."""
-    tpl = template.Template('{{ states.sensor.test.state_with_unit }}',
+    assert tpl.async_render() == 'wow'
+
+    tpl = template.Template(
+        '{% for state in states %}{{ state.state_with_unit }} {% endfor %}',
+        hass)
+
+    assert tpl.async_render() == '23 beers wow'
+
+    tpl = template.Template('{{ states.sensor.non_existing.state_with_unit }}',
                             hass)
 
     assert tpl.async_render() == '<invalid state>'

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -653,8 +653,9 @@ class TestHelpersTemplate(unittest.TestCase):
     def test_closest_function_no_location_states(self):
         """Test closest function without location states."""
         self.assertEqual(
-            'None',
-            template.Template('{{ closest(states) }}', self.hass).render())
+            '<invalid state>',
+            template.Template('{{ closest(states).entity_id }}',
+                              self.hass).render())
 
     def test_extract_entities_none_exclude_stuff(self):
         """Test extract entities function with none or exclude stuff."""

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1,4 +1,5 @@
 """Test Home Assistant template helper methods."""
+import asyncio
 from datetime import datetime
 import unittest
 import random
@@ -750,3 +751,25 @@ is_state_attr('device_tracker.phone_2', 'battery', 40)
                 " > (states('input_slider.luftfeuchtigkeit') | int +1.5)"
                 " %}true{% endif %}"
             )))
+
+
+@asyncio.coroutine
+def test_state_with_unit(hass):
+    """Test the state_with_unit property helper."""
+    hass.states.async_set('sensor.test', '23', {
+        'unit_of_measurement': 'beers',
+    })
+
+    tpl = template.Template('{{ states.sensor.test.state_with_unit }}',
+                            hass)
+
+    assert tpl.async_render() == '23 beers'
+
+
+@asyncio.coroutine
+def test_invalid_state(hass):
+    """Test rendering an invalid state."""
+    tpl = template.Template('{{ states.sensor.test.state_with_unit }}',
+                            hass)
+
+    assert tpl.async_render() == '<invalid state>'

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -653,7 +653,7 @@ class TestHelpersTemplate(unittest.TestCase):
     def test_closest_function_no_location_states(self):
         """Test closest function without location states."""
         self.assertEqual(
-            '<invalid state>',
+            '',
             template.Template('{{ closest(states).entity_id }}',
                               self.hass).render())
 
@@ -781,4 +781,4 @@ def test_state_with_unit(hass):
     tpl = template.Template('{{ states.sensor.non_existing.state_with_unit }}',
                             hass)
 
-    assert tpl.async_render() == '<invalid state>'
+    assert tpl.async_render() == ''


### PR DESCRIPTION
## Description:
By wrapping the state objects in templates, we can give a better experience:

 - ~~make sure we return `<invalid state>` when trying to fetch a property on an unknown state~~ Removed because we should not fail silently.

```
in: {{ states.something.non_existing.state }}
out: <invalid state>
```

 - Add helper properties `state_with_unit`

```
in: {{ states.sensor.temperature.state_with_unit }}
out: 23 °C
```

Still need to write tests but wanted to get this out there for discussion.

## Checklist:

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
