### PR TITLE
Fix I/O in event loop by Arlo alarm control panel

### DIFF
--- a/homeassistant/components/alarm_control_panel/arlo.py
+++ b/homeassistant/components/alarm_control_panel/arlo.py
@@ -68,8 +68,7 @@ class ArloBaseStation(AlarmControlPanel):
         """Return the state of the device."""
         return self._state
 
-    @asyncio.coroutine
-    def async_update(self):
+    def update(self):
         """Update the state of the device."""
         # PyArlo sometimes returns None for mode. So retry 3 times before
         # returning None.


### PR DESCRIPTION
## Description:
Arlo was doing I/O inside the event loop (https://github.com/home-assistant/home-assistant/issues/4210#issuecomment-334969021). This fixes it.