### PR TITLE
Add rflink cover support, take 2

### DIFF
--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -1,0 +1,88 @@
+"""
+Support for Rflink switches.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.rflink/
+"""
+import asyncio
+import logging
+
+from homeassistant.components.rflink import (
+    CONF_ALIASSES, CONF_DEVICE_DEFAULTS, CONF_DEVICES, CONF_FIRE_EVENT,
+    CONF_GROUP, CONF_GROUP_ALIASSES, CONF_NOGROUP_ALIASSES,
+    CONF_SIGNAL_REPETITIONS, DATA_ENTITY_GROUP_LOOKUP, DATA_ENTITY_LOOKUP,
+    DEVICE_DEFAULTS_SCHEMA, DOMAIN, EVENT_KEY_COMMAND, CoverableRflinkDevice,
+    cv, vol)
+from homeassistant.components.cover import (
+    CoverDevice, ATTR_TILT_POSITION, SUPPORT_OPEN_TILT,
+    SUPPORT_CLOSE_TILT, SUPPORT_STOP_TILT, SUPPORT_SET_TILT_POSITION,
+    SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_STOP, SUPPORT_SET_POSITION,
+    ATTR_POSITION)
+from homeassistant.components.cover import CoverDevice
+from homeassistant.const import CONF_NAME, CONF_PLATFORM
+DEPENDENCIES = ['rflink']
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): DOMAIN,
+    vol.Optional(CONF_DEVICE_DEFAULTS, default=DEVICE_DEFAULTS_SCHEMA({})):
+    DEVICE_DEFAULTS_SCHEMA,
+    vol.Optional(CONF_DEVICES, default={}): vol.Schema({
+        cv.string: {
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_ALIASSES, default=[]):
+                vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(CONF_GROUP_ALIASSES, default=[]):
+                vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(CONF_NOGROUP_ALIASSES, default=[]):
+                vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
+            vol.Optional(CONF_SIGNAL_REPETITIONS): vol.Coerce(int),
+            vol.Optional(CONF_GROUP, default=True): cv.boolean,
+        },
+    }),
+})
+
+
+def devices_from_config(domain_config, hass=None):
+    """Parse configuration and add Rflink switch devices."""
+    devices = []
+    for device_id, config in domain_config[CONF_DEVICES].items():
+        device_config = dict(domain_config[CONF_DEVICE_DEFAULTS], **config)
+        device = RflinkCover(device_id, hass, **device_config)
+        devices.append(device)
+
+        # Register entity (and aliasses) to listen to incoming rflink events
+        # Device id and normal aliasses respond to normal and group command
+        hass.data[DATA_ENTITY_LOOKUP][
+            EVENT_KEY_COMMAND][device_id].append(device)
+        if config[CONF_GROUP]:
+            hass.data[DATA_ENTITY_GROUP_LOOKUP][
+                EVENT_KEY_COMMAND][device_id].append(device)
+        for _id in config[CONF_ALIASSES]:
+            hass.data[DATA_ENTITY_LOOKUP][
+                EVENT_KEY_COMMAND][_id].append(device)
+            hass.data[DATA_ENTITY_GROUP_LOOKUP][
+                EVENT_KEY_COMMAND][_id].append(device)
+        # group_aliasses only respond to group commands
+        for _id in config[CONF_GROUP_ALIASSES]:
+            hass.data[DATA_ENTITY_GROUP_LOOKUP][
+                EVENT_KEY_COMMAND][_id].append(device)
+        # nogroup_aliasses only respond to normal commands
+        for _id in config[CONF_NOGROUP_ALIASSES]:
+            hass.data[DATA_ENTITY_LOOKUP][
+                EVENT_KEY_COMMAND][_id].append(device)
+
+    return devices
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Rflink platform."""
+    async_add_devices(devices_from_config(config, hass))
+
+
+class RflinkCover(CoverableRflinkDevice, CoverDevice):
+    """Representation of a Rflink cover."""
+ 
+    pass

--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -1,5 +1,6 @@
 """
 Support for Rflink switches.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.rflink/
 """
@@ -102,13 +103,13 @@ class RflinkCover(RflinkCommand, CoverDevice):
         return None
 
     def async_close_cover(self, **kwargs):
-        """Turn the device on."""
+        """Close the cover."""
         return self._async_handle_command("turn_on")
 
     def async_open_cover(self, **kwargs):
-        """Turn the device off."""
+        """Open the cover."""
         return self._async_handle_command("turn_off")
 
     def async_stop_cover(self, **kwargs):
-        """Turn the device off."""
+        """Stop the cover movement."""
         return self._async_handle_command("stop_roll")

--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -7,8 +7,8 @@ import asyncio
 import logging
 
 from homeassistant.components.rflink import (
-    CONF_ALIASSES, CONF_DEVICE_DEFAULTS, CONF_DEVICES, CONF_FIRE_EVENT,
-    CONF_GROUP, CONF_GROUP_ALIASSES, CONF_NOGROUP_ALIASSES,
+    CONF_ALIASES, CONF_DEVICE_DEFAULTS, CONF_DEVICES, CONF_FIRE_EVENT,
+    CONF_GROUP, CONF_GROUP_ALIASES, CONF_NOGROUP_ALIASES,
     CONF_SIGNAL_REPETITIONS, DATA_ENTITY_GROUP_LOOKUP, DATA_ENTITY_LOOKUP,
     DEVICE_DEFAULTS_SCHEMA, DOMAIN, EVENT_KEY_COMMAND,
     cv, vol, RflinkCommand)
@@ -26,11 +26,11 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Optional(CONF_DEVICES, default={}): vol.Schema({
         cv.string: {
             vol.Optional(CONF_NAME): cv.string,
-            vol.Optional(CONF_ALIASSES, default=[]):
+            vol.Optional(CONF_ALIASES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
-            vol.Optional(CONF_GROUP_ALIASSES, default=[]):
+            vol.Optional(CONF_GROUP_ALIASES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
-            vol.Optional(CONF_NOGROUP_ALIASSES, default=[]):
+            vol.Optional(CONF_NOGROUP_ALIASES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
             vol.Optional(CONF_SIGNAL_REPETITIONS): vol.Coerce(int),
@@ -48,24 +48,24 @@ def devices_from_config(domain_config, hass=None):
         device = RflinkCover(device_id, hass, **device_config)
         devices.append(device)
 
-        # Register entity (and aliasses) to listen to incoming rflink events
-        # Device id and normal aliasses respond to normal and group command
+        # Register entity (and aliases) to listen to incoming rflink events
+        # Device id and normal aliases respond to normal and group command
         hass.data[DATA_ENTITY_LOOKUP][
             EVENT_KEY_COMMAND][device_id].append(device)
         if config[CONF_GROUP]:
             hass.data[DATA_ENTITY_GROUP_LOOKUP][
                 EVENT_KEY_COMMAND][device_id].append(device)
-        for _id in config[CONF_ALIASSES]:
+        for _id in config[CONF_ALIASES]:
             hass.data[DATA_ENTITY_LOOKUP][
                 EVENT_KEY_COMMAND][_id].append(device)
             hass.data[DATA_ENTITY_GROUP_LOOKUP][
                 EVENT_KEY_COMMAND][_id].append(device)
-        # group_aliasses only respond to group commands
-        for _id in config[CONF_GROUP_ALIASSES]:
+        # group_aliases only respond to group commands
+        for _id in config[CONF_GROUP_ALIASES]:
             hass.data[DATA_ENTITY_GROUP_LOOKUP][
                 EVENT_KEY_COMMAND][_id].append(device)
-        # nogroup_aliasses only respond to normal commands
-        for _id in config[CONF_NOGROUP_ALIASSES]:
+        # nogroup_aliases only respond to normal commands
+        for _id in config[CONF_NOGROUP_ALIASES]:
             hass.data[DATA_ENTITY_LOOKUP][
                 EVENT_KEY_COMMAND][_id].append(device)
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -440,40 +440,6 @@ class SwitchableRflinkDevice(RflinkCommand):
         """Turn the device off."""
         return self._async_handle_command("turn_off")
 
-class CoverableRflinkDevice(RflinkCommand):
-    """Rflink entity which can switch on/stop/off (eg: cover)."""
-
-    def _handle_event(self, event):
-        """Adjust state if Rflink picks up a remote command for this device."""
-        self.cancel_queued_send_commands()
-
-        command = event['command']
-        if command in ['on', 'allon']:
-            self._state = True
-        elif command in ['off', 'alloff']:
-            self._state = False
-
-    @property
-    def should_poll(self):
-        """No polling available in RFXtrx cover."""
-        return False
-
-    @property
-    def is_closed(self):
-        """Return if the cover is closed."""
-        return None
-		
-    def async_close_cover(self, **kwargs):
-        """Turn the device on."""
-        return self._async_handle_command("turn_on")
-
-    def async_open_cover(self, **kwargs):
-        """Turn the device off."""
-        return self._async_handle_command("turn_off")
-		
-    def async_stop_cover(self, **kwargs):
-        """Turn the device off."""
-        return self._async_handle_command("stop_roll")
 
 DEPRECATED_CONFIG_OPTIONS = [
     CONF_ALIASSES,

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -370,6 +370,10 @@ class RflinkCommand(RflinkDevice):
             # if the state is true, it gets set as false
             self._state = self._state in [STATE_UNKNOWN, False]
 
+        elif command == 'stop_roll':
+            cmd = 'stop'
+            self._state = True
+
         # Send initial command and queue repetitions.
         # This allows the entity state to be updated quickly and not having to
         # wait for all repetitions to be sent
@@ -436,6 +440,40 @@ class SwitchableRflinkDevice(RflinkCommand):
         """Turn the device off."""
         return self._async_handle_command("turn_off")
 
+class CoverableRflinkDevice(RflinkCommand):
+    """Rflink entity which can switch on/stop/off (eg: cover)."""
+
+    def _handle_event(self, event):
+        """Adjust state if Rflink picks up a remote command for this device."""
+        self.cancel_queued_send_commands()
+
+        command = event['command']
+        if command in ['on', 'allon']:
+            self._state = True
+        elif command in ['off', 'alloff']:
+            self._state = False
+
+    @property
+    def should_poll(self):
+        """No polling available in RFXtrx cover."""
+        return False
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return None
+		
+    def async_close_cover(self, **kwargs):
+        """Turn the device on."""
+        return self._async_handle_command("turn_on")
+
+    def async_open_cover(self, **kwargs):
+        """Turn the device off."""
+        return self._async_handle_command("turn_off")
+		
+    def async_stop_cover(self, **kwargs):
+        """Turn the device off."""
+        return self._async_handle_command("stop_roll")
 
 DEPRECATED_CONFIG_OPTIONS = [
     CONF_ALIASSES,

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -6,7 +6,8 @@ from unittest.mock import Mock
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.rflink import (
     CONF_RECONNECT_INTERVAL, SERVICE_SEND_COMMAND)
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF
+from homeassistant.const import (
+    ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_STOP_COVER)
 from tests.common import assert_setup_component
 
 
@@ -117,6 +118,38 @@ def test_send_no_wait(hass, monkeypatch):
     yield from hass.async_block_till_done()
     assert protocol.send_command.call_args_list[0][0][0] == 'protocol_0_0'
     assert protocol.send_command.call_args_list[0][0][1] == 'off'
+
+
+@asyncio.coroutine
+def test_cover_send_no_wait(hass, monkeypatch):
+    """Test command sending to a cover device without ack."""
+    domain = 'cover'
+    config = {
+        'rflink': {
+            'port': '/dev/ttyABC0',
+            'wait_for_ack': False,
+        },
+        domain: {
+            'platform': 'rflink',
+            'devices': {
+                'protocol_0_0': {
+                        'name': 'test',
+                        'aliases': ['test_alias_0_0'],
+                },
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    _, _, protocol, _ = yield from mock_rflink(
+        hass, config, domain, monkeypatch)
+
+    hass.async_add_job(
+        hass.services.async_call(domain, SERVICE_STOP_COVER,
+                                 {ATTR_ENTITY_ID: 'cover.test'}))
+    yield from hass.async_block_till_done()
+    assert protocol.send_command.call_args_list[0][0][0] == 'protocol_0_0'
+    assert protocol.send_command.call_args_list[0][0][1] == 'stop'
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

I took @sylvaindd's previous PR https://github.com/home-assistant/home-assistant/pull/8474 and applied the modifications requested in that PR. I also made a simple unit test for it, but frankly, I'm not sure how useful or correct it is.

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  - platform: rflink
    devices:
      bofumotor_123456_01:
        name: Sample rflink cover
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

__Not yet__: Probably better to get the PR in first?

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [NA] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [NA] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [NA] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [NA] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

