### PR TITLE
Add OwnTracks over HTTP

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -1,5 +1,5 @@
 """
-Support the OwnTracks platform.
+Device tracker platform that adds support for OwnTracks over MQTT.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.owntracks/
@@ -64,13 +64,7 @@ def get_cipher():
 @asyncio.coroutine
 def async_setup_scanner(hass, config, async_see, discovery_info=None):
     """Set up an OwnTracks tracker."""
-    max_gps_accuracy = config.get(CONF_MAX_GPS_ACCURACY)
-    waypoint_import = config.get(CONF_WAYPOINT_IMPORT)
-    waypoint_whitelist = config.get(CONF_WAYPOINT_WHITELIST)
-    secret = config.get(CONF_SECRET)
-
-    context = OwnTracksContext(async_see, secret, max_gps_accuracy,
-                               waypoint_import, waypoint_whitelist)
+    context = context_from_config(async_see, config)
 
     @asyncio.coroutine
     def async_handle_mqtt_message(topic, payload, qos):
@@ -177,6 +171,17 @@ def _decrypt_payload(secret, topic, ciphertext):
             "Ignoring encrypted payload because unable to decrypt using "
             "key for topic %s", topic)
         return None
+
+
+def context_from_config(async_see, config):
+    """Create an async context from Home Assistant config."""
+    max_gps_accuracy = config.get(CONF_MAX_GPS_ACCURACY)
+    waypoint_import = config.get(CONF_WAYPOINT_IMPORT)
+    waypoint_whitelist = config.get(CONF_WAYPOINT_WHITELIST)
+    secret = config.get(CONF_SECRET)
+
+    return OwnTracksContext(async_see, secret, max_gps_accuracy,
+                            waypoint_import, waypoint_whitelist)
 
 
 class OwnTracksContext:

--- a/homeassistant/components/device_tracker/owntracks_http.py
+++ b/homeassistant/components/device_tracker/owntracks_http.py
@@ -1,0 +1,54 @@
+"""
+Device tracker platform that adds support for OwnTracks over HTTP.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.owntracks_http/
+"""
+import asyncio
+
+from aiohttp.web_exceptions import HTTPInternalServerError
+
+from homeassistant.components.http import HomeAssistantView
+
+# pylint: disable=unused-import
+from .owntracks import (  # NOQA
+    REQUIREMENTS, PLATFORM_SCHEMA, context_from_config, async_handle_message)
+
+
+DEPENDENCIES = ['http']
+
+
+@asyncio.coroutine
+def async_setup_scanner(hass, config, async_see, discovery_info=None):
+    """Set up an OwnTracks tracker."""
+    context = context_from_config(async_see, config)
+
+    hass.http.register_view(OwnTracksView(context))
+
+    return True
+
+
+class OwnTracksView(HomeAssistantView):
+    """View to handle OwnTracks HTTP requests."""
+
+    url = '/api/owntracks/{user}/{device}'
+    name = 'api:owntracks'
+
+    def __init__(self, context):
+        """Initialize OwnTracks URL endpoints."""
+        self.context = context
+
+    @asyncio.coroutine
+    def post(self, request, user, device):
+        """Handle an OwnTracks message."""
+        hass = request.app['hass']
+
+        message = yield from request.json()
+        message['topic'] = 'owntracks/{}/{}'.format(user, device)
+
+        try:
+            yield from async_handle_message(hass, self.context, message)
+            return self.json([])
+
+        except ValueError:
+            raise HTTPInternalServerError

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -1,7 +1,10 @@
 """Authentication for HTTP component."""
 import asyncio
+import base64
 import hmac
 import logging
+
+from aiohttp import hdrs
 
 from homeassistant.const import HTTP_HEADER_HA_AUTH
 from .util import get_real_ip
@@ -41,6 +44,10 @@ def auth_middleware(app, handler):
               validate_password(request, request.query[DATA_API_PASSWORD])):
             authenticated = True
 
+        elif (hdrs.AUTHORIZATION in request.headers and
+              validate_authorization_header(request)):
+            authenticated = True
+
         elif is_trusted_ip(request):
             authenticated = True
 
@@ -64,3 +71,22 @@ def validate_password(request, api_password):
     """Test if password is valid."""
     return hmac.compare_digest(
         api_password, request.app['hass'].http.api_password)
+
+
+def validate_authorization_header(request):
+    """Test an authorization header if valid password."""
+    if hdrs.AUTHORIZATION not in request.headers:
+        return False
+
+    auth_type, auth = request.headers.get(hdrs.AUTHORIZATION).split(' ', 1)
+
+    if auth_type != 'Basic':
+        return False
+
+    decoded = base64.b64decode(auth).decode('utf-8')
+    username, password = decoded.split(':', 1)
+
+    if username != 'homeassistant':
+        return False
+
+    return validate_password(request, password)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -370,6 +370,7 @@ jsonrpc-websocket==0.5
 keyring>=9.3,<10.0
 
 # homeassistant.components.device_tracker.owntracks
+# homeassistant.components.device_tracker.owntracks_http
 libnacl==1.5.2
 
 # homeassistant.components.dyson

--- a/tests/components/device_tracker/test_owntracks_http.py
+++ b/tests/components/device_tracker/test_owntracks_http.py
@@ -1,0 +1,56 @@
+"""Test the owntracks_http platform."""
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.setup import async_setup_component
+
+from tests.common import mock_coro, mock_component
+
+
+@pytest.fixture
+def mock_client(hass, test_client):
+    """Start the Hass HTTP component."""
+    mock_component(hass, 'group')
+    mock_component(hass, 'zone')
+    hass.loop.run_until_complete(
+        async_setup_component(hass, 'device_tracker', {
+            'device_tracker': {
+                'platform': 'owntracks_http'
+            }
+        }))
+    return hass.loop.run_until_complete(test_client(hass.http.app))
+
+
+@pytest.fixture
+def mock_handle_message():
+    """Mock async_handle_message."""
+    with patch('homeassistant.components.device_tracker.'
+               'owntracks_http.async_handle_message') as mock:
+        mock.return_value = mock_coro(None)
+        yield mock
+
+
+@asyncio.coroutine
+def test_forward_message_correctly(mock_client, mock_handle_message):
+    resp = yield from mock_client.post('/api/owntracks/user/device', json={
+        '_type': 'test'
+    })
+    assert resp.status == 200
+    assert len(mock_handle_message.mock_calls) == 1
+
+    data = mock_handle_message.mock_calls[0][1][2]
+    assert data == {
+        '_type': 'test',
+        'topic': 'owntracks/user/device'
+    }
+
+
+@asyncio.coroutine
+def test_handle_value_error(mock_client, mock_handle_message):
+    mock_handle_message.side_effect = ValueError
+    resp = yield from mock_client.post('/api/owntracks/user/device', json={
+        '_type': 'test'
+    })
+    assert resp.status == 500


### PR DESCRIPTION
## Description:
This PR will add a new platform `owntracks_http` that will allow OwnTracks to send messages to Home Assistant over HTTP. It is using the exact same message handling under the hood as the MQTT based OwnTracks platform.

To set it up in OwnTracks, go to Preferences -> Connection:

 - Mode: Private HTTP
 - Host: `https://your-domain.duckdns.org/api/owntracks/<username>/<device name>`
 - Identification: username `homeassistant` and password your API password

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3460

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  platform: owntracks_http
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
