### PR TITLE
Add last_seen value to state object

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -565,7 +565,7 @@ class State(object):
                 'last_updated': self.last_updated}
 
     def seen(self):
-        """Update the last_seen attribute without changing others"""
+        """Update the last_seen attribute without changing others."""
         self.last_seen = dt_util.utcnow()
 
     @classmethod

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -592,6 +592,21 @@ class TestStateMachine(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(1, len(events))
 
+    def test_last_seen_updated_on_same_state(self):
+        """Test that last_seen is updated even if the state is unchanged."""
+        state = self.states.get("light.Bowl")
+        seen = state.last_seen
+
+        future = dt_util.utcnow() + timedelta(hours=10)
+
+        with patch('homeassistant.util.dt.utcnow', return_value=future):
+            self.states.set("light.Bowl", "on")
+            self.hass.block_till_done()
+
+        state2 = self.states.get('light.Bowl')
+        assert state2 is not None
+        assert state.last_changed == state2.last_changed
+        assert seen != state2.last_seen
 
 class TestServiceCall(unittest.TestCase):
     """Test ServiceCall class."""


### PR DESCRIPTION
## Description:

This PR adds a `last_seen` value to the state object.  The value is set on any call to `set` or `async_set` in the state machine, even if there are no changes to the state/attributes.  It is not logged and does not fire any event, so it does not cause any disk writes.

The purpose for adding this value is to keep track of the last time an entity was heard from.  This is particularly important in the case of sensors - if a sensor's value is very stable and doesn't change often, then the last_updated and last_changed values will not be changed.  There is no way to tell if they have not been changed because the sensor value hasn't changed or if the sensor has failed and is no longer reporting.

If this is accepted/merged, I have a new `watchdog` sensor component to follow that lets you watch for entities that are no longer reporting, and build automation to alert or otherwise deal with it.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3639

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
