### PR TITLE
Fixed Abode device discovery bug

### DIFF
--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -52,7 +52,8 @@ def setup(hass, config):
     password = conf.get(CONF_PASSWORD)
 
     try:
-        hass.data[DATA_ABODE] = abode = abodepy.Abode(username, password)
+        hass.data[DATA_ABODE] = abode = abodepy.Abode(
+            username, password, auto_login=True, get_devices=True)
 
     except (ConnectTimeout, HTTPError) as ex:
         _LOGGER.error("Unable to connect to Abode: %s", str(ex))


### PR DESCRIPTION
## Description:

After the last Abode PR was merged a change was made that broke device discovery. This fixes that issue.

This issue is already fixed in the feature pull request #9310 however I wanted to ensure that if that PR did not make it in for 0.53 that this fix did.

**Related issue (if applicable):** fixes bug introduced in #9095

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** Not applicable

## Example entry for `configuration.yaml` (if applicable): Not applicable

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.