### PR TITLE
Add http_rgb platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -335,6 +335,7 @@ omit =
     homeassistant/components/light/decora.py
     homeassistant/components/light/decora_wifi.py
     homeassistant/components/light/flux_led.py
+    homeassistant/components/light/http_rgb.py
     homeassistant/components/light/hue.py
     homeassistant/components/light/hyperion.py
     homeassistant/components/light/lifx.py

--- a/homeassistant/components/light/http_rgb.py
+++ b/homeassistant/components/light/http_rgb.py
@@ -2,7 +2,7 @@
 Support for HTTP_RGB lights.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/light.blinkt/
+https://home-assistant.io/components/light.http_rgb/
 """
 import logging
 

--- a/homeassistant/components/light/http_rgb.py
+++ b/homeassistant/components/light/http_rgb.py
@@ -1,5 +1,5 @@
 """
-Support for HTTP_RGB lights.
+Support for http_rgb lights.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.http_rgb/
@@ -29,7 +29,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the HTTP_RGB Light platform."""
+    """Set up the http_rgb Light platform."""
     import http_rgb
 
     name = config.get(CONF_NAME)
@@ -43,10 +43,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class HttpRgbLight(Light):
-    """Representation of a HTTP_RGB! Light."""
+    """Representation of an http_rgb Light."""
 
     def __init__(self, light, name):
-        """Initialize a HTTP_RGB Light."""
+        """Initialize a http_rgb Light."""
         self._light = light
         self._name = name
         self._is_on = False

--- a/homeassistant/components/light/http_rgb.py
+++ b/homeassistant/components/light/http_rgb.py
@@ -37,12 +37,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     light = http_rgb.http_rgb(host)
 
-    device = HTTP_RGB_Light(light, name)
+    device = HttpRgbLight(light, name)
     device.setup()
     add_devices([device], True)
 
 
-class HTTP_RGB_Light(Light):
+class HttpRgbLight(Light):
     """Representation of a HTTP_RGB! Light."""
 
     def __init__(self, light, name):

--- a/homeassistant/components/light/http_rgb.py
+++ b/homeassistant/components/light/http_rgb.py
@@ -1,0 +1,106 @@
+"""
+Support for HTTP_RGB lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.blinkt/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, ATTR_RGB_COLOR, SUPPORT_RGB_COLOR,
+    Light, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_HOST, CONF_NAME)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['http_rgb==0.1.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'http_rgb'
+
+SUPPORT_HTTP_RGB = (SUPPORT_BRIGHTNESS | SUPPORT_RGB_COLOR)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the HTTP_RGB Light platform."""
+    import http_rgb
+
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+
+    light = http_rgb.http_rgb(host)
+
+    device = HTTP_RGB_Light(light, name)
+    device.setup()
+    add_devices([device], True)
+
+
+class HTTP_RGB_Light(Light):
+    """Representation of a HTTP_RGB! Light."""
+
+    def __init__(self, light, name):
+        """Initialize a HTTP_RGB Light."""
+        self._light = light
+        self._name = name
+        self._is_on = False
+        self._brightness = 255
+        self._rgb_color = [255, 255, 255]
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """Read back the brightness of the light."""
+        return self._brightness
+
+    @property
+    def rgb_color(self):
+        """Read back the color of the light."""
+        return self._rgb_color
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_HTTP_RGB
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._is_on
+
+    def turn_on(self, **kwargs):
+        """Instruct the light to turn on and set correct brightness & color."""
+        if ATTR_RGB_COLOR in kwargs:
+            self._rgb_color = kwargs[ATTR_RGB_COLOR]
+            self._light.rgb_color(self._rgb_color)
+        if ATTR_BRIGHTNESS in kwargs:
+            self._brightness = kwargs[ATTR_BRIGHTNESS]
+            self._light.brightness(self._brightness)
+
+        self._is_on = True
+        self._light.is_on(self._is_on)
+
+    def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        self._is_on = False
+        self._light.is_on(self._is_on)
+
+    def update(self):
+        """Get the remote's active color."""
+        self._is_on = self._light.is_on()
+        self._rgb_color = self._light.rgb_color()
+        self._brightness = self._light.brightness()
+
+    def setup(self):
+        """Get the hostname of the remote."""
+        self._name = self._light.name()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -315,7 +315,7 @@ holidays==0.8.1
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a
 
 # homeassistant.components.light.http_rgb
-# http_rgb==0.1.0
+http_rgb==0.1.0
 
 # homeassistant.components.sensor.dht
 # https://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -314,6 +314,9 @@ holidays==0.8.1
 # homeassistant.components.camera.onvif
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a
 
+# homeassistant.components.light.http_rgb
+# http_rgb==0.1.0
+
 # homeassistant.components.sensor.dht
 # https://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.2
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -30,7 +30,8 @@ COMMENT_REQUIREMENTS = (
     'smbus-cffi',
     'envirophat',
     'i2csense',
-    'credstash'
+    'credstash',
+    'http_rgb'
 )
 
 TEST_REQUIREMENTS = (

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -30,8 +30,7 @@ COMMENT_REQUIREMENTS = (
     'smbus-cffi',
     'envirophat',
     'i2csense',
-    'credstash',
-    'http_rgb'
+    'credstash'
 )
 
 TEST_REQUIREMENTS = (


### PR DESCRIPTION
## Description:

Add support for hobby lights using simple HTTP API.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3608

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
light:
  - platform: http_rgb
    host: IP_ADDRESS
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54