### PR TITLE
Rename input_slider to input_number and add numeric text box option

### DIFF
--- a/homeassistant/components/demo.py
+++ b/homeassistant/components/demo.py
@@ -87,8 +87,8 @@ def async_setup(hass, config):
 
     # Set up input boolean
     tasks.append(bootstrap.async_setup_component(
-        hass, 'input_slider',
-        {'input_slider': {
+        hass, 'input_number',
+        {'input_number': {
             'noise_allowance': {'icon': 'mdi:bell-ring',
                                 'min': 0,
                                 'max': 10,
@@ -163,7 +163,7 @@ def async_setup(hass, config):
         'scene.romantic_lights']))
     tasks2.append(group.Group.async_create_group(hass, 'Bedroom', [
         lights[0], switches[1], media_players[0],
-        'input_slider.noise_allowance']))
+        'input_number.noise_allowance']))
     tasks2.append(group.Group.async_create_group(hass, 'Kitchen', [
         lights[2], 'cover.kitchen_window', 'lock.kitchen_door']))
     tasks2.append(group.Group.async_create_group(hass, 'Doors', [

--- a/homeassistant/components/input_number.py
+++ b/homeassistant/components/input_number.py
@@ -1,5 +1,5 @@
 """
-Component to offer a way to select a numeric value from a slider or text box.
+Component to offer a way to set a numeric value from a slider or text box.
 
 For more details about this component, please refer to the documentation
 at https://home-assistant.io/components/input_number/
@@ -37,9 +37,9 @@ ATTR_MAX = 'max'
 ATTR_STEP = 'step'
 ATTR_MODE = 'mode'
 
-SERVICE_SELECT_VALUE = 'select_value'
+SERVICE_SET_VALUE = 'set_value'
 
-SERVICE_SELECT_VALUE_SCHEMA = vol.Schema({
+SERVICE_SET_VALUE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_VALUE): vol.Coerce(float),
 })
@@ -78,9 +78,9 @@ CONFIG_SCHEMA = vol.Schema({
 
 
 @bind_hass
-def select_value(hass, entity_id, value):
+def set_value(hass, entity_id, value):
     """Set input_number to value."""
-    hass.services.call(DOMAIN, SERVICE_SELECT_VALUE, {
+    hass.services.call(DOMAIN, SERVICE_SET_VALUE, {
         ATTR_ENTITY_ID: entity_id,
         ATTR_VALUE: value,
     })
@@ -111,18 +111,18 @@ def async_setup(hass, config):
         return False
 
     @asyncio.coroutine
-    def async_select_value_service(call):
+    def async_set_value_service(call):
         """Handle a calls to the input slider services."""
         target_inputs = component.async_extract_from_service(call)
 
-        tasks = [input_number.async_select_value(call.data[ATTR_VALUE])
+        tasks = [input_number.async_set_value(call.data[ATTR_VALUE])
                  for input_number in target_inputs]
         if tasks:
             yield from asyncio.wait(tasks, loop=hass.loop)
 
     hass.services.async_register(
-        DOMAIN, SERVICE_SELECT_VALUE, async_select_value_service,
-        schema=SERVICE_SELECT_VALUE_SCHEMA)
+        DOMAIN, SERVICE_SET_VALUE, async_set_value_service,
+        schema=SERVICE_SET_VALUE_SCHEMA)
 
     yield from component.async_add_entities(entities)
     return True
@@ -151,7 +151,7 @@ class InputNumber(Entity):
 
     @property
     def name(self):
-        """Return the name of the select input slider."""
+        """Return the name of the input slider."""
         return self._name
 
     @property
@@ -195,8 +195,8 @@ class InputNumber(Entity):
             self._current_value = self._minimum
 
     @asyncio.coroutine
-    def async_select_value(self, value):
-        """Select new value."""
+    def async_set_value(self, value):
+        """Set new value."""
         num_value = float(value)
         if num_value < self._minimum or num_value > self._maximum:
             _LOGGER.warning("Invalid value: %s (range %s - %s)",

--- a/homeassistant/components/input_number.py
+++ b/homeassistant/components/input_number.py
@@ -71,7 +71,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Optional(CONF_ICON): cv.icon,
             vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
             vol.Optional(CONF_MODE, default=MODE_SLIDER):
-                vol.In(MODE_BOX, MODE_SLIDER),
+                vol.In([MODE_BOX, MODE_SLIDER]),
         }, _cv_input_number)
     })
 }, required=True, extra=vol.ALLOW_EXTRA)

--- a/tests/components/cover/test_template.py
+++ b/tests/components/cover/test_template.py
@@ -426,7 +426,7 @@ class TestTemplateCover(unittest.TestCase):
                             'position_template':
                                 "{{ states.input_number.test.state | int }}",
                             'set_cover_position': {
-                                'service': 'input_number.select_value',
+                                'service': 'input_number.set_value',
                                 'entity_id': 'input_number.test',
                                 'data_template': {
                                     'value': '{{ position }}'

--- a/tests/components/cover/test_template.py
+++ b/tests/components/cover/test_template.py
@@ -409,8 +409,8 @@ class TestTemplateCover(unittest.TestCase):
     def test_set_position(self):
         """Test the set_position command."""
         with assert_setup_component(1, 'cover'):
-            assert setup.setup_component(self.hass, 'input_slider', {
-               'input_slider': {
+            assert setup.setup_component(self.hass, 'input_number', {
+               'input_number': {
                    'test': {
                        'min': '0',
                        'max': '100',
@@ -424,10 +424,10 @@ class TestTemplateCover(unittest.TestCase):
                     'covers': {
                         'test_template_cover': {
                             'position_template':
-                                "{{ states.input_slider.test.state | int }}",
+                                "{{ states.input_number.test.state | int }}",
                             'set_cover_position': {
-                                'service': 'input_slider.select_value',
-                                'entity_id': 'input_slider.test',
+                                'service': 'input_number.select_value',
+                                'entity_id': 'input_number.test',
                                 'data_template': {
                                     'value': '{{ position }}'
                                 },
@@ -440,7 +440,7 @@ class TestTemplateCover(unittest.TestCase):
         self.hass.start()
         self.hass.block_till_done()
 
-        state = self.hass.states.set('input_slider.test', 42)
+        state = self.hass.states.set('input_number.test', 42)
         self.hass.block_till_done()
         state = self.hass.states.get('cover.test_template_cover')
         assert state.state == STATE_OPEN

--- a/tests/components/media_player/test_universal.py
+++ b/tests/components/media_player/test_universal.py
@@ -5,7 +5,7 @@ import unittest
 from homeassistant.const import (
     STATE_OFF, STATE_ON, STATE_UNKNOWN, STATE_PLAYING, STATE_PAUSED)
 import homeassistant.components.switch as switch
-import homeassistant.components.input_slider as input_slider
+import homeassistant.components.input_number as input_number
 import homeassistant.components.input_select as input_select
 import homeassistant.components.media_player as media_player
 import homeassistant.components.media_player.universal as universal
@@ -166,7 +166,7 @@ class TestMediaPlayer(unittest.TestCase):
         self.mock_state_switch_id = switch.ENTITY_ID_FORMAT.format('state')
         self.hass.states.set(self.mock_state_switch_id, STATE_OFF)
 
-        self.mock_volume_id = input_slider.ENTITY_ID_FORMAT.format(
+        self.mock_volume_id = input_number.ENTITY_ID_FORMAT.format(
             'volume_level')
         self.hass.states.set(self.mock_volume_id, 0)
 

--- a/tests/components/test_input_number.py
+++ b/tests/components/test_input_number.py
@@ -70,6 +70,38 @@ class TestInputNumber(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(70, float(state.state))
 
+    def test_mode(self):
+        """Test mode settings."""
+        self.assertTrue(
+            setup_component(self.hass, DOMAIN, {DOMAIN: {
+                'test_default_slider': {
+                    'min': 0,
+                    'max': 100,
+                },
+                'test_explicit_box': {
+                    'min': 0,
+                    'max': 100,
+                    'mode': 'box',
+                },
+                'test_explicit_slider': {
+                    'min': 0,
+                    'max': 100,
+                    'mode': 'slider',
+                },
+            }}))
+
+        state = self.hass.states.get('input_number.test_default_slider')
+        assert state
+        self.assertEqual('slider', state.attributes['mode'])
+
+        state = self.hass.states.get('input_number.test_explicit_box')
+        assert state
+        self.assertEqual('box', state.attributes['mode'])
+
+        state = self.hass.states.get('input_number.test_explicit_slider')
+        assert state
+        self.assertEqual('slider', state.attributes['mode'])
+
 
 @asyncio.coroutine
 def test_restore_state(hass):

--- a/tests/components/test_input_number.py
+++ b/tests/components/test_input_number.py
@@ -1,17 +1,17 @@
-"""The tests for the Input slider component."""
+"""The tests for the Input number component."""
 # pylint: disable=protected-access
 import asyncio
 import unittest
 
 from homeassistant.core import CoreState, State
 from homeassistant.setup import setup_component, async_setup_component
-from homeassistant.components.input_slider import (DOMAIN, select_value)
+from homeassistant.components.input_number import (DOMAIN, select_value)
 
 from tests.common import get_test_home_assistant, mock_restore_cache
 
 
-class TestInputSlider(unittest.TestCase):
-    """Test the input slider component."""
+class TestInputNumber(unittest.TestCase):
+    """Test the input number component."""
 
     # pylint: disable=invalid-name
     def setUp(self):
@@ -47,7 +47,7 @@ class TestInputSlider(unittest.TestCase):
                 'max': 100,
             },
         }}))
-        entity_id = 'input_slider.test_1'
+        entity_id = 'input_number.test_1'
 
         state = self.hass.states.get(entity_id)
         self.assertEqual(50, float(state.state))
@@ -75,8 +75,8 @@ class TestInputSlider(unittest.TestCase):
 def test_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(hass, (
-        State('input_slider.b1', '70'),
-        State('input_slider.b2', '200'),
+        State('input_number.b1', '70'),
+        State('input_number.b2', '200'),
     ))
 
     hass.state = CoreState.starting
@@ -93,11 +93,11 @@ def test_restore_state(hass):
             },
         }})
 
-    state = hass.states.get('input_slider.b1')
+    state = hass.states.get('input_number.b1')
     assert state
     assert float(state.state) == 70
 
-    state = hass.states.get('input_slider.b2')
+    state = hass.states.get('input_number.b2')
     assert state
     assert float(state.state) == 10
 
@@ -106,8 +106,8 @@ def test_restore_state(hass):
 def test_initial_state_overrules_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(hass, (
-        State('input_slider.b1', '70'),
-        State('input_slider.b2', '200'),
+        State('input_number.b1', '70'),
+        State('input_number.b2', '200'),
     ))
 
     hass.state = CoreState.starting
@@ -126,11 +126,11 @@ def test_initial_state_overrules_restore_state(hass):
             },
         }})
 
-    state = hass.states.get('input_slider.b1')
+    state = hass.states.get('input_number.b1')
     assert state
     assert float(state.state) == 50
 
-    state = hass.states.get('input_slider.b2')
+    state = hass.states.get('input_number.b2')
     assert state
     assert float(state.state) == 60
 
@@ -148,6 +148,6 @@ def test_no_initial_state_and_no_restore_state(hass):
             },
         }})
 
-    state = hass.states.get('input_slider.b1')
+    state = hass.states.get('input_number.b1')
     assert state
     assert float(state.state) == 0

--- a/tests/components/test_input_number.py
+++ b/tests/components/test_input_number.py
@@ -5,7 +5,7 @@ import unittest
 
 from homeassistant.core import CoreState, State
 from homeassistant.setup import setup_component, async_setup_component
-from homeassistant.components.input_number import (DOMAIN, select_value)
+from homeassistant.components.input_number import (DOMAIN, set_value)
 
 from tests.common import get_test_home_assistant, mock_restore_cache
 
@@ -38,8 +38,8 @@ class TestInputNumber(unittest.TestCase):
             self.assertFalse(
                 setup_component(self.hass, DOMAIN, {DOMAIN: cfg}))
 
-    def test_select_value(self):
-        """Test select_value method."""
+    def test_set_value(self):
+        """Test set_value method."""
         self.assertTrue(setup_component(self.hass, DOMAIN, {DOMAIN: {
             'test_1': {
                 'initial': 50,
@@ -52,19 +52,19 @@ class TestInputNumber(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(50, float(state.state))
 
-        select_value(self.hass, entity_id, '30.4')
+        set_value(self.hass, entity_id, '30.4')
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)
         self.assertEqual(30.4, float(state.state))
 
-        select_value(self.hass, entity_id, '70')
+        set_value(self.hass, entity_id, '70')
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)
         self.assertEqual(70, float(state.state))
 
-        select_value(self.hass, entity_id, '110')
+        set_value(self.hass, entity_id, '110')
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -745,11 +745,11 @@ is_state_attr('device_tracker.phone_2', 'battery', 40)
         self.assertListEqual(
             sorted([
                 'sensor.luftfeuchtigkeit_mean',
-                'input_slider.luftfeuchtigkeit',
+                'input_number.luftfeuchtigkeit',
             ]),
             sorted(template.extract_entities(
                 "{% if (states('sensor.luftfeuchtigkeit_mean') | int)"
-                " > (states('input_slider.luftfeuchtigkeit') | int +1.5)"
+                " > (states('input_number.luftfeuchtigkeit') | int +1.5)"
                 " %}true{% endif %}"
             )))
 


### PR DESCRIPTION
* Rename input_slider to input_number
* Update input_number to optionally display slider, input box, or both

## Description:
Per discussion in #9112 this PR renames input_slider to input_number and adds the option to display a slider, a numeric input ('text' but only accepts numbers) box, or both.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3403

**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) with Polymer changes:** home-assistant/home-assistant-polymer#431

## Example entry for `configuration.yaml` (if applicable):

Options for `mode` are `both`, `box`, and `slider`. The default is `slider` currently to reduce the effort for updates to existing configurations (as the renaming of the component will already be a breaking change).

```yaml
input_number:
  slider1:
    name: Slider 1
    initial: 30
    min: -20
    max: 35
    step: 1
  number1:
    name: Number 1
    initial: 30
    min: -20
    max: 35
    step: 1
    mode: box
  both1:
    name: Both 1
    initial: 30
    min: -20
    max: 35
    step: 1
    mode: both
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
