### PR TITLE
fix for Twitter notifications without media

### DIFF
--- a/homeassistant/components/notify/twitter.py
+++ b/homeassistant/components/notify/twitter.py
@@ -75,7 +75,7 @@ class TwitterNotificationService(BaseNotificationService):
 
         self.upload_media_then_callback(callback, media)
 
-    def send_message_callback(self, message, media_id):
+    def send_message_callback(self, message, media_id=None):
         """Tweet a message, optionally with media."""
         if self.user:
             resp = self.api.request('direct_messages/new',
@@ -95,7 +95,7 @@ class TwitterNotificationService(BaseNotificationService):
     def upload_media_then_callback(self, callback, media_path=None):
         """Upload media."""
         if not media_path:
-            return None
+            return callback()
 
         with open(media_path, 'rb') as file:
             total_bytes = os.path.getsize(media_path)


### PR DESCRIPTION
## Description:
Fix to allow Twitter notifier to post when no media is given.

**Related issue (if applicable):** fixes #9447

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: twitter
    platform: twitter
    consumer_key: …
    consumer_secret: …
    access_token: …
    access_token_secret: …

automation twitter:
  alias: Send a test message
  initial_state: True
  hide_entity: False
  trigger:
    platform: homeassistant
    event: start
  action:
    - service: notify.twitter
      data:
        message: "Test at {{ now().strftime('%I:%M:%S %p') }}."
    - service: homeassistant.turn_off
      entity_id: automation.send_a_test_message
```