### PR TITLE
Initial submit of lutron_qse platform

### DIFF
--- a/homeassistant/components/cover/lutron_qse.py
+++ b/homeassistant/components/cover/lutron_qse.py
@@ -1,0 +1,95 @@
+"""
+Support for Lutron QSE roller shade(e.g. Sivoia QS).
+
+For more details about this platform, please refer to the documentation at
+https: // home - assistant.io / components / cover.lutron_qse
+"""
+import logging
+
+from homeassistant.components.cover import (
+    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_STOP,
+    SUPPORT_SET_POSITION)
+from homeassistant.components.lutron_qse import (
+    LUTRON_QSE_INSTANCE, LUTRON_QSE_IGNORE, LutronQSEDevice)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Lutron QSE roller shades as cover devices."""
+    qse = hass.data[LUTRON_QSE_INSTANCE]
+    ignore = hass.data[LUTRON_QSE_IGNORE]
+    devices = []
+    for roller in qse.rollers():
+        if roller.serial_number in ignore:
+            _LOGGER.info("Ignoring Lutron QSE Roller: %s",
+                         roller.serial_number)
+            continue
+        devices.append(LutronQSECover(roller))
+    add_devices(devices, True)
+
+
+class LutronQSECover(LutronQSEDevice, CoverDevice):
+    """Representation of a Lutron QSE roller shade."""
+
+    def __init__(self, device):
+        """Create a LutronQSECover instance."""
+        LutronQSEDevice.__init__(self, device)
+        self._is_closing = False
+        self._is_opening = False
+        self._position = 0
+        self._update()
+
+    def _update(self):
+        """Update state from device."""
+        self._is_opening = self._device.opening
+        self._is_closing = self._device.closing
+        self._position = self._device.target_level
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return 'window'
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return (SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION |
+                SUPPORT_STOP)
+
+    @property
+    def current_cover_position(self):
+        """Return the current position of cover."""
+        return self._position
+
+    @property
+    def is_opening(self):
+        """Return if the cover is opening or not."""
+        return self._is_opening
+
+    @property
+    def is_closing(self):
+        """Return if the cover is closing or not."""
+        return self._is_closing
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return self._position == 0
+
+    def open_cover(self):
+        """Open the cover."""
+        self._device.open()
+
+    def close_cover(self):
+        """Close the cover."""
+        self._device.close()
+
+    def set_cover_position(self, position, **kwargs):
+        """Move the roller shutter to a specific position."""
+        self._device.set_target_level(position)
+
+    def stop_cover(self, **kwargs):
+        """Stop the cover."""
+        self._device.stop()

--- a/homeassistant/components/lutron_qse.py
+++ b/homeassistant/components/lutron_qse.py
@@ -1,0 +1,104 @@
+"""
+Component for Lutron QSE network interface (QSE-CI-NWK-E).
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/lutron_qse/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_HOST
+from homeassistant.helpers import discovery
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['pylutron-qse==0.1.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'lutron_qse'
+LUTRON_QSE_INSTANCE = DOMAIN + '_instance'
+LUTRON_QSE_IGNORE = DOMAIN + '_ignore'
+LUTRON_QSE_COMPONENTS = [
+    'cover'
+]
+CONF_IGNORE = 'ignore'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_IGNORE, default=[]):
+            vol.All(cv.ensure_list, [cv.string]),
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, base_config):
+    """Setup Lutron QSE component."""
+    # pylint: disable=import-error
+    from pylutron_qse.qse import QSE
+
+    config = base_config.get(DOMAIN)
+    hass.data[LUTRON_QSE_INSTANCE] = QSE(config[CONF_HOST])
+    hass.data[LUTRON_QSE_IGNORE] = config[CONF_IGNORE]
+    if not hass.data[LUTRON_QSE_INSTANCE].connected():
+        _LOGGER.error("Unable to connect to Lutron QSE at %s",
+                      config[CONF_HOST])
+        return False
+
+    _LOGGER.info("Connected to Lutron QSE at %s", config[CONF_HOST])
+    for component in LUTRON_QSE_COMPONENTS:
+        discovery.load_platform(hass, component, DOMAIN, {}, config)
+    return True
+
+
+class LutronQSEDevice(Entity):
+    """Common base class for all Lutron QSE devices."""
+
+    def __init__(self, device):
+        """Set up the base class.
+
+        [:param]device the pylutron_qse.Device instance
+        """
+        self._device = device
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
+        self.hass.async_add_job(
+            self._device.add_subscriber, self._update_callback)
+
+    def _update_callback(self):
+        self._update()
+        self.schedule_update_ha_state()
+
+    def _update(self):
+        """Subclass should override to update their state."""
+        pass
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        if self._device.integration_id is not None:
+            return self._device.integration_id
+        return self._device.serial_number
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attr = {
+            'serial_number': self._device.serial_number,
+        }
+        return attr
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._device.connected()
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -639,6 +639,9 @@ pyloopenergy==0.0.17
 # homeassistant.components.lutron_caseta
 pylutron-caseta==0.2.7
 
+# homeassistant.components.lutron_qse
+pylutron-qse==0.1.0
+
 # homeassistant.components.lutron
 pylutron==0.1.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -97,6 +97,9 @@ pydispatcher==2.0.5
 # homeassistant.components.litejet
 pylitejet==0.1
 
+# homeassistant.components.lutron_qse
+pylutron-qse==0.1.0
+
 # homeassistant.components.alarm_control_panel.nx584
 # homeassistant.components.binary_sensor.nx584
 pynx584==0.4

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -54,6 +54,7 @@ TEST_REQUIREMENTS = (
     'sleepyq',
     'statsd',
     'pylitejet',
+    'pylutron-qse',
     'holidays',
     'evohomeclient',
     'pexpect',

--- a/tests/components/test_lutron_qse.py
+++ b/tests/components/test_lutron_qse.py
@@ -1,0 +1,70 @@
+"""Tests for Lutron QSE component."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pylutron_qse import qse
+from pylutron_qse.devices import Roller
+
+from homeassistant.core import callback
+from homeassistant.components import lutron_qse
+from homeassistant.helpers import discovery
+from tests.common import get_test_home_assistant
+
+TEST_HOST = '192.168.1.10'
+
+VALID_CONFIG = {
+    'lutron_qse': {
+        'host': TEST_HOST,
+        'ignore': ['0x00000001']
+    }
+}
+
+
+class TestLutronQSE(unittest.TestCase):
+    """Tests the Lutron QSE component."""
+
+    def setUp(self):
+        """Initialize values for this test case class."""
+        self.hass = get_test_home_assistant()
+        self.config = VALID_CONFIG
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @patch.object(qse, 'QSE')
+    def test_setup(self, mock_qse_constructor):
+        """Test the setup."""
+        mock_qse = mock_qse_constructor.return_value = MagicMock()
+        mock_qse.connected.return_value = True
+        mock_qse.rollers.return_value = []
+        response = lutron_qse.setup(self.hass, self.config)
+
+        self.assertTrue(response)
+        self.assertTrue(lutron_qse.LUTRON_QSE_INSTANCE in self.hass.data)
+        mock_qse_constructor.assert_called_once_with(TEST_HOST)
+        mock_qse.connected.assert_called_with()
+
+    @patch.object(qse, 'QSE')
+    def test_setup_with_rollers(self, mock_qse_constructor):
+        """Test the setup."""
+        mock_qse = mock_qse_constructor.return_value = MagicMock()
+        mock_qse.connected.return_value = True
+        mock_qse.rollers.return_value = [
+            Roller(mock_qse, b'0x00000001'), Roller(mock_qse, b'0x00000002')]
+
+        cover_platforms_loaded = []
+
+        @callback
+        def load_platform_callback(platform, info):
+            cover_platforms_loaded.append(platform)
+
+        discovery.listen_platform(
+            self.hass, 'cover', load_platform_callback)
+
+        response = lutron_qse.setup(self.hass, self.config)
+        self.assertTrue(response)
+        self.hass.block_till_done()
+        self.assertIn('lutron_qse', cover_platforms_loaded)
+        self.assertNotIn('cover.0x00000001', self.hass.states.entity_ids())
+        self.assertIn('cover.0x00000002', self.hass.states.entity_ids())


### PR DESCRIPTION
## Description:
New platform for interacting with the [QSE-CI-NWK-E Control Interface](http://www.lutron.com/TechnicalDocumentLibrary/qse-ci-nwk-e_ENG_24_09_2009.pdf).

Note: this is my first contribution to the project. I've tried to follow the documentation and checklists, but very likely will have made some mistakes!

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3235

## Example entry for `configuration.yaml` (if applicable):
```yaml
lutron_qse:
  host: 192.168.0.10
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.