### PR TITLE
Fix emulated hue warning message typo

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -129,7 +129,7 @@ class Config(object):
 
         if self.type == TYPE_ALEXA:
             _LOGGER.warning("Alexa type is deprecated and will be removed in a"
-                            "future version")
+                            " future version")
 
         # Get the IP address that will be passed to the Echo during discovery
         self.host_ip_addr = conf.get(CONF_HOST_IP)


### PR DESCRIPTION
## Description:

Fix emulated hue Alexa deprecation warning typo

Thanks to @david-c-smith for finding this

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
