### PR TITLE
fix mopar sensor

### DIFF
--- a/homeassistant/components/sensor/mopar.py
+++ b/homeassistant/components/sensor/mopar.py
@@ -18,7 +18,7 @@ from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
 
-REQUIREMENTS = ['motorparts==1.0.1']
+REQUIREMENTS = ['motorparts==1.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/mopar.py
+++ b/homeassistant/components/sensor/mopar.py
@@ -18,7 +18,7 @@ from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
 
-REQUIREMENTS = ['motorparts==1.0.0']
+REQUIREMENTS = ['motorparts==1.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,6 +86,7 @@ class MoparData(object):
         self.vehicles = []
         self.vhrs = {}
         self.tow_guides = {}
+        seld.update()
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self, **kwargs):

--- a/homeassistant/components/sensor/mopar.py
+++ b/homeassistant/components/sensor/mopar.py
@@ -86,7 +86,7 @@ class MoparData(object):
         self.vehicles = []
         self.vhrs = {}
         self.tow_guides = {}
-        seld.update()
+        self.update()
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self, **kwargs):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -413,7 +413,7 @@ miflora==0.1.16
 miniupnpc==1.9
 
 # homeassistant.components.sensor.mopar
-motorparts==1.0.0
+motorparts==1.0.1
 
 # homeassistant.components.tts
 mutagen==1.38

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -413,7 +413,7 @@ miflora==0.1.16
 miniupnpc==1.9
 
 # homeassistant.components.sensor.mopar
-motorparts==1.0.1
+motorparts==1.0.2
 
 # homeassistant.components.tts
 mutagen==1.38


### PR DESCRIPTION
## Description:

`mopar` sensor was DOA due to https://github.com/home-assistant/home-assistant/pull/9136/commits/85c98fb7201da74027e314546413f91c76d5d379. As far as I understand `@Throttle`, we still have to call `update()` initially. Also took this opportunity to bump the dependency version to fix a cosmetic bug.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/9373

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
