### PR TITLE
Add an input_datetime

### DIFF
--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -38,7 +38,6 @@ SERVICE_SET_DATETIME_SCHEMA = vol.Schema({
 })
 
 
-# TODO bring this into easier form?
 def _cv_input_datetime(cfg):
     """Configure validation helper for input datetime (voluptuous)."""
     has_date = cfg[CONF_HAS_DATE]
@@ -135,7 +134,6 @@ class DatetimeSelect(Entity):
         if old_state is not None:
             self._current_datetime = dt_util.parse_datetime(old_state.state)
         else:
-            # TODO is this a sane default value?
             self._current_datetime = dt_util.now()
 
     @property
@@ -187,13 +185,11 @@ class DatetimeSelect(Entity):
             if time_val is None:
                 _LOGGER.warning('"None" passed as time.')
                 return
-            # TODO cast to datetime?
             self._current_datetime = time_val
         elif not self._has_time:
             if date_val is None:
                 _LOGGER.warning('"None" passed as date.')
                 return
-            # TODO cast to datetime?
             self._current_datetime = date_val
         else:
             if time_val is None:

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -37,6 +37,7 @@ SERVICE_SET_DATETIME_SCHEMA = vol.Schema({
     vol.Optional(ATTR_TIME): cv.time,
 })
 
+
 # TODO bring this into easier form?
 def _cv_input_datetime(cfg):
     """Configure validation helper for input datetime (voluptuous)."""
@@ -46,6 +47,7 @@ def _cv_input_datetime(cfg):
     if not has_date and not has_time:
         raise vol.Invalid("Input Datetime must have at least date or time!")
     return cfg
+
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -57,15 +59,16 @@ CONFIG_SCHEMA = vol.Schema({
         }, _cv_input_datetime)})
 }, required=True, extra=vol.ALLOW_EXTRA)
 
+
 @bind_hass
 def select_datetime(hass, entity_id, dt_value):
     """Set date and / or time of input_datetime."""
-
     hass.services.call(DOMAIN, SERVICE_SET_DATETIME, {
         ATTR_ENTITY_ID: entity_id,
         ATTR_DATE: dt_value.date(),
         ATTR_TIME: dt_value.time()
     })
+
 
 @asyncio.coroutine
 def async_setup(hass, config):
@@ -79,7 +82,8 @@ def async_setup(hass, config):
         has_time = cfg.get(CONF_HAS_TIME)
         has_date = cfg.get(CONF_HAS_DATE)
         icon = cfg.get(CONF_ICON)
-        entities.append(DatetimeSelect(object_id, name, has_date, has_time, icon))
+        entities.append(DatetimeSelect(object_id, name,
+                                       has_date, has_time, icon))
 
     if not entities:
         return False
@@ -129,7 +133,8 @@ class DatetimeSelect(Entity):
         if old_state is not None:
             self._current_datetime = dt_util.parse_datetime(old_state.state)
         else:
-            self._current_datetime = dt_util.now() # TODO is this a sane default value?
+            # TODO is this a sane default value?
+            self._current_datetime = dt_util.now()
 
     @property
     def should_poll(self):
@@ -175,18 +180,19 @@ class DatetimeSelect(Entity):
 
     @asyncio.coroutine
     def async_set_datetime(self, date_val, time_val):
-        """Set a new date / time"""
-
+        """Set a new date / time."""
         if not self._has_date:
             if time_val is None:
                 _LOGGER.warning('"None" passed as time.')
                 return
-            self._current_datetime = time_val # TODO cast to datetime?
+            # TODO cast to datetime?
+            self._current_datetime = time_val
         elif not self._has_time:
             if date_val is None:
                 _LOGGER.warning('"None" passed as date.')
                 return
-            self._current_datetime = date_val # TODO cast to datetime?
+            # TODO cast to datetime?
+            self._current_datetime = date_val
         else:
             if time_val is None:
                 _LOGGER.warning('"None" passed as time.')
@@ -194,6 +200,7 @@ class DatetimeSelect(Entity):
             if date_val is None:
                 _LOGGER.warning('"None" passed as date.')
                 return
-            self._current_datetime = datetime.datetime.combine(date_val, time_val)
+            self._current_datetime = datetime.datetime.combine(date_val,
+                                                               time_val)
 
         yield from self.async_update_ha_state()

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -10,6 +10,7 @@ import datetime
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 from homeassistant.const import ATTR_ENTITY_ID, CONF_ICON, CONF_NAME
 from homeassistant.loader import bind_hass
 import homeassistant.helpers.config_validation as cv
@@ -56,7 +57,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Required(CONF_HAS_TIME): cv.boolean,
             vol.Optional(CONF_ICON): cv.icon,
         }, _cv_input_datetime)})
-}, required=True, extra=vol.ALLOW_EXTRA)
+}, extra=vol.ALLOW_EXTRA)
 
 
 @bind_hass
@@ -137,7 +138,6 @@ class DatetimeSelect(Entity):
         else:
             restore_val = dt_util.now()
 
-        print("Type is: " + str(type(restore_val)))
         if not self._has_date:
             self._current_datetime = restore_val.time()
         elif not self._has_time:
@@ -188,7 +188,7 @@ class DatetimeSelect(Entity):
 
         return attrs
 
-    @asyncio.coroutine
+    @callback
     def async_set_datetime(self, date_val, time_val):
         """Set a new date / time."""
         if not self._has_date:

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -168,10 +168,23 @@ class DatetimeSelect(Entity):
             attrs['year'] = self._current_datetime.year
             attrs['month'] = self._current_datetime.month
             attrs['day'] = self._current_datetime.day
+
         if self._has_time and self._current_datetime is not None:
             attrs['hour'] = self._current_datetime.hour
             attrs['minute'] = self._current_datetime.minute
             attrs['second'] = self._current_datetime.second
+
+        if self._current_datetime is not None:
+            if not self._has_date:
+                attrs['timestamp'] = self._current_datetime.hour * 3600 + \
+                                     self._current_datetime.minute * 60 + \
+                                     self._current_datetime.second
+            elif not self._has_time:
+                extended = datetime.datetime.combine(self._current_datetime,
+                                                     datetime.time(0, 0))
+                attrs['timestamp'] = extended.timestamp()
+            else:
+                attrs['timestamp'] = self._current_datetime.timestamp()
 
         return attrs
 

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -96,8 +96,10 @@ def async_setup(hass, config):
         tasks = []
         for input_datetime in target_inputs:
             tasks.append(
-                input_datetime.async_set_datetime(call.data.get(ATTR_DATE, None),
-                                                  call.data.get(ATTR_TIME, None))
+                input_datetime.async_set_datetime(
+                    call.data.get(ATTR_DATE, None),
+                    call.data.get(ATTR_TIME, None)
+                )
             )
 
         if tasks:

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -126,9 +126,6 @@ class InputDatetime(Entity):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Run when entity about to be added."""
-        if self._current_datetime is not None:
-            return
-
         restore_val = None
 
         # Priority 1: Initial State

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -34,7 +34,7 @@ ATTR_TIME = 'time'
 SERVICE_SET_DATETIME = 'set_datetime'
 
 SERVICE_SET_DATETIME_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Optional(ATTR_DATE): cv.date,
     vol.Optional(ATTR_TIME): cv.time,
 })

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -123,6 +123,8 @@ class DatetimeSelect(Entity):
         old_state = yield from async_get_last_state(self.hass, self.entity_id)
         if old_state is not None:
             restore_val = dt_util.parse_datetime(old_state.state)
+            if restore_val is None:
+                restore_val = dt_util.now()
         else:
             restore_val = dt_util.now()
 

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -95,7 +95,6 @@ def async_setup(hass, config):
 
         tasks = []
         for input_datetime in target_inputs:
-            print("Setting dt for " + str(input_datetime))
             tasks.append(
                 input_datetime.async_set_datetime(
                     call.data.get(ATTR_DATE, None),
@@ -166,7 +165,6 @@ class DatetimeSelect(Entity):
         if self._current_datetime is None:
             return None
 
-        print("Returning type: " + str(type(self._current_datetime)))
         return self._current_datetime
 
     @property

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -60,7 +60,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 
 @bind_hass
-def select_datetime(hass, entity_id, dt_value):
+def set_datetime(hass, entity_id, dt_value):
     """Set date and / or time of input_datetime."""
     hass.services.call(DOMAIN, SERVICE_SET_DATETIME, {
         ATTR_ENTITY_ID: entity_id,
@@ -94,6 +94,7 @@ def async_setup(hass, config):
 
         tasks = []
         for input_datetime in target_inputs:
+            print("Setting dt for " + str(input_datetime))
             tasks.append(
                 input_datetime.async_set_datetime(
                     call.data.get(ATTR_DATE, None),
@@ -132,9 +133,17 @@ class DatetimeSelect(Entity):
 
         old_state = yield from async_get_last_state(self.hass, self.entity_id)
         if old_state is not None:
-            self._current_datetime = dt_util.parse_datetime(old_state.state)
+            restore_val = dt_util.parse_datetime(old_state.state)
         else:
-            self._current_datetime = dt_util.now()
+            restore_val = dt_util.now()
+
+        print("Type is: " + str(type(restore_val)))
+        if not self._has_date:
+            self._current_datetime = restore_val.time()
+        elif not self._has_time:
+            self._current_datetime = restore_val.date()
+        else:
+            self._current_datetime = restore_val
 
     @property
     def should_poll(self):
@@ -157,6 +166,7 @@ class DatetimeSelect(Entity):
         if self._current_datetime is None:
             return None
 
+        print("Returning type: " + str(type(self._current_datetime)))
         return self._current_datetime
 
     @property

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -12,7 +12,6 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.const import ATTR_ENTITY_ID, CONF_ICON, CONF_NAME
-from homeassistant.loader import bind_hass
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
@@ -60,10 +59,10 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-@bind_hass
-def set_datetime(hass, entity_id, dt_value):
+@asyncio.coroutine
+def async_set_datetime(hass, entity_id, dt_value):
     """Set date and / or time of input_datetime."""
-    hass.services.call(DOMAIN, SERVICE_SET_DATETIME, {
+    yield from hass.services.async_call(DOMAIN, SERVICE_SET_DATETIME, {
         ATTR_ENTITY_ID: entity_id,
         ATTR_DATE: dt_value.date(),
         ATTR_TIME: dt_value.time()

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -1,0 +1,199 @@
+"""
+Component to offer a way to select a date and / or a time.
+
+For more details about this component, please refer to the documentation
+at https://home-assistant.io/components/input_datetime/
+"""
+import asyncio
+import logging
+import datetime
+
+import voluptuous as vol
+
+from homeassistant.const import ATTR_ENTITY_ID, CONF_ICON, CONF_NAME
+from homeassistant.loader import bind_hass
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.restore_state import async_get_last_state
+from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'input_datetime'
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+CONF_HAS_DATE = 'has_date'
+CONF_HAS_TIME = 'has_time'
+
+ATTR_DATE = 'date'
+ATTR_TIME = 'time'
+
+SERVICE_SET_DATETIME = 'set_datetime'
+
+SERVICE_SET_DATETIME_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_DATE): cv.date,
+    vol.Optional(ATTR_TIME): cv.time,
+})
+
+# TODO bring this into easier form?
+def _cv_input_datetime(cfg):
+    """Configure validation helper for input datetime (voluptuous)."""
+    has_date = cfg[CONF_HAS_DATE]
+    has_time = cfg[CONF_HAS_TIME]
+
+    if not has_date and not has_time:
+        raise vol.Invalid("Input Datetime must have at least date or time!")
+    return cfg
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        cv.slug: vol.All({
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Required(CONF_HAS_DATE): cv.boolean,
+            vol.Required(CONF_HAS_TIME): cv.boolean,
+            vol.Optional(CONF_ICON): cv.icon,
+        }, _cv_input_datetime)})
+}, required=True, extra=vol.ALLOW_EXTRA)
+
+@bind_hass
+def select_datetime(hass, entity_id, dt_value):
+    """Set date and / or time of input_datetime."""
+
+    hass.services.call(DOMAIN, SERVICE_SET_DATETIME, {
+        ATTR_ENTITY_ID: entity_id,
+        ATTR_DATE: dt_value.date(),
+        ATTR_TIME: dt_value.time()
+    })
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up an input datetime."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    entities = []
+
+    for object_id, cfg in config[DOMAIN].items():
+        name = cfg.get(CONF_NAME)
+        has_time = cfg.get(CONF_HAS_TIME)
+        has_date = cfg.get(CONF_HAS_DATE)
+        icon = cfg.get(CONF_ICON)
+        entities.append(DatetimeSelect(object_id, name, has_date, has_time, icon))
+
+    if not entities:
+        return False
+
+    @asyncio.coroutine
+    def async_set_datetime_service(call):
+        """Handle a call to the input datetime 'set datetime' service."""
+        target_inputs = component.async_extract_from_service(call)
+
+        tasks = []
+        for input_datetime in target_inputs:
+            tasks.append(
+              input_datetime.async_set_datetime(call.data.get(ATTR_DATE, None),
+                                                call.data.get(ATTR_TIME, None))
+            )
+
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_SET_DATETIME, async_set_datetime_service,
+        schema=SERVICE_SET_DATETIME_SCHEMA)
+
+    yield from component.async_add_entities(entities)
+    return True
+
+
+class DatetimeSelect(Entity):
+    """Representation of a select datetime."""
+
+    def __init__(self, object_id, name, has_date, has_time, icon):
+        """Initialize a select input."""
+        self.entity_id = ENTITY_ID_FORMAT.format(object_id)
+        self._name = name
+        self._has_date = has_date
+        self._has_time = has_time
+        self._icon = icon
+        self._current_datetime = None
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Run when entity about to be added."""
+        if self._current_datetime is not None:
+            return
+
+        old_state = yield from async_get_last_state(self.hass, self.entity_id)
+        if old_state is not None:
+            self._current_datetime = dt_util.parse_datetime(old_state.state)
+        else:
+            self._current_datetime = dt_util.now() # TODO is this a sane default value?
+
+    @property
+    def should_poll(self):
+        """If entity should be polled."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the select input."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon to be used for this entity."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the state of the component."""
+        if self._current_datetime is None:
+            return None
+
+        return self._current_datetime
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        attrs = {
+            'has_date': self._has_date,
+            'has_time': self._has_time,
+        }
+
+        if self._has_date and self._current_datetime is not None:
+            attrs['year'] = self._current_datetime.year
+            attrs['month'] = self._current_datetime.month
+            attrs['day'] = self._current_datetime.day
+        if self._has_time and self._current_datetime is not None:
+            attrs['hour'] = self._current_datetime.hour
+            attrs['minute'] = self._current_datetime.minute
+            attrs['second'] = self._current_datetime.second
+
+        return attrs
+
+    @asyncio.coroutine
+    def async_set_datetime(self, date_val, time_val):
+        """Set a new date / time"""
+
+        if not self._has_date:
+            if time_val is None:
+                _LOGGER.warning('"None" passed as time.')
+                return
+            self._current_datetime = time_val # TODO cast to datetime?
+        elif not self._has_time:
+            if date_val is None:
+                _LOGGER.warning('"None" passed as date.')
+                return
+            self._current_datetime = date_val # TODO cast to datetime?
+        else:
+            if time_val is None:
+                _LOGGER.warning('"None" passed as time.')
+                return
+            if date_val is None:
+                _LOGGER.warning('"None" passed as date.')
+                return
+            self._current_datetime = datetime.datetime.combine(date_val, time_val)
+
+        yield from self.async_update_ha_state()

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -195,9 +195,12 @@ class DatetimeSelect(Entity):
     @asyncio.coroutine
     def async_set_datetime(self, date_val, time_val):
         """Set a new date / time."""
-        if self._has_date and date_val:
-            self._current_datetime = time_val
-        if self._has_time and time_val:
+        if self._has_date and self._has_time and date_val and time_val:
+            self._current_datetime = datetime.datetime.combine(date_val,
+                                                               time_val)
+        elif self._has_date and not self._has_time and date_val:
             self._current_datetime = date_val
-        
+        if self._has_time and not self._has_date and time_val:
+            self._current_datetime = time_val
+
         yield from self.async_update_ha_state()

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -96,8 +96,8 @@ def async_setup(hass, config):
         tasks = []
         for input_datetime in target_inputs:
             tasks.append(
-              input_datetime.async_set_datetime(call.data.get(ATTR_DATE, None),
-                                                call.data.get(ATTR_TIME, None))
+                input_datetime.async_set_datetime(call.data.get(ATTR_DATE, None),
+                                                  call.data.get(ATTR_TIME, None))
             )
 
         if tasks:

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -37,17 +37,6 @@ SERVICE_SET_DATETIME_SCHEMA = vol.Schema({
     vol.Optional(ATTR_TIME): cv.time,
 })
 
-
-def _cv_input_datetime(cfg):
-    """Configure validation helper for input datetime (voluptuous)."""
-    has_date = cfg[CONF_HAS_DATE]
-    has_time = cfg[CONF_HAS_TIME]
-
-    if not has_date and not has_time:
-        raise vol.Invalid("Input Datetime must have at least date or time!")
-    return cfg
-
-
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         cv.slug: vol.All({
@@ -55,7 +44,8 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Required(CONF_HAS_DATE): cv.boolean,
             vol.Required(CONF_HAS_TIME): cv.boolean,
             vol.Optional(CONF_ICON): cv.icon,
-        }, _cv_input_datetime)})
+        }, cv.has_at_least_one_key_value((CONF_HAS_DATE, True),
+                                         (CONF_HAS_TIME, True)))})
 }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -147,7 +147,10 @@ time_period_dict = vol.All(
 
 def time_str(value: str) -> time_sys:
     """Validate and transform a time."""
-    time_val = dt_util.parse_time(value)
+    try:
+        time_val = dt_util.parse_time(value)
+    except TypeError:
+        raise vol.Invalid('Not a parseable type')
 
     if time_val is None:
         raise vol.Invalid('Invalid time specified: {}'.format(value))
@@ -168,7 +171,11 @@ time = vol.Any(time_str, time_time)
 
 def date_str(value: str) -> date_sys:
     """Validate and transform a date."""
-    date_val = dt_util.parse_date(value)
+    try:
+        date_val = dt_util.parse_date(value)
+    except TypeError:
+        raise vol.Invalid('Not a parseable type')
+
     if date_val is None:
         raise vol.Invalid("Could not parse date")
     return date_val

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1,5 +1,5 @@
 """Helpers for config validation using voluptuous."""
-from datetime import timedelta, datetime as datetime_sys
+from datetime import timedelta, datetime as datetime_sys, time as time_sys, date as date_sys
 import os
 import re
 from urllib.parse import urlparse
@@ -143,6 +143,29 @@ time_period_dict = vol.All(
                          'seconds', 'milliseconds'),
     lambda value: timedelta(**value))
 
+def time_str(value: str) -> time_sys:
+    """Validate and transform a time."""
+    time = dt_util.parse_time(value)
+    if time is None:
+        raise vol.Invalid("Could not parse time")
+    return time
+
+def time_time(time: time_sys) -> time_sys:
+    return time
+
+time = vol.Any(time_str, time_time)
+
+def date_str(value: str) -> date_sys:
+    """Validate and transform a date."""
+    date = dt_util.parse_date(value)
+    if date is None:
+        raise vol.Invalid("Could not parse date")
+    return date
+
+def date_date(date: date_sys) -> date_sys:
+    return date
+
+date = vol.Any(date_str, date_date)
 
 def time_period_str(value: str) -> timedelta:
     """Validate and transform time offset."""

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -58,6 +58,21 @@ def has_at_least_one_key(*keys: str) -> Callable:
     return validate
 
 
+def has_at_least_one_key_value(*items: list) -> Callable:
+    """Validate that at least one (key, value) pair exists."""
+    def validate(obj: Dict) -> Dict:
+        """Test (key,value) exist in dict."""
+        if not isinstance(obj, dict):
+            raise vol.Invalid('expected dictionary')
+
+        for item in obj.items():
+            if item in items:
+                return obj
+        raise vol.Invalid('must contain one of {}.'.format(str(items)))
+
+    return validate
+
+
 def boolean(value: Any) -> bool:
     """Validate and coerce a boolean value."""
     if isinstance(value, str):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1,5 +1,6 @@
 """Helpers for config validation using voluptuous."""
-from datetime import timedelta, datetime as datetime_sys, time as time_sys, date as date_sys
+from datetime import (timedelta, datetime as datetime_sys,
+                      time as time_sys, date as date_sys)
 import os
 import re
 from urllib.parse import urlparse
@@ -143,6 +144,7 @@ time_period_dict = vol.All(
                          'seconds', 'milliseconds'),
     lambda value: timedelta(**value))
 
+
 def time_str(value: str) -> time_sys:
     """Validate and transform a time."""
     time = dt_util.parse_time(value)
@@ -150,10 +152,14 @@ def time_str(value: str) -> time_sys:
         raise vol.Invalid("Could not parse time")
     return time
 
+
 def time_time(time: time_sys) -> time_sys:
+    """Validate a string representing a time."""
     return time
 
+
 time = vol.Any(time_str, time_time)
+
 
 def date_str(value: str) -> date_sys:
     """Validate and transform a date."""
@@ -162,10 +168,14 @@ def date_str(value: str) -> date_sys:
         raise vol.Invalid("Could not parse date")
     return date
 
+
 def date_date(date: date_sys) -> date_sys:
+    """Validate date objects by passing them through."""
     return date
 
+
 date = vol.Any(date_str, date_date)
+
 
 def time_period_str(value: str) -> timedelta:
     """Validate and transform time offset."""

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -157,6 +157,9 @@ def time_str(value: str) -> time_sys:
 
 def time_time(time_val: time_sys) -> time_sys:
     """Validate a string representing a time."""
+    if not isinstance(time_val, time_sys):
+        raise vol.Invalid('Not of "time" type')
+
     return time_val
 
 
@@ -173,6 +176,9 @@ def date_str(value: str) -> date_sys:
 
 def date_date(date_val: date_sys) -> date_sys:
     """Validate date objects by passing them through."""
+    if not isinstance(date_val, date_sys):
+        raise vol.Invalid('Not of "date" type')
+
     return date_val
 
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -147,15 +147,17 @@ time_period_dict = vol.All(
 
 def time_str(value: str) -> time_sys:
     """Validate and transform a time."""
-    time = dt_util.parse_time(value)
-    if time is None:
-        raise vol.Invalid("Could not parse time")
-    return time
+    time_val = dt_util.parse_time(value)
+
+    if time_val is None:
+        raise vol.Invalid('Invalid time specified: {}'.format(value))
+
+    return time_val
 
 
-def time_time(time: time_sys) -> time_sys:
+def time_time(time_val: time_sys) -> time_sys:
     """Validate a string representing a time."""
-    return time
+    return time_val
 
 
 time = vol.Any(time_str, time_time)
@@ -163,15 +165,15 @@ time = vol.Any(time_str, time_time)
 
 def date_str(value: str) -> date_sys:
     """Validate and transform a date."""
-    date = dt_util.parse_date(value)
-    if date is None:
+    date_val = dt_util.parse_date(value)
+    if date_val is None:
         raise vol.Invalid("Could not parse date")
-    return date
+    return date_val
 
 
-def date_date(date: date_sys) -> date_sys:
+def date_date(date_val: date_sys) -> date_sys:
     """Validate date objects by passing them through."""
-    return date
+    return date_val
 
 
 date = vol.Any(date_str, date_date)
@@ -328,16 +330,6 @@ def template_complex(value):
         return value
 
     return template(value)
-
-
-def time(value):
-    """Validate time."""
-    time_val = dt_util.parse_time(value)
-
-    if time_val is None:
-        raise vol.Invalid('Invalid time specified: {}'.format(value))
-
-    return time_val
 
 
 def datetime(value):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -160,8 +160,11 @@ time_period_dict = vol.All(
     lambda value: timedelta(**value))
 
 
-def time_str(value: str) -> time_sys:
+def time(value) -> time_sys:
     """Validate and transform a time."""
+    if isinstance(value, time_sys):
+        return value
+
     try:
         time_val = dt_util.parse_time(value)
     except TypeError:
@@ -173,19 +176,11 @@ def time_str(value: str) -> time_sys:
     return time_val
 
 
-def time_time(time_val: time_sys) -> time_sys:
-    """Validate a string representing a time."""
-    if not isinstance(time_val, time_sys):
-        raise vol.Invalid('Not of "time" type')
-
-    return time_val
-
-
-time = vol.Any(time_str, time_time)
-
-
-def date_str(value: str) -> date_sys:
+def date(value) -> date_sys:
     """Validate and transform a date."""
+    if isinstance(value, date_sys):
+        return value
+
     try:
         date_val = dt_util.parse_date(value)
     except TypeError:
@@ -193,18 +188,8 @@ def date_str(value: str) -> date_sys:
 
     if date_val is None:
         raise vol.Invalid("Could not parse date")
-    return date_val
-
-
-def date_date(date_val: date_sys) -> date_sys:
-    """Validate date objects by passing them through."""
-    if not isinstance(date_val, date_sys):
-        raise vol.Invalid('Not of "date" type')
 
     return date_val
-
-
-date = vol.Any(date_str, date_date)
 
 
 def time_period_str(value: str) -> timedelta:

--- a/tests/components/test_input_datetime.py
+++ b/tests/components/test_input_datetime.py
@@ -135,6 +135,7 @@ def test_restore_state(hass):
         State('input_datetime.test_time', '2017-09-07 19:46:00'),
         State('input_datetime.test_date', '2017-09-07 19:46:00'),
         State('input_datetime.test_datetime', '2017-09-07 19:46:00'),
+        State('input_datetime.test_bogus_data', 'this is not a date'),
     ))
 
     hass.state = CoreState.starting
@@ -153,10 +154,13 @@ def test_restore_state(hass):
                 'has_time': True,
                 'has_date': True
             },
+            'test_bogus_data': {
+                'has_time': True,
+                'has_date': True
+            },
         }})
 
     dt_obj = datetime.datetime(2017, 9, 7, 19, 46)
-
     state_time = hass.states.get('input_datetime.test_time')
     assert state_time.state == str(dt_obj.time())
 
@@ -165,3 +169,10 @@ def test_restore_state(hass):
 
     state_datetime = hass.states.get('input_datetime.test_datetime')
     assert state_datetime.state == str(dt_obj)
+
+    # Unfortunately, we don't know what exactly dt_util.now() returned, and
+    # mocking is not possible with coroutines. Thus, we only check that the
+    # status is not 'unknown', i.e., no exception occurred when restoring
+    # state
+    state_bogus = hass.states.get('input_datetime.test_bogus_data')
+    assert state_bogus.state != 'unknown'

--- a/tests/components/test_input_datetime.py
+++ b/tests/components/test_input_datetime.py
@@ -64,6 +64,13 @@ def test_set_datetime(hass):
     assert state.attributes['has_time']
     assert state.attributes['has_date']
 
+    assert state.attributes['year'] == 2017
+    assert state.attributes['month'] == 9
+    assert state.attributes['day'] == 7
+    assert state.attributes['hour'] == 19
+    assert state.attributes['minute'] == 46
+    assert state.attributes['timestamp'] == dt_obj.timestamp()
+
 
 @asyncio.coroutine
 def test_set_datetime_time(hass):
@@ -90,6 +97,8 @@ def test_set_datetime_time(hass):
     assert state.attributes['has_time']
     assert not state.attributes['has_date']
 
+    assert state.attributes['timestamp'] == (19 * 3600) + (46 * 60)
+
 
 @asyncio.coroutine
 def test_set_datetime_date(hass):
@@ -114,6 +123,9 @@ def test_set_datetime_date(hass):
     assert state.state == str(date_portion)
     assert not state.attributes['has_time']
     assert state.attributes['has_date']
+
+    date_dt_obj = datetime.datetime(2017, 9, 7)
+    assert state.attributes['timestamp'] == date_dt_obj.timestamp()
 
 
 @asyncio.coroutine

--- a/tests/components/test_input_datetime.py
+++ b/tests/components/test_input_datetime.py
@@ -1,0 +1,140 @@
+"""Tests for the Input slider component."""
+# pylint: disable=protected-access
+import asyncio
+import unittest
+import datetime
+
+from homeassistant.core import CoreState, State
+from homeassistant.setup import setup_component, async_setup_component
+from homeassistant.components.input_datetime import (DOMAIN, set_datetime)
+
+from tests.common import get_test_home_assistant, mock_restore_cache
+
+
+class TestInputDatetime(unittest.TestCase):
+    """Test the input datetime component."""
+
+    # pylint: disable=invalid-name
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    # pylint: disable=invalid-name
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_invalid_configs(self):
+        """Test config."""
+        invalid_configs = [
+            None,
+            {},
+            {'name with space': None},
+            {'test_no_value': {
+                'has_time': False,
+                'has_date': False
+            }},
+        ]
+        for cfg in invalid_configs:
+            self.assertFalse(
+                setup_component(self.hass, DOMAIN, {DOMAIN: cfg}))
+
+    def test_set_datetime(self):
+        """Test set_datetime method."""
+        self.assertTrue(setup_component(self.hass, DOMAIN, {DOMAIN: {
+            'test_datetime': {
+                'has_date': True,
+                'has_time': True,
+            },
+        }}))
+        entity_id = 'input_datetime.test_datetime'
+
+        dt_obj = datetime.datetime(2017, 9, 7, 19, 46)
+
+        set_datetime(self.hass, entity_id, dt_obj)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(state.state, str(dt_obj))
+        self.assertTrue(state.attributes['has_time'])
+        self.assertTrue(state.attributes['has_date'])
+
+    def test_set_datetime_time(self):
+        """Test set_datetime method with only time."""
+        self.assertTrue(setup_component(self.hass, DOMAIN, {DOMAIN: {
+            'test_time': {
+                'has_date': False,
+                'has_time': True,
+            },
+        }}))
+        entity_id = 'input_datetime.test_time'
+
+        dt_obj = datetime.datetime(2017, 9, 7, 19, 46)
+        time_portion = dt_obj.time()
+
+        set_datetime(self.hass, entity_id, dt_obj)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(state.state, str(time_portion))
+        self.assertTrue(state.attributes['has_time'])
+        self.assertFalse(state.attributes['has_date'])
+
+    def test_set_datetime_date(self):
+        """Test set_datetime method with only date."""
+        self.assertTrue(setup_component(self.hass, DOMAIN, {DOMAIN: {
+            'test_date': {
+                'has_date': True,
+                'has_time': False,
+            },
+        }}))
+        entity_id = 'input_datetime.test_date'
+
+        dt_obj = datetime.datetime(2017, 9, 7, 19, 46)
+        date_portion = dt_obj.date()
+
+        set_datetime(self.hass, entity_id, dt_obj)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(state.state, str(date_portion))
+        self.assertFalse(state.attributes['has_time'])
+        self.assertTrue(state.attributes['has_date'])
+
+@asyncio.coroutine
+def test_restore_state(hass):
+    """Ensure states are restored on startup."""
+    mock_restore_cache(hass, (
+        State('input_datetime.test_time', '2017-09-07 19:46:00'),
+        State('input_datetime.test_date', '2017-09-07 19:46:00'),
+        State('input_datetime.test_datetime', '2017-09-07 19:46:00'),
+    ))
+
+    hass.state = CoreState.starting
+
+    yield from async_setup_component(hass, DOMAIN, {
+        DOMAIN: {
+            'test_time': {
+                'has_time': True,
+                'has_date': False
+            },
+            'test_date': {
+                'has_time': False,
+                'has_date': True
+            },
+            'test_datetime': {
+                'has_time': True,
+                'has_date': True
+            },
+        }})
+
+    dt_obj = datetime.datetime(2017, 9, 7, 19, 46)
+
+    state_time = hass.states.get('input_datetime.test_time')
+    assert state_time.state == str(dt_obj.time())
+
+    state_date = hass.states.get('input_datetime.test_date')
+    assert state_date.state == str(dt_obj.date())
+
+    state_datetime = hass.states.get('input_datetime.test_datetime')
+    assert state_datetime.state == str(dt_obj)

--- a/tests/components/test_input_datetime.py
+++ b/tests/components/test_input_datetime.py
@@ -101,6 +101,7 @@ class TestInputDatetime(unittest.TestCase):
         self.assertFalse(state.attributes['has_time'])
         self.assertTrue(state.attributes['has_date'])
 
+
 @asyncio.coroutine
 def test_restore_state(hass):
     """Ensure states are restored on startup."""

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -405,6 +405,31 @@ def test_time_zone():
     schema('UTC')
 
 
+def test_date():
+    """Test date validation."""
+    schema = vol.Schema(cv.date)
+
+    for value in ['Not a date', '23:42', '2016-11-23T18:59:08']:
+        with pytest.raises(vol.Invalid):
+            schema(value)
+
+    schema(datetime.now().date())
+    schema('2016-11-23')
+
+
+def test_time():
+    """Test date validation."""
+    schema = vol.Schema(cv.time)
+
+    for value in ['Not a time', '2016-11-23', '2016-11-23T18:59:08']:
+        with pytest.raises(vol.Invalid):
+            schema(value)
+
+    schema(datetime.now().time())
+    schema('23:42:00')
+    schema('23:42')
+
+
 def test_datetime():
     """Test date time validation."""
     schema = vol.Schema(cv.datetime)

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -447,6 +447,21 @@ def test_has_at_least_one_key():
         schema(value)
 
 
+def test_has_at_least_one_key_value():
+    """Test has_at_least_one_key_value validator."""
+    schema = vol.Schema(cv.has_at_least_one_key_value(('drink', 'beer'),
+                                                      ('drink', 'soda'),
+                                                      ('food', 'maultaschen')))
+
+    for value in (None, [], {}, {'wine': None}, {'drink': 'water'}):
+        with pytest.raises(vol.MultipleInvalid):
+            schema(value)
+
+    for value in ({'drink': 'beer'}, {'food': 'maultaschen'},
+                  {'drink': 'soda', 'food': 'maultaschen'}):
+        schema(value)
+
+
 def test_enum():
     """Test enum validator."""
     class TestEnum(enum.Enum):


### PR DESCRIPTION
## Description:

This is a Work-in-Progress proposal. It's not ready for merging yet, but I'd appreciate some feedback.

This adds an input_datetime component allowing to set a date, a time, or both via the frontend. This date / time can then be used by automations etc. to trigger certain events at certain times, e.g. facilitating alarm clocks, time-setpoints for the opening / closing of covers, etc. pp.

Some people have requested this in the forum [0], and there are some hacks around mimicking a 'set time' functionality via a combination of input sliders or input selects (e.g., [1], [2]). Thus, I think there is a demand for such an input (I'd like to use it myself for an alarm clock).

There are some design decision that I'm not sure about. The most important one being: Depending on whether the input is configured to have time, date or both, the status of the input is a date, time or datetime object. I'm not sure whether to default to datetime in all cases. The advantage would be that the class of the state object does not depend on the configuration, the disadvantage would be that I'd need some dummy values for date / time when it's not used.

This is the accompanying polymer frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/418 

[0] https://community.home-assistant.io/t/date-time-picker/9062
[1] https://community.home-assistant.io/t/creating-a-alarm-clock/410
[2] https://community.home-assistant.io/t/alarm-clock-with-sonos-philips-hue/23421

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3390

## Example entry for `configuration.yaml` (if applicable):
```yaml
input_datetime:
  test:
    name: 'Test'
    has_time: true
    has_date: true
  test_date:
    name: 'Test Date'
    has_time: false
    has_date: true
  test_time:
    name: 'Test Time'
    has_time: true
    has_date: false
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

