### PR TITLE
Bugfix/9811 jinja autoescape

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -330,7 +330,7 @@ class IndexView(HomeAssistantView):
             autoescape=True,
             loader=FileSystemLoader(
                 os.path.join(os.path.dirname(__file__), 'templates/')
-            ),
+            )
         )
 
     @asyncio.coroutine

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -327,9 +327,10 @@ class IndexView(HomeAssistantView):
         from jinja2 import FileSystemLoader, Environment
 
         self.templates = Environment(
+            autoescape=True,
             loader=FileSystemLoader(
                 os.path.join(os.path.dirname(__file__), 'templates/')
-            )
+            ),
         )
 
     @asyncio.coroutine


### PR DESCRIPTION
## Description: Added the suggested `autoescape` kwarg to the Jinja Environment. Not 100% sure how to test this thoroughly, simple browsing around the local dev instance doesn't show any obvious escaped issues.


**Related issue (if applicable):** fixes #9811 

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
