### PR TITLE
Fix possible KeyError in mysensors callback

### DIFF
--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -485,12 +485,14 @@ def gw_callback_factory(hass):
         validated = validate_child(msg.gateway, msg.node_id, child)
         for platform, dev_ids in validated.items():
             devices = get_mysensors_devices(hass, platform)
-            for idx, dev_id in enumerate(list(dev_ids)):
+            new_dev_ids = []
+            for dev_id in dev_ids:
                 if dev_id in devices:
-                    dev_ids.pop(idx)
                     signals.append(SIGNAL_CALLBACK.format(*dev_id))
-            if dev_ids:
-                discover_mysensors_platform(hass, platform, dev_ids)
+                else:
+                    new_dev_ids.append(dev_id)
+            if new_dev_ids:
+                discover_mysensors_platform(hass, platform, new_dev_ids)
         for signal in set(signals):
             # Only one signal per device is needed.
             # A device can have multiple platforms, ie multiple schemas.


### PR DESCRIPTION
## Description:
* Multiple devices per child per platform would lead to KeyError in callback.

**Related issue (if applicable):**
https://github.com/theolind/pymysensors/issues/109

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
