### PR TITLE
LIFX: fix multi-zone color restore after effects

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -33,7 +33,7 @@ import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['aiolifx==0.5.4', 'aiolifx_effects==0.1.1']
+REQUIREMENTS = ['aiolifx==0.6.0', 'aiolifx_effects==0.1.2']
 
 UDP_BROADCAST_PORT = 56700
 
@@ -684,8 +684,7 @@ class LIFXStrip(LIFXColor):
             # Each get_color_zones can update 8 zones at once
             resp = yield from AwaitAioLIFX().wait(partial(
                 self.device.get_color_zones,
-                start_index=zone,
-                end_index=zone+7))
+                start_index=zone))
             if resp:
                 zone += 8
                 top = resp.count

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -55,10 +55,10 @@ aiodns==1.1.1
 aiohttp_cors==0.5.3
 
 # homeassistant.components.light.lifx
-aiolifx==0.5.4
+aiolifx==0.6.0
 
 # homeassistant.components.light.lifx
-aiolifx_effects==0.1.1
+aiolifx_effects==0.1.2
 
 # homeassistant.components.scene.hunterdouglas_powerview
 aiopvapi==1.4


### PR DESCRIPTION
## Description:

The aiolifx 0.6.0 release fixes an issue where an effect color could remain set after stopping the effect. This only affected multi-zone lights (i.e. LIFX Z) and only if the effect was stopped by setting the light brightness or the color (but not both).

The aiolifx 0.6.0 release also defaults end_index to start_index+7, so we can remove that argument.

Finally, aiolifx_effects 0.1.2 adds support for aiolifx 0.6.0.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
