### PR TITLE
Facebook Messenger component: add support for sending messages to user IDs

### DIFF
--- a/homeassistant/components/notify/facebook.py
+++ b/homeassistant/components/notify/facebook.py
@@ -56,8 +56,15 @@ class FacebookNotificationService(BaseNotificationService):
             return
 
         for target in targets:
+            # If the target starts with a "+", we suppose it's a phone number,
+            # otherwise it's a user id.
+            if target.startswith('+'):
+                recipient = {"phone_number": target}
+            else:
+                recipient = {"id": target}
+
             body = {
-                "recipient": {"phone_number": target},
+                "recipient": recipient,
                 "message": body_message
             }
             import json


### PR DESCRIPTION
## Description:
This change allows the Facebook messenger notify component to send messages to users that do not have their phone number stored in their Facebook profile. Instead of a phone number, you can enter a page-specific user ID as the target.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** https://github.com/home-assistant/home-assistant.github.io/pull/3489

## Example entry for `automation.yaml` (this sends a message to both a phone number as well as a user id):
```yaml
- id: dryer_done
  alias: dryer_done
  trigger:
  - entity_id: sensor.dryer_state
    from: 'On'
    platform: state
    to: 'Off'
  action:
  - data:
      message: "The dryer is done"
      target:
      - '+123456789'
      - '123456789123456789'
    service: notify.facebook_messenger
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully.


