### PR TITLE
Added support for ARM_NIGHT for manual_mqtt alarm and pending time per state

### DIFF
--- a/homeassistant/components/alarm_control_panel/manual_mqtt.py
+++ b/homeassistant/components/alarm_control_panel/manual_mqtt.py
@@ -39,6 +39,8 @@ DEFAULT_ARM_HOME = 'ARM_HOME'
 DEFAULT_ARM_NIGHT = 'ARM_NIGHT'
 DEFAULT_DISARM = 'DISARM'
 
+ATTR_POST_PENDING_STATE = 'post_pending_state'
+
 DEPENDENCIES = ['mqtt']
 
 PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
@@ -223,6 +225,16 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
         if not check:
             _LOGGER.warning("Invalid code given for %s", state)
         return check
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        state_attr = {}
+
+        if self.state == STATE_ALARM_PENDING:
+            state_attr[ATTR_POST_PENDING_STATE] = self._state
+
+        return state_attr
 
     def async_added_to_hass(self):
         """Subscribe mqtt events.

--- a/homeassistant/components/alarm_control_panel/manual_mqtt.py
+++ b/homeassistant/components/alarm_control_panel/manual_mqtt.py
@@ -143,7 +143,9 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
                   self._trigger_time) < dt_util.utcnow():
                 if self._disarm_after_trigger:
                     return STATE_ALARM_DISARMED
-                return self._pre_trigger_state
+                else:
+                    self._state = self._pre_trigger_state
+                    return self._state
 
         return self._state
 

--- a/homeassistant/components/alarm_control_panel/manual_mqtt.py
+++ b/homeassistant/components/alarm_control_panel/manual_mqtt.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/alarm_control_panel.manual_mqtt/
 """
 import asyncio
+import copy
 import datetime
 import logging
 
@@ -39,11 +40,29 @@ DEFAULT_ARM_HOME = 'ARM_HOME'
 DEFAULT_ARM_NIGHT = 'ARM_NIGHT'
 DEFAULT_DISARM = 'DISARM'
 
+SUPPORTED_PENDING_STATES = [STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
+                            STATE_ALARM_ARMED_NIGHT, STATE_ALARM_TRIGGERED]
+
 ATTR_POST_PENDING_STATE = 'post_pending_state'
+
+
+def _state_validator(config):
+    config = copy.deepcopy(config)
+    for state in SUPPORTED_PENDING_STATES:
+        if CONF_PENDING_TIME not in config[state]:
+            config[state][CONF_PENDING_TIME] = config[CONF_PENDING_TIME]
+
+    return config
+
+
+STATE_SETTING_SCHEMA = vol.Schema({
+    vol.Optional(CONF_PENDING_TIME):
+        vol.All(vol.Coerce(int), vol.Range(min=0))
+})
 
 DEPENDENCIES = ['mqtt']
 
-PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
+PLATFORM_SCHEMA = vol.Schema(vol.All(mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PLATFORM): 'manual_mqtt',
     vol.Optional(CONF_NAME, default=DEFAULT_ALARM_NAME): cv.string,
     vol.Optional(CONF_CODE): cv.string,
@@ -53,13 +72,17 @@ PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
         vol.All(vol.Coerce(int), vol.Range(min=1)),
     vol.Optional(CONF_DISARM_AFTER_TRIGGER,
                  default=DEFAULT_DISARM_AFTER_TRIGGER): cv.boolean,
+    vol.Optional(STATE_ALARM_ARMED_AWAY, default={}): STATE_SETTING_SCHEMA,
+    vol.Optional(STATE_ALARM_ARMED_HOME, default={}): STATE_SETTING_SCHEMA,
+    vol.Optional(STATE_ALARM_ARMED_NIGHT, default={}): STATE_SETTING_SCHEMA,
+    vol.Optional(STATE_ALARM_TRIGGERED, default={}): STATE_SETTING_SCHEMA,
     vol.Required(mqtt.CONF_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Required(mqtt.CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_PAYLOAD_ARM_AWAY, default=DEFAULT_ARM_AWAY): cv.string,
     vol.Optional(CONF_PAYLOAD_ARM_HOME, default=DEFAULT_ARM_HOME): cv.string,
     vol.Optional(CONF_PAYLOAD_ARM_NIGHT, default=DEFAULT_ARM_NIGHT): cv.string,
     vol.Optional(CONF_PAYLOAD_DISARM, default=DEFAULT_DISARM): cv.string,
-})
+}), _state_validator))
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,7 +102,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_PAYLOAD_DISARM),
         config.get(CONF_PAYLOAD_ARM_HOME),
         config.get(CONF_PAYLOAD_ARM_AWAY),
-        config.get(CONF_PAYLOAD_ARM_NIGHT))])
+        config.get(CONF_PAYLOAD_ARM_NIGHT),
+        config)])
 
 
 class ManualMQTTAlarm(alarm.AlarmControlPanel):
@@ -96,7 +120,7 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
                  trigger_time, disarm_after_trigger,
                  state_topic, command_topic, qos,
                  payload_disarm, payload_arm_home, payload_arm_away,
-                 payload_arm_night):
+                 payload_arm_night, config):
         """Init the manual MQTT alarm panel."""
         self._state = STATE_ALARM_DISARMED
         self._hass = hass
@@ -107,6 +131,11 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
         self._disarm_after_trigger = disarm_after_trigger
         self._pre_trigger_state = self._state
         self._state_ts = None
+
+        self._pending_time_by_state = {}
+        for state in SUPPORTED_PENDING_STATES:
+            self._pending_time_by_state[state] = datetime.timedelta(
+                seconds=config[state][CONF_PENDING_TIME])
 
         self._state_topic = state_topic
         self._command_topic = command_topic
@@ -129,17 +158,10 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
     @property
     def state(self):
         """Return the state of the device."""
-        if self._state in (STATE_ALARM_ARMED_HOME,
-                           STATE_ALARM_ARMED_AWAY,
-                           STATE_ALARM_ARMED_NIGHT) and \
-           self._pending_time and self._state_ts + self._pending_time > \
-           dt_util.utcnow():
-            return STATE_ALARM_PENDING
-
         if self._state == STATE_ALARM_TRIGGERED and self._trigger_time:
-            if self._state_ts + self._pending_time > dt_util.utcnow():
+            if self._within_pending_time(self._state):
                 return STATE_ALARM_PENDING
-            elif (self._state_ts + self._pending_time +
+            elif (self._state_ts + self._pending_time_by_state[self._state] +
                   self._trigger_time) < dt_util.utcnow():
                 if self._disarm_after_trigger:
                     return STATE_ALARM_DISARMED
@@ -147,7 +169,15 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
                     self._state = self._pre_trigger_state
                     return self._state
 
+        if self._state in SUPPORTED_PENDING_STATES and \
+                self._within_pending_time(self._state):
+            return STATE_ALARM_PENDING
+
         return self._state
+
+    def _within_pending_time(self, state):
+        pending_time = self._pending_time_by_state[state]
+        return self._state_ts + pending_time > dt_util.utcnow()
 
     @property
     def code_format(self):
@@ -168,58 +198,47 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
         if not self._validate_code(code, STATE_ALARM_ARMED_HOME):
             return
 
-        self._state = STATE_ALARM_ARMED_HOME
-        self._state_ts = dt_util.utcnow()
-        self.schedule_update_ha_state()
-
-        if self._pending_time:
-            track_point_in_time(
-                self._hass, self.async_update_ha_state,
-                self._state_ts + self._pending_time)
+        self._update_state(STATE_ALARM_ARMED_HOME)
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
         if not self._validate_code(code, STATE_ALARM_ARMED_AWAY):
             return
 
-        self._state = STATE_ALARM_ARMED_AWAY
-        self._state_ts = dt_util.utcnow()
-        self.schedule_update_ha_state()
-
-        if self._pending_time:
-            track_point_in_time(
-                self._hass, self.async_update_ha_state,
-                self._state_ts + self._pending_time)
+        self._update_state(STATE_ALARM_ARMED_AWAY)
 
     def alarm_arm_night(self, code=None):
         """Send arm night command."""
         if not self._validate_code(code, STATE_ALARM_ARMED_NIGHT):
             return
 
-        self._state = STATE_ALARM_ARMED_NIGHT
-        self._state_ts = dt_util.utcnow()
-        self.schedule_update_ha_state()
-
-        if self._pending_time:
-            track_point_in_time(
-                self._hass, self.async_update_ha_state,
-                self._state_ts + self._pending_time)
+        self._update_state(STATE_ALARM_ARMED_NIGHT)
 
     def alarm_trigger(self, code=None):
         """Send alarm trigger command. No code needed."""
         self._pre_trigger_state = self._state
-        self._state = STATE_ALARM_TRIGGERED
+
+        self._update_state(STATE_ALARM_TRIGGERED)
+
+    def _update_state(self, state):
+        self._state = state
         self._state_ts = dt_util.utcnow()
         self.schedule_update_ha_state()
 
-        if self._trigger_time:
+        pending_time = self._pending_time_by_state[state]
+
+        if state == STATE_ALARM_TRIGGERED and self._trigger_time:
             track_point_in_time(
                 self._hass, self.async_update_ha_state,
-                self._state_ts + self._pending_time)
+                self._state_ts + pending_time)
 
             track_point_in_time(
                 self._hass, self.async_update_ha_state,
-                self._state_ts + self._pending_time + self._trigger_time)
+                self._state_ts + self._trigger_time + pending_time)
+        elif state in SUPPORTED_PENDING_STATES and pending_time:
+            track_point_in_time(
+                self._hass, self.async_update_ha_state,
+                self._state_ts + pending_time)
 
     def _validate_code(self, code, state):
         """Validate given code."""

--- a/tests/components/alarm_control_panel/test_manual_mqtt.py
+++ b/tests/components/alarm_control_panel/test_manual_mqtt.py
@@ -681,6 +681,21 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
 
         entity_id = 'alarm_control_panel.test'
 
+        alarm_control_panel.alarm_arm_home(self.hass)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=10)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_ARMED_HOME,
+                         self.hass.states.get(entity_id).state)
+
         alarm_control_panel.alarm_trigger(self.hass)
         self.hass.block_till_done()
 
@@ -702,7 +717,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
             fire_time_changed(self.hass, future)
             self.hass.block_till_done()
 
-        self.assertEqual(STATE_ALARM_DISARMED,
+        self.assertEqual(STATE_ALARM_ARMED_HOME,
                          self.hass.states.get(entity_id).state)
 
     def test_arm_home_via_command_topic(self):

--- a/tests/components/alarm_control_panel/test_manual_mqtt.py
+++ b/tests/components/alarm_control_panel/test_manual_mqtt.py
@@ -566,6 +566,145 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
         self.assertEqual(STATE_ALARM_TRIGGERED,
                          self.hass.states.get(entity_id).state)
 
+    def test_armed_home_with_specific_pending(self):
+        """Test arm home method."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'pending_time': 10,
+                'armed_home': {
+                    'pending_time': 2
+                },
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        alarm_control_panel.alarm_arm_home(self.hass)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=2)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_ARMED_HOME,
+                         self.hass.states.get(entity_id).state)
+
+    def test_armed_away_with_specific_pending(self):
+        """Test arm home method."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'pending_time': 10,
+                'armed_away': {
+                    'pending_time': 2
+                },
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        alarm_control_panel.alarm_arm_away(self.hass)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=2)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         self.hass.states.get(entity_id).state)
+
+    def test_armed_night_with_specific_pending(self):
+        """Test arm home method."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'pending_time': 10,
+                'armed_night': {
+                    'pending_time': 2
+                },
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        alarm_control_panel.alarm_arm_night(self.hass)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=2)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_ARMED_NIGHT,
+                         self.hass.states.get(entity_id).state)
+
+    def test_trigger_with_specific_pending(self):
+        """Test arm home method."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'pending_time': 10,
+                'triggered': {
+                    'pending_time': 2
+                },
+                'trigger_time': 3,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        alarm_control_panel.alarm_trigger(self.hass)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_PENDING,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=2)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
     def test_arm_home_via_command_topic(self):
         """Test arming home via command topic."""
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {

--- a/tests/components/alarm_control_panel/test_manual_mqtt.py
+++ b/tests/components/alarm_control_panel/test_manual_mqtt.py
@@ -100,6 +100,11 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
 
+        self.assertTrue(
+            self.hass.states.is_state_attr(entity_id,
+                                           'post_pending_state',
+                                           STATE_ALARM_ARMED_HOME))
+
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
                     'dt_util.utcnow'), return_value=future):
@@ -184,6 +189,11 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
 
+        self.assertTrue(
+            self.hass.states.is_state_attr(entity_id,
+                                           'post_pending_state',
+                                           STATE_ALARM_ARMED_AWAY))
+
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
                     'dt_util.utcnow'), return_value=future):
@@ -267,6 +277,11 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
 
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
+
+        self.assertTrue(
+            self.hass.states.is_state_attr(entity_id,
+                                           'post_pending_state',
+                                           STATE_ALARM_ARMED_NIGHT))
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -359,6 +374,11 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
 
         self.assertEqual(STATE_ALARM_PENDING,
                          self.hass.states.get(entity_id).state)
+
+        self.assertTrue(
+            self.hass.states.is_state_attr(entity_id,
+                                           'post_pending_state',
+                                           STATE_ALARM_TRIGGERED))
 
         future = dt_util.utcnow() + timedelta(seconds=2)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'

--- a/tests/components/alarm_control_panel/test_manual_mqtt.py
+++ b/tests/components/alarm_control_panel/test_manual_mqtt.py
@@ -432,6 +432,61 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
         self.assertEqual(STATE_ALARM_DISARMED,
                          self.hass.states.get(entity_id).state)
 
+    def test_back_to_back_trigger_with_no_disarm_after_trigger(self):
+        """Test no disarm after back to back trigger."""
+        self.assertTrue(setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'trigger_time': 5,
+                'pending_time': 0,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }}))
+
+        entity_id = 'alarm_control_panel.test'
+
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_arm_away(self.hass, CODE, entity_id)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_trigger(self.hass, entity_id=entity_id)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         self.hass.states.get(entity_id).state)
+
+        alarm_control_panel.alarm_trigger(self.hass, entity_id=entity_id)
+        self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         self.hass.states.get(entity_id).state)
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         self.hass.states.get(entity_id).state)
+
     def test_disarm_while_pending_trigger(self):
         """Test disarming while pending state."""
         self.assertTrue(setup_component(


### PR DESCRIPTION
## Description:
Added support for ARM_NIGHT for manual_mqtt alarm. Also ported manual alarm panel fixes or changes to manual_mqtt:

https://github.com/home-assistant/home-assistant/pull/9249 - Fixed manual alarm not re-arm after 2nd trigger
https://github.com/home-assistant/home-assistant/pull/9264 - Add manual alarm_control_panel pending time per state
https://github.com/home-assistant/home-assistant/pull/9291 - Add post_pending_state attribute to manual alarm_control_panel

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54