### PR TITLE
Set password after connecting in media_player/mpd. Fixes #8983

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -79,14 +79,15 @@ class MpdDevice(MediaPlayerDevice):
         self._client = mpd.MPDClient()
         self._client.timeout = 5
         self._client.idletimeout = None
-        if password is not None:
-            self._client.password(password)
 
     def _connect(self):
         """Connect to MPD."""
         import mpd
         try:
             self._client.connect(self.server, self.port)
+
+            if self.password is not None:
+                self._client.password(self.password)
         except mpd.ConnectionError:
             return
 


### PR DESCRIPTION
## Description:
Set password after connecting, instead of setting it directly.

**Related issue (if applicable):** fixes #8983

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: mpd
    host: 127.0.0.1
    password: password
    name: localhost
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully.
  - [x] New dependencies have been added to the `REQUIREMENTS` variable.
  - [x] New dependencies are only imported inside functions that use them.
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.