### PR TITLE
Upgrade paho-mqtt to 1.3.1

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -30,7 +30,7 @@ from homeassistant.const import (
     CONF_PASSWORD, CONF_PORT, CONF_PROTOCOL, CONF_PAYLOAD)
 from homeassistant.components.mqtt.server import HBMQTT_CONFIG_SCHEMA
 
-REQUIREMENTS = ['paho-mqtt==1.3.0']
+REQUIREMENTS = ['paho-mqtt==1.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/shiftr.py
+++ b/homeassistant/components/shiftr.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers import state as state_helper
 
-REQUIREMENTS = ['paho-mqtt==1.3.0']
+REQUIREMENTS = ['paho-mqtt==1.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -477,7 +477,7 @@ orvibo==1.1.1
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.3.0
+paho-mqtt==1.3.1
 
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -83,7 +83,7 @@ mficlient==0.3.0
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.3.0
+paho-mqtt==1.3.1
 
 # homeassistant.components.device_tracker.aruba
 # homeassistant.components.device_tracker.asuswrt


### PR DESCRIPTION
1.3.1
=====

- Fix reconnect_delay_set which ignored the max_delay.
- Fix crash when connection is lost while trying to send message.
- Fix issue with unicode topic when some character were multi-bytes UTF-8.
- Fix issue with empty Client ID with broker that don't support them.
- Fix issue with tls_set that did not allowed cert_reqs=ssl.CERT_NONE.
- Relax requirement on pytest-runner, it's now only required for tests.

Tested with the following configuration:

``` yaml
mqtt:
  broker: localhost
  discovery: True
```

```bash
$ mosquitto_pub -h 127.0.0.1 -p 1883 -t "homeassistant/binary_sensor/garden/config" -m '{"name": "garden", "device_class": "motion"}'
```
```bash
2017-10-15 10:44:38 INFO (MainThread) [homeassistant.components.mqtt.discovery] Found new component: binary_sensor garden
2017-10-15 10:44:38 INFO (MainThread) [homeassistant.core] Bus:Handling <Event platform_discovered[L]: service=load_platform.binary_sensor, platform=mqtt, discovered=name=garden, device_class=motion, platform=mqtt, state_topic=homeassistant/binary_sensor/garden/state>
2017-10-15 10:44:38 INFO (MainThread) [homeassistant.components.binary_sensor] Setting up binary_sensor.mqtt
2017-10-15 10:44:38 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=binary_sensor.garden, old_state=None, new_state=<state binary_sensor.garden=off; friendly_name=garden, device_class=motion @ 2017-10-15T10:44:38.983567+02:00>>
```
```bash
$ mosquitto_pub -h 127.0.0.1 -p 1883 -t "homeassistant/binary_sensor/garden/state" -m ON
```
```bash
2017-10-15 10:45:41 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=binary_sensor.garden, old_state=<state binary_sensor.garden=off; friendly_name=garden, device_class=motion @ 2017-10-15T10:44:38.983567+02:00>, new_state=<state binary_sensor.garden=on; friendly_name=garden, device_class=motion @ 2017-10-15T10:45:41.475751+02:00>>
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
