### PR TITLE
Version bump of DLink switch to v0.6.0

### DIFF
--- a/homeassistant/components/switch/dlink.py
+++ b/homeassistant/components/switch/dlink.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import TEMP_CELSIUS, STATE_UNKNOWN
 
-REQUIREMENTS = ['pyW215==0.5.1']
+REQUIREMENTS = ['pyW215==0.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -539,7 +539,7 @@ pyHS100==0.2.4.2
 pyRFXtrx==0.20.0
 
 # homeassistant.components.switch.dlink
-pyW215==0.5.1
+pyW215==0.6.0
 
 # homeassistant.components.alarm_control_panel.alarmdotcom
 pyalarmdotcom==0.3.0


### PR DESCRIPTION
## Description:

Version update from 0.5.1 to 0.6.0 for the pyW215 library. This release introduces bug fixes relevant for the v1.24 and v1.25 firmware release. Other firmware versions should not experience any difference. Please read https://github.com/LinuxChristian/pyW215/issues/22 for more information.

No new parameters or docs introduced in this release.