### PR TITLE
Added insteonplm device_override multiple capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ docs/build
 
 # Windows Explorer
 desktop.ini
+/home-assistant.pyproj
+/home-assistant.sln
+/.vs/home-assistant/v14

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -79,8 +79,12 @@ def async_setup(hass, config):
         #
         # Override the device default capabilities for a specific address
         #
-        plm.protocol.devices.add_override(
-            device['address'], 'capabilities', [device['platform']])
+        if isinstance(device['platform'], list):
+            plm.protocol.devices.add_override(
+                device['address'], 'capabilities', device['platform'])
+        else:
+            plm.protocol.devices.add_override(
+                device['address'], 'capabilities', [device['platform']])
 
     hass.data['insteon_plm'] = plm
 


### PR DESCRIPTION
## Description:
Some older devices do not repsond to auto discovery correctly. The insteonplm device_override configuration setting allows for these devices to be configured with the correct capabilities. This change allows for multiple capabilities to be added to a single device to better support these items.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
insteon_plm:
  port: /dev/insteon
  device_override:
    - address: '2c3832'
      platform: 
        - light
        - dimmable
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
