### PR TITLE
Adds Hue sensors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,10 +45,12 @@ homeassistant/components/climate/sensibo.py @andrey-git
 homeassistant/components/cover/template.py @PhracturedBlue
 homeassistant/components/device_tracker/automatic.py @armills
 homeassistant/components/history_graph.py @andrey-git
+homeassistant/components/hue.py @robmarkcole
 homeassistant/components/light/tplink.py @rytilahti
 homeassistant/components/light/yeelight.py @rytilahti
 homeassistant/components/media_player/kodi.py @armills
 homeassistant/components/sensor/airvisual.py @bachya
+homeassistant/components/sensor/hue.py @robmarkcole
 homeassistant/components/sensor/miflora.py @danielhiversen
 homeassistant/components/sensor/tibber.py @danielhiversen
 homeassistant/components/sensor/waqi.py @andrey-git

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -1,0 +1,34 @@
+"""
+Support for Hue components.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/hue/
+"""
+import json
+import logging
+
+from homeassistant.const import (CONF_FILENAME)
+
+_LOGGER = logging.getLogger(__name__)
+PHUE_CONFIG_FILE = 'phue.conf'
+
+DOMAIN = 'hue'
+
+
+def load_conf(filepath):
+    """Return the URL for API requests."""
+    with open(filepath, 'r') as file_path:
+        data = json.load(file_path)
+        ip_add = next(data.keys().__iter__())
+        username = data[ip_add]['username']
+        url = 'http://' + ip_add + '/api/' + username
+    return url
+
+
+def setup(hass, config):
+    """Set up the Hue component."""
+    filename = config.get(CONF_FILENAME, PHUE_CONFIG_FILE)
+    filepath = hass.config.path(filename)
+    url = load_conf(filepath)
+    hass.data[DOMAIN] = url
+    return True

--- a/homeassistant/components/sensor/hue.py
+++ b/homeassistant/components/sensor/hue.py
@@ -1,0 +1,114 @@
+"""
+Sensor for checking the status of Hue sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.hue_sensors/
+"""
+import logging
+from datetime import timedelta
+
+import requests
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+DOMAIN = 'hue'
+_LOGGER = logging.getLogger(__name__)
+SCAN_INTERVAL = timedelta(seconds=1)
+
+REQUIREMENTS = ['hue-sensors==1.0']
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Hue sensors."""
+    import hue_sensors as hs
+    url = hass.data[DOMAIN] + '/sensors'
+    data = HueSensorData(url, hs.parse_hue_api_response)
+    data.update()
+    sensors = []
+    for key in data.data.keys():
+        sensors.append(HueSensor(key, data))
+    add_devices(sensors, True)
+
+
+class HueSensorData(object):
+    """Get the latest sensor data."""
+
+    def __init__(self, url, parse_hue_api_response):
+        """Initialize the data object."""
+        self.url = url
+        self.data = None
+        self.parse_hue_api_response = parse_hue_api_response
+
+    # Update only once in scan interval.
+    @Throttle(SCAN_INTERVAL)
+    def update(self):
+        """Get the latest data."""
+        response = requests.get(self.url)
+        if response.status_code != 200:
+            _LOGGER.warning("Invalid response from API")
+        else:
+            self.data = self.parse_hue_api_response(response.json())
+
+
+class HueSensor(Entity):
+    """Class to hold Hue Sensor basic info."""
+
+    ICON = 'mdi:run-fast'
+
+    def __init__(self, hue_id, data):
+        """Initialize the sensor object."""
+        self._hue_id = hue_id
+        self._data = data    # data is in .data
+        self._icon = None
+        self._name = self._data.data[self._hue_id]['name']
+        self._model = self._data.data[self._hue_id]['model']
+        self._state = self._data.data[self._hue_id]['state']
+        self._attributes = {}
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def device_state_attributes(self):
+        """Attributes."""
+        return self._attributes
+
+    def update(self):
+        """Update the sensor."""
+        self._data.update()
+        self._state = self._data.data[self._hue_id]['state']
+        if self._model == 'SML':
+            self._icon = 'mdi:run-fast'
+            self._attributes['light_level'] = self._data.data[
+                self._hue_id]['light_level']
+            self._attributes['battery'] = self._data.data[
+                self._hue_id]['battery']
+            self._attributes['lux'] = self._data.data[
+                self._hue_id]['lux']
+            self._attributes['dark'] = self._data.data[
+                self._hue_id]['dark']
+            self._attributes['daylight'] = self._data.data[
+                self._hue_id]['daylight']
+            self._attributes['temperature'] = self._data.data[
+                self._hue_id]['temperature']
+        elif self._model in ['RWL', 'ZGP']:
+            self._icon = 'mdi:remote'
+            self._attributes['last updated'] = self._data.data[
+                self._hue_id]['last_updated']
+            self._attributes['battery'] = self._data.data[
+                self._hue_id]['battery']
+        elif self._model == 'Geofence':
+            self._icon = 'mdi:cellphone'

--- a/homeassistant/components/sensor/hue.py
+++ b/homeassistant/components/sensor/hue.py
@@ -16,7 +16,7 @@ DOMAIN = 'hue'
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=1)
 
-REQUIREMENTS = ['hue-sensors==1.0']
+REQUIREMENTS = ['hue-sensors==1.1']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -96,6 +96,8 @@ class HueSensor(Entity):
                 self._hue_id]['light_level']
             self._attributes['battery'] = self._data.data[
                 self._hue_id]['battery']
+            self._attributes['last updated'] = self._data.data[
+                self._hue_id]['last_updated']
             self._attributes['lux'] = self._data.data[
                 self._hue_id]['lux']
             self._attributes['dark'] = self._data.data[
@@ -104,11 +106,15 @@ class HueSensor(Entity):
                 self._hue_id]['daylight']
             self._attributes['temperature'] = self._data.data[
                 self._hue_id]['temperature']
-        elif self._model in ['RWL', 'ZGP']:
+        elif self._model == 'RWL':
             self._icon = 'mdi:remote'
             self._attributes['last updated'] = self._data.data[
                 self._hue_id]['last_updated']
             self._attributes['battery'] = self._data.data[
                 self._hue_id]['battery']
+        elif self._model == 'ZGP':
+            self._icon = 'mdi:remote'
+            self._attributes['last updated'] = self._data.data[
+                self._hue_id]['last_updated']
         elif self._model == 'Geofence':
             self._icon = 'mdi:cellphone'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -347,6 +347,9 @@ https://github.com/soldag/pyflic/archive/0.4.zip#pyflic==0.4
 # homeassistant.components.media_player.lg_netcast
 https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 
+# homeassistant.components.sensor.hue
+hue-sensors==1.1
+
 # homeassistant.components.sensor.bh1750
 # homeassistant.components.sensor.bme280
 # homeassistant.components.sensor.htu21d

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -67,6 +67,9 @@ hbmqtt==0.8
 # homeassistant.components.binary_sensor.workday
 holidays==0.8.1
 
+# homeassistant.components.sensor.hue
+hue-sensors==1.1
+
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
 influxdb==4.1.1

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -46,6 +46,7 @@ TEST_REQUIREMENTS = (
     'haversine',
     'hbmqtt',
     'holidays',
+    'hue-sensors',
     'influxdb',
     'libpurecoollink',
     'libsoundtouch',

--- a/tests/components/sensor/test_hue.py
+++ b/tests/components/sensor/test_hue.py
@@ -1,9 +1,7 @@
 """The tests for the hue sensors platform."""
 
-import json
 import requests_mock
 import unittest
-from unittest.mock import patch
 
 from homeassistant.setup import setup_component
 from tests.common import (
@@ -38,3 +36,4 @@ class TestHueSensor(unittest.TestCase):
             setup_component(self.hass, 'sensor', {'sensor': VALID_CONFIG}))
         living_room_remote = self.hass.states.get('sensor.living_room_remote')
         assert living_room_remote.name == "Living room remote"
+        assert living_room_remote.state == '1_click'

--- a/tests/components/sensor/test_hue.py
+++ b/tests/components/sensor/test_hue.py
@@ -1,0 +1,33 @@
+"""The tests for the hue sensors platform."""
+
+import json
+import unittest
+from unittest.mock import patch
+
+from homeassistant.setup import setup_component
+from tests.common import (
+    get_test_home_assistant, load_fixture)
+
+DOMAIN = 'hue'
+VALID_CONFIG = {
+    'platform': 'hue'
+}
+
+
+class TestHueSensor(unittest.TestCase):
+    """Test the Hue-sensors platform."""
+
+    def setUp(self):
+        """Initialize values for this testcase class."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_setup(self):
+        """Test for operational tube_state sensor with proper attributes."""
+        self.assertTrue(
+            setup_component(self.hass, 'sensor', {'sensor': VALID_CONFIG}))
+        living_room_remote = self.hass.states.get('sensor.living_room_remote')
+        assert living_room_remote.name == "Living room remote"

--- a/tests/components/sensor/test_hue.py
+++ b/tests/components/sensor/test_hue.py
@@ -1,6 +1,7 @@
 """The tests for the hue sensors platform."""
 
 import json
+import requests_mock
 import unittest
 from unittest.mock import patch
 
@@ -9,13 +10,14 @@ from tests.common import (
     get_test_home_assistant, load_fixture)
 
 DOMAIN = 'hue'
+DUMMY_URL = "http://dummy_url"
 VALID_CONFIG = {
     'platform': 'hue'
 }
 
 
 class TestHueSensor(unittest.TestCase):
-    """Test the Hue-sensors platform."""
+    """Test the Hue sensors platform."""
 
     def setUp(self):
         """Initialize values for this testcase class."""
@@ -25,8 +27,13 @@ class TestHueSensor(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def test_setup(self):
+    @requests_mock.Mocker()
+    def test_setup(self, mock_request):
         """Test for operational tube_state sensor with proper attributes."""
+        self.hass.data[DOMAIN] = DUMMY_URL
+        mock_request.get(
+            DUMMY_URL + '/sensors', text=load_fixture('hue_sensors.json'))
+
         self.assertTrue(
             setup_component(self.hass, 'sensor', {'sensor': VALID_CONFIG}))
         living_room_remote = self.hass.states.get('sensor.living_room_remote')

--- a/tests/fixtures/hue_sensors.json
+++ b/tests/fixtures/hue_sensors.json
@@ -1,0 +1,82 @@
+{
+  "RWL_dc-02": {
+    "model": "RWL",
+    "name": "Remote bedroom",
+    "state": "2_hold",
+    "battery": 100,
+    "last_updated": [
+      "2017-10-13",
+      "06:01:04"
+    ]
+  },
+  "SML_28-02": {
+    "temperature": 19.42,
+    "model": "SML",
+    "name": "Hall motion Sensor",
+    "state": "off",
+    "battery": 100,
+    "last_updated": [
+      "2017-10-13",
+      "05:57:40"
+    ],
+    "light_level": 0,
+    "lux": 1,
+    "dark": true,
+    "daylight": false
+  },
+  "SML_ce-02": {
+    "temperature": 20.17,
+    "model": "SML",
+    "name": "Bedroom motion sensor",
+    "state": "on",
+    "battery": 100,
+    "last_updated": [
+      "2017-10-13",
+      "06:00:53"
+    ],
+    "light_level": 0,
+    "lux": 1,
+    "dark": true,
+    "daylight": false
+  },
+  "Geofence": {
+    "name": "Robins iPhone",
+    "model": "GEO",
+    "state": "on"
+  },
+  "SML_9c-02": {
+    "temperature": 22.8,
+    "model": "SML",
+    "name": "Living room motion sensor",
+    "state": "off",
+    "battery": 100,
+    "last_updated": [
+      "2017-10-13",
+      "06:01:07"
+    ],
+    "light_level": 0,
+    "lux": 1,
+    "dark": true,
+    "daylight": false
+  },
+  "RWL_1e-02": {
+    "model": "RWL",
+    "name": "Living room remote",
+    "state": "1_click",
+    "battery": 100,
+    "last_updated": [
+      "2017-10-13",
+      "05:34:33"
+    ]
+  },
+  "RWL_9c-02": {
+    "model": "RWL",
+    "name": "Hall remote",
+    "state": "1_click",
+    "battery": 100,
+    "last_updated": [
+      "2017-10-13",
+      "05:36:46"
+    ]
+  }
+}

--- a/tests/fixtures/hue_sensors.json
+++ b/tests/fixtures/hue_sensors.json
@@ -1,82 +1,488 @@
 {
-  "RWL_dc-02": {
-    "model": "RWL",
+  "1": {
+    "state": {
+      "daylight": true,
+      "lastupdated": "2017-10-13T06:52:00"
+    },
+    "config": {
+      "on": true,
+      "configured": true,
+      "sunriseoffset": 30,
+      "sunsetoffset": -30
+    },
+    "name": "Daylight",
+    "type": "Daylight",
+    "modelid": "PHDL00",
+    "manufacturername": "Philips",
+    "swversion": "1.0"
+  },
+  "2": {
+    "state": {
+      "buttonevent": 2003,
+      "lastupdated": "2017-10-13T06:01:04"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "pending": [
+
+      ]
+    },
     "name": "Remote bedroom",
-    "state": "2_hold",
-    "battery": 100,
-    "last_updated": [
-      "2017-10-13",
-      "06:01:04"
-    ]
+    "type": "ZLLSwitch",
+    "modelid": "RWL021",
+    "manufacturername": "Philips",
+    "swversion": "5.45.1.16265",
+    "uniqueid": "00:17:88:01:10:3e:3a:dc-02-fc00"
   },
-  "SML_28-02": {
-    "temperature": 19.42,
-    "model": "SML",
-    "name": "Hall motion Sensor",
-    "state": "off",
-    "battery": 100,
-    "last_updated": [
-      "2017-10-13",
-      "05:57:40"
-    ],
-    "light_level": 0,
-    "lux": 1,
-    "dark": true,
-    "daylight": false
+  "3": {
+    "state": {
+      "status": 0,
+      "lastupdated": "2017-10-13T06:01:10"
+    },
+    "config": {
+      "on": true,
+      "reachable": true
+    },
+    "name": "Dimmer Switch 2 SceneCycle",
+    "type": "CLIPGenericStatus",
+    "modelid": "PHWA01",
+    "manufacturername": "Philips",
+    "swversion": "1.0",
+    "uniqueid": "WA0001",
+    "recycle": true
   },
-  "SML_ce-02": {
-    "temperature": 20.17,
-    "model": "SML",
-    "name": "Bedroom motion sensor",
-    "state": "on",
-    "battery": 100,
-    "last_updated": [
-      "2017-10-13",
-      "06:00:53"
-    ],
-    "light_level": 0,
-    "lux": 1,
-    "dark": true,
-    "daylight": false
+  "4": {
+    "state": {
+      "temperature": 1942,
+      "lastupdated": "2017-10-13T07:07:24"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "alert": "none",
+      "ledindication": false,
+      "usertest": false,
+      "pending": [
+
+      ]
+    },
+    "name": "Hue temperature sensor 1",
+    "type": "ZLLTemperature",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "swversion": "6.1.0.18912",
+    "uniqueid": "00:17:88:01:02:00:af:28-02-0402"
   },
-  "Geofence": {
+  "5": {
+    "state": {
+      "presence": false,
+      "lastupdated": "2017-10-13T06:46:19"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "alert": "none",
+      "ledindication": false,
+      "usertest": false,
+      "sensitivity": 2,
+      "sensitivitymax": 2,
+      "pending": [
+
+      ]
+    },
+    "name": "Hall Sensor",
+    "type": "ZLLPresence",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "swversion": "6.1.0.18912",
+    "uniqueid": "00:17:88:01:02:00:af:28-02-0406"
+  },
+  "6": {
+    "state": {
+      "lightlevel": 0,
+      "dark": true,
+      "daylight": false,
+      "lastupdated": "2017-10-13T07:06:17"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "alert": "none",
+      "tholddark": 16000,
+      "tholdoffset": 7000,
+      "ledindication": false,
+      "usertest": false,
+      "pending": [
+
+      ]
+    },
+    "name": "Hue ambient light sensor 1",
+    "type": "ZLLLightLevel",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "swversion": "6.1.0.18912",
+    "uniqueid": "00:17:88:01:02:00:af:28-02-0400"
+  },
+  "7": {
+    "state": {
+      "status": 0,
+      "lastupdated": "2017-10-13T06:47:04"
+    },
+    "config": {
+      "on": true,
+      "reachable": true
+    },
+    "name": "MotionSensor 5.Companion",
+    "type": "CLIPGenericStatus",
+    "modelid": "PHA_STATE",
+    "manufacturername": "Philips",
+    "swversion": "1.0",
+    "uniqueid": "MotionSensor 5.Companion",
+    "recycle": true
+  },
+  "8": {
+    "state": {
+      "temperature": 2017,
+      "lastupdated": "2017-10-13T07:03:13"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "alert": "none",
+      "ledindication": false,
+      "usertest": false,
+      "pending": [
+
+      ]
+    },
+    "name": "Hue temperature sensor 2",
+    "type": "ZLLTemperature",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "swversion": "6.1.0.18912",
+    "uniqueid": "00:17:88:01:02:00:b5:ce-02-0402"
+  },
+  "9": {
+    "state": {
+      "presence": false,
+      "lastupdated": "2017-10-13T06:04:20"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "alert": "none",
+      "ledindication": false,
+      "usertest": false,
+      "sensitivity": 2,
+      "sensitivitymax": 2,
+      "pending": [
+
+      ]
+    },
+    "name": "Bedroom sensor",
+    "type": "ZLLPresence",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "swversion": "6.1.0.18912",
+    "uniqueid": "00:17:88:01:02:00:b5:ce-02-0406"
+  },
+  "10": {
+    "state": {
+      "lightlevel": 2464,
+      "dark": true,
+      "daylight": false,
+      "lastupdated": "2017-10-13T07:03:45"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "alert": "none",
+      "tholddark": 12853,
+      "tholdoffset": 7000,
+      "ledindication": false,
+      "usertest": false,
+      "pending": [
+
+      ]
+    },
+    "name": "Hue ambient light sensor 2",
+    "type": "ZLLLightLevel",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "swversion": "6.1.0.18912",
+    "uniqueid": "00:17:88:01:02:00:b5:ce-02-0400"
+  },
+  "11": {
+    "state": {
+      "status": 0,
+      "lastupdated": "2017-10-13T06:06:05"
+    },
+    "config": {
+      "on": true,
+      "reachable": true
+    },
+    "name": "MotionSensor 9.Companion",
+    "type": "CLIPGenericStatus",
+    "modelid": "PHA_STATE",
+    "manufacturername": "Philips",
+    "swversion": "1.0",
+    "uniqueid": "MotionSensor 9.Companion",
+    "recycle": true
+  },
+  "12": {
+    "state": {
+      "presence": true,
+      "lastupdated": "2017-10-12T20:43:07"
+    },
+    "config": {
+      "on": true,
+      "reachable": true
+    },
     "name": "Robins iPhone",
-    "model": "GEO",
-    "state": "on"
+    "type": "Geofence",
+    "modelid": "HA_GEOFENCE",
+    "manufacturername": "Philips",
+    "swversion": "A_1",
+    "uniqueid": "L_02_IYwHM",
+    "recycle": false
   },
-  "SML_9c-02": {
-    "temperature": 22.8,
-    "model": "SML",
-    "name": "Living room motion sensor",
-    "state": "off",
-    "battery": 100,
-    "last_updated": [
-      "2017-10-13",
-      "06:01:07"
-    ],
-    "light_level": 0,
-    "lux": 1,
-    "dark": true,
-    "daylight": false
+  "13": {
+    "state": {
+      "presence": true,
+      "lastupdated": "2017-10-12T20:43:07"
+    },
+    "config": {
+      "on": true,
+      "reachable": true
+    },
+    "name": "HomeAway",
+    "type": "CLIPPresence",
+    "modelid": "HOMEAWAY",
+    "manufacturername": "Philips",
+    "swversion": "A_1",
+    "uniqueid": "L_01_9rQ8A",
+    "recycle": false
   },
-  "RWL_1e-02": {
-    "model": "RWL",
+  "14": {
+    "state": {
+      "temperature": 2308,
+      "lastupdated": "2017-10-13T07:06:45"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "alert": "none",
+      "ledindication": false,
+      "usertest": false,
+      "pending": [
+
+      ]
+    },
+    "name": "Hue temperature sensor 3",
+    "type": "ZLLTemperature",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "swversion": "6.1.0.18912",
+    "uniqueid": "00:17:88:01:02:01:aa:9c-02-0402"
+  },
+  "15": {
+    "state": {
+      "presence": false,
+      "lastupdated": "2017-10-13T07:04:16"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "alert": "none",
+      "ledindication": false,
+      "usertest": false,
+      "sensitivity": 2,
+      "sensitivitymax": 2,
+      "pending": [
+
+      ]
+    },
+    "name": "Living room sensor",
+    "type": "ZLLPresence",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "swversion": "6.1.0.18912",
+    "uniqueid": "00:17:88:01:02:01:aa:9c-02-0406"
+  },
+  "16": {
+    "state": {
+      "lightlevel": 7325,
+      "dark": true,
+      "daylight": false,
+      "lastupdated": "2017-10-13T07:02:38"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "alert": "none",
+      "tholddark": 16000,
+      "tholdoffset": 7000,
+      "ledindication": false,
+      "usertest": false,
+      "pending": [
+
+      ]
+    },
+    "name": "Hue ambient light sensor 3",
+    "type": "ZLLLightLevel",
+    "modelid": "SML001",
+    "manufacturername": "Philips",
+    "swversion": "6.1.0.18912",
+    "uniqueid": "00:17:88:01:02:01:aa:9c-02-0400"
+  },
+  "18": {
+    "state": {
+      "status": 0,
+      "lastupdated": "2017-10-13T07:04:16"
+    },
+    "config": {
+      "on": true,
+      "reachable": true
+    },
+    "name": "MotionSensor 15.Companion",
+    "type": "CLIPGenericStatus",
+    "modelid": "PHA_STATE",
+    "manufacturername": "Philips",
+    "swversion": "1.0",
+    "uniqueid": "MotionSensor 15.Companion",
+    "recycle": true
+  },
+  "20": {
+    "state": {
+      "buttonevent": 1002,
+      "lastupdated": "2017-10-13T05:34:33"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "pending": [
+
+      ]
+    },
     "name": "Living room remote",
-    "state": "1_click",
-    "battery": 100,
-    "last_updated": [
-      "2017-10-13",
-      "05:34:33"
-    ]
+    "type": "ZLLSwitch",
+    "modelid": "RWL021",
+    "manufacturername": "Philips",
+    "swversion": "5.45.1.17846",
+    "uniqueid": "00:17:88:01:02:e2:47:1e-02-fc00"
   },
-  "RWL_9c-02": {
-    "model": "RWL",
+  "21": {
+    "state": {
+      "status": 2,
+      "lastupdated": "2017-10-13T05:34:33"
+    },
+    "config": {
+      "on": true,
+      "reachable": true
+    },
+    "name": "Dimmer Switch 20 SceneCycle",
+    "type": "CLIPGenericStatus",
+    "modelid": "PHWA01",
+    "manufacturername": "Philips",
+    "swversion": "1.0",
+    "uniqueid": "WA0001",
+    "recycle": true
+  },
+  "22": {
+    "state": {
+      "buttonevent": 1002,
+      "lastupdated": "2017-10-13T05:36:46"
+    },
+    "swupdate": {
+      "state": "noupdates",
+      "lastinstall": null
+    },
+    "config": {
+      "on": true,
+      "battery": 100,
+      "reachable": true,
+      "pending": [
+
+      ]
+    },
     "name": "Hall remote",
-    "state": "1_click",
-    "battery": 100,
-    "last_updated": [
-      "2017-10-13",
-      "05:36:46"
-    ]
+    "type": "ZLLSwitch",
+    "modelid": "RWL021",
+    "manufacturername": "Philips",
+    "swversion": "5.45.1.17846",
+    "uniqueid": "00:17:88:01:02:c0:e1:9c-02-fc00"
+  },
+  "23": {
+    "state": {
+      "status": 1,
+      "lastupdated": "2017-10-13T05:36:45"
+    },
+    "config": {
+      "on": true,
+      "reachable": true
+    },
+    "name": "Dimmer Switch 22 SceneCycle",
+    "type": "CLIPGenericStatus",
+    "modelid": "PHWA01",
+    "manufacturername": "Philips",
+    "swversion": "1.0",
+    "uniqueid": "WA0001",
+    "recycle": true
   }
 }


### PR DESCRIPTION
## Description:
Replaces pull [9449](https://github.com/home-assistant/home-assistant/pull/9449
) .

Component for reading Hue motion sensors and 4 button remotes.

**Fixes:** #10383

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/pull/3380) with documentation (if applicable):** home-assistant/home-assistant.github.io#3380

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:

sensor:
  - platform: hue
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

