### PR TITLE
Rollback Fitbit sensor client to previous version

### DIFF
--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util.icon import icon_for_battery_level
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['fitbit==0.3.0']
+REQUIREMENTS = ['fitbit==0.2.3']
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -222,7 +222,7 @@ fedexdeliverymanager==1.0.4
 feedparser==5.2.1
 
 # homeassistant.components.sensor.fitbit
-fitbit==0.3.0
+fitbit==0.2.3
 
 # homeassistant.components.sensor.fixer
 fixerio==0.1.1


### PR DESCRIPTION
## Description:
Client update broke the component when refreshing tokens. Rollback client to previous version until permanent fix to sensor component can be made.

**Related issue (if applicable):** fixes #9152 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
