### PR TITLE
FedEx: Adds "packages" as a unit

### DIFF
--- a/homeassistant/components/sensor/fedex.py
+++ b/homeassistant/components/sensor/fedex.py
@@ -33,14 +33,11 @@ ICON = 'mdi:package-variant-closed'
 STATUS_DELIVERED = 'delivered'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_USERNAME):
-    cv.string,
-    vol.Required(CONF_PASSWORD):
-    cv.string,
-    vol.Optional(CONF_NAME):
-    cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=1800)):
-    vol.All(cv.time_period, cv.positive_timedelta),
+        vol.All(cv.time_period, cv.positive_timedelta),
 })
 
 
@@ -55,8 +52,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         cookie = hass.config.path(COOKIE)
         session = fedexdeliverymanager.get_session(
-            config.get(CONF_USERNAME),
-            config.get(CONF_PASSWORD),
+            config.get(CONF_USERNAME), config.get(CONF_PASSWORD),
             cookie_path=cookie)
     except fedexdeliverymanager.FedexError:
         _LOGGER.exception("Could not connect to Fedex Delivery Manager")
@@ -102,7 +98,9 @@ class FedexSensor(Entity):
             if skip:
                 continue
             status_counts[status] += 1
-        self._attributes = {ATTR_ATTRIBUTION: fedexdeliverymanager.ATTRIBUTION}
+        self._attributes = {
+            ATTR_ATTRIBUTION: fedexdeliverymanager.ATTRIBUTION
+        }
         self._attributes.update(status_counts)
         self._state = sum(status_counts.values())
 

--- a/homeassistant/components/sensor/fedex.py
+++ b/homeassistant/components/sensor/fedex.py
@@ -33,11 +33,14 @@ ICON = 'mdi:package-variant-closed'
 STATUS_DELIVERED = 'delivered'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
+    vol.Required(CONF_USERNAME):
+    cv.string,
+    vol.Required(CONF_PASSWORD):
+    cv.string,
+    vol.Optional(CONF_NAME):
+    cv.string,
     vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=1800)):
-        vol.All(cv.time_period, cv.positive_timedelta),
+    vol.All(cv.time_period, cv.positive_timedelta),
 })
 
 
@@ -52,7 +55,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         cookie = hass.config.path(COOKIE)
         session = fedexdeliverymanager.get_session(
-            config.get(CONF_USERNAME), config.get(CONF_PASSWORD),
+            config.get(CONF_USERNAME),
+            config.get(CONF_PASSWORD),
             cookie_path=cookie)
     except fedexdeliverymanager.FedexError:
         _LOGGER.exception("Could not connect to Fedex Delivery Manager")
@@ -82,6 +86,11 @@ class FedexSensor(Entity):
         """Return the state of the sensor."""
         return self._state
 
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return 'packages'
+
     def _update(self):
         """Update device state."""
         import fedexdeliverymanager
@@ -93,9 +102,7 @@ class FedexSensor(Entity):
             if skip:
                 continue
             status_counts[status] += 1
-        self._attributes = {
-            ATTR_ATTRIBUTION: fedexdeliverymanager.ATTRIBUTION
-        }
+        self._attributes = {ATTR_ATTRIBUTION: fedexdeliverymanager.ATTRIBUTION}
         self._attributes.update(status_counts)
         self._state = sum(status_counts.values())
 


### PR DESCRIPTION
## Description:
Adds "packages" as a unit to be consistent with USPS and UPS (via https://github.com/home-assistant/home-assistant/pull/9587).

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: fedex
    username: <USERNAME>
    password: <PASSWORD>
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
