### PR TITLE
Added mqtt_statestream component

### DIFF
--- a/homeassistant/components/mqtt_statestream.py
+++ b/homeassistant/components/mqtt_statestream.py
@@ -36,11 +36,7 @@ def async_setup(hass, config):
     def _state_publisher(entity_id, old_state, new_state):
         if new_state is None:
             return
-
-        try:
-            payload = new_state.state
-        except KeyError:
-            return
+        payload = new_state.state
 
         topic = base_topic + entity_id.replace('.', '/')
         hass.components.mqtt.async_publish(topic, payload, 1, True)

--- a/homeassistant/components/mqtt_statestream.py
+++ b/homeassistant/components/mqtt_statestream.py
@@ -39,13 +39,16 @@ def async_setup(hass, config):
         if event.event_type == EVENT_STATE_CHANGED:
             try:
                 new_state = event.data['new_state']
+            except AttributeError:
+                return
+
+            try:
                 payload = new_state.state
             except NameError:
-                payload = None
+                return
 
-            if payload is not None:
-                topic = base_topic + new_state.entity_id.replace('.', '/')
-                mqtt.async_publish(hass, topic, payload, 1, True)
+            topic = base_topic + new_state.entity_id.replace('.', '/')
+            mqtt.async_publish(hass, topic, payload, 1, True)
 
     hass.bus.async_listen(EVENT_STATE_CHANGED, _event_publisher)
 

--- a/homeassistant/components/mqtt_statestream.py
+++ b/homeassistant/components/mqtt_statestream.py
@@ -1,0 +1,53 @@
+"""
+Publish simple item state changes via MQTT.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/mqtt_statestream/
+"""
+import asyncio
+
+import voluptuous as vol
+
+import homeassistant.loader as loader
+from homeassistant.const import EVENT_STATE_CHANGED
+from homeassistant.core import callback
+from homeassistant.components.mqtt import valid_publish_topic
+
+CONF_BASE_TOPIC = 'base_topic'
+DEPENDENCIES = ['mqtt']
+DOMAIN = 'mqtt_statestream'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_BASE_TOPIC): valid_publish_topic
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up the MQTT state feed."""
+    mqtt = loader.get_component('mqtt')
+    conf = config.get(DOMAIN, {})
+    base_topic = conf.get(CONF_BASE_TOPIC)
+    if not base_topic.endswith('/'):
+        base_topic = base_topic + '/'
+
+    @callback
+    def _event_publisher(event):
+        """Handle state change events and publish them to MQTT."""
+        if event.event_type == EVENT_STATE_CHANGED:
+            try:
+                new_state = event.data['new_state']
+                payload = new_state.state
+            except NameError:
+                payload = None
+
+            if payload is not None:
+                topic = base_topic + new_state.entity_id.replace('.', '/')
+                mqtt.async_publish(hass, topic, payload, 1, True)
+
+    hass.bus.async_listen(EVENT_STATE_CHANGED, _event_publisher)
+
+    hass.states.async_set('{domain}.initialized'.format(domain=DOMAIN), True)
+    return True

--- a/homeassistant/components/mqtt_statestream.py
+++ b/homeassistant/components/mqtt_statestream.py
@@ -52,5 +52,4 @@ def async_setup(hass, config):
 
     hass.bus.async_listen(EVENT_STATE_CHANGED, _event_publisher)
 
-    hass.states.async_set('{domain}.initialized'.format(domain=DOMAIN), True)
     return True

--- a/tests/components/test_mqtt_statestream.py
+++ b/tests/components/test_mqtt_statestream.py
@@ -1,0 +1,65 @@
+"""The tests for the MQTT statestream component."""
+from unittest.mock import patch
+
+from homeassistant.setup import setup_component
+import homeassistant.components.mqtt_statestream as statestream
+from homeassistant.core import State
+
+from tests.common import (
+    get_test_home_assistant,
+    mock_mqtt_component,
+    mock_state_change_event
+)
+
+
+class TestMqttStateStream(object):
+    """Test the MQTT statestream module."""
+
+    def setup_method(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.mock_mqtt = mock_mqtt_component(self.hass)
+
+    def teardown_method(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def add_statestream(self, base_topic=None):
+        """Add a mqtt_statestream component."""
+        config = {}
+        if base_topic:
+            config['base_topic'] = base_topic
+        return setup_component(self.hass, statestream.DOMAIN, {
+            statestream.DOMAIN: config})
+
+    def test_fails_with_no_base(self):
+        """Setup should fail if no base_topic is set."""
+        assert self.add_statestream() is False
+
+    def test_setup_succeeds(self):
+        """"Test the success of the setup with a valid base_topic."""
+        assert self.add_statestream(base_topic='pub')
+
+    @patch('homeassistant.components.mqtt.async_publish')
+    @patch('homeassistant.core.dt_util.utcnow')
+    def test_state_changed_event_sends_message(self, mock_utcnow, mock_pub):
+        """"Test the sending of a new message if event changed."""
+        e_id = 'fake.entity'
+        base_topic = 'pub'
+
+        # Add the statestream component for publishing state updates
+        assert self.add_statestream(base_topic=base_topic)
+        self.hass.block_till_done()
+
+        # Reset the mock because it will have already gotten calls for the
+        # mqtt_statestream state change on initialization, etc.
+        mock_pub.reset_mock()
+
+        # Set a state of an entity
+        mock_state_change_event(self.hass, State(e_id, 'on'))
+        self.hass.block_till_done()
+
+        # Make sure 'on' was published to pub/fake/entity
+        mock_pub.assert_called_with(self.hass, 'pub/fake/entity', 'on', 1,
+                                    True)
+        assert mock_pub.called


### PR DESCRIPTION
## Description:
This PR adds an `mqtt_statestream` component that publishes state changes to discrete MQTT topics.  My use case for this is that I have a number of external systems (including small ESP8266-driven displays) that need to monitor only certain entities.  With this component, I can subscribe those displays only to the topics that they need instead of the whole event stream.

For example, with a `base_topic` configured as `hass/states`, turning on `light.master_bedroom` will publish `on` to `hass/states/light/master_bedroom`.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3302

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt_statestream:
  base_topic: hass/states
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
