### PR TITLE
Adds MQTT Fan Discovery

### DIFF
--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -78,6 +78,9 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the MQTT fan platform."""
+    if discovery_info is not None:
+        config = PLATFORM_SCHEMA(discovery_info)
+
     async_add_devices([MqttFan(
         config.get(CONF_NAME),
         {

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -20,10 +20,11 @@ TOPIC_MATCHER = re.compile(
     r'(?P<prefix_topic>\w+)/(?P<component>\w+)/'
     r'(?:(?P<node_id>[a-zA-Z0-9_-]+)/)?(?P<object_id>[a-zA-Z0-9_-]+)/config')
 
-SUPPORTED_COMPONENTS = ['binary_sensor', 'light', 'sensor', 'switch']
+SUPPORTED_COMPONENTS = ['binary_sensor', 'fan', 'light', 'sensor', 'switch']
 
 ALLOWED_PLATFORMS = {
     'binary_sensor': ['mqtt'],
+    'fan': ['mqtt'],
     'light': ['mqtt', 'mqtt_json', 'mqtt_template'],
     'sensor': ['mqtt'],
     'switch': ['mqtt'],

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -78,6 +78,23 @@ def test_correct_config_discovery(hass, mqtt_mock, caplog):
 
 
 @asyncio.coroutine
+def test_discover_fan(hass, mqtt_mock, caplog):
+    """Test discovering an MQTT fan."""
+    yield from async_start(hass, 'homeassistant', {})
+
+    async_fire_mqtt_message(hass, 'homeassistant/fan/bla/config',
+                            ('{ "name": "Beer",'
+                             '  "command_topic": "test_topic" }'))
+    yield from hass.async_block_till_done()
+
+    state = hass.states.get('fan.beer')
+
+    assert state is not None
+    assert state.name == 'Beer'
+    assert ('fan', 'bla') in hass.data[ALREADY_DISCOVERED]
+
+
+@asyncio.coroutine
 def test_discovery_incl_nodeid(hass, mqtt_mock, caplog):
     """Test sending in correct JSON with optional node_id included."""
     yield from async_start(hass, 'homeassistant', {})


### PR DESCRIPTION
## Description:

This small change allows for discovering MQTT Fans over the MQTT Discovery system.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3386


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.
