### PR TITLE
Check if album image(s) exist in spotify

### DIFF
--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -188,6 +188,8 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             images = item.get('album').get('images')
             if images:
                 self._image_url = images[0].get('url')
+            else:
+                self._image_url = None
         # Playing state
         self._state = STATE_PAUSED
         if current.get('is_playing'):

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -186,10 +186,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
                                       for artist in item.get('artists')])
             self._uri = current.get('uri')
             images = item.get('album').get('images')
-            if images:
-                self._image_url = images[0].get('url')
-            else:
-                self._image_url = None
+            self._image_url = images[0].get('url') if images else None
         # Playing state
         self._state = STATE_PAUSED
         if current.get('is_playing'):

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -185,7 +185,9 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             self._artist = ', '.join([artist.get('name')
                                       for artist in item.get('artists')])
             self._uri = current.get('uri')
-            self._image_url = item.get('album').get('images')[0].get('url')
+            images = item.get('album').get('images')
+            if images:
+                self._image_url = images[0].get('url')
         # Playing state
         self._state = STATE_PAUSED
         if current.get('is_playing'):


### PR DESCRIPTION
## Description:
Some albums (usually collection albums) don't have album images present. This causes the Spotify component to throw errors. This fix checks whether there are any images present first, otherwise, it sets the album art to None

**Related issue (if applicable):** No opened issue yet

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** No doc changes

## Example entry for `configuration.yaml` (if applicable):
No config changes

EDIT: Tested with album URI: `spotify:album:4neIU9gg7nkWZkNltoi4lq`