### PR TITLE
Uptime sensor

### DIFF
--- a/homeassistant/components/sensor/uptime.py
+++ b/homeassistant/components/sensor/uptime.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.uptime/
 """
 
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -27,11 +28,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the uptime sensor platform."""
     name = config.get(CONF_NAME)
     units = config.get(CONF_UNIT_OF_MEASUREMENT)
-    add_devices([UptimeSensor(name, units)])
+    async_add_devices([UptimeSensor(name, units)])
 
 
 class UptimeSensor(Entity):
@@ -65,7 +67,8 @@ class UptimeSensor(Entity):
         """Return the state of the sensor."""
         return self._state
 
-    def update(self):
+    @asyncio.coroutine
+    def async_update(self):
         """Update the state of the sensor."""
         delta = dt_util.now() - self.initial
         div_factor = 3600

--- a/homeassistant/components/sensor/uptime.py
+++ b/homeassistant/components/sensor/uptime.py
@@ -1,0 +1,69 @@
+"""
+Component to retrieve uptime for Home Assistant
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.uptime/
+"""
+
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Uptime'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Version sensor platform."""
+    name = config.get(CONF_NAME)
+    add_devices([UptimeSensor(name)])
+
+
+class UptimeSensor(Entity):
+    """Representation of an uptime sensor."""
+
+    def __init__(self, name):
+        """Initialize the Version sensor."""
+        self._name = name
+        self._icon = 'mdi:clock'
+        self._units = 'days'
+        self._initial = dt_util.now()
+        self._state = 0
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Icon to display in the front end."""
+        return self._icon
+
+    @property
+    def unit_of_measurement(self):
+        """Retrun the unit of measurement the value is expressed in."""
+        return self._units
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    def update(self):
+        """Update the state of the sensor."""
+        delta = dt_util.now() - self._initial
+        delta_in_days = delta.total_seconds() / (3600 * 24)
+        self._state = round(delta_in_days, 2) 
+        _LOGGER.debug("New value: %s", delta_in_days)

--- a/homeassistant/components/sensor/uptime.py
+++ b/homeassistant/components/sensor/uptime.py
@@ -4,7 +4,6 @@ Component to retrieve uptime for Home Assistant.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.uptime/
 """
-
 import asyncio
 import logging
 
@@ -33,7 +32,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the uptime sensor platform."""
     name = config.get(CONF_NAME)
     units = config.get(CONF_UNIT_OF_MEASUREMENT)
-    async_add_devices([UptimeSensor(name, units)])
+    async_add_devices([UptimeSensor(name, units)], True)
 
 
 class UptimeSensor(Entity):
@@ -59,7 +58,7 @@ class UptimeSensor(Entity):
 
     @property
     def unit_of_measurement(self):
-        """Retrun the unit of measurement the value is expressed in."""
+        """Return the unit of measurement the value is expressed in."""
         return self._units
 
     @property

--- a/homeassistant/components/sensor/uptime.py
+++ b/homeassistant/components/sensor/uptime.py
@@ -30,7 +30,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the uptime sensor platform."""
     name = config.get(CONF_NAME)
-    units = config.get(CONF_NAME)
+    units = config.get(CONF_UNIT_OF_MEASUREMENT)
     add_devices([UptimeSensor(name, units)])
 
 

--- a/homeassistant/components/sensor/uptime.py
+++ b/homeassistant/components/sensor/uptime.py
@@ -1,10 +1,10 @@
 """
-Component to retrieve uptime for Home Assistant
+Component to retrieve uptime for Home Assistant.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.uptime/
 """
 
-import asyncio
 import logging
 
 import voluptuous as vol
@@ -38,7 +38,7 @@ class UptimeSensor(Entity):
         self._name = name
         self._icon = 'mdi:clock'
         self._units = 'days'
-        self._initial = dt_util.now()
+        self.initial = dt_util.now()
         self._state = 0
 
     @property
@@ -63,7 +63,7 @@ class UptimeSensor(Entity):
 
     def update(self):
         """Update the state of the sensor."""
-        delta = dt_util.now() - self._initial
+        delta = dt_util.now() - self.initial
         delta_in_days = delta.total_seconds() / (3600 * 24)
-        self._state = round(delta_in_days, 2) 
+        self._state = round(delta_in_days, 2)
         _LOGGER.debug("New value: %s", delta_in_days)

--- a/tests/components/sensor/test_uptime.py
+++ b/tests/components/sensor/test_uptime.py
@@ -38,9 +38,19 @@ class TestUptimeSensor(unittest.TestCase):
         }
         assert setup_component(self.hass, 'sensor', config)
 
-    def test_uptime_sensor_output(self):
+    def test_uptime_sensor_config_hours(self):
+        """Test uptime sensor with hours defined in config."""
+        config = {
+            'sensor': {
+                'platform': 'uptime',
+                'unit_of_measurement': 'hours',
+            }
+        }
+        assert setup_component(self.hass, 'sensor', config)
+
+    def test_uptime_sensor_days_output(self):
         """Test uptime sensor output data."""
-        sensor = UptimeSensor('test')
+        sensor = UptimeSensor('test', 'days')
         new_time = sensor.initial + timedelta(days=1)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             sensor.update()
@@ -49,3 +59,15 @@ class TestUptimeSensor(unittest.TestCase):
         with patch('homeassistant.util.dt.now', return_value=new_time):
             sensor.update()
             self.assertEqual(sensor.state, 111.50)
+
+    def test_uptime_sensor_hours_output(self):
+        """Test uptime sensor output data."""
+        sensor = UptimeSensor('test', 'hours')
+        new_time = sensor.initial + timedelta(hours=16)
+        with patch('homeassistant.util.dt.now', return_value=new_time):
+            sensor.update()
+            self.assertEqual(sensor.state, 16.00)
+        new_time = sensor.initial + timedelta(hours=72.499)
+        with patch('homeassistant.util.dt.now', return_value=new_time):
+            sensor.update()
+            self.assertEqual(sensor.state, 72.50)

--- a/tests/components/sensor/test_uptime.py
+++ b/tests/components/sensor/test_uptime.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch
 from datetime import timedelta
 
+from homeassistant.util.async import run_coroutine_threadsafe
 from homeassistant.setup import setup_component
 from homeassistant.components.sensor.uptime import UptimeSensor
 from tests.common import get_test_home_assistant
@@ -54,11 +55,17 @@ class TestUptimeSensor(unittest.TestCase):
         self.assertEqual(sensor.unit_of_measurement, 'days')
         new_time = sensor.initial + timedelta(days=1)
         with patch('homeassistant.util.dt.now', return_value=new_time):
-            sensor.update()
+            run_coroutine_threadsafe(
+                sensor.async_update(),
+                self.hass.loop
+            ).result()
             self.assertEqual(sensor.state, 1.00)
         new_time = sensor.initial + timedelta(days=111.499)
         with patch('homeassistant.util.dt.now', return_value=new_time):
-            sensor.update()
+            run_coroutine_threadsafe(
+                sensor.async_update(),
+                self.hass.loop
+            ).result()
             self.assertEqual(sensor.state, 111.50)
 
     def test_uptime_sensor_hours_output(self):
@@ -67,9 +74,15 @@ class TestUptimeSensor(unittest.TestCase):
         self.assertEqual(sensor.unit_of_measurement, 'hours')
         new_time = sensor.initial + timedelta(hours=16)
         with patch('homeassistant.util.dt.now', return_value=new_time):
-            sensor.update()
+            run_coroutine_threadsafe(
+                sensor.async_update(),
+                self.hass.loop
+            ).result()
             self.assertEqual(sensor.state, 16.00)
         new_time = sensor.initial + timedelta(hours=72.499)
         with patch('homeassistant.util.dt.now', return_value=new_time):
-            sensor.update()
+            run_coroutine_threadsafe(
+                sensor.async_update(),
+                self.hass.loop
+            ).result()
             self.assertEqual(sensor.state, 72.50)

--- a/tests/components/sensor/test_uptime.py
+++ b/tests/components/sensor/test_uptime.py
@@ -1,14 +1,12 @@
 """The tests for the uptime sensor platform."""
 import unittest
-from unittest.mock import MagicMock
 from unittest.mock import patch
 from datetime import timedelta
-from dateutil import parser
 
-import homeassistant.util.dt as dt_util
 from homeassistant.setup import setup_component
-from tests.common import get_test_home_assistant
 from homeassistant.components.sensor.uptime import UptimeSensor
+from tests.common import get_test_home_assistant
+
 
 class TestUptimeSensor(unittest.TestCase):
     """Test the uptime sensor."""
@@ -16,7 +14,6 @@ class TestUptimeSensor(unittest.TestCase):
     def setUp(self):
         """Set up things to run when tests begin."""
         self.hass = get_test_home_assistant()
-        self.initial_date = parser.parse('1/1/1970')
 
     def tearDown(self):
         """Stop everything that was started."""
@@ -29,7 +26,6 @@ class TestUptimeSensor(unittest.TestCase):
                 'platform': 'uptime',
             }
         }
-
         assert setup_component(self.hass, 'sensor', config)
 
     def test_uptime_sensor_name_change(self):
@@ -40,17 +36,16 @@ class TestUptimeSensor(unittest.TestCase):
                 'name': 'foobar',
             }
         }
-
         assert setup_component(self.hass, 'sensor', config)
 
     def test_uptime_sensor_output(self):
         """Test uptime sensor output data."""
         sensor = UptimeSensor('test')
-        new_time = sensor._initial + timedelta(days=1)
+        new_time = sensor.initial + timedelta(days=1)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             sensor.update()
             self.assertEqual(sensor.state, 1.00)
-        new_time = sensor._initial + timedelta(days=111.499)
+        new_time = sensor.initial + timedelta(days=111.499)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             sensor.update()
             self.assertEqual(sensor.state, 111.50)

--- a/tests/components/sensor/test_uptime.py
+++ b/tests/components/sensor/test_uptime.py
@@ -51,6 +51,7 @@ class TestUptimeSensor(unittest.TestCase):
     def test_uptime_sensor_days_output(self):
         """Test uptime sensor output data."""
         sensor = UptimeSensor('test', 'days')
+        self.assertEqual(sensor.unit_of_measurement, 'days')
         new_time = sensor.initial + timedelta(days=1)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             sensor.update()
@@ -63,6 +64,7 @@ class TestUptimeSensor(unittest.TestCase):
     def test_uptime_sensor_hours_output(self):
         """Test uptime sensor output data."""
         sensor = UptimeSensor('test', 'hours')
+        self.assertEqual(sensor.unit_of_measurement, 'hours')
         new_time = sensor.initial + timedelta(hours=16)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             sensor.update()

--- a/tests/components/sensor/test_uptime.py
+++ b/tests/components/sensor/test_uptime.py
@@ -1,0 +1,56 @@
+"""The tests for the uptime sensor platform."""
+import unittest
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from datetime import timedelta
+from dateutil import parser
+
+import homeassistant.util.dt as dt_util
+from homeassistant.setup import setup_component
+from tests.common import get_test_home_assistant
+from homeassistant.components.sensor.uptime import UptimeSensor
+
+class TestUptimeSensor(unittest.TestCase):
+    """Test the uptime sensor."""
+
+    def setUp(self):
+        """Set up things to run when tests begin."""
+        self.hass = get_test_home_assistant()
+        self.initial_date = parser.parse('1/1/1970')
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_uptime_min_config(self):
+        """Test minimum uptime configutation."""
+        config = {
+            'sensor': {
+                'platform': 'uptime',
+            }
+        }
+
+        assert setup_component(self.hass, 'sensor', config)
+
+    def test_uptime_sensor_name_change(self):
+        """Test uptime sensor with different name."""
+        config = {
+            'sensor': {
+                'platform': 'uptime',
+                'name': 'foobar',
+            }
+        }
+
+        assert setup_component(self.hass, 'sensor', config)
+
+    def test_uptime_sensor_output(self):
+        """Test uptime sensor output data."""
+        sensor = UptimeSensor('test')
+        new_time = sensor._initial + timedelta(days=1)
+        with patch('homeassistant.util.dt.now', return_value=new_time):
+            sensor.update()
+            self.assertEqual(sensor.state, 1.00)
+        new_time = sensor._initial + timedelta(days=111.499)
+        with patch('homeassistant.util.dt.now', return_value=new_time):
+            sensor.update()
+            self.assertEqual(sensor.state, 111.50)


### PR DESCRIPTION
## Description:
Creates a simple sensor to display how long Home Assistant has been up and running.  This would provide an alternative implementation to something like a command line sensor (which I currently am using).

This implementation just grabs the current time when the component is initialized and then displays the delta between 'now' and that initial time in terms of days.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3614

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: uptime
    unit_of_measurement: [hours | days]
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

