### PR TITLE
full RGB support for users of tradfri GW

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -179,8 +179,12 @@ class Tradfri(Light):
             self._api(self._light_control.set_state(True))
 
         if ATTR_RGB_COLOR in kwargs and self._light_data.hex_color is not None:
-            self._api(self._light.light_control.set_hex_color(
-                color_util.color_rgb_to_hex(*kwargs[ATTR_RGB_COLOR])))
+            #~ self._api(self._light.light_control.set_hex_color(
+            #~    color_util.color_rgb_to_hex(*kwargs[ATTR_RGB_COLOR])))
+            ## 201709013: set_hex_color() seems not to work in pytradfri api - set_rgb_color() does 
+            ## -> changed function set_hex_color() to set_rgb_color()
+            ## tested w. IKEA tradfri GW and zigbee rgb PWM module (dresden elektronik FLS-PP lp) 
+            self._api(self._light.light_control.set_rgb_color(*kwargs[ATTR_RGB_COLOR]))
 
         elif ATTR_COLOR_TEMP in kwargs and \
                 self._light_data.hex_color is not None and self._ok_temps:

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -179,12 +179,8 @@ class Tradfri(Light):
             self._api(self._light_control.set_state(True))
 
         if ATTR_RGB_COLOR in kwargs and self._light_data.hex_color is not None:
-            #~ self._api(self._light.light_control.set_hex_color(
-            #~    color_util.color_rgb_to_hex(*kwargs[ATTR_RGB_COLOR])))
-            ## 201709013: set_hex_color() seems not to work in pytradfri api - set_rgb_color() does 
-            ## -> changed function set_hex_color() to set_rgb_color()
-            ## tested w. IKEA tradfri GW and zigbee rgb PWM module (dresden elektronik FLS-PP lp) 
-            self._api(self._light.light_control.set_rgb_color(*kwargs[ATTR_RGB_COLOR]))
+            self._api(self._light.light_control.set_rgb_color(
+                *kwargs[ATTR_RGB_COLOR]))
 
         elif ATTR_COLOR_TEMP in kwargs and \
                 self._light_data.hex_color is not None and self._ok_temps:


### PR DESCRIPTION
the use of set_rgb_color() seems to be advantageous over set_hex_color() for full RGB support

## Description:
Issue: 
pytradfri's set_hex_color() does not work for arbitrary colors with the current IKEA tradfri gateway. Only setting rgb hex values (param 5706) of some predefined colors has the desired effect. Others will fall back to one predefined value. I assume, the GW doesn't allow for values deviating from the predefined values. 

However, pytradfri's set_rgb_color() does also work for arbitrary colors. Latest pytradfri (2.2/PR51?) will convert rgb to xy and send xy thru the GW (param 5709 and 5710). 

 -> changed the function used from set_hex_color() to set_rgb_color() in HA's component\light\tradfri

Result: 
Full RGB support with arbitrary colors with my setup. 

Setup: 
Home Assistant 0.53.0
pytradfri 2.2 
IKEA tradfri gateway fw 1.1.0015
zigbee rgb PWM module (dresden elektronik FLS-PP lp) 

Unfortunately I cannot test tradfri GW with other bulbs (no have hue/lightify bulbs). 
___ 

Predefined colors from <ggravlingen/pytradfri#51>: 
 this.f3891b = new HashMap();
        this.f3891b.put("f5faf6", new C1386c(0.3804d, 0.3804d, "f5faf6", 0.54d));
        this.f3891b.put("f1e0b5", new C1386c(0.4599d, 0.4106d, "CCT_LIGHT_NEUTRAL", 0.61d));
        this.f3891b.put("efd275", new C1386c(0.5056d, 0.4152d, "efd275", 0.66d));
        this.f3891b.put("dcf0f8", new C1386c(0.3221d, 0.3317d, "dcf0f8", 0.45d));
        this.f3891b.put("eaf6fb", new C1386c(0.3451d, 0.3451d, "eaf6fb", 0.48d));
        this.f3891b.put("f5faf6", new C1386c(0.3804d, 0.3804d, "f5faf6", 0.54d));
        this.f3891b.put("f2eccf", new C1386c(0.4369d, 0.4041d, "f2eccf", 0.59d));
        this.f3891b.put("CCT_LIGHT_NEUTRAL", new C1386c(0.4599d, 0.4106d, "CCT_LIGHT_NEUTRAL", 0.61d));
        this.f3891b.put("efd275", new C1386c(0.5056d, 0.4152d, "efd275", 0.66d));
        this.f3891b.put("ebb63e", new C1386c(0.5516d, 0.4075d, "ebb63e", 0.68d));
        this.f3891b.put("e78834", new C1386c(0.58d, 0.38d, "e78834", 0.69d));
        this.f3891b.put("e57345", new C1386c(0.58d, 0.35d, "e57345", 0.67d));
        this.f3891b.put("da5d41", new C1386c(0.62d, 0.34d, "da5d41", 0.7d));
        this.f3891b.put("dc4b31", new C1386c(0.66d, 0.32d, "dc4b31", 0.73d));
        this.f3891b.put("e491af", new C1386c(0.5d, 0.28d, "e491af", 0.57d));
        this.f3891b.put("e8bedd", new C1386c(0.45d, 0.28d, "e8bedd", 0.53d));
        this.f3891b.put("d9337c", new C1386c(0.5d, 0.24d, "d9337c", 0.55d));
        this.f3891b.put("c984bb", new C1386c(0.34d, 0.19d, "c984bb", 0.38d));
        this.f3891b.put("8f2686", new C1386c(0.31d, 0.12d, "8f2686", 0.33d));
        this.f3891b.put("4a418a", new C1386c(0.17d, 0.05d, "4a418a", 0.18d));
        this.f3891b.put("6c83ba", new C1386c(0.2d, 0.1d, "6c83ba", 0.22d));
        this.f3891b.put("a9d62b", new C1386c(0.4099999964237213d, 0.5099999904632568d, "a9d62b", 0.654d));
        this.f3891b.put("d6e44b", new C1386c(0.44999998807907104d, 0.4699999988079071d, "d6e44b", 0.65d));



**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
scene:
  - name: daytime
    entities:
      light.kitchen:
        state: on
        brightness: 63
        rgb_color: [255, 191, 0]
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
