### PR TITLE
Resolving bug that prevents ssl_verify option for Unifi device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -26,14 +26,14 @@ DEFAULT_VERIFY_SSL = True
 NOTIFICATION_ID = 'unifi_notification'
 NOTIFICATION_TITLE = 'Unifi Device Tracker Setup'
 
-# TODO: Change CONF_VERIFY_SSL to allow True, False, or Path
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_SITE_ID, default='default'): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): vol.Any(
+        cv.boolean, cv.isfile)
 })
 
 

--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -26,13 +26,14 @@ DEFAULT_VERIFY_SSL = True
 NOTIFICATION_ID = 'unifi_notification'
 NOTIFICATION_TITLE = 'Unifi Device Tracker Setup'
 
+# TODO: Change CONF_VERIFY_SSL to allow True, False, or Path
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_SITE_ID, default='default'): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean
 })
 
 

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -28,8 +28,10 @@ def mock_scanner():
 @mock.patch('os.access', return_value=True)
 @mock.patch('os.path.isfile', mock.Mock(return_value=True))
 def test_config_valid_verify_ssl(hass, mock_scanner, mock_ctrl):
-    """Test the setup with a string for ssl_verify representing the absolute
-    path to a CA certificate bundle"""
+    """Test the setup with a string for ssl_verify.
+
+    Representing the absolute path to a CA certificate bundle.
+    """
     config = {
         DOMAIN: unifi.PLATFORM_SCHEMA({
             CONF_PLATFORM: unifi.DOMAIN,

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -124,7 +124,7 @@ def test_config_error():
             CONF_VERIFY_SSL: 5555,  # Invalid ssl_verify
             'port': 123,
         })
-    
+
 
 def test_config_controller_failed(hass, mock_ctrl, mock_scanner):
     """Test for controller failure."""

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -25,6 +25,8 @@ def mock_scanner():
         yield scanner
 
 
+@mock.patch('os.access', return_value=True)
+@mock.patch('os.path.isfile', mock.Mock(return_value=True))
 def test_config_valid_verify_ssl(hass, mock_scanner, mock_ctrl):
     """Test the setup with a string for ssl_verify representing the absolute
     path to a CA certificate bundle"""
@@ -110,19 +112,10 @@ def test_config_error():
         })
     with pytest.raises(vol.Invalid):
         unifi.PLATFORM_SCHEMA({
-            CONF_USERNAME: 'foo',
             CONF_PLATFORM: unifi.DOMAIN,
-            CONF_HOST: 'myhost',
-            CONF_VERIFY_SSL: None,  # Invalid ssl_verify
-            'port': 123,
-        })
-    with pytest.raises(vol.Invalid):
-        unifi.PLATFORM_SCHEMA({
             CONF_USERNAME: 'foo',
-            CONF_PLATFORM: unifi.DOMAIN,
-            CONF_HOST: 'myhost',
-            CONF_VERIFY_SSL: 5555,  # Invalid ssl_verify
-            'port': 123,
+            CONF_PASSWORD: 'password',
+            CONF_VERIFY_SSL: "dfdsfsdfsd",  # Invalid ssl_verify (no file)
         })
 
 


### PR DESCRIPTION
## Description:
The unifi device_tracker takes a conf option `verify_ssl` which the docs state to accept: True, False, or an absolute path to a CA cert bundle for SSL verification. This is not the case as the code explicitly does verification on the conf option as a **boolean**.

I've updated the tests which should pass once I get the correct voluptuous config validators in place.

My question is how do I validate the CONF_VERIFY_SSL using vol and ensuring the given config value is either True, False, or a valid path? (I'd settle on string)

**Related issue (if applicable):** fixes #7892

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: unifi
  interval_seconds: 30
  verify_ssl: "/home/homeassistant/.homeassistant/unifi-ca-chain.crt"
  host: unifi.<my domain>
  port: 8443
  username: !secret unifi_username
  password: !secret unifi_password
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
