### PR TITLE
HassIO - TimeZone / Host services

### DIFF
--- a/homeassistant/components/hassio.py
+++ b/homeassistant/components/hassio.py
@@ -17,7 +17,8 @@ import async_timeout
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONTENT_TYPE_TEXT_PLAIN, SERVER_PORT
+from homeassistant.const import (
+    CONTENT_TYPE_TEXT_PLAIN, SERVER_PORT, CONF_TIME_ZONE)
 from homeassistant.components.http import (
     HomeAssistantView, KEY_AUTHENTICATED, CONF_API_PASSWORD, CONF_SERVER_PORT,
     CONF_SSL_CERTIFICATE)
@@ -33,6 +34,8 @@ SERVICE_ADDON_START = 'addon_start'
 SERVICE_ADDON_STOP = 'addon_stop'
 SERVICE_ADDON_RESTART = 'addon_restart'
 SERVICE_ADDON_STDIN = 'addon_stdin'
+SERVICE_HOST_SHUTDOWN = 'host_shutdown'
+SERVICE_HOST_REBOOT = 'host_reboot'
 
 ATTR_ADDON = 'addon'
 ATTR_INPUT = 'input'
@@ -63,6 +66,8 @@ MAP_SERVICE_API = {
     SERVICE_ADDON_STOP: ('/addons/{addon}/stop', SCHEMA_ADDON),
     SERVICE_ADDON_RESTART: ('/addons/{addon}/restart', SCHEMA_ADDON),
     SERVICE_ADDON_STDIN: ('/addons/{addon}/stdin', SCHEMA_ADDON_STDIN),
+    SERVICE_HOST_SHUTDOWN: ('/host/shutdown', None),
+    SERVICE_HOST_REBOOT: ('/host/reboot', None),
 }
 
 
@@ -91,11 +96,14 @@ def async_setup(hass, config):
     if 'http' in config:
         yield from hassio.update_hass_api(config.get('http'))
 
+    if 'homeassistant' in config:
+        yield from hassio.update_hass_timezone(config.get('core'))
+
     @asyncio.coroutine
     def async_service_handler(service):
         """Handle service calls for HassIO."""
         api_command = MAP_SERVICE_API[service.service][0]
-        addon = service.data[ATTR_ADDON]
+        addon = service.data.get(ATTR_ADDON)
         data = service.data[ATTR_INPUT] if ATTR_INPUT in service.data else None
 
         yield from hassio.send_command(
@@ -137,6 +145,15 @@ class HassIO(object):
         }
 
         return self.send_command("/homeassistant/options", payload=options)
+
+    def update_hass_timezone(self, core_config):
+        """Update Home-Assistant timezone data on HassIO.
+
+        This method return a coroutine.
+        """
+        return self.send_command("/supervisor/options", payload={
+            'timezone': core_config.get(CONF_TIME_ZONE)
+        })
 
     @asyncio.coroutine
     def send_command(self, command, method="post", payload=None, timeout=10):

--- a/homeassistant/components/hassio.py
+++ b/homeassistant/components/hassio.py
@@ -94,10 +94,10 @@ def async_setup(hass, config):
                                 'mdi:access-point-network')
 
     if 'http' in config:
-        yield from hassio.update_hass_api(config.get('http'))
+        yield from hassio.update_hass_api(config['http'])
 
     if 'homeassistant' in config:
-        yield from hassio.update_hass_timezone(config.get('core'))
+        yield from hassio.update_hass_timezone(config['homeassistant'])
 
     @asyncio.coroutine
     def async_service_handler(service):

--- a/tests/components/test_hassio.py
+++ b/tests/components/test_hassio.py
@@ -116,7 +116,7 @@ def test_setup_core_push_timezone(hass, aioclient_mock):
     """Test setup with API push default data."""
     aioclient_mock.get(
         "http://127.0.0.1/supervisor/ping", json={'result': 'ok'})
-    aioclient_mock.get(
+    aioclient_mock.post(
         "http://127.0.0.1/supervisor/options", json={'result': 'ok'})
 
     with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}):

--- a/tests/components/test_hassio.py
+++ b/tests/components/test_hassio.py
@@ -25,11 +25,13 @@ def hassio_env():
 @pytest.fixture
 def hassio_client(hassio_env, hass, test_client):
     """Create mock hassio http client."""
-    hass.loop.run_until_complete(async_setup_component(hass, 'hassio', {
-        'http': {
-            'api_password': API_PASSWORD
-        }
-    }))
+    with patch('homeassistant.components.hassio.HassIO.update_hass_api',
+               Mock(return_value=mock_coro(True))):
+        hass.loop.run_until_complete(async_setup_component(hass, 'hassio', {
+            'http': {
+                'api_password': API_PASSWORD
+            }
+        }))
     yield hass.loop.run_until_complete(test_client(hass.http.app))
 
 
@@ -110,6 +112,42 @@ def test_setup_api_push_api_data_default(hass, aioclient_mock):
 
 
 @asyncio.coroutine
+def test_setup_core_push_timezone(hass, aioclient_mock):
+    """Test setup with API push default data."""
+    aioclient_mock.get(
+        "http://127.0.0.1/supervisor/ping", json={'result': 'ok'})
+    aioclient_mock.get(
+        "http://127.0.0.1/supervisor/options", json={'result': 'ok'})
+
+    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}):
+        result = yield from async_setup_component(hass, 'hassio', {
+            'hassio': {},
+            'homeassistant': {
+                'time_zone': 'testzone',
+            },
+        })
+        assert result
+
+    assert aioclient_mock.call_count == 2
+    assert aioclient_mock.mock_calls[-1][2]['timezone'] == "testzone"
+
+
+@asyncio.coroutine
+def test_setup_hassio_no_additional_data(hass, aioclient_mock):
+    """Test setup with API push default data."""
+    aioclient_mock.get(
+        "http://127.0.0.1/supervisor/ping", json={'result': 'ok'})
+
+    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}):
+        result = yield from async_setup_component(hass, 'hassio', {
+            'hassio': {},
+        })
+        assert result
+
+    assert aioclient_mock.call_count == 1
+
+
+@asyncio.coroutine
 def test_service_register(hassio_env, hass):
     """Check if service will be settup."""
     assert (yield from async_setup_component(hass, 'hassio', {}))
@@ -117,6 +155,8 @@ def test_service_register(hassio_env, hass):
     assert hass.services.has_service('hassio', 'addon_stop')
     assert hass.services.has_service('hassio', 'addon_restart')
     assert hass.services.has_service('hassio', 'addon_stdin')
+    assert hass.services.has_service('hassio', 'host_shutdown')
+    assert hass.services.has_service('hassio', 'host_reboot')
 
 
 @asyncio.coroutine
@@ -132,6 +172,10 @@ def test_service_calls(hassio_env, hass, aioclient_mock):
         "http://127.0.0.1/addons/test/restart", json={'result': 'ok'})
     aioclient_mock.post(
         "http://127.0.0.1/addons/test/stdin", json={'result': 'ok'})
+    aioclient_mock.post(
+        "http://127.0.0.1/host/shutdown", json={'result': 'ok'})
+    aioclient_mock.post(
+        "http://127.0.0.1/host/reboot", json={'result': 'ok'})
 
     yield from hass.services.async_call(
         'hassio', 'addon_start', {'addon': 'test'})
@@ -145,6 +189,12 @@ def test_service_calls(hassio_env, hass, aioclient_mock):
 
     assert aioclient_mock.call_count == 4
     assert aioclient_mock.mock_calls[-1][2] == 'test'
+
+    yield from hass.services.async_call('hassio', 'host_shutdown', {})
+    yield from hass.services.async_call('hassio', 'host_reboot', {})
+    yield from hass.async_block_till_done()
+
+    assert aioclient_mock.call_count == 6
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

- Push timezone to hass.io on startup
- Add 2 services: `host_shutdown`, `host_reboot`

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
