### PR TITLE
MQTT climate platform [continuation of #8750]

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -266,7 +266,6 @@ omit =
     homeassistant/components/climate/heatmiser.py
     homeassistant/components/climate/homematic.py
     homeassistant/components/climate/knx.py
-    homeassistant/components/climate/mqtt.py
     homeassistant/components/climate/oem.py
     homeassistant/components/climate/proliphix.py
     homeassistant/components/climate/radiotherm.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -266,6 +266,7 @@ omit =
     homeassistant/components/climate/heatmiser.py
     homeassistant/components/climate/homematic.py
     homeassistant/components/climate/knx.py
+    homeassistant/components/climate/mqtt.py
     homeassistant/components/climate/oem.py
     homeassistant/components/climate/proliphix.py
     homeassistant/components/climate/radiotherm.py

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -242,13 +242,13 @@ class MqttClimate(ClimateDevice):
             return
 
         if self._topic[CONF_POWER_COMMAND_TOPIC] is not None:
-            if self._current_operation == STATE_OFF and \
-                        operation_mode != STATE_OFF:
+            if (self._current_operation == STATE_OFF and
+                    operation_mode != STATE_OFF):
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_POWER_COMMAND_TOPIC],
                     STATE_ON, self._qos, self._retain)
-            elif self._current_operation != STATE_OFF and \
-                          operation_mode == STATE_OFF:
+            elif (self._current_operation != STATE_OFF and
+                  operation_mode == STATE_OFF):
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_POWER_COMMAND_TOPIC],
                     STATE_OFF, self._qos, self._retain)

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -210,7 +210,7 @@ class MqttClimate(ClimateDevice):
         """Set new target temperatures."""
         if kwargs.get(ATTR_TEMPERATURE) is not None:
             self._target_temperature = kwargs.get(ATTR_TEMPERATURE)
-            if self._current_operation != 'Off':
+            if self._current_operation != STATE_OFF:
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_TEMPERATURE_COMMAND_TOPIC],
                     self._target_temperature, self._qos, self._retain)
@@ -219,7 +219,7 @@ class MqttClimate(ClimateDevice):
 
     def set_swing_mode(self, swing_mode):
         """Set new swing mode."""
-        if self._current_operation != 'Off':
+        if self._current_operation != STATE_OFF:
             mqtt.async_publish(
                 self.hass, self._topic[CONF_SWING_MODE_COMMAND_TOPIC],
                 swing_mode, self._qos, self._retain)
@@ -228,7 +228,7 @@ class MqttClimate(ClimateDevice):
 
     def set_fan_mode(self, fan):
         """Set new target temperature."""
-        if self._current_operation != 'Off':
+        if self._current_operation != STATE_OFF:
             mqtt.async_publish(
                 self.hass, self._topic[CONF_FAN_MODE_COMMAND_TOPIC],
                 fan, self._qos, self._retain)
@@ -242,14 +242,16 @@ class MqttClimate(ClimateDevice):
             return
 
         if self._topic[CONF_POWER_COMMAND_TOPIC] is not None:
-            if self._current_operation == 'Off' and operation_mode != 'Off':
+            if self._current_operation == STATE_OFF and \
+                        operation_mode != STATE_OFF:
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_POWER_COMMAND_TOPIC],
-                    "On", self._qos, self._retain)
-            elif self._current_operation != 'Off' and operation_mode == 'Off':
+                    STATE_ON, self._qos, self._retain)
+            elif self._current_operation != STATE_OFF and \
+                          operation_mode == STATE_OFF:
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_POWER_COMMAND_TOPIC],
-                    "Off", self._qos, self._retain)
+                    STATE_OFF, self._qos, self._retain)
 
         mqtt.async_publish(
             self.hass, self._topic[CONF_MODE_COMMAND_TOPIC],

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -172,7 +172,7 @@ class MqttClimate(ClimateDevice):
             """Handle current temperature coming via MQTT."""
             try:
                 self._current_temperature = float(payload)
-                self.hass.async_add_job(self.async_update_ha_state())
+                self.async_schedule_update_ha_state()
             except ValueError:
                 _LOGGER.error("Could not parse temperature from %s", payload)
 
@@ -188,7 +188,7 @@ class MqttClimate(ClimateDevice):
                 _LOGGER.error("Invalid mode: %s", payload)
             else:
                 self._current_operation = payload
-                self.hass.async_add_job(self.async_update_ha_state())
+                self.async_schedule_update_ha_state()
 
         if self._topic[CONF_MODE_STATE_TOPIC] is not None:
             yield from mqtt.async_subscribe(
@@ -200,7 +200,7 @@ class MqttClimate(ClimateDevice):
             """Handle target temperature coming via MQTT."""
             try:
                 self._target_temperature = float(payload)
-                self.hass.async_add_job(self.async_update_ha_state())
+                self.async_schedule_update_ha_state()
             except ValueError:
                 _LOGGER.error("Could not parse temperature from %s", payload)
 
@@ -216,7 +216,7 @@ class MqttClimate(ClimateDevice):
                 _LOGGER.error("Invalid fan mode: %s", payload)
             else:
                 self._current_fan_mode = payload
-                self.hass.async_add_job(self.async_update_ha_state())
+                self.async_schedule_update_ha_state()
 
         if self._topic[CONF_FAN_MODE_STATE_TOPIC] is not None:
             yield from mqtt.async_subscribe(
@@ -230,7 +230,7 @@ class MqttClimate(ClimateDevice):
                 _LOGGER.error("Invalid swing mode: %s", payload)
             else:
                 self._current_swing_mode = payload
-                self.hass.async_add_job(self.async_update_ha_state())
+                self.async_schedule_update_ha_state()
 
         if self._topic[CONF_SWING_MODE_STATE_TOPIC] is not None:
             yield from mqtt.async_subscribe(
@@ -242,12 +242,12 @@ class MqttClimate(ClimateDevice):
             """Handle receiving away mode via MQTT."""
             if payload == self._payload_on:
                 self._away = True
-                self.hass.async_add_job(self.async_update_ha_state())
             elif payload == self._payload_off:
                 self._away = False
-                self.hass.async_add_job(self.async_update_ha_state())
             else:
                 _LOGGER.error("Invalid away mode: %s", payload)
+
+            self.async_schedule_update_ha_state()
 
         if self._topic[CONF_AWAY_MODE_STATE_TOPIC] is not None:
             yield from mqtt.async_subscribe(
@@ -259,12 +259,12 @@ class MqttClimate(ClimateDevice):
             """Handle receiving aux mode via MQTT."""
             if payload == self._payload_on:
                 self._aux = True
-                self.hass.async_add_job(self.async_update_ha_state())
             elif payload == self._payload_off:
                 self._aux = False
-                self.hass.async_add_job(self.async_update_ha_state())
             else:
                 _LOGGER.error("Invalid aux mode: %s", payload)
+
+            self.async_schedule_update_ha_state()
 
         if self._topic[CONF_AUX_STATE_TOPIC] is not None:
             yield from mqtt.async_subscribe(
@@ -275,7 +275,7 @@ class MqttClimate(ClimateDevice):
         def handle_hold_mode_received(topic, payload, qos):
             """Handle receiving hold mode via MQTT."""
             self._hold = payload
-            self.hass.async_add_job(self.async_update_ha_state())
+            self.async_schedule_update_ha_state()
 
         if self._topic[CONF_HOLD_STATE_TOPIC] is not None:
             yield from mqtt.async_subscribe(
@@ -410,7 +410,7 @@ class MqttClimate(ClimateDevice):
 
         if self._topic[CONF_MODE_STATE_TOPIC] is None:
             self._current_operation = operation_mode
-            self.hass.async_add_job(self.async_update_ha_state())
+            self.async_schedule_update_ha_state()
 
     @property
     def current_swing_mode(self):
@@ -453,14 +453,14 @@ class MqttClimate(ClimateDevice):
             self.schedule_update_ha_state()
 
     def turn_aux_heat_on(self):
-        """Turn away auxillary heater on."""
+        """Turn auxillary heater on."""
         if self._topic[CONF_AUX_COMMAND_TOPIC] is not None:
             mqtt.publish(self.hass, self._topic[CONF_AUX_COMMAND_TOPIC],
                          self._payload_on, self._qos, self._retain)
 
         if self._topic[CONF_AUX_STATE_TOPIC] is None:
             self._aux = True
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
     def turn_aux_heat_off(self):
         """Turn auxillary heater off."""

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -300,12 +300,12 @@ class MqttClimate(ClimateDevice):
                     operation_mode != STATE_OFF):
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_POWER_COMMAND_TOPIC],
-                    STATE_ON, self._qos, self._retain)
+                    self._payload_on, self._qos, self._retain)
             elif (self._current_operation != STATE_OFF and
                   operation_mode == STATE_OFF):
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_POWER_COMMAND_TOPIC],
-                    STATE_OFF, self._qos, self._retain)
+                    self._payload_off, self._qos, self._retain)
 
         if self._topic[CONF_MODE_COMMAND_TOPIC] is not None:
             mqtt.async_publish(

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -366,7 +366,8 @@ class MqttClimate(ClimateDevice):
 
         self.async_schedule_update_ha_state()
 
-    def set_swing_mode(self, swing_mode):
+    @asyncio.coroutine
+    def async_set_swing_mode(self, swing_mode):
         """Set new swing mode."""
         if self._send_if_off or self._current_operation != STATE_OFF:
             mqtt.async_publish(
@@ -375,9 +376,10 @@ class MqttClimate(ClimateDevice):
 
         if self._topic[CONF_SWING_MODE_STATE_TOPIC] is None:
             self._current_swing_mode = swing_mode
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
-    def set_fan_mode(self, fan):
+    @asyncio.coroutine
+    def async_set_fan_mode(self, fan):
         """Set new target temperature."""
         if self._send_if_off or self._current_operation != STATE_OFF:
             mqtt.async_publish(
@@ -386,7 +388,7 @@ class MqttClimate(ClimateDevice):
 
         if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None:
             self._current_fan_mode = fan
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
     @asyncio.coroutine
     def async_set_operation_mode(self, operation_mode) -> None:
@@ -422,52 +424,60 @@ class MqttClimate(ClimateDevice):
         """List of available swing modes."""
         return self._swing_list
 
-    def turn_away_mode_on(self):
+    @asyncio.coroutine
+    def async_turn_away_mode_on(self):
         """Turn away mode on."""
         if self._topic[CONF_AWAY_MODE_COMMAND_TOPIC] is not None:
-            mqtt.publish(self.hass, self._topic[CONF_AWAY_MODE_COMMAND_TOPIC],
-                         self._payload_on, self._qos, self._retain)
+            mqtt.async_publish(self.hass,
+                               self._topic[CONF_AWAY_MODE_COMMAND_TOPIC],
+                               self._payload_on, self._qos, self._retain)
 
         if self._topic[CONF_AWAY_MODE_STATE_TOPIC] is None:
             self._away = True
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
-    def turn_away_mode_off(self):
+    @asyncio.coroutine
+    def async_turn_away_mode_off(self):
         """Turn away mode off."""
         if self._topic[CONF_AWAY_MODE_COMMAND_TOPIC] is not None:
-            mqtt.publish(self.hass, self._topic[CONF_AWAY_MODE_COMMAND_TOPIC],
-                         self._payload_off, self._qos, self._retain)
+            mqtt.async_publish(self.hass,
+                               self._topic[CONF_AWAY_MODE_COMMAND_TOPIC],
+                               self._payload_off, self._qos, self._retain)
 
         if self._topic[CONF_AWAY_MODE_STATE_TOPIC] is None:
             self._away = False
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
-    def set_hold_mode(self, hold):
+    @asyncio.coroutine
+    def async_set_hold_mode(self, hold):
         """Update hold mode on."""
         if self._topic[CONF_HOLD_COMMAND_TOPIC] is not None:
-            mqtt.publish(self.hass, self._topic[CONF_HOLD_COMMAND_TOPIC],
-                         hold, self._qos, self._retain)
+            mqtt.async_publish(self.hass,
+                               self._topic[CONF_HOLD_COMMAND_TOPIC],
+                               hold, self._qos, self._retain)
 
         if self._topic[CONF_HOLD_STATE_TOPIC] is None:
             self._hold = hold
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
-    def turn_aux_heat_on(self):
+    @asyncio.coroutine
+    def async_turn_aux_heat_on(self):
         """Turn auxillary heater on."""
         if self._topic[CONF_AUX_COMMAND_TOPIC] is not None:
-            mqtt.publish(self.hass, self._topic[CONF_AUX_COMMAND_TOPIC],
-                         self._payload_on, self._qos, self._retain)
+            mqtt.async_publish(self.hass, self._topic[CONF_AUX_COMMAND_TOPIC],
+                               self._payload_on, self._qos, self._retain)
 
         if self._topic[CONF_AUX_STATE_TOPIC] is None:
             self._aux = True
             self.async_schedule_update_ha_state()
 
-    def turn_aux_heat_off(self):
+    @asyncio.coroutine
+    def async_turn_aux_heat_off(self):
         """Turn auxillary heater off."""
         if self._topic[CONF_AUX_COMMAND_TOPIC] is not None:
-            mqtt.publish(self.hass, self._topic[CONF_AUX_COMMAND_TOPIC],
-                         self._payload_off, self._qos, self._retain)
+            mqtt.async_publish(self.hass, self._topic[CONF_AUX_COMMAND_TOPIC],
+                               self._payload_off, self._qos, self._retain)
 
         if self._topic[CONF_AUX_STATE_TOPIC] is None:
             self._aux = False
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -1,0 +1,294 @@
+"""
+Support for MQTT climate devices.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/climate.mqtt/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+import homeassistant.components.mqtt as mqtt
+
+from homeassistant.components.climate import (
+    STATE_HEAT, STATE_COOL, STATE_DRY, STATE_FAN_ONLY, ClimateDevice,
+    PLATFORM_SCHEMA, STATE_AUTO)
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT, STATE_ON, STATE_OFF, ATTR_TEMPERATURE,
+    CONF_NAME)
+from homeassistant.components.mqtt import (CONF_QOS, CONF_RETAIN)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import (async_track_state_change)
+from homeassistant.components.fan import (SPEED_LOW, SPEED_MEDIUM,
+                                          SPEED_HIGH)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['mqtt', 'sensor']
+
+DEFAULT_NAME = 'MQTT HVAC'
+
+CONF_SENSOR = 'target_sensor'
+CONF_POWER_COMMAND_TOPIC = 'power_command_topic'
+CONF_MODE_COMMAND_TOPIC = 'mode_command_topic'
+CONF_TEMPERATURE_COMMAND_TOPIC = 'temperature_command_topic'
+CONF_FAN_MODE_COMMAND_TOPIC = 'fan_mode_command_topic'
+CONF_SWING_MODE_COMMAND_TOPIC = 'swing_mode_command_topic'
+CONF_FAN_MODE_LIST = 'fan_modes'
+CONF_MODE_LIST = 'modes'
+CONF_SWING_MODE_LIST = 'swing_modes'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SENSOR): cv.entity_id,
+    vol.Optional(CONF_POWER_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_TEMPERATURE_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_FAN_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_SWING_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_FAN_MODE_LIST,
+                 default=[STATE_AUTO, SPEED_LOW,
+                          SPEED_MEDIUM, SPEED_HIGH]): cv.ensure_list,
+    vol.Optional(CONF_SWING_MODE_LIST,
+                 default=[STATE_ON, STATE_OFF]): cv.ensure_list,
+    vol.Optional(CONF_MODE_LIST,
+                 default=[STATE_AUTO, STATE_OFF, STATE_COOL, STATE_HEAT,
+                          STATE_DRY, STATE_FAN_ONLY]): cv.ensure_list,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Demo climate devices."""
+    async_add_devices([
+        MqttClimate(
+            hass,
+            config.get(CONF_NAME),
+            config.get(CONF_SENSOR),
+            {
+                key: config.get(key) for key in (
+                    CONF_POWER_COMMAND_TOPIC,
+                    CONF_MODE_COMMAND_TOPIC,
+                    CONF_TEMPERATURE_COMMAND_TOPIC,
+                    CONF_FAN_MODE_COMMAND_TOPIC,
+                    CONF_SWING_MODE_COMMAND_TOPIC,
+                )
+            },
+            config.get(CONF_QOS),
+            config.get(CONF_RETAIN),
+            config.get(CONF_MODE_LIST),
+            config.get(CONF_FAN_MODE_LIST),
+            config.get(CONF_SWING_MODE_LIST),
+            24, None, None, SPEED_LOW,
+            STATE_OFF, STATE_OFF, None)
+    ])
+
+
+class MqttClimate(ClimateDevice):
+    """Representation of a demo climate device."""
+
+    def __init__(self, hass, name, sensor_entity_id, topic, qos, retain,
+                 mode_list, fan_mode_list, swing_mode_list,
+                 target_temperature,
+                 away, hold, current_fan_mode,
+                 current_swing_mode,
+                 current_operation, aux):
+        """Initialize the climate device."""
+        self.hass = hass
+        self._name = name
+        self._topic = topic
+        self._qos = qos
+        self._retain = retain
+        self._target_temperature = target_temperature
+        self._unit_of_measurement = hass.config.units.temperature_unit
+        self._away = away
+        self._hold = hold
+        self._current_temperature = None
+        self._current_fan_mode = current_fan_mode
+        self._current_operation = current_operation
+        self._aux = aux
+        self._current_swing_mode = current_swing_mode
+        self._fan_list = fan_mode_list
+        self._operation_list = mode_list
+        self._swing_list = swing_mode_list
+        self._target_temperature_step = 1
+        async_track_state_change(
+            hass, sensor_entity_id, self._async_sensor_changed)
+
+        sensor_state = hass.states.get(sensor_entity_id)
+        if sensor_state:
+            self._async_update_temp(sensor_state)
+
+    @asyncio.coroutine
+    def _async_sensor_changed(self, entity_id, old_state, new_state):
+        """Handle temperature changes."""
+        if new_state is None:
+            return
+
+        self._async_update_temp(new_state)
+        yield from self.async_update_ha_state()
+
+    @callback
+    def _async_update_temp(self, state):
+        """Update thermostat with latest state from sensor."""
+        unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+
+        try:
+            self._current_temperature = self.hass.config.units.temperature(
+                float(state.state), unit)
+        except ValueError as ex:
+            _LOGGER.error('Unable to update from sensor: %s', ex)
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the climate device."""
+        return self._name
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return self._unit_of_measurement
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self._current_temperature
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._target_temperature
+
+    @property
+    def current_operation(self):
+        """Return current operation ie. heat, cool, idle."""
+        return self._current_operation
+
+    @property
+    def operation_list(self):
+        """Return the list of available operation modes."""
+        return self._operation_list
+
+    @property
+    def target_temperature_step(self):
+        """Return the supported step of target temperature."""
+        return self._target_temperature_step
+
+    @property
+    def is_away_mode_on(self):
+        """Return if away mode is on."""
+        return self._away
+
+    @property
+    def current_hold_mode(self):
+        """Return hold mode setting."""
+        return self._hold
+
+    @property
+    def is_aux_heat_on(self):
+        """Return true if away mode is on."""
+        return self._aux
+
+    @property
+    def current_fan_mode(self):
+        """Return the fan setting."""
+        return self._current_fan_mode
+
+    @property
+    def fan_list(self):
+        """Return the list of available fan modes."""
+        return self._fan_list
+
+    def set_temperature(self, **kwargs):
+        """Set new target temperatures."""
+        if kwargs.get(ATTR_TEMPERATURE) is not None:
+            self._target_temperature = kwargs.get(ATTR_TEMPERATURE)
+            if self._current_operation != 'Off':
+                mqtt.async_publish(
+                    self.hass, self._topic[CONF_TEMPERATURE_COMMAND_TOPIC],
+                    self._target_temperature, self._qos, self._retain)
+
+        self.schedule_update_ha_state()
+
+    def set_swing_mode(self, swing_mode):
+        """Set new swing mode."""
+        if self._current_operation != 'Off':
+            mqtt.async_publish(
+                self.hass, self._topic[CONF_SWING_MODE_COMMAND_TOPIC],
+                swing_mode, self._qos, self._retain)
+        self._current_swing_mode = swing_mode
+        self.schedule_update_ha_state()
+
+    def set_fan_mode(self, fan):
+        """Set new target temperature."""
+        if self._current_operation != 'Off':
+            mqtt.async_publish(
+                self.hass, self._topic[CONF_FAN_MODE_COMMAND_TOPIC],
+                fan, self._qos, self._retain)
+        self._current_fan_mode = fan
+        self.schedule_update_ha_state()
+
+    @asyncio.coroutine
+    def async_set_operation_mode(self, operation_mode) -> None:
+        """Set new operation mode."""
+        if self._topic[CONF_MODE_COMMAND_TOPIC] is None:
+            return
+
+        if self._topic[CONF_POWER_COMMAND_TOPIC] is not None:
+            if self._current_operation == 'Off' and operation_mode != 'Off':
+                mqtt.async_publish(
+                    self.hass, self._topic[CONF_POWER_COMMAND_TOPIC],
+                    "On", self._qos, self._retain)
+            elif self._current_operation != 'Off' and operation_mode == 'Off':
+                mqtt.async_publish(
+                    self.hass, self._topic[CONF_POWER_COMMAND_TOPIC],
+                    "Off", self._qos, self._retain)
+
+        mqtt.async_publish(
+            self.hass, self._topic[CONF_MODE_COMMAND_TOPIC],
+            operation_mode, self._qos, self._retain)
+
+        self._current_operation = operation_mode
+        self.hass.async_add_job(self.async_update_ha_state())
+
+    @property
+    def current_swing_mode(self):
+        """Return the swing setting."""
+        return self._current_swing_mode
+
+    @property
+    def swing_list(self):
+        """List of available swing modes."""
+        return self._swing_list
+
+    def turn_away_mode_on(self):
+        """Turn away mode on."""
+        self._away = True
+        self.schedule_update_ha_state()
+
+    def turn_away_mode_off(self):
+        """Turn away mode off."""
+        self._away = False
+        self.schedule_update_ha_state()
+
+    def set_hold_mode(self, hold):
+        """Update hold mode on."""
+        self._hold = hold
+        self.schedule_update_ha_state()
+
+    def turn_aux_heat_on(self):
+        """Turn away auxillary heater on."""
+        self._aux = True
+        self.schedule_update_ha_state()
+
+    def turn_aux_heat_off(self):
+        """Turn auxillary heater off."""
+        self._aux = False
+        self.schedule_update_ha_state()

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -134,8 +134,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             config.get(CONF_FAN_MODE_LIST),
             config.get(CONF_SWING_MODE_LIST),
             config.get(CONF_INITIAL),
-            None, None, SPEED_LOW,  # TODO make defaults false
-            STATE_OFF, STATE_OFF, None,  # TODO s.o.
+            False, None, SPEED_LOW,
+            STATE_OFF, STATE_OFF, False,
             config.get(CONF_SEND_IF_OFF),
             config.get(CONF_PAYLOAD_ON),
             config.get(CONF_PAYLOAD_OFF))

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -1,0 +1,126 @@
+"""The tests for the mqtt climate component."""
+import unittest
+
+from homeassistant.util.unit_system import (
+    METRIC_SYSTEM
+)
+from homeassistant.setup import setup_component
+from homeassistant.components import climate
+from homeassistant.const import (STATE_OFF)
+
+from tests.common import (get_test_home_assistant, mock_mqtt_component)
+
+ENTITY_CLIMATE = 'climate.test'
+ENT_SENSOR = 'sensor.test'
+
+
+class BaseMQTT(unittest.TestCase):
+    """Base climate hvac test."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.mock_publish = mock_mqtt_component(self.hass)
+        self.hass.config.units = METRIC_SYSTEM
+        self.assertTrue(setup_component(self.hass, climate.DOMAIN, {
+            'climate': {
+                'platform': 'mqtt',
+                'name': 'test',
+                'target_sensor': ENT_SENSOR,
+                'mode_command_topic': 'mode-topic',
+                'temperature_command_topic': 'temperature-topic',
+                'fan_mode_command_topic': 'fan-mode-topic',
+                'swing_mode_command_topic': 'swing-mode-topic',
+            }}))
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_setup_params(self):
+        """Test the initial parameters."""
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual(24, state.attributes.get('temperature'))
+        self.assertEqual("low", state.attributes.get('fan_mode'))
+        self.assertEqual("off", state.attributes.get('swing_mode'))
+        self.assertEqual("off", state.attributes.get('operation_mode'))
+
+
+class TestMQTTClimate(BaseMQTT):
+    """Test the mqtt climate hvac."""
+
+    def test_get_operation_modes(self):
+        """Test that the operation list returns the correct modes."""
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        modes = state.attributes.get('operation_list')
+        self.assertEqual([
+          climate.STATE_AUTO, STATE_OFF, climate.STATE_COOL,
+          climate.STATE_HEAT, climate.STATE_DRY, climate.STATE_FAN_ONLY
+        ], modes)
+
+    def test_set_fan_mode_bad_attr(self):
+        """Test setting fan mode without required attribute."""
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("low", state.attributes.get('fan_mode'))
+        climate.set_fan_mode(self.hass, None, ENTITY_CLIMATE)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("low", state.attributes.get('fan_mode'))
+
+    def test_set_fan_mode(self):
+        """Test setting of new fan mode."""
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("low", state.attributes.get('fan_mode'))
+        climate.set_fan_mode(self.hass, "low", ENTITY_CLIMATE)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("low", state.attributes.get('fan_mode'))
+
+    def test_set_swing_mode_bad_attr(self):
+        """Test setting swing mode without required attribute."""
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("off", state.attributes.get('swing_mode'))
+        climate.set_swing_mode(self.hass, None, ENTITY_CLIMATE)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("off", state.attributes.get('swing_mode'))
+
+    def test_set_swing(self):
+        """Test setting of new swing mode."""
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("off", state.attributes.get('swing_mode'))
+        climate.set_swing_mode(self.hass, "on", ENTITY_CLIMATE)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("on", state.attributes.get('swing_mode'))
+
+
+class TestMQTTClimateMode(BaseMQTT):
+    """Test the mqtt climate hvac operation mode."""
+
+    def test_set_operation_bad_attr_and_state(self):
+        """Test setting operation mode without required attribute.
+
+        Also check the state.
+        """
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("off", state.attributes.get('operation_mode'))
+        self.assertEqual("off", state.state)
+        climate.set_operation_mode(self.hass, None, ENTITY_CLIMATE)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("off", state.attributes.get('operation_mode'))
+        self.assertEqual("off", state.state)
+
+    def test_set_operation(self):
+        """Test setting of new operation mode."""
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("off", state.attributes.get('operation_mode'))
+        self.assertEqual("off", state.state)
+        climate.set_operation_mode(self.hass, "cool", ENTITY_CLIMATE)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("cool", state.attributes.get('operation_mode'))
+        self.assertEqual("cool", state.state)
+        self.assertEqual(('mode-topic', 'cool', 0, False),
+                         self.mock_publish.mock_calls[-2][1])

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -7,20 +7,17 @@ from homeassistant.util.unit_system import (
 )
 from homeassistant.setup import setup_component
 from homeassistant.components import climate
-from homeassistant.const import (STATE_OFF, ATTR_UNIT_OF_MEASUREMENT,
-                                 TEMP_CELSIUS)
+from homeassistant.const import STATE_OFF
 
 from tests.common import (get_test_home_assistant, mock_mqtt_component,
                           fire_mqtt_message, mock_component)
 
 ENTITY_CLIMATE = 'climate.test'
-ENT_SENSOR = 'sensor.test'
 
 DEFAULT_CONFIG = {
     'climate': {
         'platform': 'mqtt',
         'name': 'test',
-        'target_sensor': ENT_SENSOR,
         'mode_command_topic': 'mode-topic',
         'temperature_command_topic': 'temperature-topic',
         'fan_mode_command_topic': 'fan-mode-topic',
@@ -264,28 +261,10 @@ class TestMQTTClimate(unittest.TestCase):
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual(1701, state.attributes.get('temperature'))
 
-    def test_sensor_changed(self):
-        """Test getting the temperature from a changing sensor."""
-        self.hass.states.set(ENT_SENSOR, 0,
-                             {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
-        self.hass.block_till_done()
-
-        assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
-
-        state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual(0, state.attributes.get('current_temperature'))
-
-        self.hass.states.set(ENT_SENSOR, 42,
-                             {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual(42, state.attributes.get('current_temperature'))
-
     def test_receive_mqtt_temperature(self):
         """Test getting the current temperature via MQTT."""
         config = copy.deepcopy(DEFAULT_CONFIG)
         config['climate']['current_temperature_topic'] = 'current_temperature'
-        del config['climate']['target_sensor']
         mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, climate.DOMAIN, config)
 

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -1,5 +1,6 @@
 """The tests for the mqtt climate component."""
 import unittest
+import copy
 
 from homeassistant.util.unit_system import (
     METRIC_SYSTEM
@@ -177,8 +178,9 @@ class TestMQTTClimate(unittest.TestCase):
 
     def test_receive_mqtt_temperature(self):
         """Test getting the current temperature via MQTT."""
-        config = dict(DEFAULT_CONFIG)
+        config = copy.deepcopy(DEFAULT_CONFIG)
         config['climate']['current_temperature_topic'] = 'current_temperature'
+        del config['climate']['target_sensor']
         mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, climate.DOMAIN, config)
 

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -6,33 +6,35 @@ from homeassistant.util.unit_system import (
 )
 from homeassistant.setup import setup_component
 from homeassistant.components import climate
-from homeassistant.const import (STATE_OFF, ATTR_TEMPERATURE,
-    ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
+from homeassistant.const import (STATE_OFF, ATTR_UNIT_OF_MEASUREMENT,
+                                 TEMP_CELSIUS)
 
-from tests.common import (get_test_home_assistant, mock_mqtt_component)
+from tests.common import (get_test_home_assistant, mock_mqtt_component,
+                          fire_mqtt_message, mock_component)
 
 ENTITY_CLIMATE = 'climate.test'
 ENT_SENSOR = 'sensor.test'
 
+DEFAULT_CONFIG = {
+    'climate': {
+        'platform': 'mqtt',
+        'name': 'test',
+        'target_sensor': ENT_SENSOR,
+        'mode_command_topic': 'mode-topic',
+        'temperature_command_topic': 'temperature-topic',
+        'fan_mode_command_topic': 'fan-mode-topic',
+        'swing_mode_command_topic': 'swing-mode-topic',
+    }}
 
-class BaseMQTT(unittest.TestCase):
-    """Base climate hvac test."""
+
+class TestMQTTClimate(unittest.TestCase):
+    """Test the mqtt climate hvac."""
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
         self.hass.config.units = METRIC_SYSTEM
-        self.assertTrue(setup_component(self.hass, climate.DOMAIN, {
-            'climate': {
-                'platform': 'mqtt',
-                'name': 'test',
-                'target_sensor': ENT_SENSOR,
-                'mode_command_topic': 'mode-topic',
-                'temperature_command_topic': 'temperature-topic',
-                'fan_mode_command_topic': 'fan-mode-topic',
-                'swing_mode_command_topic': 'swing-mode-topic',
-            }}))
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop down everything that was started."""
@@ -40,23 +42,23 @@ class BaseMQTT(unittest.TestCase):
 
     def test_setup_params(self):
         """Test the initial parameters."""
+        assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
+
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual(21, state.attributes.get('temperature'))
         self.assertEqual("low", state.attributes.get('fan_mode'))
         self.assertEqual("off", state.attributes.get('swing_mode'))
         self.assertEqual("off", state.attributes.get('operation_mode'))
 
-
-class TestMQTTClimate(BaseMQTT):
-    """Test the mqtt climate hvac."""
-
     def test_get_operation_modes(self):
         """Test that the operation list returns the correct modes."""
+        assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
+
         state = self.hass.states.get(ENTITY_CLIMATE)
         modes = state.attributes.get('operation_list')
         self.assertEqual([
-          climate.STATE_AUTO, STATE_OFF, climate.STATE_COOL,
-          climate.STATE_HEAT, climate.STATE_DRY, climate.STATE_FAN_ONLY
+            climate.STATE_AUTO, STATE_OFF, climate.STATE_COOL,
+            climate.STATE_HEAT, climate.STATE_DRY, climate.STATE_FAN_ONLY
         ], modes)
 
     def test_set_operation_bad_attr_and_state(self):
@@ -64,6 +66,8 @@ class TestMQTTClimate(BaseMQTT):
 
         Also check the state.
         """
+        assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
+
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual("off", state.attributes.get('operation_mode'))
         self.assertEqual("off", state.state)
@@ -75,6 +79,8 @@ class TestMQTTClimate(BaseMQTT):
 
     def test_set_operation(self):
         """Test setting of new operation mode."""
+        assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
+
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual("off", state.attributes.get('operation_mode'))
         self.assertEqual("off", state.state)
@@ -88,6 +94,8 @@ class TestMQTTClimate(BaseMQTT):
 
     def test_set_fan_mode_bad_attr(self):
         """Test setting fan mode without required attribute."""
+        assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
+
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual("low", state.attributes.get('fan_mode'))
         climate.set_fan_mode(self.hass, None, ENTITY_CLIMATE)
@@ -97,6 +105,8 @@ class TestMQTTClimate(BaseMQTT):
 
     def test_set_fan_mode(self):
         """Test setting of new fan mode."""
+        assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
+
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual("low", state.attributes.get('fan_mode'))
         climate.set_fan_mode(self.hass, 'high', ENTITY_CLIMATE)
@@ -108,6 +118,8 @@ class TestMQTTClimate(BaseMQTT):
 
     def test_set_swing_mode_bad_attr(self):
         """Test setting swing mode without required attribute."""
+        assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
+
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual("off", state.attributes.get('swing_mode'))
         climate.set_swing_mode(self.hass, None, ENTITY_CLIMATE)
@@ -117,6 +129,8 @@ class TestMQTTClimate(BaseMQTT):
 
     def test_set_swing(self):
         """Test setting of new swing mode."""
+        assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
+
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual("off", state.attributes.get('swing_mode'))
         climate.set_swing_mode(self.hass, 'on', ENTITY_CLIMATE)
@@ -128,13 +142,16 @@ class TestMQTTClimate(BaseMQTT):
 
     def test_set_target_temperature(self):
         """Test setting the target temperature."""
+        assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
+
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual(21, state.attributes.get('temperature'))
         climate.set_operation_mode(self.hass, 'heat', ENTITY_CLIMATE)
         self.hass.block_till_done()
         self.assertEqual(('mode-topic', 'heat', 0, False),
                          self.mock_publish.mock_calls[-2][1])
-        climate.set_temperature(self.hass, temperature=47, entity_id=ENTITY_CLIMATE)
+        climate.set_temperature(self.hass, temperature=47,
+                                entity_id=ENTITY_CLIMATE)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual(47, state.attributes.get('temperature'))
@@ -143,8 +160,29 @@ class TestMQTTClimate(BaseMQTT):
 
     def test_sensor_changed(self):
         """Test getting the temperature from a changing sensor."""
+        self.hass.states.set(ENT_SENSOR, 0,
+                             {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
+        self.hass.block_till_done()
+
+        assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
+
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual(0, state.attributes.get('current_temperature'))
+
         self.hass.states.set(ENT_SENSOR, 42,
                              {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual(42, state.attributes.get('current_temperature'))
+
+    def test_receive_mqtt_temperature(self):
+        """Test getting the current temperature via MQTT."""
+        config = dict(DEFAULT_CONFIG)
+        config['climate']['current_temperature_topic'] = 'current_temperature'
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, climate.DOMAIN, config)
+
+        fire_mqtt_message(self.hass, 'current_temperature', '47')
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual(47, state.attributes.get('current_temperature'))

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -301,12 +301,12 @@ class TestMQTTClimate(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, config)
 
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual(None, state.attributes.get('away_mode'))
+        self.assertEqual('off', state.attributes.get('away_mode'))
 
         climate.set_away_mode(self.hass, True, ENTITY_CLIMATE)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual(None, state.attributes.get('away_mode'))
+        self.assertEqual('off', state.attributes.get('away_mode'))
 
         fire_mqtt_message(self.hass, 'away-state', 'ON')
         self.hass.block_till_done()
@@ -332,7 +332,7 @@ class TestMQTTClimate(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, config)
 
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual(None, state.attributes.get('away_mode'))
+        self.assertEqual('off', state.attributes.get('away_mode'))
         climate.set_away_mode(self.hass, True, ENTITY_CLIMATE)
         self.hass.block_till_done()
         self.assertEqual(('away-mode-topic', 'AN', 0, False),
@@ -398,12 +398,12 @@ class TestMQTTClimate(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, config)
 
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual(None, state.attributes.get('aux_heat'))
+        self.assertEqual('off', state.attributes.get('aux_heat'))
 
         climate.set_aux_heat(self.hass, True, ENTITY_CLIMATE)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual(None, state.attributes.get('aux_heat'))
+        self.assertEqual('off', state.attributes.get('aux_heat'))
 
         fire_mqtt_message(self.hass, 'aux-state', 'ON')
         self.hass.block_till_done()
@@ -425,7 +425,7 @@ class TestMQTTClimate(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
 
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual(None, state.attributes.get('aux_heat'))
+        self.assertEqual('off', state.attributes.get('aux_heat'))
         climate.set_aux_heat(self.hass, True, ENTITY_CLIMATE)
         self.hass.block_till_done()
         self.assertEqual(('aux-topic', 'ON', 0, False),


### PR DESCRIPTION
## Description:
***First of all***: This is based on PR #8750 by @clkao who agreed that I finish this. I mainly added further tests, fixed some bugs and added a way of receiving the current temperature via MQTT. This PR description is also mainly copied from there.

The `mqtt` climate platform let you control your MQTT enabled HVAC devices.

The platform currently works in optimistic mode, which means it does not obtain states from MQTT topics, but it sends and remembers control commands.

It uses a sensor or a MQTT topic to obtain the current temperature.

**Related issue (if applicable):** replaces #8750 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3448

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: mqtt
    name: Study
    target_sensor: sensor.study_temperature
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.