### PR TITLE
Upgrade sphinx-autodoc-typehints to 1.2.3

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
 Sphinx==1.6.3
-sphinx-autodoc-typehints==1.2.1
+sphinx-autodoc-typehints==1.2.3
 sphinx-autodoc-annotation==1.0.post1


### PR DESCRIPTION
## 1.2.3

- Fixed process_signature() clobbering any explicitly overridden signatures from the docstring

## Checklist:

If user exposed functionality or configuration variables are added/changed:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
 