### PR TITLE
Do not auto-install credstash

### DIFF
--- a/homeassistant/scripts/credstash.py
+++ b/homeassistant/scripts/credstash.py
@@ -24,6 +24,7 @@ def run(args):
         'value', help="The value to save when putting a secret",
         nargs='?', default=None)
 
+    # pylint: disable=import-error
     import credstash
     import botocore
 

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -13,7 +13,7 @@ except ImportError:
     keyring = None
 
 try:
-    import credstash
+    import credstash  # pylint: disable=import-error
 except ImportError:
     credstash = None
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -159,7 +159,7 @@ colorlog==3.0.1
 concord232==0.14
 
 # homeassistant.scripts.credstash
-credstash==1.13.3
+# credstash==1.13.3
 
 # homeassistant.components.sensor.crimereports
 crimereports==1.0.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -29,7 +29,8 @@ COMMENT_REQUIREMENTS = (
     'blinkt',
     'smbus-cffi',
     'envirophat',
-    'i2csense'
+    'i2csense',
+    'credstash'
 )
 
 TEST_REQUIREMENTS = (


### PR DESCRIPTION
## Description:
Credstash is used when the import is available. Because it is automatically installed, a request is made to Amazon or an exception is raised. We're going to make it an optional feature by requiring the user to manually install credstash.

**Related issue (if applicable):** fixes #9219

