### PR TITLE
volvooncall: Handle the case where no registration number is returned by the API for a vehicle.

### DIFF
--- a/homeassistant/components/device_tracker/volvooncall.py
+++ b/homeassistant/components/device_tracker/volvooncall.py
@@ -20,11 +20,12 @@ def setup_scanner(hass, config, see, discovery_info=None):
         return
 
     vin, _ = discovery_info
-    vehicle = hass.data[DATA_KEY].vehicles[vin]
+    voc = hass.data[DATA_KEY]
+    vehicle = voc.vehicles[vin]
 
     def see_vehicle(vehicle):
         """Handle the reporting of the vehicle position."""
-        host_name = vehicle.registration_number
+        host_name = voc.vehicle_name(vehicle)
         dev_id = 'volvo_{}'.format(slugify(host_name))
         see(dev_id=dev_id,
             host_name=host_name,

--- a/homeassistant/components/volvooncall.py
+++ b/homeassistant/components/volvooncall.py
@@ -73,14 +73,7 @@ def setup(hass, config):
 
     interval = config[DOMAIN].get(CONF_UPDATE_INTERVAL)
 
-    class state:  # pylint:disable=invalid-name
-        """Namespace to hold state for each vehicle."""
-
-        entities = {}
-        vehicles = {}
-        names = config[DOMAIN].get(CONF_NAME)
-
-    hass.data[DATA_KEY] = state
+    state = hass.data[DATA_KEY] = VolvoData(config)
 
     def discover_vehicle(vehicle):
         """Load relevant platforms."""
@@ -120,6 +113,31 @@ def setup(hass, config):
     return update(utcnow())
 
 
+class VolvoData:
+    """Hold component state."""
+
+    def __init__(self, config):
+        """Initialize the component state."""
+        self.entities = {}
+        self.vehicles = {}
+        self.names = config[DOMAIN].get(CONF_NAME)
+
+    def vehicle_name(self, vehicle):
+        """Provide a friendly name for a vehicle."""
+        if (vehicle.registration_number and
+                vehicle.registration_number.lower()) in self.names:
+            return self.names[vehicle.registration_number.lower()]
+        elif (vehicle.vin and
+              vehicle.vin.lower() in self.names):
+            return self.names[vehicle.vin.lower()]
+        elif vehicle.registration_number:
+            return vehicle.registration_number
+        elif vehicle.vin:
+            return vehicle.vin
+        else:
+            return ''
+
+
 class VolvoEntity(Entity):
     """Base class for all VOC entities."""
 
@@ -140,15 +158,12 @@ class VolvoEntity(Entity):
         return self._state.vehicles[self._vin]
 
     @property
-    def _vehicle_name(self):
-        return (self._state.names.get(self._vin.lower()) or
-                self._state.names.get(
-                    self.vehicle.registration_number.lower()) or
-                self.vehicle.registration_number)
-
-    @property
     def _entity_name(self):
         return RESOURCES[self._attribute][1]
+
+    @property
+    def _vehicle_name(self):
+        return self._state.vehicle_name(self.vehicle)
 
     @property
     def name(self):


### PR DESCRIPTION
Instead display VIN (vehicle identification number).
Closes https://github.com/molobrakos/volvooncall/issues/9
Also extract component state into a data class.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
