### PR TITLE
wunderground: fix supported language codes #9631

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -607,10 +607,10 @@ LANG_CODES = [
     'KR', 'KU', 'LA', 'LV', 'LT', 'ND',
     'MK', 'MT', 'GM', 'MI', 'MR', 'MN',
     'NO', 'OC', 'PS', 'GN', 'PL', 'BR',
-    'PA', 'PU', 'RO', 'RU', 'SR', 'SK',
-    'SL', 'SP', 'SI', 'SW', 'CH', 'TL',
-    'TT', 'TH', 'UA', 'UZ', 'VU', 'CY',
-    'SN', 'JI', 'YI',
+    'PA', 'RO', 'RU', 'SR', 'SK', 'SL',
+    'SP', 'SI', 'SW', 'CH', 'TL', 'TT',
+    'TH', 'TR', 'TK', 'UA', 'UZ', 'VU',
+    'CY', 'SN', 'JI', 'YI',
 ]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
* wunderground: removed PU, added TR language code (https://www.wunderground.com/weather/api/d/docs?d=language-support&MR=1), fixes #9631

## Description:

**Related issue (if applicable):** fixes #9631

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation: checked, update in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) not needed

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
