### PR TITLE
Wrap state when iterating a domain in templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -209,7 +209,7 @@ class DomainStates(object):
     def __iter__(self):
         """Return the iteration over all the states."""
         return iter(sorted(
-            (state for state in self._hass.states.async_all()
+            (_wrap_state(state) for state in self._hass.states.async_all()
              if state.domain == self._domain),
             key=lambda state: state.entity_id))
 


### PR DESCRIPTION
## Description:
When iterating over a domain in templates, it was not wrapped in the template state object. 

## Example template:
```jinja2
	{% for entity in states.sensor %}
		{{ entity.name }} is {{ entity.state_with_unit }}
	{% endfor %}
```
