### PR TITLE
switch.tplink, light.tplink: bump the pyhs100 version and adapt to api changes

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -17,7 +17,7 @@ from homeassistant.util.color import (
 
 from typing import Tuple
 
-REQUIREMENTS = ['pyHS100==0.2.4.2']
+REQUIREMENTS = ['pyHS100==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -124,7 +124,7 @@ class TPLinkSmartBulb(Light):
 
     def update(self):
         """Update the TP-Link Bulb's state."""
-        from pyHS100 import SmartPlugException
+        from pyHS100 import SmartDeviceException
         try:
             self._state = (
                 self.smartbulb.state == self.smartbulb.BULB_STATE_ON)
@@ -136,7 +136,7 @@ class TPLinkSmartBulb(Light):
                     self._color_temp = kelvin_to_mired(
                         self.smartbulb.color_temp)
                 self._rgb = hsv_to_rgb(self.smartbulb.hsv)
-        except (SmartPlugException, OSError) as ex:
+        except (SmartDeviceException, OSError) as ex:
             _LOGGER.warning('Could not read state for %s: %s', self.name, ex)
 
     @property

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -45,15 +45,7 @@ class SmartPlugSwitch(SwitchDevice):
     def __init__(self, smartplug, name):
         """Initialize the switch."""
         self.smartplug = smartplug
-
-        # Use the name set on the device if not set
-        if name is None:
-            self._name = self.smartplug.alias
-        else:
-            self._name = name
-
         self._state = None
-        _LOGGER.debug("Setting up TP-Link Smart Plug")
         # Set up emeter cache
         self._emeter_params = {}
 
@@ -86,6 +78,9 @@ class SmartPlugSwitch(SwitchDevice):
         try:
             self._state = self.smartplug.state == \
                 self.smartplug.SWITCH_STATE_ON
+
+            if self._name is None:
+                self._name = self.smartplug.alias
 
             if self.smartplug.has_emeter:
                 emeter_readings = self.smartplug.get_emeter_realtime()

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -14,7 +14,7 @@ from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_HOST, CONF_NAME, ATTR_VOLTAGE)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyHS100==0.2.4.2']
+REQUIREMENTS = ['pyHS100==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,7 +82,7 @@ class SmartPlugSwitch(SwitchDevice):
 
     def update(self):
         """Update the TP-Link switch's state."""
-        from pyHS100 import SmartPlugException
+        from pyHS100 import SmartDeviceException
         try:
             self._state = self.smartplug.state == \
                 self.smartplug.SWITCH_STATE_ON
@@ -107,5 +107,5 @@ class SmartPlugSwitch(SwitchDevice):
                     # device returned no daily history
                     pass
 
-        except (SmartPlugException, OSError) as ex:
+        except (SmartDeviceException, OSError) as ex:
             _LOGGER.warning('Could not read state for %s: %s', self.name, ex)

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -45,6 +45,7 @@ class SmartPlugSwitch(SwitchDevice):
     def __init__(self, smartplug, name):
         """Initialize the switch."""
         self.smartplug = smartplug
+        self._name = None
         self._state = None
         # Set up emeter cache
         self._emeter_params = {}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -547,7 +547,7 @@ pyCEC==0.4.13
 
 # homeassistant.components.light.tplink
 # homeassistant.components.switch.tplink
-pyHS100==0.2.4.2
+pyHS100==0.3.0
 
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.20.1


### PR DESCRIPTION
## Description:

Bumping the version of pyhs100 and adapting to the change API. Avoids also I/O on `__init__` (#6973).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
