### PR TITLE
Fix russound_rio for python 3.4

### DIFF
--- a/homeassistant/components/media_player/russound_rio.py
+++ b/homeassistant/components/media_player/russound_rio.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     CONF_NAME, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['russound_rio==0.1.3']
+REQUIREMENTS = ['russound_rio==0.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -869,7 +869,7 @@ roombapy==1.3.1
 russound==0.1.7
 
 # homeassistant.components.media_player.russound_rio
-russound_rio==0.1.3
+russound_rio==0.1.4
 
 # homeassistant.components.media_player.yamaha
 rxv==0.4.0


### PR DESCRIPTION
Bumped russound_rio dependency to 0.1.4 which includes a fix for python
3.4.2 (asyncio.async vs asyncio.ensure_future)

## Description:
The russound_rio module version 0.1.3 used asyncio.ensure_future which wasn't introduced until 3.4.4. Hassbian is still using 3.4.2. Version 0.1.4 of this module uses asyncio.async if ensure_future is not available.


## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
