### PR TITLE
Fix nello.io login

### DIFF
--- a/homeassistant/components/lock/nello.py
+++ b/homeassistant/components/lock/nello.py
@@ -13,7 +13,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.lock import (LockDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_PASSWORD, CONF_USERNAME)
 
-REQUIREMENTS = ['pynello==1.5']
+REQUIREMENTS = ['pynello==1.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -667,7 +667,7 @@ pymyq==0.0.8
 pymysensors==0.11.1
 
 # homeassistant.components.lock.nello
-pynello==1.5
+pynello==1.5.1
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3.3


### PR DESCRIPTION
## Description:
This morning the nello.io team updated their login procedure. This here updates `pynello` so that user can login again.

## Example entry for `configuration.yaml` (if applicable):
```yaml
lock:
  - platform: nello
    username: !secret nello_user
    password: !secret nello_pass
```