### PR TITLE
fix climate services (missing indentation, wrongly formatted example)

### DIFF
--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -101,11 +101,11 @@ set_swing_mode:
   fields:
     entity_id:
       description: Name(s) of entities to change
-      example: '.nest'
+      example: 'climate.nest'
 
     swing_mode:
-    description: New value of swing mode
-    example: 1
+      description: New value of swing mode
+      example: 1
 
 ecobee_set_fan_min_on_time:
   description: Set the minimum fan on time


### PR DESCRIPTION
## Description:
Invalid indendation for `set_swing_mode` causes its properties to be recognized as services, see "example" and "swing_mode" fields from API:
```
                "set_swing_mode": {
                    "description": "Set swing operation for climate device",
                    "fields": {
                        "description": "New value of swing mode",
                        "entity_id": {
                            "description": "Name(s) of entities to change",
                            "example": ".nest"
                        },
                        "example": 1,
                        "swing_mode": null
                    }
                },
```

and with this patch:
```
                "set_swing_mode": {
                    "description": "Set swing operation for climate device",
                    "fields": {
                        "entity_id": {
                            "description": "Name(s) of entities to change",
                            "example": "climate.nest"
                        },
                        "swing_mode": {
                            "description": "New value of swing mode",
                            "example": 1
                        }
                    }
                },
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
