### PR TITLE
Mqtt light options to fix #9330 and #7810

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -51,6 +51,7 @@ CONF_WHITE_VALUE_COMMAND_TOPIC = 'white_value_command_topic'
 CONF_WHITE_VALUE_SCALE = 'white_value_scale'
 CONF_WHITE_VALUE_STATE_TOPIC = 'white_value_state_topic'
 CONF_WHITE_VALUE_TEMPLATE = 'white_value_template'
+CONF_SEND_ON_WITH_CHANGE = 'send_on_with_change'
 
 DEFAULT_BRIGHTNESS_SCALE = 255
 DEFAULT_NAME = 'MQTT Light'
@@ -58,6 +59,9 @@ DEFAULT_OPTIMISTIC = False
 DEFAULT_PAYLOAD_OFF = 'OFF'
 DEFAULT_PAYLOAD_ON = 'ON'
 DEFAULT_WHITE_VALUE_SCALE = 255
+DEFAULT_SEND_ON_WITH_CHANGE = "BEFORE"
+
+VALUES_SEND_ON_WITH_CHANGE = ["BEFORE", "AFTER", "NONE"]
 
 PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_BRIGHTNESS_COMMAND_TOPIC): mqtt.valid_publish_topic,
@@ -89,6 +93,9 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_XY_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_XY_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_XY_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_SEND_ON_WITH_CHANGE,
+                 default=DEFAULT_SEND_ON_WITH_CHANGE):
+        vol.In(VALUES_SEND_ON_WITH_CHANGE),
 })
 
 
@@ -141,6 +148,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_OPTIMISTIC),
         config.get(CONF_BRIGHTNESS_SCALE),
         config.get(CONF_WHITE_VALUE_SCALE),
+        config.get(CONF_SEND_ON_WITH_CHANGE),
     )])
 
 
@@ -149,7 +157,7 @@ class MqttLight(Light):
 
     def __init__(self, name, effect_list, topic, templates, qos,
                  retain, payload, optimistic, brightness_scale,
-                 white_value_scale):
+                 white_value_scale, send_on_with_change):
         """Initialize MQTT light."""
         self._name = name
         self._effect_list = effect_list
@@ -173,6 +181,7 @@ class MqttLight(Light):
             optimistic or topic[CONF_XY_STATE_TOPIC] is None
         self._brightness_scale = brightness_scale
         self._white_value_scale = white_value_scale
+        self._send_on_with_change = send_on_with_change
         self._state = False
         self._brightness = None
         self._rgb = None
@@ -396,6 +405,13 @@ class MqttLight(Light):
         This method is a coroutine.
         """
         should_update = False
+        style_changed = False
+
+        if self._send_on_with_change == 'BEFORE':
+            mqtt.async_publish(
+                self.hass, self._topic[CONF_COMMAND_TOPIC],
+                self._payload['on'], self._qos, self._retain)
+            should_update = True
 
         if ATTR_RGB_COLOR in kwargs and \
            self._topic[CONF_RGB_COMMAND_TOPIC] is not None:
@@ -408,6 +424,8 @@ class MqttLight(Light):
                 rgb_color_str = tpl.async_render(variables)
             else:
                 rgb_color_str = '{},{},{}'.format(*kwargs[ATTR_RGB_COLOR])
+
+            style_changed = True
             mqtt.async_publish(
                 self.hass, self._topic[CONF_RGB_COMMAND_TOPIC],
                 rgb_color_str, self._qos, self._retain)
@@ -424,6 +442,7 @@ class MqttLight(Light):
                 self.hass, self._topic[CONF_BRIGHTNESS_COMMAND_TOPIC],
                 device_brightness, self._qos, self._retain)
 
+            style_changed = True
             if self._optimistic_brightness:
                 self._brightness = kwargs[ATTR_BRIGHTNESS]
                 should_update = True
@@ -434,6 +453,8 @@ class MqttLight(Light):
             mqtt.async_publish(
                 self.hass, self._topic[CONF_COLOR_TEMP_COMMAND_TOPIC],
                 color_temp, self._qos, self._retain)
+
+            style_changed = True
             if self._optimistic_color_temp:
                 self._color_temp = kwargs[ATTR_COLOR_TEMP]
                 should_update = True
@@ -445,6 +466,8 @@ class MqttLight(Light):
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_EFFECT_COMMAND_TOPIC],
                     effect, self._qos, self._retain)
+
+                style_changed = True
                 if self._optimistic_effect:
                     self._effect = kwargs[ATTR_EFFECT]
                     should_update = True
@@ -457,6 +480,7 @@ class MqttLight(Light):
                 self.hass, self._topic[CONF_WHITE_VALUE_COMMAND_TOPIC],
                 device_white_value, self._qos, self._retain)
 
+            style_changed = True
             if self._optimistic_white_value:
                 self._white_value = kwargs[ATTR_WHITE_VALUE]
                 should_update = True
@@ -469,13 +493,19 @@ class MqttLight(Light):
                 '{},{}'.format(*kwargs[ATTR_XY_COLOR]), self._qos,
                 self._retain)
 
+            style_changed = True
             if self._optimistic_xy:
                 self._xy = kwargs[ATTR_XY_COLOR]
                 should_update = True
 
-        mqtt.async_publish(
-            self.hass, self._topic[CONF_COMMAND_TOPIC], self._payload['on'],
-            self._qos, self._retain)
+        # Send an on command if no style item was changed (just a
+        # basic on command), or if style was changed and the on is
+        # after the style change.
+        if not style_changed or self._send_on_with_change == 'AFTER':
+            mqtt.async_publish(
+                self.hass, self._topic[CONF_COMMAND_TOPIC],
+                self._payload['on'], self._qos, self._retain)
+            should_update = True
 
         if self._optimistic:
             # Optimistically assume that switch has changed state.

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -93,7 +93,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_XY_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_XY_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_XY_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_ON_COMMAND_TYPE,default=DEFAULT_ON_COMMAND_TYPE):
+    vol.Optional(CONF_ON_COMMAND_TYPE, default=DEFAULT_ON_COMMAND_TYPE):
         vol.In(VALUES_ON_COMMAND_TYPE),
 })
 
@@ -410,6 +410,10 @@ class MqttLight(Light):
                 self.hass, self._topic[CONF_COMMAND_TOPIC],
                 self._payload['on'], self._qos, self._retain)
             should_update = True
+
+        # If brightness is being used instead of an on command, make sure
+        # there is a brightness input.  Either set the brightness to our
+        # saved value or the maximum value if this is the first call
         elif self._on_command_type == 'BRIGHTNESS':
             if ATTR_BRIGHTNESS not in kwargs:
                 kwargs[ATTR_BRIGHTNESS] = self._brightness if \
@@ -496,7 +500,7 @@ class MqttLight(Light):
 
         if self._on_command_type == 'LAST':
             mqtt.async_publish(self.hass, self._topic[CONF_COMMAND_TOPIC],
-                self._payload['on'], self._qos, self._retain)
+                               self._payload['on'], self._qos, self._retain)
             should_update = True
 
         if self._optimistic:

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -59,9 +59,9 @@ DEFAULT_OPTIMISTIC = False
 DEFAULT_PAYLOAD_OFF = 'OFF'
 DEFAULT_PAYLOAD_ON = 'ON'
 DEFAULT_WHITE_VALUE_SCALE = 255
-DEFAULT_ON_COMMAND_TYPE = "LAST"
+DEFAULT_ON_COMMAND_TYPE = "last"
 
-VALUES_ON_COMMAND_TYPE = ["FIRST", "LAST", "BRIGHTNESS"]
+VALUES_ON_COMMAND_TYPE = ["first", "last", "brightness"]
 
 PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_BRIGHTNESS_COMMAND_TOPIC): mqtt.valid_publish_topic,
@@ -405,7 +405,7 @@ class MqttLight(Light):
         """
         should_update = False
 
-        if self._on_command_type == 'FIRST':
+        if self._on_command_type == 'first':
             mqtt.async_publish(
                 self.hass, self._topic[CONF_COMMAND_TOPIC],
                 self._payload['on'], self._qos, self._retain)
@@ -414,7 +414,7 @@ class MqttLight(Light):
         # If brightness is being used instead of an on command, make sure
         # there is a brightness input.  Either set the brightness to our
         # saved value or the maximum value if this is the first call
-        elif self._on_command_type == 'BRIGHTNESS':
+        elif self._on_command_type == 'brightness':
             if ATTR_BRIGHTNESS not in kwargs:
                 kwargs[ATTR_BRIGHTNESS] = self._brightness if \
                                           self._brightness else 255
@@ -498,7 +498,7 @@ class MqttLight(Light):
                 self._xy = kwargs[ATTR_XY_COLOR]
                 should_update = True
 
-        if self._on_command_type == 'LAST':
+        if self._on_command_type == 'last':
             mqtt.async_publish(self.hass, self._topic[CONF_COMMAND_TOPIC],
                                self._payload['on'], self._qos, self._retain)
             should_update = True

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -59,9 +59,9 @@ DEFAULT_OPTIMISTIC = False
 DEFAULT_PAYLOAD_OFF = 'OFF'
 DEFAULT_PAYLOAD_ON = 'ON'
 DEFAULT_WHITE_VALUE_SCALE = 255
-DEFAULT_ON_COMMAND_TYPE = "last"
+DEFAULT_ON_COMMAND_TYPE = 'last'
 
-VALUES_ON_COMMAND_TYPE = ["first", "last", "brightness"]
+VALUES_ON_COMMAND_TYPE = ['first', 'last', 'brightness']
 
 PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_BRIGHTNESS_COMMAND_TOPIC): mqtt.valid_publish_topic,
@@ -156,7 +156,7 @@ class MqttLight(Light):
 
     def __init__(self, name, effect_list, topic, templates, qos,
                  retain, payload, optimistic, brightness_scale,
-                 white_value_scale, on_command_type='last'):
+                 white_value_scale, on_command_type):
         """Initialize MQTT light."""
         self._name = name
         self._effect_list = effect_list

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -156,7 +156,7 @@ class MqttLight(Light):
 
     def __init__(self, name, effect_list, topic, templates, qos,
                  retain, payload, optimistic, brightness_scale,
-                 white_value_scale, on_command_type='LAST'):
+                 white_value_scale, on_command_type='last'):
         """Initialize MQTT light."""
         self._name = name
         self._effect_list = effect_list

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -750,6 +750,7 @@ class TestLightMQTT(unittest.TestCase):
             'name': 'test',
             'command_topic': 'test_light/set',
             'brightness_command_topic': 'test_light/bright',
+            'rgb_command_topic': "test_light/rgb",
             'on_command_type': 'BRIGHTNESS',
         }}
 
@@ -778,5 +779,18 @@ class TestLightMQTT(unittest.TestCase):
         light.turn_on(self.hass, 'light.test', brightness=50)
         self.hass.block_till_done()
 
+        self.assertEqual(('test_light/bright', 50, 0, False),
+                         self.mock_publish.mock_calls[-2][1])
+
+        light.turn_off(self.hass, 'light.test')
+        self.hass.block_till_done()
+
+        # Turn on w/ just a color to insure brightness gets
+        # added and sent.
+        light.turn_on(self.hass, 'light.test', rgb_color=[75, 75, 75])
+        self.hass.block_till_done()
+
+        self.assertEqual(('test_light/rgb', '75,75,75', 0, False),
+                         self.mock_publish.mock_calls[-4][1])
         self.assertEqual(('test_light/bright', 50, 0, False),
                          self.mock_publish.mock_calls[-2][1])

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -677,3 +677,106 @@ class TestLightMQTT(unittest.TestCase):
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_ON, state.state)
         self.assertEqual([1, 1], state.attributes.get('xy_color'))
+
+    def test_on_command_first(self):
+        """Test on command being sent before brightness."""
+        config = {light.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'command_topic': 'test_light/set',
+            'brightness_command_topic': 'test_light/bright',
+            'on_command_type': 'FIRST',
+        }}
+
+        with assert_setup_component(1, light.DOMAIN):
+            assert setup_component(self.hass, light.DOMAIN, config)
+
+        state = self.hass.states.get('light.test')
+        self.assertEqual(STATE_OFF, state.state)
+
+        light.turn_on(self.hass, 'light.test', brightness=50)
+        self.hass.block_till_done()
+
+        # Should get the following MQTT messages.
+        #    test_light/set: 'ON'
+        #    test_light/bright: 50
+        self.assertEqual(('test_light/set', 'ON', 0, False),
+                         self.mock_publish.mock_calls[-4][1])
+        self.assertEqual(('test_light/bright', 50, 0, False),
+                         self.mock_publish.mock_calls[-2][1])
+
+        light.turn_off(self.hass, 'light.test')
+        self.hass.block_till_done()
+
+        self.assertEqual(('test_light/set', 'OFF', 0, False),
+                         self.mock_publish.mock_calls[-2][1])
+
+    def test_on_command_last(self):
+        """Test on command being sent after brightness."""
+        config = {light.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'command_topic': 'test_light/set',
+            'brightness_command_topic': 'test_light/bright',
+        }}
+
+        with assert_setup_component(1, light.DOMAIN):
+            assert setup_component(self.hass, light.DOMAIN, config)
+
+        state = self.hass.states.get('light.test')
+        self.assertEqual(STATE_OFF, state.state)
+
+        light.turn_on(self.hass, 'light.test', brightness=50)
+        self.hass.block_till_done()
+
+        # Should get the following MQTT messages.
+        #    test_light/bright: 50
+        #    test_light/set: 'ON'
+        self.assertEqual(('test_light/bright', 50, 0, False),
+                         self.mock_publish.mock_calls[-4][1])
+        self.assertEqual(('test_light/set', 'ON', 0, False),
+                         self.mock_publish.mock_calls[-2][1])
+
+        light.turn_off(self.hass, 'light.test')
+        self.hass.block_till_done()
+
+        self.assertEqual(('test_light/set', 'OFF', 0, False),
+                         self.mock_publish.mock_calls[-2][1])
+
+    def test_on_command_brightness(self):
+        """Test on command being sent as only brightness."""
+        config = {light.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'command_topic': 'test_light/set',
+            'brightness_command_topic': 'test_light/bright',
+            'on_command_type': 'BRIGHTNESS',
+        }}
+
+        with assert_setup_component(1, light.DOMAIN):
+            assert setup_component(self.hass, light.DOMAIN, config)
+
+        state = self.hass.states.get('light.test')
+        self.assertEqual(STATE_OFF, state.state)
+
+        # Turn on w/ no brightness - should set to max
+        light.turn_on(self.hass, 'light.test')
+        self.hass.block_till_done()
+
+        # Should get the following MQTT messages.
+        #    test_light/bright: 255
+        self.assertEqual(('test_light/bright', 255, 0, False),
+                         self.mock_publish.mock_calls[-2][1])
+
+        light.turn_off(self.hass, 'light.test')
+        self.hass.block_till_done()
+
+        self.assertEqual(('test_light/set', 'OFF', 0, False),
+                         self.mock_publish.mock_calls[-2][1])
+
+        # Turn on w/ brightness
+        light.turn_on(self.hass, 'light.test', brightness=50)
+        self.hass.block_till_done()
+
+        self.assertEqual(('test_light/bright', 50, 0, False),
+                         self.mock_publish.mock_calls[-2][1])

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -685,7 +685,7 @@ class TestLightMQTT(unittest.TestCase):
             'name': 'test',
             'command_topic': 'test_light/set',
             'brightness_command_topic': 'test_light/bright',
-            'on_command_type': 'FIRST',
+            'on_command_type': 'first',
         }}
 
         with assert_setup_component(1, light.DOMAIN):
@@ -751,7 +751,7 @@ class TestLightMQTT(unittest.TestCase):
             'command_topic': 'test_light/set',
             'brightness_command_topic': 'test_light/bright',
             'rgb_command_topic': "test_light/rgb",
-            'on_command_type': 'BRIGHTNESS',
+            'on_command_type': 'brightness',
         }}
 
         with assert_setup_component(1, light.DOMAIN):


### PR DESCRIPTION
## Description:
Added an option to MQTT light to control when and if an ON command topic is published.  Currently, ON is always sent after changing the light style (brightness, color, etc).  This option allows the user to specify if ON should be sent before style topics, after style topics (the default to maintain current behavior), or to use the brightness topic as the ON command.  

**Related issue (if applicable):** fixes #9330 and #7810

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3595

## Example entry for `configuration.yaml` (if applicable):
Example added to docs in io PR above
```yaml
  - platform: mqtt
    name: "Brightness light"
    state_topic: "office/light/status"
    command_topic: "office/light/switch"
    payload_off: "OFF"
    brightness_state_topic: 'office/rgb1/light/brightness'
    brightness_command_topic: 'office/rgb1/light/brightness/set'
    on_command_type: 'BRIGHTNESS'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

