### PR TITLE
[light.tradfri] Clone all of aiocoap to ensure pinned commit will be present

### DIFF
--- a/virtualization/Docker/scripts/aiocoap
+++ b/virtualization/Docker/scripts/aiocoap
@@ -17,7 +17,7 @@ cd cython
 python3 setup.py install
 
 cd ../..
-git clone --depth 1 https://github.com/chrysn/aiocoap/
+git clone https://github.com/chrysn/aiocoap
 cd aiocoap
 git reset --hard 3286f48f0b949901c8b5c04c0719dc54ab63d431
 python3 -m pip install .


### PR DESCRIPTION
## Description:

I missed this, thanks @matemaciek for spotting it, we can't pin a commit if we're only retrieving the latest.