### PR TITLE
Fix restore state with PostgreSQL

### DIFF
--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -41,6 +41,7 @@ def last_recorder_run(hass):
 
     with session_scope(hass=hass) as session:
         res = (session.query(RecorderRuns)
+               .filter(RecorderRuns.end.isnot(None))
                .order_by(RecorderRuns.end.desc()).first())
         if res is None:
             return None


### PR DESCRIPTION
## Description:

Trying to fix restore state does not work with PostgreSQL. Found root cause of this
- different DB engines handles differently sort of Null values
- `restore_state` helper checks for recorder runs via `last_recorder_run` function
- for SQLite, correct row is returned and date range then handled
- for PostgreSQL, row with Null value in `end` column is returned and then state restore is aborted (it is incorrectly row of active recorder run, and not last, as expected)

Fixed by adding query option to filter out null value column from SQL result. Should not break anything - `last_recorder_run` function is not used elsewhere

**Related issue (if applicable):** fixes #8974

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
