### PR TITLE
Add custom sensor to read temperature from in eq3btsmart

### DIFF
--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -59,8 +59,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         devices.append(thermostat)
 
         if (temperatureSensor is not None):
-            async_track_state_change(hass, [temperatureSensor], 
-                thermostat.temperature_state_changed)
+            async_track_state_change(hass, [temperatureSensor],
+                                     thermostat.temperature_state_changed)
 
     add_devices(devices)
 

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -12,8 +12,11 @@ from homeassistant.components.climate import (
     ClimateDevice, PLATFORM_SCHEMA, PRECISION_HALVES,
     STATE_AUTO, STATE_ON, STATE_OFF,
 )
+from homeassistant.core import callback
+from homeassistant.helpers.event import async_track_state_change
 from homeassistant.const import (
-    CONF_MAC, TEMP_CELSIUS, CONF_DEVICES, ATTR_TEMPERATURE)
+    CONF_MAC, TEMP_CELSIUS, CONF_DEVICES, ATTR_TEMPERATURE,
+    STATE_UNKNOWN)
 
 import homeassistant.helpers.config_validation as cv
 
@@ -31,8 +34,11 @@ ATTR_STATE_LOCKED = 'is_locked'
 ATTR_STATE_LOW_BAT = 'low_battery'
 ATTR_STATE_AWAY_END = 'away_end'
 
+CONF_TEMPERATURE_SENSOR = 'sensor'
+
 DEVICE_SCHEMA = vol.Schema({
     vol.Required(CONF_MAC): cv.string,
+    vol.Optional(CONF_TEMPERATURE_SENSOR): cv.entity_id,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -47,7 +53,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for name, device_cfg in config[CONF_DEVICES].items():
         mac = device_cfg[CONF_MAC]
-        devices.append(EQ3BTSmartThermostat(mac, name))
+        temperatureSensor = device_cfg.get(CONF_TEMPERATURE_SENSOR)
+
+        thermostat = EQ3BTSmartThermostat(mac, name, temperatureSensor)
+        devices.append(thermostat)
+
+        if (temperatureSensor is not None):
+            async_track_state_change(hass, [temperatureSensor], thermostat.temperature_state_changed)
 
     add_devices(devices)
 
@@ -56,7 +68,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class EQ3BTSmartThermostat(ClimateDevice):
     """Representation of a eQ-3 Bluetooth Smart thermostat."""
 
-    def __init__(self, _mac, _name):
+    def __init__(self, _mac, _name, _sensor):
         """Initialize the thermostat."""
         # we want to avoid name clash with this module..
         import eq3bt as eq3
@@ -72,6 +84,8 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
         self._name = _name
         self._thermostat = eq3.Thermostat(_mac)
+        self._temperatureSensor = _sensor
+        self._sensorTemperature = STATE_UNKNOWN
 
     @property
     def available(self) -> bool:
@@ -93,9 +107,26 @@ class EQ3BTSmartThermostat(ClimateDevice):
         """Return eq3bt's precision 0.5."""
         return PRECISION_HALVES
 
+    @callback
+    def temperature_state_changed(self, entity_id, _, new_state):
+        """Update the temperature status.
+
+        This callback is triggered, when the sensor state changes.
+        """
+        self._sensorTemperature = new_state.state
+
+        if self._sensorTemperature == STATE_UNKNOWN:
+            return
+
+        # Force 0.5 precision from the temperature sensor
+        self._sensorTemperature = round(float(self._sensorTemperature) * 2) / 2
+
     @property
     def current_temperature(self):
-        """Can not report temperature, so return target_temperature."""
+        """If no sensor is specified, just return target_temperature."""
+        if self._temperatureSensor is not None:
+            return self._sensorTemperature
+
         return self.target_temperature
 
     @property

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -119,7 +119,7 @@ class EQ3BTSmartThermostat(ClimateDevice):
         if new_value != STATE_UNKNOWN:
             # Force 0.5 precision from the temperature sensor
             new_value = round(float(new_value) * 2) / 2
-            
+
         self._sensor_temperature = new_value
 
     @property

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -59,7 +59,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         devices.append(thermostat)
 
         if (temperatureSensor is not None):
-            async_track_state_change(hass, [temperatureSensor], thermostat.temperature_state_changed)
+            async_track_state_change(hass, [temperatureSensor], 
+                thermostat.temperature_state_changed)
 
     add_devices(devices)
 

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -114,13 +114,13 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
         This callback is triggered, when the sensor state changes.
         """
-        self._sensor_temperature = new_state.state
+        new_value = new_state.state
 
-        if self._sensor_temperature == STATE_UNKNOWN:
-            return
-
-        # Force 0.5 precision from the temperature sensor
-        self._sensor_temperature = round(float(self._sensor_temperature) * 2) / 2
+        if new_value != STATE_UNKNOWN:
+            # Force 0.5 precision from the temperature sensor
+            new_value = round(float(new_value) * 2) / 2
+            
+        self._sensor_temperature = new_value
 
     @property
     def current_temperature(self):

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -53,13 +53,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for name, device_cfg in config[CONF_DEVICES].items():
         mac = device_cfg[CONF_MAC]
-        temperatureSensor = device_cfg.get(CONF_TEMPERATURE_SENSOR)
+        temperature_sensor = device_cfg.get(CONF_TEMPERATURE_SENSOR)
 
-        thermostat = EQ3BTSmartThermostat(mac, name, temperatureSensor)
+        thermostat = EQ3BTSmartThermostat(mac, name, temperature_sensor)
         devices.append(thermostat)
 
-        if (temperatureSensor is not None):
-            async_track_state_change(hass, [temperatureSensor],
+        if temperature_sensor is not None:
+            async_track_state_change(hass, [temperature_sensor],
                                      thermostat.temperature_state_changed)
 
     add_devices(devices)
@@ -85,8 +85,8 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
         self._name = _name
         self._thermostat = eq3.Thermostat(_mac)
-        self._temperatureSensor = _sensor
-        self._sensorTemperature = STATE_UNKNOWN
+        self._temperature_sensor = _sensor
+        self._sensor_temperature = STATE_UNKNOWN
 
     @property
     def available(self) -> bool:
@@ -114,19 +114,19 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
         This callback is triggered, when the sensor state changes.
         """
-        self._sensorTemperature = new_state.state
+        self._sensor_temperature = new_state.state
 
-        if self._sensorTemperature == STATE_UNKNOWN:
+        if self._sensor_temperature == STATE_UNKNOWN:
             return
 
         # Force 0.5 precision from the temperature sensor
-        self._sensorTemperature = round(float(self._sensorTemperature) * 2) / 2
+        self._sensor_temperature = round(float(self._sensor_temperature) * 2) / 2
 
     @property
     def current_temperature(self):
         """If no sensor is specified, just return target_temperature."""
-        if self._temperatureSensor is not None:
-            return self._sensorTemperature
+        if self._temperature_sensor is not None:
+            return self._sensor_temperature
 
         return self.target_temperature
 


### PR DESCRIPTION
## Description:
`eq3btsmart` does not natively provide temperature readings due to the thermostat not transmitting the current temperature. I found this to be rather restricting in my UI and wanted to have current temperature readings in addition to the target temperature, especially so that the graph is populated with accurate data.

Since I already have temperature sensors in most rooms it sounded logical to simply query the temperature from the sensor and include it with the thermostat.In addition, you can now also ask alexa for the correct temperature

**Note**:
I am not very experienced in developing for homeassistant. My first idea was to simply ask the configured sensor for its current value every time the `current_temperature` function is called, but I didn't find any examples of how to accomplish this. Instead I went with a callback approach, where the temperature of the thermostat is updated every time the temperature sensor changes.  
Any suggestions on how to do it differently are appreciated!

## Example entry for `configuration.yaml`:
```yaml
climate:
  - platform: eq3btsmart
    devices:
      Room1:
        mac: '00:11:22:33:44:55'
        sensor: sensor.temperature_1
      Room2:
        mac: '00:11:22:33:44:66'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
_I will update the documentation when I get approval that this functionality is wanted_

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.