### PR TITLE
IMAP Unread sensor updated for async and push

### DIFF
--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -5,20 +5,26 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.imap/
 """
 import logging
+import asyncio
 
 import voluptuous as vol
 
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME, CONF_PORT, CONF_USERNAME, CONF_PASSWORD)
+    CONF_NAME, CONF_PORT, CONF_USERNAME, CONF_PASSWORD,
+    EVENT_HOMEASSISTANT_STOP)
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_SERVER = "server"
+REQUIREMENTS = ['aioimaplib==0.7.12']
+
+CONF_SERVER = 'server'
 
 DEFAULT_PORT = 993
+
 ICON = 'mdi:email-outline'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -30,17 +36,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the IMAP platform."""
-    sensor = ImapSensor(
-        config.get(CONF_NAME, None), config.get(CONF_USERNAME),
-        config.get(CONF_PASSWORD), config.get(CONF_SERVER),
-        config.get(CONF_PORT))
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Setup the IMAP platform."""
+    sensor = ImapSensor(config.get(CONF_NAME),
+                        config.get(CONF_USERNAME),
+                        config.get(CONF_PASSWORD),
+                        config.get(CONF_SERVER),
+                        config.get(CONF_PORT))
 
-    if sensor.connection:
-        add_devices([sensor], True)
-    else:
-        return False
+    if not (yield from sensor.connection()):
+        raise PlatformNotReady
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, sensor.shutdown())
+    async_add_devices([sensor], True)
 
 
 class ImapSensor(Entity):
@@ -54,18 +63,14 @@ class ImapSensor(Entity):
         self._server = server
         self._port = port
         self._unread_count = 0
-        self.connection = self._login()
+        self._connection = None
+        self._task = None
 
-    def _login(self):
-        """Login and return an IMAP connection."""
-        import imaplib
-        try:
-            connection = imaplib.IMAP4_SSL(self._server, self._port)
-            connection.login(self._user, self._password)
-            return connection
-        except imaplib.IMAP4.error:
-            _LOGGER.error("Failed to login to %s.", self._server)
-            return False
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Handle when an entity is about to be added to Home Assistant."""
+        if not self.should_poll:
+            self._task = self.hass.loop.create_task(self.idle_loop())
 
     @property
     def name(self):
@@ -73,26 +78,92 @@ class ImapSensor(Entity):
         return self._name
 
     @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return ICON
+
+    @property
     def state(self):
         """Return the number of unread emails."""
         return self._unread_count
 
-    def update(self):
-        """Check the number of unread emails."""
-        import imaplib
-        try:
-            self.connection.select()
-            self._unread_count = len(self.connection.search(
-                None, 'UnSeen UnDeleted')[1][0].split())
-        except imaplib.IMAP4.error:
-            _LOGGER.info("Connection to %s lost, attempting to reconnect",
-                         self._server)
-            try:
-                self.connection = self._login()
-            except imaplib.IMAP4.error:
-                _LOGGER.error("Failed to reconnect.")
+    @property
+    def available(self):
+        """Return the availability of the device."""
+        return self._connection is not None
 
     @property
-    def icon(self):
-        """Return the icon to use in the frontend."""
-        return ICON
+    def should_poll(self):
+        """Return if polling is needed."""
+        return self._connection and not self._connection.has_capability('IDLE')
+
+    @asyncio.coroutine
+    def connection(self):
+        """Return a connection to the server, establishing it if necessary."""
+        import aioimaplib
+
+        if self._connection is None:
+            try:
+                self._connection = aioimaplib.IMAP4_SSL(
+                    self._server, self._port)
+                yield from self._connection.wait_hello_from_server()
+                yield from self._connection.login(self._user, self._password)
+                yield from self._connection.select()
+            except (aioimaplib.AioImapException, asyncio.TimeoutError):
+                self._connection = None
+
+        return self._connection
+
+    @asyncio.coroutine
+    def idle_loop(self):
+        """Wait for data pushed from server."""
+        import aioimaplib
+
+        while True:
+            try:
+                if (yield from self.connection()):
+                    yield from self.refresh_unread_count()
+                    yield from self.async_update_ha_state()
+
+                    idle = yield from self._connection.idle_start()
+                    yield from self._connection.wait_server_push()
+                    self._connection.idle_done()
+                    yield from asyncio.wait_for(idle, 10)
+                else:
+                    yield from self.async_update_ha_state()
+            except (aioimaplib.AioImapException, asyncio.TimeoutError):
+                self.disconnect()
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Periodic polling of state."""
+        import aioimaplib
+
+        try:
+            if (yield from self.connection()):
+                yield from self.refresh_unread_count()
+        except (aioimaplib.AioImapException, asyncio.TimeoutError):
+            self.disconnect()
+
+    @asyncio.coroutine
+    def refresh_unread_count(self):
+        """Check the number of unread emails."""
+        if self._connection:
+            yield from self._connection.noop()
+            _, lines = yield from self._connection.search('UnSeen UnDeleted')
+            self._unread_count = len(lines[0].split())
+
+    def disconnect(self):
+        """Drop the connection after exceptions."""
+        _LOGGER.warning("Lost %s, attempting to reconnect", self._server)
+        self._connection = None
+
+    @asyncio.coroutine
+    def shutdown(self):
+        """Close resources."""
+        if self._connection:
+            if self._connection.has_pending_idle():
+                self._connection.idle_done()
+            yield from self._connection.logout()
+        if self._task:
+            self._task.cancel()

--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -97,7 +97,7 @@ class ImapSensor(Entity):
     @property
     def should_poll(self):
         """Return if polling is needed."""
-        return self._does_push == False
+        return not self._does_push
 
     @asyncio.coroutine
     def connection(self):

--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -65,6 +65,7 @@ class ImapSensor(Entity):
         self._port = port
         self._unread_count = 0
         self._connection = None
+        self._does_push = None
         self._idle_loop_task = None
 
     @asyncio.coroutine
@@ -96,7 +97,7 @@ class ImapSensor(Entity):
     @property
     def should_poll(self):
         """Return if polling is needed."""
-        return self._connection and not self._connection.has_capability('IDLE')
+        return self._does_push == False
 
     @asyncio.coroutine
     def connection(self):
@@ -110,6 +111,7 @@ class ImapSensor(Entity):
                 yield from self._connection.wait_hello_from_server()
                 yield from self._connection.login(self._user, self._password)
                 yield from self._connection.select()
+                self._does_push = self._connection.has_capability('IDLE')
             except (aioimaplib.AioImapException, asyncio.TimeoutError):
                 self._connection = None
 

--- a/homeassistant/components/sensor/imap.py
+++ b/homeassistant/components/sensor/imap.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/sensor.imap/
 """
 import logging
 import asyncio
+import async_timeout
 
 import voluptuous as vol
 
@@ -128,7 +129,8 @@ class ImapSensor(Entity):
                     idle = yield from self._connection.idle_start()
                     yield from self._connection.wait_server_push()
                     self._connection.idle_done()
-                    yield from asyncio.wait_for(idle, 10)
+                    with async_timeout.timeout(10):
+                        yield from idle
                 else:
                     yield from self.async_update_ha_state()
             except (aioimaplib.AioImapException, asyncio.TimeoutError):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -57,6 +57,9 @@ aiodns==1.1.1
 # homeassistant.components.http
 aiohttp_cors==0.5.3
 
+# homeassistant.components.sensor.imap
+aioimaplib==0.7.12
+
 # homeassistant.components.light.lifx
 aiolifx==0.6.0
 


### PR DESCRIPTION
## Description:

This update makes the IMAP Unread sensor support server push through the IMAP "IDLE" capability. A polling implementation is still included because IDLE is an optional extension.

As `imaplib` does not have native IDLE support, I moved the platform over to the async `aioimaplib` library.

While at it, handling of an unavailable server has been added with `PlatformNotReady` and the `available` property.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] <s>Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)</s>

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54