### PR TITLE
Fix and optimize digitalloggers platform

### DIFF
--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -130,6 +130,7 @@ class DINRelayDevice(object):
         self._statuslist = None
 
     def get_outlet_status(self, outlet_number):
+        """Get status of outlet from cached status list"""
         return self._statuslist[outlet_number - 1]
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)

--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -130,7 +130,7 @@ class DINRelayDevice(object):
         self._statuslist = None
 
     def get_outlet_status(self, outlet_number):
-        """Get status of outlet from cached status list"""
+        """Get status of outlet from cached status list."""
         return self._statuslist[outlet_number - 1]
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)

--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -115,8 +115,8 @@ class DINRelay(SwitchDevice):
         """Trigger update for all switches on the parent device."""
         self._parent_device.update()
 
-        outlet_status = self._parent_device._statuslist[
-                            self._outlet_number - 1]
+        outlet_status = self._parent_device.get_outlet_status(
+            self._outlet_number)
 
         self._name = outlet_status[1]
         self._state = outlet_status[2] == 'ON'
@@ -128,6 +128,9 @@ class DINRelayDevice(object):
         """Initialize the DINRelay device."""
         self._power_switch = power_switch
         self._statuslist = None
+
+    def get_outlet_status(self, outlet_number):
+        return self._statuslist[outlet_number - 1]
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -121,6 +121,7 @@ class DINRelay(SwitchDevice):
         self._name = outlet_status[1]
         self._state = outlet_status[2] == 'ON'
 
+
 class DINRelayDevice(object):
     """Device representation for per device throttling."""
 

--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -46,7 +46,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import dlipower
 
     host = config.get(CONF_HOST)
-    controllername = config.get(CONF_NAME)
+    controller_name = config.get(CONF_NAME)
     user = config.get(CONF_USERNAME)
     pswd = config.get(CONF_PASSWORD)
     tout = config.get(CONF_TIMEOUT)
@@ -61,37 +61,42 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("Could not connect to DIN III Relay")
         return False
 
-    devices = []
+    outlets = []
     parent_device = DINRelayDevice(power_switch)
 
-    devices.extend(
-        DINRelay(controllername, device.outlet_number, parent_device)
-        for device in power_switch
+    outlets.extend(
+        DINRelay(controller_name, parent_device, outlet)
+        for outlet in power_switch[0:]
     )
 
-    add_devices(devices, True)
+    add_devices(outlets)
 
 
 class DINRelay(SwitchDevice):
     """Representation of a individual DIN III relay port."""
 
-    def __init__(self, name, outletnumber, parent_device):
+    def __init__(self, controller_name, parent_device, outlet):
         """Initialize the DIN III Relay switch."""
+        self._controller_name = controller_name
         self._parent_device = parent_device
-        self.controllername = name
-        self.outletnumber = outletnumber
-        self._outletname = ''
-        self._is_on = False
+        self._outlet = outlet
+
+        self._outlet_number = self._outlet.outlet_number
+        self._name = self._outlet.description
+        self._state = self._outlet.state == 'ON'
 
     @property
     def name(self):
         """Return the display name of this relay."""
-        return self._outletname
+        return '{}_{}'.format(
+            self._controller_name,
+            self._name
+        )
 
     @property
     def is_on(self):
         """Return true if relay is on."""
-        return self._is_on
+        return self._state
 
     @property
     def should_poll(self):
@@ -100,41 +105,30 @@ class DINRelay(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Instruct the relay to turn on."""
-        self._parent_device.turn_on(outlet=self.outletnumber)
+        self._outlet.on()
 
     def turn_off(self, **kwargs):
         """Instruct the relay to turn off."""
-        self._parent_device.turn_off(outlet=self.outletnumber)
+        self._outlet.off()
 
     def update(self):
         """Trigger update for all switches on the parent device."""
         self._parent_device.update()
-        self._is_on = (
-            self._parent_device.statuslocal[self.outletnumber - 1][2] == 'ON'
-        )
-        self._outletname = '{}_{}'.format(
-            self.controllername,
-            self._parent_device.statuslocal[self.outletnumber - 1][1]
-        )
 
+        outlet_status = self._parent_device._statuslist[self._outlet_number - 1]
+
+        self._name = outlet_status[1]
+        self._state = outlet_status[2] == 'ON'
 
 class DINRelayDevice(object):
     """Device representation for per device throttling."""
 
-    def __init__(self, device):
+    def __init__(self, power_switch):
         """Initialize the DINRelay device."""
-        self._device = device
-        self.statuslocal = None
-
-    def turn_on(self, **kwargs):
-        """Instruct the relay to turn on."""
-        self._device.on(**kwargs)
-
-    def turn_off(self, **kwargs):
-        """Instruct the relay to turn off."""
-        self._device.off(**kwargs)
+        self._power_switch = power_switch
+        self._statuslist = None
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Fetch new state data for this device."""
-        self.statuslocal = self._device.statuslist()
+        self._statuslist = self._power_switch.statuslist()

--- a/homeassistant/components/switch/digitalloggers.py
+++ b/homeassistant/components/switch/digitalloggers.py
@@ -115,7 +115,8 @@ class DINRelay(SwitchDevice):
         """Trigger update for all switches on the parent device."""
         self._parent_device.update()
 
-        outlet_status = self._parent_device._statuslist[self._outlet_number - 1]
+        outlet_status = self._parent_device._statuslist[
+                            self._outlet_number - 1]
 
         self._name = outlet_status[1]
         self._state = outlet_status[2] == 'ON'


### PR DESCRIPTION
## Description:
The Digital Loggers Switch platform was broken by #8878. This is a refactor with optimization that fixes it. The platform previously made 10+ HTTP requests upon initialization, and has now been reduced to two.

**Related issue (if applicable):** fixes #8990

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**