### PR TITLE
Abode push events and lock, cover, and switch components

### DIFF
--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers import config_validation as cv
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_NAME
 
-REQUIREMENTS = ['abodepy==0.5.1']
+REQUIREMENTS = ['abodepy==0.7.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -12,9 +12,9 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (ATTR_ATTRIBUTION,
-    CONF_USERNAME, CONF_PASSWORD, CONF_NAME, EVENT_HOMEASSISTANT_STOP)
+                                 CONF_USERNAME, CONF_PASSWORD, CONF_NAME, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['abodepy==0.7.2']
+REQUIREMENTS = ['abodepy==0.8.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,6 +37,11 @@ CONFIG_SCHEMA = vol.Schema({
     }),
 }, extra=vol.ALLOW_EXTRA)
 
+ABODE_COMPONENTS = [
+    'alarm_control_panel', 'binary_sensor', 'lock',  'switch', 'cover'
+]
+
+
 def setup(hass, config):
     """Set up Abode component."""
     global ABODE_CONTROLLER
@@ -55,7 +60,7 @@ def setup(hass, config):
         _LOGGER.info("Logged in to Abode and found %s devices",
                      len(devices))
 
-        for component in ['binary_sensor', 'alarm_control_panel', 'lock']:
+        for component in ABODE_COMPONENTS:
             discovery.load_platform(hass, component, DOMAIN, {}, config)
 
         def logout(event):
@@ -88,7 +93,6 @@ class AbodeDevice(Entity):
         """Initialize a sensor for Abode device."""
         self._controller = controller
         self._device = device
-        self._name = "{0} {1}".format(self._device.type, self._device.name)
         self._attrs = None
 
         self._controller.register(self._device, self._update_callback)
@@ -103,7 +107,7 @@ class AbodeDevice(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return self._name
+        return self._device.name
 
     @property
     def device_state_attributes(self):
@@ -118,5 +122,4 @@ class AbodeDevice(Entity):
     def _update_callback(self, device):
         """Update the device state."""
         _LOGGER.info("Device update received: %s", self.name)
-        self._device = device
         self.schedule_update_ha_state()

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -37,7 +37,7 @@ CONFIG_SCHEMA = vol.Schema({
     }),
 }, extra=vol.ALLOW_EXTRA)
 
-ABODE_COMPONENTS = [
+ABODE_PLATFORMS = [
     'alarm_control_panel', 'binary_sensor', 'lock', 'switch', 'cover'
 ]
 
@@ -59,8 +59,8 @@ def setup(hass, config):
         _LOGGER.info("Logged in to Abode and found %s devices",
                      len(devices))
 
-        for component in ABODE_COMPONENTS:
-            discovery.load_platform(hass, component, DOMAIN, {}, config)
+        for platform in ABODE_PLATFORMS:
+            discovery.load_platform(hass, platform, DOMAIN, {}, config)
 
         def logout(event):
             """Logout of Abode."""

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -17,7 +17,7 @@ from homeassistant.const import (ATTR_ATTRIBUTION,
                                  CONF_NAME, EVENT_HOMEASSISTANT_STOP,
                                  EVENT_HOMEASSISTANT_START)
 
-REQUIREMENTS = ['abodepy==0.8.3']
+REQUIREMENTS = ['abodepy==0.9.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -121,7 +121,8 @@ class AbodeDevice(Entity):
         return {
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
             'device_id': self._device.device_id,
-            'battery_low': self._device.battery_low
+            'battery_low': self._device.battery_low,
+            'no_response': self._device.no_response
         }
 
     def _update_callback(self, device):

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -4,6 +4,7 @@ This component provides basic support for Abode Home Security system.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/abode/
 """
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -23,9 +24,7 @@ CONF_ATTRIBUTION = "Data provided by goabode.com"
 
 DOMAIN = 'abode'
 DEFAULT_NAME = 'Abode'
-DEFAULT_ENTITY_NAMESPACE = 'abode'
-
-ABODE_CONTROLLER = None
+DATA_ABODE = 'abode'
 
 NOTIFICATION_ID = 'abode_notification'
 NOTIFICATION_TITLE = 'Abode Security Setup'
@@ -45,7 +44,6 @@ ABODE_COMPONENTS = [
 
 def setup(hass, config):
     """Set up Abode component."""
-    global ABODE_CONTROLLER
     import abodepy
 
     conf = config[DOMAIN]
@@ -53,10 +51,10 @@ def setup(hass, config):
     password = conf.get(CONF_PASSWORD)
 
     try:
-        ABODE_CONTROLLER = abodepy.Abode(username, password)
-        hass.data[DOMAIN] = ABODE_CONTROLLER
+        abode = abodepy.Abode(username, password)
+        hass.data[DATA_ABODE] = abode
 
-        devices = ABODE_CONTROLLER.get_devices()
+        devices = abode.get_devices()
 
         _LOGGER.info("Logged in to Abode and found %s devices",
                      len(devices))
@@ -66,13 +64,13 @@ def setup(hass, config):
 
         def logout(event):
             """Logout of Abode."""
-            ABODE_CONTROLLER.stop_listener()
-            ABODE_CONTROLLER.logout()
+            abode.stop_listener()
+            abode.logout()
             _LOGGER.info("Logged out of Abode")
 
         hass.bus.listen(EVENT_HOMEASSISTANT_STOP, logout)
 
-        ABODE_CONTROLLER.start_listener()
+        abode.start_listener()
 
     except (ConnectTimeout, HTTPError) as ex:
         _LOGGER.error("Unable to connect to Abode: %s", str(ex))
@@ -94,11 +92,11 @@ class AbodeDevice(Entity):
         """Initialize a sensor for Abode device."""
         self._controller = controller
         self._device = device
-        self._attrs = None
 
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Subscribe Abode events."""
         self._controller.register(self._device, self._update_callback)
-
-        _LOGGER.info("Device initialized: %s", self.name)
 
     @property
     def should_poll(self):
@@ -113,14 +111,12 @@ class AbodeDevice(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        self._attrs = {}
-        self._attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
-        self._attrs['device_id'] = self._device.device_id
-        self._attrs['battery_low'] = self._device.battery_low
-
-        return self._attrs
+        return {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+            'device_id': self._device.device_id,
+            'battery_low': self._device.battery_low
+        }
 
     def _update_callback(self, device):
         """Update the device state."""
-        _LOGGER.info("Device update received: %s", self.name)
         self.schedule_update_ha_state()

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -53,7 +53,6 @@ def setup(hass, config):
 
     try:
         hass.data[DATA_ABODE] = abode = abodepy.Abode(username, password)
-        devices = abode.get_devices()
 
     except (ConnectTimeout, HTTPError) as ex:
         _LOGGER.error("Unable to connect to Abode: %s", str(ex))

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -15,7 +15,7 @@ from homeassistant.const import (ATTR_ATTRIBUTION,
                                  CONF_USERNAME, CONF_PASSWORD,
                                  CONF_NAME, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['abodepy==0.8.2']
+REQUIREMENTS = ['abodepy==0.8.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 ABODE_COMPONENTS = [
-    'alarm_control_panel', 'binary_sensor', 'lock',  'switch', 'cover'
+    'alarm_control_panel', 'binary_sensor', 'lock', 'switch', 'cover'
 ]
 
 

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -12,7 +12,8 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (ATTR_ATTRIBUTION,
-                                 CONF_USERNAME, CONF_PASSWORD, CONF_NAME, EVENT_HOMEASSISTANT_STOP)
+                                 CONF_USERNAME, CONF_PASSWORD,
+                                 CONF_NAME, EVENT_HOMEASSISTANT_STOP)
 
 REQUIREMENTS = ['abodepy==0.8.2']
 

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -69,7 +69,6 @@ def setup(hass, config):
             notification_id=NOTIFICATION_ID)
         return False
 
-
     for platform in ABODE_PLATFORMS:
         discovery.load_platform(hass, platform, DOMAIN, {}, config)
 

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -53,11 +53,7 @@ def setup(hass, config):
 
     try:
         hass.data[DATA_ABODE] = abode = abodepy.Abode(username, password)
-
         devices = abode.get_devices()
-
-        _LOGGER.info("Logged in to Abode and found %s devices",
-                     len(devices))
 
     except (ConnectTimeout, HTTPError) as ex:
         _LOGGER.error("Unable to connect to Abode: %s", str(ex))

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -21,7 +21,6 @@ ICON = 'mdi:security'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for an Abode device."""
-
     add_devices([AbodeAlarm(hass, ABODE_CONTROLLER,
                             ABODE_CONTROLLER.get_alarm())])
 

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -24,15 +24,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for an Abode device."""
     abode = hass.data[DATA_ABODE]
 
-    add_devices([AbodeAlarm(hass, abode, abode.get_alarm())])
+    add_devices([AbodeAlarm(abode, abode.get_alarm())])
 
 
 class AbodeAlarm(AbodeDevice, AlarmControlPanel):
     """An alarm_control_panel implementation for Abode."""
 
-    def __init__(self, hass, controller, device):
+    def __init__(self, controller, device):
         """Initialize the alarm control panel."""
-        AbodeDevice.__init__(self, hass, controller, device)
+        AbodeDevice.__init__(self, controller, device)
         self._name = "{0}".format(DEFAULT_NAME)
 
     @property

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/alarm_control_panel.abode/
 import logging
 
 from homeassistant.components.abode import (
-    AbodeDevice, DATA_ABODE, DEFAULT_NAME)
+    AbodeDevice, ABODE_CONTROLLER, DEFAULT_NAME)
 from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
 import homeassistant.components.alarm_control_panel as alarm
@@ -21,17 +21,16 @@ ICON = 'mdi:security'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for an Abode device."""
-    data = hass.data.get(DATA_ABODE)
 
-    add_devices([AbodeAlarm(hass, data, data.abode.get_alarm())])
+    add_devices([AbodeAlarm(hass, ABODE_CONTROLLER, ABODE_CONTROLLER.get_alarm())])
 
 
 class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):
     """An alarm_control_panel implementation for Abode."""
 
-    def __init__(self, hass, data, device):
+    def __init__(self, hass, controller, device):
         """Initialize the alarm control panel."""
-        AbodeDevice.__init__(self, hass, data, device)
+        AbodeDevice.__init__(self, hass, controller, device)
         self._device = device
         self._name = "{0}".format(DEFAULT_NAME)
 
@@ -56,17 +55,14 @@ class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):
     def alarm_disarm(self, code=None):
         """Send disarm command."""
         self._device.set_standby()
-        self.schedule_update_ha_state()
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
         self._device.set_home()
-        self.schedule_update_ha_state()
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
         self._device.set_away()
-        self.schedule_update_ha_state()
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -10,7 +10,7 @@ from homeassistant.components.abode import (
     AbodeDevice, ABODE_CONTROLLER, DEFAULT_NAME)
 from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
-import homeassistant.components.alarm_control_panel as alarm
+from homeassistant.components.alarm_control_panel import (AlarmControlPanel)
 
 DEPENDENCIES = ['abode']
 
@@ -25,13 +25,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([AbodeAlarm(hass, ABODE_CONTROLLER, ABODE_CONTROLLER.get_alarm())])
 
 
-class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):
+class AbodeAlarm(AbodeDevice, AlarmControlPanel):
     """An alarm_control_panel implementation for Abode."""
 
     def __init__(self, hass, controller, device):
         """Initialize the alarm control panel."""
         AbodeDevice.__init__(self, hass, controller, device)
-        self._device = device
         self._name = "{0}".format(DEFAULT_NAME)
 
     @property

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -7,10 +7,11 @@ https://home-assistant.io/components/alarm_control_panel.abode/
 import logging
 
 from homeassistant.components.abode import (
-    AbodeDevice, ABODE_CONTROLLER, DEFAULT_NAME)
-from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
-                                 STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
+    AbodeDevice, DATA_ABODE, DEFAULT_NAME, CONF_ATTRIBUTION)
 from homeassistant.components.alarm_control_panel import (AlarmControlPanel)
+from homeassistant.const import (ATTR_ATTRIBUTION, STATE_ALARM_ARMED_AWAY,
+                                 STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
+
 
 DEPENDENCIES = ['abode']
 
@@ -21,8 +22,9 @@ ICON = 'mdi:security'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for an Abode device."""
-    add_devices([AbodeAlarm(hass, ABODE_CONTROLLER,
-                            ABODE_CONTROLLER.get_alarm())])
+    abode = hass.data[DATA_ABODE]
+
+    add_devices([AbodeAlarm(hass, abode, abode.get_alarm())])
 
 
 class AbodeAlarm(AbodeDevice, AlarmControlPanel):
@@ -66,8 +68,10 @@ class AbodeAlarm(AbodeDevice, AlarmControlPanel):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        self._attrs = super().device_state_attributes
-        self._attrs['battery_backup'] = self._device.battery
-        self._attrs['cellular_backup'] = self._device.is_cellular
-
-        return self._attrs
+        return {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+            'device_id': self._device.device_id,
+            'battery_low': self._device.battery_low,
+            'battery_backup': self._device.battery,
+            'cellular_backup': self._device.is_cellular
+        }

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -71,7 +71,6 @@ class AbodeAlarm(AbodeDevice, AlarmControlPanel):
         return {
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
             'device_id': self._device.device_id,
-            'battery_low': self._device.battery_low,
             'battery_backup': self._device.battery,
             'cellular_backup': self._device.is_cellular
         }

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -22,7 +22,8 @@ ICON = 'mdi:security'
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for an Abode device."""
 
-    add_devices([AbodeAlarm(hass, ABODE_CONTROLLER, ABODE_CONTROLLER.get_alarm())])
+    add_devices([AbodeAlarm(hass, ABODE_CONTROLLER,
+                            ABODE_CONTROLLER.get_alarm())])
 
 
 class AbodeAlarm(AbodeDevice, AlarmControlPanel):
@@ -41,11 +42,11 @@ class AbodeAlarm(AbodeDevice, AlarmControlPanel):
     @property
     def state(self):
         """Return the state of the device."""
-        if self._device.mode == "standby":
+        if self._device.is_standby:
             state = STATE_ALARM_DISARMED
-        elif self._device.mode == "away":
+        elif self._device.is_away:
             state = STATE_ALARM_ARMED_AWAY
-        elif self._device.mode == "home":
+        elif self._device.is_home:
             state = STATE_ALARM_ARMED_HOME
         else:
             state = None

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -47,3 +47,8 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
             return self._device.status != 'Closed'
         elif self._device.type == 'Motion Camera':
             return self._device.get_value('motion_event') == '1'
+
+    @property
+    def device_class(self):
+        """Return the class of the binary sensor."""
+        return SENSOR_TYPES.get(self._device.type)

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -48,6 +48,7 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
     def __init__(self, hass, controller, device):
         """Initialize a sensor for Abode device."""
         AbodeDevice.__init__(self, hass, controller, device)
+        self._device_class = map_abode_device_class().get(self._device.type)
 
     @property
     def is_on(self):
@@ -60,4 +61,4 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
     @property
     def device_class(self):
         """Return the class of the binary sensor."""
-        return map_abode_device_class().get(self._device.type)
+        return self._device_class

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -60,4 +60,4 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
     @property
     def device_class(self):
         """Return the class of the binary sensor."""
-        return map_abode_device_class().get(self._device.type, None)
+        return map_abode_device_class().get(self._device.type)

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -23,7 +23,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     sensors = []
     for sensor in abode.get_devices(type_filter=device_types):
-        sensors.append(AbodeBinarySensor(hass, abode, sensor))
+        sensors.append(AbodeBinarySensor(abode, sensor))
 
     add_devices(sensors)
 
@@ -45,9 +45,9 @@ def map_abode_device_class():
 class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
     """A binary sensor implementation for Abode device."""
 
-    def __init__(self, hass, controller, device):
+    def __init__(self, controller, device):
         """Initialize a sensor for Abode device."""
-        AbodeDevice.__init__(self, hass, controller, device)
+        AbodeDevice.__init__(self, controller, device)
         self._device_class = map_abode_device_class().get(self._device.type)
 
     @property

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -6,8 +6,8 @@ https://home-assistant.io/components/binary_sensor.abode/
 """
 import logging
 
-from homeassistant.components.abode import (CONF_ATTRIBUTION, DATA_ABODE)
-from homeassistant.const import (ATTR_ATTRIBUTION)
+from homeassistant.components.abode import (
+    AbodeDevice, CONF_ATTRIBUTION, DATA_ABODE)
 from homeassistant.components.binary_sensor import (BinarySensorDevice)
 
 DEPENDENCIES = ['abode']
@@ -35,23 +35,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(sensors)
 
 
-class AbodeBinarySensor(BinarySensorDevice):
+class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
     """A binary sensor implementation for Abode device."""
 
     def __init__(self, hass, data, device):
         """Initialize a sensor for Abode device."""
-        super(AbodeBinarySensor, self).__init__()
-        self._device = device
-
-    @property
-    def should_poll(self):
-        """Return the polling state."""
-        return True
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return "{0} {1}".format(self._device.type, self._device.name)
+        AbodeDevice.__init__(self, hass, data, device)
 
     @property
     def is_on(self):
@@ -60,22 +49,3 @@ class AbodeBinarySensor(BinarySensorDevice):
             return self._device.status != 'Closed'
         elif self._device.type == 'Motion Camera':
             return self._device.get_value('motion_event') == '1'
-
-    @property
-    def device_class(self):
-        """Return the class of the binary sensor."""
-        return SENSOR_TYPES.get(self._device.type)
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        attrs = {}
-        attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
-        attrs['device_id'] = self._device.device_id
-        attrs['battery_low'] = self._device.battery_low
-
-        return attrs
-
-    def update(self):
-        """Update the device state."""
-        self._device.refresh()

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/binary_sensor.abode/
 import logging
 
 from homeassistant.components.abode import (
-    AbodeDevice, CONF_ATTRIBUTION, DATA_ABODE)
+    AbodeDevice, ABODE_CONTROLLER)
 from homeassistant.components.binary_sensor import (BinarySensorDevice)
 
 DEPENDENCIES = ['abode']
@@ -23,13 +23,11 @@ SENSOR_TYPES = {
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for an Abode device."""
-    data = hass.data.get(DATA_ABODE)
-
     sensors = []
-    for sensor in data.devices:
+    for sensor in ABODE_CONTROLLER.get_devices():
         _LOGGER.debug('Sensor type %s', sensor.type)
         if sensor.type in ['Door Contact', 'Motion Camera']:
-            sensors.append(AbodeBinarySensor(hass, data, sensor))
+            sensors.append(AbodeBinarySensor(hass, ABODE_CONTROLLER, sensor))
 
     _LOGGER.debug('Adding %d sensors', len(sensors))
     add_devices(sensors)
@@ -38,9 +36,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
     """A binary sensor implementation for Abode device."""
 
-    def __init__(self, hass, data, device):
+    def __init__(self, hass, controller, device):
         """Initialize a sensor for Abode device."""
-        AbodeDevice.__init__(self, hass, data, device)
+        AbodeDevice.__init__(self, hass, controller, device)
 
     @property
     def is_on(self):

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -37,7 +37,7 @@ def map_abode_device_class():
         CONST.DEVICE_KEYPAD: 'connectivity',
         CONST.DEVICE_DOOR_CONTACT: 'opening',
         CONST.DEVICE_STATUS_DISPLAY: 'connectivity',
-        CONST.DEVICE_MOTION_CAMERA: 'motion',
+        CONST.DEVICE_MOTION_CAMERA: 'connectivity',
         CONST.DEVICE_WATER_SENSOR: 'moisture'
     }
 
@@ -53,9 +53,6 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
     @property
     def is_on(self):
         """Return True if the binary sensor is on."""
-        if self.device_class == 'motion':
-            return self._device.get_value('motion_event') == '1'
-
         return self._device.is_on
 
     @property

--- a/homeassistant/components/binary_sensor/abode.py
+++ b/homeassistant/components/binary_sensor/abode.py
@@ -23,14 +23,41 @@ SENSOR_TYPES = {
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for an Abode device."""
-    sensors = []
-    for sensor in ABODE_CONTROLLER.get_devices():
-        _LOGGER.debug('Sensor type %s', sensor.type)
-        if sensor.type in ['Door Contact', 'Motion Camera']:
-            sensors.append(AbodeBinarySensor(hass, ABODE_CONTROLLER, sensor))
+    import abodepy.helpers.constants as CONST
 
-    _LOGGER.debug('Adding %d sensors', len(sensors))
+    device_types = [
+        CONST.DEVICE_GLASS_BREAK, CONST.DEVICE_KEYPAD,
+        CONST.DEVICE_DOOR_CONTACT, CONST.DEVICE_STATUS_DISPLAY,
+        CONST.DEVICE_MOTION_CAMERA, CONST.DEVICE_WATER_SENSOR]
+
+    sensors = []
+    for sensor in ABODE_CONTROLLER.get_devices(type_filter=device_types):
+        sensors.append(AbodeBinarySensor(hass, ABODE_CONTROLLER, sensor))
+        _LOGGER.debug('Added Binary Sensor %s', sensor.name)
+
+    _LOGGER.debug('Adding %d Binary Snsors', len(sensors))
+
     add_devices(sensors)
+
+
+def map_abode_device_class(abode_device):
+    """Map Abode device types to Home Assistant binary sensor class."""
+    import abodepy.helpers.constants as CONST
+
+    if abode_device.type == CONST.DEVICE_GLASS_BREAK:
+        return 'connectivity'
+    elif abode_device.type == CONST.DEVICE_KEYPAD:
+        return 'connectivity'
+    elif abode_device.type == CONST.DEVICE_DOOR_CONTACT:
+        return 'opening'
+    elif abode_device.type == CONST.DEVICE_STATUS_DISPLAY:
+        return 'connectivity'
+    elif abode_device.type == CONST.DEVICE_MOTION_CAMERA:
+        return 'motion'
+    elif abode_device.type == CONST.DEVICE_WATER_SENSOR:
+        return 'moisture'
+
+    return None
 
 
 class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
@@ -43,12 +70,12 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
     @property
     def is_on(self):
         """Return True if the binary sensor is on."""
-        if self._device.type == 'Door Contact':
-            return self._device.status != 'Closed'
-        elif self._device.type == 'Motion Camera':
+        if self.device_class == 'motion':
             return self._device.get_value('motion_event') == '1'
+        else:
+            return self._device.is_on
 
     @property
     def device_class(self):
         """Return the class of the binary sensor."""
-        return SENSOR_TYPES.get(self._device.type)
+        return map_abode_device_class(self._device)

--- a/homeassistant/components/cover/abode.py
+++ b/homeassistant/components/cover/abode.py
@@ -42,8 +42,8 @@ class AbodeCover(AbodeDevice, CoverDevice):
 
     def close_cover(self):
         """Issue close command to cover."""
-        self._device.switch_off()
+        self._device.close_cover()
 
     def open_cover(self):
         """Issue open command to cover."""
-        self._device.switch_on()
+        self._device.open_cover()

--- a/homeassistant/components/cover/abode.py
+++ b/homeassistant/components/cover/abode.py
@@ -2,7 +2,7 @@
 This component provides HA cover support for Abode Security System.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/switch.abode/
+https://home-assistant.io/components/cover.abode/
 """
 import logging
 

--- a/homeassistant/components/cover/abode.py
+++ b/homeassistant/components/cover/abode.py
@@ -6,9 +6,9 @@ https://home-assistant.io/components/cover.abode/
 """
 import logging
 
-from homeassistant.components.abode import (
-    AbodeDevice, ABODE_CONTROLLER)
+from homeassistant.components.abode import AbodeDevice, DATA_ABODE
 from homeassistant.components.cover import CoverDevice
+
 
 DEPENDENCIES = ['abode']
 
@@ -19,14 +19,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Abode cover devices."""
     import abodepy.helpers.constants as CONST
 
+    abode = hass.data[DATA_ABODE]
+
     sensors = []
+    for sensor in abode.get_devices(type_filter=(CONST.DEVICE_SECURE_BARRIER)):
+        sensors.append(AbodeCover(hass, abode, sensor))
 
-    for sensor in ABODE_CONTROLLER.get_devices(
-            type_filter=(CONST.DEVICE_SECURE_BARRIER)):
-        sensors.append(AbodeCover(hass, ABODE_CONTROLLER, sensor))
-        _LOGGER.debug('Added Cover %s', sensor.name)
-
-    _LOGGER.debug('Adding %d Covers', len(sensors))
     add_devices(sensors)
 
 

--- a/homeassistant/components/cover/abode.py
+++ b/homeassistant/components/cover/abode.py
@@ -23,7 +23,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     sensors = []
     for sensor in abode.get_devices(type_filter=(CONST.DEVICE_SECURE_BARRIER)):
-        sensors.append(AbodeCover(hass, abode, sensor))
+        sensors.append(AbodeCover(abode, sensor))
 
     add_devices(sensors)
 
@@ -31,9 +31,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AbodeCover(AbodeDevice, CoverDevice):
     """Representation of an Abode cover."""
 
-    def __init__(self, hass, controller, device):
+    def __init__(self, controller, device):
         """Initialize the Abode device."""
-        AbodeDevice.__init__(self, hass, controller, device)
+        AbodeDevice.__init__(self, controller, device)
 
     @property
     def is_closed(self):

--- a/homeassistant/components/cover/abode.py
+++ b/homeassistant/components/cover/abode.py
@@ -40,7 +40,7 @@ class AbodeCover(AbodeDevice, CoverDevice):
     @property
     def is_closed(self):
         """Return true if cover is closed, else False."""
-        return self._device.is_open == False
+        return self._device.is_open is False
 
     def close_cover(self):
         """Issue close command to cover."""

--- a/homeassistant/components/cover/abode.py
+++ b/homeassistant/components/cover/abode.py
@@ -1,0 +1,51 @@
+"""
+This component provides HA cover support for Abode Security System.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.abode/
+"""
+import logging
+
+from homeassistant.components.abode import (
+    AbodeDevice, ABODE_CONTROLLER)
+from homeassistant.components.cover import CoverDevice
+
+DEPENDENCIES = ['abode']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Abode cover devices."""
+    import abodepy.helpers.constants as CONST
+
+    sensors = []
+
+    for sensor in ABODE_CONTROLLER.get_devices(
+            type_filter=(CONST.DEVICE_SECURE_BARRIER)):
+        sensors.append(AbodeCover(hass, ABODE_CONTROLLER, sensor))
+        _LOGGER.debug('Added Cover %s', sensor.name)
+
+    _LOGGER.debug('Adding %d Covers', len(sensors))
+    add_devices(sensors)
+
+
+class AbodeCover(AbodeDevice, CoverDevice):
+    """Representation of an Abode cover."""
+
+    def __init__(self, hass, controller, device):
+        """Initialize the Abode device."""
+        AbodeDevice.__init__(self, hass, controller, device)
+
+    @property
+    def is_closed(self):
+        """Return true if cover is closed, else False."""
+        return self._device.is_open == False
+
+    def close_cover(self):
+        """Issue close command to cover."""
+        self._device.switch_off()
+
+    def open_cover(self):
+        """Issue open command to cover."""
+        self._device.switch_on()

--- a/homeassistant/components/lock/abode.py
+++ b/homeassistant/components/lock/abode.py
@@ -6,9 +6,9 @@ https://home-assistant.io/components/lock.abode/
 """
 import logging
 
-from homeassistant.components.abode import (
-    AbodeDevice, ABODE_CONTROLLER)
+from homeassistant.components.abode import AbodeDevice, DATA_ABODE
 from homeassistant.components.lock import LockDevice
+
 
 DEPENDENCIES = ['abode']
 
@@ -19,14 +19,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Abode lock devices."""
     import abodepy.helpers.constants as CONST
 
+    abode = hass.data[DATA_ABODE]
+
     sensors = []
+    for sensor in abode.get_devices(type_filter=(CONST.DEVICE_DOOR_LOCK)):
+        sensors.append(AbodeLock(hass, abode, sensor))
 
-    for sensor in ABODE_CONTROLLER.get_devices(
-            type_filter=(CONST.DEVICE_DOOR_LOCK)):
-        sensors.append(AbodeLock(hass, ABODE_CONTROLLER, sensor))
-        _LOGGER.debug('Added Lock %s', sensor.name)
-
-    _LOGGER.debug('Adding %d Locks', len(sensors))
     add_devices(sensors)
 
 

--- a/homeassistant/components/lock/abode.py
+++ b/homeassistant/components/lock/abode.py
@@ -1,0 +1,53 @@
+"""
+This component provides HA lock support for Abode Security System.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/lock.abode/
+"""
+import logging
+
+from homeassistant.components.abode import (
+    AbodeDevice, CONF_ATTRIBUTION, DATA_ABODE)
+from homeassistant.components.lock import LockDevice
+from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
+
+DEPENDENCIES = ['abode']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Abode lock devices."""
+    data = hass.data.get(DATA_ABODE)
+
+    sensors = []
+    for sensor in data.devices:
+        _LOGGER.debug('Sensor type %s', sensor.type)
+        if sensor.type == 'Door Lock':
+            sensors.append(AbodeLock(hass, data, sensor))
+
+    _LOGGER.debug('Adding %d sensors', len(sensors))
+    add_devices(sensors)
+
+
+class AbodeLock(AbodeDevice, LockDevice):
+    """Representation of a Vera lock."""
+
+    def __init__(self, hass, data, device):
+        """Initialize the Abode device."""
+        AbodeDevice.__init__(self, hass, data, device)
+
+    def lock(self, **kwargs):
+        """Lock the device."""
+        self._device.lock()
+        self.schedule_update_ha_state()
+
+    def unlock(self, **kwargs):
+        """Unlock the device."""
+        self._device.unlock()
+        self.schedule_update_ha_state()
+
+    @property
+    def is_locked(self):
+        """Return true if device is on."""
+        return self._device.is_locked

--- a/homeassistant/components/lock/abode.py
+++ b/homeassistant/components/lock/abode.py
@@ -1,6 +1,5 @@
 """
 This component provides HA lock support for Abode Security System.
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/lock.abode/
 """
@@ -23,7 +22,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     sensors = []
     for sensor in abode.get_devices(type_filter=(CONST.DEVICE_DOOR_LOCK)):
-        sensors.append(AbodeLock(hass, abode, sensor))
+        sensors.append(AbodeLock(abode, sensor))
 
     add_devices(sensors)
 
@@ -31,9 +30,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AbodeLock(AbodeDevice, LockDevice):
     """Representation of an Abode lock."""
 
-    def __init__(self, hass, controller, device):
+    def __init__(self, controller, device):
         """Initialize the Abode device."""
-        AbodeDevice.__init__(self, hass, controller, device)
+        AbodeDevice.__init__(self, controller, device)
 
     def lock(self, **kwargs):
         """Lock the device."""

--- a/homeassistant/components/lock/abode.py
+++ b/homeassistant/components/lock/abode.py
@@ -18,18 +18,21 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Abode lock devices."""
-    sensors = []
-    for sensor in ABODE_CONTROLLER.get_devices():
-        _LOGGER.debug('Sensor type %s', sensor.type)
-        if sensor.type == 'Door Lock':
-            sensors.append(AbodeLock(hass, ABODE_CONTROLLER, sensor))
+    import abodepy.helpers.constants as CONST
 
-    _LOGGER.debug('Adding %d sensors', len(sensors))
+    sensors = []
+
+    for sensor in ABODE_CONTROLLER.get_devices(
+            type_filter=(CONST.DEVICE_DOOR_LOCK)):
+        sensors.append(AbodeLock(hass, ABODE_CONTROLLER, sensor))
+        _LOGGER.debug('Added Lock %s', sensor.name)
+
+    _LOGGER.debug('Adding %d Locks', len(sensors))
     add_devices(sensors)
 
 
 class AbodeLock(AbodeDevice, LockDevice):
-    """Representation of a Vera lock."""
+    """Representation of an Abode lock."""
 
     def __init__(self, hass, controller, device):
         """Initialize the Abode device."""

--- a/homeassistant/components/lock/abode.py
+++ b/homeassistant/components/lock/abode.py
@@ -1,5 +1,6 @@
 """
 This component provides HA lock support for Abode Security System.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/lock.abode/
 """

--- a/homeassistant/components/lock/abode.py
+++ b/homeassistant/components/lock/abode.py
@@ -9,7 +9,6 @@ import logging
 from homeassistant.components.abode import (
     AbodeDevice, ABODE_CONTROLLER)
 from homeassistant.components.lock import LockDevice
-from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
 
 DEPENDENCIES = ['abode']
 

--- a/homeassistant/components/lock/abode.py
+++ b/homeassistant/components/lock/abode.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/lock.abode/
 import logging
 
 from homeassistant.components.abode import (
-    AbodeDevice, CONF_ATTRIBUTION, DATA_ABODE)
+    AbodeDevice, ABODE_CONTROLLER)
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
 
@@ -18,13 +18,11 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Abode lock devices."""
-    data = hass.data.get(DATA_ABODE)
-
     sensors = []
-    for sensor in data.devices:
+    for sensor in ABODE_CONTROLLER.get_devices():
         _LOGGER.debug('Sensor type %s', sensor.type)
         if sensor.type == 'Door Lock':
-            sensors.append(AbodeLock(hass, data, sensor))
+            sensors.append(AbodeLock(hass, ABODE_CONTROLLER, sensor))
 
     _LOGGER.debug('Adding %d sensors', len(sensors))
     add_devices(sensors)
@@ -33,19 +31,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AbodeLock(AbodeDevice, LockDevice):
     """Representation of a Vera lock."""
 
-    def __init__(self, hass, data, device):
+    def __init__(self, hass, controller, device):
         """Initialize the Abode device."""
-        AbodeDevice.__init__(self, hass, data, device)
+        AbodeDevice.__init__(self, hass, controller, device)
 
     def lock(self, **kwargs):
         """Lock the device."""
         self._device.lock()
-        self.schedule_update_ha_state()
 
     def unlock(self, **kwargs):
         """Unlock the device."""
         self._device.unlock()
-        self.schedule_update_ha_state()
 
     @property
     def is_locked(self):

--- a/homeassistant/components/switch/abode.py
+++ b/homeassistant/components/switch/abode.py
@@ -23,7 +23,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     sensors = []
     for sensor in abode.get_devices(type_filter=(CONST.DEVICE_POWER_SWITCH)):
-        sensors.append(AbodeSwitch(hass, abode, sensor))
+        sensors.append(AbodeSwitch(abode, sensor))
 
     add_devices(sensors)
 
@@ -31,9 +31,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AbodeSwitch(AbodeDevice, SwitchDevice):
     """Representation of an Abode switch."""
 
-    def __init__(self, hass, controller, device):
+    def __init__(self, controller, device):
         """Initialize the Abode device."""
-        AbodeDevice.__init__(self, hass, controller, device)
+        AbodeDevice.__init__(self, controller, device)
 
     def turn_on(self, **kwargs):
         """Turn on the device."""

--- a/homeassistant/components/switch/abode.py
+++ b/homeassistant/components/switch/abode.py
@@ -1,0 +1,51 @@
+"""
+This component provides HA switch support for Abode Security System.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.abode/
+"""
+import logging
+
+from homeassistant.components.abode import (
+    AbodeDevice, ABODE_CONTROLLER)
+from homeassistant.components.switch import SwitchDevice
+
+DEPENDENCIES = ['abode']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Abode switch devices."""
+    import abodepy.helpers.constants as CONST
+
+    sensors = []
+
+    for sensor in ABODE_CONTROLLER.get_devices(
+            type_filter=(CONST.DEVICE_POWER_SWITCH)):
+        sensors.append(AbodeSwitch(hass, ABODE_CONTROLLER, sensor))
+        _LOGGER.debug('Added Switch %s', sensor.name)
+
+    _LOGGER.debug('Adding %d Switches', len(sensors))
+    add_devices(sensors)
+
+
+class AbodeSwitch(AbodeDevice, SwitchDevice):
+    """Representation of an Abode switch."""
+
+    def __init__(self, hass, controller, device):
+        """Initialize the Abode device."""
+        AbodeDevice.__init__(self, hass, controller, device)
+
+    def turn_on(self, **kwargs):
+        """Turn on the device."""
+        self._device.switch_on()
+
+    def turn_off(self, **kwargs):
+        """Turn off the device."""
+        self._device.switch_off()
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._device.is_on

--- a/homeassistant/components/switch/abode.py
+++ b/homeassistant/components/switch/abode.py
@@ -21,8 +21,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     abode = hass.data[DATA_ABODE]
 
+    device_types = [
+        CONST.DEVICE_POWER_SWITCH_SENSOR,
+        CONST.DEVICE_POWER_SWITCH_METER]
+
     sensors = []
-    for sensor in abode.get_devices(type_filter=(CONST.DEVICE_POWER_SWITCH)):
+    for sensor in abode.get_devices(type_filter=device_types):
         sensors.append(AbodeSwitch(abode, sensor))
 
     add_devices(sensors)

--- a/homeassistant/components/switch/abode.py
+++ b/homeassistant/components/switch/abode.py
@@ -6,9 +6,9 @@ https://home-assistant.io/components/switch.abode/
 """
 import logging
 
-from homeassistant.components.abode import (
-    AbodeDevice, ABODE_CONTROLLER)
+from homeassistant.components.abode import AbodeDevice, DATA_ABODE
 from homeassistant.components.switch import SwitchDevice
+
 
 DEPENDENCIES = ['abode']
 
@@ -19,14 +19,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Abode switch devices."""
     import abodepy.helpers.constants as CONST
 
+    abode = hass.data[DATA_ABODE]
+
     sensors = []
+    for sensor in abode.get_devices(type_filter=(CONST.DEVICE_POWER_SWITCH)):
+        sensors.append(AbodeSwitch(hass, abode, sensor))
 
-    for sensor in ABODE_CONTROLLER.get_devices(
-            type_filter=(CONST.DEVICE_POWER_SWITCH)):
-        sensors.append(AbodeSwitch(hass, ABODE_CONTROLLER, sensor))
-        _LOGGER.debug('Added Switch %s', sensor.name)
-
-    _LOGGER.debug('Adding %d Switches', len(sensors))
     add_devices(sensors)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,7 +39,7 @@ SoCo==0.12
 TwitterAPI==2.4.6
 
 # homeassistant.components.abode
-abodepy==0.5.1
+abodepy==0.7.1
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,7 +39,7 @@ SoCo==0.12
 TwitterAPI==2.4.6
 
 # homeassistant.components.abode
-abodepy==0.8.3
+abodepy==0.9.0
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,7 +39,7 @@ SoCo==0.12
 TwitterAPI==2.4.6
 
 # homeassistant.components.abode
-abodepy==0.7.1
+abodepy==0.7.2
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,7 +39,7 @@ SoCo==0.12
 TwitterAPI==2.4.6
 
 # homeassistant.components.abode
-abodepy==0.8.2
+abodepy==0.8.3
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,7 +39,7 @@ SoCo==0.12
 TwitterAPI==2.4.6
 
 # homeassistant.components.abode
-abodepy==0.7.2
+abodepy==0.8.2
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.0


### PR DESCRIPTION
## Description:
Added cloud push events to the Abode platform. Added a lock, cover and switch components.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3224

## Example entry for `configuration.yaml` (if applicable):
```yaml
abode:
  username: abode_username
  password: abode_password
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
