### PR TITLE
Upgrade python-pushover to 0.3

### DIFF
--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -14,7 +14,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-pushover==0.2']
+REQUIREMENTS = ['python-pushover==0.3']
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -754,7 +754,7 @@ python-nest==3.1.0
 python-nmap==0.6.1
 
 # homeassistant.components.notify.pushover
-python-pushover==0.2
+python-pushover==0.3
 
 # homeassistant.components.sensor.ripple
 python-ripple-api==0.0.2


### PR DESCRIPTION
## Description:
Upgrade python-pushover to 0.3

Related topic on the forum can be found [here](https://community.home-assistant.io/t/pushover-upgrading-library/24923).

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: pushover
  name: "pushover"
  api_key: !secret NOTIFY_PUSHOVER_API_KEY
  user_key: !secret NOTIFY_PUSHOVER_USER_KEY
```