### PR TITLE
Pass old values in case of error in update

### DIFF
--- a/homeassistant/components/rest_command.py
+++ b/homeassistant/components/rest_command.py
@@ -39,7 +39,7 @@ CONF_CONTENT_TYPE = 'content_type'
 
 COMMAND_SCHEMA = vol.Schema({
     vol.Required(CONF_URL): cv.template,
-    vol.Optional(CONF_AUTHENTICATION, default=HTTP_BASIC_AUTHENTICATION):
+    vol.Optional(CONF_AUTHENTICATION, default=HTTP_DIGEST_AUTHENTICATION):
         vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
     vol.Optional(CONF_METHOD, default=DEFAULT_METHOD):
         vol.All(vol.Lower, vol.In(SUPPORT_REST_METHODS)),
@@ -74,8 +74,10 @@ def async_setup(hass, config):
         if CONF_USERNAME in command_config:
             username = command_config[CONF_USERNAME]
             password = command_config.get(CONF_PASSWORD, '')
-            
-            if command_config[CONF_AUTHENTICATION] == HTTP_DIGEST_AUTHENTICATION:
+
+            auth_method = command_config[CONF_AUTHENTICATION]
+
+            if auth_method == HTTP_DIGEST_AUTHENTICATION:
                 auth = HTTPDigestAuth(username, password)
             else:
                 auth = aiohttp.BasicAuth(username, password=password)
@@ -101,31 +103,29 @@ def async_setup(hass, config):
 
             try:
                 # aiohttp don't support DigestAuth yet
-                if command_config[CONF_AUTHENTICATION] == HTTP_DIGEST_AUTHENTICATION:
+                if auth_method == HTTP_DIGEST_AUTHENTICATION:
                     def fetch():
                         """Make request"""
                         try:
                             url = template_url.async_render(variables=service.data)
-                            if command_config[CONF_METHOD] == 'get':
-                                response = requests.get(url, data=payload, timeout=10, auth=auth, headers=headers)
-                            elif command_config[CONF_METHOD] == 'post':
-                                response = requests.post(url, data=payload, timeout=10, auth=auth, headers=headers)
-                            elif command_config[CONF_METHOD] == 'delete':
-                                response = requests.delete(url, data=payload, timeout=10, auth=auth, headers=headers)
-                            elif command_config[CONF_METHOD] == 'put':
-                                response = requests.put(url, data=payload, timeout=10, auth=auth, headers=headers)
-                            elif command_config[CONF_METHOD] == 'head':
-                                response = requests.head(url, data=payload, timeout=10, auth=auth, headers=headers)
-                            elif command_config[CONF_METHOD] == 'options':
-                                response = requests.options(url, data=payload, timeout=10, auth=auth, headers=headers)
-                                
-                            return response
+
+                            if method == 'get':
+                                request = requests.get(url, data=payload, timeout=10, auth=auth, headers=headers)
+                            elif method == 'post':
+                                request = requests.post(url, data=payload, timeout=10, auth=auth, headers=headers)
+                            elif method == 'delete':
+                                request = requests.delete(url, data=payload, timeout=10, auth=auth, headers=headers)
+                            elif method == 'put':
+                                request = requests.put(url, data=payload, timeout=10, auth=auth, headers=headers)
+
+                            return request
                         except requests.exceptions.RequestException as error:
                             _LOGGER.error("Rest command error %s.", url)
 
-                        request = yield from self.hass.async_add_job(
+                    request = yield from hass.async_add_job(
                             fetch)
-                else:    
+                    response = request.status_code
+                else:
                     with async_timeout.timeout(timeout, loop=hass.loop):
                         request = yield from getattr(websession, method)(
                             template_url.async_render(variables=service.data),
@@ -133,12 +133,13 @@ def async_setup(hass, config):
                             auth=auth,
                             headers=headers
                         )
+                    response = request.status
 
-                if request.status < 400:
+                if response < 400:
                     _LOGGER.info("Success call %s.", request.url)
                 else:
                     _LOGGER.warning(
-                        "Error %d on call %s.", request.status, request.url)
+                        "Error %d on call %s.", response, request.url)
 
             except asyncio.TimeoutError:
                 _LOGGER.warning("Timeout call %s.", request.url)

--- a/homeassistant/components/rest_command.py
+++ b/homeassistant/components/rest_command.py
@@ -107,23 +107,23 @@ def async_setup(hass, config):
                         try:
                             url = template_url.async_render(variables=service.data)
                             if command_config[CONF_METHOD] == 'get':
-                                request = requests.get(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                response = requests.get(url, data=payload, timeout=10, auth=auth, headers=headers)
                             elif command_config[CONF_METHOD] == 'post':
-                                request = requests.post(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                response = requests.post(url, data=payload, timeout=10, auth=auth, headers=headers)
                             elif command_config[CONF_METHOD] == 'delete':
-                                request = requests.delete(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                response = requests.delete(url, data=payload, timeout=10, auth=auth, headers=headers)
                             elif command_config[CONF_METHOD] == 'put':
-                                request = requests.put(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                response = requests.put(url, data=payload, timeout=10, auth=auth, headers=headers)
                             elif command_config[CONF_METHOD] == 'head':
-                                request = requests.head(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                response = requests.head(url, data=payload, timeout=10, auth=auth, headers=headers)
                             elif command_config[CONF_METHOD] == 'options':
-                                request = requests.options(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                response = requests.options(url, data=payload, timeout=10, auth=auth, headers=headers)
                                 
-                            return request
+                            return response
                         except requests.exceptions.RequestException as error:
                             _LOGGER.error("Rest command error %s.", url)
 
-                        response = yield from self.hass.async_add_job(
+                        request = yield from self.hass.async_add_job(
                             fetch)
                 else:    
                     with async_timeout.timeout(timeout, loop=hass.loop):

--- a/homeassistant/components/rest_command.py
+++ b/homeassistant/components/rest_command.py
@@ -106,7 +106,19 @@ def async_setup(hass, config):
                         """Make request"""
                         try:
                             url = template_url.async_render(variables=service.data)
-                            response = requests.get(url, data=payload, timeout=10, auth=auth, headers=headers)
+                            if command_config[CONF_METHOD] == 'get':
+                                response = requests.get(url, data=payload, timeout=10, auth=auth, headers=headers)
+                            elif command_config[CONF_METHOD] == 'post':
+                                response = requests.post(url, data=payload, timeout=10, auth=auth, headers=headers)
+                            elif command_config[CONF_METHOD] == 'delete':
+                                response = requests.delete(url, data=payload, timeout=10, auth=auth, headers=headers)
+                            elif command_config[CONF_METHOD] == 'put':
+                                response = requests.put(url, data=payload, timeout=10, auth=auth, headers=headers)
+                            elif command_config[CONF_METHOD] == 'head':
+                                response = requests.head(url, data=payload, timeout=10, auth=auth, headers=headers)
+                            elif command_config[CONF_METHOD] == 'options':
+                                response = requests.options(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                
                             return response.content
                         except requests.exceptions.RequestException as error:
                             _LOGGER.error("Rest command error %s.", request.url)

--- a/homeassistant/components/rest_command.py
+++ b/homeassistant/components/rest_command.py
@@ -107,21 +107,21 @@ def async_setup(hass, config):
                         try:
                             url = template_url.async_render(variables=service.data)
                             if command_config[CONF_METHOD] == 'get':
-                                response = requests.get(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                request = requests.get(url, data=payload, timeout=10, auth=auth, headers=headers)
                             elif command_config[CONF_METHOD] == 'post':
-                                response = requests.post(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                request = requests.post(url, data=payload, timeout=10, auth=auth, headers=headers)
                             elif command_config[CONF_METHOD] == 'delete':
-                                response = requests.delete(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                request = requests.delete(url, data=payload, timeout=10, auth=auth, headers=headers)
                             elif command_config[CONF_METHOD] == 'put':
-                                response = requests.put(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                request = requests.put(url, data=payload, timeout=10, auth=auth, headers=headers)
                             elif command_config[CONF_METHOD] == 'head':
-                                response = requests.head(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                request = requests.head(url, data=payload, timeout=10, auth=auth, headers=headers)
                             elif command_config[CONF_METHOD] == 'options':
-                                response = requests.options(url, data=payload, timeout=10, auth=auth, headers=headers)
+                                request = requests.options(url, data=payload, timeout=10, auth=auth, headers=headers)
                                 
-                            return response.content
+                            return request
                         except requests.exceptions.RequestException as error:
-                            _LOGGER.error("Rest command error %s.", request.url)
+                            _LOGGER.error("Rest command error %s.", url)
 
                         response = yield from self.hass.async_add_job(
                             fetch)

--- a/homeassistant/components/rest_command.py
+++ b/homeassistant/components/rest_command.py
@@ -11,10 +11,13 @@ import aiohttp
 from aiohttp import hdrs
 import async_timeout
 import voluptuous as vol
+import requests
+from requests.auth import HTTPDigestAuth
 
 from homeassistant.const import (
     CONF_TIMEOUT, CONF_USERNAME, CONF_PASSWORD, CONF_URL, CONF_PAYLOAD,
-    CONF_METHOD)
+    CONF_METHOD, CONF_AUTHENTICATION,
+    HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
@@ -36,6 +39,8 @@ CONF_CONTENT_TYPE = 'content_type'
 
 COMMAND_SCHEMA = vol.Schema({
     vol.Required(CONF_URL): cv.template,
+    vol.Optional(CONF_AUTHENTICATION, default=HTTP_BASIC_AUTHENTICATION):
+        vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
     vol.Optional(CONF_METHOD, default=DEFAULT_METHOD):
         vol.All(vol.Lower, vol.In(SUPPORT_REST_METHODS)),
     vol.Inclusive(CONF_USERNAME, 'authentication'): cv.string,
@@ -69,7 +74,11 @@ def async_setup(hass, config):
         if CONF_USERNAME in command_config:
             username = command_config[CONF_USERNAME]
             password = command_config.get(CONF_PASSWORD, '')
-            auth = aiohttp.BasicAuth(username, password=password)
+            
+            if command_config[CONF_AUTHENTICATION] == HTTP_DIGEST_AUTHENTICATION:
+                auth = HTTPDigestAuth(username, password)
+            else:
+                auth = aiohttp.BasicAuth(username, password=password)
 
         template_payload = None
         if CONF_PAYLOAD in command_config:
@@ -91,13 +100,27 @@ def async_setup(hass, config):
                     'utf-8')
 
             try:
-                with async_timeout.timeout(timeout, loop=hass.loop):
-                    request = yield from getattr(websession, method)(
-                        template_url.async_render(variables=service.data),
-                        data=payload,
-                        auth=auth,
-                        headers=headers
-                    )
+                # aiohttp don't support DigestAuth yet
+                if command_config[CONF_AUTHENTICATION] == HTTP_DIGEST_AUTHENTICATION:
+                    def fetch():
+                        """Make request"""
+                        try:
+                            url = template_url.async_render(variables=service.data)
+                            response = requests.get(url, data=payload, timeout=10, auth=auth, headers=headers)
+                            return response.content
+                        except requests.exceptions.RequestException as error:
+                            _LOGGER.error("Rest command error %s.", request.url)
+
+                        response = yield from self.hass.async_add_job(
+                            fetch)
+                else:    
+                    with async_timeout.timeout(timeout, loop=hass.loop):
+                        request = yield from getattr(websession, method)(
+                            template_url.async_render(variables=service.data),
+                            data=payload,
+                            auth=auth,
+                            headers=headers
+                        )
 
                 if request.status < 400:
                     _LOGGER.info("Success call %s.", request.url)

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -761,4 +761,4 @@ class WUndergroundData(object):
                 self.data = result
         except ValueError as err:
             _LOGGER.error("Check WUnderground API %s", err.args)
-            self.data = None
+            pass


### PR DESCRIPTION
It's quite often that Wunderground sends error content:
2017-10-06 11:43:00 ERROR (Thread-10) [homeassistant.components.sensor.wunderground] Check WUnderground API ({'version': '0.1', 'features': {}, 'error': {'type': 'keynotfound', 'description': 'this key does not exist'}, 'termsofService': 'http://www.wunderground.com/weather/api/d/terms.html'},)

after that some sensor gets wrong values due to lambda func, i.e.: 
<function WUCurrentConditionsSensorConfig.__init__.<locals>.<lambda> at 0x6d4c43d8>
Those values brake recorder - wrong JSON value
2017-10-06 13:44:31 ERROR (Recorder) [homeassistant.components.recorder.util] Error executing query: <function <lambda> at 0x6d4c43d8> is not JSON serializable



