### PR TITLE
 Make sure Ring binary_sensor state will update only if device_id matches

### DIFF
--- a/homeassistant/components/binary_sensor/ring.py
+++ b/homeassistant/components/binary_sensor/ring.py
@@ -103,7 +103,8 @@ class RingBinarySensor(BinarySensorDevice):
         self._data.check_alerts()
 
         if self._data.alert:
-            self._state = (self._sensor_type ==
-                           self._data.alert.get('kind'))
+            if self._sensor_type == self._data.alert.get('kind') and \
+               self._data.account_id == self._data.alert.get('doorbot_id'):
+                self._state = True
         else:
             self._state = False

--- a/tests/fixtures/ring_ding_active.json
+++ b/tests/fixtures/ring_ding_active.json
@@ -2,7 +2,7 @@
     "audio_jitter_buffer_ms": 0,
     "device_kind": "lpd_v1",
     "doorbot_description": "Front Door",
-    "doorbot_id": 12345,
+    "doorbot_id": 987652,
     "expires_in": 180,
     "id": 123456789,
     "id_str": "123456789",


### PR DESCRIPTION
## Description:

This PR fixes the issue #8279 which make sure the `device.state` will only be updated if the `device.id` matches with the notification alert received.

**Related issue (if applicable):** fixes #8279 

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: ring
    monitored_conditions:
      - ding
      - motion
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.