### PR TITLE
Added satel_integra alarm panel and binary sensor platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -158,6 +158,9 @@ omit =
     homeassistant/components/rpi_pfio.py
     homeassistant/components/*/rpi_pfio.py
 
+    homeassistant/components/satel_integra.py
+    homeassistant/components/*/satel_integra.py
+
     homeassistant/components/scsgate.py
     homeassistant/components/*/scsgate.py
 

--- a/homeassistant/components/alarm_control_panel/satel_integra.py
+++ b/homeassistant/components/alarm_control_panel/satel_integra.py
@@ -39,8 +39,6 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
         self._state = None
         self._arm_home_mode = arm_home_mode
 
-        _LOGGER.debug("Setting up panel")
-
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Register callbacks."""
@@ -49,11 +47,10 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
 
     @callback
     def _message_callback(self, message):
-        _LOGGER.debug("Got message: %s", message)
 
         if message != self._state:
             self._state = message
-            self.hass.async_add_job(self.async_update_ha_state())
+            self.async_schedule_update_ha_state()
         else:
             _LOGGER.warning("Ignoring alarm status message, same state")
 
@@ -80,21 +77,18 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
     @asyncio.coroutine
     def async_alarm_disarm(self, code=None):
         """Send disarm command."""
-        _LOGGER.debug("alarm_disarm")
         if code:
             yield from self.hass.data[DATA_SATEL].disarm(code)
 
     @asyncio.coroutine
     def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
-        _LOGGER.debug("alarm_arm_away:")
         if code:
             yield from self.hass.data[DATA_SATEL].arm(code)
 
     @asyncio.coroutine
     def async_alarm_arm_home(self, code=None):
         """Send arm home command."""
-        _LOGGER.debug("alarm_arm_home")
         if code:
             yield from self.hass.data[DATA_SATEL].arm(code,
                                                       self._arm_home_mode)

--- a/homeassistant/components/alarm_control_panel/satel_integra.py
+++ b/homeassistant/components/alarm_control_panel/satel_integra.py
@@ -2,20 +2,17 @@
 Support for Satel Integra alarm, using ETHM module: https://www.satel.pl/en/ .
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/alarm_satel_integra/
+https://home-assistant.io/components/alarm_control_panel.satel_integra/
 """
 import asyncio
 import logging
 
-from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.components.alarm_control_panel as alarm
-
-from homeassistant.components.satel_integra import (DATA_AD,
+from homeassistant.components.satel_integra import (DATA_SATEL,
                                                     SIGNAL_PANEL_MESSAGE,
                                                     CONF_ARM_HOME_MODE)
-
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,22 +22,22 @@ DEPENDENCIES = ['satel_integra']
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up for AlarmDecoder alarm panels."""
+    if not discovery_info:
+        return
+
     device = SatelIntegraAlarmPanel("Alarm Panel",
-                                    hass,
                                     discovery_info.get(CONF_ARM_HOME_MODE))
     async_add_devices([device])
-
-    return True
 
 
 class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
     """Representation of an AlarmDecoder-based alarm panel."""
 
-    def __init__(self, name, hass, arm_home_mode):
+    def __init__(self, name, arm_home_mode):
         """Initialize the alarm panel."""
         self._display = ""
         self._name = name
-        self._state = STATE_UNKNOWN
+        self._state = None
         self._arm_home_mode = arm_home_mode
 
         _LOGGER.debug("Setting up panel")
@@ -53,7 +50,7 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
 
     @callback
     def _message_callback(self, message):
-        _LOGGER.info("Got message: %s", message)
+        _LOGGER.debug("Got message: %s", message)
 
         if message != self._state:
             self._state = message
@@ -84,20 +81,21 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
     @asyncio.coroutine
     def async_alarm_disarm(self, code=None):
         """Send disarm command."""
-        _LOGGER.info("alarm_disarm: %s", code)
+        _LOGGER.debug("alarm_disarm")
         if code:
-            yield from self.hass.data[DATA_AD].disarm(str(code))
+            yield from self.hass.data[DATA_SATEL].disarm(code)
 
     @asyncio.coroutine
     def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
-        _LOGGER.info("alarm_arm_away: %s", code)
+        _LOGGER.debug("alarm_arm_away:")
         if code:
-            yield from self.hass.data[DATA_AD].arm(code)
+            yield from self.hass.data[DATA_SATEL].arm(code)
 
     @asyncio.coroutine
     def async_alarm_arm_home(self, code=None):
         """Send arm home command."""
-        _LOGGER.info("alarm_arm_home: %s", code)
+        _LOGGER.debug("alarm_arm_home")
         if code:
-            yield from self.hass.data[DATA_AD].arm(code, self._arm_home_mode)
+            yield from self.hass.data[DATA_SATEL].arm(code,
+                                                      self._arm_home_mode)

--- a/homeassistant/components/alarm_control_panel/satel_integra.py
+++ b/homeassistant/components/alarm_control_panel/satel_integra.py
@@ -8,9 +8,9 @@ import asyncio
 import logging
 
 import homeassistant.components.alarm_control_panel as alarm
-from homeassistant.components.satel_integra import (DATA_SATEL,
-                                                    SIGNAL_PANEL_MESSAGE,
-                                                    CONF_ARM_HOME_MODE)
+from homeassistant.components.satel_integra import (CONF_ARM_HOME_MODE,
+                                                    DATA_SATEL,
+                                                    SIGNAL_PANEL_MESSAGE)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -35,7 +35,6 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
 
     def __init__(self, name, arm_home_mode):
         """Initialize the alarm panel."""
-        self._display = ""
         self._name = name
         self._state = None
         self._arm_home_mode = arm_home_mode

--- a/homeassistant/components/alarm_control_panel/satel_integra.py
+++ b/homeassistant/components/alarm_control_panel/satel_integra.py
@@ -1,0 +1,103 @@
+"""
+Support for Satel Integra alarm, using ETHM module: https://www.satel.pl/en/ .
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_satel_integra/
+"""
+import asyncio
+import logging
+
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+import homeassistant.components.alarm_control_panel as alarm
+
+from homeassistant.components.satel_integra import (DATA_AD,
+                                                    SIGNAL_PANEL_MESSAGE,
+                                                    CONF_ARM_HOME_MODE)
+
+from homeassistant.const import STATE_UNKNOWN
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['satel_integra']
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up for AlarmDecoder alarm panels."""
+    device = SatelIntegraAlarmPanel("Alarm Panel",
+                                    hass,
+                                    discovery_info.get(CONF_ARM_HOME_MODE))
+    async_add_devices([device])
+
+    return True
+
+
+class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
+    """Representation of an AlarmDecoder-based alarm panel."""
+
+    def __init__(self, name, hass, arm_home_mode):
+        """Initialize the alarm panel."""
+        self._display = ""
+        self._name = name
+        self._state = STATE_UNKNOWN
+        self._arm_home_mode = arm_home_mode
+
+        _LOGGER.debug("Setting up panel")
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
+        async_dispatcher_connect(
+            self.hass, SIGNAL_PANEL_MESSAGE, self._message_callback)
+
+    @callback
+    def _message_callback(self, message):
+        _LOGGER.info("Got message: %s", message)
+
+        if message != self._state:
+            self._state = message
+            self.hass.async_add_job(self.async_update_ha_state())
+        else:
+            _LOGGER.warning("Ignoring alarm status message, same state")
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    @property
+    def code_format(self):
+        """Return the regex for code format or None if no code is required."""
+        return '^\\d{4,6}$'
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @asyncio.coroutine
+    def async_alarm_disarm(self, code=None):
+        """Send disarm command."""
+        _LOGGER.info("alarm_disarm: %s", code)
+        if code:
+            yield from self.hass.data[DATA_AD].disarm(str(code))
+
+    @asyncio.coroutine
+    def async_alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        _LOGGER.info("alarm_arm_away: %s", code)
+        if code:
+            yield from self.hass.data[DATA_AD].arm(code)
+
+    @asyncio.coroutine
+    def async_alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        _LOGGER.info("alarm_arm_home: %s", code)
+        if code:
+            yield from self.hass.data[DATA_AD].arm(code, self._arm_home_mode)

--- a/homeassistant/components/binary_sensor/satel_integra.py
+++ b/homeassistant/components/binary_sensor/satel_integra.py
@@ -30,8 +30,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     devices = []
 
-    for zone_num in configured_zones:
-        device_config_data = configured_zones[zone_num]
+    for zone_num, device_config_data in configured_zones.items():
         zone_type = device_config_data[CONF_ZONE_TYPE]
         zone_name = device_config_data[CONF_ZONE_NAME]
         device = SatelIntegraBinarySensor(zone_num, zone_name, zone_type)

--- a/homeassistant/components/binary_sensor/satel_integra.py
+++ b/homeassistant/components/binary_sensor/satel_integra.py
@@ -49,8 +49,6 @@ class SatelIntegraBinarySensor(BinarySensorDevice):
         self._zone_type = zone_type
         self._state = 0
 
-        _LOGGER.debug("Setup up zone: %s", self._name)
-
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Register callbacks."""
@@ -89,4 +87,4 @@ class SatelIntegraBinarySensor(BinarySensorDevice):
         if self._zone_number in zones \
                 and self._state != zones[self._zone_number]:
             self._state = zones[self._zone_number]
-            self.hass.async_add_job(self.async_update_ha_state())
+            self.async_schedule_update_ha_state()

--- a/homeassistant/components/binary_sensor/satel_integra.py
+++ b/homeassistant/components/binary_sensor/satel_integra.py
@@ -1,0 +1,101 @@
+"""
+Support for Satel Integra zone states- represented as binary sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.alarmdecoder/
+"""
+import asyncio
+import logging
+
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.components.binary_sensor import BinarySensorDevice
+
+from homeassistant.components.satel_integra import (ZONE_SCHEMA,
+                                                    CONF_ZONES,
+                                                    CONF_ZONE_NAME,
+                                                    CONF_ZONE_TYPE,
+                                                    SIGNAL_ZONES_UPDATED)
+
+DEPENDENCIES = ['satel_integra']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Satel Integra binary sensor devices."""
+    configured_zones = discovery_info[CONF_ZONES]
+
+    devices = []
+
+    for zone_num in configured_zones:
+        device_config_data = ZONE_SCHEMA(configured_zones[zone_num])
+        zone_type = device_config_data[CONF_ZONE_TYPE]
+        zone_name = device_config_data[CONF_ZONE_NAME]
+        device = SatelIntegraBinarySensor(
+            hass, zone_num, zone_name, zone_type)
+        devices.append(device)
+
+    async_add_devices(devices)
+
+    return True
+
+
+class SatelIntegraBinarySensor(BinarySensorDevice):
+    """Representation of an Satel Integra binary sensor."""
+
+    def __init__(self, hass, zone_number, zone_name, zone_type):
+        """Initialize the binary_sensor."""
+        self._zone_number = zone_number
+        self._zone_type = zone_type
+        self._state = 0
+        self._name = zone_name
+        self._type = zone_type
+
+        _LOGGER.debug("Setup up zone: %s", self._name)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
+        async_dispatcher_connect(
+            self.hass, SIGNAL_ZONES_UPDATED, self._zones_updated)
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Icon for device by its type."""
+        if "window" in self._name.lower():
+            return "mdi:window-open" if self.is_on else "mdi:window-closed"
+
+        if self._type == 'smoke':
+            return "mdi:fire"
+
+        return None
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._state == 1
+
+    @property
+    def device_class(self):
+        """Return the class of this sensor, from DEVICE_CLASSES."""
+        return self._zone_type
+
+    @callback
+    def _zones_updated(self, zones):
+        """Update the zone's state, if needed."""
+        if self._zone_number in zones \
+                and self._state != zones[self._zone_number]:
+            self._state = zones[self._zone_number]
+            self.hass.async_add_job(self.async_update_ha_state())

--- a/homeassistant/components/satel_integra.py
+++ b/homeassistant/components/satel_integra.py
@@ -1,0 +1,153 @@
+"""
+Support for Satel Integra devices.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/alarmdecoder/
+"""
+# pylint: disable=invalid-name
+
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.core import callback
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.const import (
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
+    STATE_ALARM_TRIGGERED)
+
+REQUIREMENTS = ['satel_integra==0.1.0']
+
+DEFAULT_ALARM_NAME = 'satel_integra'
+DEFAULT_PORT = 7094
+DEFAULT_CONF_ARM_HOME_MODE = 1
+DEFAULT_DEVICE_PARTITION = 1
+DEFAULT_ZONE_TYPE = 'motion'
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'satel_integra'
+
+DATA_AD = 'satel_integra'
+
+CONF_DEVICE_HOST = 'host'
+CONF_DEVICE_PORT = 'port'
+CONF_DEVICE_PARTITION = 'partition'
+CONF_ARM_HOME_MODE = 'arm_home_mode'
+CONF_ZONE_NAME = 'name'
+CONF_ZONE_TYPE = 'type'
+CONF_ZONES = 'zones'
+
+ZONES = 'zones'
+
+SIGNAL_PANEL_MESSAGE = 'satel_integra.panel_message'
+SIGNAL_PANEL_ARM_AWAY = 'satel_integra.panel_arm_away'
+SIGNAL_PANEL_ARM_HOME = 'satel_integra.panel_arm_home'
+SIGNAL_PANEL_DISARM = 'satel_integra.panel_disarm'
+
+SIGNAL_ZONES_UPDATED = 'satel_integra.zones_updated'
+
+ZONE_SCHEMA = vol.Schema({
+    vol.Required(CONF_ZONE_NAME): cv.string,
+    vol.Optional(CONF_ZONE_TYPE, default=DEFAULT_ZONE_TYPE): cv.string})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_DEVICE_HOST): cv.string,
+        vol.Optional(CONF_DEVICE_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_DEVICE_PARTITION,
+                     default=DEFAULT_DEVICE_PARTITION): cv.positive_int,
+        vol.Optional(CONF_ARM_HOME_MODE,
+                     default=DEFAULT_CONF_ARM_HOME_MODE): vol.In([1, 2, 3]),
+        vol.Optional(CONF_ZONES): {vol.Coerce(int): ZONE_SCHEMA},
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up for the Satel Integra devices."""
+    conf = config.get(DOMAIN)
+
+    zones = conf.get(CONF_ZONES)
+    controller = False
+    host = conf.get(CONF_DEVICE_HOST)
+    port = conf.get(CONF_DEVICE_PORT)
+    partition = conf.get(CONF_DEVICE_PARTITION)
+
+    from satel_integra.satel_integra import AsyncSatel
+    controller = AsyncSatel(host, port, zones, hass.loop, partition)
+
+    hass.data[DATA_AD] = controller
+
+    result = yield from controller.connect()
+
+    if not result:
+        return False
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
+                               lambda s: controller.close())
+
+    _LOGGER.debug("Arm home config: %s, mode: %s ",
+                  conf,
+                  conf.get(CONF_ARM_HOME_MODE))
+
+    yield from async_load_platform(hass, 'alarm_control_panel',
+                                   DOMAIN, conf, config)
+
+    yield from async_load_platform(hass, 'binary_sensor',
+                                   DOMAIN, {CONF_ZONES: zones}, config)
+
+    @callback
+    def alarm_status_update_callback(status):
+        """Send status update received from alarm to home assistant."""
+        _LOGGER.info("Alarm status callback, status: %s", status)
+        hass_alarm_status = STATE_ALARM_DISARMED
+
+        from satel_integra.satel_integra import AlarmState
+
+        if status == AlarmState.ARMED_MODE0:
+            hass_alarm_status = STATE_ALARM_ARMED_AWAY
+
+        elif status in [
+                AlarmState.ARMED_MODE0,
+                AlarmState.ARMED_MODE1,
+                AlarmState.ARMED_MODE2,
+                AlarmState.ARMED_MODE3
+        ]:
+            hass_alarm_status = STATE_ALARM_ARMED_HOME
+
+        elif status in [AlarmState.TRIGGERED, AlarmState.TRIGGERED_FIRE]:
+            hass_alarm_status = STATE_ALARM_TRIGGERED
+
+        elif status == AlarmState.DISARMED:
+            hass_alarm_status = STATE_ALARM_DISARMED
+
+        _LOGGER.info("Sending hass_alarm_status: %s...", hass_alarm_status)
+        async_dispatcher_send(hass, SIGNAL_PANEL_MESSAGE, hass_alarm_status)
+
+    @callback
+    def zones_update_callback(status):
+        """Update zone objects as per notification from the alarm."""
+        _LOGGER.debug("Zones callback , status: %s", status)
+        async_dispatcher_send(hass, SIGNAL_ZONES_UPDATED, status[ZONES])
+
+    try:
+        from asyncio import ensure_future as asyncio_ensure_future
+    except ImportError:
+        from asyncio import async as asyncio_ensure_future
+    # pylint: disable=deprecated-method
+
+    hass.async_add_job(asyncio_ensure_future(controller.keep_alive()))
+    hass.async_add_job(asyncio_ensure_future(
+        controller.monitor_status(
+            alarm_status_update_callback,
+            zones_update_callback)
+    )
+                      )
+
+    return True

--- a/homeassistant/components/satel_integra.py
+++ b/homeassistant/components/satel_integra.py
@@ -101,11 +101,17 @@ def async_setup(hass, config):
                   conf,
                   conf.get(CONF_ARM_HOME_MODE))
 
-    yield from async_load_platform(hass, 'alarm_control_panel',
-                                   DOMAIN, conf, config)
+    hass.async_add_job(async_load_platform(hass, 'alarm_control_panel',
+                                   DOMAIN, conf, config))
+    hass.async_add_job(async_load_platform(hass, 'binary_sensor',
+                                   DOMAIN, {CONF_ZONES: zones}, config))
 
-    yield from async_load_platform(hass, 'binary_sensor',
-                                   DOMAIN, {CONF_ZONES: zones}, config)
+
+#    yield from async_load_platform(hass, 'alarm_control_panel',
+#                                   DOMAIN, conf, config)
+
+    # yield from async_load_platform(hass, 'binary_sensor',
+    #                                DOMAIN, {CONF_ZONES: zones}, config)
 
     @callback
     def alarm_status_update_callback(status):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -880,6 +880,9 @@ rxv==0.4.0
 # homeassistant.components.media_player.samsungtv
 samsungctl==0.6.0
 
+# homeassistant.components.satel_integra
+satel_integra==0.1.0
+
 # homeassistant.components.sensor.deutsche_bahn
 schiene==0.18
 


### PR DESCRIPTION
## Description:
Satel Integra Alarm platform added (http://www.satel.pl/en/)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3328

## Example entry for `configuration.yaml` (if applicable):
```yaml
satel_integra:
  host: 192.168.1.100
  port: 7094
  partition: 1
  arm_home_mode: 1

  zones:
    01:
      name: 'Bedroom'
      type: 'motion'
    02:
      name: 'Hall'
      type: 'motion'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
