### PR TITLE
Introducing support to Melnor RainCloud sprinkler systems

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -146,6 +146,9 @@ omit =
     homeassistant/components/rachio.py
     homeassistant/components/*/rachio.py
 
+    homeassistant/components/raincloud.py
+    homeassistant/components/*/raincloud.py
+
     homeassistant/components/raspihats.py
     homeassistant/components/*/raspihats.py
 

--- a/homeassistant/components/binary_sensor/raincloud.py
+++ b/homeassistant/components/binary_sensor/raincloud.py
@@ -1,0 +1,102 @@
+"""
+Support for Melnor RainCloud sprinkler water timer.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.raincloud/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.raincloud import CONF_ATTRIBUTION
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    CONF_MONITORED_CONDITIONS, ATTR_ATTRIBUTION)
+
+DEPENDENCIES = ['raincloud']
+
+_LOGGER = logging.getLogger(__name__)
+
+SENSOR_TYPES = {
+    'is_watering': ['Watering', ''],
+    'status': ['Status', ''],
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up a sensor for a raincloud device."""
+    raincloud = hass.data.get('raincloud').data
+
+    sensors = []
+    for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
+        if sensor_type == 'status':
+            sensors.append(
+                RainCloudBinarySensor(hass,
+                                      raincloud.controller,
+                                      sensor_type))
+            sensors.append(
+                RainCloudBinarySensor(hass,
+                                      raincloud.controller.faucet,
+                                      sensor_type))
+
+        else:
+            # create an sensor for each zone managed by faucet
+            for zone in raincloud.controller.faucet.zones:
+                sensors.append(RainCloudBinarySensor(hass, zone, sensor_type))
+
+    add_devices(sensors, True)
+    return True
+
+
+class RainCloudBinarySensor(BinarySensorDevice):
+    """A sensor implementation for raincloud device."""
+
+    def __init__(self, hass, data, sensor_type):
+        """Initialize a sensor for raincloud device."""
+        super().__init__()
+        self._sensor_type = sensor_type
+        self._data = data
+        self._name = "{0} {1}".format(
+            self._data.name, SENSOR_TYPES.get(self._sensor_type)[0])
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self._state
+
+    def update(self):
+        """Get the latest data and updates the state."""
+        _LOGGER.debug("Updating RainCloud sensor: %s", self._name)
+        self._state = getattr(self._data, self._sensor_type)
+
+    @property
+    def icon(self):
+        """Return the icon of this device."""
+        if self._sensor_type == 'is_watering':
+            return 'mdi:water' if self.is_on else 'mdi:water-off'
+        elif self._sensor_type == 'status':
+            return 'mdi:pipe' if self.is_on else 'mdi:pipe-disconnected'
+        return SENSOR_TYPES.get(self._sensor_type)[1]
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attrs = {}
+
+        attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+        attrs['current_time'] = self._data.current_time
+        attrs['identifier'] = self._data.serial
+        return attrs

--- a/homeassistant/components/binary_sensor/raincloud.py
+++ b/homeassistant/components/binary_sensor/raincloud.py
@@ -61,6 +61,7 @@ class RainCloudBinarySensor(RainCloudHub, BinarySensorDevice):
 
     def __init__(self, hass, data, sensor_type):
         """Initialize a sensor for raincloud device."""
+        super().__init__(hass, data)
         self._hass = hass
         self._sensor_type = sensor_type
         self.data = data

--- a/homeassistant/components/binary_sensor/raincloud.py
+++ b/homeassistant/components/binary_sensor/raincloud.py
@@ -25,7 +25,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 

--- a/homeassistant/components/raincloud.py
+++ b/homeassistant/components/raincloud.py
@@ -128,7 +128,7 @@ def setup(hass, config):
 
 
 class RainCloudHub(object):
-    """Base class for all Raincloud entities."""
+    """Representation of a base RainCloud device."""
 
     def __init__(self, data):
         """Initialize the entity."""
@@ -139,7 +139,7 @@ class RainCloudEntity(Entity):
     """Entity class for RainCloud devices."""
 
     def __init__(self, data, sensor_type):
-        """Initialize the entity."""
+        """Initialize the RainCloud entity."""
         self.data = data
         self._sensor_type = sensor_type
         self._name = "{0} {1}".format(
@@ -159,7 +159,7 @@ class RainCloudEntity(Entity):
 
     def _update_callback(self):
         """Callback update method."""
-        self.update()
+        self.schedule_update_ha_state(True)
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/raincloud.py
+++ b/homeassistant/components/raincloud.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant.const import (
-    CONF_USERNAME, CONF_PASSWORD, CONF_SCAN_INTERVAL)
+    ATTR_ATTRIBUTION, CONF_USERNAME, CONF_PASSWORD, CONF_SCAN_INTERVAL)
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.dispatcher import (
@@ -35,6 +35,45 @@ NOTIFICATION_TITLE = 'Rain Cloud Setup'
 DATA_RAINCLOUD = 'raincloud'
 DOMAIN = 'raincloud'
 DEFAULT_WATERING_TIME = 15
+
+KEY_MAP = {
+    'auto_watering': 'Automatic Watering',
+    'battery': 'Battery',
+    'is_watering': 'Watering',
+    'manual_watering': 'Manual Watering',
+    'next_cycle': 'Next Cycle',
+    'rain_delay': 'Rain Delay',
+    'status': 'Status',
+    'watering_time': 'Remaining Watering Time',
+}
+
+ICON_MAP = {
+    'auto_watering': 'mdi:autorenew',
+    'battery': '',
+    'is_watering': '',
+    'manual_watering': 'mdi:water-pump',
+    'next_cycle': 'mdi:calendar-clock',
+    'rain_delay': 'mdi:weather-rainy',
+    'status': '',
+    'watering_time': 'mdi:water-pump',
+}
+
+UNIT_OF_MEASUREMENT_MAP = {
+    'auto_watering': '',
+    'battery': '%',
+    'is_watering': '',
+    'manual_watering': '',
+    'next_cycle': '',
+    'rain_delay': 'days',
+    'status': '',
+    'watering_time': 'min',
+}
+
+BINARY_SENSORS = ['is_watering', 'status']
+
+SENSORS = ['battery', 'next_cycle', 'rain_delay', 'watering_time']
+
+SWITCHES = ['auto_watering', 'manual_watering']
 
 SCAN_INTERVAL = timedelta(seconds=20)
 
@@ -63,7 +102,7 @@ def setup(hass, config):
         raincloud = RainCloudy(username=username, password=password)
         if not raincloud.is_connected:
             raise HTTPError
-        hass.data[DATA_RAINCLOUD] = RainCloudHub(hass, raincloud)
+        hass.data[DATA_RAINCLOUD] = RainCloudHub(raincloud)
     except (ConnectTimeout, HTTPError) as ex:
         _LOGGER.error("Unable to connect to Rain Cloud service: %s", str(ex))
         hass.components.persistent_notification.create(
@@ -88,20 +127,55 @@ def setup(hass, config):
     return True
 
 
-class RainCloudHub(Entity):
+class RainCloudHub(object):
     """Base class for all Raincloud entities."""
 
-    def __init__(self, hass, data):
+    def __init__(self, data):
         """Initialize the entity."""
-        self._hass = hass
         self.data = data
+
+
+class RainCloudEntity(Entity):
+    """Entity class for RainCloud devices."""
+
+    def __init__(self, data, sensor_type):
+        """Initialize the entity."""
+        self.data = data
+        self._sensor_type = sensor_type
+        self._name = "{0} {1}".format(
+            self.data.name, KEY_MAP.get(self._sensor_type))
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
 
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Register callbacks."""
         async_dispatcher_connect(
-            self._hass, SIGNAL_UPDATE_RAINCLOUD, self._update_callback)
+            self.hass, SIGNAL_UPDATE_RAINCLOUD, self._update_callback)
 
     def _update_callback(self):
         """Callback update method."""
-        self.data.update()
+        self.update()
+
+    @property
+    def unit_of_measurement(self):
+        """Return the units of measurement."""
+        return UNIT_OF_MEASUREMENT_MAP.get(self._sensor_type)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+            'current_time': self.data.current_time,
+            'identifier': self.data.serial,
+        }
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return ICON_MAP.get(self._sensor_type)

--- a/homeassistant/components/raincloud.py
+++ b/homeassistant/components/raincloud.py
@@ -116,7 +116,6 @@ def setup(hass, config):
     def hub_refresh(event_time):
         """Call Raincloud hub to refresh information."""
         _LOGGER.debug("Updating RainCloud Hub component.")
-        raincloud = hass.data[DATA_RAINCLOUD]
         raincloud.data.update()
 
         dispatcher_send(hass, SIGNAL_UPDATE_RAINCLOUD)

--- a/homeassistant/components/raincloud.py
+++ b/homeassistant/components/raincloud.py
@@ -1,0 +1,95 @@
+"""
+Support for Melnor RainCloud sprinkler water timer.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/raincloud/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import track_time_interval
+
+from requests.exceptions import HTTPError, ConnectTimeout
+
+REQUIREMENTS = ['raincloudy==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+ALLOWED_WATERING_TIME = [5, 10, 15, 30, 45, 60]
+
+CONF_ATTRIBUTION = "Data provided by Melnor Aquatimer.com"
+CONF_WATERING_TIME = 'watering_minutes'
+
+NOTIFICATION_ID = 'raincloud_notification'
+NOTIFICATION_TITLE = 'Rain Cloud Setup'
+
+DOMAIN = 'raincloud'
+DEFAULT_ENTITY_NAMESPACE = 'raincloud'
+DEFAULT_WATERING_TIME = 15
+
+SCAN_INTERVAL_HUB = timedelta(seconds=20)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_WATERING_TIME, default=DEFAULT_WATERING_TIME):
+            vol.All(vol.In(ALLOWED_WATERING_TIME)),
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Set up the Melnor RainCloud component."""
+    conf = config[DOMAIN]
+    username = conf.get(CONF_USERNAME)
+    password = conf.get(CONF_PASSWORD)
+    default_watering_timer = conf.get(CONF_WATERING_TIME)
+
+    try:
+        from raincloudy.core import RainCloudy
+
+        raincloud = RainCloudy(username=username, password=password)
+        if not raincloud.is_connected:
+            return False
+        hass.data['raincloud'] = RainCloudHub(hass,
+                                              raincloud,
+                                              default_watering_timer)
+    except (ConnectTimeout, HTTPError) as ex:
+        _LOGGER.error("Unable to connect to Rain Cloud service: %s", str(ex))
+        hass.components.persistent_notification.create(
+            'Error: {}<br />'
+            'You will need to restart hass after fixing.'
+            ''.format(ex),
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID)
+        return False
+    return True
+
+
+class RainCloudHub(Entity):
+    """Base class for all Raincloud entities."""
+
+    def __init__(self, hass, data, default_watering_timer):
+        """Initialize the entity."""
+        self.data = data
+        self.default_watering_timer = default_watering_timer
+
+        # Load data
+        track_time_interval(hass, self._update_hub, SCAN_INTERVAL_HUB)
+        self._update_hub(SCAN_INTERVAL_HUB)
+
+    @property
+    def should_poll(self):
+        """Return false. RainCloud Hub object updates variables."""
+        return False
+
+    def _update_hub(self, now):
+        """Refresh data from for all child objects."""
+        _LOGGER.debug("Updating RainCloud Hub component.")
+        self.data.update()

--- a/homeassistant/components/raincloud.py
+++ b/homeassistant/components/raincloud.py
@@ -14,6 +14,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD, CONF_SCAN_INTERVAL)
 from homeassistant.helpers.event import track_time_interval
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, dispatcher_send)
 
@@ -92,12 +93,12 @@ def setup(hass, config):
     return True
 
 
-class RainCloudHub(object):
+class RainCloudHub(Entity):
     """Base class for all Raincloud entities."""
 
     def __init__(self, hass, data, default_watering_timer):
         """Initialize the entity."""
-        self.hass = hass
+        self._hass = hass
         self.data = data
         self.default_watering_timer = default_watering_timer
 
@@ -105,7 +106,7 @@ class RainCloudHub(object):
     def async_added_to_hass(self):
         """Register callbacks."""
         async_dispatcher_connect(
-            self.hass, SIGNAL_UPDATE_RAINCLOUD, self._update_callback)
+            self._hass, SIGNAL_UPDATE_RAINCLOUD, self._update_callback)
 
     def _update_callback(self):
         """Callback update method."""

--- a/homeassistant/components/raincloud.py
+++ b/homeassistant/components/raincloud.py
@@ -116,8 +116,7 @@ def setup(hass, config):
     def hub_refresh(event_time):
         """Call Raincloud hub to refresh information."""
         _LOGGER.debug("Updating RainCloud Hub component.")
-        raincloud.data.update()
-
+        hass.data[DATA_RAINCLOUD].data.update()
         dispatcher_send(hass, SIGNAL_UPDATE_RAINCLOUD)
 
     # Call the Raincloud API to refresh updates

--- a/homeassistant/components/sensor/raincloud.py
+++ b/homeassistant/components/sensor/raincloud.py
@@ -1,0 +1,108 @@
+"""
+Support for Melnor RainCloud sprinkler water timer.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.raincloud/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.raincloud import CONF_ATTRIBUTION
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_MONITORED_CONDITIONS, STATE_UNKNOWN, ATTR_ATTRIBUTION)
+from homeassistant.helpers.entity import Entity
+
+DEPENDENCIES = ['raincloud']
+
+_LOGGER = logging.getLogger(__name__)
+
+# Sensor types: label, desc, unit, icon
+SENSOR_TYPES = {
+    'battery': ['Battery', '%', ''],
+    'next_cycle': ['Next Cycle', '', 'calendar-clock'],
+    'rain_delay': ['Rain Delay', 'days', 'weather-rainy'],
+    'watering_time': ['Remaining Watering Time', 'min', 'water-pump'],
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up a sensor for a raincloud device."""
+    raincloud = hass.data.get('raincloud').data
+
+    sensors = []
+    for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
+        if sensor_type == 'battery':
+            sensors.append(
+                RainCloudSensor(raincloud.controller.faucet,
+                                sensor_type))
+        else:
+            # create an sensor for each zone managed by a faucet
+            for zone in raincloud.controller.faucet.zones:
+                sensors.append(RainCloudSensor(zone, sensor_type))
+
+    add_devices(sensors, True)
+    return True
+
+
+class RainCloudSensor(Entity):
+    """A sensor implementation for raincloud device."""
+
+    def __init__(self, data, sensor_type):
+        """Initialize a sensor for raincloud device."""
+        self._data = data
+        self._sensor_type = sensor_type
+        self._icon = 'mdi:{}'.format(SENSOR_TYPES.get(self._sensor_type)[2])
+        self._name = "{0} {1}".format(
+            self._data.name, SENSOR_TYPES.get(self._sensor_type)[0])
+        self._state = STATE_UNKNOWN
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        _LOGGER.debug("Updating RainCloud sensor: %s", self._name)
+        if self._sensor_type == 'battery':
+            self._state = self._data.battery.strip('%')
+        else:
+            self._state = getattr(self._data, self._sensor_type)
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        if self._sensor_type == 'battery' and self._state is not STATE_UNKNOWN:
+            rounded_level = round(int(self._state), -1)
+            if rounded_level < 10:
+                self._icon = 'mdi:battery-outline'
+            elif self._state == 100:
+                self._icon = 'mdi:battery'
+            else:
+                self._icon = 'mdi:battery-{}'.format(str(rounded_level))
+        return self._icon
+
+    @property
+    def unit_of_measurement(self):
+        """Return the units of measurement."""
+        return SENSOR_TYPES.get(self._sensor_type)[1]
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attrs = {}
+
+        attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+        attrs['identifier'] = self._data.serial
+        attrs['current_time'] = self._data.current_time
+        return attrs

--- a/homeassistant/components/sensor/raincloud.py
+++ b/homeassistant/components/sensor/raincloud.py
@@ -13,7 +13,6 @@ from homeassistant.components.raincloud import (
     DATA_RAINCLOUD, ICON_MAP, RainCloudEntity, SENSORS)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_MONITORED_CONDITIONS
-from homeassistant.helpers.entity import Entity
 from homeassistant.util.icon import icon_for_battery_level
 
 DEPENDENCIES = ['raincloud']
@@ -45,7 +44,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     return True
 
 
-class RainCloudSensor(RainCloudEntity, Entity):
+class RainCloudSensor(RainCloudEntity):
     """A sensor implementation for raincloud device."""
 
     @property

--- a/homeassistant/components/sensor/raincloud.py
+++ b/homeassistant/components/sensor/raincloud.py
@@ -10,10 +10,9 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.raincloud import (
-    CONF_ATTRIBUTION, DATA_RAINCLOUD, RainCloudHub)
+    DATA_RAINCLOUD, ICON_MAP, RainCloudEntity, SENSORS)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    CONF_MONITORED_CONDITIONS, STATE_UNKNOWN, ATTR_ATTRIBUTION)
+from homeassistant.const import CONF_MONITORED_CONDITIONS
 from homeassistant.helpers.entity import Entity
 from homeassistant.util.icon import icon_for_battery_level
 
@@ -21,17 +20,9 @@ DEPENDENCIES = ['raincloud']
 
 _LOGGER = logging.getLogger(__name__)
 
-# Sensor types: label, desc, unit, icon
-SENSOR_TYPES = {
-    'battery': ['Battery', '%', ''],
-    'next_cycle': ['Next Cycle', '', 'calendar-clock'],
-    'rain_delay': ['Rain Delay', 'days', 'weather-rainy'],
-    'watering_time': ['Remaining Watering Time', 'min', 'water-pump'],
-}
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
-        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSORS)):
+        vol.All(cv.ensure_list, [vol.In(SENSORS)]),
 })
 
 
@@ -43,65 +34,37 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
         if sensor_type == 'battery':
             sensors.append(
-                RainCloudSensor(hass,
-                                raincloud.controller.faucet,
+                RainCloudSensor(raincloud.controller.faucet,
                                 sensor_type))
         else:
             # create an sensor for each zone managed by a faucet
             for zone in raincloud.controller.faucet.zones:
-                sensors.append(RainCloudSensor(hass, zone, sensor_type))
+                sensors.append(RainCloudSensor(zone, sensor_type))
 
     add_devices(sensors, True)
     return True
 
 
-class RainCloudSensor(RainCloudHub, Entity):
+class RainCloudSensor(RainCloudEntity, Entity):
     """A sensor implementation for raincloud device."""
-
-    def __init__(self, hass, data, sensor_type):
-        """Initialize a sensor for raincloud device."""
-        super().__init__(hass, data)
-        self._hass = hass
-        self.data = data
-        self._sensor_type = sensor_type
-        self._icon = 'mdi:{}'.format(SENSOR_TYPES.get(self._sensor_type)[2])
-        self._name = "{0} {1}".format(
-            self.data.name, SENSOR_TYPES.get(self._sensor_type)[0])
-        self._state = STATE_UNKNOWN
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
 
     @property
     def state(self):
         """Return the state of the sensor."""
+        return self._state
+
+    def update(self):
+        """Get the latest data and updates the states."""
         _LOGGER.debug("Updating RainCloud sensor: %s", self._name)
         if self._sensor_type == 'battery':
             self._state = self.data.battery.strip('%')
         else:
             self._state = getattr(self.data, self._sensor_type)
-        return self._state
 
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-        if self._sensor_type == 'battery' and self._state is not STATE_UNKNOWN:
+        if self._sensor_type == 'battery' and self._state is not None:
             return icon_for_battery_level(battery_level=int(self._state),
                                           charging=False)
-        return self._icon
-
-    @property
-    def unit_of_measurement(self):
-        """Return the units of measurement."""
-        return SENSOR_TYPES.get(self._sensor_type)[1]
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return {
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-            'identifier': self.data.serial,
-            'current_time': self.data.current_time
-        }
+        return ICON_MAP.get(self._sensor_type)

--- a/homeassistant/components/sensor/raincloud.py
+++ b/homeassistant/components/sensor/raincloud.py
@@ -28,7 +28,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 

--- a/homeassistant/components/sensor/raincloud.py
+++ b/homeassistant/components/sensor/raincloud.py
@@ -60,6 +60,7 @@ class RainCloudSensor(RainCloudHub, Entity):
 
     def __init__(self, hass, data, sensor_type):
         """Initialize a sensor for raincloud device."""
+        super().__init__(hass, data)
         self._hass = hass
         self.data = data
         self._sensor_type = sensor_type

--- a/homeassistant/components/switch/raincloud.py
+++ b/homeassistant/components/switch/raincloud.py
@@ -30,8 +30,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for a raincloud device."""
-    raincloud_hub = hass.data[DATA_RAINCLOUD]
-    raincloud = raincloud_hub.data
+    raincloud = hass.data[DATA_RAINCLOUD].data
     default_watering_timer = config.get(CONF_WATERING_TIME)
 
     sensors = []

--- a/homeassistant/components/switch/raincloud.py
+++ b/homeassistant/components/switch/raincloud.py
@@ -25,7 +25,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 

--- a/homeassistant/components/switch/raincloud.py
+++ b/homeassistant/components/switch/raincloud.py
@@ -1,0 +1,111 @@
+"""
+Support for Melnor RainCloud sprinkler water timer.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.raincloud/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.raincloud import CONF_ATTRIBUTION
+from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_MONITORED_CONDITIONS, ATTR_ATTRIBUTION)
+
+DEPENDENCIES = ['raincloud']
+
+_LOGGER = logging.getLogger(__name__)
+
+# Sensor types: label, desc, unit, icon
+SENSOR_TYPES = {
+    'auto_watering': ['Automatic Watering', 'mdi:autorenew'],
+    'manual_watering': ['Manual Watering', 'water-pump'],
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up a sensor for a raincloud device."""
+    raincloud_hub = hass.data.get('raincloud')
+    raincloud = raincloud_hub.data
+    default_watering_timer = raincloud_hub.default_watering_timer
+
+    sensors = []
+    for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
+        # create an sensor for each zone managed by faucet
+        for zone in raincloud.controller.faucet.zones:
+            sensors.append(
+                RainCloudSwitch(zone, sensor_type, default_watering_timer))
+
+    add_devices(sensors, True)
+    return True
+
+
+class RainCloudSwitch(SwitchDevice):
+    """A switch implementation for raincloud device."""
+
+    def __init__(self, data, sensor_type, default_watering_timer):
+        """Initialize a switch for raincloud device."""
+        self._sensor_type = sensor_type
+        self._data = data
+        self._default_watering_timer = default_watering_timer
+        self._icon = 'mdi:{}'.format(SENSOR_TYPES.get(self._sensor_type)[1])
+        self._name = "{0} {1}".format(
+            self._data.name, SENSOR_TYPES.get(self._sensor_type)[0])
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    def turn_on(self):
+        """Turn the device on."""
+        if self._sensor_type == 'manual_watering':
+            self._data.watering_time = self._default_watering_timer
+        elif self._sensor_type == 'auto_watering':
+            self._data.auto_watering = True
+        self._state = True
+
+    def turn_off(self):
+        """Turn the device off."""
+        if self._sensor_type == 'manual_watering':
+            self._data.watering_time = 'off'
+        elif self._sensor_type == 'auto_watering':
+            self._data.auto_watering = False
+        self._state = False
+
+    def update(self):
+        """Update device state."""
+        _LOGGER.debug("Updating RainCloud switch: %s", self._name)
+        if self._sensor_type == 'manual_watering':
+            self._state = bool(self._data.watering_time)
+        elif self._sensor_type == 'auto_watering':
+            self._state = self._data.auto_watering
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attrs = {}
+
+        attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+        attrs['current_time'] = self._data.current_time
+        attrs['default_manual_timer'] = self._default_watering_timer
+        attrs['identifier'] = self._data.serial
+        return attrs

--- a/homeassistant/components/switch/raincloud.py
+++ b/homeassistant/components/switch/raincloud.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.raincloud import CONF_ATTRIBUTION
+from homeassistant.components.raincloud import CONF_ATTRIBUTION, DATA_RAINCLOUD
 from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, ATTR_ATTRIBUTION)
@@ -32,7 +32,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for a raincloud device."""
-    raincloud_hub = hass.data.get('raincloud')
+    raincloud_hub = hass.data[DATA_RAINCLOUD]
     raincloud = raincloud_hub.data
     default_watering_timer = raincloud_hub.default_watering_timer
 
@@ -102,10 +102,9 @@ class RainCloudSwitch(SwitchDevice):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attrs = {}
-
-        attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
-        attrs['current_time'] = self._data.current_time
-        attrs['default_manual_timer'] = self._default_watering_timer
-        attrs['identifier'] = self._data.serial
-        return attrs
+        return {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+            'current_time': self._data.current_time,
+            'default_manual_timer': self._default_watering_timer,
+            'identifier': self._data.serial
+        }

--- a/homeassistant/components/switch/raincloud.py
+++ b/homeassistant/components/switch/raincloud.py
@@ -10,7 +10,8 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.raincloud import (
-    CONF_ATTRIBUTION, DATA_RAINCLOUD, RainCloudHub)
+    ALLOWED_WATERING_TIME, CONF_ATTRIBUTION, CONF_WATERING_TIME,
+    DATA_RAINCLOUD, DEFAULT_WATERING_TIME, RainCloudHub)
 from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, ATTR_ATTRIBUTION)
@@ -28,6 +29,8 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Optional(CONF_WATERING_TIME, default=DEFAULT_WATERING_TIME):
+        vol.All(vol.In(ALLOWED_WATERING_TIME)),
 })
 
 
@@ -35,7 +38,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a sensor for a raincloud device."""
     raincloud_hub = hass.data[DATA_RAINCLOUD]
     raincloud = raincloud_hub.data
-    default_watering_timer = raincloud_hub.default_watering_timer
+    default_watering_timer = config.get(CONF_WATERING_TIME)
 
     sensors = []
     for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
@@ -56,6 +59,7 @@ class RainCloudSwitch(RainCloudHub, SwitchDevice):
 
     def __init__(self, hass, data, sensor_type, default_watering_timer):
         """Initialize a switch for raincloud device."""
+        super().__init__(hass, data)
         self._hass = hass
         self._sensor_type = sensor_type
         self.data = data

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -841,6 +841,9 @@ rachiopy==0.1.2
 # homeassistant.components.climate.radiotherm
 radiotherm==1.3
 
+# homeassistant.components.raincloud
+raincloudy==0.0.1
+
 # homeassistant.components.raspihats
 # raspihats==2.2.1
 


### PR DESCRIPTION
## Description:
Introducing support to the Melnor RainCloud sprinkler system on Home Assistant. 

This PR adds some new `binary_sensor`, `switch` and `sensor` components.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3304


![image](https://user-images.githubusercontent.com/809840/30013380-3a69f0a0-9114-11e7-8a87-49910d141ee8.png)


## Example entry for `configuration.yaml` (if applicable):
```yaml
# configuration.yaml
raincloud:
  username: user@domain
  password: secret
  watering_time: 30

binary_sensor:
  - platform: raincloud

sensor:
  - platform: raincloud

switch:
  - platform: raincloud
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
