### PR TITLE
Add recorder purge service, rework purge timer

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -54,7 +54,7 @@ DEFAULT_URL = 'sqlite:///{hass_config_path}'
 DEFAULT_DB_FILE = 'home-assistant_v2.db'
 
 CONF_DB_URL = 'db_url'
-CONF_PURGE_DAYS = 'purge_days'
+CONF_PURGE_KEEP_DAYS = 'purge_keep_days'
 CONF_PURGE_INTERVAL = 'purge_interval'
 CONF_EVENT_TYPES = 'event_types'
 
@@ -77,7 +77,7 @@ FILTER_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: FILTER_SCHEMA.extend({
-        vol.Inclusive(CONF_PURGE_DAYS, 'purge'):
+        vol.Inclusive(CONF_PURGE_KEEP_DAYS, 'purge'):
             vol.All(vol.Coerce(int), vol.Range(min=1)),
         vol.Inclusive(CONF_PURGE_INTERVAL, 'purge'):
             vol.All(vol.Coerce(int), vol.Range(min=1)),
@@ -120,7 +120,7 @@ def run_information(hass, point_in_time: Optional[datetime]=None):
 def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the recorder."""
     conf = config.get(DOMAIN, {})
-    purge_days = conf.get(CONF_PURGE_DAYS)
+    purge_days = conf.get(CONF_PURGE_KEEP_DAYS)
     purge_interval = conf.get(CONF_PURGE_INTERVAL)
 
     db_url = conf.get(CONF_DB_URL, None)

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -47,7 +47,7 @@ ATTR_KEEP_DAYS = 'keep_days'
 
 SERVICE_PURGE_SCHEMA = vol.Schema({
     vol.Required(ATTR_KEEP_DAYS):
-        vol.All(vol.Coerce(int), vol.Range(min=1))
+        vol.All(vol.Coerce(int), vol.Range(min=0))
 })
 
 DEFAULT_URL = 'sqlite:///{hass_config_path}'

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -54,7 +54,7 @@ DEFAULT_URL = 'sqlite:///{hass_config_path}'
 DEFAULT_DB_FILE = 'home-assistant_v2.db'
 
 CONF_DB_URL = 'db_url'
-CONF_PURGE_DAYS = 'purge_keep_days'
+CONF_PURGE_DAYS = 'purge_days'
 CONF_PURGE_INTERVAL = 'purge_interval'
 CONF_EVENT_TYPES = 'event_types'
 
@@ -138,27 +138,18 @@ def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     @asyncio.coroutine
     def async_handle_purge_interval(now):
         """Handle purge interval."""
-        if purge_days is not None:
-            _LOGGER.debug("Staring purge by interval, purge days is %s",
-                          purge_days)
-            instance.do_purge(purge_days)
+        instance.do_purge(purge_days)
 
     @asyncio.coroutine
     def async_handle_purge_service(service):
         """Handle calls to the purge service."""
-        purge_days = service.data.get(ATTR_KEEP_DAYS)
-        if purge_days is not None:
-            _LOGGER.debug("Staring purge by service, purge days is %s",
-                          purge_days)
-            instance.do_purge(purge_days)
-        else:
-            _LOGGER.warning("Purge by service - purge days not get")
+        instance.do_purge(service.data[ATTR_KEEP_DAYS])
 
     descriptions = yield from hass.async_add_job(
         conf_util.load_yaml_config_file, path.join(
             path.dirname(__file__), 'services.yaml'))
 
-    if purge_interval is not None:
+    if purge_interval and purge_days:
         async_track_time_interval(hass, async_handle_purge_interval,
                                   timedelta(days=purge_interval))
 

--- a/homeassistant/components/recorder/services.yaml
+++ b/homeassistant/components/recorder/services.yaml
@@ -1,0 +1,4 @@
+# Describes the format for available recorder services
+
+purge:
+  description: Start purge task, deletes events and states older than x days, according to purge_days variable setting.

--- a/homeassistant/components/recorder/services.yaml
+++ b/homeassistant/components/recorder/services.yaml
@@ -5,5 +5,5 @@ purge:
 
   fields:
     keep_days:
-      description: Number of history days to keep in database after purge. Value > 0
+      description: Number of history days to keep in database after purge. Value >= 0
       example: 2

--- a/homeassistant/components/recorder/services.yaml
+++ b/homeassistant/components/recorder/services.yaml
@@ -1,4 +1,9 @@
 # Describes the format for available recorder services
 
 purge:
-  description: Start purge task, deletes events and states older than x days, according to purge_days variable setting.
+  description: Start purge task - delete events and states older than x days, according to keep_days service data.
+
+  fields:
+    keep_days:
+      description: Number of history days to keep in database after purge. Value > 0
+      example: 2

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -195,9 +195,8 @@ def test_recorder_setup_failure():
     with patch.object(Recorder, '_setup_connection') as setup, \
             patch('homeassistant.components.recorder.time.sleep'):
         setup.side_effect = ImportError("driver not found")
-        rec = Recorder(
-            hass, purge_days=0, purge_disable_timer=False, uri='sqlite://',
-            include={}, exclude={})
+        rec = Recorder(hass, purge_days=0, uri='sqlite://', include={},
+                       exclude={})
         rec.start()
         rec.join()
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -196,7 +196,8 @@ def test_recorder_setup_failure():
             patch('homeassistant.components.recorder.time.sleep'):
         setup.side_effect = ImportError("driver not found")
         rec = Recorder(
-            hass, purge_days=0, uri='sqlite://', include={}, exclude={})
+            hass, purge_days=0, purge_disable_timer=False, uri='sqlite://',
+            include={}, exclude={})
         rec.start()
         rec.join()
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -195,8 +195,7 @@ def test_recorder_setup_failure():
     with patch.object(Recorder, '_setup_connection') as setup, \
             patch('homeassistant.components.recorder.time.sleep'):
         setup.side_effect = ImportError("driver not found")
-        rec = Recorder(hass, purge_days=0, uri='sqlite://', include={},
-                       exclude={})
+        rec = Recorder(hass, uri='sqlite://', include={}, exclude={})
         rec.start()
         rec.join()
 

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -1,6 +1,7 @@
 """Test data purging."""
 import json
 from datetime import datetime, timedelta
+from time import sleep
 import unittest
 
 from homeassistant.components import recorder
@@ -16,8 +17,9 @@ class TestRecorderPurge(unittest.TestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
+        config = {'purge_days': 4}
         self.hass = get_test_home_assistant()
-        init_recorder_component(self.hass)
+        init_recorder_component(self.hass, config)
         self.hass.start()
 
     def tearDown(self):  # pylint: disable=invalid-name
@@ -104,6 +106,35 @@ class TestRecorderPurge(unittest.TestCase):
 
             # run purge_old_data()
             purge_old_data(self.hass.data[DATA_INSTANCE], 4)
+
+            # now we should only have 3 events left
+            self.assertEqual(events.count(), 3)
+
+    def test_purge_method(self):
+        """Test purge method."""
+        self._add_test_states()
+        self._add_test_events()
+
+        # make sure we start with 5 states
+        with session_scope(hass=self.hass) as session:
+            states = session.query(States)
+            self.assertEqual(states.count(), 5)
+
+            events = session.query(Events).filter(
+                Events.event_type.like("EVENT_TEST%"))
+            self.assertEqual(events.count(), 5)
+
+            self.hass.data[DATA_INSTANCE].block_till_done()
+
+            # run purge method
+            self.hass.services.call('recorder', 'purge')
+            self.hass.async_block_till_done()
+
+            # Small wait for recorder thread
+            sleep(0.5)
+
+            # we should only have 2 states left after purging
+            self.assertEqual(states.count(), 2)
 
             # now we should only have 3 events left
             self.assertEqual(events.count(), 3)


### PR DESCRIPTION
## Description:

**Updated by final code:**

Adding alternative to default recorder purge task. Calling the service `recorder.purge` will start purge task, which deletes events and states older than x days, according to ~~~`purge_days` variable~~~ `keep_days` service data setting.

I had a problem with default purge - because I am new user and changing config / restarting HA almost every day, purge was never started. Now it is easy to schedule purge by automation action on convenient time.
~~There is also new variable `purge_disable_timer`, which disables default 2 days purge timer.~~
Purge timer reworked - **breaking change**. Configurable `purge_interval`, `purge_days` renamed to `purge_keep_days`

~~I thought also about configurable purge timer (instead fixed 2 days now), but service call seems more flexible for me.~~ I will appreciate comments from maintainers.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3413

## Example entry for `configuration.yaml` (if applicable):
```yaml
recorder:
  purge_interval: 2
  purge_keep_days: 2
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
