### PR TITLE
Simplify helpers.event.track_same_state API

### DIFF
--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -99,8 +99,8 @@ def async_trigger(hass, config, action):
             return
 
         async_remove_track_same = async_track_same_state(
-            hass, True, time_delta, call_action, entity_ids=entity_id,
-            async_check_func=check_numeric_state)
+            hass, time_delta, call_action, entity_ids=entity_id,
+            async_check_same_func=check_numeric_state)
 
     unsub = async_track_state_change(
         hass, entity_id, state_automation_listener)

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -65,7 +65,9 @@ def async_trigger(hass, config, action):
             return
 
         async_remove_track_same = async_track_same_state(
-            hass, to_s.state, time_delta, call_action, entity_ids=entity_id)
+            hass, time_delta, call_action,
+            lambda _, _2, to_state: to_state.state == to_s.state,
+            entity_ids=entity_id)
 
     unsub = async_track_state_change(
         hass, entity_id, state_automation_listener, from_state, to_state)

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -135,7 +135,7 @@ class BinarySensorTemplate(BinarySensorDevice):
         return False
 
     @callback
-    def _async_render(self, *args):
+    def _async_render(self):
         """Get the state of template."""
         try:
             return self._template.async_render().lower() == 'true'
@@ -171,5 +171,5 @@ class BinarySensorTemplate(BinarySensorDevice):
 
         period = self._delay_on if state else self._delay_off
         async_track_same_state(
-            self.hass, state, period, set_state, entity_ids=self._entities,
-            async_check_func=self._async_render)
+            self.hass, period, set_state, entity_ids=self._entities,
+            async_check_same_func=lambda *args: self._async_render() == state)

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -118,8 +118,8 @@ track_template = threaded_listener_factory(async_track_template)
 
 @callback
 @bind_hass
-def async_track_same_state(hass, orig_value, period, action,
-                           async_check_func=None, entity_ids=MATCH_ALL):
+def async_track_same_state(hass, period, action, async_check_same_func,
+                           entity_ids=MATCH_ALL):
     """Track the state of entities for a period and run a action.
 
     If async_check_func is None it use the state of orig_value.
@@ -152,14 +152,8 @@ def async_track_same_state(hass, orig_value, period, action,
     @callback
     def state_for_cancel_listener(entity, from_state, to_state):
         """Fire on changes and cancel for listener if changed."""
-        if async_check_func:
-            value = async_check_func(entity, from_state, to_state)
-        else:
-            value = to_state.state
-
-        if orig_value == value:
-            return
-        clear_listener()
+        if not async_check_same_func(entity, from_state, to_state):
+            clear_listener()
 
     async_remove_state_for_listener = async_track_point_in_utc_time(
         hass, state_for_listener, dt_util.utcnow() + period)

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -274,7 +274,8 @@ class TestEventHelpers(unittest.TestCase):
             thread_runs.append(1)
 
         track_same_state(
-            self.hass, 'on', period, thread_run_callback,
+            self.hass, period, thread_run_callback,
+            lambda _, _2, to_s: to_s.state == 'on',
             entity_ids='light.Bowl')
 
         @ha.callback
@@ -282,7 +283,8 @@ class TestEventHelpers(unittest.TestCase):
             callback_runs.append(1)
 
         track_same_state(
-            self.hass, 'on', period, callback_run_callback,
+            self.hass, period, callback_run_callback,
+            lambda _, _2, to_s: to_s.state == 'on',
             entity_ids='light.Bowl')
 
         @asyncio.coroutine
@@ -290,7 +292,8 @@ class TestEventHelpers(unittest.TestCase):
             coroutine_runs.append(1)
 
         track_same_state(
-            self.hass, 'on', period, coroutine_run_callback)
+            self.hass, period, coroutine_run_callback,
+            lambda _, _2, to_s: to_s.state == 'on')
 
         # Adding state to state machine
         self.hass.states.set("light.Bowl", "on")
@@ -317,7 +320,8 @@ class TestEventHelpers(unittest.TestCase):
             callback_runs.append(1)
 
         track_same_state(
-            self.hass, 'on', period, callback_run_callback,
+            self.hass, period, callback_run_callback,
+            lambda _, _2, to_s: to_s.state == 'on',
             entity_ids='light.Bowl')
 
         # Adding state to state machine
@@ -349,11 +353,11 @@ class TestEventHelpers(unittest.TestCase):
         @ha.callback
         def async_check_func(entity, from_s, to_s):
             check_func.append((entity, from_s, to_s))
-            return 'on'
+            return True
 
         track_same_state(
-            self.hass, 'on', period, callback_run_callback,
-            entity_ids='light.Bowl', async_check_func=async_check_func)
+            self.hass, period, callback_run_callback,
+            entity_ids='light.Bowl', async_check_same_func=async_check_func)
 
         # Adding state to state machine
         self.hass.states.set("light.Bowl", "on")


### PR DESCRIPTION
## Description:
Simplify the event helper `async_track_same_state`.

It used to take in an original value and a value to check it. This meant that there were two ways to do the same thing.

This is a simplification by removing the original value and always depending on the passed in `async_check_same_func`.

Breaking change:
 - `helpers.event.track_same_state` no longer allows an original value to be passed in and `async_check_same_func` is now always required. If you were using `orig_value`, update your code by passing in `async_check_same_func` like this instead: `lambda _, _2, to_s: to_s.state == orig_value`.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
