### PR TITLE
Fixes #9379 - Added additional string check in Wunderground sensor

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -708,7 +708,7 @@ class WUndergroundSensor(Entity):
     def entity_picture(self):
         """Return the entity picture."""
         url = self._cfg_expand("entity_picture")
-        if url is not None:
+        if url is not None and isinstance(url, str):
             return re.sub(r'^http://', 'https://', url, flags=re.IGNORECASE)
 
     @property

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -708,7 +708,7 @@ class WUndergroundSensor(Entity):
     def entity_picture(self):
         """Return the entity picture."""
         url = self._cfg_expand("entity_picture")
-        if url is not None and isinstance(url, str):
+        if isinstance(url, str):
             return re.sub(r'^http://', 'https://', url, flags=re.IGNORECASE)
 
     @property


### PR DESCRIPTION
Added additional check to see if the URL returned is a string. 

**Related issue (if applicable):** fixes #9379 
