### PR TITLE
Add serial sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -533,6 +533,7 @@ omit =
     homeassistant/components/sensor/sabnzbd.py
     homeassistant/components/sensor/scrape.py
     homeassistant/components/sensor/sensehat.py
+    homeassistant/components/sensor/serial.py
     homeassistant/components/sensor/serial_pm.py
     homeassistant/components/sensor/shodan.py
     homeassistant/components/sensor/skybeacon.py

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -1,0 +1,78 @@
+"""
+Support for reading data from a serial port.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.serial/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME, CONF_PORT
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['pyserial-asyncio==0.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "Serial Sensor"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PORT): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Serial sensor platform."""
+    name = config.get(CONF_NAME)
+    port = config.get(CONF_PORT)
+
+    async_add_devices([SerialSensor(name, port)], True)
+
+
+class SerialSensor(Entity):
+    """Representation of a Serial sensor."""
+
+    def __init__(self, name, port):
+        """Initialize the Serial sensor."""
+        self._name = name
+        self._state = None
+        self._port = port
+        self._serial_loop_task = None
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Handle when an entity is about to be added to Home Assistant."""
+        self._serial_loop_task = self.hass.loop.create_task(
+            self.serial_read(self._port))
+
+    @asyncio.coroutine
+    def serial_read(self, device, **kwargs):
+        """Read the data from the port."""
+        import serial_asyncio
+        reader, _ = yield from serial_asyncio.open_serial_connection(
+            url=device, **kwargs)
+        while True:
+            line = yield from reader.readline()
+            self._state = line.decode('utf-8').strip()
+            self.async_schedule_update_ha_state()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -721,6 +721,9 @@ pyqwikswitch==0.4
 # homeassistant.components.climate.sensibo
 pysensibo==1.0.1
 
+# homeassistant.components.sensor.serial
+pyserial-asyncio==0.4
+
 # homeassistant.components.switch.acer_projector
 pyserial==3.1.1
 


### PR DESCRIPTION
## Description:
This sensor platform allows one to read data directly for a serial port. 

Details to build a sensor are covered in home-assistant/home-assistant.github.io#3620.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3619

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: serial
    port: /dev/ttyACM0
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

