### PR TITLE
Bump raincloudy version 0.0.3

### DIFF
--- a/homeassistant/components/binary_sensor/raincloud.py
+++ b/homeassistant/components/binary_sensor/raincloud.py
@@ -59,6 +59,8 @@ class RainCloudBinarySensor(RainCloudEntity, BinarySensorDevice):
         """Get the latest data and updates the state."""
         _LOGGER.debug("Updating RainCloud sensor: %s", self._name)
         self._state = getattr(self.data, self._sensor_type)
+        if self._sensor_type == 'status' and self._state == 'Offline':
+            self._state = False
 
     @property
     def icon(self):

--- a/homeassistant/components/binary_sensor/raincloud.py
+++ b/homeassistant/components/binary_sensor/raincloud.py
@@ -60,7 +60,7 @@ class RainCloudBinarySensor(RainCloudEntity, BinarySensorDevice):
         _LOGGER.debug("Updating RainCloud sensor: %s", self._name)
         self._state = getattr(self.data, self._sensor_type)
         if self._sensor_type == 'status':
-            self._state = True if self._state == 'Online' else False
+            self._state = self._state == 'Online'
 
     @property
     def icon(self):

--- a/homeassistant/components/binary_sensor/raincloud.py
+++ b/homeassistant/components/binary_sensor/raincloud.py
@@ -59,8 +59,8 @@ class RainCloudBinarySensor(RainCloudEntity, BinarySensorDevice):
         """Get the latest data and updates the state."""
         _LOGGER.debug("Updating RainCloud sensor: %s", self._name)
         self._state = getattr(self.data, self._sensor_type)
-        if self._sensor_type == 'status' and self._state == 'Offline':
-            self._state = False
+        if self._sensor_type == 'status':
+            self._state = True if self._state == 'Online' else False
 
     @property
     def icon(self):

--- a/homeassistant/components/raincloud.py
+++ b/homeassistant/components/raincloud.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.dispatcher import (
 
 from requests.exceptions import HTTPError, ConnectTimeout
 
-REQUIREMENTS = ['raincloudy==0.0.1']
+REQUIREMENTS = ['raincloudy==0.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/raincloud.py
+++ b/homeassistant/components/sensor/raincloud.py
@@ -56,7 +56,7 @@ class RainCloudSensor(RainCloudEntity):
         """Get the latest data and updates the states."""
         _LOGGER.debug("Updating RainCloud sensor: %s", self._name)
         if self._sensor_type == 'battery':
-            self._state = self.data.battery.strip('%')
+            self._state = self.data.battery
         else:
             self._state = getattr(self.data, self._sensor_type)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -868,7 +868,7 @@ rachiopy==0.1.2
 radiotherm==1.3
 
 # homeassistant.components.raincloud
-raincloudy==0.0.1
+raincloudy==0.0.3
 
 # homeassistant.components.raspihats
 # raspihats==2.2.3


### PR DESCRIPTION
## Description:
This PR bumps the `raincloudy` version to `0.0.3` and address a couple of other issues:

* The percent signal now is stripped directly on the external library or it will return None when unable to acquire the battery level.
* Fixed the logic on the binary_sensor to return False when controller or faucet is offline. 
## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

**Note**: If you guys are planning any `0.55.1`  would be great to cherrypick this PR