### PR TITLE
Bump pywebpush and pyJWT versions

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -25,7 +25,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.frontend import add_manifest_json_key
 from homeassistant.helpers import config_validation as cv
 
-REQUIREMENTS = ['pywebpush==1.0.6', 'PyJWT==1.5.2']
+REQUIREMENTS = ['pywebpush==1.1.0', 'PyJWT==1.5.3']
 
 DEPENDENCIES = ['frontend']
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -21,7 +21,7 @@ astral==1.4
 PyISY==1.0.8
 
 # homeassistant.components.notify.html5
-PyJWT==1.5.2
+PyJWT==1.5.3
 
 # homeassistant.components.sensor.mvglive
 PyMVGLive==1.1.4
@@ -827,7 +827,7 @@ pyvizio==0.0.2
 pyvlx==0.1.3
 
 # homeassistant.components.notify.html5
-pywebpush==1.0.6
+pywebpush==1.1.0
 
 # homeassistant.components.wemo
 pywemo==0.4.20

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -21,7 +21,7 @@ freezegun>=0.3.8
 
 
 # homeassistant.components.notify.html5
-PyJWT==1.5.2
+PyJWT==1.5.3
 
 # homeassistant.components.media_player.sonos
 SoCo==0.12
@@ -111,7 +111,7 @@ python-forecastio==1.3.5
 pyunifi==2.13
 
 # homeassistant.components.notify.html5
-pywebpush==1.0.6
+pywebpush==1.1.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0a3


### PR DESCRIPTION
## Description:

Bump pywebpush to v1.1.0 and PyJWT to v1.5.3

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54