### PR TITLE
Added support for the DTE Energy Bridge v2

### DIFF
--- a/homeassistant/components/sensor/dte_energy_bridge.py
+++ b/homeassistant/components/sensor/dte_energy_bridge.py
@@ -51,8 +51,6 @@ class DteEnergyBridgeSensor(Entity):
             url_template = "http://{}/instantaneousdemand"
         elif self._version == 2:
             url_template = "http://{}:8888/zigbee/se/instantaneousdemand"
-        else:
-            raise ValueError('Invalid sensor version')
 
         self._url = url_template.format(ip_address)
 

--- a/homeassistant/components/sensor/dte_energy_bridge.py
+++ b/homeassistant/components/sensor/dte_energy_bridge.py
@@ -26,7 +26,8 @@ ICON = 'mdi:flash'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_IP_ADDRESS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_VERSION, default=DEFAULT_VERSION): vol.All(vol.Coerce(int), vol.Any(1, 2))
+    vol.Optional(CONF_VERSION, default=DEFAULT_VERSION):
+        vol.All(vol.Coerce(int), vol.Any(1, 2))
 })
 
 
@@ -47,11 +48,13 @@ class DteEnergyBridgeSensor(Entity):
         self._version = version
 
         if self._version == 1:
-            self._url = "http://{}/instantaneousdemand".format(ip_address)
+            url_template = "http://{}/instantaneousdemand"
         elif self._version == 2:
-            self._url = "http://{}:8888/zigbee/se/instantaneousdemand".format(ip_address)
+            url_template = "http://{}:8888/zigbee/se/instantaneousdemand"
         else:
             raise ValueError('Invalid sensor version')
+
+        self._url = url_template.format(ip_address)
 
         self._name = name
         self._unit_of_measurement = "kW"

--- a/homeassistant/components/sensor/dte_energy_bridge.py
+++ b/homeassistant/components/sensor/dte_energy_bridge.py
@@ -16,14 +16,17 @@ from homeassistant.const import CONF_NAME
 _LOGGER = logging.getLogger(__name__)
 
 CONF_IP_ADDRESS = 'ip'
+CONF_VERSION = 'version'
 
 DEFAULT_NAME = 'Current Energy Usage'
+DEFAULT_VERSION = 1
 
 ICON = 'mdi:flash'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_IP_ADDRESS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_VERSION, default=DEFAULT_VERSION): vol.All(vol.Coerce(int), vol.Any(1, 2))
 })
 
 
@@ -31,16 +34,25 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the DTE energy bridge sensor."""
     name = config.get(CONF_NAME)
     ip_address = config.get(CONF_IP_ADDRESS)
+    version = config.get(CONF_VERSION, 1)
 
-    add_devices([DteEnergyBridgeSensor(ip_address, name)], True)
+    add_devices([DteEnergyBridgeSensor(ip_address, name, version)], True)
 
 
 class DteEnergyBridgeSensor(Entity):
-    """Implementation of a DTE Energy Bridge sensor."""
+    """Implementation of the DTE Energy Bridge sensors."""
 
-    def __init__(self, ip_address, name):
+    def __init__(self, ip_address, name, version):
         """Initialize the sensor."""
-        self._url = "http://{}/instantaneousdemand".format(ip_address)
+        self._version = version
+
+        if self._version == 1:
+            self._url = "http://{}/instantaneousdemand".format(ip_address)
+        elif self._version == 2:
+            self._url = "http://{}:8888/zigbee/se/instantaneousdemand".format(ip_address)
+        else:
+            raise ValueError('Invalid sensor version')
+
         self._name = name
         self._unit_of_measurement = "kW"
         self._state = None


### PR DESCRIPTION
## Description:
Adds support for the DTE Energy Bridge v2. The only change is the URL of the undocumented API, so I've added an optional 

**Related issue (if applicable):** fixes #8658

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3369

## Example entry for `configuration.yaml` (if applicable):
```yaml

sensor:
  - platform: dte_energy_bridge
    ip: 192.168.1.103
    version: 2
    scan_interval: 5
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
