### PR TITLE
Upgrade async_timeout to 1.3.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,7 +6,7 @@ jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.2.5
-async_timeout==1.2.1
+async_timeout==1.3.0
 chardet==3.0.4
 astral==1.4
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -7,7 +7,7 @@ jinja2>=2.9.5
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.2.5
-async_timeout==1.2.1
+async_timeout==1.3.0
 chardet==3.0.4
 astral==1.4
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ REQUIRES = [
     'voluptuous==0.10.5',
     'typing>=3,<4',
     'aiohttp==2.2.5',
-    'async_timeout==1.2.1',
+    'async_timeout==1.3.0',
     'chardet==3.0.4',
     'astral==1.4',
 ]


### PR DESCRIPTION
## 1.3.0

- Don't suppress nested exception on timeout. Exception context points on cancelled line with suspended await
- Introduce .timeout property
- Add methods for using as async context manager

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
 