### PR TITLE
components/xiaomi: Add initial discovery using NetDisco.

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -34,6 +34,7 @@ SERVICE_HASSIO = 'hassio'
 SERVICE_AXIS = 'axis'
 SERVICE_APPLE_TV = 'apple_tv'
 SERVICE_WINK = 'wink'
+SERVICE_XIAOMI_GW = 'xiaomi_gw'
 
 SERVICE_HANDLERS = {
     SERVICE_HASS_IOS_APP: ('ios', None),
@@ -44,6 +45,7 @@ SERVICE_HANDLERS = {
     SERVICE_AXIS: ('axis', None),
     SERVICE_APPLE_TV: ('apple_tv', None),
     SERVICE_WINK: ('wink', None),
+    SERVICE_XIAOMI_GW: ('xiaomi', None),
     'philips_hue': ('light', 'hue'),
     'google_cast': ('media_player', 'cast'),
     'panasonic_viera': ('media_player', 'panasonic_viera'),

--- a/homeassistant/components/xiaomi.py
+++ b/homeassistant/components/xiaomi.py
@@ -4,9 +4,9 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
+from homeassistant.components.discovery import SERVICE_XIAOMI_GW
 from homeassistant.const import (ATTR_BATTERY_LEVEL, EVENT_HOMEASSISTANT_STOP,
                                  CONF_MAC)
-
 
 REQUIREMENTS = ['https://github.com/Danielhiversen/PyXiaomiGateway/archive/'
                 '0.3.2.zip#PyXiaomiGateway==0.3.2']
@@ -57,9 +57,22 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup(hass, config):
     """Set up the Xiaomi component."""
-    gateways = config[DOMAIN][CONF_GATEWAYS]
-    interface = config[DOMAIN][CONF_INTERFACE]
-    discovery_retry = config[DOMAIN][CONF_DISCOVERY_RETRY]
+    gateways = []
+    interface = 'any'
+    discovery_retry = 3
+    if DOMAIN in config:
+        gateways = config[DOMAIN][CONF_GATEWAYS]
+        interface = config[DOMAIN][CONF_INTERFACE]
+        discovery_retry = config[DOMAIN][CONF_DISCOVERY_RETRY]
+
+    def xiaomi_gw_discovered(service, discovery_info):
+        """Called when Xiaomi Gateway device(s) has been found."""
+        # We don't need to do anything here, the purpose of HA's
+        # discovery service is to just trigger loading of this
+        # component, and then its own discovery process kicks in.
+        _LOGGER.info("Discovered: %s", discovery_info)
+
+    discovery.listen(hass, SERVICE_XIAOMI_GW, xiaomi_gw_discovered)
 
     from PyXiaomiGateway import PyXiaomiGateway
     hass.data[PY_XIAOMI_GATEWAY] = PyXiaomiGateway(hass.add_job, gateways,


### PR DESCRIPTION
There's a kind of duplication of functionality between NetDisco and
"xiaomi" component, the latter features its own "discovery" in addition
to general HomeAssistant discovery service, based on NetDisco. As such,
this patch is pretty simple: the only purpose of NetDisco discovery
is "plug and play", "zero configuration" discovery that Xiaomi Gateway
device is present on the local network, and triggering of "xiaomi"
component loading, which then "rediscovers" the gateway using its own
method.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
