### PR TITLE
Allow customizable turn on action for LG WebOS tv

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -127,9 +127,9 @@ def setup_tv(
         configurator = hass.components.configurator
         configurator.request_done(request_id)
 
-    add_devices([LgWebOSDevice(host, mac, name, customize, config, timeout,
-        hass, turn_on_action)],
-                True)
+    add_devices(
+        [LgWebOSDevice(host, mac, name, customize, config, timeout,
+        hass, turn_on_action)], True)
 
 
 def request_configuration(
@@ -161,7 +161,8 @@ def request_configuration(
 class LgWebOSDevice(MediaPlayerDevice):
     """Representation of a LG WebOS TV."""
 
-    def __init__(self, host, mac, name, customize, config, timeout,
+    def __init__(
+        self, host, mac, name, customize, config, timeout,
         hass, on_action):
         """Initialize the webos device."""
         from pylgtv import WebOsClient

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -129,7 +129,7 @@ def setup_tv(
 
     add_devices(
         [LgWebOSDevice(host, mac, name, customize, config, timeout,
-        hass, turn_on_action)], True)
+            hass, turn_on_action)], True)
 
 
 def request_configuration(
@@ -163,7 +163,7 @@ class LgWebOSDevice(MediaPlayerDevice):
 
     def __init__(
         self, host, mac, name, customize, config, timeout,
-        hass, on_action):
+            hass, on_action):
         """Initialize the webos device."""
         from pylgtv import WebOsClient
         from wakeonlan import wol

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -86,7 +86,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     config = hass.config.path(config.get(CONF_FILENAME))
 
     setup_tv(host, name, customize, config, timeout, hass,
-    add_devices, turn_on_action)
+        add_devices, turn_on_action)
 
 
 def setup_tv(
@@ -125,9 +125,8 @@ def setup_tv(
         configurator = hass.components.configurator
         configurator.request_done(request_id)
 
-    add_devices(
-        [LgWebOSDevice(host, name, customize, config, timeout,
-            hass, turn_on_action)], True)
+    add_devices([LgWebOSDevice(host, name, customize, config, timeout,
+        hass, turn_on_action)], True)
 
 
 def request_configuration(

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     STATE_PLAYING, STATE_PAUSED,
     STATE_UNKNOWN, CONF_NAME, CONF_FILENAME)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.script import Script
 
 REQUIREMENTS = ['pylgtv==0.1.7',
                 'websockets==3.2',
@@ -32,6 +33,7 @@ _CONFIGURING = {}  # type: Dict[str, str]
 _LOGGER = logging.getLogger(__name__)
 
 CONF_SOURCES = 'sources'
+CONF_ON_ACTION = 'turn_on_action'
 
 DEFAULT_NAME = 'LG webOS Smart TV'
 
@@ -57,6 +59,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_CUSTOMIZE, default={}): CUSTOMIZE_SCHEMA,
     vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string,
     vol.Optional(CONF_TIMEOUT, default=10): cv.positive_int,
+    vol.Optional(CONF_ON_ACTION): cv.SCRIPT_SCHEMA,
 })
 
 
@@ -80,11 +83,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     customize = config.get(CONF_CUSTOMIZE)
     timeout = config.get(CONF_TIMEOUT)
+    turn_on_action = config.get(CONF_ON_ACTION)
+
     config = hass.config.path(config.get(CONF_FILENAME))
-    setup_tv(host, mac, name, customize, config, timeout, hass, add_devices)
+
+    setup_tv(host, mac, name, customize, config, timeout, hass,
+        add_devices, turn_on_action)
 
 
-def setup_tv(host, mac, name, customize, config, timeout, hass, add_devices):
+def setup_tv(host, mac, name, customize, config, timeout, hass,
+    add_devices, turn_on_action):
     """Set up a LG WebOS TV based on host parameter."""
     from pylgtv import WebOsClient
     from pylgtv import PyLGTVPairException
@@ -108,7 +116,8 @@ def setup_tv(host, mac, name, customize, config, timeout, hass, add_devices):
             # Not registered, request configuration.
             _LOGGER.warning("LG webOS TV %s needs to be paired", host)
             request_configuration(
-                host, mac, name, customize, config, timeout, hass, add_devices)
+                host, mac, name, customize, config, timeout, hass,
+                add_devices, turn_on_action)
             return
 
     # If we came here and configuring this host, mark as done.
@@ -117,12 +126,14 @@ def setup_tv(host, mac, name, customize, config, timeout, hass, add_devices):
         configurator = hass.components.configurator
         configurator.request_done(request_id)
 
-    add_devices([LgWebOSDevice(host, mac, name, customize, config, timeout)],
+    add_devices([LgWebOSDevice(host, mac, name, customize, config, timeout,
+        hass, turn_on_action)],
                 True)
 
 
 def request_configuration(
-        host, mac, name, customize, config, timeout, hass, add_devices):
+        host, mac, name, customize, config, timeout, hass,
+        add_devices, turn_on_action):
     """Request configuration steps from the user."""
     configurator = hass.components.configurator
 
@@ -136,7 +147,7 @@ def request_configuration(
     def lgtv_configuration_callback(data):
         """The actions to do when our configuration callback is called."""
         setup_tv(host, mac, name, customize, config, timeout, hass,
-                 add_devices)
+                 add_devices, turn_on_action)
 
     _CONFIGURING[host] = configurator.request_config(
         name, lgtv_configuration_callback,
@@ -149,13 +160,15 @@ def request_configuration(
 class LgWebOSDevice(MediaPlayerDevice):
     """Representation of a LG WebOS TV."""
 
-    def __init__(self, host, mac, name, customize, config, timeout):
+    def __init__(self, host, mac, name, customize, config, timeout,
+        hass, on_action):
         """Initialize the webos device."""
         from pylgtv import WebOsClient
         from wakeonlan import wol
         self._client = WebOsClient(host, config, timeout)
         self._wol = wol
         self._mac = mac
+        self._on_script = Script(hass, on_action) if on_action else None
         self._customize = customize
 
         self._name = name
@@ -273,7 +286,7 @@ class LgWebOSDevice(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        if self._mac:
+        if self._mac or self._on_script:
             return SUPPORT_WEBOSTV | SUPPORT_TURN_ON
         return SUPPORT_WEBOSTV
 
@@ -291,6 +304,8 @@ class LgWebOSDevice(MediaPlayerDevice):
         """Turn on the media player."""
         if self._mac:
             self._wol.send_magic_packet(self._mac)
+        elif self._on_script:
+            self._on_script.run()
 
     def volume_up(self):
         """Volume up the media player."""

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -19,7 +19,7 @@ from homeassistant.components.media_player import (
     SUPPORT_SELECT_SOURCE, SUPPORT_PLAY_MEDIA, MEDIA_TYPE_CHANNEL,
     MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
-    CONF_HOST, CONF_MAC, CONF_CUSTOMIZE, CONF_TIMEOUT, STATE_OFF,
+    CONF_HOST, CONF_CUSTOMIZE, CONF_TIMEOUT, STATE_OFF,
     STATE_PLAYING, STATE_PAUSED,
     STATE_UNKNOWN, CONF_NAME, CONF_FILENAME)
 import homeassistant.helpers.config_validation as cv
@@ -55,7 +55,6 @@ CUSTOMIZE_SCHEMA = vol.Schema({
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_HOST): cv.string,
-    vol.Optional(CONF_MAC): cv.string,
     vol.Optional(CONF_CUSTOMIZE, default={}): CUSTOMIZE_SCHEMA,
     vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string,
     vol.Optional(CONF_TIMEOUT, default=10): cv.positive_int,
@@ -79,7 +78,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if host in _CONFIGURING:
         return
 
-    mac = config.get(CONF_MAC)
     name = config.get(CONF_NAME)
     customize = config.get(CONF_CUSTOMIZE)
     timeout = config.get(CONF_TIMEOUT)
@@ -87,12 +85,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     config = hass.config.path(config.get(CONF_FILENAME))
 
-    setup_tv(host, mac, name, customize, config, timeout, hass,
+    setup_tv(host, name, customize, config, timeout, hass,
     add_devices, turn_on_action)
 
 
 def setup_tv(
-    host, mac, name, customize, config, timeout, hass,
+    host, name, customize, config, timeout, hass,
         add_devices, turn_on_action):
     """Set up a LG WebOS TV based on host parameter."""
     from pylgtv import WebOsClient
@@ -117,7 +115,7 @@ def setup_tv(
             # Not registered, request configuration.
             _LOGGER.warning("LG webOS TV %s needs to be paired", host)
             request_configuration(
-                host, mac, name, customize, config, timeout, hass,
+                host, name, customize, config, timeout, hass,
                 add_devices, turn_on_action)
             return
 
@@ -128,12 +126,12 @@ def setup_tv(
         configurator.request_done(request_id)
 
     add_devices(
-        [LgWebOSDevice(host, mac, name, customize, config, timeout,
+        [LgWebOSDevice(host, name, customize, config, timeout,
             hass, turn_on_action)], True)
 
 
 def request_configuration(
-        host, mac, name, customize, config, timeout, hass,
+        host, name, customize, config, timeout, hass,
         add_devices, turn_on_action):
     """Request configuration steps from the user."""
     configurator = hass.components.configurator
@@ -147,7 +145,7 @@ def request_configuration(
     # pylint: disable=unused-argument
     def lgtv_configuration_callback(data):
         """The actions to do when our configuration callback is called."""
-        setup_tv(host, mac, name, customize, config, timeout, hass,
+        setup_tv(host, name, customize, config, timeout, hass,
                  add_devices, turn_on_action)
 
     _CONFIGURING[host] = configurator.request_config(
@@ -162,14 +160,11 @@ class LgWebOSDevice(MediaPlayerDevice):
     """Representation of a LG WebOS TV."""
 
     def __init__(
-        self, host, mac, name, customize, config, timeout,
+        self, host, name, customize, config, timeout,
             hass, on_action):
         """Initialize the webos device."""
         from pylgtv import WebOsClient
-        from wakeonlan import wol
         self._client = WebOsClient(host, config, timeout)
-        self._wol = wol
-        self._mac = mac
         self._on_script = Script(hass, on_action) if on_action else None
         self._customize = customize
 
@@ -288,7 +283,7 @@ class LgWebOSDevice(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        if self._mac or self._on_script:
+        if self._on_script:
             return SUPPORT_WEBOSTV | SUPPORT_TURN_ON
         return SUPPORT_WEBOSTV
 
@@ -304,9 +299,7 @@ class LgWebOSDevice(MediaPlayerDevice):
 
     def turn_on(self):
         """Turn on the media player."""
-        if self._mac:
-            self._wol.send_magic_packet(self._mac)
-        elif self._on_script:
+        if self._on_script:
             self._on_script.run()
 
     def volume_up(self):

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -86,12 +86,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     config = hass.config.path(config.get(CONF_FILENAME))
 
     setup_tv(host, name, customize, config, timeout, hass,
-        add_devices, turn_on_action)
+             add_devices, turn_on_action)
 
 
-def setup_tv(
-    host, name, customize, config, timeout, hass,
-        add_devices, turn_on_action):
+def setup_tv(host, name, customize, config, timeout, hass,
+             add_devices, turn_on_action):
     """Set up a LG WebOS TV based on host parameter."""
     from pylgtv import WebOsClient
     from pylgtv import PyLGTVPairException
@@ -126,7 +125,7 @@ def setup_tv(
         configurator.request_done(request_id)
 
     add_devices([LgWebOSDevice(host, name, customize, config, timeout,
-        hass, turn_on_action)], True)
+                               hass, turn_on_action)], True)
 
 
 def request_configuration(
@@ -158,9 +157,8 @@ def request_configuration(
 class LgWebOSDevice(MediaPlayerDevice):
     """Representation of a LG WebOS TV."""
 
-    def __init__(
-        self, host, name, customize, config, timeout,
-            hass, on_action):
+    def __init__(self, host, name, customize, config, timeout,
+                 hass, on_action):
         """Initialize the webos device."""
         from pylgtv import WebOsClient
         self._client = WebOsClient(host, config, timeout)

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -88,10 +88,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     config = hass.config.path(config.get(CONF_FILENAME))
 
     setup_tv(host, mac, name, customize, config, timeout, hass,
-        add_devices, turn_on_action)
+    add_devices, turn_on_action)
 
 
-def setup_tv(host, mac, name, customize, config, timeout, hass,
+def setup_tv(
+    host, mac, name, customize, config, timeout, hass,
     add_devices, turn_on_action):
     """Set up a LG WebOS TV based on host parameter."""
     from pylgtv import WebOsClient

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -93,7 +93,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 def setup_tv(
     host, mac, name, customize, config, timeout, hass,
-    add_devices, turn_on_action):
+        add_devices, turn_on_action):
     """Set up a LG WebOS TV based on host parameter."""
     from pylgtv import WebOsClient
     from pylgtv import PyLGTVPairException


### PR DESCRIPTION
## Description:
Currently, the webostv media_player component allows for WoL to turn the TV on, as turning it on via network is not possible. Not all LG WebOS TV models have the WoL functionality however all (I believe) of the TVs do have some form of a RS-232 input which allows you to directly communicate with the TV to do things like turn it on (even if it is off) among other things.

I have added the ability to specify an action. We now have two ways of turning this TV on - WoL or action. Currently WoL takes precedence over default action if both are specified.

*Input Required*: As indicated, the current functionality allows for WoL and now custom action, however I _feel_ like this is a bit clunky. There should only be 1 way to do this. HASS already has a WoL switch which can be created specifically for the TV and referenced through the turn on action (and set to hidden to keep hass clean). This would allow me to get rid of the current WoL functionality for the LG WebOS tv, however this is a breaking change and I would be hesitant to do this without getting the OK of someone higher up.
Alternatively, I can leave it as is with a note in the docs about the precedence or I can somehow raise an error if both are specified. Please let me know which way you'd like. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3442

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: webostv
    host: lgtv.example.com
    name: Living Room TV
    turn_on_action:
      service: persistent_notification.create
      data:
        message: "foobar!"
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)


If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [na] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [na] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [na] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [na] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
