### PR TITLE
Bump abode to 0.11.9

### DIFF
--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -21,7 +21,7 @@ from homeassistant.const import (ATTR_ATTRIBUTION, ATTR_DATE, ATTR_TIME,
                                  EVENT_HOMEASSISTANT_STOP,
                                  EVENT_HOMEASSISTANT_START)
 
-REQUIREMENTS = ['abodepy==0.11.8']
+REQUIREMENTS = ['abodepy==0.11.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -45,7 +45,7 @@ SoCo==0.12
 TwitterAPI==2.4.6
 
 # homeassistant.components.abode
-abodepy==0.11.8
+abodepy==0.11.9
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.3


### PR DESCRIPTION
## Description:
- "Fixes" #9349 by changing the moisture sensor to a connectivity sensor.
- Cloud push notification SocketIO client will now reconnect automatically after 12 hours in an attempt to mitigate an issue that some are experiencing regarding updates not being received.

**Related issue (if applicable):** fixes #9349

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**