### PR TITLE
Add Fortigate FortiOS device tracking

### DIFF
--- a/homeassistant/components/device_tracker/fortinet_fortios.py
+++ b/homeassistant/components/device_tracker/fortinet_fortios.py
@@ -105,8 +105,8 @@ class FortinetDeviceScanner(DeviceScanner):
                         devcfg = False
 
                     _LOGGER.info("found %s/%s age %s<?%s cfg %s",
-                                ip_addr, hw_addr, seen, max_age,
-                                devcfg)
+                                 ip_addr, hw_addr, seen, max_age,
+                                 devcfg)
 
                     if devcfg is True:
                         start_index = line.index("'") + 1

--- a/homeassistant/components/device_tracker/fortinet_fortios.py
+++ b/homeassistant/components/device_tracker/fortinet_fortios.py
@@ -83,44 +83,44 @@ class FortinetDeviceScanner(DeviceScanner):
             lines_result = string_result.splitlines()
       
             for line in lines_result:
-                line=line.strip()
-                parts=line.split()
+                line = line.strip()
+                parts = line.split()
                
                 _LOGGER.debug("line %s", line)
  
                 if line.startswith('vd '):
-                    hw_addr=parts[2].upper()
-                    ip_addr=None
+                    hw_addr = parts[2].upper()
+                    ip_addr = None
                 elif line.startswith('created '):
-                    seen=int(parts[5].replace('s', ''))
-                    last_seen=datetime.datetime.now()-datetime.timedelta(seconds=seen)
+                    seen = int(parts[5].replace('s', ''))
+                    last_seen = datetime.datetime.now() - datetime.timedelta(seconds=seen)
                 elif line.startswith('ip '):
-                    ip_addr=parts[1]
+                    ip_addr = parts[1]
                 elif line.startswith('host '):
                     if " src configured" in line:
-                        device_configured=True
+                        device_configured = True
                     else:
-                        device_configured=False
+                        device_configured = False
 
                     _LOGGER.info(">found %s/%s age %s<?%s cfg %s",ip_addr,hw_addr,seen,max_age,device_configured)
-                    if device_configured==True:
-                        start_index=line.index("'")+1
-                        end_index=line.rindex("'")
+                    if device_configured is True:
+                        start_index = line.index("'") + 1
+                        end_index = line.rindex("'")
 
-                        host=line[start_index:end_index]
-                        dev_id=slugify(host)
+                        host = line[start_index:end_index]
+                        dev_id = slugify(host)
 
                         _LOGGER.debug(">host %s", host)
     
-                        if not hw_addr==None:
+                        if not hw_addr is None:
                             _LOGGER.debug(">add the device")
-                            last_results[hw_addr] = { 
+                            last_results[hw_addr] = {
                                 'id': dev_id,
                                 'name': host,
                                 'last_seen': seen,
                                 'ip': ip_addr,
                                 'mac': hw_addr
-                            }   
+                            }
 
             self.last_results = last_results
             
@@ -150,13 +150,12 @@ class FortinetDeviceScanner(DeviceScanner):
 
         return None
 
-
     def _get_device_idle_timeout(self):
         """Gets the configured device_idle_timeout or returns the default."""
 
-        fortinet_ssh=self._login_to_router()
+        fortinet_ssh = self._login_to_router()
 
-        if not fortinet_ssh==None:
+        if not fortinet_ssh is None:
             fortinet_ssh.sendline("co sys glo")
             fortinet_ssh.prompt(1)
 
@@ -186,11 +185,11 @@ class FortinetDeviceScanner(DeviceScanner):
     def _get_device_data(self):
         """Open connection to the router and get device entries."""
         
-        fortinet_ssh=self._login_to_router()
+        fortinet_ssh = self._login_to_router()
 
-        if not fortinet_ssh==None:
+        if not fortinet_ssh is None:
             # Set VDOM (optional)
-            if not self.vdom==None:
+            if not self.vdom is None:
                 _LOGGER.info('vdom '+self.vdom)
                 fortinet_ssh.sendline("co vdom")
                 fortinet_ssh.prompt(1)
@@ -204,7 +203,7 @@ class FortinetDeviceScanner(DeviceScanner):
             devices_result = fortinet_ssh.before.decode('utf-8')
             _LOGGER.debug(devices_result)
 
-            if not self.vdom==None:
+            if not self.vdom is None:
                 fortinet_ssh.sendline('end')
                 fortinet_ssh.prompt(1)
 

--- a/homeassistant/components/device_tracker/fortinet_fortios.py
+++ b/homeassistant/components/device_tracker/fortinet_fortios.py
@@ -117,7 +117,7 @@ class FortinetDeviceScanner(DeviceScanner):
 
                         _LOGGER.debug("host %s", host)
 
-                        if hw_addr is not None:
+                        if hw_addr is not None and seen < max_age:
                             _LOGGER.debug("add the device")
 
                             last_results[hw_addr] = {

--- a/homeassistant/components/device_tracker/fortinet_fortios.py
+++ b/homeassistant/components/device_tracker/fortinet_fortios.py
@@ -1,0 +1,215 @@
+"""
+Support for Fortigate/FortiWifi Routers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.fortios/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, \
+    CONF_PORT
+from homeassistant.util import slugify
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_VDOM = 'vdom'
+
+REQUIREMENTS = ['pexpect==4.0.1']
+
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_PASSWORD, default=''): cv.string,
+        vol.Optional(CONF_PORT): cv.port,
+        vol.Optional(CONF_VDOM): cv.string,
+    })
+)
+
+DEFAULT_DEVICE_IDLE_TIMEOUT=300
+
+def get_scanner(hass, config):
+    """Validate the configuration and return a Fortinet scanner."""
+    scanner = FortinetDeviceScanner(config[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+
+class FortinetDeviceScanner(DeviceScanner):
+    """This class queries a router running Fortinet fortios firmware."""
+
+    def __init__(self, config):
+        """Initialize the scanner."""
+        self.host = config.get(CONF_HOST)
+        self.username = config.get(CONF_USERNAME)
+        self.port = config.get(CONF_PORT)
+        self.password = config.get(CONF_PASSWORD)
+        self.vdom = config.get(CONF_VDOM)
+
+        self.last_results = {}
+
+        self.success_init = self._update_info()
+        _LOGGER.info('fortinet_fortios scanner initialized')
+
+    # pylint: disable=no-self-use
+    def get_device_name(self, device):
+        """Get the firmware doesn't save the name of the wireless device."""
+        return None
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+
+        return self.last_results
+
+    def _update_info(self):
+        """
+        Returns boolean if scanning successful.
+        """
+        import datetime
+
+        max_age = self._get_device_idle_timeout()
+        string_result = self._get_device_data()
+
+        if string_result:
+            self.last_results = {}
+            last_results = {}
+
+            lines_result = string_result.splitlines()
+      
+            for line in lines_result:
+                line=line.strip()
+                parts=line.split()
+               
+                _LOGGER.debug("line %s", line)
+ 
+                if line.startswith('vd '):
+                    hw_addr=parts[2].upper()
+                    ip_addr=None
+                elif line.startswith('created '):
+                    seen=int(parts[5].replace('s', ''))
+                    last_seen=datetime.datetime.now()-datetime.timedelta(seconds=seen)
+                elif line.startswith('ip '):
+                    ip_addr=parts[1]
+                elif line.startswith('host '):
+                    if " src configured" in line:
+                        device_configured=True
+                    else:
+                        device_configured=False
+
+                    _LOGGER.info(">found %s/%s age %s<?%s cfg %s",ip_addr,hw_addr,seen,max_age,device_configured)
+                    if device_configured==True:
+                        start_index=line.index("'")+1
+                        end_index=line.rindex("'")
+
+                        host=line[start_index:end_index]
+                        dev_id=slugify(host)
+
+                        _LOGGER.debug(">host %s", host)
+    
+                        if not hw_addr==None:
+                            _LOGGER.debug(">add the device")
+                            last_results[hw_addr] = { 
+                                'id': dev_id,
+                                'name': host,
+                                'last_seen': seen,
+                                'ip': ip_addr,
+                                'mac': hw_addr
+                            }   
+
+            self.last_results = last_results
+            
+            return True
+
+        return False
+
+    def _login_to_router(self):
+        from pexpect import pxssh
+        import re
+
+        try:
+            fortinet_ssh = pxssh.pxssh()
+            fortinet_ssh.login(self.host, self.username, self.password,
+                                port=self.port, auto_prompt_reset=False)
+
+            initial_line = fortinet_ssh.before.decode('utf-8').splitlines()
+            router_hostname = initial_line[len(initial_line) - 1]
+            router_hostname += "#"
+            regex_expression = ('(?i)^%s' % router_hostname).encode()
+            fortinet_ssh.PROMPT = re.compile(regex_expression, re.MULTILINE)
+        
+            return fortinet_ssh
+        except pxssh.ExceptionPxssh as px_e:
+            _LOGGER.error("pxssh failed on login")
+            _LOGGER.error(px_e)
+
+        return None
+
+
+    def _get_device_idle_timeout(self):
+        """Gets the configured device_idle_timeout or returns the default."""
+
+        fortinet_ssh=self._login_to_router()
+
+        if not fortinet_ssh==None:
+            fortinet_ssh.sendline("co sys glo")
+            fortinet_ssh.prompt(1)
+
+            fortinet_ssh.sendline("sh full-configuration | grep device-idle-timeout")
+            fortinet_ssh.prompt(1)
+
+            conf_result = fortinet_ssh.before.decode('utf-8')
+            _LOGGER.debug("config output '%s'", conf_result)
+
+            lines = conf_result.splitlines()
+            conf_result = lines[2].strip()
+
+            parts = conf_result.split()
+            max_age = int(parts[2])
+
+            _LOGGER.info("device_idle_timeout %s", max_age)
+
+            fortinet_ssh.sendline('end')
+            fortinet_ssh.prompt()
+
+            fortinet_ssh.sendline('exit')
+
+            return max_age
+
+        return DEFAULT_DEVICE_IDLE_TIMEOUT
+
+    def _get_device_data(self):
+        """Open connection to the router and get device entries."""
+        
+        fortinet_ssh=self._login_to_router()
+
+        if not fortinet_ssh==None:
+            # Set VDOM (optional)
+            if not self.vdom==None:
+                _LOGGER.info('vdom '+self.vdom)
+                fortinet_ssh.sendline("co vdom")
+                fortinet_ssh.prompt(1)
+
+                fortinet_ssh.sendline("edit '"+self.vdom+"'")
+                fortinet_ssh.prompt(1)
+            
+            fortinet_ssh.sendline("di user device list")
+            fortinet_ssh.prompt(1)
+
+            devices_result = fortinet_ssh.before.decode('utf-8')
+            _LOGGER.debug(devices_result)
+
+            if not self.vdom==None:
+                fortinet_ssh.sendline('end')
+                fortinet_ssh.prompt(1)
+
+                fortinet_ssh.sendline('exit')
+
+            return devices_result
+
+        return None

--- a/homeassistant/components/device_tracker/fortinet_fortios.py
+++ b/homeassistant/components/device_tracker/fortinet_fortios.py
@@ -94,30 +94,32 @@ class FortinetDeviceScanner(DeviceScanner):
                     ip_addr = None
                 elif line.startswith('created '):
                     seen = int(parts[5].replace('s', ''))
-                    last_seen = datetime.datetime.now() 
-                              - datetime.timedelta(seconds=seen)
+                    last_seen = datetime.datetime.now()
+                    - datetime.timedelta(seconds=seen)
                 elif line.startswith('ip '):
                     ip_addr = parts[1]
                 elif line.startswith('host '):
                     if " src configured" in line:
-                        device_configured = True
+                        devcfg = True
                     else:
-                        device_configured = False
+                        devcfg = False
 
-                    _LOGGER.info(">found %s/%s age %s<?%s cfg %s",
-                            ip_addr, hw_addr, seen, max_age, device_configured)
+                    _LOGGER.info("found %s/%s age %s<?%s cfg %s",
+                                ip_addr, hw_addr, seen, max_age,
+                                devcfg)
 
-                    if device_configured is True:
+                    if devcfg is True:
                         start_index = line.index("'") + 1
                         end_index = line.rindex("'")
 
                         host = line[start_index:end_index]
                         dev_id = slugify(host)
 
-                        _LOGGER.debug(">host %s", host)
+                        _LOGGER.debug("host %s", host)
 
                         if hw_addr is not None:
-                            _LOGGER.debug(">add the device")
+                            _LOGGER.debug("add the device")
+
                             last_results[hw_addr] = {
                                 'id': dev_id,
                                 'name': host,

--- a/homeassistant/components/device_tracker/fortinet_fortios.py
+++ b/homeassistant/components/device_tracker/fortinet_fortios.py
@@ -31,7 +31,8 @@ PLATFORM_SCHEMA = vol.All(
     })
 )
 
-DEFAULT_DEVICE_IDLE_TIMEOUT=300
+DEFAULT_DEVICE_IDLE_TIMEOUT = 300
+
 
 def get_scanner(hass, config):
     """Validate the configuration and return a Fortinet scanner."""
@@ -93,8 +94,8 @@ class FortinetDeviceScanner(DeviceScanner):
                     ip_addr = None
                 elif line.startswith('created '):
                     seen = int(parts[5].replace('s', ''))
-                    last_seen = datetime.datetime.now() -
-                              datetime.timedelta(seconds=seen)
+                    last_seen = datetime.datetime.now() 
+                              - datetime.timedelta(seconds=seen)
                 elif line.startswith('ip '):
                     ip_addr = parts[1]
                 elif line.startswith('host '):
@@ -104,7 +105,7 @@ class FortinetDeviceScanner(DeviceScanner):
                         device_configured = False
 
                     _LOGGER.info(">found %s/%s age %s<?%s cfg %s",
-                      ip_addr, hw_addr, seen, max_age, device_configured)
+                            ip_addr, hw_addr, seen, max_age, device_configured)
 
                     if device_configured is True:
                         start_index = line.index("'") + 1


### PR DESCRIPTION
## Description:

Adds device tracking via a Fortigate router with SSH and querying it's built-in device tracking. 


**Related issue (if applicable):** None

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
    platform: fortinet_fortios
    host: !secret router_ip
    username: !secret router_user
    password: !secret router_password
    vdom: "IoT"
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54