### PR TITLE
Allow sonos to select album as a source

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -897,7 +897,8 @@ class SonosDevice(MediaPlayerDevice):
                 src = fav.pop()
                 self._source_name = src['title']
 
-                if 'object.container.playlistContainer' in src['meta']:
+                if ('object.container.playlistContainer' in src['meta'] or
+                        'object.container.album.musicAlbum' in src['meta']):
                     self._replace_queue_with_playlist(src)
                     self._player.play_from_queue(0)
                 else:


### PR DESCRIPTION
Importing the fix in the PR https://github.com/home-assistant/home-assistant/pull/8258 I noticed that the same error is present also for Spotify album so I have extended the code and tested it. It works fine on my setup

## Description:


**Related issue (if applicable):** improve #5598

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
