### PR TITLE
Add test cases and fix for device_defaults fire_event option.

### DIFF
--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -48,7 +48,7 @@ PLATFORM_SCHEMA = vol.Schema({
                 vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(CONF_NOGROUP_ALIASES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
-            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
+            vol.Optional(CONF_FIRE_EVENT): cv.boolean,
             vol.Optional(CONF_SIGNAL_REPETITIONS): vol.Coerce(int),
             vol.Optional(CONF_GROUP, default=True): cv.boolean,
             # deprecated config options

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -35,7 +35,7 @@ PLATFORM_SCHEMA = vol.Schema({
                 vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(CONF_NOGROUP_ALIASES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
-            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
+            vol.Optional(CONF_FIRE_EVENT): cv.boolean,
             vol.Optional(CONF_SIGNAL_REPETITIONS): vol.Coerce(int),
             vol.Optional(CONF_GROUP, default=True): cv.boolean,
             # deprecated config options

--- a/tests/components/switch/test_rflink.py
+++ b/tests/components/switch/test_rflink.py
@@ -7,8 +7,10 @@ control of Rflink switch devices.
 
 import asyncio
 
+from homeassistant.components.rflink import EVENT_BUTTON_PRESSED
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON)
+from homeassistant.core import callback
 
 from ..test_rflink import mock_rflink
 
@@ -227,3 +229,84 @@ def test_nogroup_device_id(hass, monkeypatch):
     yield from hass.async_block_till_done()
     # should affect state
     assert hass.states.get(DOMAIN + '.test').state == 'on'
+
+
+@asyncio.coroutine
+def test_device_defaults(hass, monkeypatch):
+    """Events should be fired if device_defaults config says so."""
+    config = {
+        'rflink': {
+            'port': '/dev/ttyABC0',
+        },
+        DOMAIN: {
+            'platform': 'rflink',
+            'device_defaults': {
+                'fire_event': True,
+            },
+            'devices': {
+                'protocol_0_0': {
+                    'name': 'test',
+                    'aliases': ['test_alias_0_0'],
+                },
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, _, _, _ = yield from mock_rflink(
+        hass, config, DOMAIN, monkeypatch)
+
+    calls = []
+
+    @callback
+    def listener(event):
+        calls.append(event)
+    hass.bus.async_listen_once(EVENT_BUTTON_PRESSED, listener)
+
+    # test event for new unconfigured sensor
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'off',
+    })
+    yield from hass.async_block_till_done()
+
+    assert calls[0].data == {'state': 'off', 'entity_id': DOMAIN + '.test'}
+
+
+@asyncio.coroutine
+def test_not_firing_default(hass, monkeypatch):
+    """By default no bus events should be fired."""
+    config = {
+        'rflink': {
+            'port': '/dev/ttyABC0',
+        },
+        DOMAIN: {
+            'platform': 'rflink',
+            'devices': {
+                'protocol_0_0': {
+                    'name': 'test',
+                    'aliases': ['test_alias_0_0'],
+                },
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, _, _, _ = yield from mock_rflink(
+        hass, config, DOMAIN, monkeypatch)
+
+    calls = []
+
+    @callback
+    def listener(event):
+        calls.append(event)
+    hass.bus.async_listen_once(EVENT_BUTTON_PRESSED, listener)
+
+    # test event for new unconfigured sensor
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'off',
+    })
+    yield from hass.async_block_till_done()
+
+    assert not calls, 'an event has been fired'

--- a/tests/components/switch/test_rflink.py
+++ b/tests/components/switch/test_rflink.py
@@ -233,7 +233,7 @@ def test_nogroup_device_id(hass, monkeypatch):
 
 @asyncio.coroutine
 def test_device_defaults(hass, monkeypatch):
-    """Events should be fired if device_defaults config says so."""
+    """Event should fire if device_defaults config says so."""
     config = {
         'rflink': {
             'port': '/dev/ttyABC0',


### PR DESCRIPTION
## Description:
Do not set the fire_event default in config schema as it overwrites the `device_defaults`. 

**Related issue (if applicable):** fixes #9531
