### PR TITLE
Change TP-Link Switch power statistics attribute names

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -18,11 +18,11 @@ REQUIREMENTS = ['pyHS100==0.2.4.2']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_CURRENT_CONSUMPTION = 'Current consumption'
-ATTR_TOTAL_CONSUMPTION = 'Total consumption'
-ATTR_DAILY_CONSUMPTION = 'Daily consumption'
-ATTR_VOLTAGE = 'Voltage'
-ATTR_CURRENT = 'Current'
+ATTR_CURRENT_CONSUMPTION = 'current_consumption'
+ATTR_TOTAL_CONSUMPTION = 'total_consumption'
+ATTR_DAILY_CONSUMPTION = 'daily_consumption'
+ATTR_VOLTAGE = 'voltage'
+ATTR_CURRENT = 'current'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,


### PR DESCRIPTION
## Description:
Currently the names for power usage/statistics attributes on TP-Link HS110 use spaces instead of underscores and have unnecessary capitalization. This updates them to use underscores and brings them more inline with the attribute names used on the D-Link, FRITZ!DECT, and other switches.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
