### PR TITLE
Add new config variable to MQTT light

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -39,6 +39,7 @@ CONF_EFFECT_COMMAND_TOPIC = 'effect_command_topic'
 CONF_EFFECT_LIST = 'effect_list'
 CONF_EFFECT_STATE_TOPIC = 'effect_state_topic'
 CONF_EFFECT_VALUE_TEMPLATE = 'effect_value_template'
+CONF_RGB_COMMAND_TEMPLATE = 'rgb_command_template'
 CONF_RGB_COMMAND_TOPIC = 'rgb_command_topic'
 CONF_RGB_STATE_TOPIC = 'rgb_state_topic'
 CONF_RGB_VALUE_TEMPLATE = 'rgb_value_template'
@@ -75,6 +76,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
     vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
     vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
+    vol.Optional(CONF_RGB_COMMAND_TEMPLATE): cv.template,
     vol.Optional(CONF_RGB_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_RGB_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_RGB_VALUE_TEMPLATE): cv.template,
@@ -125,6 +127,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             CONF_COLOR_TEMP: config.get(CONF_COLOR_TEMP_VALUE_TEMPLATE),
             CONF_EFFECT: config.get(CONF_EFFECT_VALUE_TEMPLATE),
             CONF_RGB: config.get(CONF_RGB_VALUE_TEMPLATE),
+            CONF_RGB_COMMAND_TEMPLATE: config.get(CONF_RGB_COMMAND_TEMPLATE),
             CONF_STATE: config.get(CONF_STATE_VALUE_TEMPLATE),
             CONF_WHITE_VALUE: config.get(CONF_WHITE_VALUE_TEMPLATE),
             CONF_XY: config.get(CONF_XY_VALUE_TEMPLATE),
@@ -397,10 +400,17 @@ class MqttLight(Light):
         if ATTR_RGB_COLOR in kwargs and \
            self._topic[CONF_RGB_COMMAND_TOPIC] is not None:
 
+            rgb_color_str = '{},{},{}'.format(*kwargs[ATTR_RGB_COLOR])
+            tpl = self._templates[CONF_RGB_COMMAND_TEMPLATE]
+            if tpl is not None:
+                colors = {'red', 'green', 'blue'}
+                env = {}
+                for key, val in zip(colors, kwargs[ATTR_RGB_COLOR]):
+                    env[key] = val
+                rgb_color_str = tpl.async_render(env)
             mqtt.async_publish(
                 self.hass, self._topic[CONF_RGB_COMMAND_TOPIC],
-                '{},{},{}'.format(*kwargs[ATTR_RGB_COLOR]), self._qos,
-                self._retain)
+                rgb_color_str, self._qos, self._retain)
 
             if self._optimistic_rgb:
                 self._rgb = kwargs[ATTR_RGB_COLOR]

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -400,14 +400,14 @@ class MqttLight(Light):
         if ATTR_RGB_COLOR in kwargs and \
            self._topic[CONF_RGB_COMMAND_TOPIC] is not None:
 
-            rgb_color_str = '{},{},{}'.format(*kwargs[ATTR_RGB_COLOR])
             tpl = self._templates[CONF_RGB_COMMAND_TEMPLATE]
             if tpl is not None:
                 colors = {'red', 'green', 'blue'}
-                env = {}
-                for key, val in zip(colors, kwargs[ATTR_RGB_COLOR]):
-                    env[key] = val
-                rgb_color_str = tpl.async_render(env)
+                variables = {key: val for key, val in
+                             zip(colors, kwargs[ATTR_RGB_COLOR])}
+                rgb_color_str = tpl.async_render(variables)
+            else:
+                rgb_color_str = '{},{},{}'.format(*kwargs[ATTR_RGB_COLOR])
             mqtt.async_publish(
                 self.hass, self._topic[CONF_RGB_COMMAND_TOPIC],
                 rgb_color_str, self._qos, self._retain)

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -401,7 +401,7 @@ class MqttLight(Light):
            self._topic[CONF_RGB_COMMAND_TOPIC] is not None:
 
             tpl = self._templates[CONF_RGB_COMMAND_TEMPLATE]
-            if tpl is not None:
+            if tpl:
                 colors = {'red', 'green', 'blue'}
                 variables = {key: val for key, val in
                              zip(colors, kwargs[ATTR_RGB_COLOR])}


### PR DESCRIPTION
## Description: MQTT Light - New config variable rgb_command_template

Some devices do not understand Home Assistance default RGB format. The idea of this PR is to let user ability to control RGB color format in the same way as variables like *rgb_value_template* do.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation: [PR 3312](https://github.com/home-assistant/home-assistant.github.io/pull/3312)

## Example entry for `light.yaml`:
Use HEX RGB color format:
```yaml
light:
  platform: mqtt
  name: "Office Light RGB"
  state_topic: "office/rgb1/light/status"
  command_topic: "office/rgb1/light/switch"
  rgb_state_topic: "office/rgb1/rgb/status"
  rgb_command_topic: "office/rgb1/rgb/set"
  rgb_command_template: "{{ '#%02x%02x%02x' | format(red, green, blue)}}"
  qos: 0
  payload_on: "on"
  payload_off: "off"
```
Topic message will be like `#ffddee`
## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.