### PR TITLE
Fix dht22 when no data was read initially #8976

### DIFF
--- a/homeassistant/components/sensor/dht.py
+++ b/homeassistant/components/sensor/dht.py
@@ -127,7 +127,7 @@ class DHTSensor(Entity):
         humidity_offset = self.humidity_offset
         data = self.dht_client.data
 
-        if self.type == SENSOR_TEMPERATURE:
+        if self.type == SENSOR_TEMPERATURE and SENSOR_TEMPERATURE in data:
             temperature = data[SENSOR_TEMPERATURE]
             _LOGGER.debug("Temperature %.1f \u00b0C + offset %.1f",
                           temperature, temperature_offset)
@@ -135,7 +135,7 @@ class DHTSensor(Entity):
                 self._state = round(temperature + temperature_offset, 1)
                 if self.temp_unit == TEMP_FAHRENHEIT:
                     self._state = round(celsius_to_fahrenheit(temperature), 1)
-        elif self.type == SENSOR_HUMIDITY:
+        elif self.type == SENSOR_HUMIDITY and SENSOR_HUMIDITY in data:
             humidity = data[SENSOR_HUMIDITY]
             _LOGGER.debug("Humidity %.1f%% + offset %.1f",
                           humidity, humidity_offset)


### PR DESCRIPTION
This fixes https://github.com/home-assistant/home-assistant/issues/8976
When no data was available the module crashes.

## Description:


**Related issue (if applicable):** fixes #8976 
