### PR TITLE
Use simplepush module, enable event, and allow encrypted communication

### DIFF
--- a/homeassistant/components/notify/simplepush.py
+++ b/homeassistant/components/notify/simplepush.py
@@ -52,7 +52,7 @@ class SimplePushNotificationService(BaseNotificationService):
 
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
 
-        if ATTR_ENCRYPTED:
+        if self._password:
             send_encrypted(self._device_key, self._password, self._salt, title,
                            message, event=self._event)
         else:

--- a/homeassistant/components/notify/simplepush.py
+++ b/homeassistant/components/notify/simplepush.py
@@ -6,49 +6,54 @@ https://home-assistant.io/components/notify.simplepush/
 """
 import logging
 
-import requests
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
     ATTR_TITLE, ATTR_TITLE_DEFAULT, PLATFORM_SCHEMA, BaseNotificationService)
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_PASSWORD
+
+REQUIREMENTS = ['simplepush==1.1.3']
 
 _LOGGER = logging.getLogger(__name__)
-_RESOURCE = 'https://api.simplepush.io/send'
+
+ATTR_ENCRYPTED = 'encrypted'
 
 CONF_DEVICE_KEY = 'device_key'
-
-DEFAULT_TIMEOUT = 10
+CONF_EVENT = 'event'
+CONF_SALT = 'salt'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DEVICE_KEY): cv.string,
+    vol.Optional(CONF_EVENT): cv.string,
+    vol.Inclusive(CONF_PASSWORD, ATTR_ENCRYPTED): cv.string,
+    vol.Inclusive(CONF_SALT, ATTR_ENCRYPTED): cv.string,
 })
 
 
 def get_service(hass, config, discovery_info=None):
     """Get the Simplepush notification service."""
-    return SimplePushNotificationService(config.get(CONF_DEVICE_KEY))
+    return SimplePushNotificationService(config)
 
 
 class SimplePushNotificationService(BaseNotificationService):
-    """Implementation of the notification service for SimplePush."""
+    """Implementation of the notification service for Simplepush."""
 
-    def __init__(self, device_key):
-        """Initialize the service."""
-        self._device_key = device_key
+    def __init__(self, config):
+        """Initialize the Simplepush notification service."""
+        self._device_key = config.get(CONF_DEVICE_KEY)
+        self._event = config.get(CONF_EVENT)
+        self._password = config.get(CONF_PASSWORD)
+        self._salt = config.get(CONF_SALT)
 
     def send_message(self, message='', **kwargs):
-        """Send a message to a user."""
+        """Send a message to a Simplepush user."""
+        from simplepush import send, send_encrypted
+
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
 
-        # Upstream bug will be fixed soon, but no dead-line available.
-        # payload = 'key={}&title={}&msg={}'.format(
-        #     self._device_key, title, message).replace(' ', '%')
-        # response = requests.get(
-        #     _RESOURCE, data=payload, timeout=DEFAULT_TIMEOUT)
-        response = requests.get(
-            '{}/{}/{}/{}'.format(_RESOURCE, self._device_key, title, message),
-            timeout=DEFAULT_TIMEOUT)
-
-        if response.json()['status'] != 'OK':
-            _LOGGER.error("Not possible to send notification")
+        if ATTR_ENCRYPTED:
+            send_encrypted(self._device_key, self._password, self._salt, title,
+                           message, event=self._event)
+        else:
+            send(self._device_key, title, message, event=self._event)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -909,6 +909,9 @@ sharp_aquos_rc==0.3.2
 # homeassistant.components.sensor.shodan
 shodan==1.7.5
 
+# homeassistant.components.notify.simplepush
+simplepush==1.1.3
+
 # homeassistant.components.alarm_control_panel.simplisafe
 simplisafe-python==1.0.5
 


### PR DESCRIPTION
## Description:
Use simplepush module, enable event, and allow encrypted communication.

**Related issue (if applicable):** fixes [27893](https://community.home-assistant.io/t/simplepush-event-id/27893) and [6630](https://community.home-assistant.io/t/simplepush-and-event-id/6630)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3433

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: simplepush
    platform: simplepush
    device_key: j4dFd4
    event: home
    password: test123
    salt: e48desftq
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
