### PR TITLE
Communication timeout support in modbus hub.

### DIFF
--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -14,7 +14,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
-    CONF_HOST, CONF_METHOD, CONF_PORT, ATTR_STATE)
+    CONF_HOST, CONF_METHOD, CONF_PORT, CONF_TYPE, CONF_TIMEOUT, ATTR_STATE)
 
 DOMAIN = 'modbus'
 
@@ -24,9 +24,7 @@ REQUIREMENTS = ['pymodbus==1.3.1']
 CONF_BAUDRATE = 'baudrate'
 CONF_BYTESIZE = 'bytesize'
 CONF_STOPBITS = 'stopbits'
-CONF_TYPE = 'type'
 CONF_PARITY = 'parity'
-CONF_TIMEOUT = 'timeout'
 
 SERIAL_SCHEMA = {
     vol.Required(CONF_BAUDRATE): cv.positive_int,

--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -26,6 +26,7 @@ CONF_BYTESIZE = 'bytesize'
 CONF_STOPBITS = 'stopbits'
 CONF_TYPE = 'type'
 CONF_PARITY = 'parity'
+CONF_TIMEOUT = 'timeout'
 
 SERIAL_SCHEMA = {
     vol.Required(CONF_BAUDRATE): cv.positive_int,
@@ -35,12 +36,14 @@ SERIAL_SCHEMA = {
     vol.Required(CONF_PARITY): vol.Any('E', 'O', 'N'),
     vol.Required(CONF_STOPBITS): vol.Any(1, 2),
     vol.Required(CONF_TYPE): 'serial',
+    vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
 }
 
 ETHERNET_SCHEMA = {
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PORT): cv.positive_int,
     vol.Required(CONF_TYPE): vol.Any('tcp', 'udp'),
+    vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
 }
 
 
@@ -89,15 +92,18 @@ def setup(hass, config):
                               baudrate=config[DOMAIN][CONF_BAUDRATE],
                               stopbits=config[DOMAIN][CONF_STOPBITS],
                               bytesize=config[DOMAIN][CONF_BYTESIZE],
-                              parity=config[DOMAIN][CONF_PARITY])
+                              parity=config[DOMAIN][CONF_PARITY],
+                              timeout=config[DOMAIN][CONF_TIMEOUT])
     elif client_type == 'tcp':
         from pymodbus.client.sync import ModbusTcpClient as ModbusClient
         client = ModbusClient(host=config[DOMAIN][CONF_HOST],
-                              port=config[DOMAIN][CONF_PORT])
+                              port=config[DOMAIN][CONF_PORT],
+                              timeout=config[DOMAIN][CONF_TIMEOUT])
     elif client_type == 'udp':
         from pymodbus.client.sync import ModbusUdpClient as ModbusClient
         client = ModbusClient(host=config[DOMAIN][CONF_HOST],
-                              port=config[DOMAIN][CONF_PORT])
+                              port=config[DOMAIN][CONF_PORT],
+                              timeout=config[DOMAIN][CONF_TIMEOUT])
     else:
         return False
 


### PR DESCRIPTION
Timeout parameter are taken from configuration and passed to pymodbus constructor.

## Description:


**Related issue (if applicable):** fixes #9724

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3570

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry for a TCP connection
modbus:
  type: tcp
  host: IP_ADDRESS
  port: 2020
  timeout: 0.5
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

