### PR TITLE
SNMP switch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -586,6 +586,7 @@ omit =
     homeassistant/components/switch/rainmachine.py
     homeassistant/components/switch/rest.py
     homeassistant/components/switch/rpi_rf.py
+    homeassistant/components/switch/snmp.py
     homeassistant/components/switch/tplink.py
     homeassistant/components/switch/telnet.py
     homeassistant/components/switch/transmission.py

--- a/homeassistant/components/switch/snmp.py
+++ b/homeassistant/components/switch/snmp.py
@@ -1,0 +1,178 @@
+"""
+Support for an SNMP enabled switch.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.snmp/
+"""
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.helpers.entity import Entity
+from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_PORT, CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pysnmp==4.3.10']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_BASEOID = 'baseoid'
+CONF_COMMUNITY = 'community'
+CONF_VERSION = 'version'
+
+DEFAULT_NAME = 'SNMPSwitch'
+DEFAULT_HOST = 'localhost'
+DEFAULT_PORT = '161'
+DEFAULT_COMMUNITY = 'public'
+DEFAULT_VERSION = '1'
+DEFAULT_PAYLOAD_ON = 1
+DEFAULT_PAYLOAD_OFF = 0
+
+SNMP_VERSIONS = {
+    '1': 0,
+    '2c': 1
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_BASEOID): cv.string,
+    vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_VERSION, default=DEFAULT_VERSION):
+        vol.In(SNMP_VERSIONS),
+    vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
+    vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string
+})
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the SNMP switch."""
+
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    community = config.get(CONF_COMMUNITY)
+    baseoid = config.get(CONF_BASEOID)
+    version = config.get(CONF_VERSION)
+    payload_on = config.get(CONF_PAYLOAD_ON)
+    payload_off = config.get(CONF_PAYLOAD_OFF)
+
+    data = SnmpCommand(host, port, community, baseoid, version, payload_on, payload_off)
+    add_devices([SnmpSwitch(data, name)], True)
+
+class SnmpSwitch(SwitchDevice):
+    """Represents a SNMP switch"""
+
+    def __init__(self, snmp_command, name):
+        """Initialize the switch"""
+        self._cmd = snmp_command
+        self._name = name
+
+    def turn_on(self):
+        """Turns on the switch"""
+        self._cmd.turn_on()
+
+    def turn_off(self):
+        """Turns on the switch"""
+        self._cmd.turn_off()
+
+    def update(self):
+        """Updates the state"""
+        self._cmd.update()
+
+    @property
+    def name(self):
+        """Returns the switch's name"""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if switch is on; False otherwise"""
+        return self._cmd.state
+
+class SnmpCommand(object):
+    """Turn on/off the switch and update the states."""
+
+    def __init__(self, host, port, community, baseoid, version, payload_on, payload_off):
+        """Initialize the data object."""
+        self._host = host
+        self._port = port
+        self._community = community
+        self._baseoid = baseoid
+        self._version = SNMP_VERSIONS[version]
+        self._state = None
+        self._payload_on = payload_on
+        self._payload_off = payload_off
+
+    def update(self):
+        """Get the latest data from the remote SNMP capable host."""
+        from pysnmp.hlapi import (
+            getCmd, CommunityData, SnmpEngine, UdpTransportTarget, ContextData,
+            ObjectType, ObjectIdentity)
+
+        g = getCmd(SnmpEngine(),
+               CommunityData(self._community, mpModel=self._version),
+               UdpTransportTarget((self._host, self._port)),
+               ContextData(),
+               ObjectType(ObjectIdentity(self._baseoid)))
+
+        errindication, errstatus, errindex, restable = next(g)
+
+        if errindication:
+            _LOGGER.error("SNMP error: %s", errindication)
+        elif errstatus:
+            _LOGGER.error("SNMP error: %s at %s", errstatus.prettyPrint(),
+                          errindex and restable[-1][int(errindex) - 1] or '?')
+        else:
+            for resrow in restable:
+                if resrow[-1] == self._typecast(self._payload_on):
+                    self._state = True
+                elif resrow[-1] == self._typecast(self._payload_off):
+                    self._state = False
+                else:
+                    self._state = None
+
+    def turn_on(self):
+        """Send a SNMP set command to the switch to turn it on"""
+        from pysnmp.hlapi import (
+            setCmd, CommunityData, SnmpEngine, UdpTransportTarget, ContextData,
+            ObjectType, ObjectIdentity)
+
+        g = setCmd(SnmpEngine(),
+            CommunityData(self._community, mpModel=self._version),
+            UdpTransportTarget((self._host, self._port)),
+            ContextData(),
+            ObjectType(ObjectIdentity(self._baseoid), self._typecast(self._payload_on))
+            )
+
+        next(g)
+
+    def turn_off(self):
+        """Send a SNMP set command to the switch to turn it off"""
+        from pysnmp.hlapi import (
+            setCmd, CommunityData, SnmpEngine, UdpTransportTarget, ContextData,
+            ObjectType, ObjectIdentity)
+
+
+        g = setCmd(SnmpEngine(),
+            CommunityData(self._community, mpModel=self._version),
+            UdpTransportTarget((self._host, self._port)),
+            ContextData(),
+            ObjectType(ObjectIdentity(self._baseoid), self._typecast(self._payload_off))
+            )
+
+        next(g)
+
+    @property
+    def state(self):
+        if self._state == self._payload_on:
+            return True
+
+        return False
+
+    def _typecast(self, payload):
+        from pyasn1.type.univ import (Integer)
+
+        return Integer(payload)

--- a/homeassistant/components/switch/snmp.py
+++ b/homeassistant/components/switch/snmp.py
@@ -10,7 +10,6 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
-# from homeassistant.helpers.entity import Entity
 from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_PORT,
                                  CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF)
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/switch/snmp.py
+++ b/homeassistant/components/switch/snmp.py
@@ -25,7 +25,7 @@ CONF_VERSION = 'version'
 DEFAULT_NAME = 'SNMPSwitch'
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = '161'
-DEFAULT_COMMUNITY = 'public'
+DEFAULT_COMMUNITY = 'private'
 DEFAULT_VERSION = '1'
 DEFAULT_PAYLOAD_ON = 1
 DEFAULT_PAYLOAD_OFF = 0
@@ -144,15 +144,16 @@ class SnmpCommand(object):
             setCmd, CommunityData, SnmpEngine, UdpTransportTarget, ContextData,
             ObjectType, ObjectIdentity)
 
-        g = setCmd(SnmpEngine(),
-                   CommunityData(self._community, mpModel=self._version),
-                   UdpTransportTarget((self._host, self._port)),
-                   ContextData(),
-                   ObjectType(ObjectIdentity(self._baseoid),
-                   self._typecast(self._payload_on))
-                   )
+        request = setCmd(
+            SnmpEngine(),
+            CommunityData(self._community, mpModel=self._version),
+            UdpTransportTarget((self._host, self._port)),
+            ContextData(),
+            ObjectType(ObjectIdentity(self._baseoid),
+                       self._typecast(self._payload_on))
+        )
 
-        next(g)
+        next(request)
 
     def turn_off(self):
         """Send SNMP set command to the switch to turn it off."""
@@ -160,15 +161,16 @@ class SnmpCommand(object):
             setCmd, CommunityData, SnmpEngine, UdpTransportTarget, ContextData,
             ObjectType, ObjectIdentity)
 
-        g = setCmd(SnmpEngine(),
-                   CommunityData(self._community, mpModel=self._version),
-                   UdpTransportTarget((self._host, self._port)),
-                   ContextData(),
-                   ObjectType(ObjectIdentity(self._baseoid),
-                   self._typecast(self._payload_off))
-                   )
+        request = setCmd(
+            SnmpEngine(),
+            CommunityData(self._community, mpModel=self._version),
+            UdpTransportTarget((self._host, self._port)),
+            ContextData(),
+            ObjectType(ObjectIdentity(self._baseoid),
+                       self._typecast(self._payload_off))
+        )
 
-        next(g)
+        next(request)
 
     @property
     def state(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -732,6 +732,7 @@ pysma==0.1.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
+# homeassistant.components.switch.snmp
 pysnmp==4.3.10
 
 # homeassistant.components.sensor.thinkingcleaner


### PR DESCRIPTION
## Description:
New component that allows to control SNMP-enabled switches. It can be used with devices that support SNMP, or even control your router, if you're using something high-end that allows you to set configuration via SNMP.

At this stage it works only with SNMP OIDs that accepts integers. The idea is to implement also handling strings and booleans at a later stage.

I would appreciate some feedback and if someone else can do some real-world testing with their device.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3598

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: snmp
  baseoid: 1.3.6.1.4.1.19865.1.2.1.4.0
  name: "A switch"
  host: 192.168.0.2
  community: private
  payload_on: 1
  payload_off: 0
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54