### PR TITLE
Make generic_thermostat current_operation consistent with operation_list

### DIFF
--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -97,9 +97,9 @@ class TestClimateGenericThermostat(unittest.TestCase):
         """Stop down everything that was started."""
         self.hass.stop()
 
-    def test_setup_defaults_to_unknown(self):
+    def test_setup_default_operation(self):
         """Test the setting of defaults to unknown."""
-        self.assertEqual('idle', self.hass.states.get(ENTITY).state)
+        self.assertEqual('heat', self.hass.states.get(ENTITY).state)
 
     def test_default_setup_params(self):
         """Test the setup with default parameters."""
@@ -112,7 +112,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
         """Test that the operation list returns the correct modes."""
         state = self.hass.states.get(ENTITY)
         modes = state.attributes.get('operation_list')
-        self.assertEqual([climate.STATE_AUTO, STATE_OFF], modes)
+        self.assertEqual([climate.STATE_HEAT, STATE_OFF], modes)
 
     def test_set_target_temp(self):
         """Test the setting of the target temperature."""
@@ -374,6 +374,12 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         self._setup_sensor(35)
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
+
+    def test_get_operation_modes(self):
+        """Test that the operation list returns the correct modes."""
+        state = self.hass.states.get(ENTITY)
+        modes = state.attributes.get('operation_list')
+        self.assertEqual([climate.STATE_COOL, STATE_OFF], modes)
 
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
         """Setup the test sensor."""


### PR DESCRIPTION
## Description:

The current implementation returns the current operating state for
current_operation rather than reflecting the current selection for the
operation mode. This makes things weird in the Web UI for one, since
it is expecting that the current operation is always one of the options
in the operating_list, ie it is the operating mode of the thermostat.

There seems to be some lack of consensus in the other climate
components but most of widely used ones have current_operation reflect
the operation_mode. The current exact operating state support seems to
vary, but it is returned in a device specific attribute. Arguably the
climate component should have a standard attribute for the Call for
heat or cool status.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) - EDIT: I have reviewed the documentation in the climate component. This change brings the operation of generic_thermostat to be consistent with climate component documentation present, no change necessary.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
