### PR TITLE
Fixed typo in OpenCV

### DIFF
--- a/homeassistant/components/image_processing/opencv.py
+++ b/homeassistant/components/image_processing/opencv.py
@@ -28,7 +28,7 @@ CASCADE_URL = \
     'https://raw.githubusercontent.com/opencv/opencv/master/data/' + \
     'lbpcascades/lbpcascade_frontalface.xml'
 
-CONF_CLASSIFIER = 'classifer'
+CONF_CLASSIFIER = 'classifier'
 CONF_FILE = 'file'
 CONF_MIN_SIZE = 'min_size'
 CONF_NEIGHBORS = 'neighbors'


### PR DESCRIPTION
## Description:
OpenCV was ignoring the classifier specified due to a typo. Thanks @engrbm87 for highlighting the same. 

**Related issue (if applicable):** fixes #9693 
