### PR TITLE
Bump pyHik version to add IO support

### DIFF
--- a/homeassistant/components/binary_sensor/hikvision.py
+++ b/homeassistant/components/binary_sensor/hikvision.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_SSL, EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_START,
     ATTR_LAST_TRIP_TIME, CONF_CUSTOMIZE)
 
-REQUIREMENTS = ['pyhik==0.1.3']
+REQUIREMENTS = ['pyhik==0.1.4']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_IGNORED = 'ignored'
@@ -47,6 +47,7 @@ DEVICE_CLASS_MAP = {
     'PIR Alarm': 'motion',
     'Face Detection': 'motion',
     'Scene Change Detection': 'motion',
+    'I/O': None,
 }
 
 CUSTOMIZE_SCHEMA = vol.Schema({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -609,7 +609,7 @@ pyfttt==0.3
 pyharmony==1.0.16
 
 # homeassistant.components.binary_sensor.hikvision
-pyhik==0.1.3
+pyhik==0.1.4
 
 # homeassistant.components.homematic
 pyhomematic==0.1.30


### PR DESCRIPTION
## Description:
Bump the pyHik library version to add support for IO camera events.

**Related issue (if applicable):** fixes #9154 

## Checklist:

If user exposed functionality or configuration variables are added/changed:
If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
