### PR TITLE
Fix for Honeywell Round thermostats

### DIFF
--- a/homeassistant/components/climate/honeywell.py
+++ b/homeassistant/components/climate/honeywell.py
@@ -196,6 +196,11 @@ class RoundThermostat(ClimateDevice):
                 if val['id'] == self._id:
                     data = val
 
+        except KeyError:
+            _LOGGER.error("Update failed from Honeywell server")
+            self.client.user_data = None
+            return
+
         except StopIteration:
             _LOGGER.error("Did not receive any temperature data from the "
                           "evohomeclient API")


### PR DESCRIPTION
This fixes an issue (#8554) whereby the Honeywell thermostats stopped
working after a period of hours or days. We do this by forgetting the
authorisation token that was sent back to us when we first logged in,
which causes the underlying evohomeclient library to perform the full
login procedure again.

## Description:

Fixes #8554 per my analysis in that issue's thread. The token issued by Honeywell eventually times out but the underlying library has no mechanism to renew the credential. This is achieved by setting the library's "user_data" field to None when an update error has occurred, so next time a full update is performed, the log-on procedure happen and we get a new auth token.

I've tested this fix out in my environment and had stable performance from the Honeywell component for over a week now.

**Related issue (if applicable):** fixes #8554 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
