### PR TITLE
Support presence detection using Hitron Coda router

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -291,6 +291,7 @@ omit =
     homeassistant/components/device_tracker/cisco_ios.py
     homeassistant/components/device_tracker/fritz.py
     homeassistant/components/device_tracker/gpslogger.py
+    homeassistant/components/device_tracker/hitron_coda.py
     homeassistant/components/device_tracker/huawei_router.py
     homeassistant/components/device_tracker/icloud.py
     homeassistant/components/device_tracker/keenetic_ndms2.py

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -79,7 +79,7 @@ class HitronCODADeviceScanner(DeviceScanner):
               'cur_modelname': 'CODA-4582U',
               'userName': self._username,
               'password': self._password,
-              'userid': '1198377306', # magic number
+              'userid': '1198377306',  # magic number
               'modelname': 'CODA-4582U',
               'IE8': '0',
               'isEdit2': '0',

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -75,17 +75,17 @@ class HitronCODADeviceScanner(DeviceScanner):
         # doing a request
         try:
             res = requests.get(self._url, timeout=10, cookies={
-              'LANG_COOKIE': 'en_US',
-              'cur_modelname': 'CODA-4582U',
-              'userName': self._username,
-              'password': self._password,
-              'userid': '1198377306',  # magic number
-              'modelname': 'CODA-4582U',
-              'IE8': '0',
-              'isEdit2': '0',
-              'isEdit3': '0',
-              'isEdit': '0',
-              'isEdit1': '0',
+                'LANG_COOKIE': 'en_US',
+                'cur_modelname': 'CODA-4582U',
+                'userName': self._username,
+                'password': self._password,
+                'userid': '1198377306',  # magic number
+                'modelname': 'CODA-4582U',
+                'IE8': '0',
+                'isEdit2': '0',
+                'isEdit3': '0',
+                'isEdit': '0',
+                'isEdit1': '0',
             })
         except requests.exceptions.Timeout:
             _LOGGER.error(

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -1,0 +1,118 @@
+"""
+Support for the Hitron CODA-4582U, provided by Rogers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.keenetic_ndms2/
+"""
+import logging
+from collections import namedtuple
+
+import requests
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.const import (
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string
+})
+
+
+def get_scanner(_hass, config):
+    """Validate the configuration and return a Nmap scanner."""
+    scanner = HitronCODADeviceScanner(config[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+
+Device = namedtuple('Device', ['mac', 'name'])
+
+
+class HitronCODADeviceScanner(DeviceScanner):
+    """This class scans for devices using the CODA's web interface."""
+
+    def __init__(self, config):
+        """Initialize the scanner."""
+        self.last_results = []
+
+        self._url = 'http://%s/data/getConnectInfo.asp' % config[CONF_HOST]
+
+        self._username = config.get(CONF_USERNAME)
+        self._password = config.get(CONF_PASSWORD)
+
+        self.success_init = self._update_info()
+        _LOGGER.info("Scanner initialized")
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+
+        return [device.mac for device in self.last_results]
+
+    def get_device_name(self, mac):
+        """Return the name of the given device or None if we don't know."""
+        filter_named = [device.name for device in self.last_results
+                        if device.mac == mac]
+
+        if filter_named:
+            return filter_named[0]
+        return None
+
+    def _update_info(self):
+        """Get ARP from router."""
+        _LOGGER.info("Fetching...")
+
+        last_results = []
+
+        # doing a request
+        try:
+            res = requests.get(self._url, timeout=10, cookies={
+              'LANG_COOKIE': 'en_US',
+              'cur_modelname': 'CODA-4582U',
+              'userName': self._username,
+              'password': self._password,
+              'userid': '1198377306', # magic number
+              'modelname': 'CODA-4582U',
+              'IE8': '0',
+              'isEdit2': '0',
+              'isEdit3': '0',
+              'isEdit': '0',
+              'isEdit1': '0',
+            })
+        except requests.exceptions.Timeout:
+            _LOGGER.error(
+                "Connection to the router timed out at URL %s", self._url)
+            return False
+        if res.status_code != 200:
+            _LOGGER.error(
+                "Connection failed with http code %s", res.status_code)
+            return False
+        try:
+            result = res.json()
+        except ValueError:
+            # If json decoder could not parse the response
+            _LOGGER.error("Failed to parse response from router")
+            return False
+
+        # parsing response
+        for info in result:
+            mac = info.macAddr
+            name = info.hostName
+            # No address = no item :)
+            if mac is None:
+                continue
+
+            last_results.append(Device(mac.upper(), name))
+
+        self.last_results = last_results
+
+        _LOGGER.info("Request successful")
+        return True

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -63,7 +63,7 @@ class HitronCODADeviceScanner(DeviceScanner):
     def get_device_name(self, mac):
         """Return the name of the device with the given MAC address."""
         name = next((
-            device.name for device in self.last_result
+            device.name for device in self.last_results
             if device.mac == mac), None)
         return name
 

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -42,10 +42,9 @@ class HitronCODADeviceScanner(DeviceScanner):
     def __init__(self, config):
         """Initialize the scanner."""
         self.last_results = []
-
-        self._url = 'http://{}/data/getConnectInfo.asp'
-            .format(config[CONF_HOST])
-        self._loginurl = 'http://{}/goform/login'.format(config[CONF_HOST])
+        host = config[CONF_HOST]
+        self._url = 'http://{}/data/getConnectInfo.asp'.format(host)
+        self._loginurl = 'http://{}/goform/login'.format(host)
 
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -44,6 +44,7 @@ class HitronCODADeviceScanner(DeviceScanner):
         self.last_results = []
 
         self._url = 'http://%s/data/getConnectInfo.asp' % config[CONF_HOST]
+        self._loginurl = 'http://%s/goform/login' % config[CONF_HOST]
 
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)
@@ -77,7 +78,7 @@ class HitronCODADeviceScanner(DeviceScanner):
                 ('user', self._username),
                 ('pws', self._password),
             ]
-            res = requests.post('http://192.168.0.1/goform/login', data=data)
+            res = requests.post(self._loginurl, data=data)
         except requests.exceptions.Timeout:
             _LOGGER.error(
                 "Connection to the router timed out at URL %s", self._url)

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -77,7 +77,7 @@ class HitronCODADeviceScanner(DeviceScanner):
                 ('user', self._username),
                 ('pws', self._password),
             ]
-            res = requests.post(self._loginurl, data=data. timeout=10)
+            res = requests.post(self._loginurl, data=data, timeout=10)
         except requests.exceptions.Timeout:
             _LOGGER.error(
                 "Connection to the router timed out at URL %s", self._url)

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -43,7 +43,8 @@ class HitronCODADeviceScanner(DeviceScanner):
         """Initialize the scanner."""
         self.last_results = []
 
-        self._url = 'http://{}/data/getConnectInfo.asp'.format(config[CONF_HOST])
+        self._url = 'http://{}/data/getConnectInfo.asp'
+            .format(config[CONF_HOST])
         self._loginurl = 'http://{}/goform/login'.format(config[CONF_HOST])
 
         self._username = config.get(CONF_USERNAME)

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -2,7 +2,7 @@
 Support for the Hitron CODA-4582U, provided by Rogers.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/device_tracker.keenetic_ndms2/
+https://home-assistant.io/components/device_tracker.hitron_coda/
 """
 import logging
 from collections import namedtuple

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -43,8 +43,8 @@ class HitronCODADeviceScanner(DeviceScanner):
         """Initialize the scanner."""
         self.last_results = []
 
-        self._url = 'http://%s/data/getConnectInfo.asp' % config[CONF_HOST]
-        self._loginurl = 'http://%s/goform/login' % config[CONF_HOST]
+        self._url = 'http://{}/data/getConnectInfo.asp'.format(config[CONF_HOST])
+        self._loginurl = 'http://{}/goform/login'.format(config[CONF_HOST])
 
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)
@@ -61,13 +61,11 @@ class HitronCODADeviceScanner(DeviceScanner):
         return [device.mac for device in self.last_results]
 
     def get_device_name(self, mac):
-        """Return the name of the given device or None if we don't know."""
-        filter_named = [device.name for device in self.last_results
-                        if device.mac == mac]
-
-        if filter_named:
-            return filter_named[0]
-        return None
+        """Return the name of the device with the given MAC address."""
+        name = next((
+            device.name for device in self.last_result
+            if device.mac == mac), None)
+        return name
 
     def _login(self):
         """Log in to the router. This is required for subsequent api calls."""
@@ -78,7 +76,7 @@ class HitronCODADeviceScanner(DeviceScanner):
                 ('user', self._username),
                 ('pws', self._password),
             ]
-            res = requests.post(self._loginurl, data=data)
+            res = requests.post(self._loginurl, data=data. timeout=10)
         except requests.exceptions.Timeout:
             _LOGGER.error(
                 "Connection to the router timed out at URL %s", self._url)

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -69,7 +69,7 @@ class HitronCODADeviceScanner(DeviceScanner):
         return None
 
     def _login(self):
-        """Log in to the router. This is required for any subsequent api calls."""
+        """Log in to the router. This is required for subsequent api calls."""
         _LOGGER.info("Logging in to CODA...")
 
         try:


### PR DESCRIPTION
## Description:
Add support for the Hitron CODA series of routers for presence detction.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3512

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: hitron_coda
    host: !secret router_ip
    username: !secret router_username
    password: !secret router_password
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
