### PR TITLE
Xiaomi Gateway: Allow static configuration of a gateway without discovery

### DIFF
--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -39,6 +39,20 @@ def _validate_conf(config):
             raise vol.Invalid('Invalid key %s.'
                               ' Key must be 16 characters', key)
         res_gw_conf['key'] = key
+
+        host = gw_conf.get('host')
+        if host is not None:
+            res_gw_conf['host'] = host
+            port = gw_conf.get('port')
+            if port is not None:
+                res_gw_conf['port'] = port
+            else:
+                res_gw_conf['port'] = 9898
+
+            _LOGGER.warning(
+                'Static address (%s:%s) of the gateway provided.'
+                'Discovery of this host will be skipped.', host, port)
+
         res_config.append(res_gw_conf)
     return res_config
 
@@ -89,7 +103,7 @@ def setup(hass, config):
         _LOGGER.error("No gateway discovered")
         return False
     hass.data[PY_XIAOMI_GATEWAY].listen()
-    _LOGGER.debug("Listening for broadcast")
+    _LOGGER.debug("Gateways discovered. Listening for broadcasts")
 
     for component in ['binary_sensor', 'sensor', 'switch', 'light', 'cover']:
         discovery.load_platform(hass, component, DOMAIN, {}, config)

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -44,13 +44,12 @@ def _validate_conf(config):
         if host is not None:
             res_gw_conf['host'] = host
             port = gw_conf.get('port')
-            if port is not None:
-                res_gw_conf['port'] = port
-            else:
-                res_gw_conf['port'] = 9898
+            if port is None:
+                port = 9898
+            res_gw_conf['port'] = port
 
             _LOGGER.warning(
-                'Static address (%s:%s) of the gateway provided.'
+                'Static address (%s:%s) of the gateway provided. '
                 'Discovery of this host will be skipped.', host, port)
 
         res_config.append(res_gw_conf)

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -43,14 +43,12 @@ def _validate_conf(config):
         host = gw_conf.get('host')
         if host is not None:
             res_gw_conf['host'] = host
-            port = gw_conf.get('port')
-            if port is None:
-                port = 9898
-            res_gw_conf['port'] = port
+            res_gw_conf['port'] = gw_conf.get('port', 9898)
 
             _LOGGER.warning(
                 'Static address (%s:%s) of the gateway provided. '
-                'Discovery of this host will be skipped.', host, port)
+                'Discovery of this host will be skipped.',
+                res_gw_conf['host'], res_gw_conf['port'])
 
         res_config.append(res_gw_conf)
     return res_config

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -9,7 +9,7 @@ from homeassistant.const import (ATTR_BATTERY_LEVEL, EVENT_HOMEASSISTANT_STOP,
                                  CONF_MAC)
 
 REQUIREMENTS = ['https://github.com/Danielhiversen/PyXiaomiGateway/archive/'
-                '0.3.2.zip#PyXiaomiGateway==0.3.2']
+                '0.4.0.zip#PyXiaomiGateway==0.4.0']
 
 ATTR_GW_MAC = 'gw_mac'
 ATTR_RINGTONE_ID = 'ringtone_id'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -299,7 +299,7 @@ holidays==0.8.1
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a
 
 # homeassistant.components.xiaomi_aqara
-https://github.com/Danielhiversen/PyXiaomiGateway/archive/0.3.2.zip#PyXiaomiGateway==0.3.2
+https://github.com/Danielhiversen/PyXiaomiGateway/archive/0.4.0.zip#PyXiaomiGateway==0.4.0
 
 # homeassistant.components.sensor.dht
 # https://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.2


### PR DESCRIPTION
## Description:

A few people using hassio are unable to discover the local xiaomi gateway. Depending on the setup and/or infrastructure the multicast broadcast needed for discovery cannot be received at the docker container. This does not affect every docker setup.

This feature introduces an optional host parameter for a static configuration of the gateway. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/3388

## Example entry for `configuration.yaml` (if applicable):
```yaml
xiaomi_aqara:
  gateways:
    - mac: 34ceeeeeeeee
      key: fasdfasdfasdfasd
      host: 192.168.130.64
      port: 9898
    - mac: 34ceffffffff
      key: asdfasdfasdfasdf
      host: 192.168.130.63
    - mac: 34ceddddddddd
      key: sdfasdfasdfasdfa
```
