### PR TITLE
added services.yaml integration for input_boolean

### DIFF
--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -6,6 +6,7 @@ at https://home-assistant.io/components/input_boolean/
 """
 import asyncio
 import logging
+import os
 
 import voluptuous as vol
 
@@ -14,6 +15,7 @@ from homeassistant.const import (
     SERVICE_TOGGLE, STATE_ON)
 from homeassistant.loader import bind_hass
 import homeassistant.helpers.config_validation as cv
+from homeassistant.config import load_yaml_config_file
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import async_get_last_state
@@ -102,12 +104,23 @@ def async_setup(hass, config):
         if tasks:
             yield from asyncio.wait(tasks, loop=hass.loop)
 
+    descriptions = yield from hass.async_add_job(
+        load_yaml_config_file, os.path.join(
+            os.path.dirname(__file__), 'services.yaml')
+    )
+
     hass.services.async_register(
-        DOMAIN, SERVICE_TURN_OFF, async_handler_service, schema=SERVICE_SCHEMA)
+        DOMAIN, SERVICE_TURN_OFF, async_handler_service, 
+        descriptions[DOMAIN][SERVICE_TURN_OFF], 
+        schema=SERVICE_SCHEMA)
     hass.services.async_register(
-        DOMAIN, SERVICE_TURN_ON, async_handler_service, schema=SERVICE_SCHEMA)
+        DOMAIN, SERVICE_TURN_ON, async_handler_service, 
+        descriptions[DOMAIN][SERVICE_TURN_ON], 
+        schema=SERVICE_SCHEMA)
     hass.services.async_register(
-        DOMAIN, SERVICE_TOGGLE, async_handler_service, schema=SERVICE_SCHEMA)
+        DOMAIN, SERVICE_TOGGLE, async_handler_service, 
+        descriptions[DOMAIN][SERVICE_TOGGLE], 
+        schema=SERVICE_SCHEMA)
 
     yield from component.async_add_entities(entities)
     return True

--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -110,16 +110,16 @@ def async_setup(hass, config):
     )
 
     hass.services.async_register(
-        DOMAIN, SERVICE_TURN_OFF, async_handler_service, 
-        descriptions[DOMAIN][SERVICE_TURN_OFF], 
+        DOMAIN, SERVICE_TURN_OFF, async_handler_service,
+        descriptions[DOMAIN][SERVICE_TURN_OFF],
         schema=SERVICE_SCHEMA)
     hass.services.async_register(
-        DOMAIN, SERVICE_TURN_ON, async_handler_service, 
-        descriptions[DOMAIN][SERVICE_TURN_ON], 
+        DOMAIN, SERVICE_TURN_ON, async_handler_service,
+        descriptions[DOMAIN][SERVICE_TURN_ON],
         schema=SERVICE_SCHEMA)
     hass.services.async_register(
-        DOMAIN, SERVICE_TOGGLE, async_handler_service, 
-        descriptions[DOMAIN][SERVICE_TOGGLE], 
+        DOMAIN, SERVICE_TOGGLE, async_handler_service,
+        descriptions[DOMAIN][SERVICE_TOGGLE],
         schema=SERVICE_SCHEMA)
 
     yield from component.async_add_entities(entities)

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -600,3 +600,28 @@ abode:
       entity_id:
         description: Entity id of the quick action to trigger.
         example: 'binary_sensor.home_quick_action'
+
+input_boolean:
+  toggle:
+    description: Toggles an input boolean
+
+    fields:
+      entity_id:
+        description: Entity id of the input boolean to toggle
+        example: 'input_boolean.notify_alerts'
+
+  turn_off:
+    description: Turns OFF an input boolean
+
+    fields:
+      entity_id:
+        description: Entity id of the input boolean to turn off
+        example: 'input_boolean.notify_alerts'
+
+  turn_on:
+    description: Turns ON an input boolean
+    
+    fields:
+      entity_id:
+        description: Entity id of the input boolean to turn on
+        example: 'input_boolean.notify_alerts'


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
