### PR TITLE
Fixes broken source links in API docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -117,7 +117,6 @@ def linkcode_resolve(domain, info):
         linespec = "#L%d" % (lineno + 1)
     else:
         linespec = ""
-    
     index = fn.find("/homeassistant/")
     if index == -1:
         index = 0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -117,7 +117,12 @@ def linkcode_resolve(domain, info):
         linespec = "#L%d" % (lineno + 1)
     else:
         linespec = ""
-    fn = relpath(fn, start='../')
+    
+    index = fn.find("/homeassistant/")
+    if index == -1:
+        index = 0
+
+    fn = fn[index:]
 
     return '{}/blob/{}/{}{}'.format(GITHUB_URL, code_branch, fn, linespec)
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** fixes #9255 

An alternative solution to that proposed in #9635. I'm just parsing the file's
path to find `homeassistant` and working from there, which should work
both when the package is installed and when it's just the local repo being
used

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
