### PR TITLE
Issue #6893 in rfxtrx

### DIFF
--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -77,14 +77,6 @@ def _valid_device(value, device_type):
         if not len(key) % 2 == 0:
             key = '0' + key
 
-        try:
-            if get_rfx_object(key) is None:
-                raise vol.Invalid('Rfxtrx device {} is invalid: Invalid'
-                                  ' device id for {}'.format(key, value))
-        except ImportError:
-            _LOGGER.warning('Restart Home Assistant to'
-                            ' validate the rfxtrx config again.')
-
         if device_type == 'sensor':
             config[key] = DEVICE_SCHEMA_SENSOR(device)
         elif device_type == 'binary_sensor':
@@ -297,6 +289,7 @@ def get_devices_from_config(config, device, hass):
     for packet_id, entity_info in config[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
         if event is None:
+            _LOGGER.error("Invalid device: %s", packet_id)
             continue
         device_id = slugify(event.device.id_string.lower())
         if device_id in RFX_DEVICES:

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -77,9 +77,13 @@ def _valid_device(value, device_type):
         if not len(key) % 2 == 0:
             key = '0' + key
 
-        if get_rfx_object(key) is None:
-            raise vol.Invalid('Rfxtrx device {} is invalid: '
-                              'Invalid device id for {}'.format(key, value))
+        try:
+            if get_rfx_object(key) is None:
+                raise vol.Invalid('Rfxtrx device {} is invalid: Invalid'
+                                  ' device id for {}'.format(key, value))
+        except ImportError:
+            _LOGGER.warning('Restart Home Assistant to'
+                            ' validate the rfxtrx config again.')
 
         if device_type == 'sensor':
             config[key] = DEVICE_SCHEMA_SENSOR(device)

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -296,6 +296,8 @@ def get_devices_from_config(config, device, hass):
     devices = []
     for packet_id, entity_info in config[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
+        if event is None:
+            continue
         device_id = slugify(event.device.id_string.lower())
         if device_id in RFX_DEVICES:
             continue


### PR DESCRIPTION
## Description:
From https://github.com/home-assistant/home-assistant/issues/6893#issuecomment-322027224 :
> This happens cause rfxtrx platforms depend on RFXtrx in the validation of the config. This won't work since the automatic install of requirements happen after the process of the config during setup, which includes config validation.

This might not be the best solution, so I am open for suggestions.
Merging this will make the make HA start for the first time without need of manually install PyRfxtrx, and still validate the config as good as possible with the available libraries.

**Related issue (if applicable):** fixes #6893
