### PR TITLE
raspihats: unmet dependency fix

### DIFF
--- a/homeassistant/components/raspihats.py
+++ b/homeassistant/components/raspihats.py
@@ -12,7 +12,8 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 )
 
-REQUIREMENTS = ['raspihats==2.2.1']
+REQUIREMENTS = ['raspihats==2.2.3'
+                'smbus-cffi==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/raspihats.py
+++ b/homeassistant/components/raspihats.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 )
 
-REQUIREMENTS = ['raspihats==2.2.3'
+REQUIREMENTS = ['raspihats==2.2.3',
                 'smbus-cffi==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -865,7 +865,7 @@ radiotherm==1.3
 raincloudy==0.0.1
 
 # homeassistant.components.raspihats
-# raspihats==2.2.1
+# raspihats==2.2.3
 
 # homeassistant.components.switch.rainmachine
 regenmaschine==0.4.1
@@ -934,6 +934,7 @@ sleekxmpp==1.3.2
 # homeassistant.components.sleepiq
 sleepyq==0.6
 
+# homeassistant.components.raspihats
 # homeassistant.components.sensor.bh1750
 # homeassistant.components.sensor.bme280
 # homeassistant.components.sensor.envirophat

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -865,7 +865,7 @@ radiotherm==1.3
 raincloudy==0.0.1
 
 # homeassistant.components.raspihats
-raspihats==2.2.3
+# raspihats==2.2.3smbus-cffi==0.5.1
 
 # homeassistant.components.switch.rainmachine
 regenmaschine==0.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -865,7 +865,7 @@ radiotherm==1.3
 raincloudy==0.0.1
 
 # homeassistant.components.raspihats
-# raspihats==2.2.3
+raspihats==2.2.3
 
 # homeassistant.components.switch.rainmachine
 regenmaschine==0.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -934,7 +934,6 @@ sleekxmpp==1.3.2
 # homeassistant.components.sleepiq
 sleepyq==0.6
 
-# homeassistant.components.raspihats
 # homeassistant.components.sensor.bh1750
 # homeassistant.components.sensor.bme280
 # homeassistant.components.sensor.envirophat

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -865,7 +865,7 @@ radiotherm==1.3
 raincloudy==0.0.1
 
 # homeassistant.components.raspihats
-# raspihats==2.2.3smbus-cffi==0.5.1
+# raspihats==2.2.3
 
 # homeassistant.components.switch.rainmachine
 regenmaschine==0.4.1
@@ -934,6 +934,7 @@ sleekxmpp==1.3.2
 # homeassistant.components.sleepiq
 sleepyq==0.6
 
+# homeassistant.components.raspihats
 # homeassistant.components.sensor.bh1750
 # homeassistant.components.sensor.bme280
 # homeassistant.components.sensor.envirophat


### PR DESCRIPTION
Raspihats platform update, upstream fixed enum34 requirements, added smbus dependency

**Related issue (if applicable):** fixes #9547 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3483

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
