### PR TITLE
Fix netdata system_load and add disk_free.

### DIFF
--- a/homeassistant/components/sensor/netdata.py
+++ b/homeassistant/components/sensor/netdata.py
@@ -38,11 +38,12 @@ SENSOR_TYPES = {
                           'running', 0],
     'processes_blocked': ['Processes Blocked', 'Count', 'system.processes',
                           'blocked', 0],
-    'system_load': ['System Load', '15 min', 'system.processes', 'running', 2],
+    'system_load': ['System Load', '15 min', 'system.load', 'load15', 2],
     'system_io_in': ['System IO In', 'Count', 'system.io', 'in', 0],
     'system_io_out': ['System IO Out', 'Count', 'system.io', 'out', 0],
     'ipv4_in': ['IPv4 In', 'kb/s', 'system.ipv4', 'received', 0],
     'ipv4_out': ['IPv4 Out', 'kb/s', 'system.ipv4', 'sent', 0],
+    'disk_free': ['Disk Free', 'GiB', 'disk_space._', 'avail', 2],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
## Description:
`system_load` was incorrectly returning the number of processes, I guess due to a copy paste error from `processes_running`.
I've also added `disk_free` that fetches the amount of free disk space on the `/`-mountpoint.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
