### PR TITLE
Deprecate Python 3.4 support

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -88,8 +88,12 @@ def async_from_config_dict(config: Dict[str, Any],
         async_enable_logging(hass, verbose, log_rotate_days, log_file)
 
     if sys.version_info[:2] < (3, 5):
-        _LOGGER.warning('Python 3.4 support has been deprecated and will be '
-                        'removed in 2018. Please upgrade Python.')
+        _LOGGER.warning(
+            'Python 3.4 support has been deprecated and will be removed in '
+            'the begining of 2018. Please upgrade Python or your operating '
+            'system. More info: https://home-assistant.io/blog/2017/10/06/'
+            'deprecating-python-3.4-support/'
+        )
 
     core_config = config.get(core.DOMAIN, {})
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -83,6 +83,14 @@ def async_from_config_dict(config: Dict[str, Any],
     This method is a coroutine.
     """
     start = time()
+
+    if enable_log:
+        async_enable_logging(hass, verbose, log_rotate_days, log_file)
+
+    if sys.version_info[:2] < (3, 5):
+        _LOGGER.warning('Python 3.4 support has been deprecated and will be '
+                        'removed in 2018. Please upgrade Python.')
+
     core_config = config.get(core.DOMAIN, {})
 
     try:
@@ -92,9 +100,6 @@ def async_from_config_dict(config: Dict[str, Any],
         return None
 
     yield from hass.async_add_job(conf_util.process_ha_config_upgrade, hass)
-
-    if enable_log:
-        async_enable_logging(hass, verbose, log_rotate_days, log_file)
 
     hass.config.skip_pip = skip_pip
     if skip_pip:


### PR DESCRIPTION
## Description:
Add a warning for people running Python 3.4 that we will remove support in 2018. I am still not 100% sure if this will be in January or that it will be later in the year. It depends on how the rest of the ecosystem will move.

Added the warning inside `bootstrap` instead of `__main__` because I want this to get logged in the logger, so they can see it in the UI.

**Related issue (if applicable):** #9328 
