### PR TITLE
Add HTTP Basic auth to RESTful Switch

### DIFF
--- a/homeassistant/components/switch/rest.py
+++ b/homeassistant/components/switch/rest.py
@@ -74,7 +74,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     try:
         switch = RestSwitch(name, resource, method, auth, body_on, body_off,
-                    is_on_template, timeout)
+                            is_on_template, timeout)
 
         req = yield from switch._update_current_state(hass)
         if req.status >= 400:
@@ -125,8 +125,9 @@ class RestSwitch(SwitchDevice):
             if req.status == 200:
                 self._state = True
             else:
-                _LOGGER.error("Can't turn on %s. Is resource/endpoint offline?",
-                              self._resource)
+                _LOGGER.error(
+                    "Can't turn on %s. Is resource/endpoint offline?",
+                    self._resource)
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Error while turn on %s", self._resource)
 
@@ -140,8 +141,9 @@ class RestSwitch(SwitchDevice):
             if req.status == 200:
                 self._state = False
             else:
-                _LOGGER.error("Can't turn off %s. Is resource/endpoint offline?",
-                              self._resource)
+                _LOGGER.error(
+                    "Can't turn off %s. Is resource/endpoint offline?",
+                    self._resource)
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Error while turn off %s", self._resource)
 

--- a/homeassistant/components/switch/rest.py
+++ b/homeassistant/components/switch/rest.py
@@ -74,7 +74,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     timeout = config.get(CONF_TIMEOUT)
 
     try:
-        with async_timeout.timeout(timeout, loop=hass.loop):
+        with async_timeout.timeout(timeout):
             req = yield from websession.get(resource, auth=auth)
 
         if req.status >= 400:
@@ -90,18 +90,17 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         return False
 
     async_add_devices(
-        [RestSwitch(hass, name, resource, method, auth, body_on, body_off,
+        [RestSwitch(name, resource, method, auth, body_on, body_off,
                     is_on_template, timeout)])
 
 
 class RestSwitch(SwitchDevice):
     """Representation of a switch that can be toggled using REST."""
 
-    def __init__(self, hass, name, resource, method, auth, body_on, body_off,
+    def __init__(self, name, resource, method, auth, body_on, body_off,
                  is_on_template, timeout):
         """Initialize the REST switch."""
         self._state = None
-        self.hass = hass
         self._name = name
         self._resource = resource
         self._method = method
@@ -128,7 +127,7 @@ class RestSwitch(SwitchDevice):
         websession = async_get_clientsession(self.hass)
 
         try:
-            with async_timeout.timeout(self._timeout, loop=self.hass.loop):
+            with async_timeout.timeout(self._timeout):
                 request = yield from getattr(websession, self._method)(
                     self._resource, auth=self._auth,
                     data=bytes(body_on_t, 'utf-8'))
@@ -149,7 +148,7 @@ class RestSwitch(SwitchDevice):
         websession = async_get_clientsession(self.hass)
 
         try:
-            with async_timeout.timeout(self._timeout, loop=self.hass.loop):
+            with async_timeout.timeout(self._timeout):
                 request = yield from getattr(websession, self._method)(
                     self._resource, auth=self._auth,
                     data=bytes(body_off_t, 'utf-8'))
@@ -169,7 +168,7 @@ class RestSwitch(SwitchDevice):
         websession = async_get_clientsession(self.hass)
 
         try:
-            with async_timeout.timeout(self._timeout, loop=self.hass.loop):
+            with async_timeout.timeout(self._timeout):
                 request = yield from websession.get(self._resource,
                     auth=self._auth)
                 text = yield from request.text()

--- a/tests/components/switch/test_rest.py
+++ b/tests/components/switch/test_rest.py
@@ -99,11 +99,13 @@ class TestRestSwitch:
         self.name = 'foo'
         self.method = 'post'
         self.resource = 'http://localhost/'
+        self.auth = None
         self.body_on = Template('on', self.hass)
         self.body_off = Template('off', self.hass)
         self.switch = rest.RestSwitch(
-            self.hass, self.name, self.resource, self.method, self.body_on,
+            self.name, self.resource, self.method, self.auth, self.body_on,
             self.body_off, None, 10)
+        self.switch.hass = self.hass
 
     def teardown_method(self):
         """Stop everything that was started."""


### PR DESCRIPTION
## Description:

This adds HTTP authentication options to `switch.rest` and reworks things a bit to avoid some code duplication.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3258

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: rest
    resource: http://10.11.12.13/api/endpoint
    username: !secret service_username
    password: !secret service_password
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).</s>
  - [ ] <s>New dependencies are only imported inside functions that use them ([example][ex-import]).</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54