### PR TITLE
Bump pywemo, handle more ports.

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.19']
+REQUIREMENTS = ['pywemo==0.4.20']
 
 DOMAIN = 'wemo'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -827,7 +827,7 @@ pyvlx==0.1.3
 pywebpush==1.0.6
 
 # homeassistant.components.wemo
-pywemo==0.4.19
+pywemo==0.4.20
 
 # homeassistant.components.zabbix
 pyzabbix==0.7.4


### PR DESCRIPTION
## Description:
THis PR bumps the pywemo library to handle 2 extra ports that it seems wemo devices are using (49151, 49155) - thanks to @exxamalte for sorting this

**Related issue (if applicable):** fixes #9263 


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
