### PR TITLE
InfluxDb: Include the unit_of_measurement attribute as a measurement field

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -149,6 +149,7 @@ def setup(hass, config):
             _state = state.state
             _state_key = "state"
 
+        include_uom = True
         measurement = component_config.get(state.entity_id).get(
             CONF_OVERRIDE_MEASUREMENT)
         if measurement in (None, ''):
@@ -161,6 +162,8 @@ def setup(hass, config):
                         measurement = default_measurement
                     else:
                         measurement = state.entity_id
+                else:
+                    include_uom = False
 
         json_body = [
             {
@@ -179,7 +182,7 @@ def setup(hass, config):
         for key, value in state.attributes.items():
             if key in tags_attributes:
                 json_body[0]['tags'][key] = value
-            elif key != 'unit_of_measurement':
+            elif key != 'unit_of_measurement' or include_uom:
                 # If the key is already in fields
                 if key in json_body[0]['fields']:
                     key = key + "_"


### PR DESCRIPTION
## Description:
Currently, the unit-of-measurement field is never sent to InfluxDb presumably because the default measurement name is set to be the uom. However, recent changes have allowed for custom measurement names so this is not always the case.

This PR adds the unit_of_measurement attribute to the field key/value pairs list when the u-o-m information is not already held in the measurement name. This gives those that are using custom measurement names (e.g. via the override_measurement configuration option) a way to gain access to the unit_of_measurement information.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
influxdb:
  host: server
  port: 8086
  database: home_assistant
  override_measurement: state
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
