### PR TITLE
Fix recorder does not vacuum SQLite DB on purge

### DIFF
--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -26,6 +26,7 @@ def purge_old_data(instance, purge_days):
         _LOGGER.debug("Deleted %s events", deleted_rows)
 
     # Execute sqlite vacuum command to free up space on disk
-    if instance.engine.driver == 'sqlite':
+    _LOGGER.debug("DB engine driver: %s", instance.engine.driver)
+    if instance.engine.driver == 'pysqlite':
         _LOGGER.info("Vacuuming SQLite to free space")
         instance.engine.execute("VACUUM")


### PR DESCRIPTION
## Description:

Fixes incorrect IF condition in purge operation for SQLite sqlalchemy driver. Vacuum does not work, because different driver name.

**Related issue (if applicable):** fixes #9441

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** n/a

## Checklist:

  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
