### PR TITLE
Update input_text

### DIFF
--- a/tests/components/test_input_text.py
+++ b/tests/components/test_input_text.py
@@ -5,7 +5,7 @@ import unittest
 
 from homeassistant.core import CoreState, State
 from homeassistant.setup import setup_component, async_setup_component
-from homeassistant.components.input_text import (DOMAIN, select_value)
+from homeassistant.components.input_text import (DOMAIN, set_value)
 
 from tests.common import get_test_home_assistant, mock_restore_cache
 
@@ -38,8 +38,8 @@ class TestInputText(unittest.TestCase):
             self.assertFalse(
                 setup_component(self.hass, DOMAIN, {DOMAIN: cfg}))
 
-    def test_select_value(self):
-        """Test select_value method."""
+    def test_set_value(self):
+        """Test set_value method."""
         self.assertTrue(setup_component(self.hass, DOMAIN, {DOMAIN: {
             'test_1': {
                 'initial': 'test',
@@ -52,13 +52,13 @@ class TestInputText(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual('test', str(state.state))
 
-        select_value(self.hass, entity_id, 'testing')
+        set_value(self.hass, entity_id, 'testing')
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)
         self.assertEqual('testing', str(state.state))
 
-        select_value(self.hass, entity_id, 'testing too long')
+        set_value(self.hass, entity_id, 'testing too long')
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)


### PR DESCRIPTION
## Description:
 - Remove disabled attribute. It was hardcoded and so makes a very weird user experience
 - Update service to be set_value

Not a breaking change because hasn't been released yet.

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant-polymer/pull/408

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3327

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
