### PR TITLE
Make Arlo battery_level icon dynamic

### DIFF
--- a/homeassistant/components/sensor/arlo.py
+++ b/homeassistant/components/sensor/arlo.py
@@ -87,7 +87,7 @@ class ArloSensor(Entity):
         """Icon to use in the frontend, if any."""
         if self._sensor_type == 'battery_level' and self._state is not None:
             return icon_for_battery_level(battery_level=int(self._state),
-                                         charging=False)
+                                          charging=False)
         return self._icon
 
     @property

--- a/homeassistant/components/sensor/arlo.py
+++ b/homeassistant/components/sensor/arlo.py
@@ -16,6 +16,7 @@ from homeassistant.components.arlo import (
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS)
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.icon import icon_for_battery_level
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -84,6 +85,9 @@ class ArloSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
+        if self._sensor_type == 'battery_level' and self._state is not None:
+            return icon_for_battery_level(battery_level=int(self._state),
+                                         charging=False)
         return self._icon
 
     @property


### PR DESCRIPTION
## Description:
Make Arlo battery_level icon to use the helper `icon_for_battery_level` for a dynamic icon.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.