### PR TITLE
Upgrade onkyo-eiscp to 1.2.4 (fixes #8995)

### DIFF
--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -14,7 +14,7 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (STATE_OFF, STATE_ON, CONF_HOST, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['onkyo-eiscp==1.2.3']
+REQUIREMENTS = ['onkyo-eiscp==1.2.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -438,7 +438,7 @@ oauth2client==4.0.0
 oemthermostat==1.1
 
 # homeassistant.components.media_player.onkyo
-onkyo-eiscp==1.2.3
+onkyo-eiscp==1.2.4
 
 # homeassistant.components.camera.onvif
 onvif-py3==0.1.3


### PR DESCRIPTION
## 1.2.4
 - Fix crash in previous release.

**Related issue (if applicable):** fixes #8995

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
