### PR TITLE
0.55.1

### DIFF
--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.aiohttp_client import (
     async_aiohttp_proxy_web)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['py-synology==0.1.1']
+REQUIREMENTS = ['py-synology==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -103,6 +103,11 @@ class RflinkCover(RflinkCommand, CoverDevice):
         """No polling available in RFlink cover."""
         return False
 
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return None
+
     def async_close_cover(self, **kwargs):
         """Turn the device close."""
         return self._async_handle_command("close_cover")

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -407,7 +407,8 @@ def async_handle_message(hass, context, message):
     handler = HANDLERS.get(msgtype)
 
     if handler is None:
-        error = 'Received unsupported message type: {}.'.format(msgtype)
-        _LOGGER.warning(error)
+        _LOGGER.warning(
+            'Received unsupported message type: %s.', msgtype)
+        return
 
     yield from handler(hass, context, message)

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -329,6 +329,7 @@ class IndexView(HomeAssistantView):
         from jinja2 import FileSystemLoader, Environment
 
         self.templates = Environment(
+            autoescape=True,
             loader=FileSystemLoader(
                 os.path.join(os.path.dirname(__file__), 'templates/')
             )

--- a/homeassistant/components/google.py
+++ b/homeassistant/components/google.py
@@ -269,7 +269,7 @@ def load_config(path):
     calendars = {}
     try:
         with open(path) as file:
-            data = yaml.load(file)
+            data = yaml.safe_load(file)
             for calendar in data:
                 try:
                     calendars.update({calendar[CONF_CAL_ID]:

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -105,7 +105,7 @@ class TradfriGroup(Light):
         """Instruct the group lights to turn on, or dim."""
         keys = {}
         if ATTR_TRANSITION in kwargs:
-            keys['transition_time'] = int(kwargs[ATTR_TRANSITION])
+            keys['transition_time'] = int(kwargs[ATTR_TRANSITION]) * 10
 
         if ATTR_BRIGHTNESS in kwargs:
             self.hass.async_add_job(self._api(
@@ -259,7 +259,7 @@ class TradfriLight(Light):
 
         keys = {}
         if ATTR_TRANSITION in kwargs:
-            keys['transition_time'] = int(kwargs[ATTR_TRANSITION])
+            keys['transition_time'] = int(kwargs[ATTR_TRANSITION]) * 10
 
         if ATTR_BRIGHTNESS in kwargs:
             self.hass.async_add_job(self._api(

--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -18,10 +18,10 @@ from homeassistant.components.media_player import (
     MEDIA_TYPE_CHANNEL, MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_HOST, CONF_PORT, STATE_ON, STATE_OFF, STATE_PLAYING,
-    STATE_PAUSED, STATE_UNKNOWN, CONF_NAME)
+    STATE_PAUSED, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['liveboxplaytv==1.4.9']
+REQUIREMENTS = ['liveboxplaytv==1.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ class LiveboxPlayTvDevice(MediaPlayerDevice):
         self._muted = False
         self._name = name
         self._current_source = None
-        self._state = STATE_UNKNOWN
+        self._state = None
         self._channel_list = {}
         self._current_channel = None
         self._current_program = None
@@ -92,7 +92,7 @@ class LiveboxPlayTvDevice(MediaPlayerDevice):
                     self._client.get_current_channel_image(img_size=300)
                 self.refresh_channel_list()
         except requests.ConnectionError:
-            self._state = STATE_OFF
+            self._state = None
 
     @property
     def name(self):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 55
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -540,7 +540,7 @@ pwmled==1.2.1
 py-cpuinfo==3.3.0
 
 # homeassistant.components.camera.synology
-py-synology==0.1.1
+py-synology==0.1.3
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -398,7 +398,7 @@ lightify==1.0.6
 limitlessled==1.0.8
 
 # homeassistant.components.media_player.liveboxplaytv
-liveboxplaytv==1.4.9
+liveboxplaytv==1.5.0
 
 # homeassistant.components.lametric
 # homeassistant.components.notify.lametric


### PR DESCRIPTION
- Fix for TypeError in synology camera ([@snjoetw] - [#9754]) ([camera.synology docs])
- missing is_closed ( rflink cover fix ) ([@passie] - [#9776]) ([cover.rflink docs])
- [light.tradfri] Fix transition time ([@lwis] - [#9785]) ([light.tradfri docs])
- OwnTracks: Fix handler is None checking ([@balloob] - [#9794]) ([device_tracker.owntracks docs])
- Changed yaml.load into yaml.safe_load ([@GenericStudent] - [#9841]) ([google docs])
- Bugfix/9811 jinja autoescape ([@GenericStudent] - [#9842])
- Fix #9839 ([@pschmitt] - [#9880]) ([media_player.liveboxplaytv docs])

[#9754]: https://github.com/home-assistant/home-assistant/pull/9754
[#9776]: https://github.com/home-assistant/home-assistant/pull/9776
[#9785]: https://github.com/home-assistant/home-assistant/pull/9785
[#9794]: https://github.com/home-assistant/home-assistant/pull/9794
[#9841]: https://github.com/home-assistant/home-assistant/pull/9841
[#9842]: https://github.com/home-assistant/home-assistant/pull/9842
[#9880]: https://github.com/home-assistant/home-assistant/pull/9880
[@GenericStudent]: https://github.com/GenericStudent
[@balloob]: https://github.com/balloob
[@lwis]: https://github.com/lwis
[@passie]: https://github.com/passie
[@pschmitt]: https://github.com/pschmitt
[@snjoetw]: https://github.com/snjoetw
[camera.synology docs]: https://home-assistant.io/components/camera.synology/
[cover.rflink docs]: https://home-assistant.io/components/cover.rflink/
[device_tracker.owntracks docs]: https://home-assistant.io/components/device_tracker.owntracks/
[google docs]: https://home-assistant.io/components/google/
[light.tradfri docs]: https://home-assistant.io/components/light.tradfri/
[media_player.liveboxplaytv docs]: https://home-assistant.io/components/media_player.liveboxplaytv/
