### PR TITLE
Allow empty hostnames when detecting devices with the aruba device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/aruba.py
+++ b/homeassistant/components/device_tracker/aruba.py
@@ -19,9 +19,9 @@ _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ['pexpect==4.0.1']
 
 _DEVICES_REGEX = re.compile(
-    r'(?P<name>([^\s]+))\s+' +
+    r'(?P<name>([^\s]+)?)\s+' +
     r'(?P<ip>([0-9]{1,3}[\.]){3}[0-9]{1,3})\s+' +
-    r'(?P<mac>(([0-9a-f]{2}[:-]){5}([0-9a-f]{2})))\s+')
+    r'(?P<mac>([0-9a-f]{2}[:-]){5}([0-9a-f]{2}))\s+')
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,


### PR DESCRIPTION
## Description:
Some devices have no hostname in my access point. The regex to parse the line required a hostname so it missed these entries. I've made this optional and removed obsolete parentheses in the mac parsing.
