### PR TITLE
Added new Clickatell SMS messaging Notify Platform

### DIFF
--- a/homeassistant/components/notify/clickatell.py
+++ b/homeassistant/components/notify/clickatell.py
@@ -6,10 +6,9 @@ This platform is to enable the sending of SMS notfiy messages with Clickatell
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.clickatell/
 """
-import json
+
 import logging
 import requests
-
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -45,7 +44,9 @@ class ClickatellNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        data = {'apiKey': self.api_key, 'to': self.recipient, 'content': message}
+        data = {'apiKey': self.api_key, 
+                'to': self.recipient, 
+                'content': message}
 
         try:
             resp = requests.get(BASE_API_URL, params=data, timeout=5)
@@ -53,5 +54,3 @@ class ClickatellNotificationService(BaseNotificationService):
                 _LOGGER.error("Error %s : %s", resp.status_code, resp.text)
         except Exception as err:
             _LOGGER.error("Error %s : %s", type(err), err.message)
-            
-

--- a/homeassistant/components/notify/clickatell.py
+++ b/homeassistant/components/notify/clickatell.py
@@ -44,8 +44,8 @@ class ClickatellNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        data = {'apiKey': self.api_key, 
-                'to': self.recipient, 
+        data = {'apiKey': self.api_key,
+                'to': self.recipient,
                 'content': message}
 
         try:

--- a/homeassistant/components/notify/clickatell.py
+++ b/homeassistant/components/notify/clickatell.py
@@ -1,0 +1,57 @@
+"""
+Clickatell platform for notify component.
+
+This platform is to enable the sending of SMS notfiy messages with Clickatell
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.clickatell/
+"""
+import json
+import logging
+import requests
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (CONF_API_KEY, CONF_RECIPIENT)
+from homeassistant.components.notify import (
+                PLATFORM_SCHEMA, BaseNotificationService)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'clickatell'
+
+BASE_API_URL = 'https://platform.clickatell.com/messages/http/send'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_RECIPIENT): cv.string,
+})
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the Clickatell notification service."""
+
+    return ClickatellNotificationService(config)
+
+
+class ClickatellNotificationService(BaseNotificationService):
+    """Implementation of a notification service for the Clickatell service."""
+
+    def __init__(self, config):
+        """Initialize the service."""
+        self.api_key = config.get(CONF_API_KEY)
+        self.recipient = config.get(CONF_RECIPIENT)
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to a user."""
+        data = {'apiKey': self.api_key, 'to': self.recipient, 'content': message}
+
+        try:
+            resp = requests.get(BASE_API_URL, params=data, timeout=5)
+            if (resp.status_code != 200) or (resp.status_code != 201):
+                _LOGGER.error("Error %s : %s", resp.status_code, resp.text)
+        except Exception as err:
+            _LOGGER.error("Error %s : %s", type(err), err.message)
+            
+

--- a/homeassistant/components/notify/clickatell.py
+++ b/homeassistant/components/notify/clickatell.py
@@ -50,4 +50,3 @@ class ClickatellNotificationService(BaseNotificationService):
         resp = requests.get(BASE_API_URL, params=data, timeout=5)
         if (resp.status_code != 200) or (resp.status_code != 201):
             _LOGGER.error("Error %s : %s", resp.status_code, resp.text)
-        _LOGGER.error("Error %s : %s", type(err), err.message)

--- a/homeassistant/components/notify/clickatell.py
+++ b/homeassistant/components/notify/clickatell.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_API_KEY, CONF_RECIPIENT)
 from homeassistant.components.notify import (
-                PLATFORM_SCHEMA, BaseNotificationService)
+    PLATFORM_SCHEMA, BaseNotificationService)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +30,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def get_service(hass, config, discovery_info=None):
     """Get the Clickatell notification service."""
-
     return ClickatellNotificationService(config)
 
 
@@ -48,9 +47,7 @@ class ClickatellNotificationService(BaseNotificationService):
                 'to': self.recipient,
                 'content': message}
 
-        try:
-            resp = requests.get(BASE_API_URL, params=data, timeout=5)
-            if (resp.status_code != 200) or (resp.status_code != 201):
-                _LOGGER.error("Error %s : %s", resp.status_code, resp.text)
-        except Exception as err:
-            _LOGGER.error("Error %s : %s", type(err), err.message)
+        resp = requests.get(BASE_API_URL, params=data, timeout=5)
+        if (resp.status_code != 200) or (resp.status_code != 201):
+            _LOGGER.error("Error %s : %s", resp.status_code, resp.text)
+        _LOGGER.error("Error %s : %s", type(err), err.message)

--- a/homeassistant/components/notify/clickatell.py
+++ b/homeassistant/components/notify/clickatell.py
@@ -1,13 +1,11 @@
 """
 Clickatell platform for notify component.
 
-This platform is to enable the sending of SMS notfiy messages with Clickatell
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.clickatell/
 """
-
 import logging
+
 import requests
 import voluptuous as vol
 
@@ -43,9 +41,11 @@ class ClickatellNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        data = {'apiKey': self.api_key,
-                'to': self.recipient,
-                'content': message}
+        data = {
+            'apiKey': self.api_key,
+            'to': self.recipient,
+            'content': message,
+        }
 
         resp = requests.get(BASE_API_URL, params=data, timeout=5)
         if (resp.status_code != 200) or (resp.status_code != 201):

--- a/script/dev_docker
+++ b/script/dev_docker
@@ -14,21 +14,19 @@ docker build -t home-assistant-dev -f virtualization/Docker/Dockerfile.dev .
 if [ $# -gt 0 ]
 then
   docker run \
-    -d \
+    --net=host \
     --device=/dev/ttyUSB0:/zwaveusbstick:rwm \
     -e "TZ=$1" \
     -v `pwd`:/usr/src/app \
     -v `pwd`/config:/config \
-    -p 8123:8123 \
     -t -i home-assistant-dev
 
 else
   docker run \
-    -d \
+    --net=host \
     -v /etc/localtime:/etc/localtime:ro \
     -v `pwd`:/usr/src/app \
     -v `pwd`/config:/config \
-    -p 8123:8123 \
     --rm \
     -t -i home-assistant-dev
 

--- a/script/dev_docker
+++ b/script/dev_docker
@@ -14,19 +14,21 @@ docker build -t home-assistant-dev -f virtualization/Docker/Dockerfile.dev .
 if [ $# -gt 0 ]
 then
   docker run \
-    --net=host \
+    -d \
     --device=/dev/ttyUSB0:/zwaveusbstick:rwm \
     -e "TZ=$1" \
     -v `pwd`:/usr/src/app \
     -v `pwd`/config:/config \
+    -p 8123:8123 \
     -t -i home-assistant-dev
 
 else
   docker run \
-    --net=host \
+    -d \
     -v /etc/localtime:/etc/localtime:ro \
     -v `pwd`:/usr/src/app \
     -v `pwd`/config:/config \
+    -p 8123:8123 \
     --rm \
     -t -i home-assistant-dev
 


### PR DESCRIPTION
## Description:
New platform to enable support for the Clickatell SMS service (http://clickatell.com) for SMS based notfication services.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3569

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - name: clickatell
    platform: clickatell
    api_key: MY_API_KEY
    recipient: TARGET_PHONE_NUMBER

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

done

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
