### PR TITLE
config_validation.py

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -307,20 +307,30 @@ def time(value):
     return time_val
 
 
+def date(value):
+    """Validate date."""
+    date_val = dt_util.parse_date(value)
+
+    if date_val is None:
+        raise vol.Invalid('Invalid date specified: {}'.format(value))
+
+    return date_val
+
+
 def datetime(value):
     """Validate datetime."""
     if isinstance(value, datetime_sys):
         return value
 
     try:
-        date_val = dt_util.parse_datetime(value)
+        datetime_val = dt_util.parse_datetime(value)
     except TypeError:
-        date_val = None
+        datetime_val = None
 
-    if date_val is None:
+    if datetime_val is None:
         raise vol.Invalid('Invalid datetime specified: {}'.format(value))
 
-    return date_val
+    return datetime_val
 
 
 def time_zone(value):
@@ -450,10 +460,11 @@ TEMPLATE_CONDITION_SCHEMA = vol.Schema({
 
 TIME_CONDITION_SCHEMA = vol.All(vol.Schema({
     vol.Required(CONF_CONDITION): 'time',
+    'day': date,
     'before': time,
     'after': time,
     'weekday': weekdays,
-}), has_at_least_one_key('before', 'after', 'weekday'))
+}), has_at_least_one_key('day','before', 'after', 'weekday'))
 
 ZONE_CONDITION_SCHEMA = vol.Schema({
     vol.Required(CONF_CONDITION): 'zone',

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -464,7 +464,7 @@ TIME_CONDITION_SCHEMA = vol.All(vol.Schema({
     'before': time,
     'after': time,
     'weekday': weekdays,
-}), has_at_least_one_key('day','before', 'after', 'weekday'))
+}), has_at_least_one_key('day', 'before', 'after', 'weekday'))
 
 ZONE_CONDITION_SCHEMA = vol.Schema({
     vol.Required(CONF_CONDITION): 'zone',


### PR DESCRIPTION
To configure the automation with date .

## Description: To create configuration validation in this file which helps for https://github.com/home-assistant/home-assistant/pull/9342 to handle.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation :
  trigger:
    platform: time
    # When 'at' is used, you cannot also match on hour, minute, seconds.
    # Military time format.
    date: "9/9/2017"
    at: '15:32:00'

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
