### PR TITLE
Bump version of abodepy

### DIFF
--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -21,7 +21,7 @@ from homeassistant.const import (ATTR_ATTRIBUTION, ATTR_DATE, ATTR_TIME,
                                  EVENT_HOMEASSISTANT_STOP,
                                  EVENT_HOMEASSISTANT_START)
 
-REQUIREMENTS = ['abodepy==0.11.5']
+REQUIREMENTS = ['abodepy==0.11.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -42,7 +42,7 @@ SoCo==0.12
 TwitterAPI==2.4.6
 
 # homeassistant.components.abode
-abodepy==0.11.5
+abodepy==0.11.6
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.3


### PR DESCRIPTION
## Description:

Simple bump of the abodepy version fixing an error with automatic re-connection to the push notification service.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
