### PR TITLE
Recorder: Extra check to incoming connections which could be not sqlite3 ones

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -351,6 +351,7 @@ class Recorder(threading.Thread):
         from sqlalchemy.engine import Engine
         from sqlalchemy.orm import scoped_session
         from sqlalchemy.orm import sessionmaker
+        from sqlite3 import Connection
 
         from . import models
 
@@ -361,7 +362,7 @@ class Recorder(threading.Thread):
         def set_sqlite_pragma(dbapi_connection, connection_record):
             """Set sqlite's WAL mode."""
             if (self.db_url.startswith("sqlite://") and
-                    type(dbapi_connection) == 'sqlite3.Connection'):
+                    isinstance(dbapi_connection, Connection)):
                 old_isolation = dbapi_connection.isolation_level
                 dbapi_connection.isolation_level = None
                 cursor = dbapi_connection.cursor()

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -360,7 +360,8 @@ class Recorder(threading.Thread):
         @event.listens_for(Engine, "connect")
         def set_sqlite_pragma(dbapi_connection, connection_record):
             """Set sqlite's WAL mode."""
-            if self.db_url.startswith("sqlite://"):
+            if (self.db_url.startswith("sqlite://") and
+                    type(dbapi_connection) == 'sqlite3.Connection'):
                 old_isolation = dbapi_connection.isolation_level
                 dbapi_connection.isolation_level = None
                 cursor = dbapi_connection.cursor()

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -361,8 +361,7 @@ class Recorder(threading.Thread):
         @event.listens_for(Engine, "connect")
         def set_sqlite_pragma(dbapi_connection, connection_record):
             """Set sqlite's WAL mode."""
-            if (self.db_url.startswith("sqlite://") and
-                    isinstance(dbapi_connection, Connection)):
+            if isinstance(dbapi_connection, Connection):
                 old_isolation = dbapi_connection.isolation_level
                 dbapi_connection.isolation_level = None
                 cursor = dbapi_connection.cursor()


### PR DESCRIPTION
## Description:

The recorder listen for connection events (`@event.listens_for(Engine, "connect")`), and, if they're sqlite3, it access to the `dbapi_connection.isolation_level` attrib.

To check it, it tests `if (self.db_url.startswith("sqlite://")`, but this is not sufficient, because the incoming connection could be other than the main one (`self.db_url`), because some 'custom_component' could be making these, and then, if they're not sqlite3 connections, an error will raise because those haven't the `dbapi_connection.isolation_level` attrib.

A simple double check of the incoming connection fixes it.

I discovered it when using a custom_component who connects with a mysql DB to pull the data. I've been using that component for near a year, but always from the main HA instance, which also uses mysql to recorder the history. When I used that component on a dev machine, with the default recorder config (sqlite3), the error showed up.
