### PR TITLE
abode: Set device_type in state attributes

### DIFF
--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -297,7 +297,8 @@ class AbodeDevice(Entity):
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
             'device_id': self._device.device_id,
             'battery_low': self._device.battery_low,
-            'no_response': self._device.no_response
+            'no_response': self._device.no_response,
+            'device_type': self._device.type
         }
 
     def _update_callback(self, device):


### PR DESCRIPTION
## Description:

This gets displayed when clicking on the binary sensors. It is
useful to distinguish different devices with the same name (e.g.
the room name) but different types.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
