### PR TITLE
Update requests requirement

### DIFF
--- a/homeassistant/components/media_player/vizio.py
+++ b/homeassistant/components/media_player/vizio.py
@@ -32,7 +32,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import config_validation as cv
 
-REQUIREMENTS = ['pyvizio==0.0.2', 'urllib3=1.22']
+REQUIREMENTS = ['pyvizio==0.0.2', 'urllib3==1.22']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/vizio.py
+++ b/homeassistant/components/media_player/vizio.py
@@ -80,7 +80,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         urllib3.exceptions.InsecureRequestWarning
         _LOGGER.warning('InsecureRequestWarning is disabled '
                         'because of Vizio platform configuration.')
-        urllib3.disable_warnings(InsecureRequestWarning)
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     add_devices([device], True)
 
 

--- a/homeassistant/components/media_player/vizio.py
+++ b/homeassistant/components/media_player/vizio.py
@@ -76,10 +76,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if config.get(CONF_SUPPRESS_WARNING):
         import requests
-        from requests.packages.urllib3.exceptions import InsecureRequestWarning
+        from requests.packages import urllib3
+        urllib3.exceptions.InsecureRequestWarning
         _LOGGER.warning('InsecureRequestWarning is disabled '
                         'because of Vizio platform configuration.')
-        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+        urllib3.disable_warnings(InsecureRequestWarning)
     add_devices([device], True)
 
 

--- a/homeassistant/components/media_player/vizio.py
+++ b/homeassistant/components/media_player/vizio.py
@@ -75,7 +75,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     if config.get(CONF_SUPPRESS_WARNING):
-        import requests
         from requests.packages import urllib3
         urllib3.exceptions.InsecureRequestWarning
         _LOGGER.warning('InsecureRequestWarning is disabled '

--- a/homeassistant/components/media_player/vizio.py
+++ b/homeassistant/components/media_player/vizio.py
@@ -76,7 +76,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if config.get(CONF_SUPPRESS_WARNING):
         from requests.packages import urllib3
-        urllib3.exceptions.InsecureRequestWarning
         _LOGGER.warning('InsecureRequestWarning is disabled '
                         'because of Vizio platform configuration.')
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)

--- a/homeassistant/components/media_player/vizio.py
+++ b/homeassistant/components/media_player/vizio.py
@@ -32,7 +32,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import config_validation as cv
 
-REQUIREMENTS = ['pyvizio==0.0.2']
+REQUIREMENTS = ['pyvizio==0.0.2', 'urllib3=1.22']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,11 +75,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     if config.get(CONF_SUPPRESS_WARNING):
-        import requests
-        from requests.packages.urllib3.exceptions import InsecureRequestWarning
+        import urllib3
+        from urllib3.exceptions import InsecureRequestWarning
         _LOGGER.warning('InsecureRequestWarning is disabled '
                         'because of Vizio platform configuration.')
-        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+        urllib3.disable_warnings(InsecureRequestWarning)
     add_devices([device], True)
 
 

--- a/homeassistant/components/media_player/vizio.py
+++ b/homeassistant/components/media_player/vizio.py
@@ -32,7 +32,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import config_validation as cv
 
-REQUIREMENTS = ['pyvizio==0.0.2', 'urllib3==1.22']
+REQUIREMENTS = ['pyvizio==0.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,4 +1,4 @@
-requests==2.14.2
+requests==2.18.4
 pyyaml>=3.11,<4
 pytz>=2017.02
 pip>=8.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,5 +1,5 @@
 # Home Assistant core
-requests==2.14.2
+requests==2.18.4
 pyyaml>=3.11,<4
 pytz>=2017.02
 pip>=8.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -111,7 +111,7 @@ batinfo==0.4.2
 beautifulsoup4==4.6.0
 
 # homeassistant.components.zha
-bellows==0.3.4
+bellows==0.4.0
 
 # homeassistant.components.blink
 blinkpy==0.6.0
@@ -401,7 +401,7 @@ lightify==1.0.6
 limitlessled==1.0.8
 
 # homeassistant.components.media_player.liveboxplaytv
-liveboxplaytv==1.4.9
+liveboxplaytv==1.5.0
 
 # homeassistant.components.lametric
 # homeassistant.components.notify.lametric
@@ -477,7 +477,7 @@ orvibo==1.1.1
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.3.0
+paho-mqtt==1.3.1
 
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.2
@@ -806,7 +806,7 @@ python-synology==0.1.0
 python-tado==0.2.2
 
 # homeassistant.components.telegram_bot
-python-telegram-bot==8.0.0
+python-telegram-bot==8.1.1
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0
@@ -1020,6 +1020,9 @@ uber_rides==0.6.0
 # homeassistant.components.sensor.ups
 upsmychoice==1.0.6
 
+# homeassistant.components.media_player.vizio
+urllib3==1.2.2
+
 # homeassistant.components.camera.uvc
 uvcclient==0.10.1
 
@@ -1059,7 +1062,7 @@ xbee-helper==0.0.7
 xboxapi==0.1.1
 
 # homeassistant.components.knx
-xknx==0.7.14
+xknx==0.7.16
 
 # homeassistant.components.media_player.bluesound
 # homeassistant.components.sensor.swiss_hydrological_data

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -111,7 +111,7 @@ batinfo==0.4.2
 beautifulsoup4==4.6.0
 
 # homeassistant.components.zha
-bellows==0.4.0
+bellows==0.3.4
 
 # homeassistant.components.blink
 blinkpy==0.6.0
@@ -401,7 +401,7 @@ lightify==1.0.6
 limitlessled==1.0.8
 
 # homeassistant.components.media_player.liveboxplaytv
-liveboxplaytv==1.5.0
+liveboxplaytv==1.4.9
 
 # homeassistant.components.lametric
 # homeassistant.components.notify.lametric
@@ -477,7 +477,7 @@ orvibo==1.1.1
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.3.1
+paho-mqtt==1.3.0
 
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.2
@@ -806,7 +806,7 @@ python-synology==0.1.0
 python-tado==0.2.2
 
 # homeassistant.components.telegram_bot
-python-telegram-bot==8.1.1
+python-telegram-bot==8.0.0
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0
@@ -1021,7 +1021,7 @@ uber_rides==0.6.0
 upsmychoice==1.0.6
 
 # homeassistant.components.media_player.vizio
-urllib3==1.2.2
+urllib3==1.22
 
 # homeassistant.components.camera.uvc
 uvcclient==0.10.1
@@ -1062,7 +1062,7 @@ xbee-helper==0.0.7
 xboxapi==0.1.1
 
 # homeassistant.components.knx
-xknx==0.7.16
+xknx==0.7.14
 
 # homeassistant.components.media_player.bluesound
 # homeassistant.components.sensor.swiss_hydrological_data

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ DOWNLOAD_URL = ('{}/archive/'
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
 REQUIRES = [
-    'requests==2.14.2',
+    'requests==2.18.4',
     'pyyaml>=3.11,<4',
     'pytz>=2017.02',
     'pip>=8.0.3',


### PR DESCRIPTION
Update request requirement from version v2.14.2 to v2.18.4

## Description:
I've checked the dependencies with https://requires.io/github/TopdRob/home-assistant/requirements/?branch=dev to check if I could update the dependencies. I started with requests package to update it from v2.14.2 to v2.18.4

### Changelog (copied from https://github.com/requests/requests/blob/master/HISTORY.rst)
2.18.4 (2017-08-15)
+++++++++++++++++++

**Improvements**

- Error messages for invalid headers now include the header name for easier debugging

**Dependencies**

- We now support idna v2.6.

2.18.3 (2017-08-02)
+++++++++++++++++++

**Improvements**

- Running ``$ python -m requests.help`` now includes the installed version of idna.

**Bugfixes**

- Fixed issue where Requests would raise ``ConnectionError`` instead of
  ``SSLError`` when encountering SSL problems when using urllib3 v1.22.

2.18.2 (2017-07-25)
+++++++++++++++++++

**Bugfixes**

- ``requests.help`` no longer fails on Python 2.6 due to the absence of
  ``ssl.OPENSSL_VERSION_NUMBER``.

**Dependencies**

- We now support urllib3 v1.22.

2.18.1 (2017-06-14)
+++++++++++++++++++

**Bugfixes**

- Fix an error in the packaging whereby the ``*.whl`` contained incorrect data
  that regressed the fix in v2.17.3.

2.18.0 (2017-06-14)
+++++++++++++++++++

**Improvements**

- ``Response`` is now a context manager, so can be used directly in a ``with`` statement
  without first having to be wrapped by ``contextlib.closing()``.

**Bugfixes**

- Resolve installation failure if multiprocessing is not available
- Resolve tests crash if multiprocessing is not able to determine the number of CPU cores
- Resolve error swallowing in utils set_environ generator


2.17.3 (2017-05-29)
+++++++++++++++++++

**Improvements**

- Improved ``packages`` namespace identity support, for monkeypatching libraries.


2.17.2 (2017-05-29)
+++++++++++++++++++

**Improvements**

- Improved ``packages`` namespace identity support, for monkeypatching libraries.


2.17.1 (2017-05-29)
+++++++++++++++++++

**Improvements**

- Improved ``packages`` namespace identity support, for monkeypatching libraries.


2.17.0 (2017-05-29)
+++++++++++++++++++

**Improvements**

- Removal of the 301 redirect cache. This improves thread-safety.


2.16.5 (2017-05-28)
+++++++++++++++++++

- Improvements to ``$ python -m requests.help``.

2.16.4 (2017-05-27)
+++++++++++++++++++

- Introduction of the ``$ python -m requests.help`` command, for debugging with maintainers!

2.16.3 (2017-05-27)
+++++++++++++++++++

- Further restored the ``requests.packages`` namespace for compatibility reasons.

2.16.2 (2017-05-27)
+++++++++++++++++++

- Further restored the ``requests.packages`` namespace for compatibility reasons.

No code modification (noted below) should be neccessary any longer.

2.16.1 (2017-05-27)
+++++++++++++++++++

- Restored the ``requests.packages`` namespace for compatibility reasons.
- Bugfix for ``urllib3`` version parsing.

**Note**: code that was written to import against the ``requests.packages``
namespace previously will have to import code that rests at this module-level
now.

For example::

    from requests.packages.urllib3.poolmanager import PoolManager

Will need to be re-written to be::

    from requests.packages import urllib3
    urllib3.poolmanager.PoolManager

Or, even better::

    from urllib3.poolmanager import PoolManager

2.16.0 (2017-05-26)
+++++++++++++++++++

- Unvendor ALL the things!

2.15.1 (2017-05-26)
+++++++++++++++++++

- Everyone makes mistakes.

2.15.0 (2017-05-26)
+++++++++++++++++++

**Improvements**

- Introduction of the ``Response.next`` property, for getting the next
  ``PreparedResponse`` from a redirect chain (when ``allow_redirects=False``).
- Internal refactoring of ``__version__`` module.

**Bugfixes**

- Restored once-optional parameter for ``requests.utils.get_environ_proxies()``.

2.14.2 (2017-05-10)
+++++++++++++++++++

**Bugfixes**

- Changed a less-than to an equal-to and an or in the dependency markers to
  widen compatibility with older setuptools releases.

### Vizio
Because the requests package no longer includes third party libraries they we had to update the Vizio implementation as well. Therefore this is also added to this pull request.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
