### PR TITLE
Cast attribute values to string before publishing to MQTT

### DIFF
--- a/homeassistant/components/mqtt_statestream.py
+++ b/homeassistant/components/mqtt_statestream.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/mqtt_statestream/
 """
 import asyncio
+import json
 
 import voluptuous as vol
 
@@ -12,6 +13,7 @@ from homeassistant.const import MATCH_ALL
 from homeassistant.core import callback
 from homeassistant.components.mqtt import valid_publish_topic
 from homeassistant.helpers.event import async_track_state_change
+from homeassistant.remote import JSONEncoder
 import homeassistant.helpers.config_validation as cv
 
 CONF_BASE_TOPIC = 'base_topic'
@@ -65,8 +67,9 @@ def async_setup(hass, config):
         if publish_attributes:
             for key, val in new_state.attributes.items():
                 if val:
+                    encoded_val = json.dumps(val, cls=JSONEncoder)
                     hass.components.mqtt.async_publish(mybase + key,
-                                                       str(val), 1, True)
+                                                       encoded_val, 1, True)
 
     async_track_state_change(hass, MATCH_ALL, _state_publisher)
     return True

--- a/homeassistant/components/mqtt_statestream.py
+++ b/homeassistant/components/mqtt_statestream.py
@@ -65,9 +65,8 @@ def async_setup(hass, config):
         if publish_attributes:
             for key, val in new_state.attributes.items():
                 if val:
-                    val_str = str(val)
                     hass.components.mqtt.async_publish(mybase + key,
-                                                       val_str, 1, True)
+                                                       str(val), 1, True)
 
     async_track_state_change(hass, MATCH_ALL, _state_publisher)
     return True

--- a/homeassistant/components/mqtt_statestream.py
+++ b/homeassistant/components/mqtt_statestream.py
@@ -65,8 +65,9 @@ def async_setup(hass, config):
         if publish_attributes:
             for key, val in new_state.attributes.items():
                 if val:
+                    val_str = str(val)
                     hass.components.mqtt.async_publish(mybase + key,
-                                                       val, 1, True)
+                                                       val_str, 1, True)
 
     async_track_state_change(hass, MATCH_ALL, _state_publisher)
     return True

--- a/tests/components/test_mqtt_statestream.py
+++ b/tests/components/test_mqtt_statestream.py
@@ -127,7 +127,11 @@ class TestMqttStateStream(object):
         # mqtt_statestream state change on initialization, etc.
         mock_pub.reset_mock()
 
-        test_attributes = {"testing": "YES"}
+        test_attributes = {
+            "testing": "YES",
+            "list": ["a", "b", "c"],
+            "bool": True
+        }
 
         # Set a state of an entity
         mock_state_change_event(self.hass, State(e_id, 'off',
@@ -138,7 +142,11 @@ class TestMqttStateStream(object):
         calls = [
             call.async_publish(self.hass, 'pub/fake/entity/state', 'off', 1,
                                True),
-            call.async_publish(self.hass, 'pub/fake/entity/testing', 'YES',
+            call.async_publish(self.hass, 'pub/fake/entity/testing', '"YES"',
+                               1, True),
+            call.async_publish(self.hass, 'pub/fake/entity/list',
+                               '["a", "b", "c"]', 1, True),
+            call.async_publish(self.hass, 'pub/fake/entity/bool', "true",
                                1, True)
         ]
 


### PR DESCRIPTION
## Description:

**Breaking Change**: MQTT Statestream now serializes all data to JSON before publishing. This means that string attributes and values will be quoted from now on (e.g.: '"on"' instead of 'on'). You can still read these strings without the quotes by using 'value_json' instead of 'value' where applicable (e.g., templates). This causes automatic JSON deserialization. Other simple types are not affected.

This fixes errors when an entity has an attribute that is not "a string, bytearray, int, float or None" and mqtt_statestream is used. As of now, the attribute is just handed over to paho, and paho can only send the aforementioned types. This patch fixes the issue by just casting everything to string before handing it over to paho.

There are a number of components / entities which have "other" attributes, e.g. light that have an RGB attribute which is a list.

**Related issue (if applicable):** fixes #9815 

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
