### PR TITLE
Fix zwave light switches never updating correctly

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -85,6 +85,10 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         self._refresh_value = refresh
         self._zw098 = None
 
+        if self._refresh_value:
+            _LOGGER.warning("The device_config option: refresh_value and "
+                            "delay will be deprecated, please remove from "
+                            " configuration.")
         # Enable appropriate workaround flags for our device
         # Make sure that we have values for the key before converting to int
         if (self.node.manufacturer_id.strip() and
@@ -102,6 +106,7 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         _LOGGER.debug('self._refreshing=%s self.delay=%s',
                       self._refresh_value, self._delay)
         self.value_added()
+        self.values.primary.set_change_verified(True)
         self.update_properties()
 
     def update_properties(self):

--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -46,15 +46,9 @@ TEMP_COLD_HASS = (TEMP_COLOR_MAX - TEMP_COLOR_MIN) / 3 + TEMP_COLOR_MIN
 
 def get_device(node, values, node_config, **kwargs):
     """Create Z-Wave entity device."""
-    refresh = node_config.get(zwave.CONF_REFRESH_VALUE)
-    delay = node_config.get(zwave.CONF_REFRESH_DELAY)
-    _LOGGER.debug("node=%d value=%d node_config=%s CONF_REFRESH_VALUE=%s"
-                  " CONF_REFRESH_DELAY=%s", node.node_id,
-                  values.primary.value_id, node_config, refresh, delay)
-
     if node.has_command_class(zwave.const.COMMAND_CLASS_SWITCH_COLOR):
-        return ZwaveColorLight(values, refresh, delay)
-    return ZwaveDimmer(values, refresh, delay)
+        return ZwaveColorLight(values)
+    return ZwaveDimmer(values)
 
 
 def brightness_state(value):
@@ -74,20 +68,14 @@ def ct_to_rgb(temp):
 class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
     """Representation of a Z-Wave dimmer."""
 
-    def __init__(self, values, refresh, delay):
+    def __init__(self, values):
         """Initialize the light."""
         zwave.ZWaveDeviceEntity.__init__(self, values, DOMAIN)
         self._brightness = None
         self._state = None
         self._supported_features = None
-        self._delay = delay
-        self._refresh_value = refresh
         self._zw098 = None
 
-        if self._delay:
-            _LOGGER.warning("The device_config option: "
-                            "delay will be deprecated, please remove from "
-                            " configuration.")
         # Enable appropriate workaround flags for our device
         # Make sure that we have values for the key before converting to int
         if (self.node.manufacturer_id.strip() and
@@ -99,11 +87,7 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
                     _LOGGER.debug("AEOTEC ZW098 workaround enabled")
                     self._zw098 = 1
 
-        # Used for value change event handling
-        _LOGGER.debug('self._refreshing=%s self.delay=%s',
-                      self._refresh_value, self._delay)
         self.value_added()
-        self.values.primary.set_change_verified(refresh)
         self.update_properties()
 
     def update_properties(self):
@@ -116,10 +100,6 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         self._supported_features = SUPPORT_BRIGHTNESS
         if self.values.dimming_duration is not None:
             self._supported_features |= SUPPORT_TRANSITION
-
-    def value_changed(self):
-        """Call when a value for this entity's node has changed."""
-        super().value_changed()
 
     @property
     def brightness(self):
@@ -193,13 +173,13 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
 class ZwaveColorLight(ZwaveDimmer):
     """Representation of a Z-Wave color changing light."""
 
-    def __init__(self, values, refresh, delay):
+    def __init__(self, values):
         """Initialize the light."""
         self._color_channels = None
         self._rgb = None
         self._ct = None
 
-        super().__init__(values, refresh, delay)
+        super().__init__(values)
 
     def value_added(self):
         """Call when a new value is added to this entity."""

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -49,7 +49,6 @@ CONF_CONFIG_PATH = 'config_path'
 CONF_IGNORED = 'ignored'
 CONF_INVERT_OPENCLOSE_BUTTONS = 'invert_openclose_buttons'
 CONF_REFRESH_VALUE = 'refresh_value'
-CONF_REFRESH_DELAY = 'delay'
 CONF_DEVICE_CONFIG = 'device_config'
 CONF_DEVICE_CONFIG_GLOB = 'device_config_glob'
 CONF_DEVICE_CONFIG_DOMAIN = 'device_config_domain'
@@ -65,7 +64,6 @@ DEFAULT_DEBUG = False
 DEFAULT_CONF_IGNORED = False
 DEFAULT_CONF_INVERT_OPENCLOSE_BUTTONS = False
 DEFAULT_CONF_REFRESH_VALUE = False
-DEFAULT_CONF_REFRESH_DELAY = 5
 
 RENAME_NODE_SCHEMA = vol.Schema({
     vol.Required(const.ATTR_NODE_ID): vol.Coerce(int),
@@ -129,9 +127,7 @@ DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({
     vol.Optional(CONF_INVERT_OPENCLOSE_BUTTONS,
                  default=DEFAULT_CONF_INVERT_OPENCLOSE_BUTTONS): cv.boolean,
     vol.Optional(CONF_REFRESH_VALUE, default=DEFAULT_CONF_REFRESH_VALUE):
-        cv.boolean,
-    vol.Optional(CONF_REFRESH_DELAY, default=DEFAULT_CONF_REFRESH_DELAY):
-        cv.positive_int
+        cv.boolean
 })
 
 SIGNAL_REFRESH_ENTITY_FORMAT = 'zwave_refresh_entity_{}'
@@ -808,6 +804,12 @@ class ZWaveDeviceEntityValues():
             node_config.get(CONF_POLLING_INTENSITY), int)
         if polling_intensity:
             self.primary.enable_poll(polling_intensity)
+
+        if node_config.get(CONF_REFRESH_VALUE):
+            self.primary.set_change_verified(True)
+            _LOGGER.info("Values for %s are forced refreshed.", generated_id)
+        else:
+            self.primary.set_change_verified(DEFAULT_CONF_REFRESH_VALUE)
 
         platform = get_platform(component, DOMAIN)
         device = platform.get_device(

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -807,7 +807,6 @@ class ZWaveDeviceEntityValues():
 
         if node_config.get(CONF_REFRESH_VALUE):
             self.primary.set_change_verified(True)
-            _LOGGER.info("Values for %s are forced refreshed.", generated_id)
         else:
             self.primary.set_change_verified(DEFAULT_CONF_REFRESH_VALUE)
 
@@ -851,7 +850,6 @@ class ZWaveDeviceEntity(ZWaveBaseEntity):
         from pydispatch import dispatcher
         self.values = values
         self.node = values.primary.node
-        self.values.primary.set_change_verified(False)
 
         self._name = _value_name(self.values.primary)
         self._unique_id = "ZWAVE-{}-{}".format(self.node.node_id,

--- a/tests/components/light/test_zwave.py
+++ b/tests/components/light/test_zwave.py
@@ -167,45 +167,6 @@ def test_dimmer_value_changed(mock_openzwave):
     assert device.brightness == 118
 
 
-def test_dimmer_refresh_value(mock_openzwave):
-    """Test value changed for dimmer lights."""
-    node = MockNode()
-    value = MockValue(data=0, node=node)
-    values = MockLightValues(primary=value)
-    device = zwave.get_device(node=node, values=values, node_config={
-        homeassistant.components.zwave.CONF_REFRESH_VALUE: True,
-        homeassistant.components.zwave.CONF_REFRESH_DELAY: 5,
-    })
-
-    assert not device.is_on
-
-    with patch.object(zwave, 'Timer', MagicMock()) as mock_timer:
-        value.data = 46
-        value_changed(value)
-
-        assert not device.is_on
-        assert mock_timer.called
-        assert len(mock_timer.mock_calls) == 2
-        timeout, callback = mock_timer.mock_calls[0][1][:2]
-        assert timeout == 5
-        assert mock_timer().start.called
-        assert len(mock_timer().start.mock_calls) == 1
-
-        with patch.object(zwave, 'Timer', MagicMock()) as mock_timer_2:
-            value_changed(value)
-            assert not device.is_on
-            assert mock_timer().cancel.called
-            assert len(mock_timer_2.mock_calls) == 2
-            timeout, callback = mock_timer_2.mock_calls[0][1][:2]
-            assert timeout == 5
-            assert mock_timer_2().start.called
-            assert len(mock_timer_2().start.mock_calls) == 1
-
-            callback()
-            assert device.is_on
-            assert device.brightness == 118
-
-
 def test_set_rgb_color(mock_openzwave):
     """Test setting zwave light color."""
     node = MockNode(command_classes=[const.COMMAND_CLASS_SWITCH_COLOR])

--- a/tests/components/light/test_zwave.py
+++ b/tests/components/light/test_zwave.py
@@ -1,7 +1,6 @@
 """Test Z-Wave lights."""
 from unittest.mock import patch, MagicMock
 
-import homeassistant.components.zwave
 from homeassistant.components.zwave import const
 from homeassistant.components.light import (
     zwave, ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_RGB_COLOR, ATTR_TRANSITION,

--- a/tests/components/light/test_zwave.py
+++ b/tests/components/light/test_zwave.py
@@ -31,7 +31,6 @@ def test_get_device_detects_dimmer(mock_openzwave):
     device = zwave.get_device(node=node, values=values, node_config={})
     assert isinstance(device, zwave.ZwaveDimmer)
     assert device.supported_features == SUPPORT_BRIGHTNESS
-    assert values.primary.set_change_verified.called
 
 
 def test_get_device_detects_colorlight(mock_openzwave):
@@ -43,7 +42,6 @@ def test_get_device_detects_colorlight(mock_openzwave):
     device = zwave.get_device(node=node, values=values, node_config={})
     assert isinstance(device, zwave.ZwaveColorLight)
     assert device.supported_features == SUPPORT_BRIGHTNESS | SUPPORT_RGB_COLOR
-    assert values.primary.set_change_verified.called
 
 
 def test_get_device_detects_zw098(mock_openzwave):
@@ -56,7 +54,6 @@ def test_get_device_detects_zw098(mock_openzwave):
     assert isinstance(device, zwave.ZwaveColorLight)
     assert device.supported_features == (
         SUPPORT_BRIGHTNESS | SUPPORT_RGB_COLOR | SUPPORT_COLOR_TEMP)
-    assert values.primary.set_change_verified.called
 
 
 def test_dimmer_turn_on(mock_openzwave):

--- a/tests/components/light/test_zwave.py
+++ b/tests/components/light/test_zwave.py
@@ -32,6 +32,7 @@ def test_get_device_detects_dimmer(mock_openzwave):
     device = zwave.get_device(node=node, values=values, node_config={})
     assert isinstance(device, zwave.ZwaveDimmer)
     assert device.supported_features == SUPPORT_BRIGHTNESS
+    assert values.primary.set_change_verified.called
 
 
 def test_get_device_detects_colorlight(mock_openzwave):
@@ -43,6 +44,7 @@ def test_get_device_detects_colorlight(mock_openzwave):
     device = zwave.get_device(node=node, values=values, node_config={})
     assert isinstance(device, zwave.ZwaveColorLight)
     assert device.supported_features == SUPPORT_BRIGHTNESS | SUPPORT_RGB_COLOR
+    assert values.primary.set_change_verified.called
 
 
 def test_get_device_detects_zw098(mock_openzwave):
@@ -55,6 +57,7 @@ def test_get_device_detects_zw098(mock_openzwave):
     assert isinstance(device, zwave.ZwaveColorLight)
     assert device.supported_features == (
         SUPPORT_BRIGHTNESS | SUPPORT_RGB_COLOR | SUPPORT_COLOR_TEMP)
+    assert values.primary.set_change_verified.called
 
 
 def test_dimmer_turn_on(mock_openzwave):

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -771,7 +771,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         assert discovery.async_load_platform.called
         assert self.primary.set_change_verified.called
         assert len(self.primary.set_change_verified.mock_calls) == 1
-        assert self.primary.set_change_verified.mock_calls[0][1][0] == True
+        assert self.primary.set_change_verified.mock_calls[0][1][0]
 
     @patch.object(zwave, 'get_platform')
     @patch.object(zwave, 'discovery')
@@ -802,7 +802,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         assert discovery.async_load_platform.called
         assert self.primary.set_change_verified.called
         assert len(self.primary.set_change_verified.mock_calls) == 1
-        assert self.primary.set_change_verified.mock_calls[0][1][0] == False
+        assert not self.primary.set_change_verified.mock_calls[0][1][0]
 
 
 class TestZwave(unittest.TestCase):

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -742,6 +742,68 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         assert len(self.primary.enable_poll.mock_calls) == 1
         assert self.primary.enable_poll.mock_calls[0][1][0] == 123
 
+    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'discovery')
+    def test_config_refresh_value_true(self, discovery, get_platform):
+        """Test refresh value."""
+        mock_platform = MagicMock()
+        get_platform.return_value = mock_platform
+        mock_device = MagicMock()
+        mock_device.name = 'test_device'
+        mock_platform.get_device.return_value = mock_device
+        self.node.values = {
+            self.primary.value_id: self.primary,
+            self.secondary.value_id: self.secondary,
+        }
+        self.device_config = {self.entity_id: {
+            zwave.CONF_REFRESH_VALUE: True,
+        }}
+        values = zwave.ZWaveDeviceEntityValues(
+            hass=self.hass,
+            schema=self.mock_schema,
+            primary_value=self.primary,
+            zwave_config=self.zwave_config,
+            device_config=self.device_config,
+        )
+        values._check_entity_ready()
+        self.hass.block_till_done()
+
+        assert discovery.async_load_platform.called
+        assert self.primary.set_change_verified.called
+        assert len(self.primary.set_change_verified.mock_calls) == 1
+        assert self.primary.set_change_verified.mock_calls[0][1][0] == True
+
+    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'discovery')
+    def test_config_refresh_value_false(self, discovery, get_platform):
+        """Test refresh value."""
+        mock_platform = MagicMock()
+        get_platform.return_value = mock_platform
+        mock_device = MagicMock()
+        mock_device.name = 'test_device'
+        mock_platform.get_device.return_value = mock_device
+        self.node.values = {
+            self.primary.value_id: self.primary,
+            self.secondary.value_id: self.secondary,
+        }
+        self.device_config = {self.entity_id: {
+            zwave.CONF_REFRESH_VALUE: False,
+        }}
+        values = zwave.ZWaveDeviceEntityValues(
+            hass=self.hass,
+            schema=self.mock_schema,
+            primary_value=self.primary,
+            zwave_config=self.zwave_config,
+            device_config=self.device_config,
+        )
+        values._check_entity_ready()
+        self.hass.block_till_done()
+
+        assert discovery.async_load_platform.called
+        assert self.primary.set_change_verified.called
+        assert len(self.primary.set_change_verified.mock_calls) == 1
+        assert self.primary.set_change_verified.mock_calls[0][1][0] == False
+
 
 class TestZwave(unittest.TestCase):
     """Test zwave init."""


### PR DESCRIPTION
## Description:
I finally got around to buy me a test zwave dimmer to try and fix the problem that everybody encounters with dimmer switches: The ui never updates correctly. Either from a manual physical update at the switch or transitioning from off to on or vice versa. The simple fix was to apply `set_change_verified(True)` to the value. That makes OZW refresh the value a second time to verify that the value has settled.
This is tested with a Aeotec DSC27103 dimmer. 

Breaking change note:
The additional `delay` config parameter has been removed, and is no longer needed.

**Related issue (if applicable):** fixes #9406 #8232 #7937 #4867
