### PR TITLE
Add image attribute to html5 notify

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -94,8 +94,8 @@ NOTIFY_CALLBACK_EVENT = 'html5_notification'
 
 # Badge and timestamp are Chrome specific (not in official spec)
 HTML5_SHOWNOTIFICATION_PARAMETERS = (
-    'actions', 'badge', 'body', 'dir', 'icon', 'lang', 'renotify',
-    'requireInteraction', 'tag', 'timestamp', 'vibrate')
+    'actions', 'badge', 'body', 'dir', 'icon', 'image', 'lang',
+    'renotify', 'requireInteraction', 'tag', 'timestamp', 'vibrate')
 
 
 def get_service(hass, config, discovery_info=None):


### PR DESCRIPTION
## Description:
Adds image attribute to HTML5 notify component as detailed in #9832 and https://community.home-assistant.io/t/html5-missing-image-support/29333/2

**Related issue (if applicable):** fixes #9832

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3596

## Example entry for `configuration.yaml` (if applicable):
```yaml
  action:
    - service: notify.notify
      data:
        title: 'GATE'
        message: 'Closed'
        target: 
          - 'PHONE_MyPhone'
        data:
          tag: alert
          url: 'https://mysite.com/kiosk/group.garage' #onclick go to this site
          image: "http://10.60.27.12:8765/picture/2/current/gate.jpg"
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
