### PR TITLE
Upgrade discord.py to 0.16.11

### DIFF
--- a/homeassistant/components/notify/discord.py
+++ b/homeassistant/components/notify/discord.py
@@ -15,7 +15,7 @@ from homeassistant.components.notify import (
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['discord.py==0.16.10']
+REQUIREMENTS = ['discord.py==0.16.11']
 
 CONF_TOKEN = 'token'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -172,7 +172,7 @@ denonavr==0.5.2
 directpy==0.1
 
 # homeassistant.components.notify.discord
-discord.py==0.16.10
+discord.py==0.16.11
 
 # homeassistant.components.updater
 distro==1.0.4


### PR DESCRIPTION
## 0.16.11
- [Commit log](https://github.com/Rapptz/discord.py/commits/async)

Tested with the following configuration:

``` yaml
notify:
  - name: discord
    platform: discord
    token: !secret discord
```

Message sent with "Call Service"

``` json
{
  "message": "A message from Home Assistant",
  "target": [
    "3342155142827212455"
    ]
}
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.