### PR TITLE
Fixes "unknown" value for precipitation type in Dark Sky

### DIFF
--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -292,7 +292,7 @@ class DarkSkySensor(Entity):
         state = getattr(data, lookup_type, None)
 
         if state is None:
-            return state
+            return 'none'
 
         if 'summary' in self.type:
             self._icon = getattr(data, 'icon', '')


### PR DESCRIPTION
## Description:
Currently, the Dark Sky API returns precipitation type only when there's active precipitation; otherwise, the API skips that attribute. As a result, the HASS sensor shows `unknown`. This update change this behavior so that when _any_ Dark Sky sensor (including precipitation type) is missing an attribute, `none` is shown instead.

**Related issue (if applicable):** fixes #5110 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A
## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: darksky
  api_key: API_KEY
  monitored_conditions:
    - precip_type
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
