### PR TITLE
Wait_template - support for 'trigger.entity_id' and data_template values

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -110,7 +110,7 @@ def async_track_template(hass, template, action, variables=None):
             already_triggered = False
 
     return async_track_state_change(
-        hass, template.extract_entities(), template_condition_listener)
+        hass, template.extract_entities(variables), template_condition_listener)
 
 
 track_template = threaded_listener_factory(async_track_template)

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -110,7 +110,8 @@ def async_track_template(hass, template, action, variables=None):
             already_triggered = False
 
     return async_track_state_change(
-        hass, template.extract_entities(variables), template_condition_listener)
+        hass, template.extract_entities(variables),
+        template_condition_listener)
 
 
 track_template = threaded_listener_factory(async_track_template)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -129,7 +129,7 @@ class Script():
                     self.hass.async_add_job(self.async_run(variables))
 
                 self._async_listener.append(async_track_template(
-                    self.hass, wait_template, async_script_wait))
+                    self.hass, wait_template, async_script_wait, variables))
 
                 self._cur = cur + 1
                 if self._change_listener:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -29,8 +29,8 @@ _RE_GET_ENTITIES = re.compile(
     re.I | re.M
 )
 _RE_GET_POSSIBLE_ENTITIES = re.compile(
-    r"(?:(?:states\.|(?:is_state|is_state_attr|states) \
-    \(.)([\w]+\.[\w]+)|([\w]+))", re.I | re.M
+    r"""(?:(?:states\.|(?:is_state|is_state_attr|
+    states)\(.)([\w]+\.[\w]+)|([\w]+))""", re.I | re.M
 )
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -29,8 +29,8 @@ _RE_GET_ENTITIES = re.compile(
     re.I | re.M
 )
 _RE_GET_POSSIBLE_ENTITIES = re.compile(
-    r"(?:(?:states\.|(?:is_state|is_state_attr|states)\(.)([\w]+\.[\w]+)|([\w]+))",
-    re.I | re.M
+    r"(?:(?:states\.|(?:is_state|is_state_attr|states) \
+    \(.)([\w]+\.[\w]+)|([\w]+))", re.I | re.M
 )
 
 
@@ -73,7 +73,7 @@ def extract_entities_with_variables(template, variables):
         elif result[0]:
             extraction_final.append(result[0])
 
-        if result[1] in variables and isinstance(variables[result[1]], str) :
+        if result[1] in variables and isinstance(variables[result[1]], str):
             extraction_final.append(variables[result[1]])
 
     if extraction_final:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -25,12 +25,8 @@ DATE_STR_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 _RE_NONE_ENTITIES = re.compile(r"distance\(|closest\(", re.I | re.M)
 _RE_GET_ENTITIES = re.compile(
-    r"(?:(?:states\.|(?:is_state|is_state_attr|states)\(.)([\w]+\.[\w]+))",
-    re.I | re.M
-)
-_RE_GET_POSSIBLE_ENTITIES = re.compile(
-    r"""(?:(?:states\.|(?:is_state|is_state_attr|
-    states)\(.)([\w]+\.[\w]+)|([\w]+))""", re.I | re.M
+    r"(?:(?:states\.|(?:is_state|is_state_attr|states)"
+    r"\(.)([\w]+\.[\w]+)|([\w]+))", re.I | re.M
 )
 
 
@@ -47,23 +43,12 @@ def attach(hass, obj):
         obj.hass = hass
 
 
-def extract_entities(template):
+def extract_entities(template, variables=None):
     """Extract all entities for state_changed listener from template string."""
     if template is None or _RE_NONE_ENTITIES.search(template):
         return MATCH_ALL
 
     extraction = _RE_GET_ENTITIES.findall(template)
-    if extraction:
-        return list(set(extraction))
-    return MATCH_ALL
-
-
-def extract_entities_with_variables(template, variables):
-    """Extract all entities for state_changed listener from template string."""
-    if template is None or _RE_NONE_ENTITIES.search(template):
-        return MATCH_ALL
-
-    extraction = _RE_GET_POSSIBLE_ENTITIES.findall(template)
     extraction_final = []
 
     for result in extraction:
@@ -73,7 +58,8 @@ def extract_entities_with_variables(template, variables):
         elif result[0]:
             extraction_final.append(result[0])
 
-        if result[1] in variables and isinstance(variables[result[1]], str):
+        if variables and result[1] in variables and \
+           isinstance(variables[result[1]], str):
             extraction_final.append(variables[result[1]])
 
     if extraction_final:
@@ -106,10 +92,7 @@ class Template(object):
 
     def extract_entities(self, variables=None):
         """Extract all entities for state_changed listener."""
-        if not variables:
-            return extract_entities(self.template)
-        else:
-            return extract_entities_with_variables(self.template, variables)
+        return extract_entities(self.template, variables)
 
     def render(self, variables=None, **kwargs):
         """Render given template."""

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -26,7 +26,7 @@ DATE_STR_FORMAT = "%Y-%m-%d %H:%M:%S"
 _RE_NONE_ENTITIES = re.compile(r"distance\(|closest\(", re.I | re.M)
 _RE_GET_ENTITIES = re.compile(
     r"(?:(?:states\.|(?:is_state|is_state_attr|states)"
-    r"\(.)([\w]+\.[\w]+)|([\w]+))", re.I | re.M
+    r"\((?:[\ \'\"]?))([\w]+\.[\w]+)|([\w]+))", re.I | re.M
 )
 
 

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -714,16 +714,16 @@ class TestAutomationNumericState(unittest.TestCase):
                     'entity_id': 'test.entity',
                     'above': 10,
                 },
-                'action': [{
-                    'wait_template':
+                'action': [
+                    {'wait_template':
                         "{{ states( trigger.entity_id ) | int < 10 }}"},
                     {'service': 'test.automation',
                      'data_template': {
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'to_state.state'))
-                     },
-                }],
+                        }}
+                ],
             }
         })
 

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -704,3 +704,38 @@ class TestAutomationNumericState(unittest.TestCase):
         fire_time_changed(self.hass, dt_util.utcnow() + timedelta(seconds=10))
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
+
+    def test_wait_template_with_trigger(self):
+        """Test using wait template with 'trigger.entity_id'."""
+        assert setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'numeric_state',
+                    'entity_id': 'test.entity',
+                    'above': 10,
+                },
+                'action': {
+                    'wait_template': "{{ states( trigger.entity_id ) < 10 }}"
+                },
+                'action': {
+                    'service': 'test.automation',
+                    'data_template': {
+                        'some':
+                        '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
+                            'platform', 'entity_id', 'to_state.state'))
+                    },
+                },
+            }
+        })
+
+        self.hass.block_till_done()
+        self.calls = []
+
+        self.hass.states.set('test.entity', '12')
+        self.hass.block_till_done()
+        self.hass.states.set('test.entity', '8')
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        self.assertEqual(
+            'numeric_state - test.entity - 12',
+            self.calls[0].data['some'])

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -717,12 +717,12 @@ class TestAutomationNumericState(unittest.TestCase):
                 'action': [{
                     'wait_template':
                         "{{ states( trigger.entity_id ) | int < 10 }}"},
-                   {'service': 'test.automation',
-                    'data_template': {
+                    {'service': 'test.automation',
+                     'data_template': {
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'to_state.state'))
-                   },
+                    },
                 }],
             }
         })

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -714,17 +714,16 @@ class TestAutomationNumericState(unittest.TestCase):
                     'entity_id': 'test.entity',
                     'above': 10,
                 },
-                'action': {
-                    'wait_template': "{{ states( trigger.entity_id ) < 10 }}"
-                },
-                'action': {
-                    'service': 'test.automation',
+                'action': [{
+                    'wait_template':
+                        "{{ states( trigger.entity_id ) | int < 10 }}"},
+                    {'service': 'test.automation',
                     'data_template': {
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'to_state.state'))
                     },
-                },
+                }],
             }
         })
 

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -716,7 +716,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 },
                 'action': [
                     {'wait_template':
-                        "{{ states( trigger.entity_id ) | int < 10 }}"},
+                        "{{ states(trigger.entity_id) | int < 10 }}"},
                     {'service': 'test.automation',
                      'data_template': {
                         'some':

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -722,7 +722,7 @@ class TestAutomationNumericState(unittest.TestCase):
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'to_state.state'))
-                    },
+                     },
                 }],
             }
         })

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -722,7 +722,7 @@ class TestAutomationNumericState(unittest.TestCase):
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'to_state.state'))
-                    },
+                   },
                 }],
             }
         })

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -717,7 +717,7 @@ class TestAutomationNumericState(unittest.TestCase):
                 'action': [{
                     'wait_template':
                         "{{ states( trigger.entity_id ) | int < 10 }}"},
-                    {'service': 'test.automation',
+                   {'service': 'test.automation',
                     'data_template': {
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -518,7 +518,7 @@ class TestAutomationState(unittest.TestCase):
                 },
                 'action': [
                     {'wait_template':
-                        "{{ is_state( trigger.entity_id , 'hello') }}"},
+                        "{{ is_state(trigger.entity_id, 'hello') }}"},
                     {'service': 'test.automation',
                      'data_template': {
                         'some':

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -506,3 +506,40 @@ class TestAutomationState(unittest.TestCase):
                     },
                     'action': {'service': 'test.automation'},
                 }})
+
+    def test_wait_template_with_trigger(self):
+        """Test using wait template with 'trigger.entity_id'."""
+        assert setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'state',
+                    'entity_id': 'test.entity',
+                    'to': 'world',
+                },
+                'action': {
+                    'wait_template': 
+                        "{{ is_state( trigger.entity_id , 'hello' ) }}"
+                },
+                'action': {
+                    'service': 'test.automation',
+                    'data_template': {
+                        'some':
+                        '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
+                            'platform', 'entity_id', 'from_state.state',
+                            'to_state.state'))
+                    },
+                },
+            }
+        })
+
+        self.hass.block_till_done()
+        self.calls = []
+
+        self.hass.states.set('test.entity', 'world')
+        self.hass.block_till_done()
+        self.hass.states.set('test.entity', 'hello')
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        self.assertEqual(
+            'state - test.entity - hello - world',
+            self.calls[0].data['some'])

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -525,7 +525,7 @@ class TestAutomationState(unittest.TestCase):
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'from_state.state',
                             'to_state.state'))
-                    },
+                     },
                 }],
             }
         })

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -516,19 +516,17 @@ class TestAutomationState(unittest.TestCase):
                     'entity_id': 'test.entity',
                     'to': 'world',
                 },
-                'action': {
-                    'wait_template': 
-                        "{{ is_state( trigger.entity_id , 'hello' ) }}"
-                },
-                'action': {
-                    'service': 'test.automation',
+                'action': [{
+                    'wait_template':
+                        "{{ is_state( trigger.entity_id , 'hello') }}"},
+                    {'service': 'test.automation',
                     'data_template': {
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'from_state.state',
                             'to_state.state'))
                     },
-                },
+                }],
             }
         })
 

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -516,8 +516,8 @@ class TestAutomationState(unittest.TestCase):
                     'entity_id': 'test.entity',
                     'to': 'world',
                 },
-                'action': [{
-                    'wait_template':
+                'action': [
+                    {'wait_template':
                         "{{ is_state( trigger.entity_id , 'hello') }}"},
                     {'service': 'test.automation',
                      'data_template': {
@@ -525,8 +525,8 @@ class TestAutomationState(unittest.TestCase):
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'from_state.state',
                             'to_state.state'))
-                     },
-                }],
+                        }}
+                ],
             }
         })
 

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -519,7 +519,7 @@ class TestAutomationState(unittest.TestCase):
                 'action': [{
                     'wait_template':
                         "{{ is_state( trigger.entity_id , 'hello') }}"},
-                    {'service': 'test.automation',
+                   {'service': 'test.automation',
                     'data_template': {
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -519,13 +519,13 @@ class TestAutomationState(unittest.TestCase):
                 'action': [{
                     'wait_template':
                         "{{ is_state( trigger.entity_id , 'hello') }}"},
-                   {'service': 'test.automation',
-                    'data_template': {
+                    {'service': 'test.automation',
+                     'data_template': {
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'from_state.state',
                             'to_state.state'))
-                   },
+                    },
                 }],
             }
         })

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -525,7 +525,7 @@ class TestAutomationState(unittest.TestCase):
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'from_state.state',
                             'to_state.state'))
-                    },
+                   },
                 }],
             }
         })

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -399,3 +399,40 @@ class TestAutomationTemplate(unittest.TestCase):
         self.hass.states.set('test.entity', 'world')
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
+
+    def test_wait_template_with_trigger(self):
+        """Test using wait template with 'trigger.entity_id'."""
+        assert setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'template',
+                    'value_template': 
+                        "{{ states.test.entity.state == 'world' }}",
+                },
+                'action': {
+                    'wait_template':
+                        "{{ is_state( trigger.entity_id , 'hello' ) }}"
+                },
+                'action': {
+                    'service': 'test.automation',
+                    'data_template': {
+                        'some':
+                        '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
+                            'platform', 'entity_id', 'from_state.state',
+                            'to_state.state'))
+                    },
+                },
+            }
+        })
+
+        self.hass.block_till_done()
+        self.calls = []
+
+        self.hass.states.set('test.entity', 'world')
+        self.hass.block_till_done()
+        self.hass.states.set('test.entity', 'hello')
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        self.assertEqual(
+            'template - test.entity - hello - world',
+            self.calls[0].data['some'])

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -411,7 +411,7 @@ class TestAutomationTemplate(unittest.TestCase):
                 },
                 'action': [
                     {'wait_template':
-                        "{{ is_state( trigger.entity_id , 'hello') }}"},
+                        "{{ is_state(trigger.entity_id, 'hello') }}"},
                     {'service': 'test.automation',
                      'data_template': {
                         'some':

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -418,7 +418,7 @@ class TestAutomationTemplate(unittest.TestCase):
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'from_state.state',
                             'to_state.state'))
-                    },
+                     },
                 }],
             }
         })

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -412,13 +412,13 @@ class TestAutomationTemplate(unittest.TestCase):
                 'action': [{
                     'wait_template':
                         "{{ is_state( trigger.entity_id , 'hello') }}"},
-                   {'service': 'test.automation',
-                    'data_template': {
+                    {'service': 'test.automation',
+                     'data_template': {
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'from_state.state',
                             'to_state.state'))
-                   },
+                    },
                 }],
             }
         })

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -412,7 +412,7 @@ class TestAutomationTemplate(unittest.TestCase):
                 'action': [{
                     'wait_template':
                         "{{ is_state( trigger.entity_id , 'hello') }}"},
-                    {'service': 'test.automation',
+                   {'service': 'test.automation',
                     'data_template': {
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -409,8 +409,8 @@ class TestAutomationTemplate(unittest.TestCase):
                     'value_template':
                         "{{ states.test.entity.state == 'world' }}",
                 },
-                'action': [{
-                    'wait_template':
+                'action': [
+                    {'wait_template':
                         "{{ is_state( trigger.entity_id , 'hello') }}"},
                     {'service': 'test.automation',
                      'data_template': {
@@ -418,8 +418,8 @@ class TestAutomationTemplate(unittest.TestCase):
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'from_state.state',
                             'to_state.state'))
-                     },
-                }],
+                     }}
+                ],
             }
         })
 

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -406,22 +406,20 @@ class TestAutomationTemplate(unittest.TestCase):
             automation.DOMAIN: {
                 'trigger': {
                     'platform': 'template',
-                    'value_template': 
+                    'value_template':
                         "{{ states.test.entity.state == 'world' }}",
                 },
-                'action': {
+                'action': [{
                     'wait_template':
-                        "{{ is_state( trigger.entity_id , 'hello' ) }}"
-                },
-                'action': {
-                    'service': 'test.automation',
+                        "{{ is_state( trigger.entity_id , 'hello') }}"},
+                    {'service': 'test.automation',
                     'data_template': {
                         'some':
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'from_state.state',
                             'to_state.state'))
                     },
-                },
+                }],
             }
         })
 

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -418,7 +418,7 @@ class TestAutomationTemplate(unittest.TestCase):
                         '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
                             'platform', 'entity_id', 'from_state.state',
                             'to_state.state'))
-                    },
+                   },
                 }],
             }
         })

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -345,6 +345,41 @@ class TestScriptHelper(unittest.TestCase):
         assert not script_obj.is_running
         assert len(events) == 1
 
+    def test_wait_template_variables(self):
+        """Test the wait template with variables."""
+        event = 'test_event'
+        events = []
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        self.hass.states.set('switch.test', 'on')
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
+            {'event': event},
+            {'wait_template': "{{is_state( data , 'off')}}"},
+            {'event': event}]))
+
+        script_obj.run({
+            'data': 'switch.test'
+        })
+        self.hass.block_till_done()
+
+        assert script_obj.is_running
+        assert script_obj.can_cancel
+        assert script_obj.last_action == event
+        assert len(events) == 1
+
+        self.hass.states.set('switch.test', 'off')
+        self.hass.block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 2
+
     def test_passing_variables_to_script(self):
         """Test if we can pass variables to script."""
         calls = []

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -361,7 +361,7 @@ class TestScriptHelper(unittest.TestCase):
 
         script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'event': event},
-            {'wait_template': "{{is_state( data , 'off')}}"},
+            {'wait_template': "{{is_state(data, 'off')}}"},
             {'event': event}]))
 
         script_obj.run({

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -683,7 +683,7 @@ class TestHelpersTemplate(unittest.TestCase):
             MATCH_ALL,
             template.extract_entities("""
 {% for state in states.sensor %}
-  {{ state.entity_id }}={{ state.state }},
+  {{ state.entity_id }}={{ state.state }},d
 {% endfor %}
             """))
 
@@ -752,6 +752,15 @@ is_state_attr('device_tracker.phone_2', 'battery', 40)
                 " > (states('input_number.luftfeuchtigkeit') | int +1.5)"
                 " %}true{% endif %}"
             )))
+
+    def test_extract_entities_with_variables_match_entities(self):
+        """Test extract entities with variables function 
+           with entities stuff."""
+
+        self.assertEqual(
+            ['input_boolean.switch'],
+            template.extract_entities_with_variables(
+                "{{ is_state('input_boolean.switch', 'off') }}", {}))
 
 
 @asyncio.coroutine

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -763,23 +763,23 @@ is_state_attr('device_tracker.phone_2', 'battery', 40)
         self.assertEqual(
             ['trigger.entity_id'],
             template.extract_entities(
-                "{{ is_state( trigger.entity_id , 'off') }}", {}))
+                "{{ is_state(trigger.entity_id, 'off') }}", {}))
 
         self.assertEqual(
             MATCH_ALL,
             template.extract_entities(
-                "{{ is_state( data , 'off') }}", {}))
+                "{{ is_state(data, 'off') }}", {}))
 
         self.assertEqual(
             ['input_boolean.switch'],
             template.extract_entities(
-                "{{ is_state( data , 'off') }}",
+                "{{ is_state(data, 'off') }}",
                 {'data': 'input_boolean.switch'}))
 
         self.assertEqual(
             ['input_boolean.switch'],
             template.extract_entities(
-                "{{ is_state( trigger.entity_id , 'off') }}",
+                "{{ is_state(trigger.entity_id, 'off') }}",
                 {'trigger': {'entity_id': 'input_boolean.switch'}}))
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -753,14 +753,34 @@ is_state_attr('device_tracker.phone_2', 'battery', 40)
                 " %}true{% endif %}"
             )))
 
-    def test_extract_entities_with_variables_match_entities(self):
-        """Test extract entities with variables function 
-           with entities stuff."""
+    def test_extract_entities_with_variables(self):
+        """Test extract entities function with variables and entities stuff."""
+        self.assertEqual(
+            ['input_boolean.switch'],
+            template.extract_entities(
+                "{{ is_state('input_boolean.switch', 'off') }}", {}))
+
+        self.assertEqual(
+            ['trigger.entity_id'],
+            template.extract_entities(
+                "{{ is_state( trigger.entity_id , 'off') }}", {} ))
+
+        self.assertEqual(
+            MATCH_ALL,
+            template.extract_entities(
+                "{{ is_state( data , 'off') }}", {} ))
 
         self.assertEqual(
             ['input_boolean.switch'],
-            template.extract_entities_with_variables(
-                "{{ is_state('input_boolean.switch', 'off') }}", {}))
+            template.extract_entities(
+                "{{ is_state( data , 'off') }}",
+                {'data': 'input_boolean.switch'}))
+
+        self.assertEqual(
+            ['input_boolean.switch'],
+            template.extract_entities(
+                "{{ is_state( trigger.entity_id , 'off') }}",
+                {'trigger': {'entity_id': 'input_boolean.switch'}}))
 
 
 @asyncio.coroutine

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -763,12 +763,12 @@ is_state_attr('device_tracker.phone_2', 'battery', 40)
         self.assertEqual(
             ['trigger.entity_id'],
             template.extract_entities(
-                "{{ is_state( trigger.entity_id , 'off') }}", {} ))
+                "{{ is_state( trigger.entity_id , 'off') }}", {}))
 
         self.assertEqual(
             MATCH_ALL,
             template.extract_entities(
-                "{{ is_state( data , 'off') }}", {} ))
+                "{{ is_state( data , 'off') }}", {}))
 
         self.assertEqual(
             ['input_boolean.switch'],


### PR DESCRIPTION
## Description:
Recently I noticed that wait_template currently doesn't support the use of any trigger values (in automations) or data_template values in scripts. Regarding the trigger values: it should work with 'trigger.entity_id' for state, numeric state and template triggers.
Suggestions are more than welcome.

**Pull request in home-assistant.github.io with documentation:** home-assistant/home-assistant.github.io#3593


## Example entry for `configuration.yaml` (if applicable):
```yaml
input_boolean:
  test:
    initial: 'off'

automation:
  - alias: Test 1
    trigger:
      - platform: state
        enitiy_id: input_boolean.test
        to: 'on'
    action:
      - wait_template: "{{ is_state(trigger.entity_id, 'off') }}"

  - alias: Test 2
    trigger:
      - platform: state
        enitiy_id: input_boolean.test
        to: 'on'
    action:
      - service: script.test
        data_template:
          test_data: "{{trigger.entity_id}}"

script:
  test:
    sequence:
      - wait_template: "{{ is_state(test_data, 'off') }}"
```

## Issues:
* Due to the regular expression it's important to leave one whitespace/character/number/... in front of `trigger.entity_id` and `test_data`


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.