### PR TITLE
Handle spotify failing to refresh access_token

### DIFF
--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -162,7 +162,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
     def update(self):
         """Update state and attributes."""
         self.refresh_spotify_instance()
-        
+
         # Don't true update when token is expired
         if self._oauth.is_token_expired(self._token_info):
             _LOGGER.warning("Spotify failed to update, token expired.")

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -148,6 +148,10 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             new_token = \
                 self._oauth.refresh_access_token(
                     self._token_info['refresh_token'])
+            # skip when refresh failed
+            if new_token is None:
+                return
+
             self._token_info = new_token
             token_refreshed = True
         if self._player is None or token_refreshed:
@@ -158,6 +162,12 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
     def update(self):
         """Update state and attributes."""
         self.refresh_spotify_instance()
+        
+        # Don't true update when token is expired
+        if self._oauth.is_token_expired(self._token_info):
+            _LOGGER.warning("Spotify failed to update, token expired.")
+            return
+
         # Available devices
         player_devices = self._player.devices()
         if player_devices is not None:


### PR DESCRIPTION
## Description:
The used Spotipy library doesn't handle failed oauth requests gracefully, as you can see in the following lines: https://github.com/plamere/spotipy/blob/master/spotipy/oauth2.py#L240-L246
What happens, is that our implementation continues ahead with the None as token info, which causes the system to fail on the next update cycle (Since there's no more info in the token)

This change check whether the token_info is None, and skips over the refresh of the spotify instance. During update an additional check is done, to make sure the access token is still valid, preventing the system from throwing more errors when an update failed.

**Related issue (if applicable):** fixes #8470 (and I believe #8273 as well) 

## Example entry for `configuration.yaml` (if applicable):
No changes

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests 

Ideally a fix should be issued in the spotipy repo itself, but it seems the maintainer is inactive lately.