### PR TITLE
InfluxDb: Populate measurement "state" field for HA states like home/not_home, on/off

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -143,11 +143,16 @@ def setup(hass, config):
                     (whitelist_d and state.domain not in whitelist_d):
                 return
 
-            _state = float(state_helper.state_as_number(state))
-            _state_key = "value"
+            _include_state = _include_value = False
+
+            _state_as_value = float(state.state)
+            _include_value = True
         except ValueError:
-            _state = state.state
-            _state_key = "state"
+            try:
+                _state_as_value = float(state_helper.state_as_number(state))
+                _include_state = _include_value = True
+            except ValueError:
+                _include_state = True
 
         measurement = component_config.get(state.entity_id).get(
             CONF_OVERRIDE_MEASUREMENT)
@@ -171,10 +176,13 @@ def setup(hass, config):
                 },
                 'time': event.time_fired,
                 'fields': {
-                    _state_key: _state,
                 }
             }
         ]
+        if _include_state:
+            json_body[0]['fields']['state'] = state.state
+        if _include_value:
+            json_body[0]['fields']['value'] = _state_as_value
 
         for key, value in state.attributes.items():
             if key in tags_attributes:

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -7,7 +7,8 @@ import influxdb as influx_client
 
 from homeassistant.setup import setup_component
 import homeassistant.components.influxdb as influxdb
-from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
+from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON, \
+                                STATE_STANDBY
 
 from tests.common import get_test_home_assistant
 
@@ -110,12 +111,14 @@ class TestInfluxDB(unittest.TestCase):
         """Test the event listener."""
         self._setup()
 
+        # map of HA State to valid influxdb [state, value] fields
         valid = {
-            '1': 1,
-            '1.0': 1.0,
-            STATE_ON: 1,
-            STATE_OFF: 0,
-            'foo': 'foo'
+            '1': [None, 1],
+            '1.0': [None, 1.0],
+            STATE_ON: [STATE_ON, 1],
+            STATE_OFF: [STATE_OFF, 0],
+            STATE_STANDBY: [STATE_STANDBY, None],
+            'foo': ['foo', None]
         }
         for in_, out in valid.items():
             attrs = {
@@ -132,53 +135,32 @@ class TestInfluxDB(unittest.TestCase):
                 state=in_, domain='fake', entity_id='fake.entity-id',
                 object_id='entity', attributes=attrs)
             event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
-            if isinstance(out, str):
-                body = [{
-                    'measurement': 'foobars',
-                    'tags': {
-                        'domain': 'fake',
-                        'entity_id': 'entity',
-                    },
-                    'time': 12345,
-                    'fields': {
-                        'state': out,
-                        'longitude': 1.1,
-                        'latitude': 2.2,
-                        'battery_level_str': '99%',
-                        'battery_level': 99.0,
-                        'temperature_str': '20c',
-                        'temperature': 20.0,
-                        'last_seen_str': 'Last seen 23 minutes ago',
-                        'last_seen': 23.0,
-                        'updated_at_str': '2017-01-01 00:00:00',
-                        'updated_at': 20170101000000,
-                        'multi_periods_str': '0.120.240.2023873'
-                    },
-                }]
+            body = [{
+                'measurement': 'foobars',
+                'tags': {
+                    'domain': 'fake',
+                    'entity_id': 'entity',
+                },
+                'time': 12345,
+                'fields': {
+                    'longitude': 1.1,
+                    'latitude': 2.2,
+                    'battery_level_str': '99%',
+                    'battery_level': 99.0,
+                    'temperature_str': '20c',
+                    'temperature': 20.0,
+                    'last_seen_str': 'Last seen 23 minutes ago',
+                    'last_seen': 23.0,
+                    'updated_at_str': '2017-01-01 00:00:00',
+                    'updated_at': 20170101000000,
+                    'multi_periods_str': '0.120.240.2023873'
+                },
+            }]
+            if out[0] is not None:
+                body[0]['fields']['state'] = out[0]
+            if out[1] is not None:
+                body[0]['fields']['value'] = out[1]
 
-            else:
-                body = [{
-                    'measurement': 'foobars',
-                    'tags': {
-                        'domain': 'fake',
-                        'entity_id': 'entity',
-                    },
-                    'time': 12345,
-                    'fields': {
-                        'value': out,
-                        'longitude': 1.1,
-                        'latitude': 2.2,
-                        'battery_level_str': '99%',
-                        'battery_level': 99.0,
-                        'temperature_str': '20c',
-                        'temperature': 20.0,
-                        'last_seen_str': 'Last seen 23 minutes ago',
-                        'last_seen': 23.0,
-                        'updated_at_str': '2017-01-01 00:00:00',
-                        'updated_at': 20170101000000,
-                        'multi_periods_str': '0.120.240.2023873'
-                    },
-                }]
             self.handler_method(event)
             self.assertEqual(
                 mock_client.return_value.write_points.call_count, 1
@@ -428,12 +410,14 @@ class TestInfluxDB(unittest.TestCase):
         """Test the event listener when an attribute has an invalid type."""
         self._setup()
 
+        # map of HA State to valid influxdb [state, value] fields
         valid = {
-            '1': 1,
-            '1.0': 1.0,
-            STATE_ON: 1,
-            STATE_OFF: 0,
-            'foo': 'foo'
+            '1': [None, 1],
+            '1.0': [None, 1.0],
+            STATE_ON: [STATE_ON, 1],
+            STATE_OFF: [STATE_OFF, 0],
+            STATE_STANDBY: [STATE_STANDBY, None],
+            'foo': ['foo', None]
         }
         for in_, out in valid.items():
             attrs = {
@@ -446,37 +430,24 @@ class TestInfluxDB(unittest.TestCase):
                 state=in_, domain='fake', entity_id='fake.entity-id',
                 object_id='entity', attributes=attrs)
             event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
-            if isinstance(out, str):
-                body = [{
-                    'measurement': 'foobars',
-                    'tags': {
-                        'domain': 'fake',
-                        'entity_id': 'entity',
-                    },
-                    'time': 12345,
-                    'fields': {
-                        'state': out,
-                        'longitude': 1.1,
-                        'latitude': 2.2,
-                        'invalid_attribute_str': "['value1', 'value2']"
-                    },
-                }]
+            body = [{
+                'measurement': 'foobars',
+                'tags': {
+                    'domain': 'fake',
+                    'entity_id': 'entity',
+                },
+                'time': 12345,
+                'fields': {
+                    'longitude': 1.1,
+                    'latitude': 2.2,
+                    'invalid_attribute_str': "['value1', 'value2']"
+                },
+            }]
+            if out[0] is not None:
+                body[0]['fields']['state'] = out[0]
+            if out[1] is not None:
+                body[0]['fields']['value'] = out[1]
 
-            else:
-                body = [{
-                    'measurement': 'foobars',
-                    'tags': {
-                        'domain': 'fake',
-                        'entity_id': 'entity',
-                    },
-                    'time': 12345,
-                    'fields': {
-                        'value': float(out),
-                        'longitude': 1.1,
-                        'latitude': 2.2,
-                        'invalid_attribute_str': "['value1', 'value2']"
-                    },
-                }]
             self.handler_method(event)
             self.assertEqual(
                 mock_client.return_value.write_points.call_count, 1


### PR DESCRIPTION
## Description:
I am seeing cases where an entity's states get mapped across both the InfluxDb "state" ***and*** "value" fields. This behaviour makes it difficult to create state queries in Grafana (e.g. to display location for components like Owntracks) without additional mapping logic.

```
Influxdb: select entity_id,state,value from events

entity_id         state       value           # HA State
---------         -----       -----           # -----------------
tv                            1               # state = "on"
tv                standby                     # state = "standby"
tv                            0               # state = "off"
...
ibeacon                       1               # state = "home"
ibeacon           away                        # state = "away"
ibeacon                       1               # state = "home"
...
phone_owntracks               1               # state = "home"
phone_owntracks               0               # state = "not_home"
phone_owntracks   work                        # state = "work"
```
The behaviour results from using `helper.state.state_as_number()` in the InfluxDb component to determine whether to send the state as a number or a string. The helper routine translates some standard state strings (e.g. on|off, home|not_home, open|closed) to 0 or 1 as if they were binary states. Any component that uses those standard states in combination with other state strings will see this cross-column result.

The outcome I'm looking for is as in the table below where the original state string is preserved but a numeric equivalent continues to be provided where possible i.e.

```
entity_id         state       value           # HA State
---------         -----       -----           # -----------------
phone_owntracks   home        1               # state = "home"
phone_owntracks   not_home    0               # state = "not_home"
phone_owntracks   work                        # state = "work"
```
Two possible ways of implementing this would be:
1) Change the logic to ***always*** populate the "state" field and continue to populate "value" field when possible. The "state" field would mirror the HA state with the "value" field available for graphing. The downside an increased database size to store two variants of largely the same information.

2) Continue the current approach but test for those "standard states" and only then populate both "state" and "value" field. This has a negligable impact on database size and current queries but doesn't have the advantage of replicating HA state into the InfluxDb "state" field.

Option 1 feels like the purist approach with option 2 being perhaps more pragmatic. I am sure there are other solutions as well. The PR implements option 2 to test the approach but, to be honest, would appreciate thoughts on best way forward.

**Related issue (if applicable): ** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
