### PR TITLE
Clicksend Audio TTS messages platform for notify

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -541,6 +541,7 @@ omit =
     homeassistant/components/sensor/tank_utility.py
     homeassistant/components/sensor/ted5000.py
     homeassistant/components/sensor/temper.py
+    homeassistant/components/sensor/tibber.py
     homeassistant/components/sensor/time_date.py
     homeassistant/components/sensor/torque.py
     homeassistant/components/sensor/transmission.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -402,6 +402,7 @@ omit =
     homeassistant/components/notify/aws_sqs.py
     homeassistant/components/notify/ciscospark.py
     homeassistant/components/notify/clicksend.py
+    homeassistant/components/notify/clicksendaudio.py
     homeassistant/components/notify/discord.py
     homeassistant/components/notify/facebook.py
     homeassistant/components/notify/free_mobile.py

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -25,6 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_REPORT_SERVER_CODES = 'report_server_codes'
 CONF_REPORT_SERVER_ENABLED = 'report_server_enabled'
 CONF_REPORT_SERVER_PORT = 'report_server_port'
+CONF_REPORT_SERVER_CODES_IGNORE = 'ignore'
 
 DEFAULT_NAME = 'Egardia'
 DEFAULT_PORT = 80
@@ -148,9 +149,15 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
 
     def parsestatus(self, status):
         """Parse the status."""
-        newstatus = ([v for k, v in STATES.items()
-                      if status.upper() == k][0])
-        self._status = newstatus
+        _LOGGER.debug("Parsing status %s", status)
+        # Ignore the statuscode if it is IGNORE
+        if status.lower().strip() != CONF_REPORT_SERVER_CODES_IGNORE:
+            _LOGGER.debug("Not ignoring status")
+            newstatus = ([v for k, v in STATES.items()
+                          if status.upper() == k][0])
+            self._status = newstatus
+        else:
+            _LOGGER.error("Ignoring status")
 
     def update(self):
         """Update the alarm status."""

--- a/homeassistant/components/demo.py
+++ b/homeassistant/components/demo.py
@@ -87,8 +87,8 @@ def async_setup(hass, config):
 
     # Set up input boolean
     tasks.append(bootstrap.async_setup_component(
-        hass, 'input_slider',
-        {'input_slider': {
+        hass, 'input_number',
+        {'input_number': {
             'noise_allowance': {'icon': 'mdi:bell-ring',
                                 'min': 0,
                                 'max': 10,
@@ -163,7 +163,7 @@ def async_setup(hass, config):
         'scene.romantic_lights']))
     tasks2.append(group.Group.async_create_group(hass, 'Bedroom', [
         lights[0], switches[1], media_players[0],
-        'input_slider.noise_allowance']))
+        'input_number.noise_allowance']))
     tasks2.append(group.Group.async_create_group(hass, 'Kitchen', [
         lights[2], 'cover.kitchen_window', 'lock.kitchen_door']))
     tasks2.append(group.Group.async_create_group(hass, 'Doors', [

--- a/homeassistant/components/google.py
+++ b/homeassistant/components/google.py
@@ -99,10 +99,10 @@ def do_authentication(hass, config):
     from oauth2client.file import Storage
 
     oauth = OAuth2WebServerFlow(
-        config[CONF_CLIENT_ID],
-        config[CONF_CLIENT_SECRET],
-        'https://www.googleapis.com/auth/calendar.readonly',
-        'Home-Assistant.io',
+        client_id=config[CONF_CLIENT_ID],
+        client_secret=config[CONF_CLIENT_SECRET],
+        scope='https://www.googleapis.com/auth/calendar.readonly',
+        redirect_uri='Home-Assistant.io',
     )
 
     try:

--- a/homeassistant/components/hassio.py
+++ b/homeassistant/components/hassio.py
@@ -14,9 +14,13 @@ from aiohttp import web
 from aiohttp.web_exceptions import HTTPBadGateway
 from aiohttp.hdrs import CONTENT_TYPE
 import async_timeout
+import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONTENT_TYPE_TEXT_PLAIN
-from homeassistant.components.http import HomeAssistantView, KEY_AUTHENTICATED
+from homeassistant.components.http import (
+    HomeAssistantView, KEY_AUTHENTICATED, CONF_API_PASSWORD, CONF_SERVER_PORT,
+    CONF_SSL_CERTIFICATE)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.components.frontend import register_built_in_panel
 
@@ -25,14 +29,40 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'hassio'
 DEPENDENCIES = ['http']
 
+SERVICE_ADDON_START = 'addon_start'
+SERVICE_ADDON_STOP = 'addon_stop'
+SERVICE_ADDON_RESTART = 'addon_restart'
+SERVICE_ADDON_STDIN = 'addon_stdin'
+
+ATTR_ADDON = 'addon'
+ATTR_INPUT = 'input'
+
 NO_TIMEOUT = {
-    re.compile(r'^homeassistant/update$'), re.compile(r'^host/update$'),
-    re.compile(r'^supervisor/update$'), re.compile(r'^addons/[^/]*/update$'),
-    re.compile(r'^addons/[^/]*/install$')
+    re.compile(r'^homeassistant/update$'),
+    re.compile(r'^host/update$'),
+    re.compile(r'^supervisor/update$'),
+    re.compile(r'^addons/[^/]*/update$'),
+    re.compile(r'^addons/[^/]*/install$'),
+    re.compile(r'^addons/[^/]*/rebuild$')
 }
 
 NO_AUTH = {
     re.compile(r'^panel$'), re.compile(r'^addons/[^/]*/logo$')
+}
+
+SCHEMA_ADDON = vol.Schema({
+    vol.Required(ATTR_ADDON): cv.slug,
+})
+
+SCHEMA_ADDON_STDIN = SCHEMA_ADDON.extend({
+    vol.Required(ATTR_INPUT): vol.Any(dict, cv.string)
+})
+
+MAP_SERVICE_API = {
+    SERVICE_ADDON_START: ('/addons/{addon}/start', SCHEMA_ADDON),
+    SERVICE_ADDON_STOP: ('/addons/{addon}/stop', SCHEMA_ADDON),
+    SERVICE_ADDON_RESTART: ('/addons/{addon}/restart', SCHEMA_ADDON),
+    SERVICE_ADDON_STDIN: ('/addons/{addon}/stdin', SCHEMA_ADDON_STDIN),
 }
 
 
@@ -48,8 +78,7 @@ def async_setup(hass, config):
     websession = async_get_clientsession(hass)
     hassio = HassIO(hass.loop, websession, host)
 
-    api_ok = yield from hassio.is_connected()
-    if not api_ok:
+    if not (yield from hassio.is_connected()):
         _LOGGER.error("Not connected with HassIO!")
         return False
 
@@ -58,6 +87,23 @@ def async_setup(hass, config):
     if 'frontend' in hass.config.components:
         register_built_in_panel(hass, 'hassio', 'Hass.io',
                                 'mdi:access-point-network')
+
+    if 'http' in config:
+        yield from hassio.update_hass_api(config.get('http'))
+
+    @asyncio.coroutine
+    def async_service_handler(service):
+        """Handle service calls for HassIO."""
+        api_command = MAP_SERVICE_API[service.service][0]
+        addon = service.data[ATTR_ADDON]
+        data = service.data[ATTR_INPUT] if ATTR_INPUT in service.data else None
+
+        yield from hassio.send_command(
+            api_command.format(addon=addon), payload=data, timeout=60)
+
+    for service, settings in MAP_SERVICE_API.items():
+        hass.services.async_register(
+            DOMAIN, service, async_service_handler, schema=settings[1])
 
     return True
 
@@ -71,30 +117,55 @@ class HassIO(object):
         self.websession = websession
         self._ip = ip
 
-    @asyncio.coroutine
     def is_connected(self):
         """Return True if it connected to HassIO supervisor.
+
+        This method return a coroutine.
+        """
+        return self.send_command("/supervisor/ping", method="get")
+
+    def update_hass_api(self, http_config):
+        """Update Home-Assistant API data on HassIO.
+
+        This method return a coroutine.
+        """
+        options = {
+            'ssl': CONF_SSL_CERTIFICATE in http_config,
+        }
+
+        if http_config.get(CONF_SERVER_PORT):
+            options['port'] = http_config[CONF_SERVER_PORT]
+
+        if http_config.get(CONF_API_PASSWORD):
+            options['password'] = http_config[CONF_API_PASSWORD]
+
+        return self.send_command("/homeassistant/options", payload=options)
+
+    @asyncio.coroutine
+    def send_command(self, command, method="post", payload=None, timeout=10):
+        """Send API command to HassIO.
 
         This method is a coroutine.
         """
         try:
-            with async_timeout.timeout(10, loop=self.loop):
-                request = yield from self.websession.get(
-                    "http://{}{}".format(self._ip, "/supervisor/ping")
-                )
+            with async_timeout.timeout(timeout, loop=self.loop):
+                request = yield from self.websession.request(
+                    method, "http://{}{}".format(self._ip, command),
+                    json=payload)
 
                 if request.status != 200:
-                    _LOGGER.error("Ping return code %d.", request.status)
+                    _LOGGER.error(
+                        "%s return code %d.", command, request.status)
                     return False
 
                 answer = yield from request.json()
                 return answer and answer['result'] == 'ok'
 
         except asyncio.TimeoutError:
-            _LOGGER.error("Timeout on ping request")
+            _LOGGER.error("Timeout on %s request", command)
 
         except aiohttp.ClientError as err:
-            _LOGGER.error("Client error on ping request %s", err)
+            _LOGGER.error("Client error on %s request %s", command, err)
 
         return False
 

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -283,9 +283,10 @@ class HistoryPeriodView(HomeAssistantView):
 
         end_time = request.query.get('end_time')
         if end_time:
-            end_time = dt_util.as_utc(
-                dt_util.parse_datetime(end_time))
-            if end_time is None:
+            end_time = dt_util.parse_datetime(end_time)
+            if end_time:
+                end_time = dt_util.as_utc(end_time)
+            else:
                 return self.json_message('Invalid end_time', HTTP_BAD_REQUEST)
         else:
             end_time = start_time + one_day

--- a/homeassistant/components/notify/clicksendaudio.py
+++ b/homeassistant/components/notify/clicksendaudio.py
@@ -1,0 +1,94 @@
+"""
+Clicksend audio platform for notify component.
+
+This platform sends text to speech audio messages through clicksend
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.clicksendaudio/
+"""
+import json
+import logging
+import requests
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    CONF_USERNAME, CONF_API_KEY, CONF_RECIPIENT, HTTP_HEADER_CONTENT_TYPE,
+    CONTENT_TYPE_JSON)
+from homeassistant.components.notify import (
+    PLATFORM_SCHEMA, BaseNotificationService)
+
+_LOGGER = logging.getLogger(__name__)
+
+BASE_API_URL = 'https://rest.clicksend.com/v3'
+
+HEADERS = {HTTP_HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON}
+
+CONF_LANGUAGE = 'language'
+CONF_VOICE = 'voice'
+
+DEFAULT_LANGUAGE = 'en-us'
+DEFAULT_VOICE = 'female'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_RECIPIENT): cv.string,
+    vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): cv.string,
+    vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): cv.string,
+})
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the ClickSend notification service."""
+    if _authenticate(config) is False:
+        _LOGGER.exception("You are not authorized to access ClickSend")
+        return None
+
+    return ClicksendNotificationService(config)
+
+
+class ClicksendNotificationService(BaseNotificationService):
+    """Implementation of a notification service for the ClickSend service."""
+
+    def __init__(self, config):
+        """Initialize the service."""
+        self.username = config.get(CONF_USERNAME)
+        self.api_key = config.get(CONF_API_KEY)
+        self.recipient = config.get(CONF_RECIPIENT)
+        self.language = config.get(CONF_LANGUAGE)
+        self.voice = config.get(CONF_VOICE)
+        _LOGGER.debug(self.voice)
+
+    def send_message(self, message="", **kwargs):
+        """Send a voice call to a user."""
+        _LOGGER.debug(message)
+        data = ({'messages': [{'source': 'hass.notify', 'from': self.recipient,
+                               'to': self.recipient, 'body': message,
+                               'lang': self.language, 'voice': self.voice}]})
+        api_url = "{}/voice/send".format(BASE_API_URL)
+        _LOGGER.debug(api_url)
+        resp = requests.post(api_url, data=json.dumps(data), headers=HEADERS,
+                             auth=(self.username, self.api_key), timeout=5)
+
+        obj = json.loads(resp.text)
+        response_msg = obj['response_msg']
+        response_code = obj['response_code']
+        _LOGGER.error(str(obj))
+        if resp.status_code != 200:
+            _LOGGER.error("Error %s : %s (Code %s)", resp.status_code,
+                          response_msg, response_code)
+
+
+def _authenticate(config):
+    """Authenticate with ClickSend."""
+    api_url = '{}/account'.format(BASE_API_URL)
+    resp = requests.get(api_url, headers=HEADERS,
+                        auth=(config.get(CONF_USERNAME),
+                              config.get(CONF_API_KEY)), timeout=5)
+
+    if resp.status_code != 200:
+        return False
+
+    return True

--- a/homeassistant/components/notify/clicksendaudio.py
+++ b/homeassistant/components/notify/clicksendaudio.py
@@ -43,7 +43,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def get_service(hass, config, discovery_info=None):
     """Get the ClickSend notification service."""
     if _authenticate(config) is False:
-        _LOGGER.exception("You are not authorized to access ClickSend")
+        _LOGGER.error("You are not authorized to access ClickSend")
         return None
 
     return ClicksendNotificationService(config)
@@ -59,23 +59,19 @@ class ClicksendNotificationService(BaseNotificationService):
         self.recipient = config.get(CONF_RECIPIENT)
         self.language = config.get(CONF_LANGUAGE)
         self.voice = config.get(CONF_VOICE)
-        _LOGGER.debug(self.voice)
 
     def send_message(self, message="", **kwargs):
         """Send a voice call to a user."""
-        _LOGGER.debug(message)
         data = ({'messages': [{'source': 'hass.notify', 'from': self.recipient,
                                'to': self.recipient, 'body': message,
                                'lang': self.language, 'voice': self.voice}]})
         api_url = "{}/voice/send".format(BASE_API_URL)
-        _LOGGER.debug(api_url)
         resp = requests.post(api_url, data=json.dumps(data), headers=HEADERS,
                              auth=(self.username, self.api_key), timeout=5)
 
         obj = json.loads(resp.text)
         response_msg = obj['response_msg']
         response_code = obj['response_code']
-        _LOGGER.error(str(obj))
         if resp.status_code != 200:
             _LOGGER.error("Error %s : %s (Code %s)", resp.status_code,
                           response_msg, response_code)

--- a/homeassistant/components/notify/clicksendaudio.py
+++ b/homeassistant/components/notify/clicksendaudio.py
@@ -62,7 +62,6 @@ class ClicksendNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a voice call to a user."""
-
         data = ({'messages': [{'source': 'hass.notify', 'from': self.recipient,
                                'to': self.recipient, 'body': message,
                                'lang': self.language, 'voice': self.voice}]})

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -40,7 +40,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
     vol.Optional(CONF_HOST, default=None): cv.string,
     vol.Optional(CONF_DSMR_VERSION, default=DEFAULT_DSMR_VERSION): vol.All(
-        cv.string, vol.In(['4', '2.2'])),
+        cv.string, vol.In(['5', '4', '2.2'])),
     vol.Optional(CONF_RECONNECT_INTERVAL, default=30): int,
 })
 
@@ -73,7 +73,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     devices = [DSMREntity(name, obis) for name, obis in obis_mapping]
 
     # Protocol version specific obis
-    if dsmr_version == '4':
+    if dsmr_version in ('4', '5'):
         gas_obis = obis_ref.HOURLY_GAS_METER_READING
     else:
         gas_obis = obis_ref.GAS_METER_READING

--- a/homeassistant/components/sensor/tibber.py
+++ b/homeassistant/components/sensor/tibber.py
@@ -1,0 +1,99 @@
+"""
+Support for Tibber.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.tibber/
+"""
+import asyncio
+
+import logging
+
+from datetime import timedelta
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import dt as dt_util
+
+REQUIREMENTS = ['pyTibber==0.1.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ACCESS_TOKEN): cv.string
+})
+
+ICON = 'mdi:currency-usd'
+SCAN_INTERVAL = timedelta(minutes=1)
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Tibber sensor."""
+    import Tibber
+    tibber = Tibber.Tibber(config[CONF_ACCESS_TOKEN],
+                           websession=async_get_clientsession(hass))
+    yield from tibber.update_info()
+    dev = []
+    for home in tibber.get_homes():
+        yield from home.update_info()
+        dev.append(TibberSensor(home))
+
+    async_add_devices(dev)
+
+
+class TibberSensor(Entity):
+    """Representation of an Tibber sensor."""
+
+    def __init__(self, tibber_home):
+        """Initialize the sensor."""
+        self._tibber_home = tibber_home
+        self._last_updated = None
+        self._state = None
+        self._device_state_attributes = None
+        self._unit_of_measurement = None
+        self._name = 'Electricity price {}'.format(self._tibber_home.address1)
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Get the latest data and updates the states."""
+        if self._tibber_home.current_price_total and self._last_updated and \
+           dt_util.as_utc(dt_util.parse_datetime(self._last_updated)).hour\
+           == dt_util.utcnow().hour:
+            return
+
+        yield from self._tibber_home.update_current_price_info()
+
+        self._state = self._tibber_home.current_price_total
+        self._last_updated = self._tibber_home.current_price_info.\
+            get('startsAt')
+        self._device_state_attributes = self._tibber_home.current_price_info
+        self._unit_of_measurement = self._tibber_home.price_unit
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._device_state_attributes
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return ICON
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity."""
+        return self._unit_of_measurement

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -552,6 +552,9 @@ pyHS100==0.2.4.2
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.20.1
 
+# homeassistant.components.sensor.tibber
+pyTibber==0.1.1
+
 # homeassistant.components.switch.dlink
 pyW215==0.6.0
 

--- a/tests/components/cover/test_template.py
+++ b/tests/components/cover/test_template.py
@@ -409,8 +409,8 @@ class TestTemplateCover(unittest.TestCase):
     def test_set_position(self):
         """Test the set_position command."""
         with assert_setup_component(1, 'cover'):
-            assert setup.setup_component(self.hass, 'input_slider', {
-               'input_slider': {
+            assert setup.setup_component(self.hass, 'input_number', {
+               'input_number': {
                    'test': {
                        'min': '0',
                        'max': '100',
@@ -424,10 +424,10 @@ class TestTemplateCover(unittest.TestCase):
                     'covers': {
                         'test_template_cover': {
                             'position_template':
-                                "{{ states.input_slider.test.state | int }}",
+                                "{{ states.input_number.test.state | int }}",
                             'set_cover_position': {
-                                'service': 'input_slider.select_value',
-                                'entity_id': 'input_slider.test',
+                                'service': 'input_number.set_value',
+                                'entity_id': 'input_number.test',
                                 'data_template': {
                                     'value': '{{ position }}'
                                 },
@@ -440,7 +440,7 @@ class TestTemplateCover(unittest.TestCase):
         self.hass.start()
         self.hass.block_till_done()
 
-        state = self.hass.states.set('input_slider.test', 42)
+        state = self.hass.states.set('input_number.test', 42)
         self.hass.block_till_done()
         state = self.hass.states.get('cover.test_template_cover')
         assert state.state == STATE_OPEN

--- a/tests/components/media_player/test_universal.py
+++ b/tests/components/media_player/test_universal.py
@@ -5,7 +5,7 @@ import unittest
 from homeassistant.const import (
     STATE_OFF, STATE_ON, STATE_UNKNOWN, STATE_PLAYING, STATE_PAUSED)
 import homeassistant.components.switch as switch
-import homeassistant.components.input_slider as input_slider
+import homeassistant.components.input_number as input_number
 import homeassistant.components.input_select as input_select
 import homeassistant.components.media_player as media_player
 import homeassistant.components.media_player.universal as universal
@@ -166,7 +166,7 @@ class TestMediaPlayer(unittest.TestCase):
         self.mock_state_switch_id = switch.ENTITY_ID_FORMAT.format('state')
         self.hass.states.set(self.mock_state_switch_id, STATE_OFF)
 
-        self.mock_volume_id = input_slider.ENTITY_ID_FORMAT.format(
+        self.mock_volume_id = input_number.ENTITY_ID_FORMAT.format(
             'volume_level')
         self.hass.states.set(self.mock_volume_id, 0)
 

--- a/tests/components/test_hassio.py
+++ b/tests/components/test_hassio.py
@@ -52,6 +52,102 @@ def test_fail_setup_cannot_connect(hass):
 
 
 @asyncio.coroutine
+def test_setup_api_ping(hass, aioclient_mock):
+    """Test setup with API ping."""
+    aioclient_mock.get(
+        "http://127.0.0.1/supervisor/ping", json={'result': 'ok'})
+
+    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}):
+        result = yield from async_setup_component(hass, 'hassio', {})
+        assert result
+
+    assert aioclient_mock.call_count == 1
+
+
+@asyncio.coroutine
+def test_setup_api_push_api_data(hass, aioclient_mock):
+    """Test setup with API push."""
+    aioclient_mock.get(
+        "http://127.0.0.1/supervisor/ping", json={'result': 'ok'})
+    aioclient_mock.post(
+        "http://127.0.0.1/homeassistant/options", json={'result': 'ok'})
+
+    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}):
+        result = yield from async_setup_component(hass, 'hassio', {
+            'http': {
+                'api_password': "123456",
+                'server_port': 9999
+            },
+            'hassio': {}
+        })
+        assert result
+
+    assert aioclient_mock.call_count == 2
+    assert not aioclient_mock.mock_calls[-1][2]['ssl']
+    assert aioclient_mock.mock_calls[-1][2]['password'] == "123456"
+    assert aioclient_mock.mock_calls[-1][2]['port'] == 9999
+
+
+@asyncio.coroutine
+def test_setup_api_push_api_data_default(hass, aioclient_mock):
+    """Test setup with API push default data."""
+    aioclient_mock.get(
+        "http://127.0.0.1/supervisor/ping", json={'result': 'ok'})
+    aioclient_mock.post(
+        "http://127.0.0.1/homeassistant/options", json={'result': 'ok'})
+
+    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}):
+        result = yield from async_setup_component(hass, 'hassio', {
+            'http': {},
+            'hassio': {}
+        })
+        assert result
+
+    assert aioclient_mock.call_count == 2
+    assert not aioclient_mock.mock_calls[-1][2]['ssl']
+    assert 'password' not in aioclient_mock.mock_calls[-1][2]
+    assert 'port' not in aioclient_mock.mock_calls[-1][2]
+
+
+@asyncio.coroutine
+def test_service_register(hassio_env, hass):
+    """Check if service will be settup."""
+    assert (yield from async_setup_component(hass, 'hassio', {}))
+    assert hass.services.has_service('hassio', 'addon_start')
+    assert hass.services.has_service('hassio', 'addon_stop')
+    assert hass.services.has_service('hassio', 'addon_restart')
+    assert hass.services.has_service('hassio', 'addon_stdin')
+
+
+@asyncio.coroutine
+def test_service_calls(hassio_env, hass, aioclient_mock):
+    """Call service and check the API calls behind that."""
+    assert (yield from async_setup_component(hass, 'hassio', {}))
+
+    aioclient_mock.post(
+        "http://127.0.0.1/addons/test/start", json={'result': 'ok'})
+    aioclient_mock.post(
+        "http://127.0.0.1/addons/test/stop", json={'result': 'ok'})
+    aioclient_mock.post(
+        "http://127.0.0.1/addons/test/restart", json={'result': 'ok'})
+    aioclient_mock.post(
+        "http://127.0.0.1/addons/test/stdin", json={'result': 'ok'})
+
+    yield from hass.services.async_call(
+        'hassio', 'addon_start', {'addon': 'test'})
+    yield from hass.services.async_call(
+        'hassio', 'addon_stop', {'addon': 'test'})
+    yield from hass.services.async_call(
+        'hassio', 'addon_restart', {'addon': 'test'})
+    yield from hass.services.async_call(
+        'hassio', 'addon_stdin', {'addon': 'test', 'input': 'test'})
+    yield from hass.async_block_till_done()
+
+    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.mock_calls[-1][2] == 'test'
+
+
+@asyncio.coroutine
 def test_forward_request(hassio_client):
     """Test fetching normal path."""
     response = MagicMock()

--- a/tests/components/test_input_number.py
+++ b/tests/components/test_input_number.py
@@ -1,17 +1,17 @@
-"""The tests for the Input slider component."""
+"""The tests for the Input number component."""
 # pylint: disable=protected-access
 import asyncio
 import unittest
 
 from homeassistant.core import CoreState, State
 from homeassistant.setup import setup_component, async_setup_component
-from homeassistant.components.input_slider import (DOMAIN, select_value)
+from homeassistant.components.input_number import (DOMAIN, set_value)
 
 from tests.common import get_test_home_assistant, mock_restore_cache
 
 
-class TestInputSlider(unittest.TestCase):
-    """Test the input slider component."""
+class TestInputNumber(unittest.TestCase):
+    """Test the input number component."""
 
     # pylint: disable=invalid-name
     def setUp(self):
@@ -38,8 +38,8 @@ class TestInputSlider(unittest.TestCase):
             self.assertFalse(
                 setup_component(self.hass, DOMAIN, {DOMAIN: cfg}))
 
-    def test_select_value(self):
-        """Test select_value method."""
+    def test_set_value(self):
+        """Test set_value method."""
         self.assertTrue(setup_component(self.hass, DOMAIN, {DOMAIN: {
             'test_1': {
                 'initial': 50,
@@ -47,36 +47,68 @@ class TestInputSlider(unittest.TestCase):
                 'max': 100,
             },
         }}))
-        entity_id = 'input_slider.test_1'
+        entity_id = 'input_number.test_1'
 
         state = self.hass.states.get(entity_id)
         self.assertEqual(50, float(state.state))
 
-        select_value(self.hass, entity_id, '30.4')
+        set_value(self.hass, entity_id, '30.4')
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)
         self.assertEqual(30.4, float(state.state))
 
-        select_value(self.hass, entity_id, '70')
+        set_value(self.hass, entity_id, '70')
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)
         self.assertEqual(70, float(state.state))
 
-        select_value(self.hass, entity_id, '110')
+        set_value(self.hass, entity_id, '110')
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)
         self.assertEqual(70, float(state.state))
+
+    def test_mode(self):
+        """Test mode settings."""
+        self.assertTrue(
+            setup_component(self.hass, DOMAIN, {DOMAIN: {
+                'test_default_slider': {
+                    'min': 0,
+                    'max': 100,
+                },
+                'test_explicit_box': {
+                    'min': 0,
+                    'max': 100,
+                    'mode': 'box',
+                },
+                'test_explicit_slider': {
+                    'min': 0,
+                    'max': 100,
+                    'mode': 'slider',
+                },
+            }}))
+
+        state = self.hass.states.get('input_number.test_default_slider')
+        assert state
+        self.assertEqual('slider', state.attributes['mode'])
+
+        state = self.hass.states.get('input_number.test_explicit_box')
+        assert state
+        self.assertEqual('box', state.attributes['mode'])
+
+        state = self.hass.states.get('input_number.test_explicit_slider')
+        assert state
+        self.assertEqual('slider', state.attributes['mode'])
 
 
 @asyncio.coroutine
 def test_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(hass, (
-        State('input_slider.b1', '70'),
-        State('input_slider.b2', '200'),
+        State('input_number.b1', '70'),
+        State('input_number.b2', '200'),
     ))
 
     hass.state = CoreState.starting
@@ -93,11 +125,11 @@ def test_restore_state(hass):
             },
         }})
 
-    state = hass.states.get('input_slider.b1')
+    state = hass.states.get('input_number.b1')
     assert state
     assert float(state.state) == 70
 
-    state = hass.states.get('input_slider.b2')
+    state = hass.states.get('input_number.b2')
     assert state
     assert float(state.state) == 10
 
@@ -106,8 +138,8 @@ def test_restore_state(hass):
 def test_initial_state_overrules_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(hass, (
-        State('input_slider.b1', '70'),
-        State('input_slider.b2', '200'),
+        State('input_number.b1', '70'),
+        State('input_number.b2', '200'),
     ))
 
     hass.state = CoreState.starting
@@ -126,11 +158,11 @@ def test_initial_state_overrules_restore_state(hass):
             },
         }})
 
-    state = hass.states.get('input_slider.b1')
+    state = hass.states.get('input_number.b1')
     assert state
     assert float(state.state) == 50
 
-    state = hass.states.get('input_slider.b2')
+    state = hass.states.get('input_number.b2')
     assert state
     assert float(state.state) == 60
 
@@ -148,6 +180,6 @@ def test_no_initial_state_and_no_restore_state(hass):
             },
         }})
 
-    state = hass.states.get('input_slider.b1')
+    state = hass.states.get('input_number.b1')
     assert state
     assert float(state.state) == 0

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -745,11 +745,11 @@ is_state_attr('device_tracker.phone_2', 'battery', 40)
         self.assertListEqual(
             sorted([
                 'sensor.luftfeuchtigkeit_mean',
-                'input_slider.luftfeuchtigkeit',
+                'input_number.luftfeuchtigkeit',
             ]),
             sorted(template.extract_entities(
                 "{% if (states('sensor.luftfeuchtigkeit_mean') | int)"
-                " > (states('input_slider.luftfeuchtigkeit') | int +1.5)"
+                " > (states('input_number.luftfeuchtigkeit') | int +1.5)"
                 " %}true{% endif %}"
             )))
 


### PR DESCRIPTION
First implementation of Clicksend Audio for sending TTS messages through Clicksend

## Description:
Introducing a new platform for sending text to speech (tts) messages through Clicksend and notify.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3504

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: clicksendaudio
  - username: [YourUsername]
  - api_key: [YouAPIKey]
  - recipient: [PhoneNumberOfRecipient]
  - language: [YourLanguage, default en-us]
  - voice: [MaleOrFemaleVoice, default female]
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
