### PR TITLE
Xiaomi MiIO Switch: Support for different device types

### DIFF
--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -28,7 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-mirobo==0.2.0']
+REQUIREMENTS = ['python-miio==0.3.0']
 
 # The light does not accept cct values < 1
 CCT_MIN = 1

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -25,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-mirobo==0.2.0']
+REQUIREMENTS = ['python-miio==0.3.0']
 
 ATTR_POWER = 'power'
 ATTR_TEMPERATURE = 'temperature'
@@ -38,7 +38,7 @@ SUCCESS = ['ok']
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the switch from config."""
-    from mirobo import Device, DeviceException
+    from miio import Device, DeviceException
 
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
@@ -51,12 +51,12 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         plug = Device(host, token)
         device_info = plug.info()
         _LOGGER.info("%s %s %s initialized",
-                     device_info.raw['model'],
-                     device_info.raw['fw_ver'],
-                     device_info.raw['hw_ver'])
+                     device_info.model,
+                     device_info.firmware_version,
+                     device_info.hardware_version)
 
-        if device_info.raw['model'] in ['chuangmi.plug.v1']:
-            from mirobo import PlugV1
+        if device_info.model in ['chuangmi.plug.v1']:
+            from miio import PlugV1
             plug = PlugV1(host, token)
 
             # The device has two switchable channels (mains and a USB port).
@@ -66,15 +66,15 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                     name, plug, device_info, channel_usb)
                 devices.append(device)
 
-        elif device_info.raw['model'] in ['qmi.powerstrip.v1',
-                                          'zimi.powerstrip.v2']:
-            from mirobo import Strip
+        elif device_info.model in ['qmi.powerstrip.v1',
+                                   'zimi.powerstrip.v2']:
+            from miio import Strip
             plug = Strip(host, token)
             device = XiaomiPowerStripSwitch(name, plug, device_info)
             devices.append(device)
-        elif device_info.raw['model'] in ['chuangmi.plug.m1',
-                                          'chuangmi.plug.v2']:
-            from mirobo import Plug
+        elif device_info.model in ['chuangmi.plug.m1',
+                                   'chuangmi.plug.v2']:
+            from miio import Plug
             plug = Plug(host, token)
             device = XiaomiPlugGenericSwitch(name, plug, device_info)
             devices.append(device)
@@ -82,7 +82,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             _LOGGER.error(
                 'Unsupported device found! Please create an issue at '
                 'https://github.com/rytilahti/python-miio/issues '
-                'and provide the following data: %s', device_info.raw['model'])
+                'and provide the following data: %s', device_info.model)
     except DeviceException:
         raise PlatformNotReady
 
@@ -102,7 +102,7 @@ class XiaomiPlugGenericSwitch(SwitchDevice):
         self._state = None
         self._state_attrs = {
             ATTR_TEMPERATURE: None,
-            ATTR_MODEL: self._device_info.raw['model'],
+            ATTR_MODEL: self._device_info.model,
         }
         self._skip_update = False
 
@@ -139,7 +139,7 @@ class XiaomiPlugGenericSwitch(SwitchDevice):
     @asyncio.coroutine
     def _try_command(self, mask_error, func, *args, **kwargs):
         """Call a plug command handling error messages."""
-        from mirobo import DeviceException
+        from miio import DeviceException
         try:
             result = yield from self.hass.async_add_job(
                 partial(func, *args, **kwargs))
@@ -174,7 +174,7 @@ class XiaomiPlugGenericSwitch(SwitchDevice):
     @asyncio.coroutine
     def async_update(self):
         """Fetch state from the device."""
-        from mirobo import DeviceException
+        from miio import DeviceException
 
         # On state change the device doesn't provide the new state immediately.
         if self._skip_update:
@@ -206,13 +206,13 @@ class XiaomiPowerStripSwitch(XiaomiPlugGenericSwitch, SwitchDevice):
         self._state_attrs = {
             ATTR_TEMPERATURE: None,
             ATTR_LOAD_POWER: None,
-            ATTR_MODEL: self._device_info.raw['model'],
+            ATTR_MODEL: self._device_info.model,
         }
 
     @asyncio.coroutine
     def async_update(self):
         """Fetch state from the device."""
-        from mirobo import DeviceException
+        from miio import DeviceException
 
         # On state change the device doesn't provide the new state immediately.
         if self._skip_update:
@@ -226,10 +226,7 @@ class XiaomiPowerStripSwitch(XiaomiPlugGenericSwitch, SwitchDevice):
             self._state = state.is_on
             self._state_attrs.update({
                 ATTR_TEMPERATURE: state.temperature,
-                # FIXME: The device implementation of the power strip at
-                #        python-mirobo needs to be fixed.
-                # ATTR_LOAD_POWER: state.load_power,
-                ATTR_LOAD_POWER: state.current * 110
+                ATTR_LOAD_POWER: state.load_power
             })
 
         except DeviceException as ex:
@@ -249,6 +246,7 @@ class ChuangMiPlugV1Switch(XiaomiPlugGenericSwitch, SwitchDevice):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn a channel on."""
+
         if self._channel_usb:
             result = yield from self._try_command(
                 "Turning the plug on failed.", self._plug.usb_on)
@@ -277,7 +275,7 @@ class ChuangMiPlugV1Switch(XiaomiPlugGenericSwitch, SwitchDevice):
     @asyncio.coroutine
     def async_update(self):
         """Fetch state from the device."""
-        from mirobo import DeviceException
+        from miio import DeviceException
 
         # On state change the device doesn't provide the new state immediately.
         if self._skip_update:

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -18,7 +18,7 @@ from homeassistant.exceptions import PlatformNotReady
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Xiaomi Miio Switch'
-PLATFORM = 'xiaomi_miio'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_TOKEN): vol.All(cv.string, vol.Length(min=32, max=32)),

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -244,7 +244,6 @@ class ChuangMiPlugV1Switch(XiaomiPlugGenericSwitch, SwitchDevice):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn a channel on."""
-
         if self._channel_usb:
             result = yield from self._try_command(
                 "Turning the plug on failed.", self._plug.usb_on)

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -220,7 +220,8 @@ class XiaomiPowerStripSwitch(XiaomiPlugGenericSwitch, SwitchDevice):
             self._state = state.is_on
             self._state_attrs.update({
                 ATTR_TEMPERATURE: state.temperature,
-                # FIXME: The device implementation of the power strip at python-mirobo needs to be fixed.
+                # FIXME: The device implementation of the power strip at 
+                #        python-mirobo needs to be fixed.
                 # ATTR_LOAD_POWER: state.load_power,
                 ATTR_LOAD_POWER: state.current * 110
             })

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -18,7 +18,7 @@ from homeassistant.exceptions import PlatformNotReady
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Xiaomi Miio Switch'
-
+PLATFORM = 'xiaomi_miio'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_TOKEN): vol.All(cv.string, vol.Length(min=32, max=32)),
@@ -154,16 +154,20 @@ class XiaomiPlugGenericSwitch(SwitchDevice):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the plug on."""
-        if (yield from self._try_command("Turning the plug on failed.",
-                                         self._plug.on)):
+        result = yield from self._try_command(
+            "Turning the plug on failed.", self._plug.on)
+
+        if result:
             self._state = True
             self._skip_update = True
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the plug off."""
-        if (yield from self._try_command("Turning the plug off failed.",
-                                         self._plug.off)):
+        result = yield from self._try_command(
+            "Turning the plug off failed.", self._plug.off)
+
+        if result:
             self._state = False
             self._skip_update = True
 

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -197,8 +197,6 @@ class XiaomiPlugGenericSwitch(SwitchDevice):
 class XiaomiPowerStripSwitch(XiaomiPlugGenericSwitch, SwitchDevice):
     """Representation of a Xiaomi Power Strip."""
 
-    # TODO: Add support for set_power_mode: normal/eco
-
     def __init__(self, name, plug, device_info):
         """Initialize the plug switch."""
         XiaomiPlugGenericSwitch.__init__(self, name, plug, device_info)

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -249,7 +249,6 @@ class ChuangMiPlugV1Switch(XiaomiPlugGenericSwitch, SwitchDevice):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn a channel on."""
-
         if self._channel_usb:
             result = yield from self._try_command(
                 "Turning the plug on failed.", self._plug.usb_on)

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -79,9 +79,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             device = XiaomiPlugGenericSwitch(name, plug, device_info)
             devices.append(device)
         else:
-            _LOGGER.error('Unsupported device found! Please create an issue at '
-                          'https://github.com/rytilahti/python-miio/issues '
-                          'and provide the following data: %s', device_info.raw['model'])
+            _LOGGER.error(
+                'Unsupported device found! Please create an issue at '
+                'https://github.com/rytilahti/python-miio/issues '
+                'and provide the following data: %s', device_info.raw['model'])
     except DeviceException:
         raise PlatformNotReady
 

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -220,7 +220,7 @@ class XiaomiPowerStripSwitch(XiaomiPlugGenericSwitch, SwitchDevice):
             self._state = state.is_on
             self._state_attrs.update({
                 ATTR_TEMPERATURE: state.temperature,
-                # FIXME: The device implementation of the power strip at 
+                # FIXME: The device implementation of the power strip at
                 #        python-mirobo needs to be fixed.
                 # ATTR_LOAD_POWER: state.load_power,
                 ATTR_LOAD_POWER: state.current * 110

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -38,7 +38,7 @@ SUCCESS = ['ok']
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the switch from config."""
-    from mirobo import Plug, DeviceException
+    from mirobo import Device, DeviceException
 
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
@@ -46,23 +46,45 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
 
+    devices = []
     try:
-        plug = Plug(host, token)
+        plug = Device(host, token)
         device_info = plug.info()
         _LOGGER.info("%s %s %s initialized",
                      device_info.raw['model'],
                      device_info.raw['fw_ver'],
                      device_info.raw['hw_ver'])
 
-        xiaomi_plug_switch = XiaomiPlugSwitch(name, plug, device_info)
+        if device_info.raw['model'] in ['chuangmi.plug.v1']:
+            from mirobo import PlugV1
+            plug = PlugV1(host, token)
+
+            for channel_usb in [True, False]:
+                device = ChuangMiPlugV1Switch(
+                    name, plug, device_info, channel_usb)
+                devices.append(device)
+
+        elif device_info.raw['model'] in ['qmi.powerstrip.v1',
+                                          'zimi.powerstrip.v2']:
+            from mirobo import Strip
+            plug = Strip(host, token)
+            device = XiaomiPowerStripSwitch(name, plug, device_info)
+            devices.append(device)
+        else:
+            # chuangmi.plug.m1, chuangmi.plug.v2
+            from mirobo import Plug
+            plug = Plug(host, token)
+            device = XiaomiPlugGenericSwitch(name, plug, device_info)
+            devices.append(device)
+
     except DeviceException:
         raise PlatformNotReady
 
-    async_add_devices([xiaomi_plug_switch], update_before_add=True)
+    async_add_devices(devices, update_before_add=True)
 
 
-class XiaomiPlugSwitch(SwitchDevice):
-    """Representation of a Xiaomi Plug."""
+class XiaomiPlugGenericSwitch(SwitchDevice):
+    """Representation of a Xiaomi Plug Generic."""
 
     def __init__(self, name, plug, device_info):
         """Initialize the plug switch."""
@@ -74,7 +96,6 @@ class XiaomiPlugSwitch(SwitchDevice):
         self._state = None
         self._state_attrs = {
             ATTR_TEMPERATURE: None,
-            ATTR_LOAD_POWER: None,
             ATTR_MODEL: self._device_info.raw['model'],
         }
         self._skip_update = False
@@ -160,9 +181,116 @@ class XiaomiPlugSwitch(SwitchDevice):
 
             self._state = state.is_on
             self._state_attrs.update({
-                ATTR_TEMPERATURE: state.temperature,
-                ATTR_LOAD_POWER: state.load_power,
+                ATTR_TEMPERATURE: state.temperature
             })
+
+        except DeviceException as ex:
+            _LOGGER.error("Got exception while fetching the state: %s", ex)
+
+
+class XiaomiPowerStripSwitch(XiaomiPlugGenericSwitch, SwitchDevice):
+    """Representation of a Xiaomi Power Strip."""
+
+    # TODO: Add support for set_power_mode: normal/eco
+
+    def __init__(self, name, plug, device_info):
+        """Initialize the plug switch."""
+        XiaomiPlugGenericSwitch.__init__(self, name, plug, device_info)
+
+        self._state_attrs = {
+            ATTR_TEMPERATURE: None,
+            ATTR_LOAD_POWER: None,
+            ATTR_MODEL: self._device_info.raw['model'],
+        }
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Fetch state from the device."""
+        from mirobo import DeviceException
+
+        # On state change the device doesn't provide the new state immediately.
+        if self._skip_update:
+            self._skip_update = False
+            return
+
+        try:
+            state = yield from self.hass.async_add_job(self._plug.status)
+            _LOGGER.debug("Got new state: %s", state)
+
+            self._state = state.is_on
+            self._state_attrs.update({
+                ATTR_TEMPERATURE: state.temperature,
+                # FIXME: The device implementation of the power strip at python-mirobo needs to be fixed.
+                # ATTR_LOAD_POWER: state.load_power,
+                ATTR_LOAD_POWER: state.current * 110
+            })
+
+        except DeviceException as ex:
+            _LOGGER.error("Got exception while fetching the state: %s", ex)
+
+
+class ChuangMiPlugV1Switch(XiaomiPlugGenericSwitch, SwitchDevice):
+    """Representation of a Chuang Mi Plug V1."""
+
+    def __init__(self, name, plug, device_info, channel_usb):
+        """Initialize the plug switch."""
+        name = name + ' USB' if channel_usb else name
+
+        XiaomiPlugGenericSwitch.__init__(self, name, plug, device_info)
+        self._channel_usb = channel_usb
+
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """Turn a channel on."""
+
+        if self._channel_usb:
+            result = yield from self._try_command(
+                "Turning the plug on failed.", self._plug.usb_on)
+        else:
+            result = yield from self._try_command(
+                "Turning the plug on failed.", self._plug.on)
+
+        if result:
+            self._state = True
+            self._skip_update = True
+
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
+        """Turn a channel off."""
+        if self._channel_usb:
+            result = yield from self._try_command(
+                "Turning the plug on failed.", self._plug.usb_off)
+        else:
+            result = yield from self._try_command(
+                "Turning the plug on failed.", self._plug.off)
+
+        if result:
+            self._state = False
+            self._skip_update = True
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Fetch state from the device."""
+        from mirobo import DeviceException
+
+        # On state change the device doesn't provide the new state immediately.
+        if self._skip_update:
+            self._skip_update = False
+            return
+
+        try:
+            state = yield from self.hass.async_add_job(self._plug.status)
+            _LOGGER.debug("Got new state: %s", state)
+
+            if self._channel_usb:
+                self._state = state.usb_power
+            else:
+                self._state = state.is_on
+
+                # FIXME: Does the device provide a temperature?
+                # self._state_attrs.update({
+                #    ATTR_TEMPERATURE: state.temperature,
+                # })
 
         except DeviceException as ex:
             _LOGGER.error("Got exception while fetching the state: %s", ex)

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -18,7 +18,7 @@ from homeassistant.exceptions import PlatformNotReady
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Xiaomi Miio Switch'
-PLATFORM = 'xiaomi_miio'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_TOKEN): vol.All(cv.string, vol.Length(min=32, max=32)),
@@ -154,20 +154,16 @@ class XiaomiPlugGenericSwitch(SwitchDevice):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the plug on."""
-        result = yield from self._try_command(
-            "Turning the plug on failed.", self._plug.on)
-
-        if result:
+        if (yield from self._try_command("Turning the plug on failed.",
+                                         self._plug.on)):
             self._state = True
             self._skip_update = True
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the plug off."""
-        result = yield from self._try_command(
-            "Turning the plug off failed.", self._plug.off)
-
-        if result:
+        if (yield from self._try_command("Turning the plug off failed.",
+                                         self._plug.off)):
             self._state = False
             self._skip_update = True
 

--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_TOKEN, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-mirobo==0.2.0']
+REQUIREMENTS = ['python-miio==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -775,7 +775,7 @@ python-juicenet==0.0.5
 # homeassistant.components.light.xiaomi_miio
 # homeassistant.components.switch.xiaomi_miio
 # homeassistant.components.vacuum.xiaomi_miio
-python-mirobo==0.2.0
+python-miio==0.3.0
 
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5


### PR DESCRIPTION
## Description:

The following devices are supported now:

* Xiaomi Smart WiFi Socket (called Plug): mains on/off, temperature
* Xiaomi Smart Power Strip: mains on/off, temperature, load_power
* Xiaomi Chuang Mi Plug V1: mains on/off, usb on/off
