### PR TITLE
handle OpenWeatherMap API exceptions

### DIFF
--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -142,8 +142,15 @@ class OpenWeatherMapWeather(WeatherEntity):
 
     def update(self):
         """Get the latest data from OWM and updates the states."""
-        self._owm.update()
-        self._owm.update_forecast()
+        from pyowm.exceptions.api_call_error import APICallError
+
+        try:
+            self._owm.update()
+            self._owm.update_forecast()
+        except APICallError:
+            _LOGGER.error("Exception when calling OWM web API to update data")
+            return
+
         self.data = self._owm.data
         self.forecast_data = self._owm.forecast_data
 
@@ -172,8 +179,15 @@ class WeatherData(object):
     @Throttle(MIN_TIME_BETWEEN_FORECAST_UPDATES)
     def update_forecast(self):
         """Get the lastest forecast from OpenWeatherMap."""
-        fcd = self.owm.three_hours_forecast_at_coords(
-            self.latitude, self.longitude)
+        from pyowm.exceptions.api_call_error import APICallError
+
+        try:
+            fcd = self.owm.three_hours_forecast_at_coords(
+                self.latitude, self.longitude)
+        except APICallError:
+            _LOGGER.error("Exception when calling OWM web API "
+                          "to update forecast")
+            return
 
         if fcd is None:
             _LOGGER.warning("Failed to fetch forecast data from OWM")


### PR DESCRIPTION
## Description:

Sometimes the OpenWeatherMap API doesn't respond correctly, and the `pyowm` library raises `APICallError`exceptions, which aren't handled properly.
