### PR TITLE
Fix for TypeError in synology camera

### DIFF
--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.aiohttp_client import (
     async_aiohttp_proxy_web)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['py-synology==0.1.1']
+REQUIREMENTS = ['py-synology==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -543,7 +543,7 @@ pwmled==1.2.1
 py-cpuinfo==3.3.0
 
 # homeassistant.components.camera.synology
-py-synology==0.1.1
+py-synology==0.1.3
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13


### PR DESCRIPTION
## Description:
Synology camera is not working in 0.5.5 when running with Python 3.5. This should be fixed in py-synology == 0.1.3

**Related issue (if applicable):** fixes #9735 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54