### PR TITLE
fix usps (again)

### DIFF
--- a/homeassistant/components/sensor/usps.py
+++ b/homeassistant/components/sensor/usps.py
@@ -57,7 +57,7 @@ class USPSPackageSensor(Entity):
         for package in self._usps.packages:
             status = slugify(package['primary_status'])
             if status == STATUS_DELIVERED and \
-                    package['date'] < now().date():
+                    package['delivery_date'] < now().date():
                 continue
             status_counts[status] += 1
         self._attributes = {

--- a/homeassistant/components/usps.py
+++ b/homeassistant/components/usps.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import (config_validation as cv, discovery)
 from homeassistant.util import Throttle
 from homeassistant.util.dt import now
 
-REQUIREMENTS = ['myusps==1.2.1']
+REQUIREMENTS = ['myusps==1.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,6 +23,7 @@ DOMAIN = 'usps'
 DATA_USPS = 'data_usps'
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 COOKIE = 'usps_cookies.pickle'
+CACHE = 'usps_cache'
 
 USPS_TYPE = ['sensor', 'camera']
 
@@ -45,7 +46,9 @@ def setup(hass, config):
     import myusps
     try:
         cookie = hass.config.path(COOKIE)
-        session = myusps.get_session(username, password, cookie_path=cookie)
+        cache = hass.config.path(CACHE)
+        session = myusps.get_session(username, password,
+                                     cookie_path=cookie, cache_path=cache)
     except myusps.USPSError:
         _LOGGER.exception('Could not connect to My USPS')
         return False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -428,7 +428,7 @@ mutagen==1.38
 mycroftapi==2.0
 
 # homeassistant.components.usps
-myusps==1.2.1
+myusps==1.2.2
 
 # homeassistant.components.media_player.nad
 # homeassistant.components.media_player.nadtcp


### PR DESCRIPTION
## Description:
`usps` needs some more fixes, specifically the cache path needs to respect the hass config location.

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/9552

## Checklist:

If user exposed functionality or configuration variables are added/changed:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
