### PR TITLE
Added year/month/day/hour/minute attributes to time_date sensor

### DIFF
--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -74,7 +74,6 @@ class TimeDateSensor(Entity):
         self._day = None
         self._hour = None
         self._minute = None
-        self._second = None
         self.hass = hass
 
         self._update_internal_state(dt_util.utcnow())

--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -20,6 +20,13 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_YEAR = 'year'
+ATTR_MONTH = 'month'
+ATTR_DAY = 'day'
+
+ATTR_HOUR = 'hour'
+ATTR_MINUTE = 'minute'
+
 TIME_STR_FORMAT = '%H:%M'
 
 OPTION_TYPES = {
@@ -62,6 +69,12 @@ class TimeDateSensor(Entity):
         self._name = OPTION_TYPES[option_type]
         self.type = option_type
         self._state = None
+        self._year = None
+        self._month = None
+        self._day = None
+        self._hour = None
+        self._minute = None
+        self._second = None
         self.hass = hass
 
         self._update_internal_state(dt_util.utcnow())
@@ -100,10 +113,27 @@ class TimeDateSensor(Entity):
         delta = interval - (timestamp % interval)
         return now + timedelta(seconds=delta)
 
+    @property
+    def state_attributes(self):
+        """Return time/date state attributes."""
+        attrs = {}
+        if 'time' in self.type:
+            attrs[ATTR_HOUR] = self._hour
+            attrs[ATTR_MINUTE] = self._minute
+        if 'date' in self.type:
+            attrs[ATTR_YEAR] = self._year
+            attrs[ATTR_MONTH] = self._month
+            attrs[ATTR_DAY] = self._day
+        return attrs
+
     def _update_internal_state(self, time_date):
-        time = dt_util.as_local(time_date).strftime(TIME_STR_FORMAT)
-        time_utc = time_date.strftime(TIME_STR_FORMAT)
-        date = dt_util.as_local(time_date).date().isoformat()
+        time = time_date if self.type == 'time_utc' else dt_util.as_local(time_date)
+        date = dt_util.as_local(time_date).date()
+        self._hour = time.hour
+        self._minute = time.minute
+        self._year = date.year
+        self._month = date.month
+        self._day = date.day
 
         # Calculate Swatch Internet Time.
         time_bmt = time_date + timedelta(hours=1)
@@ -112,7 +142,9 @@ class TimeDateSensor(Entity):
             seconds=time_bmt.second, microseconds=time_bmt.microsecond)
         beat = int((delta.seconds + delta.microseconds / 1000000.0) / 86.4)
 
-        if self.type == 'time':
+        date = date.isoformat()
+        time = time.strftime(TIME_STR_FORMAT)
+        if self.type in ['time', 'time_utc']:
             self._state = time
         elif self.type == 'date':
             self._state = date
@@ -120,8 +152,6 @@ class TimeDateSensor(Entity):
             self._state = '{}, {}'.format(date, time)
         elif self.type == 'time_date':
             self._state = '{}, {}'.format(time, date)
-        elif self.type == 'time_utc':
-            self._state = time_utc
         elif self.type == 'beat':
             self._state = '@{0:03d}'.format(beat)
 

--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -127,7 +127,8 @@ class TimeDateSensor(Entity):
         return attrs
 
     def _update_internal_state(self, time_date):
-        time = time_date if self.type == 'time_utc' else dt_util.as_local(time_date)
+        time = time_date if self.type == 'time_utc' else \
+            dt_util.as_local(time_date)
         date = dt_util.as_local(time_date).date()
         self._hour = time.hour
         self._minute = time.minute

--- a/tests/components/sensor/test_time_date.py
+++ b/tests/components/sensor/test_time_date.py
@@ -1,6 +1,8 @@
 """The tests for Kira sensor platform."""
 import unittest
 
+from components.sensor.time_date import (ATTR_HOUR, ATTR_MINUTE,
+                                         ATTR_YEAR, ATTR_MONTH, ATTR_DAY)
 from homeassistant.components.sensor import time_date as time_date
 import homeassistant.util.dt as dt_util
 
@@ -55,6 +57,56 @@ class TestTimeDateSensor(unittest.TestCase):
         device = time_date.TimeDateSensor(self.hass, 'time_date')
         next_time = device.get_next_interval()
         assert next_time > now
+
+    def test_attributes(self):
+        """Test attributes of sensors."""
+        now = dt_util.utc_from_timestamp(1495068856)
+        device = time_date.TimeDateSensor(self.hass, 'time')
+        device._update_internal_state(now)
+        attrs = device.state_attributes
+        assert len(attrs) == 2
+        assert attrs[ATTR_HOUR] == 0
+        assert attrs[ATTR_MINUTE] == 54
+
+        device = time_date.TimeDateSensor(self.hass, 'date')
+        device._update_internal_state(now)
+        attrs = device.state_attributes
+        assert len(attrs) == 3
+        assert attrs[ATTR_YEAR] == 2017
+        assert attrs[ATTR_MONTH] == 5
+        assert attrs[ATTR_DAY] == 18
+
+        device = time_date.TimeDateSensor(self.hass, 'time_date')
+        device._update_internal_state(now)
+        attrs = device.state_attributes
+        assert len(attrs) == 5
+        assert attrs[ATTR_YEAR] == 2017
+        assert attrs[ATTR_MONTH] == 5
+        assert attrs[ATTR_DAY] == 18
+        assert attrs[ATTR_HOUR] == 0
+        assert attrs[ATTR_MINUTE] == 54
+
+        device = time_date.TimeDateSensor(self.hass, 'date_time')
+        device._update_internal_state(now)
+        attrs = device.state_attributes
+        assert len(attrs) == 5
+        assert attrs[ATTR_YEAR] == 2017
+        assert attrs[ATTR_MONTH] == 5
+        assert attrs[ATTR_DAY] == 18
+        assert attrs[ATTR_HOUR] == 0
+        assert attrs[ATTR_MINUTE] == 54
+
+        device = time_date.TimeDateSensor(self.hass, 'time_utc')
+        device._update_internal_state(now)
+        attrs = device.state_attributes
+        assert len(attrs) == 2
+        assert attrs[ATTR_HOUR] == 0
+        assert attrs[ATTR_MINUTE] == 54
+
+        device = time_date.TimeDateSensor(self.hass, 'beat')
+        device._update_internal_state(now)
+        attrs = device.state_attributes
+        assert len(attrs) == 0
 
     def test_states(self):
         """Test states of sensors."""


### PR DESCRIPTION
## Description:

Added the following attributes to time_date sensor platform:
- `year` - returns current year as integer  
- `month` - returns month as integer (1 - 12)
- `day` - returns day as integer (1-31)
- `hour` - returns hour as integer in 24h format (0-23)
- `minute` - returns minute as integer (0-59)

The rationale behind this is to simplify the extraction of individual parts of the date in templates:

```{{states.sensor.time.attributes.hour}}``` is much easier than ```{{strptime(states.sensor.time.state, '%H:%M').hour}}```

**Note**
Some sensor types don't have all or some of these attributes:
- `time` and `time_utc` have only `hour` and `minute` attributes
- `date_time` and `time_date` have `year`, `month`, `day`, `hour` and `minute`
- `beat` doesn't have any attributes


**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
