### PR TITLE
Fix Geizhals index issue when not 4 prices available

### DIFF
--- a/homeassistant/components/sensor/geizhals.py
+++ b/homeassistant/components/sensor/geizhals.py
@@ -80,6 +80,8 @@ class Geizwatch(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
+        while (len(self.data.prices) < 4):
+            self.data.prices.append("None")
         attrs = {'device_name': self.data.device_name,
                  'description': self.description,
                  'unit_of_measurement': self.data.unit_of_measurement,

--- a/homeassistant/components/sensor/geizhals.py
+++ b/homeassistant/components/sensor/geizhals.py
@@ -80,7 +80,7 @@ class Geizwatch(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        while (len(self.data.prices) < 4):
+        while len(self.data.prices) < 4:
             self.data.prices.append("None")
         attrs = {'device_name': self.data.device_name,
                  'description': self.description,


### PR DESCRIPTION
## Description:
Bugfix for an issue with IndexError: list index out of range.


**Related issue (if applicable):** fixes #8946 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```
sensor: 
- platform: geizhals
    name: BondAstroPlace100DE
    product_id: 682283
    unit_of_measurement: 'EUR'
    description: "Bond Nr.9 Astor Place 100ml"
    domain: 'geizhals.de'
    regex: '\D\s(\d*)[\,|\.](\d*)'

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
