### PR TITLE
Changed yaml.load into yaml.safe_load

### DIFF
--- a/homeassistant/components/google.py
+++ b/homeassistant/components/google.py
@@ -269,7 +269,7 @@ def load_config(path):
     calendars = {}
     try:
         with open(path) as file:
-            data = yaml.load(file)
+            data = yaml.safe_load(file)
             for calendar in data:
                 try:
                     calendars.update({calendar[CONF_CAL_ID]:


### PR DESCRIPTION
## Description: Simple fix to resolve unsafe loading of Google calender YAML file.


**Related issue (if applicable):** fixes #9812 

## Example entry for `configuration.yaml` (if applicable):
```yaml
google:
  client_id: *Value_created_from_steps_above*
  client_secret: *Value_created_from_steps_above*
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
