### PR TITLE
Move 'voltage' to const

### DIFF
--- a/homeassistant/components/sensor/pvoutput.py
+++ b/homeassistant/components/sensor/pvoutput.py
@@ -15,7 +15,8 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.components.sensor.rest import RestData
 from homeassistant.const import (
-    ATTR_TEMPERATURE, CONF_API_KEY, CONF_NAME, ATTR_DATE, ATTR_TIME)
+    ATTR_TEMPERATURE, CONF_API_KEY, CONF_NAME, ATTR_DATE, ATTR_TIME,
+    ATTR_VOLTAGE)
 
 _LOGGER = logging.getLogger(__name__)
 _ENDPOINT = 'http://pvoutput.org/service/r2/getstatus.jsp'
@@ -25,7 +26,6 @@ ATTR_POWER_GENERATION = 'power_generation'
 ATTR_ENERGY_CONSUMPTION = 'energy_consumption'
 ATTR_POWER_CONSUMPTION = 'power_consumption'
 ATTR_EFFICIENCY = 'efficiency'
-ATTR_VOLTAGE = 'voltage'
 
 CONF_SYSTEM_ID = 'system_id'
 

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -11,7 +11,7 @@ import time
 import voluptuous as vol
 
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_HOST, CONF_NAME)
+from homeassistant.const import (CONF_HOST, CONF_NAME, ATTR_VOLTAGE)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pyHS100==0.2.4.2']
@@ -21,7 +21,6 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_CURRENT_CONSUMPTION = 'current_consumption'
 ATTR_TOTAL_CONSUMPTION = 'total_consumption'
 ATTR_DAILY_CONSUMPTION = 'daily_consumption'
-ATTR_VOLTAGE = 'voltage'
 ATTR_CURRENT = 'current'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -246,6 +246,9 @@ ATTR_UNIT_OF_MEASUREMENT = 'unit_of_measurement'
 CONF_UNIT_SYSTEM_METRIC = 'metric'  # type: str
 CONF_UNIT_SYSTEM_IMPERIAL = 'imperial'  # type: str
 
+# Electrical attributes
+ATTR_VOLTAGE = 'voltage'
+
 # Temperature attribute
 ATTR_TEMPERATURE = 'temperature'
 TEMP_CELSIUS = '°C'


### PR DESCRIPTION
## Description:
#9607 changed attributes which make it possible to move it to `const.py`.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
