### PR TITLE
Bump pyatv to 0.3.5

### DIFF
--- a/homeassistant/components/apple_tv.py
+++ b/homeassistant/components/apple_tv.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import discovery
 from homeassistant.components.discovery import SERVICE_APPLE_TV
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyatv==0.3.4']
+REQUIREMENTS = ['pyatv==0.3.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -96,7 +96,8 @@ class AppleTvDevice(MediaPlayerDevice):
         if self._playing is not None:
             from pyatv import const
             state = self._playing.play_state
-            if state == const.PLAY_STATE_NO_MEDIA or \
+            if state == const.PLAY_STATE_IDLE or \
+                    state == const.PLAY_STATE_NO_MEDIA or \
                     state == const.PLAY_STATE_LOADING:
                 return STATE_IDLE
             elif state == const.PLAY_STATE_PLAYING:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -554,7 +554,7 @@ pyasn1-modules==0.1.1
 pyasn1==0.3.3
 
 # homeassistant.components.apple_tv
-pyatv==0.3.4
+pyatv==0.3.5
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox


### PR DESCRIPTION
## Description:
Bump to latest version of pyatv with the following fixes:

* Handles genre to avoid exceptions
* Support playstate "0" (idle) which is used in tvOS 11
* Better handling of airplay playback

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
