### PR TITLE
Bump aioautomatic to prevent leaking exceptions

### DIFF
--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 
-REQUIREMENTS = ['aioautomatic==0.6.0']
+REQUIREMENTS = ['aioautomatic==0.6.2']
 DEPENDENCIES = ['http']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -42,7 +42,7 @@ TwitterAPI==2.4.6
 abodepy==0.7.1
 
 # homeassistant.components.device_tracker.automatic
-aioautomatic==0.6.0
+aioautomatic==0.6.2
 
 # homeassistant.components.sensor.dnsip
 aiodns==1.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -27,7 +27,7 @@ PyJWT==1.5.2
 SoCo==0.12
 
 # homeassistant.components.device_tracker.automatic
-aioautomatic==0.6.0
+aioautomatic==0.6.2
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Description:
This PR bumps the version of aioautomatic. Invalid messages from Automatic no longer bubble up exceptions. They are now logged as errors. Related to #9137.
