### PR TITLE
Bump rxv library to 0.5.1

### DIFF
--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -18,7 +18,7 @@ from homeassistant.const import (CONF_NAME, CONF_HOST, STATE_OFF, STATE_ON,
                                  STATE_PLAYING, STATE_IDLE)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['rxv==0.4.0']
+REQUIREMENTS = ['rxv==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -902,7 +902,7 @@ russound==0.1.7
 russound_rio==0.1.4
 
 # homeassistant.components.media_player.yamaha
-rxv==0.4.0
+rxv==0.5.1
 
 # homeassistant.components.media_player.samsungtv
 samsungctl==0.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -130,7 +130,7 @@ rflink==0.0.34
 ring_doorbell==0.1.4
 
 # homeassistant.components.media_player.yamaha
-rxv==0.4.0
+rxv==0.5.1
 
 # homeassistant.components.sleepiq
 sleepyq==0.6


### PR DESCRIPTION
This fixes some bugs with interfacing with yamaha receivers, including
closing bug #5209.