### PR TITLE
Upgrade credstash to 1.13.3

### DIFF
--- a/homeassistant/scripts/credstash.py
+++ b/homeassistant/scripts/credstash.py
@@ -4,13 +4,13 @@ import getpass
 
 from homeassistant.util.yaml import _SECRET_NAMESPACE
 
-REQUIREMENTS = ['credstash==1.13.2', 'botocore==1.4.93']
+REQUIREMENTS = ['credstash==1.13.3', 'botocore==1.4.93']
 
 
 def run(args):
     """Handle credstash script."""
     parser = argparse.ArgumentParser(
-        description=("Modify Home-Assistant secrets in credstash."
+        description=("Modify Home Assistant secrets in credstash."
                      "Use the secrets in configuration files with: "
                      "!secret <name>"))
     parser.add_argument(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -147,7 +147,7 @@ colorlog==3.0.1
 concord232==0.14
 
 # homeassistant.scripts.credstash
-credstash==1.13.2
+credstash==1.13.3
 
 # homeassistant.components.sensor.crimereports
 crimereports==1.0.0


### PR DESCRIPTION
## 1.13.3
* Only fetch the session resource and client once
* README updates for c# and node imlpementations
* python 3.2 removed frmo build matrix
* fixed hmac checking
* removed build constraint on `cryptography` <2.0

```bash
$ hass --script credstash --help
INFO:homeassistant.util.package:Attempting install of credstash==1.13.3
INFO:homeassistant.util.package:Attempting install of botocore==1.4.93
usage: hass [-h] [--script {credstash}] {get,put,del,list} [name] [value]

Modify Home Assistant secrets in credstash.Use the secrets in configuration
files with: !secret <name>

positional arguments:
  {get,put,del,list}    Get, put or delete a secret, or list all available
                        secrets
  name                  Name of the secret
  value                 The value to save when putting a secret

optional arguments:
  -h, --help            show this help message and exit
  --script {credstash}
```