### PR TITLE
Added configurable timeout for receiver HTTP requests | Additional AV…

### DIFF
--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -56,7 +56,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
 })
 
-NewHost = namedtuple('NewHost', ['host', 'name', 'timeout'])
+NewHost = namedtuple('NewHost', ['host', 'name'])
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -90,13 +90,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if config.get(CONF_HOST) is not None:
         host = config.get(CONF_HOST)
         name = config.get(CONF_NAME)
-        new_hosts.append(NewHost(host=host, name=name, timeout=timeout))
+        new_hosts.append(NewHost(host=host, name=name))
 
     # 2. option: discovery using netdisco
     if discovery_info is not None:
         host = discovery_info.get('host')
         name = discovery_info.get('name')
-        new_hosts.append(NewHost(host=host, name=name, timeout=timeout))
+        new_hosts.append(NewHost(host=host, name=name))
 
     # 3. option: discovery using denonavr library
     if config.get(CONF_HOST) is None and discovery_info is None:
@@ -107,14 +107,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 host = d_receiver["host"]
                 name = d_receiver["friendlyName"]
                 new_hosts.append(
-                    NewHost(host=host, name=name, timeout=timeout))
+                    NewHost(host=host, name=name))
 
     for entry in new_hosts:
         # Check if host not in cache, append it and save for later
         # starting
         if entry.host not in cache:
             new_device = denonavr.DenonAVR(
-                entry.host, entry.name, show_all_sources, add_zones)
+                host=entry.host, name=entry.name,
+                show_all_inputs=show_all_sources, timeout=timeout,
+                add_zones=add_zones)
             for new_zone in new_device.zones.values():
                 receivers.append(DenonDevice(new_zone))
             cache.add(host)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -166,7 +166,7 @@ datapoint==0.4.3
 # decora_wifi==1.3
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.5.2
+denonavr==0.5.3
 
 # homeassistant.components.media_player.directv
 directpy==0.1


### PR DESCRIPTION
…R-X detection based on CommApiVers | Treat Marantz SR6007 - SR6010 as AVR-X device

## Description:
Version 0.5.3 of denonavr library including...
- Added configurable timeout for receiver HTTP requests
- Additional AVR-X detection based on CommApiVers
- Treat Marantz SR6007 - SR6010 as AVR-X device

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3289

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
media_player:
  - platform: denonavr
    host: IP_ADDRESS
    name: NAME
    show_all_sources: True / False
    timeout: POSITIVE INTEGER
    zones:
      - zone: Zone2 / Zone3
        name: NAME
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
