### PR TITLE
Properly handle an invalid end_time

### DIFF
--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -283,9 +283,10 @@ class HistoryPeriodView(HomeAssistantView):
 
         end_time = request.query.get('end_time')
         if end_time:
-            end_time = dt_util.as_utc(
-                dt_util.parse_datetime(end_time))
-            if end_time is None:
+            end_time = dt_util.parse_datetime(end_time)
+            if end_time:
+                end_time = dt_util.as_utc(end_time)
+            else:
                 return self.json_message('Invalid end_time', HTTP_BAD_REQUEST)
         else:
             end_time = start_time + one_day


### PR DESCRIPTION
## Description:
This properly handles an invalid end_time from parse_datetime instead of just passing it off to as_utc.

**Related issue (if applicable):** fixes #9674