### PR TITLE
Use builtin constants for Abode alarm_control_panel

### DIFF
--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/alarm_control_panel.abode/
 import logging
 
 from homeassistant.components.abode import (DATA_ABODE, DEFAULT_NAME)
-from homeassistant.const import (STATE_UNKNOWN, STATE_ALARM_ARMED_AWAY,
+from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
 import homeassistant.components.alarm_control_panel as alarm
 
@@ -59,7 +59,7 @@ class AbodeAlarm(alarm.AlarmControlPanel):
         elif self._device.mode == "home":
             state = STATE_ALARM_ARMED_HOME
         else:
-            state = STATE_UNKNOWN
+            state = None
         return state
 
     def alarm_disarm(self, code=None):

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -7,16 +7,14 @@ https://home-assistant.io/components/alarm_control_panel.abode/
 import logging
 
 from homeassistant.components.abode import (DATA_ABODE, DEFAULT_NAME)
-from homeassistant.const import (STATE_UNKNOWN)
+from homeassistant.const import (STATE_UNKNOWN, STATE_ALARM_ARMED_AWAY,
+                                 STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
 import homeassistant.components.alarm_control_panel as alarm
 
 DEPENDENCIES = ['abode']
 
 _LOGGER = logging.getLogger(__name__)
 
-ALARM_STATE_HOME = 'home'
-ALARM_STATE_STANDBY = 'standby'
-ALARM_STATE_AWAY = 'away'
 ICON = 'mdi:security'
 
 
@@ -54,26 +52,30 @@ class AbodeAlarm(alarm.AlarmControlPanel):
     @property
     def state(self):
         """Return the state of the device."""
-        status = self._device.mode
+        state = STATE_UNKNOWN
 
-        if status in [ALARM_STATE_STANDBY, ALARM_STATE_HOME, ALARM_STATE_AWAY]:
-            return status
+        if self._device.mode == "standby":
+            state = STATE_ALARM_DISARMED
+        elif self._device.mode == "away":
+            state = STATE_ALARM_ARMED_AWAY
+        elif self._device.mode == "home":
+            state = STATE_ALARM_ARMED_HOME
 
-        return STATE_UNKNOWN
+        return state
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""
-        self._device.set_mode(mode=ALARM_STATE_STANDBY)
+        self._device.set_standby()
         self.schedule_update_ha_state()
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
-        self._device.set_mode(mode=ALARM_STATE_HOME)
+        self._device.set_home()
         self.schedule_update_ha_state()
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
-        self._device.set_mode(mode=ALARM_STATE_AWAY)
+        self._device.set_away()
         self.schedule_update_ha_state()
 
     def update(self):

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -52,15 +52,14 @@ class AbodeAlarm(alarm.AlarmControlPanel):
     @property
     def state(self):
         """Return the state of the device."""
-        state = STATE_UNKNOWN
-
         if self._device.mode == "standby":
             state = STATE_ALARM_DISARMED
         elif self._device.mode == "away":
             state = STATE_ALARM_ARMED_AWAY
         elif self._device.mode == "home":
             state = STATE_ALARM_ARMED_HOME
-
+        else:
+            state = STATE_UNKNOWN
         return state
 
     def alarm_disarm(self, code=None):


### PR DESCRIPTION
Uses built-in constants so that the alarm_control_panel displays the buttons to arm/disarm security. The panel now appears as follows:

![image](https://user-images.githubusercontent.com/18319734/29496297-8ee057a0-859d-11e7-95f2-ef163e352fe3.png)
