### PR TITLE
missing is_closed ( rflink cover fix )

### DIFF
--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -102,6 +102,11 @@ class RflinkCover(RflinkCommand, CoverDevice):
     def should_poll(self):
         """No polling available in RFlink cover."""
         return False
+    
+    @property
+ -  def is_closed(self):
+ -      """Return if the cover is closed."""
+  -     return None
 
     def async_close_cover(self, **kwargs):
         """Turn the device close."""

--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -104,9 +104,9 @@ class RflinkCover(RflinkCommand, CoverDevice):
         return False
     
     @property
- -  def is_closed(self):
- -      """Return if the cover is closed."""
-  -     return None
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return None
 
     def async_close_cover(self, **kwargs):
         """Turn the device close."""

--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -102,7 +102,7 @@ class RflinkCover(RflinkCommand, CoverDevice):
     def should_poll(self):
         """No polling available in RFlink cover."""
         return False
-    
+
     @property
  -  def is_closed(self):
  -      """Return if the cover is closed."""


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
