### PR TITLE
Command line flag to control logging output file

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -127,6 +127,12 @@ def get_arguments() -> argparse.Namespace:
         default=None,
         help='Enables daily log rotation and keeps up to the specified days')
     parser.add_argument(
+        '--log-file',
+        type=str,
+        default=None,
+        help='Log file to write to.  If not set, CONFIG/home-assistant.log '
+             'is used')
+    parser.add_argument(
         '--runner',
         action='store_true',
         help='On restart exit with code {}'.format(RESTART_EXIT_CODE))
@@ -256,13 +262,14 @@ def setup_and_run_hass(config_dir: str,
         }
         hass = bootstrap.from_config_dict(
             config, config_dir=config_dir, verbose=args.verbose,
-            skip_pip=args.skip_pip, log_rotate_days=args.log_rotate_days)
+            skip_pip=args.skip_pip, log_rotate_days=args.log_rotate_days,
+            log_file=args.log_file)
     else:
         config_file = ensure_config_file(config_dir)
         print('Config directory:', config_dir)
         hass = bootstrap.from_config_file(
             config_file, verbose=args.verbose, skip_pip=args.skip_pip,
-            log_rotate_days=args.log_rotate_days)
+            log_rotate_days=args.log_rotate_days, log_file=args.log_file)
 
     if hass is None:
         return None


### PR DESCRIPTION
## Description:
Add a hass command line flag to control where the log file is written to.  If not set, the current system (CONFIG/home-assistant.log) is used.  This allows users to control where the log file is written to.  Many/most Linux app logs are written to /var/log.  On the Pi, it's useful to have logs written to a ram disk to avoid wearing the SD card.  Original feature [request thread is here](https://community.home-assistant.io/t/custom-log-file-location/12360).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant.github.io) (if applicable):** home-assistant/home-assistant.github.io#3365

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
