### PR TITLE
LIFX: avoid rare NoneType errors

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -335,7 +335,7 @@ class LIFXManager(object):
             if version_resp:
                 color_resp = yield from ack(device.get_color)
 
-            if (version_resp is None or color_resp is None):
+            if version_resp is None or color_resp is None:
                 _LOGGER.error("Failed to initialize %s", device.ip_addr)
             else:
                 device.timeout = MESSAGE_TIMEOUT


### PR DESCRIPTION
## Description:

This avoids accessing uninitialized variables in two cases. One is setting the state of multizone lights right after startup (before the first poll). The other is the unlikely case of a dropped UDP packet during the initial device registration.

**Related issue (if applicable):** fixes #8882

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
