### PR TITLE
Add "status" to Sonarr sensor

### DIFF
--- a/homeassistant/components/sensor/radarr.py
+++ b/homeassistant/components/sensor/radarr.py
@@ -162,7 +162,7 @@ class RadarrSensor(Entity):
             res = requests.get(
                 ENDPOINTS[self.type].format(
                     self.ssl, self.host, self.port, self.urlbase, start, end),
-                headers={'X-Api-Key': self.apikey}, timeout=5)
+                headers={'X-Api-Key': self.apikey}, timeout=10)
         except OSError:
             _LOGGER.error("Host %s is not available", self.host)
             self._available = False

--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -204,9 +204,9 @@ class SonarrSensor(Entity):
                     '{}?pageSize={}'.format(
                         ENDPOINTS[self.type].format(
                             self.ssl, self.host, self.port, self.urlbase),
-                            data['totalRecords']),
-                        headers={'X-Api-Key': self.apikey},
-                        timeout=10)
+                        data['totalRecords']),
+                    headers={'X-Api-Key': self.apikey},
+                    timeout=10)
                 self.data = res.json()['records']
                 self._state = len(self.data)
             elif self.type == 'diskspace':

--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -170,7 +170,7 @@ class SonarrSensor(Entity):
         try:
             res = requests.get(ENDPOINTS[self.type].format(
                 self.ssl, self.host, self.port, self.urlbase,
-                start, end), headers={'X-Api-Key': self.apikey}, timeout=5)
+                start, end), headers={'X-Api-Key': self.apikey}, timeout=10)
         except OSError:
             _LOGGER.error("Host %s is not available", self.host)
             self._available = False
@@ -197,7 +197,7 @@ class SonarrSensor(Entity):
                     ENDPOINTS[self.type].format(
                         self.ssl, self.host, self.port, self.urlbase),
                         data['totalRecords']),
-                        headers={'X-Api-Key': self.apikey}, timeout=5)
+                        headers={'X-Api-Key': self.apikey}, timeout=10)
                 self.data = res.json()['records']
                 self._state = len(self.data)
             elif self.type == 'diskspace':

--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -40,13 +40,13 @@ SENSOR_TYPES = {
 }
 
 ENDPOINTS = {
-    'diskspace': 'http{0}://{1}:{2}/{3}api/diskspace?apikey={4}',
-    'queue': 'http{0}://{1}:{2}/{3}api/queue?apikey={4}',
+    'diskspace': 'http{0}://{1}:{2}/{3}api/diskspace',
+    'queue': 'http{0}://{1}:{2}/{3}api/queue',
     'upcoming':
-        'http{0}://{1}:{2}/{3}api/calendar?apikey={4}&start={5}&end={6}',
-    'wanted': 'http{0}://{1}:{2}/{3}api/wanted/missing?apikey={4}',
-    'series': 'http{0}://{1}:{2}/{3}api/series?apikey={4}',
-    'commands': 'http{0}://{1}:{2}/{3}api/command?apikey={4}'
+        'http{0}://{1}:{2}/{3}api/calendar?start={4}&end={5}',
+    'wanted': 'http{0}://{1}:{2}/{3}api/wanted/missing',
+    'series': 'http{0}://{1}:{2}/{3}api/series',
+    'commands': 'http{0}://{1}:{2}/{3}api/command'
 }
 
 # Support to Yottabytes for the future, why not
@@ -169,8 +169,8 @@ class SonarrSensor(Entity):
         end = get_date(self._tz, self.days)
         try:
             res = requests.get(ENDPOINTS[self.type].format(
-                self.ssl, self.host, self.port, self.urlbase, self.apikey,
-                start, end), timeout=5)
+                self.ssl, self.host, self.port, self.urlbase,
+                start, end), headers={'X-Api-Key': self.apikey}, timeout=5)
         except OSError:
             _LOGGER.error("Host %s is not available", self.host)
             self._available = False
@@ -193,10 +193,11 @@ class SonarrSensor(Entity):
                 self._state = len(self.data)
             elif self.type == 'wanted':
                 data = res.json()
-                res = requests.get('{}&pageSize={}'.format(
+                res = requests.get('{}?pageSize={}'.format(
                     ENDPOINTS[self.type].format(
-                        self.ssl, self.host, self.port, self.urlbase,
-                        self.apikey), data['totalRecords']), timeout=5)
+                        self.ssl, self.host, self.port, self.urlbase),
+                        data['totalRecords']),
+                        headers={'X-Api-Key': self.apikey}, timeout=5)
                 self.data = res.json()['records']
                 self._state = len(self.data)
             elif self.type == 'diskspace':

--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -172,9 +172,12 @@ class SonarrSensor(Entity):
         start = get_date(self._tz)
         end = get_date(self._tz, self.days)
         try:
-            res = requests.get(ENDPOINTS[self.type].format(
-                self.ssl, self.host, self.port, self.urlbase,
-                start, end), headers={'X-Api-Key': self.apikey}, timeout=10)
+            res = requests.get(
+                ENDPOINTS[self.type].format(
+                    self.ssl, self.host, self.port,
+                    self.urlbase, start, end),
+                headers={'X-Api-Key': self.apikey},
+                timeout=10)
         except OSError:
             _LOGGER.error("Host %s is not available", self.host)
             self._available = False
@@ -197,11 +200,13 @@ class SonarrSensor(Entity):
                 self._state = len(self.data)
             elif self.type == 'wanted':
                 data = res.json()
-                res = requests.get('{}?pageSize={}'.format(
-                    ENDPOINTS[self.type].format(
-                        self.ssl, self.host, self.port, self.urlbase),
-                        data['totalRecords']),
-                        headers={'X-Api-Key': self.apikey}, timeout=10)
+                res = requests.get(
+                    '{}?pageSize={}'.format(
+                        ENDPOINTS[self.type].format(
+                            self.ssl, self.host, self.port, self.urlbase),
+                            data['totalRecords']),
+                        headers={'X-Api-Key': self.apikey},
+                        timeout=10)
                 self.data = res.json()['records']
                 self._state = len(self.data)
             elif self.type == 'diskspace':

--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -36,7 +36,8 @@ SENSOR_TYPES = {
     'upcoming': ['Upcoming', 'Episodes', 'mdi:television'],
     'wanted': ['Wanted', 'Episodes', 'mdi:television'],
     'series': ['Series', 'Shows', 'mdi:television'],
-    'commands': ['Commands', 'Commands', 'mdi:code-braces']
+    'commands': ['Commands', 'Commands', 'mdi:code-braces'],
+    'status': ['Status', 'Status', 'mdi:information']
 }
 
 ENDPOINTS = {
@@ -46,7 +47,8 @@ ENDPOINTS = {
         'http{0}://{1}:{2}/{3}api/calendar?start={4}&end={5}',
     'wanted': 'http{0}://{1}:{2}/{3}api/wanted/missing',
     'series': 'http{0}://{1}:{2}/{3}api/series',
-    'commands': 'http{0}://{1}:{2}/{3}api/command'
+    'commands': 'http{0}://{1}:{2}/{3}api/command',
+    'status': 'http{0}://{1}:{2}/{3}api/system/status'
 }
 
 # Support to Yottabytes for the future, why not
@@ -156,6 +158,8 @@ class SonarrSensor(Entity):
             for show in self.data:
                 attributes[show['title']] = '{}/{} Episodes'.format(
                     show['episodeFileCount'], show['episodeCount'])
+        elif self.type == 'status':
+            attributes = self.data
         return attributes
 
     @property
@@ -218,6 +222,9 @@ class SonarrSensor(Entity):
                         self._unit
                     )
                 )
+            elif self.type == 'status':
+                self.data = res.json()
+                self._state = self.data['version']
             self._available = True
 
 

--- a/tests/components/sensor/test_sonarr.py
+++ b/tests/components/sensor/test_sonarr.py
@@ -828,7 +828,7 @@ class TestSonarrSetup(unittest.TestCase):
                 'status'
             ]
         }
-        radarr.setup_platform(self.hass, config, self.add_devices, None)
+        sonarr.setup_platform(self.hass, config, self.add_devices, None)
         for device in self.DEVICES:
             device.update()
             self.assertEqual('2.0.0.1121', device.state)

--- a/tests/components/sensor/test_sonarr.py
+++ b/tests/components/sensor/test_sonarr.py
@@ -553,18 +553,18 @@ def mocked_requests_get(*args, **kwargs):
         return MockResponse({
             "version": "2.0.0.1121",
             "buildTime": "2014-02-08T20:49:36.5560392Z",
-            "isDebug": false,
-            "isProduction": true,
-            "isAdmin": true,
-            "isUserInteractive": false,
+            "isDebug": "false",
+            "isProduction": "true",
+            "isAdmin": "true",
+            "isUserInteractive": "false",
             "startupPath": "C:\\ProgramData\\NzbDrone\\bin",
             "appData": "C:\\ProgramData\\NzbDrone",
             "osVersion": "6.2.9200.0",
-            "isMono": false,
-            "isLinux": false,
-            "isWindows": true,
+            "isMono": "false",
+            "isLinux": "false",
+            "isWindows": "true",
             "branch": "develop",
-            "authentication": false,
+            "authentication": "false",
             "startOfWeek": 0,
             "urlBase": ""
         }, 200)
@@ -837,7 +837,7 @@ class TestSonarrSetup(unittest.TestCase):
             self.assertEqual(
                 '6.2.9200.0',
                 device.device_state_attributes['osVersion'])
-            
+
     @pytest.mark.skip
     @unittest.mock.patch('requests.get', side_effect=mocked_requests_get)
     def test_ssl(self, req_mock):

--- a/tests/components/sensor/test_sonarr.py
+++ b/tests/components/sensor/test_sonarr.py
@@ -549,6 +549,25 @@ def mocked_requests_get(*args, **kwargs):
                 "totalSpace": 499738734592
             }
         ], 200)
+    elif 'api/system/status' in url:
+        return MockResponse({
+            "version": "2.0.0.1121",
+            "buildTime": "2014-02-08T20:49:36.5560392Z",
+            "isDebug": false,
+            "isProduction": true,
+            "isAdmin": true,
+            "isUserInteractive": false,
+            "startupPath": "C:\\ProgramData\\NzbDrone\\bin",
+            "appData": "C:\\ProgramData\\NzbDrone",
+            "osVersion": "6.2.9200.0",
+            "isMono": false,
+            "isLinux": false,
+            "isWindows": true,
+            "branch": "develop",
+            "authentication": false,
+            "startOfWeek": 0,
+            "urlBase": ""
+        }, 200)
     else:
         return MockResponse({
             "error": "Unauthorized"
@@ -794,6 +813,31 @@ class TestSonarrSetup(unittest.TestCase):
                 device.device_state_attributes["Bob's Burgers"]
             )
 
+    @unittest.mock.patch('requests.get', side_effect=mocked_requests_get)
+    def test_system_status(self, req_mock):
+        """Test getting system status"""
+        config = {
+            'platform': 'sonarr',
+            'api_key': 'foo',
+            'days': '2',
+            'unit': 'GB',
+            "include_paths": [
+                '/data'
+            ],
+            'monitored_conditions': [
+                'status'
+            ]
+        }
+        radarr.setup_platform(self.hass, config, self.add_devices, None)
+        for device in self.DEVICES:
+            device.update()
+            self.assertEqual('2.0.0.1121', device.state)
+            self.assertEqual('mdi:information', device.icon)
+            self.assertEqual('Sonarr Status', device.name)
+            self.assertEqual(
+                '6.2.9200.0',
+                device.device_state_attributes['osVersion'])
+            
     @pytest.mark.skip
     @unittest.mock.patch('requests.get', side_effect=mocked_requests_get)
     def test_ssl(self, req_mock):


### PR DESCRIPTION
## Description:
Adds [system status](https://github.com/Sonarr/Sonarr/wiki/System-Status) information to the Sonarr sensor.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: sonarr
    api_key: !secret sonarr_api_key
    host: 192.168.1.100
    days: 7
    monitored_conditions:
      - status
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
