### PR TITLE
RFC: Do not warn about overlapping updates

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -299,7 +299,6 @@ class Entity(object):
             self._update_again = False
             self.async_schedule_update_ha_state(force_refresh=True)
 
-
     def schedule_update_ha_state(self, force_refresh=False):
         """Schedule a update ha state change task.
 


### PR DESCRIPTION
## Description:

Since #6511 we have prevented simultaneous updates, which is good.

However, that PR introduced a warning for overlapping updates and this is a source of confusion, see for example issue #6812 and [this forum post](https://community.home-assistant.io/t/0-41-and-sonos-update-is-already-in-progress-error/14453), both with many affected participants.

I believe the warning was introduced to catch slow updates but it will also be logged for normal updates. For example, the Sonos platform mentioned in those reports will call [`schedule_update_ha_state(force_refresh=True)`](https://github.com/home-assistant/home-assistant/blob/a298b0790b8f10e7de2a80d885f2cc87a898758c/homeassistant/components/media_player/sonos.py#L757) after push events. This can trigger the warning if another update just happens to be ongoing.

As the warning has many false positives and an actual slow execution is logged by other warnings as well, I propose to remove the warning.

This PR goes a bit further and schedules another update if a race was detected. I am not so sure about that part but it does seem to be needed for correctness. That is, the running update could already have missed the new state that the overlapping update is trying to pick up.

Anyway, this is presented for discussion; I know you prefer to discuss code rather than bug reports ;-)


**Related issue (if applicable):** fixes #6812

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54