### PR TITLE
HassIO replace config changes

### DIFF
--- a/homeassistant/components/hassio.py
+++ b/homeassistant/components/hassio.py
@@ -17,7 +17,7 @@ import async_timeout
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONTENT_TYPE_TEXT_PLAIN
+from homeassistant.const import CONTENT_TYPE_TEXT_PLAIN, SERVER_PORT
 from homeassistant.components.http import (
     HomeAssistantView, KEY_AUTHENTICATED, CONF_API_PASSWORD, CONF_SERVER_PORT,
     CONF_SSL_CERTIFICATE)
@@ -129,15 +129,12 @@ class HassIO(object):
 
         This method return a coroutine.
         """
+        port = http_config.get(CONF_SERVER_PORT) else SERVER_PORT
         options = {
             'ssl': CONF_SSL_CERTIFICATE in http_config,
+            'port': port,
+            'password': http_config.get(CONF_API_PASSWORD),
         }
-
-        if http_config.get(CONF_SERVER_PORT):
-            options['port'] = http_config[CONF_SERVER_PORT]
-
-        if http_config.get(CONF_API_PASSWORD):
-            options['password'] = http_config[CONF_API_PASSWORD]
 
         return self.send_command("/homeassistant/options", payload=options)
 

--- a/homeassistant/components/hassio.py
+++ b/homeassistant/components/hassio.py
@@ -129,7 +129,7 @@ class HassIO(object):
 
         This method return a coroutine.
         """
-        port = http_config.get(CONF_SERVER_PORT) else SERVER_PORT
+        port = http_config.get(CONF_SERVER_PORT) or SERVER_PORT
         options = {
             'ssl': CONF_SSL_CERTIFICATE in http_config,
             'port': port,

--- a/tests/components/test_hassio.py
+++ b/tests/components/test_hassio.py
@@ -105,8 +105,8 @@ def test_setup_api_push_api_data_default(hass, aioclient_mock):
 
     assert aioclient_mock.call_count == 2
     assert not aioclient_mock.mock_calls[-1][2]['ssl']
-    assert 'password' not in aioclient_mock.mock_calls[-1][2]
-    assert 'port' not in aioclient_mock.mock_calls[-1][2]
+    assert aioclient_mock.mock_calls[-1][2]['password'] is None
+    assert aioclient_mock.mock_calls[-1][2]['port'] == 8123
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

The old code have not set it back to default after config was removed.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
