### PR TITLE
Fix missing timeout for Netatmo binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -14,7 +14,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDevice, PLATFORM_SCHEMA)
 from homeassistant.components.netatmo import CameraData
 from homeassistant.loader import get_component
-from homeassistant.const import CONF_TIMEOUT, CONF_OFFSET
+from homeassistant.const import CONF_TIMEOUT
 from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -207,5 +207,3 @@ class NetatmoBinarySensor(BinarySensorDevice):
                 self._data.camera_data.moduleOpened(
                     self._home, self._module_name, self._camera_name,
                     self._timeout)
-        else:
-            return None

--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -44,14 +44,12 @@ CONF_WELCOME_SENSORS = 'welcome_sensors'
 CONF_PRESENCE_SENSORS = 'presence_sensors'
 CONF_TAG_SENSORS = 'tag_sensors'
 
-DEFAULT_TIMEOUT = 15
-DEFAULT_OFFSET = 90
+DEFAULT_TIMEOUT = 90
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_CAMERAS, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_HOME): cv.string,
-    vol.Optional(CONF_OFFSET, default=DEFAULT_OFFSET): cv.positive_int,
     vol.Optional(CONF_PRESENCE_SENSORS, default=PRESENCE_SENSOR_TYPES):
         vol.All(cv.ensure_list, [vol.In(PRESENCE_SENSOR_TYPES)]),
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
@@ -66,7 +64,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     netatmo = get_component('netatmo')
     home = config.get(CONF_HOME)
     timeout = config.get(CONF_TIMEOUT)
-    offset = config.get(CONF_OFFSET)
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT
 
     module_name = None
 
@@ -94,7 +93,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             for variable in welcome_sensors:
                 add_devices([NetatmoBinarySensor(
                     data, camera_name, module_name, home, timeout,
-                    offset, camera_type, variable)], True)
+                    camera_type, variable)], True)
         if camera_type == 'NOC':
             if CONF_CAMERAS in config:
                 if config[CONF_CAMERAS] != [] and \
@@ -102,14 +101,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                     continue
             for variable in presence_sensors:
                 add_devices([NetatmoBinarySensor(
-                    data, camera_name, module_name, home, timeout, offset,
+                    data, camera_name, module_name, home, timeout,
                     camera_type, variable)], True)
 
         for module_name in data.get_module_names(camera_name):
             for variable in tag_sensors:
                 camera_type = None
                 add_devices([NetatmoBinarySensor(
-                    data, camera_name, module_name, home, timeout, offset,
+                    data, camera_name, module_name, home, timeout,
                     camera_type, variable)], True)
 
 
@@ -117,14 +116,13 @@ class NetatmoBinarySensor(BinarySensorDevice):
     """Represent a single binary sensor in a Netatmo Camera device."""
 
     def __init__(self, data, camera_name, module_name, home,
-                 timeout, offset, camera_type, sensor):
+                 timeout, camera_type, sensor):
         """Set up for access to the Netatmo camera events."""
         self._data = data
         self._camera_name = camera_name
         self._module_name = module_name
         self._home = home
         self._timeout = timeout
-        self._offset = offset
         if home:
             self._name = '{} / {}'.format(home, camera_name)
         else:
@@ -173,40 +171,41 @@ class NetatmoBinarySensor(BinarySensorDevice):
             if self._sensor_name == "Someone known":
                 self._state =\
                     self._data.camera_data.someoneKnownSeen(
-                        self._home, self._camera_name, self._timeout*60)
+                        self._home, self._camera_name, self._timeout)
             elif self._sensor_name == "Someone unknown":
                 self._state =\
                     self._data.camera_data.someoneUnknownSeen(
-                        self._home, self._camera_name, self._timeout*60)
+                        self._home, self._camera_name, self._timeout)
             elif self._sensor_name == "Motion":
                 self._state =\
                     self._data.camera_data.motionDetected(
-                        self._home, self._camera_name, self._timeout*60)
+                        self._home, self._camera_name, self._timeout)
         elif self._cameratype == 'NOC':
             if self._sensor_name == "Outdoor motion":
                 self._state =\
                     self._data.camera_data.outdoormotionDetected(
-                        self._home, self._camera_name, self._offset)
+                        self._home, self._camera_name, self._timeout)
             elif self._sensor_name == "Outdoor human":
                 self._state =\
                     self._data.camera_data.humanDetected(
-                        self._home, self._camera_name, self._offset)
+                        self._home, self._camera_name, self._timeout)
             elif self._sensor_name == "Outdoor animal":
                 self._state =\
                     self._data.camera_data.animalDetected(
-                        self._home, self._camera_name, self._offset)
+                        self._home, self._camera_name, self._timeout)
             elif self._sensor_name == "Outdoor vehicle":
                 self._state =\
                     self._data.camera_data.carDetected(
-                        self._home, self._camera_name, self._offset)
+                        self._home, self._camera_name, self._timeout)
         if self._sensor_name == "Tag Vibration":
             self._state =\
                 self._data.camera_data.moduleMotionDetected(
                     self._home, self._module_name, self._camera_name,
-                    self._timeout*60)
+                    self._timeout)
         elif self._sensor_name == "Tag Open":
             self._state =\
                 self._data.camera_data.moduleOpened(
-                    self._home, self._module_name, self._camera_name)
+                    self._home, self._module_name, self._camera_name,
+                    self._timeout)
         else:
             return None


### PR DESCRIPTION
## Description:
The default settings was not given to this component when using auto-discovery.
This fix also merges timeout and offset because there were the same thing.

**Related issue (if applicable):** fixes #8985, #9723

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3609

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

