### PR TITLE
typo in WAYPOINT_TOPIC preventing waypoint import

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -42,7 +42,7 @@ VALIDATE_WAYPOINTS = 'waypoints'
 
 WAYPOINT_LAT_KEY = 'lat'
 WAYPOINT_LON_KEY = 'lon'
-WAYPOINT_TOPIC = 'owntracks/{}/{}/waypoint'
+WAYPOINT_TOPIC = 'owntracks/{}/{}/waypoints'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MAX_GPS_ACCURACY): vol.Coerce(float),


### PR DESCRIPTION
## Description:
owntracks (tested on ios version 9.6.3/de_DE) publishes single waypoints under the topic `owntracks/<user>/<device>/waypoint` (singular).
owntrack publishes a waypoint export (publish) under the topic `owntracks/<user>/<device>/waypoints` (plural).

the owntracks component did not catch my waypoint export to mqtt, only single waypoint updates (i.e. after editing a waypoint or creating a new one). these single waypoints were rejected „because of missing or malformatted data“. when i changed the `WAYPOINT_TOPIC` to `'owntracks/{}/{}/waypoints'`, owntracks imported my published waypoint list, after i triggered it under Setting / Publish Waypoints.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54