### PR TITLE
update usps

### DIFF
--- a/homeassistant/components/camera/usps.py
+++ b/homeassistant/components/camera/usps.py
@@ -77,7 +77,7 @@ class USPSCamera(Camera):
     def model(self):
         """Return date of mail as model."""
         try:
-            return 'Date: {}'.format(self._usps.mail[0]['date'])
+            return 'Date: {}'.format(str(self._usps.mail[0]['date']))
         except IndexError:
             return None
 

--- a/homeassistant/components/sensor/usps.py
+++ b/homeassistant/components/sensor/usps.py
@@ -57,7 +57,7 @@ class USPSPackageSensor(Entity):
         for package in self._usps.packages:
             status = slugify(package['primary_status'])
             if status == STATUS_DELIVERED and \
-                    package['date']) < now().date():
+                    package['date'] < now().date():
                 continue
             status_counts[status] += 1
         self._attributes = {

--- a/homeassistant/components/sensor/usps.py
+++ b/homeassistant/components/sensor/usps.py
@@ -11,7 +11,7 @@ from homeassistant.components.usps import DATA_USPS
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_DATE
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
-from homeassistant.util.dt import now, parse_datetime
+from homeassistant.util.dt import now
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ class USPSPackageSensor(Entity):
         for package in self._usps.packages:
             status = slugify(package['primary_status'])
             if status == STATUS_DELIVERED and \
-                    parse_datetime(package['date']).date() < now().date():
+                    package['date']) < now().date():
                 continue
             status_counts[status] += 1
         self._attributes = {
@@ -116,7 +116,7 @@ class USPSMailSensor(Entity):
         attr = {}
         attr[ATTR_ATTRIBUTION] = self._usps.attribution
         try:
-            attr[ATTR_DATE] = self._usps.mail[0]['date']
+            attr[ATTR_DATE] = str(self._usps.mail[0]['date'])
         except IndexError:
             pass
         return attr

--- a/homeassistant/components/usps.py
+++ b/homeassistant/components/usps.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import (config_validation as cv, discovery)
 from homeassistant.util import Throttle
 from homeassistant.util.dt import now
 
-REQUIREMENTS = ['myusps==1.1.3']
+REQUIREMENTS = ['myusps==1.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -428,7 +428,7 @@ mutagen==1.38
 mycroftapi==2.0
 
 # homeassistant.components.usps
-myusps==1.1.3
+myusps==1.2.1
 
 # homeassistant.components.media_player.nad
 # homeassistant.components.media_player.nadtcp


### PR DESCRIPTION
## Description:

USPS made changes that broke the dependency, `python-myusps`. It was updated to work again (`1.2.1`). The updates contained an API-breaking change - dates are represented as `datetime` objects instead of strings. The HASS components were updated accordingly.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
