### PR TITLE
Load WebComponent polyfill on header.

### DIFF
--- a/homeassistant/components/frontend/templates/index.html
+++ b/homeassistant/components/frontend/templates/index.html
@@ -68,6 +68,19 @@
         suppressBindingNotifications: true,
       };
     </script>
+    <script>
+      var webComponentsSupported = (
+        'customElements' in window &&
+        'import' in document.createElement('link') &&
+        'content' in document.createElement('template'));
+      if (!webComponentsSupported) {
+        var e = document.createElement('script');
+        e.async = true;
+        e.onerror = initError;
+        e.src = '/static/webcomponents-lite.js';
+        document.head.appendChild(e);
+      }
+    </script>
   </head>
   <body>
     <div id='ha-init-skeleton'>
@@ -100,19 +113,5 @@
     {% for extra_url in extra_urls -%}
       <link rel='import' href='{{ extra_url }}' async>
     {% endfor -%}
-
-    <script>
-      var webComponentsSupported = (
-        'registerElement' in document &&
-        'import' in document.createElement('link') &&
-        'content' in document.createElement('template'));
-      if (!webComponentsSupported) {
-        var e = document.createElement('script');
-        e.async = true;
-        e.onerror = initError;
-        e.src = '/static/webcomponents-lite.js';
-        document.head.appendChild(e);
-      }
-    </script>
   </body>
 </html>

--- a/homeassistant/components/frontend/templates/index.html
+++ b/homeassistant/components/frontend/templates/index.html
@@ -68,19 +68,6 @@
         suppressBindingNotifications: true,
       };
     </script>
-    <script>
-      var webComponentsSupported = (
-        'customElements' in window &&
-        'import' in document.createElement('link') &&
-        'content' in document.createElement('template'));
-      if (!webComponentsSupported) {
-        var e = document.createElement('script');
-        e.async = true;
-        e.onerror = initError;
-        e.src = '/static/webcomponents-lite.js';
-        document.head.appendChild(e);
-      }
-    </script>
   </head>
   <body>
     <div id='ha-init-skeleton'>
@@ -105,6 +92,18 @@
     {% if not dev_mode %}
     <script src='/static/custom-elements-es5-adapter.js'></script>
     {% endif %}
+    <script>
+      var webComponentsSupported = (
+        'customElements' in window &&
+        'import' in document.createElement('link') &&
+        'content' in document.createElement('template'));
+      if (!webComponentsSupported) {
+        var e = document.createElement('script');
+        e.onerror = initError;
+        e.src = '/static/webcomponents-lite.js';
+        document.head.appendChild(e);
+      }
+    </script>
     <link rel='import' href='{{ ui_url }}' onerror='initError()'>
     {% if panel_url -%}
       <link rel='import' href='{{ panel_url }}' onerror='initError()' async>


### PR DESCRIPTION
## Description:

Fix for Chrome 53 `document.regtisterElement` exists but `window.customElements` does not.
Move the script to `<head>` to load the script earlier on some browsers to make sure polyfill is loaded when loading Polymer.
Fix for Tencent X5 browser on Android(Chrome 53 based).
