### PR TITLE
switch.flux: add interval and transition attributes

### DIFF
--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -11,7 +11,8 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.light import is_on, turn_on
+from homeassistant.components.light import (
+    is_on, turn_on, VALID_TRANSITION, ATTR_TRANSITION)
 from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
 from homeassistant.helpers.event import track_time_change
@@ -36,6 +37,7 @@ CONF_STOP_CT = 'stop_colortemp'
 CONF_BRIGHTNESS = 'brightness'
 CONF_DISABLE_BRIGTNESS_ADJUST = 'disable_brightness_adjust'
 CONF_MODE = 'mode'
+CONF_INTERVAL = 'interval'
 
 MODE_XY = 'xy'
 MODE_MIRED = 'mired'
@@ -58,37 +60,39 @@ PLATFORM_SCHEMA = vol.Schema({
         vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
     vol.Optional(CONF_DISABLE_BRIGTNESS_ADJUST): cv.boolean,
     vol.Optional(CONF_MODE, default=DEFAULT_MODE):
-        vol.Any(MODE_XY, MODE_MIRED, MODE_RGB)
+        vol.Any(MODE_XY, MODE_MIRED, MODE_RGB),
+    vol.Optional(CONF_INTERVAL, default=30): cv.positive_int,
+    vol.Optional(ATTR_TRANSITION, default=30): VALID_TRANSITION
 })
 
 
-def set_lights_xy(hass, lights, x_val, y_val, brightness):
+def set_lights_xy(hass, lights, x_val, y_val, brightness, transition):
     """Set color of array of lights."""
     for light in lights:
         if is_on(hass, light):
             turn_on(hass, light,
                     xy_color=[x_val, y_val],
                     brightness=brightness,
-                    transition=30)
+                    transition=transition)
 
 
-def set_lights_temp(hass, lights, mired, brightness):
+def set_lights_temp(hass, lights, mired, brightness, transition):
     """Set color of array of lights."""
     for light in lights:
         if is_on(hass, light):
             turn_on(hass, light,
                     color_temp=int(mired),
                     brightness=brightness,
-                    transition=30)
+                    transition=transition)
 
 
-def set_lights_rgb(hass, lights, rgb):
+def set_lights_rgb(hass, lights, rgb, transition):
     """Set color of array of lights."""
     for light in lights:
         if is_on(hass, light):
             turn_on(hass, light,
                     rgb_color=rgb,
-                    transition=30)
+                    transition=transition)
 
 
 # pylint: disable=unused-argument
@@ -104,9 +108,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     brightness = config.get(CONF_BRIGHTNESS)
     disable_brightness_adjust = config.get(CONF_DISABLE_BRIGTNESS_ADJUST)
     mode = config.get(CONF_MODE)
-    flux = FluxSwitch(name, hass, False, lights, start_time, stop_time,
+    interval = config.get(CONF_INTERVAL)
+    transition = config.get(ATTR_TRANSITION)
+    flux = FluxSwitch(name, hass, lights, start_time, stop_time,
                       start_colortemp, sunset_colortemp, stop_colortemp,
-                      brightness, disable_brightness_adjust, mode)
+                      brightness, disable_brightness_adjust, mode, interval,
+                      transition)
     add_devices([flux])
 
     def update(call=None):
@@ -120,9 +127,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class FluxSwitch(SwitchDevice):
     """Representation of a Flux switch."""
 
-    def __init__(self, name, hass, state, lights, start_time, stop_time,
+    def __init__(self, name, hass, lights, start_time, stop_time,
                  start_colortemp, sunset_colortemp, stop_colortemp,
-                 brightness, disable_brightness_adjust, mode):
+                 brightness, disable_brightness_adjust, mode, interval,
+                 transition):
         """Initialize the Flux switch."""
         self._name = name
         self.hass = hass
@@ -135,6 +143,8 @@ class FluxSwitch(SwitchDevice):
         self._brightness = brightness
         self._disable_brightness_adjust = disable_brightness_adjust
         self._mode = mode
+        self._interval = interval
+        self._transition = transition
         self.unsub_tracker = None
 
     @property
@@ -156,7 +166,7 @@ class FluxSwitch(SwitchDevice):
         self.flux_update()
 
         self.unsub_tracker = track_time_change(
-            self.hass, self.flux_update, second=[0, 30])
+            self.hass, self.flux_update, second=[0, self._interval])
 
         self.schedule_update_ha_state()
 
@@ -233,20 +243,21 @@ class FluxSwitch(SwitchDevice):
             brightness = None
         if self._mode == MODE_XY:
             set_lights_xy(self.hass, self._lights, x_val,
-                          y_val, brightness)
+                          y_val, brightness, self._transition)
             _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%% "
                          "of %s cycle complete at %s", x_val, y_val,
                          brightness, round(
                              percentage_complete * 100), time_state, now)
         elif self._mode == MODE_RGB:
-            set_lights_rgb(self.hass, self._lights, rgb)
+            set_lights_rgb(self.hass, self._lights, rgb, self._transition)
             _LOGGER.info("Lights updated to rgb:%s, %s%% "
                          "of %s cycle complete at %s", rgb,
                          round(percentage_complete * 100), time_state, now)
         else:
             # Convert to mired and clamp to allowed values
             mired = color_temperature_kelvin_to_mired(temp)
-            set_lights_temp(self.hass, self._lights, mired, brightness)
+            set_lights_temp(self.hass, self._lights, mired, brightness,
+                            self._transition)
             _LOGGER.info("Lights updated to mired:%s brightness:%s, %s%% "
                          "of %s cycle complete at %s", mired, brightness,
                          round(percentage_complete * 100), time_state, now)


### PR DESCRIPTION
## Description:
Allow setting interval and transition time attributes.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3517

## Example entry for `configuration.yaml` (if applicable):
```yaml

switch:
  - platform: flux
    lights:
      - light.my_light
    name: office_fluxer
    start_time: '07:00'
    stop_time: '01:00'
    start_colortemp: 4000
    sunset_colortemp: 3845
    stop_colortemp: 2000
    brightness: 255
    disable_brightness_adjust: False
    mode: mired
    transition: 30
    interval: 60
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
