### PR TITLE
Add namecheap DNS component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -441,6 +441,7 @@ omit =
     homeassistant/components/notify/twitter.py
     homeassistant/components/notify/xmpp.py
     homeassistant/components/nuimo_controller.py
+    homeassistant/components/namecheap.py
     homeassistant/components/prometheus.py
     homeassistant/components/remote/harmony.py
     homeassistant/components/remote/itach.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -441,7 +441,6 @@ omit =
     homeassistant/components/notify/twitter.py
     homeassistant/components/notify/xmpp.py
     homeassistant/components/nuimo_controller.py
-    homeassistant/components/namecheap.py
     homeassistant/components/prometheus.py
     homeassistant/components/remote/harmony.py
     homeassistant/components/remote/itach.py

--- a/homeassistant/components/namecheapdns.py
+++ b/homeassistant/components/namecheapdns.py
@@ -3,7 +3,6 @@ import asyncio
 from datetime import timedelta
 import logging
 
-import xml.etree.ElementTree as ET
 import voluptuous as vol
 
 from homeassistant.const import CONF_HOST, CONF_ACCESS_TOKEN, CONF_DOMAIN
@@ -57,6 +56,8 @@ def async_setup(hass, config):
 @asyncio.coroutine
 def _update_namecheapdns(session, host, domain, token):
     """Update NamecheapDNS."""
+    import xml.etree.ElementTree as ET
+
     params = {
         'host': host,
         'domain': domain,

--- a/homeassistant/components/namecheapdns.py
+++ b/homeassistant/components/namecheapdns.py
@@ -1,0 +1,75 @@
+"""Integrate with NamecheapDNS."""
+import asyncio
+from datetime import timedelta
+import logging
+
+import xml.etree.ElementTree as ET
+import voluptuous as vol
+
+from homeassistant.const import CONF_HOST, CONF_ACCESS_TOKEN, CONF_DOMAIN
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+DOMAIN = 'namecheapdns'
+UPDATE_URL = 'https://dynamicdns.park-your-domain.com/update'
+INTERVAL = timedelta(minutes=5)
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_DOMAIN): cv.string,
+        vol.Required(CONF_ACCESS_TOKEN): cv.string,
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Initialize the NamecheapDNS component."""
+    host = config[DOMAIN][CONF_HOST]
+    domain = config[DOMAIN][CONF_DOMAIN]
+    token = config[DOMAIN][CONF_ACCESS_TOKEN]
+    session = async_get_clientsession(hass)
+
+    result = yield from _update_namecheapdns(session, host, domain, token)
+
+    if not result:
+        return False
+
+    @asyncio.coroutine
+    def update_domain_interval(now):
+        """Update the NamecheapDNS entry."""
+        yield from _update_namecheapdns(session, host, domain, token)
+
+    @asyncio.coroutine
+    def update_domain_service(call):
+        """Update the NamecheapDNS entry."""
+        yield from _update_namecheapdns(session, host, domain, token)
+
+    async_track_time_interval(hass, update_domain_interval, INTERVAL)
+    hass.services.async_register(DOMAIN, 'update dns', update_domain_service)
+
+    return result
+
+
+@asyncio.coroutine
+def _update_namecheapdns(session, host, domain, token):
+    """Update NamecheapDNS."""
+    params = {
+        'host': host,
+        'domain': domain,
+        'password': token,
+    }
+
+    resp = yield from session.get(UPDATE_URL, params=params)
+    xml_string = yield from resp.text()
+    root = ET.fromstring(xml_string)
+    err_count = root.find('ErrCount').text
+
+    if int(err_count) != 0:
+        _LOGGER.warning('Updating Namecheap domain %s failed', domain)
+        return False
+
+    return True

--- a/tests/components/test_namecheapdns.py
+++ b/tests/components/test_namecheapdns.py
@@ -1,0 +1,79 @@
+"""Test the NamecheapDNS component."""
+import asyncio
+from datetime import timedelta
+
+import xml.etree.ElementTree as ET
+import pytest
+
+from homeassistant.setup import async_setup_component
+from homeassistant.components import namecheapdns
+from homeassistant.util.dt import utcnow
+
+from tests.common import async_fire_time_changed
+
+HOST = 'test'
+DOMAIN = 'bla'
+TOKEN = 'abcdefgh'
+
+
+@pytest.fixture
+def setup_namecheapdns(hass, aioclient_mock):
+    """Fixture that sets up NamecheapDNS."""
+    aioclient_mock.get(namecheapdns.UPDATE_URL, params={
+        'host': HOST,
+        'domain': DOMAIN,
+        'password': TOKEN
+    }, text='<interface-response><ErrCount>0</ErrCount></interface-response>')
+
+    hass.loop.run_until_complete(async_setup_component(
+        hass, namecheapdns.DOMAIN, {
+            'namecheapdns': {
+                'host': HOST,
+                'domain': DOMAIN,
+                'access_token': TOKEN
+            }
+        }))
+
+
+@asyncio.coroutine
+def test_setup(hass, aioclient_mock):
+    """Test setup works if update passes."""
+    aioclient_mock.get(namecheapdns.UPDATE_URL, params={
+        'host': HOST,
+        'domain': DOMAIN,
+        'password': TOKEN
+    }, text='<interface-response><ErrCount>0</ErrCount></interface-response>')
+
+    result = yield from async_setup_component(hass, namecheapdns.DOMAIN, {
+        'namecheapdns': {
+            'host': HOST,
+            'domain': DOMAIN,
+            'access_token': TOKEN
+        }
+    })
+    assert result
+    assert aioclient_mock.call_count == 1
+
+    async_fire_time_changed(hass, utcnow() + timedelta(minutes=5))
+    yield from hass.async_block_till_done()
+    assert aioclient_mock.call_count == 2
+
+
+@asyncio.coroutine
+def test_setup_fails_if_update_fails(hass, aioclient_mock):
+    """Test setup fails if first update fails."""
+    aioclient_mock.get(namecheapdns.UPDATE_URL, params={
+        'host': HOST,
+        'domain': DOMAIN,
+        'password': TOKEN
+    }, text='<interface-response><ErrCount>1</ErrCount></interface-response>')
+
+    result = yield from async_setup_component(hass, namecheapdns.DOMAIN, {
+        'namecheapdns': {
+            'host': HOST,
+            'domain': DOMAIN,
+            'access_token': TOKEN
+        }
+    })
+    assert not result
+    assert aioclient_mock.call_count == 1

--- a/tests/components/test_namecheapdns.py
+++ b/tests/components/test_namecheapdns.py
@@ -2,7 +2,6 @@
 import asyncio
 from datetime import timedelta
 
-import xml.etree.ElementTree as ET
 import pytest
 
 from homeassistant.setup import async_setup_component


### PR DESCRIPTION
## Description:

This adds a new component to automatically update namecheap subdomains with the ip from home-assistant. It is primarily a copy/paste from @balloob DuckDNS component 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3589

## Example entry for `configuration.yaml` (if applicable):
```yaml
namecheapdns:
  host: ha
  domain: example.com
  access_token: 0123456789
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

One Question: I am not an python dev and i do not know what this REQUIREMENTS var is so do i have to write the xml-parser lib in there?