### PR TITLE
Add hysteresis attribute to threshold binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/threshold.py
+++ b/homeassistant/components/binary_sensor/threshold.py
@@ -59,7 +59,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     async_add_devices([ThresholdSensor(
         hass, entity_id, name, threshold,
         hysteresis, limit_type, device_class)
-    ], True)
+                      ], True)
 
     return True
 

--- a/homeassistant/components/binary_sensor/threshold.py
+++ b/homeassistant/components/binary_sensor/threshold.py
@@ -31,6 +31,7 @@ CONF_THRESHOLD = 'threshold'
 CONF_UPPER = 'upper'
 
 DEFAULT_NAME = 'Threshold'
+DEFAULT_HYSTERESIS = 0.0
 
 SENSOR_TYPES = [CONF_LOWER, CONF_UPPER]
 
@@ -38,7 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Required(CONF_THRESHOLD): vol.Coerce(float),
     vol.Required(CONF_TYPE): vol.In(SENSOR_TYPES),
-    vol.Optional(CONF_HYSTERESIS, default=0.0): vol.Coerce(float),
+    vol.Optional(CONF_HYSTERESIS, default=DEFAULT_HYSTERESIS): vol.Coerce(float),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
 })

--- a/homeassistant/components/binary_sensor/threshold.py
+++ b/homeassistant/components/binary_sensor/threshold.py
@@ -39,7 +39,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Required(CONF_THRESHOLD): vol.Coerce(float),
     vol.Required(CONF_TYPE): vol.In(SENSOR_TYPES),
-    vol.Optional(CONF_HYSTERESIS, default=DEFAULT_HYSTERESIS): vol.Coerce(float),
+    vol.Optional(
+        CONF_HYSTERESIS, default=DEFAULT_HYSTERESIS): vol.Coerce(float),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
 })
@@ -55,17 +56,19 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     limit_type = config.get(CONF_TYPE)
     device_class = config.get(CONF_DEVICE_CLASS)
 
-    async_add_devices(
-        [ThresholdSensor(hass, entity_id, name, threshold, hysteresis, limit_type,
-                         device_class)], True)
+    async_add_devices([ThresholdSensor(
+        hass, entity_id, name, threshold,
+        hysteresis, limit_type, device_class)
+    ], True)
+
     return True
 
 
 class ThresholdSensor(BinarySensorDevice):
     """Representation of a Threshold sensor."""
 
-    def __init__(self, hass, entity_id, name, threshold, hysteresis, limit_type,
-                 device_class):
+    def __init__(self, hass, entity_id, name, threshold,
+                 hysteresis, limit_type, device_class):
         """Initialize the Threshold sensor."""
         self._hass = hass
         self._entity_id = entity_id
@@ -129,12 +132,15 @@ class ThresholdSensor(BinarySensorDevice):
     @asyncio.coroutine
     def async_update(self):
         """Get the latest data and updates the states."""
+        # Change the sensor state if we have exceeded the set point or dropped
+        # below the reset point.
 
-        # Change the sensor state if we have exceeded the set point or dropped below the reset point.
-        # By using is_upper for the state we automatically handle both upper and lower threshold types.
-        
-        # If the sensor is configured with no hysteresis and the sensor value is equal to the threshold,
-        # we explicitly turn the sensor off since it is not 'lower' or 'upper' w.r.t. the threshold
+        # By using is_upper for the state we automatically handle both upper
+        # and lower threshold types.
+
+        # If the sensor is configured with no hysteresis and the sensor value
+        # is equal to the threshold, we explicitly turn the sensor off since it
+        # is not 'lower' or 'upper' w.r.t. the threshold
 
         if self._hysteresis == 0 and self.sensor_value == self._threshold:
             self._state = False

--- a/homeassistant/components/binary_sensor/threshold.py
+++ b/homeassistant/components/binary_sensor/threshold.py
@@ -73,7 +73,7 @@ class ThresholdSensor(BinarySensorDevice):
         self._threshold = threshold
         self._hysteresis = hysteresis
         self._device_class = device_class
-        self._deviation = False
+        self._state = False
         self.sensor_value = 0
 
         @callback
@@ -102,7 +102,7 @@ class ThresholdSensor(BinarySensorDevice):
     @property
     def is_on(self):
         """Return true if sensor is on."""
-        return self._deviation
+        return self._state
 
     @property
     def should_poll(self):
@@ -136,8 +136,8 @@ class ThresholdSensor(BinarySensorDevice):
         # we explicitly turn the sensor off since it is not 'lower' or 'upper' w.r.t. the threshold
 
         if self._hysteresis == 0 and self.sensor_value == self._threshold:
-            self._deviation = False
+            self._state = False
         elif self.sensor_value > (self._threshold + self._hysteresis):
-            self._deviation = self.is_upper
+            self._state = self.is_upper
         elif self.sensor_value < (self._threshold - self._hysteresis):
-            self._deviation = not self.is_upper
+            self._state = not self.is_upper

--- a/homeassistant/components/binary_sensor/threshold.py
+++ b/homeassistant/components/binary_sensor/threshold.py
@@ -132,16 +132,6 @@ class ThresholdSensor(BinarySensorDevice):
     @asyncio.coroutine
     def async_update(self):
         """Get the latest data and updates the states."""
-        # Change the sensor state if we have exceeded the set point or dropped
-        # below the reset point.
-
-        # By using is_upper for the state we automatically handle both upper
-        # and lower threshold types.
-
-        # If the sensor is configured with no hysteresis and the sensor value
-        # is equal to the threshold, we explicitly turn the sensor off since it
-        # is not 'lower' or 'upper' w.r.t. the threshold
-
         if self._hysteresis == 0 and self.sensor_value == self._threshold:
             self._state = False
         elif self.sensor_value > (self._threshold + self._hysteresis):

--- a/tests/components/binary_sensor/test_threshold.py
+++ b/tests/components/binary_sensor/test_threshold.py
@@ -96,3 +96,53 @@ class TestThresholdSensor(unittest.TestCase):
         state = self.hass.states.get('binary_sensor.test_threshold')
 
         assert state.state == 'off'
+
+    def test_sensor_hysteresis(self):
+        """Test if source is above threshold using hysteresis."""
+        config = {
+            'binary_sensor': {
+                'platform': 'threshold',
+                'threshold': '15',
+                'hysteresis': '2.5',
+                'name': 'Test_threshold',
+                'type': 'upper',
+                'entity_id': 'sensor.test_monitored',
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.states.set('sensor.test_monitored', 20)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_threshold')
+
+        assert state.state == 'on'
+
+        self.hass.states.set('sensor.test_monitored', 13)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_threshold')
+
+        assert state.state == 'on'
+
+        self.hass.states.set('sensor.test_monitored', 12)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_threshold')
+
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', 17)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_threshold')
+
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', 18)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_threshold')
+
+        assert state.state == 'on'


### PR DESCRIPTION
## Description:
Adds a hysteresis attribute to the threshold binary sensor.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3449

## Example entry for `configuration.yaml` (if applicable):
An example config entry has been added in the updated documentation

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
