### PR TITLE
Expose time module in Python Scripts

### DIFF
--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -181,6 +181,7 @@ class TimeWrapper:
     # Class variable, only going to warn once per Home Assistant run
     warned = False
 
+    # pylint: disable=no-self-use
     def sleep(self, *args, **kwargs):
         """Sleep method that warns once."""
         if not TimeWrapper.warned:

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -29,6 +29,7 @@ ALLOWED_STATEMACHINE = set(['entity_ids', 'all', 'get', 'is_state',
 ALLOWED_SERVICEREGISTRY = set(['services', 'has_service', 'call'])
 ALLOWED_TIME = set(['sleep', 'strftime', 'strptime', 'gmtime', 'localtime',
                     'ctime', 'time', 'mktime'])
+ALLOWED_DATETIME = set(['date', 'time', 'datetime', 'timedelta', 'tzinfo'])
 ALLOWED_DT_UTIL = set([
     'utcnow', 'now', 'as_utc', 'as_timestamp', 'as_local',
     'utc_from_timestamp', 'start_of_local_day', 'parse_datetime', 'parse_date',
@@ -121,6 +122,7 @@ def execute(hass, filename, source, data=None):
               obj is hass.states and name not in ALLOWED_STATEMACHINE or
               obj is hass.services and name not in ALLOWED_SERVICEREGISTRY or
               obj is dt_util and name not in ALLOWED_DT_UTIL or
+              obj is datetime and name not in ALLOWED_DATETIME or
               obj is time and name not in ALLOWED_TIME):
             raise ScriptError('Not allowed to access {}.{}'.format(
                 obj.__class__.__name__, name))

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -1,8 +1,9 @@
 """Component to allow running Python scripts."""
-import glob
-import os
-import logging
 import datetime
+import glob
+import logging
+import os
+import time
 
 import voluptuous as vol
 
@@ -120,6 +121,7 @@ def execute(hass, filename, source, data=None):
     builtins = safe_builtins.copy()
     builtins.update(utility_builtins)
     builtins['datetime'] = datetime
+    builtins['time'] = time
     restricted_globals = {
         '__builtins__': builtins,
         '_print_': StubPrinter,

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -28,7 +28,7 @@ ALLOWED_STATEMACHINE = set(['entity_ids', 'all', 'get', 'is_state',
                             'is_state_attr', 'remove', 'set'])
 ALLOWED_SERVICEREGISTRY = set(['services', 'has_service', 'call'])
 ALLOWED_TIME = set(['sleep', 'strftime', 'strptime', 'gmtime', 'localtime',
-                    'ctime', 'time'])
+                    'ctime', 'time', 'mktime'])
 ALLOWED_DT_UTIL = set([
     'utcnow', 'now', 'as_utc', 'as_timestamp', 'as_local',
     'utc_from_timestamp', 'start_of_local_day', 'parse_datetime', 'parse_date',

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -27,6 +27,8 @@ ALLOWED_EVENTBUS = set(['fire'])
 ALLOWED_STATEMACHINE = set(['entity_ids', 'all', 'get', 'is_state',
                             'is_state_attr', 'remove', 'set'])
 ALLOWED_SERVICEREGISTRY = set(['services', 'has_service', 'call'])
+ALLOWED_TIME = set(['sleep', 'strftime', 'strptime', 'gmtime', 'localtime',
+                    'ctime', 'time'])
 ALLOWED_DT_UTIL = set([
     'utcnow', 'now', 'as_utc', 'as_timestamp', 'as_local',
     'utc_from_timestamp', 'start_of_local_day', 'parse_datetime', 'parse_date',
@@ -118,7 +120,8 @@ def execute(hass, filename, source, data=None):
               obj is hass.bus and name not in ALLOWED_EVENTBUS or
               obj is hass.states and name not in ALLOWED_STATEMACHINE or
               obj is hass.services and name not in ALLOWED_SERVICEREGISTRY or
-              obj is dt_util and name not in ALLOWED_DT_UTIL):
+              obj is dt_util and name not in ALLOWED_DT_UTIL or
+              obj is time and name not in ALLOWED_TIME):
             raise ScriptError('Not allowed to access {}.{}'.format(
                 obj.__class__.__name__, name))
 

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -11,6 +11,7 @@ from homeassistant.const import SERVICE_RELOAD
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import bind_hass
 from homeassistant.util import sanitize_filename
+import homeassistant.util.dt as dt_util
 
 DOMAIN = 'python_script'
 REQUIREMENTS = ['restrictedpython==4.0a3']
@@ -26,6 +27,10 @@ ALLOWED_EVENTBUS = set(['fire'])
 ALLOWED_STATEMACHINE = set(['entity_ids', 'all', 'get', 'is_state',
                             'is_state_attr', 'remove', 'set'])
 ALLOWED_SERVICEREGISTRY = set(['services', 'has_service', 'call'])
+ALLOWED_DT_UTIL = set([
+    'utcnow', 'now', 'as_utc', 'as_timestamp', 'as_local',
+    'utc_from_timestamp', 'start_of_local_day', 'parse_datetime', 'parse_date',
+    'get_age'])
 
 
 class ScriptError(HomeAssistantError):
@@ -112,7 +117,8 @@ def execute(hass, filename, source, data=None):
         elif (obj is hass and name not in ALLOWED_HASS or
               obj is hass.bus and name not in ALLOWED_EVENTBUS or
               obj is hass.states and name not in ALLOWED_STATEMACHINE or
-              obj is hass.services and name not in ALLOWED_SERVICEREGISTRY):
+              obj is hass.services and name not in ALLOWED_SERVICEREGISTRY or
+              obj is dt_util and name not in ALLOWED_DT_UTIL):
             raise ScriptError('Not allowed to access {}.{}'.format(
                 obj.__class__.__name__, name))
 
@@ -122,6 +128,7 @@ def execute(hass, filename, source, data=None):
     builtins.update(utility_builtins)
     builtins['datetime'] = datetime
     builtins['time'] = time
+    builtins['dt_util'] = dt_util
     restricted_globals = {
         '__builtins__': builtins,
         '_print_': StubPrinter,

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -206,6 +206,26 @@ hass.states.set('hello.ab_list', '{}'.format(ab_list))
 
 
 @asyncio.coroutine
+def test_exposed_modules(hass, caplog):
+    """Test datetime and time modules exposed."""
+    caplog.set_level(logging.ERROR)
+    source = """
+hass.states.set('module.time', time.ctime(521276400))
+hass.states.set('module.datetime',
+                datetime.timedelta(minutes=1).total_seconds())
+"""
+
+    hass.async_add_job(execute, hass, 'test.py', source, {})
+    yield from hass.async_block_till_done()
+
+    assert hass.states.is_state('module.time', 'Wed Jul  9 00:00:00 1986')
+    assert hass.states.is_state('module.datetime', '60.0')
+
+    # No errors logged = good
+    assert caplog.text == ''
+
+
+@asyncio.coroutine
 def test_reload(hass):
     """Test we can re-discover scripts."""
     scripts = [

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -161,6 +161,7 @@ def test_accessing_forbidden_methods(hass, caplog):
     for source, name in {
         'hass.stop()': 'HomeAssistant.stop',
         'dt_util.set_default_time_zone()': 'module.set_default_time_zone',
+        'datetime.non_existing': 'module.non_existing',
         'time.tzset()': 'module.tzset',
     }.items():
         caplog.records.clear()

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -160,7 +160,8 @@ def test_accessing_forbidden_methods(hass, caplog):
 
     for source, name in {
         'hass.stop()': 'HomeAssistant.stop',
-        'dt_util.set_default_time_zone': 'module.set_default_time_zone'
+        'dt_util.set_default_time_zone()': 'module.set_default_time_zone',
+        'time.tzset()': 'module.tzset',
     }.items():
         caplog.records.clear()
         hass.async_add_job(execute, hass, 'test.py', source, {})
@@ -212,7 +213,7 @@ def test_exposed_modules(hass, caplog):
     """Test datetime and time modules exposed."""
     caplog.set_level(logging.ERROR)
     source = """
-hass.states.set('module.time', time.ctime(521276400))
+hass.states.set('module.time', time.strftime('%Y', time.gmtime(521276400)))
 hass.states.set('module.datetime',
                 datetime.timedelta(minutes=1).total_seconds())
 """
@@ -220,7 +221,7 @@ hass.states.set('module.datetime',
     hass.async_add_job(execute, hass, 'test.py', source, {})
     yield from hass.async_block_till_done()
 
-    assert hass.states.is_state('module.time', 'Wed Jul  9 00:00:00 1986')
+    assert hass.states.is_state('module.time', '1986')
     assert hass.states.is_state('module.datetime', '60.0')
 
     # No errors logged = good

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -157,14 +157,16 @@ logger.info('Logging from inside script: %s %s' % (mydict["a"], mylist[2]))
 def test_accessing_forbidden_methods(hass, caplog):
     """Test compile error logs error."""
     caplog.set_level(logging.ERROR)
-    source = """
-hass.stop()
-    """
 
-    hass.async_add_job(execute, hass, 'test.py', source, {})
-    yield from hass.async_block_till_done()
+    for source, name in {
+        'hass.stop()': 'HomeAssistant.stop',
+        'dt_util.set_default_time_zone': 'module.set_default_time_zone'
+    }.items():
+        caplog.records.clear()
+        hass.async_add_job(execute, hass, 'test.py', source, {})
+        yield from hass.async_block_till_done()
 
-    assert "Not allowed to access HomeAssistant.stop" in caplog.text
+        assert "Not allowed to access ".format(name) in caplog.text
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:
This exposes `util.dt` and the time module in Python Scripts. This does allow people to use `time.sleep()`, but they should do so at their own risk.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
