### PR TITLE
Adds pan-tilt hat

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -500,6 +500,7 @@ omit =
     homeassistant/components/sensor/opensky.py
     homeassistant/components/sensor/openweathermap.py
     homeassistant/components/sensor/otp.py
+    homeassistant/components/sensor/pan_tilt_phat.py  
     homeassistant/components/sensor/pi_hole.py
     homeassistant/components/sensor/plex.py
     homeassistant/components/sensor/pocketcasts.py

--- a/homeassistant/components/sensor/pan_tilt_phat.py
+++ b/homeassistant/components/sensor/pan_tilt_phat.py
@@ -1,0 +1,79 @@
+"""
+Support for pan-tilt pHAT.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/sensor.pan_tilt_phat
+"""
+
+from datetime import timedelta
+import logging
+
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['pantilthat==0.0.4']
+_LOGGER = logging.getLogger(__name__)
+DOMAIN = 'pan_tilt_phat'
+SCAN_INTERVAL = timedelta(seconds=1)
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    try:
+        import pantilthat
+    except OSError:
+        _LOGGER.error("No pan-tilt pHAT was found.")
+        return False
+
+    def home_service(call):
+        """Return the stage to home."""
+        pantilthat.pan(0)
+        pantilthat.tilt(0)
+        return True
+
+    def pan_service(call):
+        """Pan the stage."""
+        pantilthat.pan(call.data.get("Pan"))
+        return True
+
+    def tilt_service(call):
+        """Pan the stage."""
+        pantilthat.tilt(call.data.get("Tilt"))
+        return True
+
+    hass.services.register(DOMAIN, 'home', home_service)
+    hass.services.register(DOMAIN, 'tilt', tilt_service)
+    hass.services.register(DOMAIN, 'pan', pan_service)
+    add_devices([PanTiltPhat(pantilthat)], True)
+    return True
+
+
+class PanTiltPhat(Entity):
+    """Representation of the stage."""
+
+    ICON = 'mdi:camera-switch'
+
+    def __init__(self, pantilthat):
+        """Initialize the stage."""
+        self._name = DOMAIN
+        self._state = None       # json obj with pan and tilt
+        self._pantilthat = pantilthat
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self.ICON
+
+    def update(self):
+        """Get the latest data from the stage.
+        Issue with tilt"""
+        self._pan = self._pantilthat.get_pan()
+        self._tilt = self._pantilthat.get_tilt()
+        self._state = "Pan:{}".format(self._pan)

--- a/homeassistant/components/sensor/pan_tilt_phat.py
+++ b/homeassistant/components/sensor/pan_tilt_phat.py
@@ -17,6 +17,7 @@ SCAN_INTERVAL = timedelta(seconds=1)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the pan-tilt sensor."""
     try:
         import pantilthat
     except OSError:
@@ -56,6 +57,8 @@ class PanTiltPhat(Entity):
         self._name = DOMAIN
         self._state = None       # json obj with pan and tilt
         self._pantilthat = pantilthat
+        self._pan = self._pantilthat.get_pan()
+        self._tilt = self._pantilthat.get_tilt()
 
     @property
     def name(self):
@@ -73,8 +76,7 @@ class PanTiltPhat(Entity):
         return self.ICON
 
     def update(self):
-        """Get the latest data from the stage.
-        Issue with tilt"""
+        """Get the latest data from the stage."""
         self._pan = self._pantilthat.get_pan()
         self._tilt = self._pantilthat.get_tilt()
         self._state = "Pan:{}".format(self._pan)

--- a/homeassistant/components/sensor/pan_tilt_phat.py
+++ b/homeassistant/components/sensor/pan_tilt_phat.py
@@ -15,6 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'pan_tilt_phat'
 SCAN_INTERVAL = timedelta(seconds=1)
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         import pantilthat

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -468,6 +468,9 @@ paho-mqtt==1.3.0
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.2
 
+# homeassistant.components.sensor.pan_tilt_phat
+pantilthat==0.0.4
+
 # homeassistant.components.media_player.dunehd
 pdunehd==1.3
 


### PR DESCRIPTION
## Description:
Adds the pimoroni pan-tilt hat, making use of the module provided by pimoroni. 
Adds services to home and move the servos, and sensor displays the current pan angle. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/pull/3293) <3293>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: pan_tilt_phat
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass** 
  - [ x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x ] New files were added to `.coveragerc`.
