### PR TITLE
mqtt_statestream: Update to append 'state' to topic for mqtt_discovery

### DIFF
--- a/homeassistant/components/mqtt_statestream.py
+++ b/homeassistant/components/mqtt_statestream.py
@@ -38,7 +38,7 @@ def async_setup(hass, config):
             return
         payload = new_state.state
 
-        topic = base_topic + entity_id.replace('.', '/')
+        topic = base_topic + entity_id.replace('.', '/') + '/state'
         hass.components.mqtt.async_publish(topic, payload, 1, True)
 
     async_track_state_change(hass, MATCH_ALL, _state_publisher)

--- a/tests/components/test_mqtt_statestream.py
+++ b/tests/components/test_mqtt_statestream.py
@@ -59,7 +59,7 @@ class TestMqttStateStream(object):
         mock_state_change_event(self.hass, State(e_id, 'on'))
         self.hass.block_till_done()
 
-        # Make sure 'on' was published to pub/fake/entity
-        mock_pub.assert_called_with(self.hass, 'pub/fake/entity', 'on', 1,
-                                    True)
+        # Make sure 'on' was published to pub/fake/entity/state
+        mock_pub.assert_called_with(self.hass, 'pub/fake/entity/state',
+                                    'on', 1, True)
         assert mock_pub.called


### PR DESCRIPTION
## Description:

This patch updates the mqtt_statestream component to append `/state` at the end of the publish topic.  After discussion in the forum of adding publishing of attributes and mqtt discovery data, it makes sense to make this change now before the component is published to avoid the need for a breaking change later if/when the other capabilities are added.

For example, given the base_topic of `homeassistant`, the state of an entity called `light.master_bedroom` would be published to `homeassistant/light/master_bedroom/state`.  In the future, attributes would be published at this same level (ie. `homeassistant/light/master_bedroom/brightness`).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3379

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt_statestream:
  base_topic: homeassistant
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
