### PR TITLE
move icon battery function from util to helpers

### DIFF
--- a/homeassistant/components/sensor/android_ip_webcam.py
+++ b/homeassistant/components/sensor/android_ip_webcam.py
@@ -9,6 +9,7 @@ import asyncio
 from homeassistant.components.android_ip_webcam import (
     KEY_MAP, ICON_MAP, DATA_IP_WEBCAM, AndroidIPCamEntity, CONF_HOST,
     CONF_NAME, CONF_SENSORS)
+from homeassistant.helpers.icon import icon_for_battery_level
 
 DEPENDENCIES = ['android_ip_webcam']
 
@@ -75,14 +76,5 @@ class IPWebcamSensor(AndroidIPCamEntity):
     def icon(self):
         """Return the icon for the sensor."""
         if self._sensor == 'battery_level' and self._state is not None:
-            rounded_level = round(int(self._state), -1)
-            returning_icon = 'mdi:battery'
-            if rounded_level < 10:
-                returning_icon = 'mdi:battery-outline'
-            elif self._state == 100:
-                returning_icon = 'mdi:battery'
-            else:
-                returning_icon = 'mdi:battery-{}'.format(str(rounded_level))
-
-            return returning_icon
+            return icon_for_battery_level(int(self._state))
         return ICON_MAP.get(self._sensor, 'mdi:eye')

--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -17,7 +17,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.helpers.entity import Entity
-from homeassistant.util.icon import icon_for_battery_level
+from homeassistant.helpers.icon import icon_for_battery_level
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['fitbit==0.3.0']

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -6,7 +6,7 @@ https://home-assistant.io/ecosystem/ios/
 """
 from homeassistant.components import ios
 from homeassistant.helpers.entity import Entity
-from homeassistant.util.icon import icon_for_battery_level
+from homeassistant.helpers.icon import icon_for_battery_level
 
 DEPENDENCIES = ['ios']
 

--- a/homeassistant/components/sensor/raincloud.py
+++ b/homeassistant/components/sensor/raincloud.py
@@ -13,7 +13,7 @@ from homeassistant.components.raincloud import (
     DATA_RAINCLOUD, ICON_MAP, RainCloudEntity, SENSORS)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_MONITORED_CONDITIONS
-from homeassistant.util.icon import icon_for_battery_level
+from homeassistant.helpers.icon import icon_for_battery_level
 
 DEPENDENCIES = ['raincloud']
 

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.util.icon import icon_for_battery_level
+from homeassistant.helpers.icon import icon_for_battery_level
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/vacuum/dyson.py
+++ b/homeassistant/components/vacuum/dyson.py
@@ -14,7 +14,7 @@ from homeassistant.components.vacuum import (SUPPORT_BATTERY,
                                              SUPPORT_STATUS, SUPPORT_STOP,
                                              SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
                                              VacuumDevice)
-from homeassistant.util.icon import icon_for_battery_level
+from homeassistant.helpers.icon import icon_for_battery_level
 
 ATTR_FULL_CLEAN_TYPE = "full_clean_type"
 ATTR_CLEAN_ID = "clean_id"

--- a/homeassistant/components/vacuum/mqtt.py
+++ b/homeassistant/components/vacuum/mqtt.py
@@ -18,7 +18,7 @@ from homeassistant.components.vacuum import (
     VacuumDevice)
 from homeassistant.const import ATTR_SUPPORTED_FEATURES, CONF_NAME
 from homeassistant.core import callback
-from homeassistant.util.icon import icon_for_battery_level
+from homeassistant.helpers.icon import icon_for_battery_level
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/helpers/icon.py
+++ b/homeassistant/helpers/icon.py
@@ -1,4 +1,4 @@
-"""Icon util methods."""
+"""Icon helper methods."""
 from typing import Optional
 
 
@@ -11,8 +11,10 @@ def icon_for_battery_level(battery_level: Optional[int]=None,
     if charging and battery_level > 10:
         icon += '-charging-{}'.format(
             int(round(battery_level / 20 - .01)) * 20)
-    elif charging or battery_level <= 5:
+    elif charging:
         icon += '-outline'
+    elif battery_level <= 5:
+        icon += '-alert'
     elif 5 < battery_level < 95:
         icon += '-{}'.format(int(round(battery_level / 10 - .01)) * 10)
     return icon

--- a/tests/helpers/test_icon.py
+++ b/tests/helpers/test_icon.py
@@ -7,7 +7,7 @@ class TestIconUtil(unittest.TestCase):
 
     def test_battery_icon(self):
         """Test icon generator for battery sensor."""
-        from homeassistant.util.icon import icon_for_battery_level
+        from homeassistant.helpers.icon import icon_for_battery_level
 
         self.assertEqual('mdi:battery-unknown',
                          icon_for_battery_level(None, True))
@@ -16,7 +16,7 @@ class TestIconUtil(unittest.TestCase):
 
         self.assertEqual('mdi:battery-outline',
                          icon_for_battery_level(5, True))
-        self.assertEqual('mdi:battery-outline',
+        self.assertEqual('mdi:battery-alert',
                          icon_for_battery_level(5, False))
 
         self.assertEqual('mdi:battery-charging-100',
@@ -44,7 +44,7 @@ class TestIconUtil(unittest.TestCase):
             if 5 < level < 95:
                 postfix = '-{}'.format(int(round(level / 10 - .01)) * 10)
             elif level <= 5:
-                postfix = '-outline'
+                postfix = '-alert'
             else:
                 postfix = ''
             self.assertEqual(iconbase + postfix,


### PR DESCRIPTION
## Description:

Per discussion at https://github.com/home-assistant/home-assistant/pull/9593, https://github.com/home-assistant/home-assistant/pull/9594

- Move `icon_for_battery_level` from `util` to `helpers`
- Use `alert` battery icon for < 5 (non-charging)
- Uses in `sensor/android_ip_camera`

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
