### PR TITLE
Upgrade python-telegram-bot to 8.1.1

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -24,7 +24,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import TemplateError
 from homeassistant.setup import async_prepare_setup_platform
 
-REQUIREMENTS = ['python-telegram-bot==8.0.0']
+REQUIREMENTS = ['python-telegram-bot==8.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -806,7 +806,7 @@ python-synology==0.1.0
 python-tado==0.2.2
 
 # homeassistant.components.telegram_bot
-python-telegram-bot==8.0.0
+python-telegram-bot==8.1.1
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0


### PR DESCRIPTION
## python-telegram-bot 8.1.1

New features
- Support Bot API 3.4 (PR python-telegram-bot/python-telegram-bot#865).

Changes
- MessgaeHandler & RegexHandler now consider channel_updates.
- Fix Commandhandler crashing on single character messages (PR python-telegram-bot/python-telegram-bot#873)
- Fix command not recognized if it is directly followed by a newline (PR python-telegram-bot/python-telegram-bot#869).
- Removed Bot._message_wrapper (PR python-telegram-bot/python-telegram-bot#822).
- Unitests are now also running on Appveyor (Windows VM).
- Various unitest improvments.
- Documentation fixes.

**Tested with the `polling`and the `webhooks` platforms**:

```yaml
telegram_bot:
  platform: webhooks
  api_key: !secret telegram_bot_api_key
  allowed_chat_ids:
    - !secret telegram_bot_chat_id_admin
    - !secret telegram_bot_chat_id_2
    - !secret telegram_bot_group

notify:
  - platform: telegram
    name: telegram_bot
    chat_id: !secret telegram_bot_chat_id_admin
  - platform: telegram
    name: telegram_group
    chat_id: !secret telegram_bot_group


# and

telegram_bot:
  platform: polling
  api_key: !secret telegram_bot_api_key
  allowed_chat_ids:
    - !secret telegram_bot_chat_id_admin
    - !secret telegram_bot_group
    - !secret telegram_bot_group2

notify:
  - platform: telegram
    name: telegram_group
    chat_id: -225190494

  - platform: telegram
    name: telegram_admin
    chat_id: !secret telegram_bot_chat_id_admin
```