### PR TITLE
Fix for DTE Energy Bridge returning the wrong units from time to time

### DIFF
--- a/homeassistant/components/sensor/dte_energy_bridge.py
+++ b/homeassistant/components/sensor/dte_energy_bridge.py
@@ -91,4 +91,9 @@ class DteEnergyBridgeSensor(Entity):
                 response.text, self._name)
             return
 
-        self._state = float(response_split[0])
+        val = float(response_split[0])
+
+        # A workaround for a bug in the DTE energy bridge.
+        # The returned value can randomly be in W or kW.  Checking for a
+        # a decimal seems to be a reliable way to determine the units.
+        self._state = val if '.' in response_split[0] else val / 1000

--- a/tests/components/sensor/test_dte_energy_bridge.py
+++ b/tests/components/sensor/test_dte_energy_bridge.py
@@ -1,0 +1,68 @@
+"""The tests for the DTE Energy Bridge."""
+
+import unittest
+
+import requests_mock
+
+from homeassistant.setup import setup_component
+
+from tests.common import get_test_home_assistant
+
+DTE_ENERGY_BRIDGE_CONFIG = {
+    'platform': 'dte_energy_bridge',
+    'ip': '192.168.1.1',
+}
+
+
+class TestDteEnergyBridgeSetup(unittest.TestCase):
+    """Test the DTE Energy Bridge platform."""
+
+    def setUp(self):
+        """Initialize values for this testcase class."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_setup_with_config(self):
+        """Test the platform setup with configuration."""
+        self.assertTrue(
+            setup_component(self.hass, 'sensor',
+                            {'dte_energy_bridge': DTE_ENERGY_BRIDGE_CONFIG}))
+
+    @requests_mock.Mocker()
+    def test_setup_correct_reading(self, mock_req):
+        """Test DTE Energy bridge returns a correct value."""
+        mock_req.get("http://{}/instantaneousdemand"
+                     .format(DTE_ENERGY_BRIDGE_CONFIG['ip']),
+                     text='.411 kW')
+        assert setup_component(self.hass, 'sensor', {
+            'sensor': DTE_ENERGY_BRIDGE_CONFIG})
+        self.assertEqual('0.411',
+                         self.hass.states
+                         .get('sensor.current_energy_usage').state)
+
+    @requests_mock.Mocker()
+    def test_setup_incorrect_units_reading(self, mock_req):
+        """Test DTE Energy bridge handles a value with incorrect units."""
+        mock_req.get("http://{}/instantaneousdemand"
+                     .format(DTE_ENERGY_BRIDGE_CONFIG['ip']),
+                     text='411 kW')
+        assert setup_component(self.hass, 'sensor', {
+            'sensor': DTE_ENERGY_BRIDGE_CONFIG})
+        self.assertEqual('0.411',
+                         self.hass.states
+                         .get('sensor.current_energy_usage').state)
+
+    @requests_mock.Mocker()
+    def test_setup_bad_format_reading(self, mock_req):
+        """Test DTE Energy bridge handles an invalid value."""
+        mock_req.get("http://{}/instantaneousdemand"
+                     .format(DTE_ENERGY_BRIDGE_CONFIG['ip']),
+                     text='411')
+        assert setup_component(self.hass, 'sensor', {
+            'sensor': DTE_ENERGY_BRIDGE_CONFIG})
+        self.assertEqual('unknown',
+                         self.hass.states
+                         .get('sensor.current_energy_usage').state)


### PR DESCRIPTION
## Description:

The DTE Energy Bridge seems to return the current energy
usage randomly in either W or kW.  The only way to tell the difference
is if there is a decimal or not in the result.

Also added some tests.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
