### PR TITLE
Upgrade pyhomematic

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['pyhomematic==0.1.30']
+REQUIREMENTS = ['pyhomematic==0.1.32']
 
 DOMAIN = 'homematic'
 
@@ -65,7 +65,8 @@ HM_DEVICE_TYPES = {
         'WaterSensor', 'PowermeterGas', 'LuxSensor', 'WeatherSensor',
         'WeatherStation', 'ThermostatWall2', 'TemperatureDiffSensor',
         'TemperatureSensor', 'CO2Sensor', 'IPSwitchPowermeter', 'HMWIOSwitch',
-        'FillingLevel', 'ValveDrive', 'EcoLogic'],
+        'FillingLevel', 'ValveDrive', 'EcoLogic', 'IPThermostatWall',
+        'IPSmoke'],
     DISCOVER_CLIMATE: [
         'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2',
         'MAXWallThermostat', 'IPThermostat', 'IPThermostatWall'],

--- a/homeassistant/components/sensor/homematic.py
+++ b/homeassistant/components/sensor/homematic.py
@@ -16,6 +16,7 @@ HM_STATE_HA_CAST = {
     'RotaryHandleSensor': {0: 'closed', 1: 'tilted', 2: 'open'},
     'WaterSensor': {0: 'dry', 1: 'wet', 2: 'water'},
     'CO2Sensor': {0: 'normal', 1: 'added', 2: 'strong'},
+    'IPSmoke': {0: 'off', 1: 'primary', 2: 'intrusion', 3: 'secondary'}
 }
 
 HM_UNIT_HA_CAST = {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -615,7 +615,7 @@ pyharmony==1.0.16
 pyhik==0.1.4
 
 # homeassistant.components.homematic
-pyhomematic==0.1.30
+pyhomematic==0.1.32
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==1.2.0


### PR DESCRIPTION
## Description:
Upgrading the dependency adds support for:
- HMIP-WRC2
- HmIP-PSM-CH
- HmIP-eTRV-2
- HmIP-STHD
- HmIP-SWSD

Minor changes were required to make use of some new devices.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
