### PR TITLE
Fix issue 8894 with uk_transport component if no next_buses or next_trains

### DIFF
--- a/homeassistant/components/sensor/uk_transport.py
+++ b/homeassistant/components/sensor/uk_transport.py
@@ -10,6 +10,7 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -180,9 +181,12 @@ class UkTransportLiveBusTimeSensor(UkTransportSensor):
                             'estimated': departure['best_departure_estimate']
                         })
 
-            self._state = min(map(
-                _delta_mins, [bus['scheduled'] for bus in self._next_buses]
-            ))
+            if self._next_buses:
+                self._state = min(map(
+                    _delta_mins, [bus['scheduled'] for bus in self._next_buses]
+                    ))
+            else:
+                self._state = STATE_UNKNOWN
 
     @property
     def device_state_attributes(self):
@@ -242,10 +246,13 @@ class UkTransportLiveTrainTimeSensor(UkTransportSensor):
                         'operator_name': departure['operator_name']
                         })
 
-                self._state = min(map(
-                    _delta_mins,
-                    [train['scheduled'] for train in self._next_trains]
-                ))
+                if self._next_trains:
+                    self._state = min(map(
+                        _delta_mins,
+                        [train['scheduled'] for train in self._next_trains]
+                        ))
+                else:
+                    self._state = STATE_UNKNOWN
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/sensor/uk_transport.py
+++ b/homeassistant/components/sensor/uk_transport.py
@@ -10,7 +10,6 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -182,11 +181,11 @@ class UkTransportLiveBusTimeSensor(UkTransportSensor):
                         })
 
             if self._next_buses:
-                self._state = min(map(
-                    _delta_mins, [bus['scheduled'] for bus in self._next_buses]
-                    ))
+                self._state = min(
+                    _delta_mins(bus['scheduled'])
+                    for bus in self._next_buses)
             else:
-                self._state = STATE_UNKNOWN
+                self._state = None
 
     @property
     def device_state_attributes(self):
@@ -247,12 +246,11 @@ class UkTransportLiveTrainTimeSensor(UkTransportSensor):
                         })
 
                 if self._next_trains:
-                    self._state = min(map(
-                        _delta_mins,
-                        [train['scheduled'] for train in self._next_trains]
-                        ))
+                    self._state = min(
+                        _delta_mins(train['scheduled'])
+                        for train in self._next_trains)
                 else:
-                    self._state = STATE_UNKNOWN
+                    self._state = None
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
Fixes https://github.com/home-assistant/home-assistant/issues/8894

## Description:
Fixes https://github.com/home-assistant/home-assistant/issues/8894 where an error was thrown if there were no next-buses or trains

**Related issue (if applicable):** fixes #8894

If the code communicates with devices, web services, or third-party tools:
  - [ x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**