### PR TITLE
WIP: vacuum.xiaomi_miio: read dnd status properly instead of using impreci…

### DIFF
--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_TOKEN, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-mirobo==0.2.0']
+REQUIREMENTS = ['python-miio==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +48,8 @@ FAN_SPEEDS = {
 
 ATTR_CLEANING_TIME = 'cleaning_time'
 ATTR_DO_NOT_DISTURB = 'do_not_disturb'
+ATTR_DO_NOT_DISTURB_START = 'do_not_disturb_start'
+ATTR_DO_NOT_DISTURB_END = 'do_not_disturb_end'
 ATTR_MAIN_BRUSH_LEFT = 'main_brush_left'
 ATTR_SIDE_BRUSH_LEFT = 'side_brush_left'
 ATTR_FILTER_LEFT = 'filter_left'
@@ -155,6 +157,7 @@ class MiroboVacuum(VacuumDevice):
 
         self.consumable_state = None
         self.clean_history = None
+        self.dnd_state = None
 
     @property
     def name(self):
@@ -196,11 +199,14 @@ class MiroboVacuum(VacuumDevice):
     @property
     def device_state_attributes(self):
         """Return the specific state attributes of this vacuum cleaner."""
+
         attrs = {}
         if self.vacuum_state is not None:
             attrs.update({
                 ATTR_DO_NOT_DISTURB:
-                    STATE_ON if self.vacuum_state.dnd else STATE_OFF,
+                    STATE_ON if self.dnd_state.enabled else STATE_OFF,
+                ATTR_DO_NOT_DISTURB_START: str(self.dnd_state.start),
+                ATTR_DO_NOT_DISTURB_END: str(self.dnd_state.end),
                 # Not working --> 'Cleaning mode':
                 #    STATE_ON if self.vacuum_state.in_cleaning else STATE_OFF,
                 ATTR_CLEANING_TIME: int(
@@ -223,7 +229,6 @@ class MiroboVacuum(VacuumDevice):
                     / 3600)})
             if self.vacuum_state.got_error:
                 attrs[ATTR_ERROR] = self.vacuum_state.error
-
         return attrs
 
     @property
@@ -366,7 +371,7 @@ class MiroboVacuum(VacuumDevice):
     @asyncio.coroutine
     def async_update(self):
         """Fetch state from the device."""
-        from mirobo import DeviceException
+        from miio import DeviceException
         try:
             state = yield from self.hass.async_add_job(self._vacuum.status)
             _LOGGER.debug("Got new state from the vacuum: %s", state.data)
@@ -375,6 +380,9 @@ class MiroboVacuum(VacuumDevice):
                 self._vacuum.consumable_status)
             self.clean_history = yield from self.hass.async_add_job(
                 self._vacuum.clean_history)
+            self.dnd_state = yield from self.hass.async_add_job(
+                self._vacuum.dnd_status)
+
             self._is_on = state.is_on
             self._available = True
         except OSError as exc:

--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_TOKEN, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-miio==0.2.0']
+REQUIREMENTS = ['python-miio==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -790,8 +790,10 @@ python-juicenet==0.0.5
 
 # homeassistant.components.light.xiaomi_miio
 # homeassistant.components.switch.xiaomi_miio
-# homeassistant.components.vacuum.xiaomi_miio
 python-mirobo==0.2.0
+
+# homeassistant.components.vacuum.xiaomi_miio
+python-miio==0.3.0
 
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5


### PR DESCRIPTION
…se dnd flag from vacuum_state

## Description:
The value stored in the `vacuum_state`'s `dnd` is not precise, and does not at least always correlate with the correct state. Therefore another call has to be made to find out the real settings.
This also exposes the currently used start and end hours.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
