### PR TITLE
MQTT Binary Sensor - Add availability_topic for online/offline status

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -16,14 +16,21 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import (
     CONF_NAME, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF,
     CONF_DEVICE_CLASS)
-from homeassistant.components.mqtt import (CONF_STATE_TOPIC, CONF_QOS)
+from homeassistant.components.mqtt import (
+    CONF_STATE_TOPIC, CONF_AVAILABILITY_TOPIC, CONF_QOS, valid_subscribe_topic)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_PAYLOAD_AVAILABLE = 'payload_available'
+CONF_PAYLOAD_NOT_AVAILABLE = 'payload_not_available'
+
 DEFAULT_NAME = 'MQTT Binary sensor'
 DEFAULT_PAYLOAD_OFF = 'OFF'
 DEFAULT_PAYLOAD_ON = 'ON'
+DEFAULT_PAYLOAD_AVAILABLE = 'online'
+DEFAULT_PAYLOAD_NOT_AVAILABLE = 'offline'
+
 DEPENDENCIES = ['mqtt']
 
 PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
@@ -31,6 +38,11 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
     vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+    vol.Optional(CONF_AVAILABILITY_TOPIC): valid_subscribe_topic,
+    vol.Optional(CONF_PAYLOAD_AVAILABLE,
+                 default=DEFAULT_PAYLOAD_AVAILABLE): cv.string,
+    vol.Optional(CONF_PAYLOAD_NOT_AVAILABLE,
+                 default=DEFAULT_PAYLOAD_NOT_AVAILABLE): cv.string,
 })
 
 
@@ -47,10 +59,13 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     async_add_devices([MqttBinarySensor(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
+        config.get(CONF_AVAILABILITY_TOPIC),
         config.get(CONF_DEVICE_CLASS),
         config.get(CONF_QOS),
         config.get(CONF_PAYLOAD_ON),
         config.get(CONF_PAYLOAD_OFF),
+        config.get(CONF_PAYLOAD_AVAILABLE),
+        config.get(CONF_PAYLOAD_NOT_AVAILABLE),
         value_template
     )])
 
@@ -58,15 +73,20 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class MqttBinarySensor(BinarySensorDevice):
     """Representation a binary sensor that is updated by MQTT."""
 
-    def __init__(self, name, state_topic, device_class, qos, payload_on,
-                 payload_off, value_template):
+    def __init__(self, name, state_topic, availability_topic, device_class,
+                 qos, payload_on, payload_off, payload_available,
+                 payload_not_available, value_template):
         """Initialize the MQTT binary sensor."""
         self._name = name
-        self._state = False
+        self._state = None
         self._state_topic = state_topic
+        self._availability_topic = availability_topic
+        self._available = True if availability_topic is None else False
         self._device_class = device_class
         self._payload_on = payload_on
         self._payload_off = payload_off
+        self._payload_available = payload_available
+        self._payload_not_available = payload_not_available
         self._qos = qos
         self._template = value_template
 
@@ -76,8 +96,8 @@ class MqttBinarySensor(BinarySensorDevice):
         This method must be run in the event loop and returns a coroutine.
         """
         @callback
-        def message_received(topic, payload, qos):
-            """Handle a new received MQTT message."""
+        def state_message_received(topic, payload, qos):
+            """Handle a new received MQTT state message."""
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(
                     payload)
@@ -88,8 +108,23 @@ class MqttBinarySensor(BinarySensorDevice):
 
             self.async_schedule_update_ha_state()
 
-        return mqtt.async_subscribe(
-            self.hass, self._state_topic, message_received, self._qos)
+        @callback
+        def availability_message_received(topic, payload, qos):
+            """Handle a new received MQTT availability message."""
+            if payload == self._payload_available:
+                self._available = True
+            elif payload == self._payload_not_available:
+                self._available = False
+
+            self.async_schedule_update_ha_state()
+
+        yield from mqtt.async_subscribe(
+            self.hass, self._state_topic, state_message_received, self._qos)
+
+        if self._availability_topic is not None:
+            yield from mqtt.async_subscribe(
+                self.hass, self._availability_topic,
+                availability_message_received, self._qos)
 
     @property
     def should_poll(self):
@@ -100,6 +135,11 @@ class MqttBinarySensor(BinarySensorDevice):
     def name(self):
         """Return the name of the binary sensor."""
         return self._name
+
+    @property
+    def available(self) -> bool:
+        """Return if the binary sensor is available."""
+        return self._available
 
     @property
     def is_on(self):

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -108,6 +108,9 @@ class MqttBinarySensor(BinarySensorDevice):
 
             self.async_schedule_update_ha_state()
 
+        yield from mqtt.async_subscribe(
+            self.hass, self._state_topic, state_message_received, self._qos)
+
         @callback
         def availability_message_received(topic, payload, qos):
             """Handle a new received MQTT availability message."""
@@ -117,9 +120,6 @@ class MqttBinarySensor(BinarySensorDevice):
                 self._available = False
 
             self.async_schedule_update_ha_state()
-
-        yield from mqtt.async_subscribe(
-            self.hass, self._state_topic, state_message_received, self._qos)
 
         if self._availability_topic is not None:
             yield from mqtt.async_subscribe(


### PR DESCRIPTION
## Description:

Allows Home Assistant to set the MQTT binary sensor state to "unavailable" if the MQTT device sends an "offline" message on the availability_topic (i.e. as a LWT), and "available" if the MQTT device sends an "online" message on the same topic (i.e. as a birth message). Both payloads ("offline" and "online" messages) are user configurable, and the "available"/"unavailable" function is disabled if the user does not specify an availability_topic in configuration.yaml (i.e. Home Assistant assumes the device is available).

This PR also changes the default state of the binary sensor from 'off' to 'unknown' when there is no retained message on the state_topic. In my view the default of 'off' is misleading in the situation where there is no retained message and the MQTT device is 'on'; in that case, Home Assistant would display the binary sensor as 'off' and the user would be misled as to the true device state. The default of 'unknown' alerts the user to the true state of affairs: the device may be 'on' or 'off', but Home Assistant has no way of knowing which.

Modelled on similar functionality added to the MQTT switch platform in PRs home-assistant/home-assistant#8593 and home-assistant/home-assistant#8934, and the MQTT cover platform in PR home-assistant/home-assistant#9445.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3378

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: mqtt
    name: "Window Contact Sensor"
    state_topic: "home-assistant/window/contact"
    payload_on: "ON"
    payload_off: "OFF"
    availability_topic: "home-assistant/window/availability"
    payload_available: "online"
    payload_not_available: "offline"
    device_class: opening
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
