### PR TITLE
Upgrade netdisco to 1.2.2

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==1.2.0']
+REQUIREMENTS = ['netdisco==1.2.2']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -443,7 +443,7 @@ myusps==1.2.2
 nad_receiver==0.0.6
 
 # homeassistant.components.discovery
-netdisco==1.2.0
+netdisco==1.2.2
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1


### PR DESCRIPTION
## Description:
Upgrade netdisco to 1.2.2

## Example entry for `configuration.yaml` (if applicable):
```yaml
discovery:
```
Output:

```
2017-10-02 10:03:06 INFO (MainThread) [homeassistant.components.discovery] Found new service: ikea_tradfri {'host': '192.168.12.35', 'port': 5684, 'hostname': 'gw:b3-32-ba-21-a9-21.local.', 'properties': {'version': '1.1.0015'}}
```

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

