### PR TITLE
Yamaha MusicCast: check known_hosts

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -668,7 +668,7 @@ pymochad==0.1.1
 pymodbus==1.3.1
 
 # homeassistant.components.media_player.yamaha_musiccast
-pymusiccast==0.1.0
+pymusiccast==0.1.1
 
 # homeassistant.components.cover.myq
 pymyq==0.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -668,7 +668,7 @@ pymochad==0.1.1
 pymodbus==1.3.1
 
 # homeassistant.components.media_player.yamaha_musiccast
-pymusiccast==0.1.1
+pymusiccast==0.1.2
 
 # homeassistant.components.cover.myq
 pymyq==0.0.8


### PR DESCRIPTION
## Description:
Yamaha MusicCast: now checks for known_hosts
- Updated pymusiccast

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
