### PR TITLE
 Suppress InsecureRequestWarning when verify_ssl is False for camera.synology

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,6 +40,7 @@ homeassistant/components/*/zwave.py @home-assistant/z-wave
 
 # Indiviudal components
 homeassistant/components/alarm_control_panel/egardia.py @jeroenterheerdt
+homeassistant/components/camera/synology.py @snjoetw
 homeassistant/components/climate/eq3btsmart.py @rytilahti
 homeassistant/components/climate/sensibo.py @andrey-git
 homeassistant/components/cover/template.py @PhracturedBlue

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -44,6 +44,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     verify_ssl = config.get(CONF_VERIFY_SSL)
     timeout = config.get(CONF_TIMEOUT)
 
+    if not verify_ssl:
+        from requests.packages import urllib3
+        _LOGGER.warning('InsecureRequestWarning is disabled for camera.synology platform')
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
     try:
         from synology.surveillance_station import SurveillanceStation
         surveillance = SurveillanceStation(

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -46,7 +46,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     if not verify_ssl:
         from requests.packages import urllib3
-        _LOGGER.warning('InsecureRequestWarning is disabled for camera.synology platform')
+        _LOGGER.warning('InsecureRequestWarning is disabled '
+                        'for camera.synology platform.')
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     try:


### PR DESCRIPTION
## Description:

camera.synology is spewing logs like this:
```
/usr/local/lib/python3.6/site-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
```

I'm guessing most users are running synology surveillance camera without valid SSL certificate, so this is annoying. The change made is that if user specifically turned off ssl_verify, then we should suppress InsecureRequestWarning as well

## Checklist:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54