### PR TITLE
Configurable timeout for webostv.

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -56,7 +56,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MAC): cv.string,
     vol.Optional(CONF_CUSTOMIZE, default={}): CUSTOMIZE_SCHEMA,
     vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string,
-    vol.Optional(CONF_TIMEOUT, default=10): cv.positive_int
+    vol.Optional(CONF_TIMEOUT, default=10): cv.positive_int,
 })
 
 
@@ -85,7 +85,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 def setup_tv(host, mac, name, customize, config, timeout, hass, add_devices):
-    """Setup a LG WebOS TV based on host parameter."""
+    """Set up a LG WebOS TV based on host parameter."""
     from pylgtv import WebOsClient
     from pylgtv import PyLGTVPairException
     from websockets.exceptions import ConnectionClosed

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -19,7 +19,7 @@ from homeassistant.components.media_player import (
     SUPPORT_SELECT_SOURCE, SUPPORT_PLAY_MEDIA, MEDIA_TYPE_CHANNEL,
     MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
-    CONF_HOST, CONF_MAC, CONF_CUSTOMIZE, STATE_OFF,
+    CONF_HOST, CONF_MAC, CONF_CUSTOMIZE, CONF_TIMEOUT, STATE_OFF,
     STATE_PLAYING, STATE_PAUSED,
     STATE_UNKNOWN, CONF_NAME, CONF_FILENAME)
 import homeassistant.helpers.config_validation as cv
@@ -55,7 +55,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_MAC): cv.string,
     vol.Optional(CONF_CUSTOMIZE, default={}): CUSTOMIZE_SCHEMA,
-    vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string
+    vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=10): cv.positive_int
 })
 
 
@@ -78,17 +79,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     mac = config.get(CONF_MAC)
     name = config.get(CONF_NAME)
     customize = config.get(CONF_CUSTOMIZE)
+    timeout = config.get(CONF_TIMEOUT)
     config = hass.config.path(config.get(CONF_FILENAME))
-    setup_tv(host, mac, name, customize, config, hass, add_devices)
+    setup_tv(host, mac, name, customize, config, timeout, hass, add_devices)
 
 
-def setup_tv(host, mac, name, customize, config, hass, add_devices):
-    """Set up a LG WebOS TV based on host parameter."""
+def setup_tv(host, mac, name, customize, config, timeout, hass, add_devices):
+    """Setup a LG WebOS TV based on host parameter."""
     from pylgtv import WebOsClient
     from pylgtv import PyLGTVPairException
     from websockets.exceptions import ConnectionClosed
 
-    client = WebOsClient(host, config)
+    client = WebOsClient(host, config, timeout)
 
     if not client.is_registered():
         if host in _CONFIGURING:
@@ -99,15 +101,14 @@ def setup_tv(host, mac, name, customize, config, hass, add_devices):
                 _LOGGER.warning(
                     "Connected to LG webOS TV %s but not paired", host)
                 return
-            except (OSError, ConnectionClosed, TypeError,
-                    asyncio.TimeoutError):
+            except (OSError, ConnectionClosed, asyncio.TimeoutError):
                 _LOGGER.error("Unable to connect to host %s", host)
                 return
         else:
             # Not registered, request configuration.
             _LOGGER.warning("LG webOS TV %s needs to be paired", host)
             request_configuration(
-                host, mac, name, customize, config, hass, add_devices)
+                host, mac, name, customize, config, timeout, hass, add_devices)
             return
 
     # If we came here and configuring this host, mark as done.
@@ -116,11 +117,12 @@ def setup_tv(host, mac, name, customize, config, hass, add_devices):
         configurator = hass.components.configurator
         configurator.request_done(request_id)
 
-    add_devices([LgWebOSDevice(host, mac, name, customize, config)], True)
+    add_devices([LgWebOSDevice(host, mac, name, customize, config, timeout)],
+                True)
 
 
 def request_configuration(
-        host, mac, name, customize, config, hass, add_devices):
+        host, mac, name, customize, config, timeout, hass, add_devices):
     """Request configuration steps from the user."""
     configurator = hass.components.configurator
 
@@ -132,8 +134,9 @@ def request_configuration(
 
     # pylint: disable=unused-argument
     def lgtv_configuration_callback(data):
-        """Handle configuration changes."""
-        setup_tv(host, mac, name, customize, config, hass, add_devices)
+        """The actions to do when our configuration callback is called."""
+        setup_tv(host, mac, name, customize, config, timeout, hass,
+                 add_devices)
 
     _CONFIGURING[host] = configurator.request_config(
         name, lgtv_configuration_callback,
@@ -146,11 +149,11 @@ def request_configuration(
 class LgWebOSDevice(MediaPlayerDevice):
     """Representation of a LG WebOS TV."""
 
-    def __init__(self, host, mac, name, customize, config):
+    def __init__(self, host, mac, name, customize, config, timeout):
         """Initialize the webos device."""
         from pylgtv import WebOsClient
         from wakeonlan import wol
-        self._client = WebOsClient(host, config)
+        self._client = WebOsClient(host, config, timeout)
         self._wol = wol
         self._mac = mac
         self._customize = customize


### PR DESCRIPTION
## Description:

Adds timeout option to the configuration of the component.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3204

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: webostv
    timeout: 4
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
 
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
