### PR TITLE
Fixes #9353 Twitter notifications with certain media such as small images

### DIFF
--- a/homeassistant/components/notify/twitter.py
+++ b/homeassistant/components/notify/twitter.py
@@ -116,6 +116,9 @@ class TwitterNotificationService(BaseNotificationService):
                 self.log_error_resp(resp)
                 return None
 
+            if resp.json().get('processing_info') is None:
+                return callback(media_id)
+
             self.check_status_until_done(media_id, callback)
 
     def media_info(self, media_path):


### PR DESCRIPTION
Follow [Twitter's guidance](https://dev.twitter.com/rest/reference/post/media/upload-finalize) for media uploads: 
> If and (only if) the response of the FINALIZE command contains a processing_info field, it may also be necessary to use a STATUS command and wait for it to return success before proceeding to Tweet creation.

**Related issue (if applicable):** fixes #9353 

```yaml
notify:
  - name: twitter
    platform: twitter
    consumer_key: …
    consumer_secret: …
    access_token: …
    access_token_secret: …

automation twitter:
  alias: Send a test message
  initial_state: True
  hide_entity: False
  trigger:
    platform: homeassistant
    event: start
  action:
    - service: notify.twitter
      data:
        message: "Test at {{ now().strftime('%I:%M:%S %p') }}."
        data:
          media: /tmp/my-awesome-image.jpg
    - service: homeassistant.turn_off
      entity_id: automation.send_a_test_message
```
