### PR TITLE
Added super attributes to Wink binary sensors

### DIFF
--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -9,7 +9,6 @@ import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.wink import WinkDevice, DOMAIN
-from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/binary_sensor/wink.py
+++ b/homeassistant/components/binary_sensor/wink.py
@@ -87,7 +87,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 _LOGGER.info("Device isn't a sensor, skipping")
 
 
-class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
+class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice):
     """Representation of a Wink binary sensor."""
 
     def __init__(self, wink, hass):
@@ -117,6 +117,11 @@ class WinkBinarySensorDevice(WinkDevice, BinarySensorDevice, Entity):
         """Return the class of this sensor, from DEVICE_CLASSES."""
         return SENSOR_TYPES.get(self.capability)
 
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return super().device_state_attributes
+
 
 class WinkSmokeDetector(WinkBinarySensorDevice):
     """Representation of a Wink Smoke detector."""
@@ -124,9 +129,9 @@ class WinkSmokeDetector(WinkBinarySensorDevice):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {
-            'test_activated': self.wink.test_activated()
-        }
+        _attributes = super().device_state_attributes
+        _attributes['test_activated'] = self.wink.test_activated()
+        return _attributes
 
 
 class WinkHub(WinkBinarySensorDevice):
@@ -135,11 +140,11 @@ class WinkHub(WinkBinarySensorDevice):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {
-            'update_needed': self.wink.update_needed(),
-            'firmware_version': self.wink.firmware_version(),
-            'pairing_mode': self.wink.pairing_mode()
-        }
+        _attributes = super().device_state_attributes
+        _attributes['update_needed'] = self.wink.update_needed()
+        _attributes['firmware_version'] = self.wink.firmware_version()
+        _attributes['pairing_mode'] = self.wink.pairing_mode()
+        return _attributes
 
 
 class WinkRemote(WinkBinarySensorDevice):
@@ -148,12 +153,12 @@ class WinkRemote(WinkBinarySensorDevice):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {
-            'button_on_pressed': self.wink.button_on_pressed(),
-            'button_off_pressed': self.wink.button_off_pressed(),
-            'button_up_pressed': self.wink.button_up_pressed(),
-            'button_down_pressed': self.wink.button_down_pressed()
-        }
+        _attributes = super().device_state_attributes
+        _attributes['button_on_pressed'] = self.wink.button_on_pressed()
+        _attributes['button_off_pressed'] = self.wink.button_off_pressed()
+        _attributes['button_up_pressed'] = self.wink.button_up_pressed()
+        _attributes['button_down_pressed'] = self.wink.button_down_pressed()
+        return _attributes
 
     @property
     def device_class(self):
@@ -167,10 +172,10 @@ class WinkButton(WinkBinarySensorDevice):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {
-            'pressed': self.wink.pressed(),
-            'long_pressed': self.wink.long_pressed()
-        }
+        _attributes = super().device_state_attributes
+        _attributes['pressed'] = self.wink.pressed()
+        _attributes['long_pressed'] = self.wink.long_pressed()
+        return _attributes
 
 
 class WinkGang(WinkBinarySensorDevice):


### PR DESCRIPTION
## Description:
Base Wink attributes weren't being added to the Wink binary sensors. This was reported by a user that wasn't seeing battery level on smoke detectors. 

This pulls the super objects attributes and adds the specific device's attributes as well. 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
