### PR TITLE
Added support for Yeelight scenes

### DIFF
--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -200,3 +200,26 @@ lifx_effect_stop:
     entity_id:
       description: Name(s) of entities to stop effects on. Leave out to stop effects everywhere.
       example: 'light.bedroom'
+
+yeelight_set_scene:
+  description: Set the smart LED directly to a specified state.
+
+  fields:
+    entity_id:
+      description: Name(s) of entities to turn on
+      example: 'light.kitchen'
+
+    name:
+      description: Scene type ("color_and_brightness" - color and brigntess, "temperature_and_brightness" - temperature and brigtness, "nightlight" - switch to moonlight mode)
+
+    rgb_color:
+      description: Color for the light in RGB-format
+      example: '[255, 100, 100]'
+
+    brightness_pct:
+      description: Number between 0..100 indicating percentage of full brightness
+      example: 47
+
+    kelvin:
+      description: Color temperature for the light in Kelvin
+      example: 4000

--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -100,6 +100,7 @@ SCENE_COLOR_AND_BRIGNTNESS = "color_and_brightness"
 SCENE_TEMPERATURE_AND_BRIGHTNESS = "temperature_and_brightness"
 SCENE_NIGHTLIGHT = "nightlight"
 
+
 # Travis-CI runs too old astroid https://github.com/PyCQA/pylint/issues/1212
 # pylint: disable=invalid-sequence-index
 def hsv_to_rgb(hsv: Tuple[float, float, float]) -> Tuple[int, int, int]:


### PR DESCRIPTION
## Description:

This adds support for direct scene setting for Yeelight LED lights. More about scenes can be found in the [Yeelight developer documentation](https://www.yeelight.com/en_US/developer).
The main motivation was to allow switching of the Yeelight ceiling light to a moonlight mode which is distinct from the default daylight mode and provides lower brightness levels.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
