### PR TITLE
Upgrade uber_rides to 0.6.0

### DIFF
--- a/homeassistant/components/sensor/uber.py
+++ b/homeassistant/components/sensor/uber.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['uber_rides==0.5.2']
+REQUIREMENTS = ['uber_rides==0.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -978,7 +978,7 @@ transmissionrpc==0.11
 twilio==5.7.0
 
 # homeassistant.components.sensor.uber
-uber_rides==0.5.2
+uber_rides==0.6.0
 
 # homeassistant.components.sensor.ups
 upsmychoice==1.0.6


### PR DESCRIPTION
## 0.6.0
- Added support for Uber Driver Sandbox
- BC Break: Renamed auth.CLIENT_CREDENTIAL_GRANT to auth.CLIENT_CREDENTIALS_GRANT

Tested with the following configuration:

``` yaml
sensor:
# Melborne
  - platform: uber
    server_token: !secret uber_api
    start_latitude: -37.8136
    start_longitude: 144.9631
# Paris
  - platform: uber
    server_token: !secret uber_api
    start_latitude: 48.8459759
    start_longitude: 2.3707804
    end_latitude: 48.8630169
    end_longitude: 2.3763798
# San Francisco
  - platform: uber
    server_token: !secret uber_api
    start_longitude: -122.420443
    start_latitude: 37.780248
    end_longitude: -122.393289
    end_latitude: 37.795833
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

Also, catch an exception if the data is not present.