### PR TITLE
Rewrite Alexa Smart-Home skill to v3

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -119,7 +119,7 @@ def async_api_discovery(hass, request):
 
         # static actions
         if class_data[1]:
-            actions += set(class_data[1])
+            actions |= set(class_data[1])
 
         # dynamic actions
         if class_data[2]:

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -141,7 +141,7 @@ def async_api_discovery(hass, request):
         discovery_endpoints.append(endpoint)
 
     return api_message(
-        request, name='Discover', namespace='Alexa.Discovery',
+        request, name='Discover.Response', namespace='Alexa.Discovery',
         payload={'endpoints': discovery_endpoints})
 
 

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -31,7 +31,7 @@ MAPPING_COMPONENT = {
 @asyncio.coroutine
 def async_handle_message(hass, message):
     """Handle incoming API messages."""
-    assert message[API_DIRECTIVE][API_HEADER]['payloadVersion'] == 3
+    assert message[API_DIRECTIVE][API_HEADER]['payloadVersion'] == '3'
 
     # Read head data
     message = message[API_DIRECTIVE]

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -191,7 +191,7 @@ def async_api_turn_off(hass, request, entity):
 @HANDLERS.register(('Alexa.BrightnessController', 'SetBrightness'))
 @extract_entity
 @asyncio.coroutine
-def async_api_set_percentage(hass, request, entity):
+def async_api_set_brightness(hass, request, entity):
     """Process a set brightness request."""
     brightness = request[API_PAYLOAD]['brightness']
 

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -48,7 +48,7 @@ def async_handle_message(hass, message):
     return (yield from funct_ref(hass, message))
 
 
-def api_message(request, name='Alexa', namespace='Response', payload=None):
+def api_message(request, name='Response', namespace='Alexa', payload=None):
     """Create a API formatted response message.
 
     Async friendly.

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -142,7 +142,7 @@ def async_api_discovery(hass, request):
 
     return api_message(
         request, name='Discover', namespace='Alexa.Discovery',
-        payload=discovery_endpoints)
+        payload={'endpoints': discovery_endpoints})
 
 
 def extract_entity(funct):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -51,8 +51,8 @@ def test_create_api_message_defaults():
     assert msg['header']['messageId'] != request['header']['messageId']
     assert msg['header']['correlationToken'] == \
         request['header']['correlationToken']
-    assert msg['header']['name'] == 'Alexa'
-    assert msg['header']['namespace'] == 'Response'
+    assert msg['header']['name'] == 'Response'
+    assert msg['header']['namespace'] == 'Alexa'
     assert msg['header']['payloadVersion'] == '3'
 
     assert 'test' in msg['payload']

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -236,7 +236,7 @@ def test_api_set_brightness(hass):
         'Alexa.BrightnessController', 'SetBrightness', 'light#test')
 
     # add payload
-    msg['directive']['payload']['brightness'] = '50'
+    request['directive']['payload']['brightness'] = '50'
 
     # settup test devices
     hass.states.async_set(

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -140,8 +140,14 @@ def test_discovery_request(hass):
             assert appliance['displayCategories'][0] == "LIGHT"
             assert appliance['friendlyName'] == "Test light 2"
             assert len(appliance['capabilities']) == 2
-            assert appliance['capabilities'][-1]['interface'] == \
-                'Alexa.BrightnessController'
+
+            caps = set()
+            for feature in appliance['capabilities']:
+                caps.add(feature['interface'])
+
+            assert 'Alexa.BrightnessController' in caps
+            assert 'Alexa.PowerController' in caps
+
             continue
 
         raise AssertionError("Unknown appliance!")

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -67,6 +67,7 @@ def test_create_api_message_special():
     request = request['directive']
 
     request['header'].pop('correlationToken')
+    request.pop['endpoint']
 
     msg = smart_home.api_message(request, 'testName', 'testNameSpace')
 
@@ -97,7 +98,8 @@ def test_wrong_version(hass):
 @asyncio.coroutine
 def test_discovery_request(hass):
     """Test alexa discovery request."""
-    msg = get_new_request('Alexa.Discovery', 'Discover')
+    request = get_new_request('Alexa.Discovery', 'Discover')
+    request.pop['endpoint']
 
     # settup test devices
     hass.states.async_set(
@@ -110,16 +112,16 @@ def test_discovery_request(hass):
             'friendly_name': "Test light 2", 'supported_features': 1
         })
 
-    resp = yield from smart_home.async_handle_message(hass, msg)
+    msg = yield from smart_home.async_handle_message(hass, request)
 
     assert 'event' in msg
     msg = msg['event']
 
-    assert len(resp['payload']['endpoints']) == 3
-    assert resp['header']['name'] == 'Discover.Response'
-    assert resp['header']['namespace'] == 'Alexa.Discovery'
+    assert len(msg['payload']['endpoints']) == 3
+    assert msg['header']['name'] == 'Discover.Response'
+    assert msg['header']['namespace'] == 'Alexa.Discovery'
 
-    for appliance in resp['payload']['endpoints']:
+    for appliance in msg['payload']['endpoints']:
         if appliance['endpointId'] == 'switch#test':
             assert appliance['displayCategories'][0] == "SWITCH"
             assert appliance['friendlyName'] == "Test switch"

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1,5 +1,6 @@
 """Test for smart home alexa support."""
 import asyncio
+from uuid import uuid4
 
 import pytest
 
@@ -8,22 +9,86 @@ from homeassistant.components.alexa import smart_home
 from tests.common import async_mock_service
 
 
-def test_create_api_message():
-    """Create a API message."""
-    msg = smart_home.api_message('testName', 'testNameSpace')
+def get_new_request(namespace, name, endpoint=True):
+    """Generate a new API message."""
+    raw_msg = {
+        'directive': {
+            'header': {
+                'namespace': namespace,
+                'name': name,
+                'messageId': str(uuid4()),
+                'correlationToken': str(uuid4()),
+                'payloadVersion': '3',
+            },
+            'endpoint': {
+                'scope': {
+                    'type': 'BearerToken',
+                    'token': str(uuid4()),
+                },
+                'endpointId': endpoint,
+            },
+            'payload': {},
+        }
+    }
+
+    if not endpoint:
+        raw_msg['directive'].pop('endpoint')
+
+    return raw_msg
+
+
+def test_create_api_message_defaults():
+    """Create a API message response of a request with defaults."""
+    request = get_new_request('Alexa.PowerController', 'TurnOn', 'switch#xy')
+    request = request['directive']
+
+    msg = smart_home.api_message(request, payload={'test': 3})
+
+    assert 'event' in msg
+    msg = msg['event']
 
     assert msg['header']['messageId'] is not None
+    assert msg['header']['messageId'] != request['header']['messageId']
+    assert msg['header']['correlationToken'] == \
+        request['header']['correlationToken']
+    assert msg['header']['name'] == 'Alexa'
+    assert msg['header']['namespace'] == 'Response'
+    assert msg['header']['payloadVersion'] == '3'
+
+    assert 'test' in msg['payload']
+    assert msg['payload']['test'] == 3
+
+    assert msg['endpoint'] == request['endpoint']
+
+
+def test_create_api_message_special():
+    """Create a API message response of a request with non defaults."""
+    request = get_new_request('Alexa.PowerController', 'TurnOn')
+    request = request['directive']
+
+    request['header'].pop('correlationToken')
+
+    msg = smart_home.api_message(request, 'testName', 'testNameSpace')
+
+    assert 'event' in msg
+    msg = msg['event']
+
+    assert msg['header']['messageId'] is not None
+    assert msg['header']['messageId'] != request['header']['messageId']
+    assert 'correlationToken' not in msg['header']
     assert msg['header']['name'] == 'testName'
     assert msg['header']['namespace'] == 'testNameSpace'
-    assert msg['header']['payloadVersion'] == '2'
+    assert msg['header']['payloadVersion'] == '3'
+
     assert msg['payload'] == {}
+    assert 'endpoint' not in msg
 
 
 @asyncio.coroutine
 def test_wrong_version(hass):
     """Test with wrong version."""
-    msg = smart_home.api_message('testName', 'testNameSpace')
-    msg['header']['payloadVersion'] = '3'
+    msg = get_new_request('Alexa.PowerController', 'TurnOn')
+    msg['directive']['header']['payloadVersion'] = '2'
 
     with pytest.raises(AssertionError):
         yield from smart_home.async_handle_message(hass, msg)
@@ -32,8 +97,7 @@ def test_wrong_version(hass):
 @asyncio.coroutine
 def test_discovery_request(hass):
     """Test alexa discovery request."""
-    msg = smart_home.api_message(
-        'DiscoverAppliancesRequest', 'Alexa.ConnectedHome.Discovery')
+    msg = get_new_request('Alexa.Discovery', 'Discover')
 
     # settup test devices
     hass.states.async_set(
@@ -46,30 +110,38 @@ def test_discovery_request(hass):
             'friendly_name': "Test light 2", 'supported_features': 1
         })
 
-    resp = yield from smart_home.async_api_discovery(hass, msg)
+    resp = yield from smart_home.async_handle_message(hass, msg)
 
-    assert len(resp['payload']['discoveredAppliances']) == 3
-    assert resp['header']['name'] == 'DiscoverAppliancesResponse'
-    assert resp['header']['namespace'] == 'Alexa.ConnectedHome.Discovery'
+    assert 'event' in msg
+    msg = msg['event']
 
-    for i, appliance in enumerate(resp['payload']['discoveredAppliances']):
-        if appliance['applianceId'] == 'switch#test':
-            assert appliance['applianceTypes'][0] == "SWITCH"
+    assert len(resp['payload']['endpoints']) == 3
+    assert resp['header']['name'] == 'Discover.Response'
+    assert resp['header']['namespace'] == 'Alexa.Discovery'
+
+    for appliance in resp['payload']['endpoints']:
+        if appliance['endpointId'] == 'switch#test':
+            assert appliance['displayCategories'][0] == "SWITCH"
             assert appliance['friendlyName'] == "Test switch"
-            assert appliance['actions'] == ['turnOff', 'turnOn']
+            assert len(appliance['capabilities']) == 1
+            assert appliance['capabilities'][-1]['interface'] == \
+                'Alexa.PowerController'
             continue
 
-        if appliance['applianceId'] == 'light#test_1':
-            assert appliance['applianceTypes'][0] == "LIGHT"
+        if appliance['endpointId'] == 'light#test_1':
+            assert appliance['displayCategories'][0] == "LIGHT"
             assert appliance['friendlyName'] == "Test light 1"
-            assert appliance['actions'] == ['turnOff', 'turnOn']
+            assert len(appliance['capabilities']) == 1
+            assert appliance['capabilities'][-1]['interface'] == \
+                'Alexa.PowerController'
             continue
 
-        if appliance['applianceId'] == 'light#test_2':
-            assert appliance['applianceTypes'][0] == "LIGHT"
+        if appliance['endpointId'] == 'light#test_2':
+            assert appliance['displayCategories'][0] == "LIGHT"
             assert appliance['friendlyName'] == "Test light 2"
-            assert appliance['actions'] == \
-                ['turnOff', 'turnOn', 'setPercentage']
+            assert len(appliance['capabilities']) == 2
+            assert appliance['capabilities'][-1]['interface'] == \
+                'Alexa.BrightnessController'
             continue
 
         raise AssertionError("Unknown appliance!")
@@ -78,31 +150,41 @@ def test_discovery_request(hass):
 @asyncio.coroutine
 def test_api_entity_not_exists(hass):
     """Test api turn on process without entity."""
-    msg_switch = smart_home.api_message(
-        'TurnOnRequest', 'Alexa.ConnectedHome.Control', {
-            'appliance': {
-                'applianceId': 'switch#test'
-            }
-        })
+    request = get_new_request('Alexa.PowerController', 'TurnOn', 'switch#test')
 
     call_switch = async_mock_service(hass, 'switch', 'turn_on')
 
-    resp = yield from smart_home.async_api_turn_on(hass, msg_switch)
+    msg = yield from smart_home.async_handle_message(hass, msg)
+
+    assert 'event' in msg
+    msg = msg['event']
+
     assert len(call_switch) == 0
-    assert resp['header']['name'] == 'DriverInternalError'
-    assert resp['header']['namespace'] == 'Alexa.ConnectedHome.Control'
+    assert msg['header']['name'] == 'ErrorResponse'
+    assert msg['header']['namespace'] == 'Alexa'
+    assert msg['payload']['type'] == 'NO_SUCH_ENDPOINT'
+
+
+@asyncio.coroutine
+def test_api_function_not_implemented(hass):
+    """Test api call that is not implemented to us."""
+    request = get_new_request('Alexa.HAHAAH', 'Sweet')
+    msg = yield from smart_home.async_handle_message(hass, msg)
+
+    assert 'event' in msg
+    msg = msg['event']
+
+    assert msg['header']['name'] == 'ErrorResponse'
+    assert msg['header']['namespace'] == 'Alexa'
+    assert msg['payload']['type'] == 'INTERNAL_ERROR'
 
 
 @asyncio.coroutine
 @pytest.mark.parametrize("domain", ['light', 'switch'])
 def test_api_turn_on(hass, domain):
     """Test api turn on process."""
-    msg = smart_home.api_message(
-        'TurnOnRequest', 'Alexa.ConnectedHome.Control', {
-            'appliance': {
-                'applianceId': '{}#test'.format(domain)
-            }
-        })
+    msg = get_new_request(
+        'Alexa.PowerController', 'TurnOn', '{}#test'.format(domain))
 
     # settup test devices
     hass.states.async_set(
@@ -112,22 +194,22 @@ def test_api_turn_on(hass, domain):
 
     call = async_mock_service(hass, domain, 'turn_on')
 
-    resp = yield from smart_home.async_api_turn_on(hass, msg)
+    msg = yield from smart_home.async_handle_message(hass, msg)
+
+    assert 'event' in msg
+    msg = msg['event']
+
     assert len(call) == 1
     assert call[0].data['entity_id'] == '{}.test'.format(domain)
-    assert resp['header']['name'] == 'TurnOnConfirmation'
+    assert msg['header']['name'] == 'Response'
 
 
 @asyncio.coroutine
 @pytest.mark.parametrize("domain", ['light', 'switch'])
 def test_api_turn_off(hass, domain):
     """Test api turn on process."""
-    msg = smart_home.api_message(
-        'TurnOffRequest', 'Alexa.ConnectedHome.Control', {
-            'appliance': {
-                'applianceId': '{}#test'.format(domain)
-            }
-        })
+    msg = get_new_request(
+        'Alexa.PowerController', 'TurnOff', '{}#test'.format(domain))
 
     # settup test devices
     hass.states.async_set(
@@ -137,24 +219,24 @@ def test_api_turn_off(hass, domain):
 
     call = async_mock_service(hass, domain, 'turn_off')
 
-    resp = yield from smart_home.async_api_turn_off(hass, msg)
+    msg = yield from smart_home.async_handle_message(hass, msg)
+
+    assert 'event' in msg
+    msg = msg['event']
+
     assert len(call) == 1
     assert call[0].data['entity_id'] == '{}.test'.format(domain)
-    assert resp['header']['name'] == 'TurnOffConfirmation'
+    assert msg['header']['name'] == 'Response'
 
 
 @asyncio.coroutine
-def test_api_set_percentage_light(hass):
+def test_api_set_brightness(hass):
     """Test api set brightness process."""
-    msg_light = smart_home.api_message(
-        'SetPercentageRequest', 'Alexa.ConnectedHome.Control', {
-            'appliance': {
-                'applianceId': 'light#test'
-            },
-            'percentageState': {
-                'value': '50'
-            }
-        })
+    msg = get_new_request(
+        'Alexa.BrightnessController', 'SetBrightness', 'light#test')
+
+    # add payload
+    msg['directive']['payload']['brightness'] = '50'
 
     # settup test devices
     hass.states.async_set(
@@ -162,8 +244,12 @@ def test_api_set_percentage_light(hass):
 
     call_light = async_mock_service(hass, 'light', 'turn_on')
 
-    resp = yield from smart_home.async_api_set_percentage(hass, msg_light)
+    msg = yield from smart_home.async_handle_message(hass, msg)
+
+    assert 'event' in msg
+    msg = msg['event']
+
     assert len(call_light) == 1
     assert call_light[0].data['entity_id'] == 'light.test'
     assert call_light[0].data['brightness'] == '50'
-    assert resp['header']['name'] == 'SetPercentageConfirmation'
+    assert msg['header']['name'] == 'Response'

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -9,7 +9,7 @@ from homeassistant.components.alexa import smart_home
 from tests.common import async_mock_service
 
 
-def get_new_request(namespace, name, endpoint=True):
+def get_new_request(namespace, name, endpoint=None):
     """Generate a new API message."""
     raw_msg = {
         'directive': {
@@ -67,7 +67,6 @@ def test_create_api_message_special():
     request = request['directive']
 
     request['header'].pop('correlationToken')
-    request.pop['endpoint']
 
     msg = smart_home.api_message(request, 'testName', 'testNameSpace')
 
@@ -99,7 +98,6 @@ def test_wrong_version(hass):
 def test_discovery_request(hass):
     """Test alexa discovery request."""
     request = get_new_request('Alexa.Discovery', 'Discover')
-    request.pop['endpoint']
 
     # settup test devices
     hass.states.async_set(

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -154,7 +154,7 @@ def test_api_entity_not_exists(hass):
 
     call_switch = async_mock_service(hass, 'switch', 'turn_on')
 
-    msg = yield from smart_home.async_handle_message(hass, msg)
+    msg = yield from smart_home.async_handle_message(hass, request)
 
     assert 'event' in msg
     msg = msg['event']
@@ -169,7 +169,7 @@ def test_api_entity_not_exists(hass):
 def test_api_function_not_implemented(hass):
     """Test api call that is not implemented to us."""
     request = get_new_request('Alexa.HAHAAH', 'Sweet')
-    msg = yield from smart_home.async_handle_message(hass, msg)
+    msg = yield from smart_home.async_handle_message(hass, request)
 
     assert 'event' in msg
     msg = msg['event']
@@ -183,7 +183,7 @@ def test_api_function_not_implemented(hass):
 @pytest.mark.parametrize("domain", ['light', 'switch'])
 def test_api_turn_on(hass, domain):
     """Test api turn on process."""
-    msg = get_new_request(
+    request = get_new_request(
         'Alexa.PowerController', 'TurnOn', '{}#test'.format(domain))
 
     # settup test devices
@@ -194,7 +194,7 @@ def test_api_turn_on(hass, domain):
 
     call = async_mock_service(hass, domain, 'turn_on')
 
-    msg = yield from smart_home.async_handle_message(hass, msg)
+    msg = yield from smart_home.async_handle_message(hass, request)
 
     assert 'event' in msg
     msg = msg['event']
@@ -208,7 +208,7 @@ def test_api_turn_on(hass, domain):
 @pytest.mark.parametrize("domain", ['light', 'switch'])
 def test_api_turn_off(hass, domain):
     """Test api turn on process."""
-    msg = get_new_request(
+    request = get_new_request(
         'Alexa.PowerController', 'TurnOff', '{}#test'.format(domain))
 
     # settup test devices
@@ -219,7 +219,7 @@ def test_api_turn_off(hass, domain):
 
     call = async_mock_service(hass, domain, 'turn_off')
 
-    msg = yield from smart_home.async_handle_message(hass, msg)
+    msg = yield from smart_home.async_handle_message(hass, request)
 
     assert 'event' in msg
     msg = msg['event']
@@ -232,7 +232,7 @@ def test_api_turn_off(hass, domain):
 @asyncio.coroutine
 def test_api_set_brightness(hass):
     """Test api set brightness process."""
-    msg = get_new_request(
+    request = get_new_request(
         'Alexa.BrightnessController', 'SetBrightness', 'light#test')
 
     # add payload
@@ -244,7 +244,7 @@ def test_api_set_brightness(hass):
 
     call_light = async_mock_service(hass, 'light', 'turn_on')
 
-    msg = yield from smart_home.async_handle_message(hass, msg)
+    msg = yield from smart_home.async_handle_message(hass, request)
 
     assert 'event' in msg
     msg = msg['event']


### PR DESCRIPTION
## Description:

https://developer.amazon.com/docs/smarthome/smart-home-skill-api-message-reference.html

- [x] API messages
- [x] Discovery
- [x] Set percent
- [x] Turn on/off
- [x] Fix/update tests

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
