### PR TITLE
Cover service schema - added 'vol.ALLOW_EXTRA'

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -59,7 +59,7 @@ ATTR_TILT_POSITION = 'tilt_position'
 
 COVER_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-})
+}, extra=vol.ALLOW_EXTRA)
 
 COVER_SET_COVER_POSITION_SCHEMA = COVER_SERVICE_SCHEMA.extend({
     vol.Required(ATTR_POSITION):


### PR DESCRIPTION
## Description:
I added "vol.ALLOW_EXTRA" to the basic cover service schema. Sometimes when using service_templates it's more convenient to allow extra parameters in return for a simpler script (example below). It could make sense to edit [config_validation.py](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/helpers/config_validation.py#L449) instead, to enable the option for all components.

```yaml
cover:
  sequence:
    - service_template: "cover.{{action}}"
         # action beeing the service name
         # (start_cover, stop_cover, close_cover, set_cover_position)
      data_template:
        position: "{{position}}"
```

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
