### PR TITLE
Xiaomi Smart WiFi Socket and Smart Power Strip integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -577,7 +577,7 @@ omit =
     homeassistant/components/switch/telnet.py
     homeassistant/components/switch/transmission.py
     homeassistant/components/switch/wake_on_lan.py
-    homeassistant/components/switch/xiaomi_plug.py
+    homeassistant/components/switch/xiaomi_miio.py
     homeassistant/components/telegram_bot/*
     homeassistant/components/thingspeak.py
     homeassistant/components/tts/amazon_polly.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -577,6 +577,7 @@ omit =
     homeassistant/components/switch/telnet.py
     homeassistant/components/switch/transmission.py
     homeassistant/components/switch/wake_on_lan.py
+    homeassistant/components/switch/xiaomi_plug.py
     homeassistant/components/telegram_bot/*
     homeassistant/components/thingspeak.py
     homeassistant/components/tts/amazon_polly.py

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -2,7 +2,7 @@
 Support for Xiaomi Smart WiFi Socket and Smart Power Strip.
 
 For more details about this platform, please refer to the documentation
-https://home-assistant.io/components/switch.xiaomi_plug/
+https://home-assistant.io/components/switch.xiaomi_miio/
 """
 import asyncio
 from functools import partial
@@ -17,8 +17,8 @@ from homeassistant.exceptions import PlatformNotReady
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_NAME = 'Xiaomi Plug'
-PLATFORM = 'xiaomi_plug'
+DEFAULT_NAME = 'Xiaomi Miio Switch'
+PLATFORM = 'xiaomi_miio'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_TOKEN): vol.All(cv.string, vol.Length(min=32, max=32)),
@@ -37,7 +37,7 @@ SUCCESS = ['ok']
 # pylint: disable=unused-argument
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-    """Set up the plug from config."""
+    """Set up the switch from config."""
     from mirobo import Plug, DeviceException
     if PLATFORM not in hass.data:
         hass.data[PLATFORM] = {}

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -39,8 +39,6 @@ SUCCESS = ['ok']
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the switch from config."""
     from mirobo import Plug, DeviceException
-    if PLATFORM not in hass.data:
-        hass.data[PLATFORM] = {}
 
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
@@ -57,7 +55,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                      device_info.raw['hw_ver'])
 
         xiaomi_plug_switch = XiaomiPlugSwitch(name, plug, device_info)
-        hass.data[PLATFORM][host] = xiaomi_plug_switch
     except DeviceException:
         raise PlatformNotReady
 

--- a/homeassistant/components/switch/xiaomi_plug.py
+++ b/homeassistant/components/switch/xiaomi_plug.py
@@ -145,7 +145,7 @@ class XiaomiPlugSwitch(SwitchDevice):
         """Fetch state from the device."""
         from mirobo import DeviceException
 
-        # On changed state the device doesn't provide the new state immediately.
+        # On state change the device doesn't provide the new state immediately.
         if self._skip_update:
             self._skip_update = False
             return

--- a/homeassistant/components/switch/xiaomi_plug.py
+++ b/homeassistant/components/switch/xiaomi_plug.py
@@ -1,0 +1,164 @@
+"""
+Support for Xiaomi Smart WiFi Socket and Smart Power Strip.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/switch.xiaomi_plug/
+"""
+import asyncio
+from functools import partial
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA, )
+from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_TOKEN, )
+from homeassistant.exceptions import PlatformNotReady
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Xiaomi Plug'
+PLATFORM = 'xiaomi_plug'
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_TOKEN): vol.All(cv.string, vol.Length(min=32, max=32)),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+REQUIREMENTS = ['python-mirobo==0.1.3']
+
+ATTR_POWER = 'power'
+ATTR_TEMPERATURE = 'temperature'
+ATTR_CURRENT = 'current'
+SUCCESS = ['ok']
+
+
+# pylint: disable=unused-argument
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the plug from config."""
+    from mirobo import Plug, DeviceException
+    if PLATFORM not in hass.data:
+        hass.data[PLATFORM] = {}
+
+    host = config.get(CONF_HOST)
+    name = config.get(CONF_NAME)
+    token = config.get(CONF_TOKEN)
+
+    _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
+
+    try:
+        plug = Plug(host, token)
+
+        xiaomi_plug_switch = XiaomiPlugSwitch(name, plug)
+        hass.data[PLATFORM][host] = xiaomi_plug_switch
+    except DeviceException:
+        raise PlatformNotReady
+
+    async_add_devices([xiaomi_plug_switch], update_before_add=True)
+
+
+class XiaomiPlugSwitch(SwitchDevice):
+    """Representation of a Xiaomi Plug."""
+
+    def __init__(self, name, plug):
+        """Initialize the plug switch."""
+        self._name = name
+        self._icon = 'mdi:power-socket'
+
+        self._plug = plug
+        self._state = None
+        self._state_attrs = {
+            ATTR_TEMPERATURE: None,
+            ATTR_CURRENT: None
+        }
+        self._skip_update = False
+
+    @property
+    def should_poll(self):
+        """Poll the plug."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon to use for device if any."""
+        return self._icon
+
+    @property
+    def available(self):
+        """Return true when state is known."""
+        return self._state is not None
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the device."""
+        return self._state_attrs
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._state
+
+    @asyncio.coroutine
+    def _try_command(self, mask_error, func, *args, **kwargs):
+        """Call a plug command handling error messages."""
+        from mirobo import DeviceException
+        try:
+            result = yield from self.hass.async_add_job(
+                partial(func, *args, **kwargs))
+
+            _LOGGER.debug("Response received from plug: %s", result)
+
+            return result == SUCCESS
+        except DeviceException as exc:
+            _LOGGER.error(mask_error, exc)
+            return False
+
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """Turn the plug on."""
+
+        result = yield from self._try_command(
+            "Turning the plug on failed.", self._plug.on)
+
+        if result:
+            self._state = True
+            self._skip_update = True
+
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
+        """Turn the plug off."""
+        result = yield from self._try_command(
+            "Turning the plug off failed.", self._plug.off)
+
+        if result:
+            self._state = False
+            self._skip_update = True
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Fetch state from the device."""
+        from mirobo import DeviceException
+
+        # On changed state the device doesn't provide the new state immediately.
+        if self._skip_update:
+            self._skip_update = False
+            return
+
+        try:
+            state = yield from self.hass.async_add_job(self._plug.status)
+            _LOGGER.debug("Got new state: %s", state)
+
+            self._state = state.is_on
+            self._state_attrs = {
+                ATTR_TEMPERATURE: state.temperature,
+                ATTR_CURRENT: state.current,
+            }
+
+        except DeviceException as ex:
+            _LOGGER.error("Got exception while fetching the state: %s", ex)

--- a/homeassistant/components/switch/xiaomi_plug.py
+++ b/homeassistant/components/switch/xiaomi_plug.py
@@ -25,11 +25,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-mirobo==0.2.0']
+REQUIREMENTS = ['python-mirobo>=0.1.5']
 
 ATTR_POWER = 'power'
 ATTR_TEMPERATURE = 'temperature'
-ATTR_CURRENT = 'current'
+ATTR_LOAD_POWER = 'load_power'
 SUCCESS = ['ok']
 
 
@@ -70,7 +70,7 @@ class XiaomiPlugSwitch(SwitchDevice):
         self._state = None
         self._state_attrs = {
             ATTR_TEMPERATURE: None,
-            ATTR_CURRENT: None
+            ATTR_LOAD_POWER: None
         }
         self._skip_update = False
 
@@ -156,7 +156,7 @@ class XiaomiPlugSwitch(SwitchDevice):
             self._state = state.is_on
             self._state_attrs = {
                 ATTR_TEMPERATURE: state.temperature,
-                ATTR_CURRENT: state.current,
+                ATTR_LOAD_POWER: state.load_power,
             }
 
         except DeviceException as ex:

--- a/homeassistant/components/switch/xiaomi_plug.py
+++ b/homeassistant/components/switch/xiaomi_plug.py
@@ -25,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-mirobo==0.1.3']
+REQUIREMENTS = ['python-mirobo==0.1.4']
 
 ATTR_POWER = 'power'
 ATTR_TEMPERATURE = 'temperature'

--- a/homeassistant/components/switch/xiaomi_plug.py
+++ b/homeassistant/components/switch/xiaomi_plug.py
@@ -25,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-mirobo==0.1.4']
+REQUIREMENTS = ['python-mirobo==0.2.0']
 
 ATTR_POWER = 'power'
 ATTR_TEMPERATURE = 'temperature'

--- a/homeassistant/components/switch/xiaomi_plug.py
+++ b/homeassistant/components/switch/xiaomi_plug.py
@@ -25,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-mirobo>=0.1.5']
+REQUIREMENTS = ['python-mirobo==0.2.0']
 
 ATTR_POWER = 'power'
 ATTR_TEMPERATURE = 'temperature'

--- a/homeassistant/components/switch/xiaomi_plug.py
+++ b/homeassistant/components/switch/xiaomi_plug.py
@@ -122,7 +122,6 @@ class XiaomiPlugSwitch(SwitchDevice):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the plug on."""
-
         result = yield from self._try_command(
             "Turning the plug on failed.", self._plug.on)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -756,6 +756,7 @@ python-juicenet==0.0.5
 # python-lirc==1.2.3
 
 # homeassistant.components.light.xiaomi_miio
+# homeassistant.components.switch.xiaomi_plug
 # homeassistant.components.vacuum.xiaomi_miio
 python-mirobo==0.2.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -756,7 +756,7 @@ python-juicenet==0.0.5
 # python-lirc==1.2.3
 
 # homeassistant.components.light.xiaomi_miio
-# homeassistant.components.switch.xiaomi_plug
+# homeassistant.components.switch.xiaomi_miio
 # homeassistant.components.vacuum.xiaomi_miio
 python-mirobo==0.2.0
 


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** https://github.com/home-assistant/home-assistant.github.io/pull/3248

## Example entry for `configuration.yaml`:
```yaml
switch:
  - platform: xiaomi_miio
    name: Original Xiaomi Mi Smart WiFi Socket
    host: 192.168.130.59
    token: b7c4a758c251955d2c24b1d9e41ce47d
  - platform: xiaomi_miio
    name: Xiaomi Mi Smart WiFi Socket 2
    host: 192.168.130.60
    token: 0ed0fdccb2d0cd718108f18a447726a6
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
