### PR TITLE
Fix displaying of friendly_name for light template component

### DIFF
--- a/homeassistant/components/light/template.py
+++ b/homeassistant/components/light/template.py
@@ -128,6 +128,11 @@ class LightTemplate(Light):
         return self._brightness
 
     @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
     def supported_features(self):
         """Flag supported features."""
         if self._level_script is not None:

--- a/tests/components/light/test_template.py
+++ b/tests/components/light/test_template.py
@@ -590,6 +590,44 @@ class TestTemplateLight:
 
         assert state.attributes.get('brightness') == '42'
 
+    def test_friendly_name(self):
+        """Test the accessibility of the friendly_name attribute."""
+        with assert_setup_component(1, 'light'):
+            assert setup.setup_component(self.hass, 'light', {
+                'light': {
+                    'platform': 'template',
+                    'lights': {
+                        'test_template_light': {
+                            'friendly_name': 'Template light',
+                            'value_template': "{{ 1 == 1 }}",
+                            'turn_on': {
+                                'service': 'light.turn_on',
+                                'entity_id': 'light.test_state'
+                            },
+                            'turn_off': {
+                                'service': 'light.turn_off',
+                                'entity_id': 'light.test_state'
+                            },
+                            'set_level': {
+                                'service': 'light.turn_on',
+                                'data_template': {
+                                    'entity_id': 'light.test_state',
+                                    'brightness': '{{brightness}}'
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('light.test_template_light')
+        assert state is not None
+
+        assert state.attributes.get('friendly_name') == 'Template light'
+
 
 @asyncio.coroutine
 def test_restore_state(hass):


### PR DESCRIPTION
## Description:

Currently the friendly name for the light template component is not accessible.

** ~~Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>~~ already documented

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] ~~Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~~

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
