### PR TITLE
Optionally disable ssl certificate validity check.

### DIFF
--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -60,7 +60,8 @@ class XmppNotificationService(BaseNotificationService):
                      self._recipient, self._tls, self._verify, data)
 
 
-def send_message(sender, password, recipient, use_tls, verify_certificate, message):
+def send_message(sender, password, recipient, use_tls, 
+                verify_certificate, message):
     """Send a message over XMPP."""
     import sleekxmpp
 
@@ -78,7 +79,8 @@ def send_message(sender, password, recipient, use_tls, verify_certificate, messa
             self.add_event_handler('failed_auth', self.check_credentials)
             self.add_event_handler('session_start', self.start)
             if not verify_certificate:
-                self.add_event_handler('ssl_invalid_cert', self.discard_ssl_invalid_cert)
+                self.add_event_handler('ssl_invalid_cert', 
+                    self.discard_ssl_invalid_cert)
 
             self.connect(use_tls=self.use_tls, use_ssl=False)
             self.process()

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -96,7 +96,8 @@ def send_message(sender, password, recipient, use_tls,
             """Disconnect from the server if credentials are invalid."""
             self.disconnect()
 
-        def discard_ssl_invalid_cert(self, event):
+        @staticmethod
+        def discard_ssl_invalid_cert(event):
             """Do nothing if ssl certificate is invalid."""
             _LOGGER.info('Ignoring invalid ssl certificate as requested.')
             return

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -21,12 +21,14 @@ REQUIREMENTS = ['sleekxmpp==1.3.2',
 _LOGGER = logging.getLogger(__name__)
 
 CONF_TLS = 'tls'
+CONF_VERIFY = 'verify'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SENDER): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_RECIPIENT): cv.string,
     vol.Optional(CONF_TLS, default=True): cv.boolean,
+    vol.Optional(CONF_VERIFY, default=True): cv.boolean,
 })
 
 
@@ -34,18 +36,20 @@ def get_service(hass, config, discovery_info=None):
     """Get the Jabber (XMPP) notification service."""
     return XmppNotificationService(
         config.get(CONF_SENDER), config.get(CONF_PASSWORD),
-        config.get(CONF_RECIPIENT), config.get(CONF_TLS))
+        config.get(CONF_RECIPIENT), config.get(CONF_TLS),
+        config.get(CONF_VERIFY))
 
 
 class XmppNotificationService(BaseNotificationService):
     """Implement the notification service for Jabber (XMPP)."""
 
-    def __init__(self, sender, password, recipient, tls):
+    def __init__(self, sender, password, recipient, tls, verify):
         """Initialize the service."""
         self._sender = sender
         self._password = password
         self._recipient = recipient
         self._tls = tls
+        self._verify = verify
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
@@ -53,10 +57,10 @@ class XmppNotificationService(BaseNotificationService):
         data = '{}: {}'.format(title, message) if title else message
 
         send_message('{}/home-assistant'.format(self._sender), self._password,
-                     self._recipient, self._tls, data)
+                     self._recipient, self._tls, self._verify, data)
 
 
-def send_message(sender, password, recipient, use_tls, message):
+def send_message(sender, password, recipient, use_tls, verify_certificate, message):
     """Send a message over XMPP."""
     import sleekxmpp
 
@@ -73,6 +77,9 @@ def send_message(sender, password, recipient, use_tls, message):
             self.use_ipv6 = False
             self.add_event_handler('failed_auth', self.check_credentials)
             self.add_event_handler('session_start', self.start)
+            if not verify_certificate:
+                self.add_event_handler('ssl_invalid_cert', self.discard_ssl_invalid_cert)
+
             self.connect(use_tls=self.use_tls, use_ssl=False)
             self.process()
 
@@ -86,5 +93,10 @@ def send_message(sender, password, recipient, use_tls, message):
         def check_credentials(self, event):
             """Disconnect from the server if credentials are invalid."""
             self.disconnect()
+
+        def discard_ssl_invalid_cert(self, event):
+            """Do nothing if ssl certificate is invalid."""
+            _LOGGER.info('Ignoring invalid ssl certificate as requested.')
+            return
 
     SendNotificationBot()

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -60,8 +60,8 @@ class XmppNotificationService(BaseNotificationService):
                      self._recipient, self._tls, self._verify, data)
 
 
-def send_message(sender, password, recipient, use_tls, 
-                verify_certificate, message):
+def send_message(sender, password, recipient, use_tls,
+                 verify_certificate, message):
     """Send a message over XMPP."""
     import sleekxmpp
 
@@ -79,8 +79,8 @@ def send_message(sender, password, recipient, use_tls,
             self.add_event_handler('failed_auth', self.check_credentials)
             self.add_event_handler('session_start', self.start)
             if not verify_certificate:
-                self.add_event_handler('ssl_invalid_cert', 
-                    self.discard_ssl_invalid_cert)
+                self.add_event_handler('ssl_invalid_cert',
+                                       self.discard_ssl_invalid_cert)
 
             self.connect(use_tls=self.use_tls, use_ssl=False)
             self.process()


### PR DESCRIPTION
## Description:
Optionally disable SSL certificate validity check. Allow to connect to a TLS enabled server using a self signed certificate. By default, the verification is still done. The user need to add the parameter `verify: false` to disable the certificate validity check.

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: xmpp
    platform: xmpp
    sender: hass@example.com
    password: pa$$w0rd
    recipient: user@example.com
    verify: false
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/pull/3282)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
