### PR TITLE
Fixes UPS MyChoice exception

### DIFF
--- a/homeassistant/components/sensor/ups.py
+++ b/homeassistant/components/sensor/ups.py
@@ -83,6 +83,11 @@ class UPSSensor(Entity):
         """Return the state of the sensor."""
         return self._state
 
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return 'packages'
+
     def _update(self):
         """Update device state."""
         import upsmychoice

--- a/homeassistant/components/sensor/ups.py
+++ b/homeassistant/components/sensor/ups.py
@@ -30,14 +30,11 @@ ICON = 'mdi:package-variant-closed'
 STATUS_DELIVERED = 'delivered'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_USERNAME):
-    cv.string,
-    vol.Required(CONF_PASSWORD):
-    cv.string,
-    vol.Optional(CONF_NAME):
-    cv.string,
-    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=1800)):
-    (vol.All(cv.time_period, cv.positive_timedelta)),
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=1800)): (
+        vol.All(cv.time_period, cv.positive_timedelta)),
 })
 
 
@@ -45,21 +42,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the UPS platform."""
     import upsmychoice
-
     try:
         cookie = hass.config.path(COOKIE)
         session = upsmychoice.get_session(
-            config.get(CONF_USERNAME),
-            config.get(CONF_PASSWORD),
+            config.get(CONF_USERNAME), config.get(CONF_PASSWORD),
             cookie_path=cookie)
     except upsmychoice.UPSError:
         _LOGGER.exception("Could not connect to UPS My Choice")
         return False
 
-    add_devices([
-        UPSSensor(session,
-                  config.get(CONF_NAME), config.get(CONF_UPDATE_INTERVAL))
-    ], True)
+    add_devices([UPSSensor(session, config.get(CONF_NAME),
+                           config.get(CONF_UPDATE_INTERVAL))], True)
 
 
 class UPSSensor(Entity):
@@ -91,7 +84,6 @@ class UPSSensor(Entity):
     def _update(self):
         """Update device state."""
         import upsmychoice
-
         status_counts = defaultdict(int)
         try:
             for package in upsmychoice.get_packages(self._session):
@@ -102,9 +94,11 @@ class UPSSensor(Entity):
                     continue
                 status_counts[status] += 1
         except upsmychoice.UPSError:
-            _LOGGER.error('Could not retrieve info from UPS My Choice account')
+            _LOGGER.error('Could not connect to UPS My Choice account')
 
-        self._attributes = {ATTR_ATTRIBUTION: upsmychoice.ATTRIBUTION}
+        self._attributes = {
+            ATTR_ATTRIBUTION: upsmychoice.ATTRIBUTION
+        }
         self._attributes.update(status_counts)
         self._state = sum(status_counts.values())
 

--- a/homeassistant/components/sensor/ups.py
+++ b/homeassistant/components/sensor/ups.py
@@ -30,11 +30,14 @@ ICON = 'mdi:package-variant-closed'
 STATUS_DELIVERED = 'delivered'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=1800)): (
-        vol.All(cv.time_period, cv.positive_timedelta)),
+    vol.Required(CONF_USERNAME):
+    cv.string,
+    vol.Required(CONF_PASSWORD):
+    cv.string,
+    vol.Optional(CONF_NAME):
+    cv.string,
+    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=1800)):
+    (vol.All(cv.time_period, cv.positive_timedelta)),
 })
 
 
@@ -42,17 +45,21 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the UPS platform."""
     import upsmychoice
+
     try:
         cookie = hass.config.path(COOKIE)
         session = upsmychoice.get_session(
-            config.get(CONF_USERNAME), config.get(CONF_PASSWORD),
+            config.get(CONF_USERNAME),
+            config.get(CONF_PASSWORD),
             cookie_path=cookie)
     except upsmychoice.UPSError:
         _LOGGER.exception("Could not connect to UPS My Choice")
         return False
 
-    add_devices([UPSSensor(session, config.get(CONF_NAME),
-                           config.get(CONF_UPDATE_INTERVAL))], True)
+    add_devices([
+        UPSSensor(session,
+                  config.get(CONF_NAME), config.get(CONF_UPDATE_INTERVAL))
+    ], True)
 
 
 class UPSSensor(Entity):
@@ -79,17 +86,20 @@ class UPSSensor(Entity):
     def _update(self):
         """Update device state."""
         import upsmychoice
+
         status_counts = defaultdict(int)
-        for package in upsmychoice.get_packages(self._session):
-            status = slugify(package['status'])
-            skip = status == STATUS_DELIVERED and \
-                parse_date(package['delivery_date']) < now().date()
-            if skip:
-                continue
-            status_counts[status] += 1
-        self._attributes = {
-            ATTR_ATTRIBUTION: upsmychoice.ATTRIBUTION
-        }
+        try:
+            for package in upsmychoice.get_packages(self._session):
+                status = slugify(package['status'])
+                skip = status == STATUS_DELIVERED and \
+                    parse_date(package['delivery_date']) < now().date()
+                if skip:
+                    continue
+                status_counts[status] += 1
+        except upsmychoice.UPSError:
+            _LOGGER.error('Could not retrieve info from UPS My Choice account')
+
+        self._attributes = {ATTR_ATTRIBUTION: upsmychoice.ATTRIBUTION}
         self._attributes.update(status_counts)
         self._state = sum(status_counts.values())
 


### PR DESCRIPTION
## Description:
1. Adds "packages" as a unit (to be consistent with USPS).

2. In certain (somewhat unknown) situations, such as when new UPS ToS need to be accepted, the platform would raise exceptions. This replaces those with an error message.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: ups
    username: <USERNAME>
    password: <PASSWORD>
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
