### PR TITLE
Workalendar

### DIFF
--- a/homeassistant/components/binary_sensor/workalendar.py
+++ b/homeassistant/components/binary_sensor/workalendar.py
@@ -1,10 +1,11 @@
 """
-Sensor to indicate whether the current day is a workday base on workalendar module.
-The code is based on binary_sensor.workday home-assistant component
+Sensor to indicate whether the current day is a workday based on workalendar.
+module. The code is based on binary_sensor.workday home-assistant component
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.workday/
 """
+
 import asyncio
 import importlib
 import logging
@@ -46,7 +47,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Workday sensor."""
-
     sensor_name = config.get(CONF_NAME)
     country = config.get(CONF_COUNTRY)
     workdays = config.get(CONF_WORKDAYS)
@@ -57,7 +57,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     components = country.split('.')
 
     if len(components) != 2:
-        _LOGGER.error('You must specify a continent and a country in the form continent.Country')
+        _LOGGER.error('You must specify a continent and a country in the form '
+                      'continent.Country')
         return False
 
     try:
@@ -115,7 +116,8 @@ class IsWorkdaySensor(BinarySensorDevice):
         """Check if given day is in the includes list."""
         if day in self._workdays:
             return True
-        elif 'holiday' in self._workdays and not self.calendar.is_working_day(now):
+        elif 'holiday' in self._workdays and \
+                not self.calendar.is_working_day(now):
             return True
 
         return False
@@ -124,7 +126,8 @@ class IsWorkdaySensor(BinarySensorDevice):
         """Check if given day is in the excludes list."""
         if day in self._excludes:
             return True
-        elif 'holiday' in self._excludes and not self.calendar.is_working_day(now):
+        elif 'holiday' in self._excludes and \
+                not self.calendar.is_working_day(now):
             return True
 
         return False
@@ -155,4 +158,3 @@ class IsWorkdaySensor(BinarySensorDevice):
 
         if self.is_exclude(day_of_week, date):
             self._state = False
-

--- a/homeassistant/components/binary_sensor/workalendar.py
+++ b/homeassistant/components/binary_sensor/workalendar.py
@@ -1,0 +1,157 @@
+"""
+Sensor to indicate whether the current day is a workday base on workalendar module.
+The code is based on binary_sensor.workday home-assistant component
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.workday/
+"""
+import asyncio
+import importlib
+import logging
+from datetime import datetime, timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME, WEEKDAYS
+from homeassistant.components.binary_sensor import BinarySensorDevice
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['workalendar==2.3.1']
+
+CONF_COUNTRY = 'country'
+CONF_WORKDAYS = 'workdays'
+# By default, Monday - Friday are workdays
+DEFAULT_WORKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri']
+CONF_EXCLUDES = 'excludes'
+# By default, public holidays, Saturdays and Sundays are excluded from workdays
+DEFAULT_EXCLUDES = ['sat', 'sun', 'holiday']
+DEFAULT_NAME = 'Workday Sensor'
+ALLOWED_DAYS = WEEKDAYS + ['holiday']
+CONF_OFFSET = 'days_offset'
+DEFAULT_OFFSET = 0
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_COUNTRY): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_OFFSET, default=DEFAULT_OFFSET): vol.Coerce(int),
+    vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):
+        vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
+    vol.Optional(CONF_EXCLUDES, default=DEFAULT_EXCLUDES):
+        vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Workday sensor."""
+
+    sensor_name = config.get(CONF_NAME)
+    country = config.get(CONF_COUNTRY)
+    workdays = config.get(CONF_WORKDAYS)
+    excludes = config.get(CONF_EXCLUDES)
+    days_offset = config.get(CONF_OFFSET)
+
+    year = (datetime.now() + timedelta(days=days_offset)).year
+    components = country.split('.')
+
+    if len(components) != 2:
+        _LOGGER.error('You must specify a continent and a country in the form continent.Country')
+        return False
+
+    try:
+        workalendar = importlib.import_module('workalendar.' + components[0])
+    except TypeError:
+        _LOGGER.error('You must specify a continent supported in workalendar')
+        return False
+    except ImportError:
+        return False
+
+    if not hasattr(workalendar, components[1]):
+        _LOGGER.error('You must specify a country supported in workalendar')
+        return False
+
+    calendar = getattr(workalendar, components[1])()
+    _LOGGER.debug("Found the following holidays for your configuration:")
+    for date, name in sorted(calendar.holidays(year)):
+        _LOGGER.debug("%s %s", date, name)
+
+    add_devices([IsWorkdaySensor(
+        calendar, workdays, excludes, days_offset, sensor_name)], True)
+
+
+def day_to_string(day):
+    """Convert day index 0 - 7 to string."""
+    try:
+        return ALLOWED_DAYS[day]
+    except IndexError:
+        return None
+
+
+class IsWorkdaySensor(BinarySensorDevice):
+    """Implementation of a Workday sensor."""
+
+    def __init__(self, calendar, workdays, excludes, days_offset, name):
+        """Initialize the Workday sensor."""
+        self._name = name
+        self.calendar = calendar
+        self._workdays = workdays
+        self._excludes = excludes
+        self._days_offset = days_offset
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return the state of the device."""
+        return self._state
+
+    def is_include(self, day, now):
+        """Check if given day is in the includes list."""
+        if day in self._workdays:
+            return True
+        elif 'holiday' in self._workdays and not self.calendar.is_working_day(now):
+            return True
+
+        return False
+
+    def is_exclude(self, day, now):
+        """Check if given day is in the excludes list."""
+        if day in self._excludes:
+            return True
+        elif 'holiday' in self._excludes and not self.calendar.is_working_day(now):
+            return True
+
+        return False
+
+    @property
+    def state_attributes(self):
+        """Return the attributes of the entity."""
+        # return self._attributes
+        return {
+            CONF_WORKDAYS: self._workdays,
+            CONF_EXCLUDES: self._excludes,
+            CONF_OFFSET: self._days_offset
+        }
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Get date and look whether it is a holiday."""
+        # Default is no workday
+        self._state = False
+
+        # Get iso day of the week (1 = Monday, 7 = Sunday)
+        date = datetime.today() + timedelta(days=self._days_offset)
+        day = date.isoweekday() - 1
+        day_of_week = day_to_string(day)
+
+        if self.is_include(day_of_week, date):
+            self._state = True
+
+        if self.is_exclude(day_of_week, date):
+            self._state = False

--- a/homeassistant/components/binary_sensor/workalendar.py
+++ b/homeassistant/components/binary_sensor/workalendar.py
@@ -153,5 +153,8 @@ class IsWorkdaySensor(BinarySensorDevice):
         if self.is_include(day_of_week, date):
             self._state = True
 
+        _LOGGER.debug('------------- %d %s',self._state,day_of_week)
         if self.is_exclude(day_of_week, date):
             self._state = False
+
+        _LOGGER.debug('------------- %d %s',self._state,day_of_week)

--- a/homeassistant/components/binary_sensor/workalendar.py
+++ b/homeassistant/components/binary_sensor/workalendar.py
@@ -153,8 +153,6 @@ class IsWorkdaySensor(BinarySensorDevice):
         if self.is_include(day_of_week, date):
             self._state = True
 
-        _LOGGER.debug('------------- %d %s',self._state,day_of_week)
         if self.is_exclude(day_of_week, date):
             self._state = False
 
-        _LOGGER.debug('------------- %d %s',self._state,day_of_week)

--- a/homeassistant/components/binary_sensor/workalendar.py
+++ b/homeassistant/components/binary_sensor/workalendar.py
@@ -5,7 +5,6 @@ module. The code is based on binary_sensor.workday home-assistant component
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.workday/
 """
-
 import asyncio
 import importlib
 import logging
@@ -24,15 +23,15 @@ REQUIREMENTS = ['workalendar==2.3.1']
 
 CONF_COUNTRY = 'country'
 CONF_WORKDAYS = 'workdays'
-# By default, Monday - Friday are workdays
-DEFAULT_WORKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri']
+CONF_OFFSET = 'days_offset'
 CONF_EXCLUDES = 'excludes'
-# By default, public holidays, Saturdays and Sundays are excluded from workdays
+
+DEFAULT_WORKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri']
 DEFAULT_EXCLUDES = ['sat', 'sun', 'holiday']
 DEFAULT_NAME = 'Workday Sensor'
-ALLOWED_DAYS = WEEKDAYS + ['holiday']
-CONF_OFFSET = 'days_offset'
 DEFAULT_OFFSET = 0
+
+ALLOWED_DAYS = WEEKDAYS + ['holiday']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COUNTRY): cv.string,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -295,6 +295,9 @@ hipnotify==1.0.8
 # homeassistant.components.binary_sensor.workday
 holidays==0.8.1
 
+# homeassistant components.binary_sensor.workalendar
+workalendar=2.3.1
+
 # homeassistant.components.camera.onvif
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -295,9 +295,6 @@ hipnotify==1.0.8
 # homeassistant.components.binary_sensor.workday
 holidays==0.8.1
 
-# homeassistant components.binary_sensor.workalendar
-workalendar=2.3.1
-
 # homeassistant.components.camera.onvif
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a
 
@@ -1008,6 +1005,9 @@ websocket-client==0.37.0
 # homeassistant.components.spc
 # homeassistant.components.media_player.webostv
 websockets==3.2
+
+# homeassistant.components.binary_sensor.workalendar
+workalendar==2.3.1
 
 # homeassistant.components.zigbee
 xbee-helper==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -60,6 +60,9 @@ hbmqtt==0.8
 # homeassistant.components.binary_sensor.workday
 holidays==0.8.1
 
+# homeassistant.components.binary_sensor.workalendar
+workalendar==2.3.1
+
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
 influxdb==3.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -60,9 +60,6 @@ hbmqtt==0.8
 # homeassistant.components.binary_sensor.workday
 holidays==0.8.1
 
-# homeassistant components.binary_sensor.workalendar
-workalendar=2.3.1
-
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
 influxdb==3.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -60,6 +60,9 @@ hbmqtt==0.8
 # homeassistant.components.binary_sensor.workday
 holidays==0.8.1
 
+# homeassistant components.binary_sensor.workalendar
+workalendar=2.3.1
+
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
 influxdb==3.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -60,9 +60,6 @@ hbmqtt==0.8
 # homeassistant.components.binary_sensor.workday
 holidays==0.8.1
 
-# homeassistant.components.binary_sensor.workalendar
-workalendar==2.3.1
-
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
 influxdb==3.0.0
@@ -143,6 +140,9 @@ statsd==3.2.1
 
 # homeassistant.components.camera.uvc
 uvcclient==0.10.0
+
+# homeassistant.components.binary_sensor.workalendar
+workalendar==2.3.1
 
 # homeassistant.components.sensor.yahoo_finance
 yahoo-finance==1.4.0

--- a/tests/components/binary_sensor/test_workalendar.py
+++ b/tests/components/binary_sensor/test_workalendar.py
@@ -1,0 +1,232 @@
+"""Tests the HASS workday binary sensor."""
+from freezegun import freeze_time
+from homeassistant.components.binary_sensor.workalendar import day_to_string
+from homeassistant.setup import setup_component
+
+from tests.common import (
+    get_test_home_assistant, assert_setup_component)
+
+
+class TestWorkdaySetup(object):
+    """Test class for workday sensor."""
+
+    def setup_method(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+        # Set valid default config for test
+        self.config_province = {
+            'binary_sensor': {
+                'platform': 'workalendar',
+                'country': 'europe.Italy',
+            },
+        }
+
+        self.config_noprovince = {
+            'binary_sensor': {
+                'platform': 'workalendar',
+                'country': 'europe.Italy',
+            },
+        }
+
+        self.config_state = {
+            'binary_sensor': {
+                'platform': 'workalendar',
+                'country': 'usa.California',
+            },
+        }
+
+        self.config_nostate = {
+            'binary_sensor': {
+                'platform': 'workalendar',
+                'country': 'usa.UnitedStates',
+            },
+        }
+
+        self.config_includeholiday = {
+            'binary_sensor': {
+                'platform': 'workalendar',
+                'country': 'europe.Italy',
+                'workdays': ['holiday'],
+                'excludes': ['sat', 'sun']
+            },
+        }
+
+        self.config_tomorrow = {
+            'binary_sensor': {
+                'platform': 'workalendar',
+                'country': 'europe.Germany',
+                'days_offset': 1
+            },
+        }
+
+        self.config_day_after_tomorrow = {
+            'binary_sensor': {
+                'platform': 'workalendar',
+                'country': 'europe.Germany',
+                'days_offset': 2
+            },
+        }
+
+        self.config_yesterday = {
+            'binary_sensor': {
+                'platform': 'workalendar',
+                'country': 'europe.Germany',
+                'days_offset': -1
+            },
+        }
+
+    def teardown_method(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_setup_component_province(self):
+        """Setup workday component."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_province)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+    # Freeze time to a workday
+    @freeze_time("Mar 15th, 2017")
+    def test_workday_province(self):
+        """Test if workdays are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_province)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'on'
+
+    # Freeze time to a weekend
+    @freeze_time("Mar 12th, 2017")
+    def test_weekend_province(self):
+        """Test if weekends are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_province)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'off'
+
+    # Freeze time to a public holiday in province BW
+    @freeze_time("Jan 6th, 2017")
+    def test_public_holiday_province(self):
+        """Test if public holidays are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_province)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'off'
+
+    def test_setup_component_noprovince(self):
+        """Setup workday component."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_noprovince)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+    # Freeze time to a public holiday in state CA
+    @freeze_time("Mar 31st, 2017")
+    def test_public_holiday_state(self):
+        """Test if public holidays are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_state)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'off'
+
+    # Freeze time to a public holiday in state CA
+    @freeze_time("Mar 31st, 2017")
+    def test_public_holiday_nostate(self):
+        """Test if public holidays are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor', self.config_nostate)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'on'
+
+    # Freeze time to a public holiday in province BW
+    @freeze_time("Jan 6th, 2017")
+    def test_public_holiday_includeholiday(self):
+        """Test if public holidays are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_includeholiday)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'on'
+
+    # Freeze time to a saturday to test offset
+    @freeze_time("Aug 5th, 2017")
+    def test_tomorrow(self):
+        """Test if tomorrow are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_tomorrow)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'off'
+
+    # Freeze time to a saturday to test offset
+    @freeze_time("Aug 5th, 2017")
+    def test_day_after_tomorrow(self):
+        """Test if the day after tomorrow are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_day_after_tomorrow)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'on'
+
+    # Freeze time to a saturday to test offset
+    @freeze_time("Aug 5th, 2017")
+    def test_yesterday(self):
+        """Test if yesterday are reported correctly."""
+        with assert_setup_component(1, 'binary_sensor'):
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_yesterday)
+
+        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+
+        self.hass.start()
+
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity.state == 'on'
+
+    def test_day_to_string(self):
+        """Test if day_to_string is behaving correctly."""
+        assert day_to_string(0) == 'mon'
+        assert day_to_string(1) == 'tue'
+        assert day_to_string(7) == 'holiday'
+        assert day_to_string(8) is None


### PR DESCRIPTION
## Description:
This component is derived from workday binary_sensor component, it uses the workalendar module instead of the holidays module. I created this module because holidays module does not support some countries (like mine)

## Example entry for `configuration.yaml` (if applicable):
```
binary_sensor:
  - platform: workalendar
    country: europe.Italy
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

