### PR TITLE
Catch no longer existing process in systemmonitor

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -140,10 +140,14 @@ class SystemMonitorSensor(Entity):
         elif self.type == 'processor_use':
             self._state = round(psutil.cpu_percent(interval=None))
         elif self.type == 'process':
-            if any(self.argument in l.name() for l in psutil.process_iter()):
-                self._state = STATE_ON
-            else:
-                self._state = STATE_OFF
+            for proc in psutil.process_iter():
+                try:
+                    if self.argument == proc.name():
+                        self._state = STATE_ON
+                        return
+                except psutil.NoSuchProcess as err:
+                    _LOGGER.warning('psutil failed to load process with id: %s, old name: %s', err.pid, err.name)
+            self._state = STATE_OFF
         elif self.type == 'network_out' or self.type == 'network_in':
             counters = psutil.net_io_counters(pernic=True)
             if self.argument in counters:

--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -146,8 +146,9 @@ class SystemMonitorSensor(Entity):
                         self._state = STATE_ON
                         return
                 except psutil.NoSuchProcess as err:
-                    _LOGGER.warning("Failed to load process with id: %s, old name: %s",
-                                    err.pid, err.name)
+                    _LOGGER.warning(
+                        "Failed to load process with id: %s, old name: %s",
+                        err.pid, err.name)
             self._state = STATE_OFF
         elif self.type == 'network_out' or self.type == 'network_in':
             counters = psutil.net_io_counters(pernic=True)

--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -146,7 +146,8 @@ class SystemMonitorSensor(Entity):
                         self._state = STATE_ON
                         return
                 except psutil.NoSuchProcess as err:
-                    _LOGGER.warning('psutil failed to load process with id: %s, old name: %s', err.pid, err.name)
+                    _LOGGER.warning("Failed to load process with id: %s, old name: %s",
+                                    err.pid, err.name)
             self._state = STATE_OFF
         elif self.type == 'network_out' or self.type == 'network_in':
             counters = psutil.net_io_counters(pernic=True)


### PR DESCRIPTION
## Description:
psutil sometimes fails to load the process name, after the iteration has been done on the available processes (especially on slower systems). This change catches possible no longer existing processes and shows a warning in the logs (can be reduced to info or debug maybe?)
When the process has been encountered, break out of the processes iteration (to simulate the previously used `any` clause)
If no process has been found, state will be set to off

**Related issue (if applicable):** fixes #5582

## Example entry for `configuration.yaml` (if applicable):
No config changes needed
