### PR TITLE
Add Pilight light support

### DIFF
--- a/homeassistant/components/light/pilight.py
+++ b/homeassistant/components/light/pilight.py
@@ -10,9 +10,9 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 import homeassistant.components.pilight as pilight
-from homeassistant.components.light import (ATTR_BRIGHTNESS, 
+from homeassistant.components.light import (ATTR_BRIGHTNESS,
                                             SUPPORT_BRIGHTNESS, Light,
-											PLATFORM_SCHEMA)
+                                            PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_NAME, CONF_ID, CONF_DEVICES, CONF_STATE,
                                  CONF_PROTOCOL)
 

--- a/homeassistant/components/light/pilight.py
+++ b/homeassistant/components/light/pilight.py
@@ -135,7 +135,7 @@ class PilightDimmableLight(Light):
 
     @property
     def brightness(self):
-        """Return the brightness"""
+        """Return the brightness."""
         return self._brightness
 
     @property
@@ -146,7 +146,6 @@ class PilightDimmableLight(Light):
     @property
     def supported_features(self):
         """Flag supported features."""
-
         if self._dimmable:
             return SUPPORT_BRIGHTNESS
         else:

--- a/homeassistant/components/light/pilight.py
+++ b/homeassistant/components/light/pilight.py
@@ -10,7 +10,9 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 import homeassistant.components.pilight as pilight
-from homeassistant.components.light import (ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light, PLATFORM_SCHEMA)
+from homeassistant.components.light import (ATTR_BRIGHTNESS, 
+                                            SUPPORT_BRIGHTNESS, Light,
+											PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_NAME, CONF_ID, CONF_DEVICES, CONF_STATE,
                                  CONF_PROTOCOL)
 
@@ -95,7 +97,7 @@ class _ReceiveHandle(object):
 
     def run(self, light, turn_on):
         """Change the state of the switch."""
-        switch.set_state(turn_on=turn_on, send_code=self.echo)
+        light.set_state(turn_on=turn_on, send_code=self.echo)
 
 
 class PilightDimmableLight(Light):
@@ -183,7 +185,7 @@ class PilightDimmableLight(Light):
                 code = self._code_on
 
                 if self._dimmable:
-                    code.update({'dimlevel':dimlevel})
+                    code.update({'dimlevel': dimlevel})
 
                 self._hass.services.call(pilight.DOMAIN, pilight.SERVICE_NAME,
                                          code, blocking=True)

--- a/homeassistant/components/light/pilight.py
+++ b/homeassistant/components/light/pilight.py
@@ -1,0 +1,206 @@
+"""
+Support for lights via Pilight.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.pilight/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+import homeassistant.components.pilight as pilight
+from homeassistant.components.light import (ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_NAME, CONF_ID, CONF_DEVICES, CONF_STATE,
+                                 CONF_PROTOCOL)
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_OFF_CODE = 'off_code'
+CONF_OFF_CODE_RECIEVE = 'off_code_receive'
+CONF_ON_CODE = 'on_code'
+CONF_ON_CODE_RECIEVE = 'on_code_receive'
+CONF_SYSTEMCODE = 'systemcode'
+CONF_UNIT = 'unit'
+CONF_UNITCODE = 'unitcode'
+CONF_ECHO = 'echo'
+CONF_DIMMABLE = 'dimmable'
+
+DEPENDENCIES = ['pilight']
+
+COMMAND_SCHEMA = vol.Schema({
+    vol.Optional(CONF_PROTOCOL): cv.string,
+    vol.Optional('on'): cv.positive_int,
+    vol.Optional('off'): cv.positive_int,
+    vol.Optional(CONF_UNIT): cv.positive_int,
+    vol.Optional(CONF_UNITCODE): cv.positive_int,
+    vol.Optional(CONF_ID): vol.Any(cv.positive_int, cv.string),
+    vol.Optional(CONF_STATE): cv.string,
+    vol.Optional(CONF_SYSTEMCODE): cv.positive_int,
+}, extra=vol.ALLOW_EXTRA)
+
+RECEIVE_SCHEMA = COMMAND_SCHEMA.extend({
+    vol.Optional(CONF_ECHO): cv.boolean
+})
+
+SWITCHES_SCHEMA = vol.Schema({
+    vol.Required(CONF_ON_CODE): COMMAND_SCHEMA,
+    vol.Required(CONF_OFF_CODE): COMMAND_SCHEMA,
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_OFF_CODE_RECIEVE, default=[]): vol.All(cv.ensure_list,
+                                                             [COMMAND_SCHEMA]),
+    vol.Optional(CONF_ON_CODE_RECIEVE, default=[]): vol.All(cv.ensure_list,
+                                                            [COMMAND_SCHEMA]),
+    vol.Optional(CONF_DIMMABLE, default=False): cv.boolean
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_DEVICES):
+        vol.Schema({cv.string: SWITCHES_SCHEMA}),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Pilight platform."""
+    devices = []
+
+    for dev_name, properties in config.get(CONF_DEVICES).items():
+        devices.append(
+            PilightDimmableLight(
+                hass,
+                properties.get(CONF_NAME, dev_name),
+                properties.get(CONF_ON_CODE),
+                properties.get(CONF_OFF_CODE),
+                properties.get(CONF_ON_CODE_RECIEVE),
+                properties.get(CONF_OFF_CODE_RECIEVE),
+                properties.get(CONF_DIMMABLE)
+            )
+        )
+
+    add_devices(devices)
+
+
+class _ReceiveHandle(object):
+    def __init__(self, config, echo):
+        """Initialize the handle."""
+        self.config_items = config.items()
+        self.echo = echo
+
+    def match(self, code):
+        """Test if the received code matches the configured values.
+
+        The received values have to be a subset of the configured options.
+        """
+        return self.config_items <= code.items()
+
+    def run(self, light, turn_on):
+        """Change the state of the switch."""
+        switch.set_state(turn_on=turn_on, send_code=self.echo)
+
+
+class PilightDimmableLight(Light):
+    """Representation of a Pilight light."""
+
+    def __init__(self, hass, name, code_on, code_off, code_on_receive,
+                 code_off_receive, dimmable):
+        """Initialize the light."""
+        self._hass = hass
+        self._name = name
+        self._state = False
+
+        self._code_on = code_on
+        self._code_off = code_off
+
+        self._code_on_receive = []
+        self._code_off_receive = []
+
+        self._brightness = 255
+        self._dimmable = dimmable
+
+        for code_list, conf in ((self._code_on_receive, code_on_receive),
+                                (self._code_off_receive, code_off_receive)):
+            for code in conf:
+                echo = code.pop(CONF_ECHO, True)
+                code_list.append(_ReceiveHandle(code, echo))
+
+        if any(self._code_on_receive) or any(self._code_off_receive):
+            hass.bus.listen(pilight.EVENT, self._handle_code)
+
+    @property
+    def name(self):
+        """Get the name of the light."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """Return the brightness"""
+        return self._brightness
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._state
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+
+        if self._dimmable:
+            return SUPPORT_BRIGHTNESS
+        else:
+            return None
+
+    def _handle_code(self, call):
+        """Check if received code by the pilight-daemon.
+
+        If the code matches the receive on/off codes of this switch the switch
+        state is changed accordingly.
+        """
+        # - True if off_code/on_code is contained in received code dict, not
+        #   all items have to match.
+        # - Call turn on/off only once, even if more than one code is received
+        if any(self._code_on_receive):
+            for on_code in self._code_on_receive:
+                if on_code.match(call.data):
+                    on_code.run(light=self, turn_on=True)
+                    break
+
+        if any(self._code_off_receive):
+            for off_code in self._code_off_receive:
+                if off_code.match(call.data):
+                    off_code.run(light=self, turn_on=False)
+                    break
+
+    def set_state(self, turn_on, dimlevel=15, send_code=True):
+        """Set the state of the switch.
+
+        This sets the state of the switch. If send_code is set to True, then
+        it will call the pilight.send service to actually send the codes
+        to the pilight daemon.
+        """
+        if send_code:
+            if turn_on:
+                code = self._code_on
+
+                if self._dimmable:
+                    code.update({'dimlevel':dimlevel})
+
+                self._hass.services.call(pilight.DOMAIN, pilight.SERVICE_NAME,
+                                         code, blocking=True)
+            else:
+                self._hass.services.call(pilight.DOMAIN, pilight.SERVICE_NAME,
+                                         self._code_off, blocking=True)
+
+        self._state = turn_on
+        self.schedule_update_ha_state()
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on by calling pilight.send service with on code."""
+        self._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        dimlevel = int(self._brightness / 17)
+
+        self.set_state(turn_on=True, dimlevel=dimlevel)
+
+    def turn_off(self, **kwargs):
+        """Turn the switch on by calling pilight.send service with off code."""
+        self.set_state(turn_on=False)


### PR DESCRIPTION
## Description:
Support for lights in pilight. This will add dimmer functionality which the current switch lacks off.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

I don't have an envoirement now to setup rake, is there anyone who can copy the switch documentation and edit it for light? Only change is that 'dimmable' (optional) has been added for dimmer support.

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: pilight
    devices:
      test2:
        dimmable: true
        on_code:
          protocol: kaku_dimmer
          id: 23298822
          unit: 10
          'on': 1
        off_code:
          protocol: kaku_dimmer
          id: 23298822
          unit: 10
          'off': 1
        on_code_receive:
          protocol: kaku_dimmer
          id: 23298822
          unit: 10
          state: 'on'
        off_code_receive:
          protocol: kaku_dimmer
          id: 23298822
          unit: 10
          state: 'off'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
