### PR TITLE
Upgrade pymysensors to 0.11.1

### DIFF
--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.loader import get_component
 from homeassistant.setup import setup_component
 
-REQUIREMENTS = ['pymysensors==0.11.0']
+REQUIREMENTS = ['pymysensors==0.11.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -658,7 +658,7 @@ pymodbus==1.3.1
 pymyq==0.0.8
 
 # homeassistant.components.mysensors
-pymysensors==0.11.0
+pymysensors==0.11.1
 
 # homeassistant.components.lock.nello
 pynello==1.5


### PR DESCRIPTION
## Description:
Hotfix update for pymysensors. See https://github.com/theolind/pymysensors/releases/tag/0.11.1 for more info.

**Related issue (if applicable):**
Issues reported in our forums:
https://community.home-assistant.io/t/problem-with-mysensors-mqtt-client-gateway-in-0-52/25623
https://community.home-assistant.io/t/0-52-0-mysensors-sensor-value-out-of-bounds-but-really-isnt/25631

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
