### PR TITLE
Fix: Last Played Media Title in plex would stay even when player was …

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -431,43 +431,38 @@ class PlexClient(MediaPlayerDevice):
                 self._convert_na_to_none(self._session.year) is not None):
             self._media_title += ' (' + str(self._session.year) + ')'
 
-        if self._is_player_active:
-            # TV Show
-            if self._media_content_type is MEDIA_TYPE_TVSHOW:
-                # season number (00)
-                if callable(self._convert_na_to_none(self._session.seasons)):
-                    self._media_season = self._convert_na_to_none(
-                        self._session.seasons()[0].index).zfill(2)
-                elif self._convert_na_to_none(
-                        self._session.parentIndex) is not None:
-                    self._media_season = self._session.parentIndex.zfill(2)
-                else:
-                    self._media_season = None
+        # TV Show
+        if self._media_content_type is MEDIA_TYPE_TVSHOW:
+            # season number (00)
+            if callable(self._convert_na_to_none(self._session.seasons)):
+                self._media_season = self._convert_na_to_none(
+                    self._session.seasons()[0].index).zfill(2)
+            elif self._convert_na_to_none(
+                    self._session.parentIndex) is not None:
+                self._media_season = self._session.parentIndex.zfill(2)
+            else:
+                self._media_season = None
+            # show name
+            self._media_series_title = self._convert_na_to_none(
+                self._session.grandparentTitle)
+            # episode number (00)
+            if self._convert_na_to_none(self._session.index) is not None:
+                self._media_episode = str(self._session.index).zfill(2)
 
-                # show name
-                self._media_series_title = self._convert_na_to_none(
-                    self._session.grandparentTitle)
-
-                # episode number (00)
-                if self._convert_na_to_none(
-                        self._session.index) is not None:
-                    self._media_episode = str(self._session.index).zfill(2)
-
-            # Music
-            if self._media_content_type == MEDIA_TYPE_MUSIC:
-                self._media_album_name = self._convert_na_to_none(
-                    self._session.parentTitle)
-                self._media_album_artist = self._convert_na_to_none(
-                    self._session.grandparentTitle)
-                self._media_track = self._convert_na_to_none(
-                    self._session.index)
-                self._media_artist = self._convert_na_to_none(
-                    self._session.originalTitle)
-                # use album artist if track artist is missing
-                if self._media_artist is None:
-                    _LOGGER.debug("Using album artist because track artist "
-                                  "was not found: %s", self.entity_id)
-                    self._media_artist = self._media_album_artist
+        # Music
+        if self._media_content_type == MEDIA_TYPE_MUSIC:
+            self._media_album_name = self._convert_na_to_none(
+                self._session.parentTitle)
+            self._media_album_artist = self._convert_na_to_none(
+                self._session.grandparentTitle)
+            self._media_track = self._convert_na_to_none(self._session.index)
+            self._media_artist = self._convert_na_to_none(
+                self._session.originalTitle)
+            # use album artist if track artist is missing
+            if self._media_artist is None:
+                _LOGGER.debug("Using album artist because track artist "
+                              "was not found: %s", self.entity_id)
+                self._media_artist = self._media_album_artist
 
         # set app name to library name
         if (self._session is not None

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -302,7 +302,7 @@ class PlexClient(MediaPlayerDevice):
         self.update_devices = update_devices
         self.update_sessions = update_sessions
 
-        self._clearMedia()
+        self._clear_media()
 
         self.refresh(device, session)
 
@@ -324,7 +324,7 @@ class PlexClient(MediaPlayerDevice):
                         'media_player', prefix,
                         self.name.lower().replace('-', '_'))
 
-    def _clearMedia(self):
+    def _clear_media(self):
         """Set all Media Items to None."""
         # General
         self._media_content_id = None
@@ -347,7 +347,7 @@ class PlexClient(MediaPlayerDevice):
     def refresh(self, device, session):
         """Refresh key device data."""
         # new data refresh
-        self._clearMedia()
+        self._clear_media()
 
         if session:  # Not being triggered by Chrome or FireTablet Plex App
             self._session = session
@@ -494,8 +494,6 @@ class PlexClient(MediaPlayerDevice):
                 thumb_url = self._get_thumbnail_url(self._session.art)
 
             self._media_image_url = thumb_url
-        else:
-            self._media_image_url = None
 
     def _get_thumbnail_url(self, property_value):
         """Return full URL (if exists) for a thumbnail property."""
@@ -514,6 +512,7 @@ class PlexClient(MediaPlayerDevice):
         """Force client to idle."""
         self._state = STATE_IDLE
         self._session = None
+        self._clear_media()
 
     @property
     def unique_id(self):

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -423,11 +423,11 @@ class PlexClient(MediaPlayerDevice):
             self._media_content_type = None
 
         # title (movie name, tv episode name, music song name)
-        if self._session:
-            if self._is_player_active:
-                self._media_title = self._convert_na_to_none(self._session.title)
-            else:
-                self._media_title = None
+        if self._session and self._is_player_active:
+            self._media_title = self._convert_na_to_none(self._session.title)
+
+        if self._session and not self._is_player_active:
+            self._media_title = None
 
         # Movies
         if (self.media_content_type == MEDIA_TYPE_VIDEO and

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -347,6 +347,7 @@ class PlexClient(MediaPlayerDevice):
         if device:
             self._device = device
             self._session = None
+            self._media_title = None
 
         if self._device:
             self._machine_identifier = self._convert_na_to_none(
@@ -423,7 +424,10 @@ class PlexClient(MediaPlayerDevice):
 
         # title (movie name, tv episode name, music song name)
         if self._session:
-            self._media_title = self._convert_na_to_none(self._session.title)
+            if self._is_player_active:
+                self._media_title = self._convert_na_to_none(self._session.title)
+            else:
+                self._media_title = None
 
         # Movies
         if (self.media_content_type == MEDIA_TYPE_VIDEO and

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -351,10 +351,8 @@ class PlexClient(MediaPlayerDevice):
 
         if session:  # Not being triggered by Chrome or FireTablet Plex App
             self._session = session
-            print("Session".format(session))
         if device:
             self._device = device
-            print("Device".format(device))
             self._session = None
 
         if self._device:


### PR DESCRIPTION
…idle/off

     Primary Fix is in the "if self._device" portion.
     code in "if self._session" is a catch all but i'm not 100% if it is needed.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
