### PR TITLE
Introducing support to Travis-CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -546,6 +546,7 @@ omit =
     homeassistant/components/sensor/time_date.py
     homeassistant/components/sensor/torque.py
     homeassistant/components/sensor/transmission.py
+    homeassistant/components/sensor/travisci.py
     homeassistant/components/sensor/twitch.py
     homeassistant/components/sensor/uber.py
     homeassistant/components/sensor/upnp.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -544,6 +544,7 @@ omit =
     homeassistant/components/sensor/time_date.py
     homeassistant/components/sensor/torque.py
     homeassistant/components/sensor/transmission.py
+    homeassistant/components/sensor/travisci.py
     homeassistant/components/sensor/twitch.py
     homeassistant/components/sensor/uber.py
     homeassistant/components/sensor/upnp.py

--- a/homeassistant/components/sensor/travisci.py
+++ b/homeassistant/components/sensor/travisci.py
@@ -1,0 +1,181 @@
+"""
+This component provides HA sensor support for Travis CI framework.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.travisci/
+"""
+import asyncio
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, CONF_SCAN_INTERVAL, CONF_MONITORED_CONDITIONS,
+    STATE_UNKNOWN)
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['TravisPy==0.3.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ATTRIBUTION = "Information provided by https://travis-ci.org/"
+CONF_BRANCH_NAME = 'default_branch'
+CONF_GITHUB_TOKEN = 'github_token'
+CONF_REPOSITORY_NAME = 'repository_name'
+
+DEFAULT_BRANCH_NAME = 'master'
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
+# sensor_type [ description, unit, icon ]
+SENSOR_TYPES = {
+    'last_build_id': ['Last Build ID', '', 'mdi:account-card-details'],
+    'last_build_finished_at': ['Last Build Finished At', '', 'mdi:timetable'],
+    'last_build_duration': ['Last Build Duration', 'sec', 'mdi:timelapse'],
+    'last_build_state': ['Last Build State', '', 'mdi:github-circle'],
+    'state': ['State', '', 'mdi:github-circle'],
+
+}
+
+NOTIFICATION_ID = 'travisci'
+NOTIFICATION_TITLE = 'Travis CI Sensor Setup'
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_GITHUB_TOKEN): cv.string,
+    vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Required(CONF_BRANCH_NAME, default=DEFAULT_BRANCH_NAME): cv.string,
+    vol.Optional(CONF_REPOSITORY_NAME, default=[]):
+        vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL):
+        cv.time_period,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Travis CI sensor."""
+    from travispy import TravisPy
+    from travispy.errors import TravisError
+
+    token = config.get(CONF_GITHUB_TOKEN)
+    repositories = config.get(CONF_REPOSITORY_NAME)
+    default_branch = config.get(CONF_BRANCH_NAME)
+
+    try:
+        travis = TravisPy.github_auth(token)
+        user = travis.user()
+
+    except TravisError as ex:
+        _LOGGER.error("Unable to connect to Travis CI service: %s", str(ex))
+        hass.components.persistent_notification.create(
+            'Error: {}<br />'
+            'You will need to restart hass after fixing.'
+            ''.format(ex),
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID)
+        return False
+
+    sensors = []
+
+    # non specificy repository selected, then show all associated
+    if not repositories:
+        all_repos = travis.repos(member=user.login)
+        repositories = [repo.slug for repo in all_repos]
+
+    for repo in repositories:
+        if '/' not in repo:
+            repo = "{0}/{1}".format(user.login, repo)
+
+        for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
+            sensors.append(TravisCISensor(travis,
+                                          repo,
+                                          user,
+                                          default_branch,
+                                          sensor_type))
+
+    async_add_devices(sensors, True)
+    return True
+
+
+class TravisCISensor(Entity):
+    """Representation of a Travis CI sensor."""
+
+    def __init__(self, data, repo_name, user, default_branch, sensor_type):
+        """Initialize the sensor."""
+        self._repo = None
+        self._build = None
+        self._sensor_type = sensor_type
+        self._data = data
+        self._repo_name = repo_name
+        self._user = user
+        self._default_branch = default_branch
+        self._state = STATE_UNKNOWN
+        self._name = "{0} {1}".format(self._repo_name,
+                                      SENSOR_TYPES[self._sensor_type][0])
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return SENSOR_TYPES[self._sensor_type][1]
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attrs = {}
+        attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+
+        if self._build and self._state is not STATE_UNKNOWN:
+            if self._user and self._sensor_type == 'state':
+                attrs['Owner Name'] = self._user.name
+                attrs['Owner Email'] = self._user.email
+            else:
+                attrs['Committer Name'] = self._build.commit.committer_name
+                attrs['Committer Email'] = self._build.commit.committer_email
+                attrs['Commit Branch'] = self._build.commit.branch
+                attrs['Committed Date'] = self._build.commit.committed_at
+                attrs['Commit SHA'] = self._build.commit.sha
+
+        return attrs
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return SENSOR_TYPES[self._sensor_type][2]
+
+    def update(self):
+        """Get the latest data and updates the states."""
+        _LOGGER.debug("Updating sensor %s - %s", self._name, self._state)
+        self._repo = self._data.repo(self._repo_name)
+        self._build = self._data.build(self._repo.last_build_id)
+        if self._repo:
+            if self._sensor_type == 'last_build_id':
+                self._state = self._repo.last_build_id
+
+            elif self._sensor_type == 'last_build_state':
+                self._state = self._repo.last_build_state
+
+            elif self._sensor_type == 'last_build_finished_at':
+                self._state = self._repo.last_build_finished_at
+
+            elif self._sensor_type == 'last_build_duration':
+                self._state = self._repo.last_build_duration
+
+            elif self._sensor_type == 'state':
+                branch_stats = \
+                    self._data.branch(self._default_branch, self._repo_name)
+                self._state = branch_stats.state

--- a/homeassistant/components/sensor/travisci.py
+++ b/homeassistant/components/sensor/travisci.py
@@ -159,7 +159,7 @@ class TravisCISensor(Entity):
 
     def update(self):
         """Get the latest data and updates the states."""
-        _LOGGER.debug("Updating sensor %s - %s", self._name, self._state)
+        _LOGGER.debug("Updating sensor %s", self._name)
 
         repo = self._data.repo(self._repo_name)
         self._build = self._data.build(repo.last_build_id)

--- a/homeassistant/components/sensor/travisci.py
+++ b/homeassistant/components/sensor/travisci.py
@@ -4,7 +4,6 @@ This component provides HA sensor support for Travis CI framework.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.travisci/
 """
-import asyncio
 import logging
 from datetime import timedelta
 
@@ -57,8 +56,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Travis CI sensor."""
     from travispy import TravisPy
     from travispy.errors import TravisError
@@ -99,7 +97,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                                           default_branch,
                                           sensor_type))
 
-    async_add_devices(sensors, True)
+    add_devices(sensors, True)
     return True
 
 

--- a/homeassistant/components/sensor/travisci.py
+++ b/homeassistant/components/sensor/travisci.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ATTRIBUTION = "Information provided by https://travis-ci.org/"
 CONF_BRANCH_NAME = 'default_branch'
 CONF_GITHUB_TOKEN = 'github_token'
-CONF_REPOSITORY_NAME = 'repository_name'
+CONF_REPOSITORY_NAME = 'repository_names'
 
 DEFAULT_BRANCH_NAME = 'master'
 

--- a/homeassistant/components/sensor/travisci.py
+++ b/homeassistant/components/sensor/travisci.py
@@ -108,7 +108,6 @@ class TravisCISensor(Entity):
 
     def __init__(self, data, repo_name, user, default_branch, sensor_type):
         """Initialize the sensor."""
-        self._repo = None
         self._build = None
         self._sensor_type = sensor_type
         self._data = data
@@ -162,13 +161,15 @@ class TravisCISensor(Entity):
         """Get the latest data and updates the states."""
         _LOGGER.debug("Updating sensor %s - %s", self._name, self._state)
 
-        self._repo = self._data.repo(self._repo_name)
-        self._build = self._data.build(self._repo.last_build_id)
+        repo = self._data.repo(self._repo_name)
+        self._build = self._data.build(repo.last_build_id)
 
-        if self._repo:
+        if self._build:
             if self._sensor_type == 'state':
                 branch_stats = \
                     self._data.branch(self._default_branch, self._repo_name)
                 self._state = branch_stats.state
+
             else:
-                self._state = getattr(self._repo, self._sensor_type)
+                param = self._sensor_type.replace('last_build_', '')
+                self._state = getattr(self._build, param)

--- a/homeassistant/components/sensor/travisci.py
+++ b/homeassistant/components/sensor/travisci.py
@@ -33,8 +33,9 @@ SCAN_INTERVAL = timedelta(seconds=30)
 # sensor_type [ description, unit, icon ]
 SENSOR_TYPES = {
     'last_build_id': ['Last Build ID', '', 'mdi:account-card-details'],
-    'last_build_finished_at': ['Last Build Finished At', '', 'mdi:timetable'],
     'last_build_duration': ['Last Build Duration', 'sec', 'mdi:timelapse'],
+    'last_build_finished_at': ['Last Build Finished At', '', 'mdi:timetable'],
+    'last_build_started_at': ['Last Build Started At', '', 'mdi:timetable'],
     'last_build_state': ['Last Build State', '', 'mdi:github-circle'],
     'state': ['State', '', 'mdi:github-circle'],
 
@@ -160,22 +161,14 @@ class TravisCISensor(Entity):
     def update(self):
         """Get the latest data and updates the states."""
         _LOGGER.debug("Updating sensor %s - %s", self._name, self._state)
+
         self._repo = self._data.repo(self._repo_name)
         self._build = self._data.build(self._repo.last_build_id)
+
         if self._repo:
-            if self._sensor_type == 'last_build_id':
-                self._state = self._repo.last_build_id
-
-            elif self._sensor_type == 'last_build_state':
-                self._state = self._repo.last_build_state
-
-            elif self._sensor_type == 'last_build_finished_at':
-                self._state = self._repo.last_build_finished_at
-
-            elif self._sensor_type == 'last_build_duration':
-                self._state = self._repo.last_build_duration
-
-            elif self._sensor_type == 'state':
+            if self._sensor_type == 'state':
                 branch_stats = \
                     self._data.branch(self._default_branch, self._repo_name)
                 self._state = branch_stats.state
+            else:
+                self._state = getattr(self._repo, self._sensor_type)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -41,6 +41,9 @@ PyXiaomiGateway==0.5.1
 # homeassistant.components.media_player.sonos
 SoCo==0.12
 
+# homeassistant.components.sensor.travisci
+TravisPy==0.3.5
+
 # homeassistant.components.notify.twitter
 TwitterAPI==2.4.6
 


### PR DESCRIPTION
## Description:
This PR introduces support to Home Assistant to monitor the result of a test build performed by Travis-CI. 

Basically this platform will allow to monitor the following conditions:
- state of a given branch
- Last build state
- started time from the last build
- elapsed time from the last build
- finished time from the last build
- last build ID

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3519

![image](https://user-images.githubusercontent.com/809840/31209493-44b4fb1a-a959-11e7-8a23-c9c60cf164d5.png)

![image](https://user-images.githubusercontent.com/809840/31209506-52e2142a-a959-11e7-920f-c3017f5b7b88.png)

![image](https://user-images.githubusercontent.com/809840/31209513-66616e7e-a959-11e7-9059-aa07b1da0a44.png)


## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: travisci
  github_token: !secret travisci_github_token
  scan_interval: 30
  default_branch: master
  repository_names:
    - raincloudy
    - home-assistant
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

