### PR TITLE
upgrade pylint for Python 3.6 support

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 # make new things fail. Manually update these pins when pulling in a
 # new version
 flake8==3.3
-pylint==1.6.5
+pylint==1.7.0
 mypy==0.521
 pydocstyle==1.1.1
 coveralls>=1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -3,7 +3,7 @@
 # make new things fail. Manually update these pins when pulling in a
 # new version
 flake8==3.3
-pylint==1.6.5
+pylint==1.7.0
 mypy==0.521
 pydocstyle==1.1.1
 coveralls>=1.1


### PR DESCRIPTION
Python 3.6 isn't supported by Pylint 1.6.5. See https://github.com/PyCQA/pylint/issues/1241.

[Pylint changelog](https://pylint.readthedocs.io/en/latest/whatsnew/1.7.html).