### PR TITLE
Fixed bug with all Abode switch devices being excluded.

### DIFF
--- a/homeassistant/components/switch/abode.py
+++ b/homeassistant/components/switch/abode.py
@@ -27,7 +27,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     # Get all regular switches that are not excluded or marked as lights
     for device in data.abode.get_devices(generic_type=CONST.TYPE_SWITCH):
-        if data.is_excluded(device) or not data.is_light(device):
+        if data.is_excluded(device) or data.is_light(device):
             continue
 
         devices.append(AbodeSwitch(data, device))


### PR DESCRIPTION
## Description:
Fixed bug with all Abode switch devices being excluded.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.