### PR TITLE
Add CAPSman master to mikrotik presence detection

### DIFF
--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -133,8 +133,7 @@ class MikrotikScanner(DeviceScanner):
             self.host
         )
 
-        device_names = self.client(cmd='/ip/dhcp-server/lease/getall')
-        
+        device_names = self.client(cmd='/ip/dhcp-server/lease/getall')        
         if devices_tracker == 'capsman':
             devices = self.client(
                 cmd='/caps-man/registration-table/getall'

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -133,7 +133,7 @@ class MikrotikScanner(DeviceScanner):
             self.host
         )
 
-        device_names = self.client(cmd='/ip/dhcp-server/lease/getall')        
+        device_names = self.client(cmd='/ip/dhcp-server/lease/getall')
         if devices_tracker == 'capsman':
             devices = self.client(
                 cmd='/caps-man/registration-table/getall'

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -83,6 +83,15 @@ class MikrotikScanner(DeviceScanner):
                              routerboard_info[0].get('model', 'Router'),
                              self.host)
                 self.connected = True
+                self.capsman_exist = self.client(
+                    cmd='/capsman/interface/getall'
+                )
+                if not self.capsman_exist:
+                    _LOGGER.info(
+                        'Mikrotik %s: Not a CAPSman controller. Trying '
+                        'local interfaces ',
+                        self.host
+                    )
                 self.wireless_exist = self.client(
                     cmd='/interface/wireless/getall'
                 )
@@ -111,7 +120,9 @@ class MikrotikScanner(DeviceScanner):
 
     def _update_info(self):
         """Retrieve latest information from the Mikrotik box."""
-        if self.wireless_exist:
+        if self.capsman_exist:
+            devices_tracker = 'capsman'
+        elif self.wireless_exist:
             devices_tracker = 'wireless'
         else:
             devices_tracker = 'ip'
@@ -123,7 +134,12 @@ class MikrotikScanner(DeviceScanner):
         )
 
         device_names = self.client(cmd='/ip/dhcp-server/lease/getall')
-        if self.wireless_exist:
+        
+        if devices_tracker == 'capsman':
+            devices = self.client(
+                cmd='/caps-man/registration-table/getall'
+            )
+        elif devices_tracker == 'wireless':
             devices = self.client(
                 cmd='/interface/wireless/registration-table/getall'
             )


### PR DESCRIPTION
## Description
Automatically prefer caps-man registered clients over locally connected

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
