### PR TITLE
Upgrade psutil to 5.3.0

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -16,9 +16,11 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==5.2.2']
+REQUIREMENTS = ['psutil==5.3.0']
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_ARG = 'arg'
 
 SENSOR_TYPES = {
     'disk_free': ['Disk Free', 'GiB', 'mdi:harddisk'],
@@ -49,7 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_RESOURCES, default=['disk_use']):
         vol.All(cv.ensure_list, [vol.Schema({
             vol.Required(CONF_TYPE): vol.In(SENSOR_TYPES),
-            vol.Optional('arg'): cv.string,
+            vol.Optional(CONF_ARG): cv.string,
         })])
 })
 
@@ -71,9 +73,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the system monitor sensors."""
     dev = []
     for resource in config[CONF_RESOURCES]:
-        if 'arg' not in resource:
-            resource['arg'] = ''
-        dev.append(SystemMonitorSensor(resource[CONF_TYPE], resource['arg']))
+        if CONF_ARG not in resource:
+            resource[CONF_ARG] = ''
+        dev.append(SystemMonitorSensor(
+            resource[CONF_TYPE], resource[CONF_ARG]))
 
     add_devices(dev, True)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -510,7 +510,7 @@ proliphix==0.4.1
 prometheus_client==0.0.19
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.2.2
+psutil==5.3.0
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.2


### PR DESCRIPTION
## Description:
Changelog: https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#530

**Related issue (if applicable):** fixes #9167

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: load_1m
      - type: 'disk_use_percent'
        arg: '/'
      - type: 'disk_use'
        arg: '/home'
      - type: 'disk_free'
        arg: '/'
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

