### PR TITLE
Add Abode home security component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,9 @@ omit =
     homeassistant/helpers/signal.py
 
     # omit pieces of code that rely on external devices being present
+    homeassistant/components/abode.py
+    homeassistant/components/*/abode.py
+
     homeassistant/components/alarmdecoder.py
     homeassistant/components/*/alarmdecoder.py
 

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -48,8 +48,6 @@ def setup(hass, config):
         for component in ['binary_sensor', 'alarm_control_panel']:
             discovery.load_platform(hass, component, DOMAIN, {}, config)
 
-        data.abode.start_listener()
-
     except (ConnectTimeout, HTTPError) as ex:
         _LOGGER.error("Unable to connect to Abode: %s", str(ex))
         hass.components.persistent_notification.create(

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -1,0 +1,76 @@
+"""
+This component provides basic support for Abode Home Security system.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/abode/
+"""
+import logging
+
+import voluptuous as vol
+from requests.exceptions import HTTPError, ConnectTimeout
+from homeassistant.helpers import discovery
+from homeassistant.helpers import config_validation as cv
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_NAME
+
+REQUIREMENTS = ['abodepy==0.5.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ATTRIBUTION = "Data provided by goabode.com"
+
+DOMAIN = 'abode'
+DEFAULT_NAME = 'Abode'
+DATA_ABODE = 'data_abode'
+DEFAULT_ENTITY_NAMESPACE = 'abode'
+
+NOTIFICATION_ID = 'abode_notification'
+NOTIFICATION_TITLE = 'Abode Security Setup'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Set up Abode component."""
+    conf = config[DOMAIN]
+    username = conf.get(CONF_USERNAME)
+    password = conf.get(CONF_PASSWORD)
+
+    try:
+        data = AbodeData(hass, username, password)
+        hass.data[DATA_ABODE] = data
+
+        for component in ['binary_sensor', 'alarm_control_panel']:
+            discovery.load_platform(hass, component, DOMAIN, {}, config)
+
+        data.abode.start_listener()
+
+    except (ConnectTimeout, HTTPError) as ex:
+        _LOGGER.error("Unable to connect to Abode: %s", str(ex))
+        hass.components.persistent_notification.create(
+            'Error: {}<br />'
+            'You will need to restart hass after fixing.'
+            ''.format(ex),
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID)
+
+    return True
+
+
+class AbodeData:
+    """Shared Abode data."""
+
+    def __init__(self, hass, username, password):
+        """Initialize Abode oject."""
+        import abodepy
+
+        self.abode = abodepy.Abode(username, password)
+        self.devices = self.abode.get_devices()
+
+        _LOGGER.debug("Abode Security set up with %s devices",
+                      len(self.devices))

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -42,7 +42,7 @@ def setup(hass, config):
     password = conf.get(CONF_PASSWORD)
 
     try:
-        data = AbodeData(hass, username, password)
+        data = AbodeData(username, password)
         hass.data[DATA_ABODE] = data
 
         for component in ['binary_sensor', 'alarm_control_panel']:
@@ -56,6 +56,7 @@ def setup(hass, config):
             ''.format(ex),
             title=NOTIFICATION_TITLE,
             notification_id=NOTIFICATION_ID)
+        return False
 
     return True
 
@@ -63,7 +64,7 @@ def setup(hass, config):
 class AbodeData:
     """Shared Abode data."""
 
-    def __init__(self, hass, username, password):
+    def __init__(self, username, password):
         """Initialize Abode oject."""
         import abodepy
 

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -36,8 +36,6 @@ class AbodeAlarm(alarm.AlarmControlPanel):
         self._device = device
         self._name = "{0}".format(DEFAULT_NAME)
 
-        data.abode.register(device, self.refresh)
-
     @property
     def should_poll(self):
         """Return the polling state."""
@@ -80,10 +78,6 @@ class AbodeAlarm(alarm.AlarmControlPanel):
         self._device.set_mode(mode=ALARM_STATE_AWAY)
         self.schedule_update_ha_state()
         _LOGGER.debug("Abode security armed")
-
-    def refresh(self):
-        """Refresh HA state when the device has changed."""
-        self.schedule_update_ha_state()
 
     def update(self):
         """Update the device state."""

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -65,19 +65,16 @@ class AbodeAlarm(alarm.AlarmControlPanel):
         """Send disarm command."""
         self._device.set_mode(mode=ALARM_STATE_STANDBY)
         self.schedule_update_ha_state()
-        _LOGGER.debug("Abode security disarmed")
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
         self._device.set_mode(mode=ALARM_STATE_HOME)
         self.schedule_update_ha_state()
-        _LOGGER.debug("Abode security home")
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
         self._device.set_mode(mode=ALARM_STATE_AWAY)
         self.schedule_update_ha_state()
-        _LOGGER.debug("Abode security armed")
 
     def update(self):
         """Update the device state."""

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -1,0 +1,96 @@
+"""
+This component provides HA alarm_control_panel support for Abode System.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_control_panel.abode/
+"""
+import logging
+
+from homeassistant.components.abode import (DATA_ABODE, DEFAULT_NAME)
+from homeassistant.const import (STATE_UNKNOWN)
+import homeassistant.components.alarm_control_panel as alarm
+
+DEPENDENCIES = ['abode']
+
+_LOGGER = logging.getLogger(__name__)
+
+ALARM_STATE_HOME = 'home'
+ALARM_STATE_STANDBY = 'standby'
+ALARM_STATE_AWAY = 'away'
+ICON = 'mdi:security'
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up a sensor for an Abode device."""
+    data = hass.data.get(DATA_ABODE)
+    if not data:
+        _LOGGER.debug('No DATA_ABODE')
+        return False
+
+    add_devices([AbodeAlarm(hass, data, data.abode.get_alarm())])
+    return True
+
+
+class AbodeAlarm(alarm.AlarmControlPanel):
+    """An alarm_control_panel implementation for Abode."""
+
+    def __init__(self, hass, data, device):
+        """Initialize a alarm control panel for Abode."""
+        super(AbodeAlarm, self).__init__()
+        self._device = device
+        self._name = "{0}".format(DEFAULT_NAME)
+
+        data.abode.register(device, self.refresh)
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return icon."""
+        return ICON
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        status = self._device.mode
+
+        if status in [ALARM_STATE_STANDBY, ALARM_STATE_HOME, ALARM_STATE_AWAY]:
+            return status
+
+        return STATE_UNKNOWN
+
+    def alarm_disarm(self, code=None):
+        """Send disarm command."""
+        self._device.set_mode(mode=ALARM_STATE_STANDBY)
+        self.schedule_update_ha_state()
+        _LOGGER.debug("Abode security disarmed")
+
+    def alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        self._device.set_mode(mode=ALARM_STATE_HOME)
+        self.schedule_update_ha_state()
+        _LOGGER.debug("Abode security home")
+
+    def alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        self._device.set_mode(mode=ALARM_STATE_AWAY)
+        self.schedule_update_ha_state()
+        _LOGGER.debug("Abode security armed")
+
+    def refresh(self):
+        """Refresh HA state when the device has changed."""
+        _LOGGER.debug("Abode refresh")
+        self.schedule_update_ha_state()
+
+    def update(self):
+        """Update the device state."""
+        _LOGGER.debug("Abode update alarm")
+        self._device.refresh()

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -87,10 +87,8 @@ class AbodeAlarm(alarm.AlarmControlPanel):
 
     def refresh(self):
         """Refresh HA state when the device has changed."""
-        _LOGGER.debug("Abode refresh")
         self.schedule_update_ha_state()
 
     def update(self):
         """Update the device state."""
-        _LOGGER.debug("Abode update alarm")
         self._device.refresh()

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -35,7 +35,7 @@ class AbodeAlarm(alarm.AlarmControlPanel):
     """An alarm_control_panel implementation for Abode."""
 
     def __init__(self, hass, data, device):
-        """Initialize a alarm control panel for Abode."""
+        """Initialize the alarm control panel."""
         super(AbodeAlarm, self).__init__()
         self._device = device
         self._name = "{0}".format(DEFAULT_NAME)

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -23,12 +23,8 @@ ICON = 'mdi:security'
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for an Abode device."""
     data = hass.data.get(DATA_ABODE)
-    if not data:
-        _LOGGER.debug('No DATA_ABODE')
-        return False
 
     add_devices([AbodeAlarm(hass, data, data.abode.get_alarm())])
-    return True
 
 
 class AbodeAlarm(alarm.AlarmControlPanel):

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -65,7 +65,7 @@ class AbodeBinarySensor(BinarySensorDevice):
         if self._device.type == 'Door Contact':
             return self._device.status != 'Closed'
         elif self._device.type == 'Motion Camera':
-            return self._device._json_state.get('motion_event') == '1'
+            return self._device.get_value('motion_event') == '1'
 
     @property
     def device_class(self):

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -1,0 +1,93 @@
+"""
+This component provides HA binary_sensor support for Abode Security System.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.abode/
+"""
+import logging
+
+from homeassistant.components.abode import (CONF_ATTRIBUTION, DATA_ABODE)
+from homeassistant.const import (ATTR_ATTRIBUTION)
+from homeassistant.components.binary_sensor import (BinarySensorDevice)
+
+DEPENDENCIES = ['abode']
+
+_LOGGER = logging.getLogger(__name__)
+
+# Sensor types: Name, device_class
+SENSOR_TYPES = {
+    'Door Contact': 'opening',
+    'Motion Camera': 'motion',
+}
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up a sensor for an Abode device."""
+    data = hass.data.get(DATA_ABODE)
+    if not data:
+        _LOGGER.debug('No DATA_ABODE')
+        return False
+
+    sensors = []
+    for sensor in data.devices:
+        _LOGGER.debug('Sensor type %s', sensor.type)
+        if sensor.type in ['Door Contact', 'Motion Camera']:
+            sensors.append(AbodeBinarySensor(hass, data, sensor))
+
+    _LOGGER.debug('Adding %d sensors', len(sensors))
+    add_devices(sensors)
+    return True
+
+
+class AbodeBinarySensor(BinarySensorDevice):
+    """A binary sensor implementation for Abode device."""
+
+    def __init__(self, hass, data, device):
+        """Initialize a sensor for Abode device."""
+        super(AbodeBinarySensor, self).__init__()
+        self._device = device
+
+        data.abode.register(device, self.refresh)
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return "{0} {1}".format(self._device.type, self._device.name)
+
+    @property
+    def is_on(self):
+        """Return True if the binary sensor is on."""
+        if self._device.type == 'Door Contact':
+            return self._device.status != 'Closed'
+        elif self._device.type == 'Motion Camera':
+            return self._device._json_state.get('motion_event') == '1'
+
+    @property
+    def device_class(self):
+        """Return the class of the binary sensor."""
+        return SENSOR_TYPES.get(self._device.type)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attrs = {}
+        attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+        attrs['device_id'] = self._device.device_id
+        attrs['battery_low'] = self._device.battery_low
+
+        return attrs
+
+    def refresh(self):
+        """Refresh HA state when the device has changed."""
+        _LOGGER.debug("Abode refresh")
+        self.schedule_update_ha_state()
+
+    def update(self):
+        """Update the device state."""
+        _LOGGER.debug("Abode update sensor")
+        self._device.refresh()

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -24,9 +24,6 @@ SENSOR_TYPES = {
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for an Abode device."""
     data = hass.data.get(DATA_ABODE)
-    if not data:
-        _LOGGER.debug('No DATA_ABODE')
-        return False
 
     sensors = []
     for sensor in data.devices:
@@ -36,7 +33,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     _LOGGER.debug('Adding %d sensors', len(sensors))
     add_devices(sensors)
-    return True
 
 
 class AbodeBinarySensor(BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -84,10 +84,8 @@ class AbodeBinarySensor(BinarySensorDevice):
 
     def refresh(self):
         """Refresh HA state when the device has changed."""
-        _LOGGER.debug("Abode refresh")
         self.schedule_update_ha_state()
 
     def update(self):
         """Update the device state."""
-        _LOGGER.debug("Abode update sensor")
         self._device.refresh()

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -43,8 +43,6 @@ class AbodeBinarySensor(BinarySensorDevice):
         super(AbodeBinarySensor, self).__init__()
         self._device = device
 
-        data.abode.register(device, self.refresh)
-
     @property
     def should_poll(self):
         """Return the polling state."""
@@ -77,10 +75,6 @@ class AbodeBinarySensor(BinarySensorDevice):
         attrs['battery_low'] = self._device.battery_low
 
         return attrs
-
-    def refresh(self):
-        """Refresh HA state when the device has changed."""
-        self.schedule_update_ha_state()
 
     def update(self):
         """Update the device state."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -14,6 +14,9 @@ astral==1.4
 # homeassistant.components.nuimo_controller
 --only-binary=all https://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0
 
+# homeassistant.components.abode
+abodepy==0.5.1
+
 # homeassistant.components.bbb_gpio
 # Adafruit_BBIO==1.0.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -14,9 +14,6 @@ astral==1.4
 # homeassistant.components.nuimo_controller
 --only-binary=all https://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0
 
-# homeassistant.components.abode
-abodepy==0.5.1
-
 # homeassistant.components.bbb_gpio
 # Adafruit_BBIO==1.0.0
 
@@ -40,6 +37,9 @@ SoCo==0.12
 
 # homeassistant.components.notify.twitter
 TwitterAPI==2.4.6
+
+# homeassistant.components.abode
+abodepy==0.5.1
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.0


### PR DESCRIPTION
This adds the [Abode Home Security](https://goabode.com/) component and the accompanying sensors to HA. Abode is one of the newer DIY home security systems (similar to Simplisafe). 

The component will add the `alarm_control_panel` and `door_contact` and `motion_camera` sensors. 

Sincere thanks to @amelchio and @w1ll1am23 for their assistance, especially @amelchio who fundamentally rewrote the code. 

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/abode-home-security-integration/24166

Working on the documentation and will have it ready soon. In the meantime, look forward to your comments. 
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3208

## Example entry for `configuration.yaml`:
```yaml
abode:
  username: !secret abode_username
  password: !secret abode_password
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.