### PR TITLE
Round off probability to 2 decimals.

### DIFF
--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -201,7 +201,7 @@ class BayesianBinarySensor(BinarySensorDevice):
         """Return the state attributes of the sensor."""
         return {
             'observations': [val for val in self.current_obs.values()],
-            'probability': self.probability,
+            'probability': round(self.probability, 2),
             'probability_threshold': self._probability_threshold
         }
 

--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -126,7 +126,6 @@ class BayesianBinarySensor(BinarySensorDevice):
             self.watchers[platform](entity_obs)
 
             prior = self.prior
-            print(self.current_obs.values())
             for obs in self.current_obs.values():
                 prior = update_probability(prior, obs['prob_true'],
                                            obs['prob_false'])

--- a/tests/components/binary_sensor/test_bayesian.py
+++ b/tests/components/binary_sensor/test_bayesian.py
@@ -73,7 +73,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
             'prob_false': 0.1,
             'prob_true': 0.9
         }], state.attributes.get('observations'))
-        self.assertAlmostEqual(0.7714285714285715,
+        self.assertAlmostEqual(0.77,
                                state.attributes.get('probability'))
 
         assert state.state == 'on'
@@ -141,7 +141,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
             'prob_true': 0.8,
             'prob_false': 0.4
         }], state.attributes.get('observations'))
-        self.assertAlmostEqual(0.33333333, state.attributes.get('probability'))
+        self.assertAlmostEqual(0.33, state.attributes.get('probability'))
 
         assert state.state == 'on'
 


### PR DESCRIPTION
Currently, the sensor returns a long probability value:

![image](https://user-images.githubusercontent.com/18319734/30251011-d3cb891e-9625-11e7-9a78-a0d2901546e3.png)

Not sure if we need so many decimal places. Rounding it off to 2 decimals seems more useful. 