### PR TITLE
Ensure display-name does not exceed 12 characters for CecAdapter.

### DIFF
--- a/homeassistant/components/hdmi_cec.py
+++ b/homeassistant/components/hdmi_cec.py
@@ -31,7 +31,7 @@ DOMAIN = 'hdmi_cec'
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_DISPLAY_NAME = "HomeAssistant"
+DEFAULT_DISPLAY_NAME = "HA"
 CONF_TYPES = 'types'
 
 ICON_UNKNOWN = 'mdi:help'
@@ -181,7 +181,7 @@ def setup(hass: HomeAssistant, base_config):
     if host:
         adapter = TcpAdapter(host, name=display_name, activate_source=False)
     else:
-        adapter = CecAdapter(name=display_name, activate_source=False)
+        adapter = CecAdapter(name=display_name[:13], activate_source=False)
     hdmi_network = HDMINetwork(adapter, loop=loop)
 
     def _volume(call):

--- a/homeassistant/components/hdmi_cec.py
+++ b/homeassistant/components/hdmi_cec.py
@@ -181,7 +181,7 @@ def setup(hass: HomeAssistant, base_config):
     if host:
         adapter = TcpAdapter(host, name=display_name, activate_source=False)
     else:
-        adapter = CecAdapter(name=display_name[:13], activate_source=False)
+        adapter = CecAdapter(name=display_name[:12], activate_source=False)
     hdmi_network = HDMINetwork(adapter, loop=loop)
 
     def _volume(call):


### PR DESCRIPTION
## Description:
The pyCEC ```CecAdapter``` class has a 12 character limit on it's name parameter. By default components/hdmi_cec.py is passing "HomeAssistant" which exceeds this and fails. Overriding in configuration.xml with ```osd_name:``` less than 13 characters avoids this bug, but this fix changes the default to 'HA' and also truncates in the case the user configures ```osd_name``` > 12 chars. This doesn't affect the ```TcpAdapter``` (when ```host:``` is used), it has no such restriction.

**Related issue (if applicable):** fixes #7745 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
