### PR TITLE
Prevent error when no forecast data was available

### DIFF
--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -220,7 +220,12 @@ class BrSensor(Entity):
 
             # update all other sensors
             if self.type.startswith(SYMBOL) or self.type.startswith(CONDITION):
-                condition = data.get(FORECAST)[fcday].get(CONDITION)
+                try:
+                    condition = data.get(FORECAST)[fcday].get(CONDITION)
+                except IndexError:
+                    _LOGGER.debug("Data contained no forecast for fcday=%s...", fcday)
+                    return False
+                
                 if condition:
                     new_state = condition.get(CONDITION, None)
                     if self.type.startswith(SYMBOL):
@@ -240,7 +245,11 @@ class BrSensor(Entity):
                         return True
                 return False
             else:
-                new_state = data.get(FORECAST)[fcday].get(self.type[:-3])
+                try:
+                    new_state = data.get(FORECAST)[fcday].get(self.type[:-3])
+                except IndexError:
+                    _LOGGER.debug("Data contained no forecast for fcday=%s...", fcday)
+                    return False
 
                 if new_state != self._state:
                     self._state = new_state

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -223,7 +223,7 @@ class BrSensor(Entity):
                 try:
                     condition = data.get(FORECAST)[fcday].get(CONDITION)
                 except IndexError:
-                    _LOGGER.debug("No forecast for fcday=%s...", fcday)
+                    _LOGGER.warning("No forecast for fcday=%s...", fcday)
                     return False
 
                 if condition:
@@ -248,7 +248,7 @@ class BrSensor(Entity):
                 try:
                     new_state = data.get(FORECAST)[fcday].get(self.type[:-3])
                 except IndexError:
-                    _LOGGER.debug("No forecast for fcday=%s...", fcday)
+                    _LOGGER.warning("No forecast for fcday=%s...", fcday)
                     return False
 
                 if new_state != self._state:

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -223,9 +223,9 @@ class BrSensor(Entity):
                 try:
                     condition = data.get(FORECAST)[fcday].get(CONDITION)
                 except IndexError:
-                    _LOGGER.debug("Data contained no forecast for fcday=%s...", fcday)
+                    _LOGGER.debug("No forecast for fcday=%s...", fcday)
                     return False
-                
+
                 if condition:
                     new_state = condition.get(CONDITION, None)
                     if self.type.startswith(SYMBOL):
@@ -248,7 +248,7 @@ class BrSensor(Entity):
                 try:
                     new_state = data.get(FORECAST)[fcday].get(self.type[:-3])
                 except IndexError:
-                    _LOGGER.debug("Data contained no forecast for fcday=%s...", fcday)
+                    _LOGGER.debug("No forecast for fcday=%s...", fcday)
                     return False
 
                 if new_state != self._state:


### PR DESCRIPTION
Prevent an Error when buienradar data was available, but no forecasted data was retrieved for the requested day.

No docu change
No changes in configuration
