### PR TITLE
Emulated Hue UPnP crashes on special characters

### DIFF
--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -136,7 +136,7 @@ USN: uuid:Socket-1_0-221438K0100073::urn:schemas-upnp-org:device:basic:1
                 # because the data object has not been initialized
                 continue
 
-            if "M-SEARCH" in data.decode('utf-8'):
+            if "M-SEARCH" in data.decode('utf-8', errors='ignore'):
                 # SSDP M-SEARCH method received, respond to it with our info
                 resp_socket = socket.socket(
                     socket.AF_INET, socket.SOCK_DGRAM)


### PR DESCRIPTION
## Description:
Me and others have reported issues where Alexa (and Google home) were note able to connect to the Emulated Hue bridge as it's UPnP thread crashed by UPnP traffic coming from another device using a non-utf-8 character before Alexa has a chance to complete discovery. The proposed fix from the thread improves the components stability and allowed Alexa to discover my devices. 

**Related issue (if applicable):** fixes #5728

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
