### PR TITLE
Fix #9839

### DIFF
--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     STATE_PAUSED, STATE_UNKNOWN, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['liveboxplaytv==1.4.9']
+REQUIREMENTS = ['liveboxplaytv==1.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ class LiveboxPlayTvDevice(MediaPlayerDevice):
                     self._client.get_current_channel_image(img_size=300)
                 self.refresh_channel_list()
         except requests.ConnectionError:
-            self._state = STATE_OFF
+            self._state = STATE_UNKNOWN
 
     @property
     def name(self):

--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -18,7 +18,7 @@ from homeassistant.components.media_player import (
     MEDIA_TYPE_CHANNEL, MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_HOST, CONF_PORT, STATE_ON, STATE_OFF, STATE_PLAYING,
-    STATE_PAUSED, STATE_UNKNOWN, CONF_NAME)
+    STATE_PAUSED, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['liveboxplaytv==1.5.0']
@@ -72,7 +72,7 @@ class LiveboxPlayTvDevice(MediaPlayerDevice):
         self._muted = False
         self._name = name
         self._current_source = None
-        self._state = STATE_UNKNOWN
+        self._state = None
         self._channel_list = {}
         self._current_channel = None
         self._current_program = None

--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -92,7 +92,7 @@ class LiveboxPlayTvDevice(MediaPlayerDevice):
                     self._client.get_current_channel_image(img_size=300)
                 self.refresh_channel_list()
         except requests.ConnectionError:
-            self._state = STATE_UNKNOWN
+            self._state = None
 
     @property
     def name(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -401,7 +401,7 @@ lightify==1.0.6
 limitlessled==1.0.8
 
 # homeassistant.components.media_player.liveboxplaytv
-liveboxplaytv==1.4.9
+liveboxplaytv==1.5.0
 
 # homeassistant.components.lametric
 # homeassistant.components.notify.lametric


### PR DESCRIPTION
## Description:
Bump `liveboxplaytv` to 1.5.0.
Previous versions relied on a now deprecated API endpoint to fetch program data.
This also changes the default state to be `STATE_UNKNOWN` in case an error is raised during the `update` function, which seems more appropriate than to default to `STATE_OFF`.

**Related issue (if applicable):** fixes #9839

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: liveboxplaytv
    host: 192.168.1.2
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
