### PR TITLE
Upgrade pysnmp to 4.3.10

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -16,7 +16,7 @@ from homeassistant.const import CONF_HOST
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pysnmp==4.3.9']
+REQUIREMENTS = ['pysnmp==4.3.10']
 
 CONF_COMMUNITY = 'community'
 CONF_AUTHKEY = 'authkey'
@@ -36,7 +36,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 # pylint: disable=unused-argument
 def get_scanner(hass, config):
-    """Validate the configuration and return an snmp scanner."""
+    """Validate the configuration and return an SNMP scanner."""
     scanner = SnmpScanner(config[DOMAIN])
 
     return scanner if scanner.success_init else None

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PORT, CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN,
     CONF_VALUE_TEMPLATE)
 
-REQUIREMENTS = ['pysnmp==4.3.9']
+REQUIREMENTS = ['pysnmp==4.3.10']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -729,7 +729,7 @@ pysma==0.1.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
-pysnmp==4.3.9
+pysnmp==4.3.10
 
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner


### PR DESCRIPTION
## 4.3.10
- Refactored partial SNMP message decoding to make it less dependent on unpublished pyasn1 API features.
- Fix to MibTableRow.setFromName() to keep the input parameter type when it propagates to the return value. Before this fix   ObjectIdentity.prettyPrint() may crash when rendering malformed SNMP table indices.
- Fixed NotificationReceiver to include SNMPv1 TRAP Message community tring into SNMPv2c/v3 TRAP PDU
- Fixed multiple bugs in SNMP table indices rendering, especially the InetAddressIPv6 type which was severely broken.
- Fixed crashing Bits.prettyPrint() implementation
- Fixed crashing Bits.clone()/subtype() implementation
- Fixed leaking exceptions bubbling up from the asyncio and Twisted adapters

Tested with the following configuration:

``` yaml
sensor:
  - platform: snmp
    name: SNMP TEST String
    host: demo.snmplabs.com
    community: public
    baseoid: 1.3.6.1.4.1.2021.10.1.3.1
    unit_of_measurement: "load"
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.