### PR TITLE
Cleanup entity & remove warning

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -198,7 +198,7 @@ class Entity(object):
         # update entity data
         if force_refresh:
             if self._update_warn:
-                # Update is already in progress. Protect overtasks our core
+                # Update is already in progress.
                 return
 
             self._update_warn = self.hass.loop.call_later(

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -180,15 +180,6 @@ class Entity(object):
     # are used to perform a very specific function. Overwriting these may
     # produce undesirable effects in the entity's operation.
 
-    def update_ha_state(self, force_refresh=False):
-        """Update Home Assistant with current state of entity.
-
-        If force_refresh == True will update entity before setting state.
-        """
-        _LOGGER.warning("'update_ha_state' is deprecated. "
-                        "Use 'schedule_update_ha_state' instead.")
-        self.schedule_update_ha_state(force_refresh)
-
     @asyncio.coroutine
     def async_update_ha_state(self, force_refresh=False):
         """Update Home Assistant with current state of entity.
@@ -207,8 +198,7 @@ class Entity(object):
         # update entity data
         if force_refresh:
             if self._update_warn:
-                _LOGGER.warning("Update for %s is already in progress",
-                                self.entity_id)
+                # Update is already in progress. Protect overtasks our core
                 return
 
             self._update_warn = self.hass.loop.call_later(


### PR DESCRIPTION
## Description:

I remove old code. I think after 8 month we do not need it anymore. And I remove the warning while he is not needed. We make a update like the caller want do. It dosn't matter if they will be done with a other task, the result will be the same.

Fix for #9581

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
