### PR TITLE
fitbit fixes

### DIFF
--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -37,8 +37,8 @@ CONF_ATTRIBUTION = 'Data provided by Fitbit.com'
 
 DEPENDENCIES = ['http']
 
-FITBIT_AUTH_CALLBACK_PATH = '/auth/fitbit/callback'
-FITBIT_AUTH_START = '/auth/fitbit'
+FITBIT_AUTH_CALLBACK_PATH = '/api/fitbit/callback'
+FITBIT_AUTH_START = '/api/fitbit'
 FITBIT_CONFIG_FILE = 'fitbit.conf'
 FITBIT_DEFAULT_RESOURCES = ['activities/steps']
 
@@ -320,8 +320,8 @@ class FitbitAuthCallbackView(HomeAssistantView):
     """Handle OAuth finish callback requests."""
 
     requires_auth = False
-    url = '/auth/fitbit/callback'
-    name = 'auth:fitbit:callback'
+    url = FITBIT_AUTH_CALLBACK_PATH
+    name = 'api:fitbit:callback'
 
     def __init__(self, config, add_devices, oauth):
         """Initialize the OAuth callback view."""
@@ -381,7 +381,8 @@ class FitbitAuthCallbackView(HomeAssistantView):
                 ATTR_ACCESS_TOKEN: result.get('access_token'),
                 ATTR_REFRESH_TOKEN: result.get('refresh_token'),
                 ATTR_CLIENT_ID: self.oauth.client_id,
-                ATTR_CLIENT_SECRET: self.oauth.client_secret
+                ATTR_CLIENT_SECRET: self.oauth.client_secret,
+                ATTR_LAST_SAVED_AT: int(time.time())
             }
         if not config_from_file(hass.config.path(FITBIT_CONFIG_FILE),
                                 config_contents):


### PR DESCRIPTION
## Description:
Fix a few `fitbit` issues.

- Put endpoints behind `/api` like the other oauth-using components (breaking change)
- Add `ATTR_LAST_SAVED_AT` on setup (https://github.com/home-assistant/home-assistant/issues/9359)

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/9359

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
