### PR TITLE
Allow value_template in template_switch to be optional (script switch)

### DIFF
--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -256,34 +256,6 @@ class TestTemplateSwitch:
 
         assert self.hass.states.all() == []
 
-    def test_missing_template_does_not_create(self):
-        """Test missing template."""
-        with assert_setup_component(0, 'switch'):
-            assert setup.setup_component(self.hass, 'switch', {
-                'switch': {
-                    'platform': 'template',
-                    'switches': {
-                        'test_template_switch': {
-                            'not_value_template':
-                                "{{ states.switch.test_state.state }}",
-                            'turn_on': {
-                                'service': 'switch.turn_on',
-                                'entity_id': 'switch.test_state'
-                            },
-                            'turn_off': {
-                                'service': 'switch.turn_off',
-                                'entity_id': 'switch.test_state'
-                            },
-                        }
-                    }
-                }
-            })
-
-        self.hass.start()
-        self.hass.block_till_done()
-
-        assert self.hass.states.all() == []
-
     def test_missing_on_does_not_create(self):
         """Test missing on."""
         with assert_setup_component(0, 'switch'):
@@ -410,6 +382,67 @@ class TestTemplateSwitch:
         self.hass.block_till_done()
 
         assert len(self.calls) == 1
+
+    def test_assumed_state_should_be_true_if_template_is_none(self):
+        """Test with state value."""
+        with assert_setup_component(1, 'switch'):
+            assert setup.setup_component(self.hass, 'switch', {
+                'switch': {
+                    'platform': 'template',
+                    'switches': {
+                        'test_template_switch': {
+                            'turn_on': {
+                                'service': 'switch.turn_on',
+                                'entity_id': 'switch.test_state'
+                            },
+                            'turn_off': {
+                                'service': 'switch.turn_off',
+                                'entity_id': 'switch.test_state'
+                            },
+                        }
+                    }
+                }
+            })
+
+        state = self.hass.states.get('switch.test_template_switch')
+        assert state.attributes.get('assumed_state') is True
+
+    def test_no_template_assumed_state_handling(self):
+        """Test missing template."""
+        assert setup.setup_component(self.hass, 'switch', {
+            'switch': {
+                'platform': 'template',
+                'switches': {
+                    'test_template_switch': {
+                        'turn_on': {
+                            'service': 'test.automation',
+                        },
+                        'turn_off': {
+                            'service': 'test.automation',
+                        },
+                    }
+                }
+            }
+        })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        core.switch.turn_on(self.hass, 'switch.test_template_switch')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.test_template_switch')
+        assert state.state == STATE_ON
+
+        assert len(self.calls) == 1
+
+        core.switch.turn_off(self.hass, 'switch.test_template_switch')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.test_template_switch')
+        assert state.state == STATE_OFF
+
+        assert len(self.calls) == 2
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

Allow value_template in template_switch to be optional.

Based on a previously requested feature as seen: https://community.home-assistant.io/t/how-create-switch-to-run-one-script-for-on-and-a-different-script-for-off/8882/9 and https://community.home-assistant.io/t/generic-switch/8915 this allows a template switch to not require a template. The state of the switch is still tracked in this case and the switch essentially becomes the internal script equivalent of the command_switch component which also allows state tracking to be optional.

A motivating example are components like generic_thermostat that uses a switch target. In some cases getting the actual state of the switch from another target component is not feasible (such as targetting set-back on a remote hardware thermostat).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3296

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.
