### PR TITLE
Synology camera shows correct state based on is_streaming and is_recording flag

### DIFF
--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -158,7 +158,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
             device = SynologyCamera(
                 hass, websession, config, camera_id, camera['name'],
-                snapshot_path, streaming_path, camera_path, auth_path, timeout, is_enabled, is_recording
+                snapshot_path, streaming_path, camera_path, auth_path,
+                timeout, is_enabled, is_recording
             )
             devices.append(device)
 

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -72,6 +72,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def _is_recording_status(status):
     return status in SYNO_RECORDING_STATUS
 
+
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up a Synology IP Camera."""


### PR DESCRIPTION
## Description:
Updated Synology camera to show correct state based on is_streaming and is_recording flag

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54