### PR TITLE
fix group order

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -500,12 +500,12 @@ class Group(Entity):
         """Return the state attributes for the group."""
         data = {
             ATTR_ENTITY_ID: self.tracking,
-            ATTR_ORDER: self._order,
         }
         if not self._user_defined:
             data[ATTR_AUTO] = True
         if self.view:
             data[ATTR_VIEW] = True
+            data[ATTR_ORDER] = self._order
         if self.control:
             data[ATTR_CONTROL] = self.control
         return data

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -274,7 +274,6 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertIsNone(group_state.attributes.get(group.ATTR_VIEW))
         self.assertIsNone(group_state.attributes.get(group.ATTR_CONTROL))
         self.assertIsNone(group_state.attributes.get(ATTR_HIDDEN))
-        self.assertEqual(2, group_state.attributes.get(group.ATTR_ORDER))
 
     def test_groups_get_unique_names(self):
         """Two groups with same name should both have a unique entity id."""


### PR DESCRIPTION
## Description:
This fixes the order of groups defined inside views. 
The issue was caused by setting the "order" attribute as the order in which the group appears on config, which is then passed to the frontend. Simply removing this attribute from groups fixes the issue, since groups are then loaded by the order they are specified in views.
Views still have the "order" attribute, since there is no way to order them except by the order that they are specified in config.

**Related issue (if applicable):** fixes #2432

## Checklist:
If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

