### PR TITLE
Add /usr/sbin to PATH

### DIFF
--- a/homeassistant/scripts/macos/launchd.plist
+++ b/homeassistant/scripts/macos/launchd.plist
@@ -8,7 +8,7 @@
     <key>EnvironmentVariables</key>
     <dict>
       <key>PATH</key>
-      <string>/usr/local/bin/:/usr/bin:$PATH</string>
+      <string>/usr/local/bin/:/usr/bin:/usr/sbin:$PATH</string>
     </dict>
 
     <key>Program</key>


### PR DESCRIPTION
The `braviatv`platform needs the `arp` command to finalize configuration. This resides in `/usr/sbin`, at least on macOS 10.10.