### PR TITLE
Add post_pending_state attribute to manual alarm_control_panel

### DIFF
--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -24,6 +24,8 @@ DEFAULT_PENDING_TIME = 60
 DEFAULT_TRIGGER_TIME = 120
 DEFAULT_DISARM_AFTER_TRIGGER = False
 
+ATTR_POST_PENDING_STATE = 'post_pending_state'
+
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'manual',
     vol.Optional(CONF_NAME, default=DEFAULT_ALARM_NAME): cv.string,
@@ -185,3 +187,13 @@ class ManualAlarm(alarm.AlarmControlPanel):
         if not check:
             _LOGGER.warning("Invalid code given for %s", state)
         return check
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        state_attr = super().state_attributes
+
+        if self.state == STATE_ALARM_PENDING:
+            state_attr[ATTR_POST_PENDING_STATE] = self._state
+
+        return state_attr

--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -191,7 +191,7 @@ class ManualAlarm(alarm.AlarmControlPanel):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        state_attr = super().state_attributes
+        state_attr = {}
 
         if self.state == STATE_ALARM_PENDING:
             state_attr[ATTR_POST_PENDING_STATE] = self._state

--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -189,7 +189,7 @@ class ManualAlarm(alarm.AlarmControlPanel):
         return check
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
         state_attr = super().state_attributes
 

--- a/tests/components/alarm_control_panel/test_manual.py
+++ b/tests/components/alarm_control_panel/test_manual.py
@@ -72,6 +72,11 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
 
+        self.assertTrue(self.hass.states.
+                        is_state_attr(entity_id,
+                                      'post_pending_state',
+                                      STATE_ALARM_ARMED_HOME))
+
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
                     'dt_util.utcnow'), return_value=future):
@@ -150,6 +155,11 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
 
+        self.assertTrue(self.hass.states.
+                        is_state_attr(entity_id,
+                                      'post_pending_state',
+                                      STATE_ALARM_ARMED_AWAY))
+
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
                     'dt_util.utcnow'), return_value=future):
@@ -227,6 +237,11 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
+
+        self.assertTrue(self.hass.states.
+                        is_state_attr(entity_id,
+                                      'post_pending_state',
+                                      STATE_ALARM_ARMED_NIGHT))
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -313,6 +328,11 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
+
+        self.assertTrue(self.hass.states.
+                        is_state_attr(entity_id,
+                                      'post_pending_state',
+                                      STATE_ALARM_TRIGGERED))
 
         future = dt_util.utcnow() + timedelta(seconds=2)
         with patch(('homeassistant.components.alarm_control_panel.manual.'

--- a/tests/components/alarm_control_panel/test_manual.py
+++ b/tests/components/alarm_control_panel/test_manual.py
@@ -72,10 +72,10 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
 
-        self.assertTrue(self.hass.states.
-                        is_state_attr(entity_id,
-                                      'post_pending_state',
-                                      STATE_ALARM_ARMED_HOME))
+        self.assertTrue(
+            self.hass.states.is_state_attr(entity_id,
+                                           'post_pending_state',
+                                           STATE_ALARM_ARMED_HOME))
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -155,10 +155,10 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
 
-        self.assertTrue(self.hass.states.
-                        is_state_attr(entity_id,
-                                      'post_pending_state',
-                                      STATE_ALARM_ARMED_AWAY))
+        self.assertTrue(
+            self.hass.states.is_state_attr(entity_id,
+                                           'post_pending_state',
+                                           STATE_ALARM_ARMED_AWAY))
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -238,10 +238,10 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
 
-        self.assertTrue(self.hass.states.
-                        is_state_attr(entity_id,
-                                      'post_pending_state',
-                                      STATE_ALARM_ARMED_NIGHT))
+        self.assertTrue(
+            self.hass.states.is_state_attr(entity_id,
+                                           'post_pending_state',
+                                           STATE_ALARM_ARMED_NIGHT))
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -329,10 +329,10 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
 
-        self.assertTrue(self.hass.states.
-                        is_state_attr(entity_id,
-                                      'post_pending_state',
-                                      STATE_ALARM_TRIGGERED))
+        self.assertTrue(
+            self.hass.states.is_state_attr(entity_id,
+                                           'post_pending_state',
+                                           STATE_ALARM_TRIGGERED))
 
         future = dt_util.utcnow() + timedelta(seconds=2)
         with patch(('homeassistant.components.alarm_control_panel.manual.'


### PR DESCRIPTION
## Description:
- Added "post_pending_state" attribute to manual alarm_control_panel to indicate what the next state is after pending state.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
