### PR TITLE
arlo: Add alarm control panel component

### DIFF
--- a/homeassistant/components/alarm_control_panel/arlo.py
+++ b/homeassistant/components/alarm_control_panel/arlo.py
@@ -1,5 +1,5 @@
 """
-This component provides HA alarm_control_panel support for Arlo System.
+This component provides HA alarm_control_panel support for Arlo.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/alarm_control_panel.arlo/
@@ -13,7 +13,7 @@ from homeassistant.components.alarm_control_panel import (AlarmControlPanel,
                                                           PLATFORM_SCHEMA)
 from homeassistant.const import (ATTR_ATTRIBUTION, STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv
 
 DEPENDENCIES = ['arlo']
 
@@ -31,7 +31,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-    """Set up a sensor for an Arlo device."""
+    """Set up Arlo Base Stations."""
     data = hass.data[DATA_ARLO]
 
     if not data.base_stations:
@@ -45,7 +45,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
 
 class ArloBaseStation(AlarmControlPanel):
-    """An alarm_control_panel implementation for Arlo."""
+    """An AlarmControlPanel implementation for Arlo."""
 
     def __init__(self, data, home_mode_name):
         """Initialize the alarm control panel."""
@@ -107,6 +107,7 @@ class ArloBaseStation(AlarmControlPanel):
         }
 
     def _get_state_from_mode(self, mode):
+        """Convert Arlo mode to HA state."""
         if mode == ARMED:
             return STATE_ALARM_ARMED_AWAY
         elif mode == DISARMED:

--- a/homeassistant/components/alarm_control_panel/arlo.py
+++ b/homeassistant/components/alarm_control_panel/arlo.py
@@ -1,0 +1,106 @@
+"""
+This component provides HA alarm_control_panel support for Arlo System.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_control_panel.arlo/
+"""
+import asyncio
+import logging
+import voluptuous as vol
+
+from homeassistant.components.arlo import (DATA_ARLO, CONF_ATTRIBUTION)
+from homeassistant.components.alarm_control_panel import (AlarmControlPanel, PLATFORM_SCHEMA)
+from homeassistant.const import (ATTR_ATTRIBUTION, STATE_ALARM_ARMED_AWAY,
+                                 STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
+import homeassistant.helpers.config_validation as cv
+
+DEPENDENCIES = ['arlo']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_HOME_MODE_NAME = 'home_mode_name'
+ICON = 'mdi:security'
+ARMED = "armed"
+DISARMED = "disarmed"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOME_MODE_NAME, default=ARMED): cv.string,
+})
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up a sensor for an Arlo device."""
+    data = hass.data[DATA_ARLO]
+
+    if not data.base_stations:
+        return
+
+    home_mode_name = config.get(CONF_HOME_MODE_NAME)
+    base_stations = [ArloBaseStation(base_station, home_mode_name) for base_station in data.base_stations]
+    async_add_devices(base_stations)
+
+
+class ArloBaseStation(AlarmControlPanel):
+    """An alarm_control_panel implementation for Arlo."""
+
+    def __init__(self, data, home_mode_name):
+        """Initialize the alarm control panel."""
+        self._base_station = data
+        self._home_mode_name = home_mode_name
+
+    @property
+    def icon(self):
+        """Return icon."""
+        return ICON
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        # PyArlo sometimes returns None for mode. So retry 3 times before
+        # returning None.
+        num_retries = 3
+        i = 0
+        while i < num_retries:
+            mode = self._base_station.mode
+            if mode:
+                return self._get_state_from_mode(mode)
+            i += 1
+        return None
+
+    @asyncio.coroutine
+    def async_alarm_disarm(self, code=None):
+        """Send disarm command."""
+        self._base_station.mode = DISARMED
+
+    @asyncio.coroutine
+    def async_alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        self._base_station.mode = ARMED
+
+    @asyncio.coroutine
+    def async_alarm_arm_home(self, code=None):
+        """Send arm home command. Uses custom mode."""
+        self._base_station.mode = self._home_mode_name
+
+    @property
+    def name(self):
+        """Return the name of the base station."""
+        return self._base_station.name
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+            'device_id': self._base_station.device_id
+        }
+
+    def _get_state_from_mode(self, mode):
+        if mode == ARMED:
+            return STATE_ALARM_ARMED_AWAY
+        elif mode == DISARMED:
+            return STATE_ALARM_DISARMED
+        elif mode == self._home_mode_name:
+            return STATE_ALARM_ARMED_HOME
+        else:
+            return None

--- a/homeassistant/components/alarm_control_panel/arlo.py
+++ b/homeassistant/components/alarm_control_panel/arlo.py
@@ -51,6 +51,7 @@ class ArloBaseStation(AlarmControlPanel):
         """Initialize the alarm control panel."""
         self._base_station = data
         self._home_mode_name = home_mode_name
+        self._state = self._base_station.mode
 
     @property
     def icon(self):
@@ -60,6 +61,11 @@ class ArloBaseStation(AlarmControlPanel):
     @property
     def state(self):
         """Return the state of the device."""
+        return self._state
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Update the state of the device."""
         # PyArlo sometimes returns None for mode. So retry 3 times before
         # returning None.
         num_retries = 3
@@ -67,9 +73,11 @@ class ArloBaseStation(AlarmControlPanel):
         while i < num_retries:
             mode = self._base_station.mode
             if mode:
-                return self._get_state_from_mode(mode)
+                self._state = self._get_state_from_mode(mode)
+                return self._state
             i += 1
-        return None
+        self._state = None
+        return self._state
 
     @asyncio.coroutine
     def async_alarm_disarm(self, code=None):

--- a/homeassistant/components/alarm_control_panel/arlo.py
+++ b/homeassistant/components/alarm_control_panel/arlo.py
@@ -41,7 +41,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     base_stations = []
     for base_station in data.base_stations:
         base_stations.append(ArloBaseStation(base_station, home_mode_name))
-    async_add_devices(base_stations)
+    async_add_devices(base_stations, True)
 
 
 class ArloBaseStation(AlarmControlPanel):
@@ -51,7 +51,7 @@ class ArloBaseStation(AlarmControlPanel):
         """Initialize the alarm control panel."""
         self._base_station = data
         self._home_mode_name = home_mode_name
-        self._state = self._base_station.mode
+        self._state = None
 
     @property
     def icon(self):
@@ -74,10 +74,9 @@ class ArloBaseStation(AlarmControlPanel):
             mode = self._base_station.mode
             if mode:
                 self._state = self._get_state_from_mode(mode)
-                return self._state
+                return
             i += 1
         self._state = None
-        return self._state
 
     @asyncio.coroutine
     def async_alarm_disarm(self, code=None):

--- a/homeassistant/components/alarm_control_panel/arlo.py
+++ b/homeassistant/components/alarm_control_panel/arlo.py
@@ -9,7 +9,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.arlo import (DATA_ARLO, CONF_ATTRIBUTION)
-from homeassistant.components.alarm_control_panel import (AlarmControlPanel, PLATFORM_SCHEMA)
+from homeassistant.components.alarm_control_panel import (AlarmControlPanel,
+                                                          PLATFORM_SCHEMA)
 from homeassistant.const import (ATTR_ATTRIBUTION, STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
 import homeassistant.helpers.config_validation as cv
@@ -27,6 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOME_MODE_NAME, default=ARMED): cv.string,
 })
 
+
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up a sensor for an Arlo device."""
@@ -36,7 +38,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         return
 
     home_mode_name = config.get(CONF_HOME_MODE_NAME)
-    base_stations = [ArloBaseStation(base_station, home_mode_name) for base_station in data.base_stations]
+    base_stations = []
+    for base_station in data.base_stations:
+        base_stations.append(ArloBaseStation(base_station, home_mode_name))
     async_add_devices(base_stations)
 
 
@@ -102,5 +106,4 @@ class ArloBaseStation(AlarmControlPanel):
             return STATE_ALARM_DISARMED
         elif mode == self._home_mode_name:
             return STATE_ALARM_ARMED_HOME
-        else:
-            return None
+        return None


### PR DESCRIPTION
## Description:

Allows importing arlo base stations as an alarm control panel
component in HA. Lets the users configure a custom home mode since
arlo does not have a built-in home mode.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**

https://github.com/home-assistant/home-assistant.github.io/pull/3535

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: arlo
    home_mode_name: Home
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
