### PR TITLE
Allow specifying custom html urls to load.

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -174,12 +174,12 @@ def register_panel(hass, component_name, path, md5=None, sidebar_title=None,
 
 
 @bind_hass
-def add_extra_html_urls(hass, urls):
-    """Register extra html urls to load."""
+def add_extra_html_url(hass, url):
+    """Register extra html url to load."""
     url_set = hass.data.get(DATA_EXTRA_HTML_URL)
     if url_set is None:
         url_set = hass.data[DATA_EXTRA_HTML_URL] = set()
-    url_set.update(urls)
+    url_set.add(url)
 
 
 def add_manifest_json_key(key, val):
@@ -233,8 +233,8 @@ def setup(hass, config):
     themes = config.get(DOMAIN, {}).get(ATTR_THEMES)
     setup_themes(hass, themes)
 
-    add_extra_html_urls(
-        hass, config.get(DOMAIN, {}).get(ATTR_EXTRA_HTML_URL, []))
+    for url in config.get(DOMAIN, {}).get(ATTR_EXTRA_HTML_URL, []):
+        add_extra_html_url(hass, url)
 
     return True
 

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -28,6 +28,7 @@ URL_PANEL_COMPONENT_FP = '/frontend/panels/{}-{}.html'
 STATIC_PATH = os.path.join(os.path.dirname(__file__), 'www_static/')
 
 ATTR_THEMES = 'themes'
+ATTR_EXTRA_HTML_URL = 'extra_html_url'
 DEFAULT_THEME_COLOR = '#03A9F4'
 MANIFEST_JSON = {
     'background_color': '#FFFFFF',
@@ -50,6 +51,7 @@ for size in (192, 384, 512, 1024):
     })
 
 DATA_PANELS = 'frontend_panels'
+DATA_EXTRA_HTML_URL = 'frontend_extra_html_url'
 DATA_INDEX_VIEW = 'frontend_index_view'
 DATA_THEMES = 'frontend_themes'
 DATA_DEFAULT_THEME = 'frontend_default_theme'
@@ -66,6 +68,8 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(ATTR_THEMES): vol.Schema({
             cv.string: {cv.string: cv.string}
         }),
+        vol.Optional(ATTR_EXTRA_HTML_URL):
+            vol.All(cv.ensure_list, [cv.string]),
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -169,6 +173,15 @@ def register_panel(hass, component_name, path, md5=None, sidebar_title=None,
             'get', '/{}/{{extra:.+}}'.format(url_path), index_view.get)
 
 
+@bind_hass
+def add_extra_html_urls(hass, urls):
+    """Register extra html urls to load."""
+    url_set = hass.data.get(DATA_EXTRA_HTML_URL)
+    if url_set is None:
+        url_set = hass.data[DATA_EXTRA_HTML_URL] = set()
+    url_set.update(urls)
+
+
 def add_manifest_json_key(key, val):
     """Add a keyval to the manifest.json."""
     MANIFEST_JSON[key] = val
@@ -208,6 +221,9 @@ def setup(hass, config):
     else:
         hass.data[DATA_PANELS] = {}
 
+    if DATA_EXTRA_HTML_URL not in hass.data:
+        hass.data[DATA_EXTRA_HTML_URL] = set()
+
     register_built_in_panel(hass, 'map', 'Map', 'mdi:account-location')
 
     for panel in ('dev-event', 'dev-info', 'dev-service', 'dev-state',
@@ -216,6 +232,9 @@ def setup(hass, config):
 
     themes = config.get(DOMAIN, {}).get(ATTR_THEMES)
     setup_themes(hass, themes)
+
+    add_extra_html_urls(
+        hass, config.get(DOMAIN, {}).get(ATTR_EXTRA_HTML_URL, []))
 
     return True
 
@@ -362,7 +381,9 @@ class IndexView(HomeAssistantView):
             compatibility_url=compatibility_url, no_auth=no_auth,
             icons_url=icons_url, icons=FINGERPRINTS['mdi.html'],
             panel_url=panel_url, panels=hass.data[DATA_PANELS],
-            dev_mode=request.app[KEY_DEVELOPMENT])
+            dev_mode=request.app[KEY_DEVELOPMENT],
+            theme_color=MANIFEST_JSON['theme_color'],
+            extra_urls=hass.data[DATA_EXTRA_HTML_URL])
 
         return web.Response(text=resp, content_type='text/html')
 

--- a/homeassistant/components/frontend/templates/index.html
+++ b/homeassistant/components/frontend/templates/index.html
@@ -21,7 +21,7 @@
     <meta name="msapplication-TileColor" content="#3fbbf4ff"/>
     <meta name='mobile-web-app-capable' content='yes'>
     <meta name='viewport' content='width=device-width, user-scalable=no'>
-    <meta name='theme-color' content='#03a9f4'>
+    <meta name='theme-color' content='{{ theme_color }}'>
     <style>
       body {
         font-family: 'Roboto', 'Noto', sans-serif;
@@ -97,6 +97,10 @@
       <link rel='import' href='{{ panel_url }}' onerror='initError()' async>
     {% endif -%}
     <link rel='import' href='{{ icons_url }}' async>
+    {% for extra_url in extra_urls -%}
+      <link rel='import' href='{{ extra_url }}' async>
+    {% endfor -%}
+
     <script>
       var webComponentsSupported = (
         'registerElement' in document &&

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.setup import async_setup_component
-from homeassistant.components.frontend import DOMAIN, ATTR_THEMES
+from homeassistant.components.frontend import (
+    DOMAIN, ATTR_THEMES, ATTR_EXTRA_HTML_URL)
 
 
 @pytest.fixture
@@ -26,6 +27,16 @@ def mock_http_client_with_themes(hass, test_client):
                     'primary-color': 'red'
                 }
             }
+        }}))
+    return hass.loop.run_until_complete(test_client(hass.http.app))
+
+
+@pytest.fixture
+def mock_http_client_with_urls(hass, test_client):
+    """Start the Hass HTTP component."""
+    hass.loop.run_until_complete(async_setup_component(hass, 'frontend', {
+        DOMAIN: {
+            ATTR_EXTRA_HTML_URL: ["https://domain.com/my_extra_url.html"]
         }}))
     return hass.loop.run_until_complete(test_client(hass.http.app))
 
@@ -143,3 +154,12 @@ def test_missing_themes(mock_http_client):
     json = yield from resp.json()
     assert json['default_theme'] == 'default'
     assert json['themes'] == {}
+
+
+@asyncio.coroutine
+def test_extra_urls(mock_http_client_with_urls):
+    """Test that extra urls are loaded"""
+    resp = yield from mock_http_client_with_urls.get('/states')
+    assert resp.status == 200
+    text = yield from resp.text()
+    assert text.find('href=\'https://domain.com/my_extra_url.html\'') >= 0

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -158,7 +158,7 @@ def test_missing_themes(mock_http_client):
 
 @asyncio.coroutine
 def test_extra_urls(mock_http_client_with_urls):
-    """Test that extra urls are loaded"""
+    """Test that extra urls are loaded."""
     resp = yield from mock_http_client_with_urls.get('/states')
     assert resp.status == 200
     text = yield from resp.text()


### PR DESCRIPTION
## Description:

Allow specifying custom html urls to load.

## Proposed release text:
The frontend component now supports loading custom html files when Home Assistant front end starts.
It could be Javascript, CSS or custom Web Components.
Along there was a breaking change in the way Custom UI is used:
* `custom_ui_state_card` now specifies the exact element name and not a suffix after `state-card`. So if you had `state_card_custom_ui: custom-ui` in your config, you should change it to `state_card_custom_ui: state-card-custom-ui`
* `custom_ui_state_card` no longer makes the html fetch, you should make it separately:
```
frontend:
  extra_html_url:
    - /local/custom_ui/state-card-custom-ui.html
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3260

## Example entry for `configuration.yaml` (if applicable):
```yaml
frontend:
  extra_html_url:
    - https://example.com/file1.html
    - /icons.html
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
