### PR TITLE
Fix googlemaps exceptions module import

### DIFF
--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -142,7 +142,7 @@ class GoogleTravelTimeSensor(Entity):
         else:
             self._destination = destination
 
-        import googlemaps
+        import googlemaps.exceptions
         self._client = googlemaps.Client(api_key, timeout=10)
         try:
             self.update()


### PR DESCRIPTION
If an exception is raised in __init__, it throws again because the module isn't imported.

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3.6/site-packages/homeassistant/components/sensor/google_travel_time.py", line 113, in run_setup
    hass, name, api_key, origin, destination, options)
  File "/usr/lib/python3.6/site-packages/homeassistant/components/sensor/google_travel_time.py", line 149, in __init__
    except googlemaps.exceptions.ApiError as exp:
AttributeError: module 'googlemaps' has no attribute 'exceptions'
2017-09-01 16:11:36 ERROR (Recorder) [homeassistant.core] Error doing job: Future exception was never retrieved
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/homeassistant/components/sensor/google_travel_time.py", line 148, in __init__
    self.update()
  File "/usr/lib/python3.6/site-packages/homeassistant/util/__init__.py", line 306, in wrapper
    result = method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/homeassistant/components/sensor/google_travel_time.py", line 229, in update
    self._origin, self._destination, **options_copy)
  File "/usr/lib/python3.6/site-packages/googlemaps/client.py", line 356, in wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/googlemaps/distance_matrix.py", line 130, in distance_matrix
    return client._request("/maps/api/distancematrix/json", params)
  File "/usr/lib/python3.6/site-packages/googlemaps/client.py", line 253, in _request
    result = self._get_body(response)
  File "/usr/lib/python3.6/site-packages/googlemaps/client.py", line 280, in _get_body
    body["error_message"])
googlemaps.exceptions.ApiError: REQUEST_DENIED (This IP, site or mobile application is not authorized to use this API key. Request received from IP address XXXXXXXXX, with empty referer)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3.6/site-packages/homeassistant/components/sensor/google_travel_time.py", line 113, in run_setup
    hass, name, api_key, origin, destination, options)
  File "/usr/lib/python3.6/site-packages/homeassistant/components/sensor/google_travel_time.py", line 149, in __init__
    except googlemaps.exceptions.ApiError as exp:
AttributeError: module 'googlemaps' has no attribute 'exceptions'
```

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
