### PR TITLE
Add show_on_map config option to AirVisual

### DIFF
--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -13,9 +13,9 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    ATTR_ATTRIBUTION, CONF_API_KEY,
-    CONF_LATITUDE, CONF_LONGITUDE, CONF_MONITORED_CONDITIONS, CONF_STATE)
+from homeassistant.const import (ATTR_ATTRIBUTION, CONF_API_KEY, CONF_LATITUDE,
+                                 CONF_LONGITUDE, CONF_MONITORED_CONDITIONS,
+                                 CONF_STATE)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
@@ -301,8 +301,8 @@ class AirVisualData(object):
                 self._longitude, self._latitude = resp.get('location').get(
                     'coordinates')
             else:
-                resp = self._client.nearest_city(self.latitude, self.longitude,
-                                                 self._radius).get('data')
+                resp = self._client.nearest_city(
+                    self._latitude, self._longitude, self._radius).get('data')
             _LOGGER.debug('New data retrieved: %s', resp)
 
             self.city = resp.get('city')

--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_ATTRIBUTION, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_API_KEY,
+    ATTR_ATTRIBUTION, CONF_API_KEY,
     CONF_LATITUDE, CONF_LONGITUDE, CONF_MONITORED_CONDITIONS, CONF_STATE)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -183,8 +183,6 @@ class AirVisualBaseSensor(Entity):
             ATTR_CITY: self._data.city,
             ATTR_COUNTRY: self._data.country,
             ATTR_REGION: self._data.state,
-            ATTR_LATITUDE: self._data.latitude,
-            ATTR_LONGITUDE: self._data.longitude,
             ATTR_TIMESTAMP: self._data.pollution_info.get('ts')
         }
 
@@ -287,8 +285,8 @@ class AirVisualData(object):
         self.state = kwargs.get(CONF_STATE)
         self.country = kwargs.get(CONF_COUNTRY)
 
-        self.latitude = kwargs.get(CONF_LATITUDE)
-        self.longitude = kwargs.get(CONF_LONGITUDE)
+        self._latitude = kwargs.get(CONF_LATITUDE)
+        self._longitude = kwargs.get(CONF_LONGITUDE)
         self._radius = kwargs.get(CONF_RADIUS)
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
@@ -300,7 +298,7 @@ class AirVisualData(object):
             if self.city and self.state and self.country:
                 resp = self._client.city(self.city, self.state,
                                          self.country).get('data')
-                self.longitude, self.latitude = resp.get('location').get(
+                self._longitude, self._latitude = resp.get('location').get(
                     'coordinates')
             else:
                 resp = self._client.nearest_city(self.latitude, self.longitude,

--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -13,9 +13,9 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (ATTR_ATTRIBUTION, CONF_API_KEY, CONF_LATITUDE,
-                                 CONF_LONGITUDE, CONF_MONITORED_CONDITIONS,
-                                 CONF_STATE)
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_API_KEY,
+    CONF_LATITUDE, CONF_LONGITUDE, CONF_MONITORED_CONDITIONS, CONF_STATE)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
@@ -32,6 +32,7 @@ ATTR_TIMESTAMP = 'timestamp'
 CONF_CITY = 'city'
 CONF_COUNTRY = 'country'
 CONF_RADIUS = 'radius'
+CONF_SHOW_ON_MAP = 'show_on_map'
 
 MASS_PARTS_PER_MILLION = 'ppm'
 MASS_PARTS_PER_BILLION = 'ppb'
@@ -114,7 +115,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_STATE):
     cv.string,
     vol.Optional(CONF_COUNTRY):
-    cv.string
+    cv.string,
+    vol.Optional(CONF_SHOW_ON_MAP, default=True):
+    cv.boolean
 })
 
 
@@ -133,12 +136,17 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     city = config.get(CONF_CITY)
     state = config.get(CONF_STATE)
     country = config.get(CONF_COUNTRY)
+    show_on_map = config.get(CONF_SHOW_ON_MAP)
 
     if city and state and country:
         _LOGGER.debug('Using city, state, and country: %s, %s, %s', city,
                       state, country)
         data = AirVisualData(
-            pav.Client(api_key), city=city, state=state, country=country)
+            pav.Client(api_key),
+            city=city,
+            state=state,
+            country=country,
+            show_on_map=show_on_map)
     else:
         _LOGGER.debug('Using latitude and longitude: %s, %s', latitude,
                       longitude)
@@ -146,7 +154,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             pav.Client(api_key),
             latitude=latitude,
             longitude=longitude,
-            radius=radius)
+            radius=radius,
+            show_on_map=show_on_map)
 
     sensors = []
     for locale in monitored_locales:
@@ -178,13 +187,22 @@ class AirVisualBaseSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {
-            ATTR_ATTRIBUTION: 'AirVisual©',
+        attrs = {
+            ATTR_ATTRIBUTION: '©AirVisual',
             ATTR_CITY: self._data.city,
             ATTR_COUNTRY: self._data.country,
             ATTR_REGION: self._data.state,
             ATTR_TIMESTAMP: self._data.pollution_info.get('ts')
         }
+
+        if self._data.show_on_map:
+            attrs[ATTR_LATITUDE] = self._data.latitude
+            attrs[ATTR_LONGITUDE] = self._data.longitude
+        else:
+            attrs['lati'] = self._data.latitude
+            attrs['long'] = self._data.longitude
+
+        return attrs
 
     @property
     def icon(self):
@@ -285,9 +303,11 @@ class AirVisualData(object):
         self.state = kwargs.get(CONF_STATE)
         self.country = kwargs.get(CONF_COUNTRY)
 
-        self._latitude = kwargs.get(CONF_LATITUDE)
-        self._longitude = kwargs.get(CONF_LONGITUDE)
+        self.latitude = kwargs.get(CONF_LATITUDE)
+        self.longitude = kwargs.get(CONF_LONGITUDE)
         self._radius = kwargs.get(CONF_RADIUS)
+
+        self.show_on_map = kwargs.get(CONF_SHOW_ON_MAP)
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
@@ -298,16 +318,16 @@ class AirVisualData(object):
             if self.city and self.state and self.country:
                 resp = self._client.city(self.city, self.state,
                                          self.country).get('data')
-                self._longitude, self._latitude = resp.get('location').get(
-                    'coordinates')
             else:
-                resp = self._client.nearest_city(
-                    self._latitude, self._longitude, self._radius).get('data')
+                resp = self._client.nearest_city(self.latitude, self.longitude,
+                                                 self._radius).get('data')
             _LOGGER.debug('New data retrieved: %s', resp)
 
             self.city = resp.get('city')
             self.state = resp.get('state')
             self.country = resp.get('country')
+            self.longitude, self.latitude = resp.get('location').get(
+                'coordinates')
             self.pollution_info = resp.get('current', {}).get('pollution', {})
         except exceptions.HTTPError as exc_info:
             _LOGGER.error('Unable to retrieve data on this location: %s',


### PR DESCRIPTION
## Description:
This PR adds a new configuration option to AirVisual: `show_on_map`:

* When `true` (the default in order to preserve backwards compatibility), a marker is show on the map at the corresponding latitude/longitude.
* When `false`, the marker is not shown.

To accomplish this, the latitude/longitude attribute names change depending on the value of `show_on_map`:

* `true`: `latitude` and `longitude`
* `false`: `lati` (`lat` is swallowed up by HASS for some reason) and `long`

**Related issue (if applicable):** fixes #9591

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/3492

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: airvisual
    api_key: qePWFp2pHoP37txTx
    monitored_conditions:
      - us
      - cn
    show_on_map: false
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
