### PR TITLE
splunk: Handle datetime objects in event payload

### DIFF
--- a/homeassistant/components/splunk.py
+++ b/homeassistant/components/splunk.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_NAME, CONF_HOST, CONF_PORT, CONF_SSL, CONF_TOKEN, EVENT_STATE_CHANGED)
 from homeassistant.helpers import state as state_helper
 import homeassistant.helpers.config_validation as cv
+from homeassistant.remote import JSONEncoder
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,7 +82,8 @@ def setup(hass, config):
                 "host": event_collector,
                 "event": json_body,
             }
-            requests.post(event_collector, data=json.dumps(payload),
+            requests.post(event_collector,
+                          data=json.dumps(payload, cls=JSONEncoder),
                           headers=headers, timeout=10)
         except requests.exceptions.RequestException as error:
             _LOGGER.exception("Error saving event to Splunk: %s", error)


### PR DESCRIPTION
If an event contained a datetime.datetime object it would cause an
exception in the Splunk component. Most of the media_player
components do this in their `media_position_updated_at` attribute.

Use the JSONEncoder from homeassistant.remote instead of just using the
standard json.dumps encoder.

## Description:

**Related issue (if applicable):** fixes #9590 

```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
