### PR TITLE
Polymer access to log file broken when using new log file command line

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -51,7 +51,9 @@ def setup(hass, config):
     hass.http.register_view(APIComponentsView)
     hass.http.register_view(APITemplateView)
 
-    hass.http.register_static_path(URL_API_ERROR_LOG, ERROR_LOG_PATH, False)
+    if ERROR_LOG_PATH is not None:
+        hass.http.register_static_path(URL_API_ERROR_LOG, ERROR_LOG_PATH,
+                                       False)
 
     return True
 

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -13,7 +13,7 @@ import async_timeout
 
 import homeassistant.core as ha
 import homeassistant.remote as rem
-from homeassistant.bootstrap import ERROR_LOG_FILENAME
+from homeassistant.bootstrap import ERROR_LOG_PATH
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP, EVENT_TIME_CHANGED,
     HTTP_BAD_REQUEST, HTTP_CREATED, HTTP_NOT_FOUND,
@@ -51,8 +51,7 @@ def setup(hass, config):
     hass.http.register_view(APIComponentsView)
     hass.http.register_view(APITemplateView)
 
-    hass.http.register_static_path(
-        URL_API_ERROR_LOG, hass.config.path(ERROR_LOG_FILENAME), False)
+    hass.http.register_static_path(URL_API_ERROR_LOG, ERROR_LOG_PATH, False)
 
     return True
 

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -13,7 +13,7 @@ import async_timeout
 
 import homeassistant.core as ha
 import homeassistant.remote as rem
-from homeassistant.bootstrap import ERROR_LOG_PATH
+from homeassistant.bootstrap import DATA_LOGGING
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP, EVENT_TIME_CHANGED,
     HTTP_BAD_REQUEST, HTTP_CREATED, HTTP_NOT_FOUND,
@@ -51,9 +51,9 @@ def setup(hass, config):
     hass.http.register_view(APIComponentsView)
     hass.http.register_view(APITemplateView)
 
-    if ERROR_LOG_PATH is not None:
-        hass.http.register_static_path(URL_API_ERROR_LOG, ERROR_LOG_PATH,
-                                       False)
+    log_path = hass.data.get(DATA_LOGGING, None)
+    if log_path:
+        hass.http.register_static_path(URL_API_ERROR_LOG, log_path, False)
 
     return True
 


### PR DESCRIPTION
## Description:

If the new command line input for the log file is used from PR #9422, the polymer developer tools info page cannot find the log file location.  It uses the default log file location and the hass config path to load a file that is no longer there.  This PR fixes that issue by creating a new variable ERROR_LOG_PATH which components/api.py can access to load the actual log file location.

FYI I could not run tox.  The current state of the dev branch throws the following error.  Manual tests were run w/ the fix and the webui finds the default or custom log file correctly now.
```
tests/components/cloud/test_auth_api.py:4: in <module>
    from botocore.exceptions import ClientError
E   ImportError: No module named 'botocore'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

