### PR TITLE
Update AbodePy to 0.11.8

### DIFF
--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -21,7 +21,7 @@ from homeassistant.const import (ATTR_ATTRIBUTION, ATTR_DATE, ATTR_TIME,
                                  EVENT_HOMEASSISTANT_STOP,
                                  EVENT_HOMEASSISTANT_START)
 
-REQUIREMENTS = ['abodepy==0.11.7']
+REQUIREMENTS = ['abodepy==0.11.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -45,7 +45,7 @@ SoCo==0.12
 TwitterAPI==2.4.6
 
 # homeassistant.components.abode
-abodepy==0.11.7
+abodepy==0.11.8
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.3


### PR DESCRIPTION
## Description:
Fixes attribute errors with nest devices being pulled in from Abode.

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
