### PR TITLE
Mysensors nodes can be renamed in config file

### DIFF
--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -50,7 +50,6 @@ CONF_TOPIC_OUT_PREFIX = 'topic_out_prefix'
 CONF_VERSION = 'version'
 
 CONF_NODES = 'nodes'
-CONF_NODE_ID = 'id'
 CONF_NODE_NAME = 'name'
 
 DEFAULT_BAUD_RATE = 115200
@@ -136,13 +135,11 @@ def deprecated(key):
     return validator
 
 
-NODE_SCHEMA = vol.All(
-    cv.ensure_list,
-    [{
-        vol.Required(CONF_NODE_ID): cv.positive_int,
-        vol.Optional(CONF_NODE_NAME): cv.string
-    }]
-)
+NODE_SCHEMA = vol.Schema({
+    cv.positive_int: {
+        vol.Required(CONF_NODE_NAME): cv.string
+    }
+})
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema(vol.All(deprecated(CONF_DEBUG), {
@@ -163,7 +160,7 @@ CONFIG_SCHEMA = vol.Schema({
                     CONF_TOPIC_IN_PREFIX, default=''): valid_subscribe_topic,
                 vol.Optional(
                     CONF_TOPIC_OUT_PREFIX, default=''): valid_publish_topic,
-                vol.Optional(CONF_NODES, default=[]): NODE_SCHEMA,
+                vol.Optional(CONF_NODES, default={}): NODE_SCHEMA,
             }]
         ),
         vol.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,


### PR DESCRIPTION
## Description:

Make it possible to change the node names. Node configuration is now independent from the node id. Also replacing a node is easier.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3236

## Example entry for `configuration.yaml` (if applicable):
```yaml
mysensors:
  gateways:
  - device: '/dev/ttyUSB0'
    baud_rate: 115200
    nodes:
      1:
        name: 'kitchen'
      3: 
        name: 'living_room'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
