### PR TITLE
More netdata sensors

### DIFF
--- a/homeassistant/components/sensor/netdata.py
+++ b/homeassistant/components/sensor/netdata.py
@@ -44,6 +44,18 @@ SENSOR_TYPES = {
     'ipv4_in': ['IPv4 In', 'kb/s', 'system.ipv4', 'received', 0],
     'ipv4_out': ['IPv4 Out', 'kb/s', 'system.ipv4', 'sent', 0],
     'disk_free': ['Disk Free', 'GiB', 'disk_space._', 'avail', 2],
+    'cpu_iowait': ['CPU IOWait', '%', 'system.cpu', 'iowait', 1],
+    'cpu_user': ['CPU User', '%', 'system.cpu', 'user', 1],
+    'cpu_system': ['CPU System', '%', 'system.cpu', 'system', 1],
+    'cpu_softirq': ['CPU SoftIRQ', '%', 'system.cpu', 'softirq', 1],
+    'cpu_guest': ['CPU Guest', '%', 'system.cpu', 'guest', 1],
+    'uptime': ['Uptime', 's', 'system.uptime', 'uptime', 2],
+    'packets_received': ['Packets Received', 'packets/s', 'ipv4.packets',
+                         'received', 1],
+    'packets_sent': ['Packets Sent', 'packets/s', 'ipv4.packets',
+                     'sent', 1],
+    'connections': ['Active Connections', 'Count',
+                    'netfilter.conntrack_sockets', 'connections', 1]
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/sensor/netdata.py
+++ b/homeassistant/components/sensor/netdata.py
@@ -49,13 +49,13 @@ SENSOR_TYPES = {
     'cpu_system': ['CPU System', '%', 'system.cpu', 'system', 1],
     'cpu_softirq': ['CPU SoftIRQ', '%', 'system.cpu', 'softirq', 1],
     'cpu_guest': ['CPU Guest', '%', 'system.cpu', 'guest', 1],
-    'uptime': ['Uptime', 's', 'system.uptime', 'uptime', 2],
+    'uptime': ['Uptime', 's', 'system.uptime', 'uptime', 0],
     'packets_received': ['Packets Received', 'packets/s', 'ipv4.packets',
-                         'received', 1],
+                         'received', 0],
     'packets_sent': ['Packets Sent', 'packets/s', 'ipv4.packets',
-                     'sent', 1],
+                     'sent', 0],
     'connections': ['Active Connections', 'Count',
-                    'netfilter.conntrack_sockets', 'connections', 1]
+                    'netfilter.conntrack_sockets', 'connections', 0]
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
## Description:
Adds the following resources for the `netdata` sensor to monitor:
- CPU Usage
    - iowait, user, system, softirq, and guest
- Uptime
- Received packets
- Sent packets
- Number of connections

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3613

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: netdata
    resources:
      - cpu_iowait
      - cpu_user
      - cpu_system
      - cpu_softirq
      - cpu_guest
      - uptime
      - packets_received
      - packets_sent
      - connections
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
