### PR TITLE
Event trigger nested conditions

### DIFF
--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 TRIGGER_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'event',
     vol.Required(CONF_EVENT_TYPE): cv.string,
-    vol.Optional(CONF_EVENT_DATA): dict,
+    vol.Optional(CONF_EVENT_DATA, default={}): dict,
 })
 
 
@@ -29,18 +29,24 @@ TRIGGER_SCHEMA = vol.Schema({
 def async_trigger(hass, config, action):
     """Listen for events based on configuration."""
     event_type = config.get(CONF_EVENT_TYPE)
-    event_data = config.get(CONF_EVENT_DATA)
+    event_data_schema = vol.Schema(
+        config.get(CONF_EVENT_DATA),
+        extra=vol.ALLOW_EXTRA)
 
     @callback
     def handle_event(event):
         """Listen for events and calls the action when data matches."""
-        if not event_data or all(val == event.data.get(key) for key, val
-                                 in event_data.items()):
-            hass.async_run_job(action, {
-                'trigger': {
-                    'platform': 'event',
-                    'event': event,
-                },
-            })
+        try:
+            event_data_schema(event.data)
+        except vol.Invalid:
+            # If event data doesn't match requested schema, skip event
+            return
+
+        hass.async_run_job(action, {
+            'trigger': {
+                'platform': 'event',
+                'event': event,
+            },
+        })
 
     return hass.bus.async_listen(event_type, handle_event)

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -74,6 +74,34 @@ class TestAutomationEvent(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
 
+    def test_if_fires_on_event_with_nested_data(self):
+        """Test the firing of events with nested data."""
+        assert setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'event',
+                    'event_type': 'test_event',
+                    'event_data': {
+                        'parent_attr': {
+                            'some_attr': 'some_value'
+                        }
+                    }
+                },
+                'action': {
+                    'service': 'test.automation',
+                }
+            }
+        })
+
+        self.hass.bus.fire('test_event', {
+            'parent_attr': {
+                'some_attr': 'some_value',
+                'another': 'value'
+            }
+        })
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
     def test_if_not_fires_if_event_data_not_matches(self):
         """Test firing of event if no match."""
         assert setup_component(self.hass, automation.DOMAIN, {


### PR DESCRIPTION
## Description:
This PR updates the event trigger data option to allow specifying nested event data filters. The current use case for me is the Automatic device tracker. The events send out nested data, with a format similar to what's shown below. The goal is to filter events on a vehicle ID:

```json
{
  "event_type": "ignition:on",
  "vehicle": {
    "id": "1234",
    "name": "Civic",
  }
}
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3548

## Example entry for `configuration.yaml` (if applicable):

```yaml
automation:
  - trigger: 
      - platform: event
        event_type: automatic_update
        event_data:
          type: "ignition:on"
          vehicle:
            id: "1234"
```