### PR TITLE
Updated Lutron Caseta component to support additional shade types (Triathlon and Sivoia QS Wireless)

### DIFF
--- a/homeassistant/components/cover/lutron_caseta.py
+++ b/homeassistant/components/cover/lutron_caseta.py
@@ -1,14 +1,14 @@
 """
-Support for Lutron Caseta SerenaRollerShade.
+Support for Lutron Caseta shades.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.lutron_caseta/
 """
 import logging
 
-
 from homeassistant.components.cover import (
-    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_SET_POSITION)
+    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_SET_POSITION,
+    ATTR_POSITION, DOMAIN)
 from homeassistant.components.lutron_caseta import (
     LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice)
 
@@ -19,11 +19,10 @@ DEPENDENCIES = ['lutron_caseta']
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the Lutron Caseta Serena shades as a cover device."""
+    """Set up the Lutron Caseta shades as a cover device."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
-    cover_devices = bridge.get_devices_by_types(["SerenaRollerShade",
-                                                 "SerenaHoneycombShade"])
+    cover_devices = bridge.get_devices_by_domain(DOMAIN)
     for cover_device in cover_devices:
         dev = LutronCasetaCover(cover_device, bridge)
         devs.append(dev)
@@ -32,7 +31,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class LutronCasetaCover(LutronCasetaDevice, CoverDevice):
-    """Representation of a Lutron Serena shade."""
+    """Representation of a Lutron shade."""
 
     @property
     def supported_features(self):
@@ -42,24 +41,26 @@ class LutronCasetaCover(LutronCasetaDevice, CoverDevice):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        return self._state["current_state"] < 1
+        return self._state['current_state'] < 1
 
     @property
     def current_cover_position(self):
         """Return the current position of cover."""
-        return self._state["current_state"]
+        return self._state['current_state']
 
-    def close_cover(self):
+    def close_cover(self, **kwargs):
         """Close the cover."""
         self._smartbridge.set_value(self._device_id, 0)
 
-    def open_cover(self):
+    def open_cover(self, **kwargs):
         """Open the cover."""
         self._smartbridge.set_value(self._device_id, 100)
 
-    def set_cover_position(self, position, **kwargs):
-        """Move the roller shutter to a specific position."""
-        self._smartbridge.set_value(self._device_id, position)
+    def set_cover_position(self, **kwargs):
+        """Move the shade to a specific position."""
+        if ATTR_POSITION in kwargs:
+            position = kwargs[ATTR_POSITION]
+            self._smartbridge.set_value(self._device_id, position)
 
     def update(self):
         """Call when forcing a refresh of the device."""

--- a/homeassistant/components/light/lutron_caseta.py
+++ b/homeassistant/components/light/lutron_caseta.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/light.lutron_caseta/
 import logging
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light, DOMAIN)
 from homeassistant.components.light.lutron import (
     to_hass_level, to_lutron_level)
 from homeassistant.components.lutron_caseta import (
@@ -23,7 +23,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Lutron Caseta lights."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
-    light_devices = bridge.get_devices_by_types(["WallDimmer", "PlugInDimmer"])
+    light_devices = bridge.get_devices_by_domain(DOMAIN)
     for light_device in light_devices:
         dev = LutronCasetaLight(light_device, bridge)
         devs.append(dev)

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pylutron-caseta==0.2.7']
+REQUIREMENTS = ['pylutron-caseta==0.2.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/lutron_caseta.py
+++ b/homeassistant/components/switch/lutron_caseta.py
@@ -8,7 +8,7 @@ import logging
 
 from homeassistant.components.lutron_caseta import (
     LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice)
-from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.switch import SwitchDevice, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Lutron switch."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
-    switch_devices = bridge.get_devices_by_type("WallSwitch")
+    switch_devices = bridge.get_devices_by_domain(DOMAIN)
 
     for switch_device in switch_devices:
         dev = LutronCasetaLight(switch_device, bridge)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -646,7 +646,7 @@ pylitejet==0.1
 pyloopenergy==0.0.17
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.2.7
+pylutron-caseta==0.2.8
 
 # homeassistant.components.lutron
 pylutron==0.1.0


### PR DESCRIPTION
## Description:
Updated Lutron Caseta component to support additional shade types (Triathlon and Sivoia QS Wireless).

As suggested in the closed Pull Request #8903, the upstream pylutron-caseta library has been updated to support getting devices by their domain such as 'light', 'switch' and 'cover'. This avoids having to update Home Assistant to add new device support and pushes the responsibility to the third-party library. 

Upstream library [pylutron-caseta 0.2.8](https://pypi.python.org/pypi/pylutron_caseta) is now available and supports this new function.

In addition:

- Removed all references to 'Serena' shades since multiple types are now supported.
- As suggested by pylint, modified functions in cover/lutron_caseta.py to match the functions they are overriding.
- Updated lutron_caseta.py and requirements_all.txt with new pylutron-caseta 0.2.8 dependency.
- Minor update to single quotes in cover/lutron_caseta.py to follow Home Assistant style guide.

**Related issue (if applicable):** None

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3310

## Example entry for `configuration.yaml` (if applicable):

```yaml
lutron_caseta:
    host: IP_ADDRESS
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
