### PR TITLE
Bump pytradfri to 2.2.1

### DIFF
--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import CONF_HOST, CONF_API_KEY
 from homeassistant.components.discovery import SERVICE_IKEA_TRADFRI
 
-REQUIREMENTS = ['pytradfri==2.2']
+REQUIREMENTS = ['pytradfri==2.2.1']
 
 DOMAIN = 'tradfri'
 CONFIG_FILE = 'tradfri.conf'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -812,7 +812,7 @@ pythonegardia==1.0.20
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-pytradfri==2.2
+pytradfri==2.2.1
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13


### PR DESCRIPTION
## Description:

This is a version bump to 2.2.1, where @lwis referenced the master branch of aiocoap, which now supports dtls.



**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

