### PR TITLE
Split map panel out into its own component

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -225,8 +225,6 @@ def setup(hass, config):
     if DATA_EXTRA_HTML_URL not in hass.data:
         hass.data[DATA_EXTRA_HTML_URL] = set()
 
-    register_built_in_panel(hass, 'map', 'Map', 'mdi:account-location')
-
     for panel in ('dev-event', 'dev-info', 'dev-service', 'dev-state',
                   'dev-template', 'dev-mqtt', 'kiosk'):
         register_built_in_panel(hass, panel)

--- a/homeassistant/components/map.py
+++ b/homeassistant/components/map.py
@@ -1,0 +1,18 @@
+"""
+Provides a map panel for showing device locations.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/map/
+"""
+import asyncio
+
+from homeassistant.components.frontend import register_built_in_panel
+
+DOMAIN = 'map'
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Register the built-in map panel."""
+    register_built_in_panel(hass, 'map', 'Map', 'mdi:account-location')
+    return True

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -96,6 +96,9 @@ history:
 # View all events in a logbook
 logbook:
 
+# Enables a map showing the location of tracked devices
+map:
+
 # Track the sun
 sun:
 


### PR DESCRIPTION
## Description:
Splits map panel out into it's own component. This allows it to be disabled by removing `map:` from the configuration, for people who may not be using it. This also better aligns it with the rest of the built-in panels as they all have their own components. Will also allow for future additional configuration/new features.

Updated default configuration file to include `map:` by default.

**This is a breaking change**, as users will need to add `map:` to their config to re-enable the panel.

Working on PR to update documentation.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3588

## Example entry for `configuration.yaml` (if applicable):
```yaml
map:
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
