### PR TITLE
bump the version and catch all exceptions to avoid showing backtraces…

### DIFF
--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-eq3bt==0.1.5']
+REQUIREMENTS = ['python-eq3bt==0.1.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -164,4 +164,7 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
     def update(self):
         """Update the data from the thermostat."""
-        self._thermostat.update()
+        try:
+            self._thermostat.update()
+        except Exception as ex:
+            _LOGGER.warning("Updating the state failed: %s" % ex)

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -164,7 +164,8 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
     def update(self):
         """Update the data from the thermostat."""
+        from bluepy.btle import BTLEException
         try:
             self._thermostat.update()
-        except Exception as ex:
-            _LOGGER.warning("Updating the state failed: %s" % ex)
+        except BTLEException as ex:
+            _LOGGER.warning("Updating the state failed: %s", ex)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -748,7 +748,7 @@ python-digitalocean==1.12
 python-ecobee-api==0.0.10
 
 # homeassistant.components.climate.eq3btsmart
-# python-eq3bt==0.1.5
+# python-eq3bt==0.1.6
 
 # homeassistant.components.sensor.etherscan
 python-etherscan-api==0.0.1


### PR DESCRIPTION
… but a more sane error message

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
