### PR TITLE
Upgrade pyasn1 to 0.3.6

### DIFF
--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_SENDER, CONF_RECIPIENT
 
 REQUIREMENTS = ['sleekxmpp==1.3.2',
                 'dnspython3==1.15.0',
-                'pyasn1==0.3.5',
+                'pyasn1==0.3.6',
                 'pyasn1-modules==0.1.4']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -557,7 +557,7 @@ pyarlo==0.0.4
 pyasn1-modules==0.1.4
 
 # homeassistant.components.notify.xmpp
-pyasn1==0.3.5
+pyasn1==0.3.6
 
 # homeassistant.components.apple_tv
 pyatv==0.3.4


### PR DESCRIPTION
## pyasn1 0.3.6
- End-of-octets encoding optimized at ASN.1 encoders
- The __getitem__/__setitem__ behavior of Set/Sequence and SetOf/SequenceOf objects aligned with the canonical Mapping and Sequence protocols in part
- Fixed crash in ASN.1 encoder when encoding an explicitly tagged component of a Sequence

Tested with the following configuration:

``` yaml
notify:
  - platform: xmpp
    name: jabber
    sender: !secret xmpp_sender
    password: !secret xmpp_password
    recipient: !secret xmpp_recipient
```

Message sent with "Call Service"

``` json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.