### PR TITLE
improve RGB support for tradfri

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -104,7 +104,7 @@ class Tradfri(Light):
         self._name = self._light.name
         self._rgb_color = None
         self._features = SUPPORT_BRIGHTNESS
-        
+
         if self._light_data.hex_color is not None:
             if self._light.device_info.manufacturer == IKEA:
                 if "CWS" in self._light.device_info.model_number:
@@ -113,9 +113,10 @@ class Tradfri(Light):
                     self._features |= SUPPORT_COLOR_TEMP
             else:
                 self._features |= SUPPORT_RGB_COLOR
-            
-        _LOGGER.debug("features detected for %s %s: %d", self._name, self._light.device_info.model_number, self._features)
-        
+
+        _LOGGER.debug("features detected for %s %s: %d", 
+            self._name, self._light.device_info.model_number, self._features)
+
         self._ok_temps = \
             self._light.device_info.manufacturer in ALLOWED_TEMPERATURES
 

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -208,7 +208,8 @@ class Tradfri(Light):
         # handle GW behavoiur which does report hex color '0' whenevener
         # a bulb is set to a color_xy which isn't one of the predefined ones
         # -> convert xyb to rgb when available
-        elif self._light_data.xy_color not in (None, '0') and \
+        elif self._light_data.xy_color[0] not in (None, '0') and \
+                self._light_data.xy_color[1] not in (None, '0') and \
                 self._light_data.dimmer not in (None, '0'):
             self._rgb_color = color_util.color_xy_brightness_to_RGB(
                 self._light_data.xy_color[0]/65536,

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -114,8 +114,10 @@ class Tradfri(Light):
             else:
                 self._features |= SUPPORT_RGB_COLOR
 
-        _LOGGER.debug("features detected for %s %s: %d",
-                self._name, self._light.device_info.model_number, self._features)
+        _LOGGER.debug(
+            "features detected for %s %s: %d",
+            self._name, self._light.device_info.model_number, self._features
+        )
 
         self._ok_temps = \
             self._light.device_info.manufacturer in ALLOWED_TEMPERATURES

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -201,16 +201,16 @@ class Tradfri(Light):
 
         # Handle Hue lights paired with the gateway
         # hex_color is 0 when bulb is unreachable
-        if self._light_data.hex_color not in (None, '0'): 
+        if self._light_data.hex_color not in (None, '0'):
             self._rgb_color = color_util.rgb_hex_to_rgb_list(
                 self._light_data.hex_color)
 
-        # handle GW behavoiur which does report hex color '0' whenevener 
+        # handle GW behavoiur which does report hex color '0' whenevener
         # a bulb is set to a color_xy which isn't one of the predefined ones
-        # -> convert xyb to rgb when available 
+        # -> convert xyb to rgb when available
         elif self._light_data.xy_color not in (None, '0') and \
                 self._light_data.dimmer not in (None, '0'):
             self._rgb_color = color_util.color_xy_brightness_to_RGB(
-                self._light_data.xy_color[0]/65536, 
-                self._light_data.xy_color[1]/65536, 
+                self._light_data.xy_color[0]/65536,
+                self._light_data.xy_color[1]/65536,
                 self._light_data.dimmer)

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -114,11 +114,6 @@ class Tradfri(Light):
             else:
                 self._features |= SUPPORT_RGB_COLOR
 
-        _LOGGER.debug(
-            "features detected for %s %s: %d",
-            self._name, self._light.device_info.model_number, self._features
-        )
-
         self._ok_temps = \
             self._light.device_info.manufacturer in ALLOWED_TEMPERATURES
 
@@ -206,6 +201,16 @@ class Tradfri(Light):
 
         # Handle Hue lights paired with the gateway
         # hex_color is 0 when bulb is unreachable
-        if self._light_data.hex_color not in (None, '0'):
+        if self._light_data.hex_color not in (None, '0'): 
             self._rgb_color = color_util.rgb_hex_to_rgb_list(
                 self._light_data.hex_color)
+
+        # handle GW behavoiur which does report hex color '0' whenevener 
+        # a bulb is set to a color_xy which isn't one of the predefined ones
+        # -> convert xyb to rgb when available 
+        elif self._light_data.xy_color not in (None, '0') and \
+                self._light_data.dimmer not in (None, '0'):
+            self._rgb_color = color_util.color_xy_brightness_to_RGB(
+                self._light_data.xy_color[0]/65536, 
+                self._light_data.xy_color[1]/65536, 
+                self._light_data.dimmer)

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -114,8 +114,8 @@ class Tradfri(Light):
             else:
                 self._features |= SUPPORT_RGB_COLOR
 
-        _LOGGER.debug("features detected for %s %s: %d", 
-            self._name, self._light.device_info.model_number, self._features)
+        _LOGGER.debug("features detected for %s %s: %d",
+                self._name, self._light.device_info.model_number, self._features)
 
         self._ok_temps = \
             self._light.device_info.manufacturer in ALLOWED_TEMPERATURES

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -104,13 +104,18 @@ class Tradfri(Light):
         self._name = self._light.name
         self._rgb_color = None
         self._features = SUPPORT_BRIGHTNESS
-
+        
         if self._light_data.hex_color is not None:
             if self._light.device_info.manufacturer == IKEA:
-                self._features |= SUPPORT_COLOR_TEMP
+                if "CWS" in self._light.device_info.model_number:
+                    self._features |= SUPPORT_RGB_COLOR
+                else:
+                    self._features |= SUPPORT_COLOR_TEMP
             else:
                 self._features |= SUPPORT_RGB_COLOR
-
+            
+        _LOGGER.debug("features detected for %s %s: %d", self._name, self._light.device_info.model_number, self._features)
+        
         self._ok_temps = \
             self._light.device_info.manufacturer in ALLOWED_TEMPERATURES
 


### PR DESCRIPTION
Added feature detection (SUPPORT_RGB_COLOR) for IKEA tradfri RGB bulbs.

String comparison with manufacturer/device id used because I think there isn't a suitable property/param to identify the RGB capability. Both IKEA WS and RGB have data in the same parameters (x, y, rgb).

Added on the fly conversion of xyb values to rgb list to update method resulting in: 
    - bulb icon in UI is color scaled with current color (tested with IKEA WS+RGB and FLS-pp RGB) 
    - UI color picker or color temperature slider is displayed for respective bulb types

see also:
home-assistant#9603

Tested with the following setup:
Home Assistant 0.53.1
pytradfri 2.2
IKEA tradfri gateway fw 1.1.0015
zigbee rgb PWM module (dresden elektronik FLS-PP lp)
IKEA RGB, WS and dimmable-only bulbs

## Description:


**Related issue (if applicable):** fixes #9603 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#9411

## Example entry for `configuration.yaml` (if applicable):
```yaml
scene:
  - name: daytime
    entities:
      light.kitchen:
        state: on
        brightness: 63
        rgb_color: [255, 191, 0]
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ y ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ na ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ na ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ na ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ na ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ na ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
