### PR TITLE
Migrate Alexa smart home to registry

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -6,7 +6,9 @@ from uuid import uuid4
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF)
 from homeassistant.components import switch, light
+from homeassistant.util.decorator import Registry
 
+HANDLERS = Registry()
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_HEADER = 'header'
@@ -27,27 +29,13 @@ MAPPING_COMPONENT = {
 }
 
 
-def mapping_api_function(name):
-    """Return function pointer to api function for name.
-
-    Async friendly.
-    """
-    mapping = {
-        'DiscoverAppliancesRequest': async_api_discovery,
-        'TurnOnRequest': async_api_turn_on,
-        'TurnOffRequest': async_api_turn_off,
-        'SetPercentageRequest': async_api_set_percentage,
-    }
-    return mapping.get(name, None)
-
-
 @asyncio.coroutine
 def async_handle_message(hass, message):
     """Handle incoming API messages."""
     assert int(message[ATTR_HEADER][ATTR_PAYLOAD_VERSION]) == 2
 
     # Do we support this API request?
-    funct_ref = mapping_api_function(message[ATTR_HEADER][ATTR_NAME])
+    funct_ref = HANDLERS.get(message[ATTR_HEADER][ATTR_NAME])
     if not funct_ref:
         _LOGGER.warning(
             "Unsupported API request %s", message[ATTR_HEADER][ATTR_NAME])
@@ -64,7 +52,7 @@ def api_message(name, namespace, payload=None):
     payload = payload or {}
     return {
         ATTR_HEADER: {
-            ATTR_MESSAGE_ID: uuid4(),
+            ATTR_MESSAGE_ID: str(uuid4()),
             ATTR_NAME: name,
             ATTR_NAMESPACE: namespace,
             ATTR_PAYLOAD_VERSION: '2',
@@ -81,6 +69,7 @@ def api_error(request, exc='DriverInternalError'):
     return api_message(exc, request[ATTR_HEADER][ATTR_NAMESPACE])
 
 
+@HANDLERS.register('DiscoverAppliancesRequest')
 @asyncio.coroutine
 def async_api_discovery(hass, request):
     """Create a API formatted discovery response.
@@ -146,6 +135,7 @@ def extract_entity(funct):
     return async_api_entity_wrapper
 
 
+@HANDLERS.register('TurnOnRequest')
 @extract_entity
 @asyncio.coroutine
 def async_api_turn_on(hass, request, entity):
@@ -157,6 +147,7 @@ def async_api_turn_on(hass, request, entity):
     return api_message('TurnOnConfirmation', 'Alexa.ConnectedHome.Control')
 
 
+@HANDLERS.register('TurnOffRequest')
 @extract_entity
 @asyncio.coroutine
 def async_api_turn_off(hass, request, entity):
@@ -168,6 +159,7 @@ def async_api_turn_off(hass, request, entity):
     return api_message('TurnOffConfirmation', 'Alexa.ConnectedHome.Control')
 
 
+@HANDLERS.register('SetPercentageRequest')
 @extract_entity
 @asyncio.coroutine
 def async_api_set_percentage(hass, request, entity):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -19,19 +19,6 @@ def test_create_api_message():
     assert msg['payload'] == {}
 
 
-def test_mapping_api_funct():
-    """Test function ref from mapping function."""
-    assert smart_home.mapping_api_function('notExists') is None
-    assert smart_home.mapping_api_function('DiscoverAppliancesRequest') == \
-        smart_home.async_api_discovery
-    assert smart_home.mapping_api_function('TurnOnRequest') == \
-        smart_home.async_api_turn_on
-    assert smart_home.mapping_api_function('TurnOffRequest') == \
-        smart_home.async_api_turn_off
-    assert smart_home.mapping_api_function('SetPercentageRequest') == \
-        smart_home.async_api_set_percentage
-
-
 @asyncio.coroutine
 def test_wrong_version(hass):
     """Test with wrong version."""


### PR DESCRIPTION
## Description:
Migrate Alexa Smart Home skill to use the new registry decorator.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
