### PR TITLE
Upgrade sendgrid to 5.0.0

### DIFF
--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import (CONF_API_KEY, CONF_SENDER, CONF_RECIPIENT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['sendgrid==4.2.1']
+REQUIREMENTS = ['sendgrid==5.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -871,7 +871,7 @@ schiene==0.18
 scsgate==0.1.0
 
 # homeassistant.components.notify.sendgrid
-sendgrid==4.2.1
+sendgrid==5.0.0
 
 # homeassistant.components.light.sensehat
 # homeassistant.components.sensor.sensehat


### PR DESCRIPTION
## 5.0.0
-  Replaces error handling via HTTPError from urllib in favor of custom error handling via the HTTPError class as was the case in version 4.2.0.

Tested with the following configuration:

``` yaml
notify:
  - name: sendgrid
    platform: sendgrid
    api_key: !secret sendgrid_api
    sender: !secret sendgrid_sender
    recipient: !secret sendgrid_recipient
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```