### PR TITLE
minimal fixes in the owntracks mqtt device tracker

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -75,6 +75,7 @@ def async_setup_scanner(hass, config, async_see, discovery_info=None):
         except ValueError:
             # If invalid JSON
             _LOGGER.error("Unable to parse payload as JSON: %s", payload)
+            return
 
         message['topic'] = topic
 
@@ -91,7 +92,11 @@ def _parse_topic(topic):
 
     Async friendly.
     """
-    _, user, device, *_ = topic.split('/', 3)
+    try:
+        _, user, device, *_ = topic.split('/', 3)
+    except ValueError:
+        _LOGGER.error("Can't parse topic: '%s'", topic)
+        raise ValueError
 
     return user, device
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -96,7 +96,7 @@ def _parse_topic(topic):
         _, user, device, *_ = topic.split('/', 3)
     except ValueError:
         _LOGGER.error("Can't parse topic: '%s'", topic)
-        raise ValueError
+        raise
 
     return user, device
 


### PR DESCRIPTION
## Description:

Minimal fix of a UnboundLocalError when unable to parse the mqtt payload, and also log the bad topic when a ValueError is raised trying to parse it.
