### PR TITLE
Prevent iCloud exceptions in logfile

### DIFF
--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -307,12 +307,15 @@ class Icloud(DeviceScanner):
             self.api.authenticate()
 
         currentminutes = dt_util.now().hour * 60 + dt_util.now().minute
-        for devicename in self.devices:
-            interval = self._intervals.get(devicename, 1)
-            if ((currentminutes % interval == 0) or
-                    (interval > 10 and
-                     currentminutes % interval in [2, 4])):
-                self.update_device(devicename)
+        try:
+            for devicename in self.devices:
+                interval = self._intervals.get(devicename, 1)
+                if ((currentminutes % interval == 0) or
+                        (interval > 10 and
+                         currentminutes % interval in [2, 4])):
+                    self.update_device(devicename)
+        except ValueError:
+            _LOGGER.debug('iCloud API returned an error.')
 
     def determine_interval(self, devicename, latitude, longitude, battery):
         """Calculate new interval."""

--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -315,7 +315,7 @@ class Icloud(DeviceScanner):
                          currentminutes % interval in [2, 4])):
                     self.update_device(devicename)
         except ValueError:
-            _LOGGER.debug('iCloud API returned an error.')
+            _LOGGER.debug("iCloud API returned an error")
 
     def determine_interval(self, devicename, latitude, longitude, battery):
         """Calculate new interval."""
@@ -400,7 +400,7 @@ class Icloud(DeviceScanner):
                     self.see(**kwargs)
                     self.seen_devices[devicename] = True
         except PyiCloudNoDevicesException:
-            _LOGGER.error('No iCloud Devices found!')
+            _LOGGER.error("No iCloud Devices found")
 
     def lost_iphone(self, devicename):
         """Call the lost iPhone function if the device is found."""


### PR DESCRIPTION
With this change ValueError exceptions in the logfile caused by this component will disappear.
These errors are caused by the iCloud API returning an HTTP 450 error and the external lib throwing a ValueError because of it.

A PR has been raised against the external library, but that fix did not yet make it into a new version of the library. This will catch the exception in the mean time.... https://github.com/picklepete/pyicloud/pull/138
