### PR TITLE
Bump uvcclient to work with beta releases of Ubiquiti Unifi Camera NVR

### DIFF
--- a/homeassistant/components/camera/uvc.py
+++ b/homeassistant/components/camera/uvc.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_PORT
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['uvcclient==0.10.0']
+REQUIREMENTS = ['uvcclient==0.10.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -978,7 +978,7 @@ uber_rides==0.5.2
 upsmychoice==1.0.6
 
 # homeassistant.components.camera.uvc
-uvcclient==0.10.0
+uvcclient==0.10.1
 
 # homeassistant.components.volvooncall
 volvooncall==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -139,7 +139,7 @@ sqlalchemy==1.1.13
 statsd==3.2.1
 
 # homeassistant.components.camera.uvc
-uvcclient==0.10.0
+uvcclient==0.10.1
 
 # homeassistant.components.cloud
 warrant==0.2.0


### PR DESCRIPTION
## Description:

Bumps the latest uvcclient to 0.10.1 to fix issues related to running beta releases of Unifi Camera NVR.

https://github.com/kk7ds/uvcclient/commit/f1778b07e6d87f9d77251bc36114182b4bb614c3

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
