### PR TITLE
WIP: Timer component

### DIFF
--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -488,54 +488,6 @@ counter:
         description: Entity id of the counter to reset.
         example: 'counter.count0'
 
-timer:
-  start:
-    description: Start a timer.
-
-    fields:
-      entity_id:
-        description: Entity id of the timer to start. [optional]
-        example: 'timer.timer0'
-      weeks:
-        description: Duration in weeks the timer should be running. [optional]
-        example: 1
-      days:
-        description: Duration in days the timer should be running. [optional]
-        example: 7
-      hours:
-        description: Duration in hours the timer should be running. [optional]
-        example: 24
-      minutes:
-        description: Duration in minutes the timer should be running. [optional]
-        example: 60
-      seconds:
-        description: Duration in seconds the timer should be running. [optional]
-        example: 60
-
-  pause:
-    description: Pause a timer.
-
-    fields:
-      entity_id:
-        description: Entity id of the timer to pause. [optional]
-        example: 'timer.timer0'
-
-  cancel:
-    description: Cancel a timer.
-
-    fields:
-      entity_id:
-        description: Entity id of the timer to cancel. [optional]
-        example: 'timer.timer0'
-
-  finish:
-    description: Finish a timer.
-
-    fields:
-      entity_id:
-        description: Entity id of the timer to finish. [optional]
-        example: 'timer.timer0'
-
 abode:
   change_setting:
     description: Change an Abode system setting.

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -496,7 +496,19 @@ timer:
       entity_id:
         description: Entity id of the timer to start. [optional]
         example: 'timer.timer0'
-      duration:
+      weeks:
+        description: Duration in weeks the timer should be running. [optional]
+        example: 1
+      days:
+        description: Duration in days the timer should be running. [optional]
+        example: 7
+      hours:
+        description: Duration in hours the timer should be running. [optional]
+        example: 24
+      minutes:
+        description: Duration in minutes the timer should be running. [optional]
+        example: 60
+      seconds:
         description: Duration in seconds the timer should be running. [optional]
         example: 60
 

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -496,6 +496,9 @@ timer:
       entity_id:
         description: Entity id of the timer to start. [optional]
         example: 'timer.timer0'
+      duration:
+        description: Duration in seconds the timer should be running. [optional]
+        example: 60
 
   pause:
     description: Pause a timer.
@@ -505,16 +508,13 @@ timer:
         description: Entity id of the timer to pause. [optional]
         example: 'timer.timer0'
 
-  reset:
-    description: Reset a timer.
+  cancel:
+    description: Cancel a timer.
 
     fields:
       entity_id:
-        description: Entity id of the timer to reset. [optional]
+        description: Entity id of the timer to cancel. [optional]
         example: 'timer.timer0'
-      duration:
-        description: Duration in seconds the timer should be running. [optional]
-        example: 60
 
 abode:
   change_setting:

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -516,6 +516,14 @@ timer:
         description: Entity id of the timer to cancel. [optional]
         example: 'timer.timer0'
 
+  finish:
+    description: Finish a timer.
+
+    fields:
+      entity_id:
+        description: Entity id of the timer to finish. [optional]
+        example: 'timer.timer0'
+
 abode:
   change_setting:
     description: Change an Abode system setting.

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -488,6 +488,34 @@ counter:
         description: Entity id of the counter to reset.
         example: 'counter.count0'
 
+timer:
+  start:
+    description: Start a timer.
+
+    fields:
+      entity_id:
+        description: Entity id of the timer to start. [optional]
+        example: 'timer.timer0'
+
+  pause:
+    description: Pause a timer.
+
+    fields:
+      entity_id:
+        description: Entity id of the timer to pause. [optional]
+        example: 'timer.timer0'
+
+  reset:
+    description: Reset a timer.
+
+    fields:
+      entity_id:
+        description: Entity id of the timer to reset. [optional]
+        example: 'timer.timer0'
+      duration:
+        description: Duration in seconds the timer should be running. [optional]
+        example: 60
+
 abode:
   change_setting:
     description: Change an Abode system setting.

--- a/homeassistant/components/timer.py
+++ b/homeassistant/components/timer.py
@@ -236,9 +236,8 @@ class Timer(Entity):
         if self._state is not None:
             return
 
-        # pylint: disable=undefined-variable
-        state = yield from hass.helpers.restore_state.async_get_last_state(
-            self.entity_id)
+        restore_state = self._hass.helpers.restore_state
+        state = yield from restore_state.async_get_last_state(self.entity_id)
         self._state = state and state.state == state
 
     @asyncio.coroutine

--- a/homeassistant/components/timer.py
+++ b/homeassistant/components/timer.py
@@ -103,12 +103,11 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=redefined-outer-name
 @bind_hass
-def start(hass, entity_id,
-          weeks=DEFAULT_DURATION, days=DEFAULT_DURATION,
-          hours=DEFAULT_DURATION, minutes=DEFAULT_DURATION,
-          seconds=DEFAULT_DURATION):
+def sync_start(hass, entity_id,
+               weeks=DEFAULT_DURATION, days=DEFAULT_DURATION,
+               hours=DEFAULT_DURATION, minutes=DEFAULT_DURATION,
+               seconds=DEFAULT_DURATION):
     """Start a timer."""
     hass.add_job(async_start, hass, entity_id,
                  **{ATTR_ENTITY_ID: entity_id,

--- a/homeassistant/components/timer.py
+++ b/homeassistant/components/timer.py
@@ -263,6 +263,7 @@ class Timer(Entity):
         self._duration = duration if duration else self._duration
         yield from self.async_update_ha_state()
 
+    @asyncio.coroutine
     def async_finished(self, time):
         """Get the latest data and updates the states."""
         if self._state == STATUS_ACTIVE:
@@ -270,5 +271,5 @@ class Timer(Entity):
             self._remaining = None
             self._hass.bus.async_fire(EVENT_TIMER_FINISHED,
                                       {"entity_id": self.entity_id})
-            self.async_update_ha_state()
+            yield from self.async_update_ha_state()
         return

--- a/homeassistant/components/timer.py
+++ b/homeassistant/components/timer.py
@@ -263,7 +263,6 @@ class Timer(Entity):
         self._duration = duration if duration else self._duration
         yield from self.async_update_ha_state()
 
-    @asyncio.coroutine
     def async_finished(self, time):
         """Get the latest data and updates the states."""
         if self._state == STATUS_ACTIVE:
@@ -271,5 +270,5 @@ class Timer(Entity):
             self._remaining = None
             self._hass.bus.async_fire(EVENT_TIMER_FINISHED,
                                       {"entity_id": self.entity_id})
-            yield from self.async_update_ha_state()
+            self.async_update_ha_state()
         return

--- a/homeassistant/components/timer.py
+++ b/homeassistant/components/timer.py
@@ -263,7 +263,7 @@ class Timer(Entity):
         self._name = name
         self._state = STATUS_IDLE
         self._duration = timedelta(weeks=weeks, days=days, hours=hours,
-            minutes=minutes, seconds=seconds)
+                                   minutes=minutes, seconds=seconds)
         self._remaining = self._duration
         self._icon = icon
         self._hass = hass

--- a/homeassistant/components/timer.py
+++ b/homeassistant/components/timer.py
@@ -1,0 +1,261 @@
+"""
+Timer component.
+
+For more details about this component, please refer to the documentation
+at https://home-assistant.io/components/timer/
+"""
+import asyncio
+import logging
+import os
+from datetime import timedelta
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.config import load_yaml_config_file
+from homeassistant.const import (ATTR_ENTITY_ID, CONF_ICON, CONF_NAME)
+from homeassistant.core import callback
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.restore_state import async_get_last_state
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.loader import bind_hass
+
+_LOGGER = logging.getLogger(__name__)
+
+INTERVAL = timedelta(seconds=1)
+
+EVENT_TIMER_FINISHED = 'timer.finished'
+
+ATTR_INITIAL = 'initial'
+ATTR_STATUS = 'status'
+ATTR_DURATION = 'duration'
+
+STATUS_IDLE = 0
+STATUS_ACTIVE = 1
+STATUS_PAUSED = 2
+
+STATUS_MAPPING = {
+    STATUS_IDLE: 'idle',
+    STATUS_ACTIVE: 'active',
+    STATUS_PAUSED: 'paused'
+}
+
+CONF_INITIAL = 'initial'
+
+DEFAULT_INITIAL = 0
+DOMAIN = 'timer'
+
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+SERVICE_START = 'start'
+SERVICE_PAUSE = 'pause'
+SERVICE_RESET = 'reset'
+
+SERVICE_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+})
+
+SERVICE_SCHEMA_RESET = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_DURATION): cv.positive_int,
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        cv.slug: vol.Any({
+            vol.Optional(CONF_ICON): cv.icon,
+            vol.Optional(CONF_INITIAL, default=DEFAULT_INITIAL):
+                cv.positive_int,
+            vol.Optional(CONF_NAME): cv.string,
+        }, None)
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+@bind_hass
+def start(hass, entity_id):
+    """Start a timer."""
+    hass.add_job(async_start, hass, entity_id)
+
+
+@callback
+@bind_hass
+def async_start(hass, entity_id):
+    """Start a timer."""
+    hass.async_add_job(hass.services.async_call(
+        DOMAIN, SERVICE_START, {ATTR_ENTITY_ID: entity_id}))
+
+
+@bind_hass
+def pause(hass, entity_id):
+    """Pause a timer."""
+    hass.add_job(async_pause, hass, entity_id)
+
+
+@callback
+@bind_hass
+def async_pause(hass, entity_id):
+    """Pause a timer."""
+    hass.async_add_job(hass.services.async_call(
+        DOMAIN, SERVICE_PAUSE, {ATTR_ENTITY_ID: entity_id}))
+
+
+@bind_hass
+def reset(hass, entity_id, duration):
+    """Reset a timer."""
+    hass.add_job(async_reset, hass, entity_id, duration)
+
+
+@callback
+@bind_hass
+def async_reset(hass, entity_id, duration):
+    """Reset a timer."""
+    hass.async_add_job(hass.services.async_call(
+        DOMAIN, SERVICE_RESET, {ATTR_ENTITY_ID: entity_id,
+                                ATTR_DURATION: duration}))
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up a timer."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    entities = []
+
+    for object_id, cfg in config[DOMAIN].items():
+        if not cfg:
+            cfg = {}
+
+        name = cfg.get(CONF_NAME)
+        initial = cfg.get(CONF_INITIAL)
+        icon = cfg.get(CONF_ICON)
+
+        entities.append(Timer(hass, object_id, name, initial, icon))
+
+    if not entities:
+        return False
+
+    @asyncio.coroutine
+    def async_handler_service(service):
+        """Handle a call to the timer services."""
+        target_timers = component.async_extract_from_service(service)
+
+        attr = None
+        if service.service == SERVICE_START:
+            attr = 'async_start'
+        elif service.service == SERVICE_PAUSE:
+            attr = 'async_pause'
+
+        tasks = [getattr(timer, attr)() for timer in target_timers if attr]
+        if service.service == SERVICE_RESET:
+            for timer in target_timers:
+                tasks.append(
+                    timer.async_reset(service.data.get(ATTR_DURATION,
+                                                       DEFAULT_INITIAL)))
+        if tasks:
+            yield from asyncio.wait(tasks, loop=hass.loop)
+
+    descriptions = yield from hass.async_add_job(
+        load_yaml_config_file, os.path.join(
+            os.path.dirname(__file__), 'services.yaml')
+    )
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_START, async_handler_service,
+        descriptions[DOMAIN][SERVICE_START], SERVICE_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_PAUSE, async_handler_service,
+        descriptions[DOMAIN][SERVICE_PAUSE], SERVICE_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_RESET, async_handler_service,
+        descriptions[DOMAIN][SERVICE_RESET], SERVICE_SCHEMA_RESET)
+
+    yield from component.async_add_entities(entities)
+    return True
+
+
+class Timer(Entity):
+    """Representation of a timer."""
+
+    def __init__(self, hass, object_id, name, initial, icon):
+        """Initialize a timer."""
+        self.entity_id = ENTITY_ID_FORMAT.format(object_id)
+        self._name = name
+        self._state = self._initial = initial
+        self._icon = icon
+        self._status = STATUS_IDLE
+        self._hass = hass
+
+        async_track_time_interval(
+            hass, self.async_update, INTERVAL
+        )
+
+    @property
+    def should_poll(self):
+        """If entity should be polled."""
+        return False
+
+    @property
+    def name(self):
+        """Return name of the timer."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon to be used for this entity."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the current value of the timer."""
+        return self._state
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_INITIAL: self._initial,
+            ATTR_STATUS: self._status,
+        }
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Call when entity is about to be added to Home Assistant."""
+        # If not None, we got an initial value.
+        if self._state is not None:
+            return
+
+        state = yield from async_get_last_state(self.hass, self.entity_id)
+        self._state = state and state.state == state
+
+    @asyncio.coroutine
+    def async_start(self):
+        """Start a timer."""
+        self._status = STATUS_ACTIVE
+        yield from self.async_update_ha_state()
+
+    @asyncio.coroutine
+    def async_pause(self):
+        """Pause a timer."""
+        self._status = STATUS_PAUSED
+        yield from self.async_update_ha_state()
+
+    @asyncio.coroutine
+    def async_reset(self, duration):
+        """Reset a timer."""
+        self._status = STATUS_IDLE
+        self._state = duration if duration else self._initial
+        yield from self.async_update_ha_state()
+
+    @asyncio.coroutine
+    def async_update(self, time):
+        """Get the latest data and updates the states."""
+        if self._status == STATUS_ACTIVE and self._state > 0:
+            self._state -= 1
+            if self._state == 0:
+                self._status = STATUS_IDLE
+                self._hass.bus.async_fire(EVENT_TIMER_FINISHED,
+                                          {"entity_id": self.entity_id})
+            yield from self.async_update_ha_state()
+        return

--- a/homeassistant/components/timer.py
+++ b/homeassistant/components/timer.py
@@ -150,14 +150,14 @@ def async_pause(hass, entity_id):
 
 
 @bind_hass
-def cancel(hass, entity_id, duration):
+def cancel(hass, entity_id):
     """Cancel a timer."""
     hass.add_job(async_cancel, hass, entity_id)
 
 
 @callback
 @bind_hass
-def async_cancel(hass, entity_id, duration):
+def async_cancel(hass, entity_id):
     """Cancel a timer."""
     hass.async_add_job(hass.services.async_call(
         DOMAIN, SERVICE_CANCEL, {ATTR_ENTITY_ID: entity_id}))

--- a/homeassistant/components/timer.py
+++ b/homeassistant/components/timer.py
@@ -24,27 +24,19 @@ from homeassistant.loader import bind_hass
 
 _LOGGER = logging.getLogger(__name__)
 
-EVENT_TIMER_FINISHED = 'timer.finished'
-EVENT_TIMER_CANCELLED = 'timer.cancelled'
-
-ATTR_DURATION = 'duration'
-
-STATUS_IDLE = 0
-STATUS_ACTIVE = 1
-STATUS_PAUSED = 2
-
-STATUS_MAPPING = {
-    STATUS_IDLE: 'idle',
-    STATUS_ACTIVE: 'active',
-    STATUS_PAUSED: 'paused'
-}
-
-CONF_DURATION = 'duration'
+DOMAIN = 'timer'
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 DEFAULT_DURATION = 0
-DOMAIN = 'timer'
+ATTR_DURATION = 'duration'
+CONF_DURATION = 'duration'
 
-ENTITY_ID_FORMAT = DOMAIN + '.{}'
+STATUS_IDLE = 'idle'
+STATUS_ACTIVE = 'active'
+STATUS_PAUSED = 'paused'
+
+EVENT_TIMER_FINISHED = 'timer.finished'
+EVENT_TIMER_CANCELLED = 'timer.cancelled'
 
 SERVICE_START = 'start'
 SERVICE_PAUSE = 'pause'

--- a/homeassistant/components/timer.py
+++ b/homeassistant/components/timer.py
@@ -106,7 +106,6 @@ def start(hass, entity_id,
           hours=DEFAULT_DURATION, minutes=DEFAULT_DURATION,
           seconds=DEFAULT_DURATION):
     """Start a timer."""
-    _LOGGER.warning("start")
     hass.add_job(async_start, hass, entity_id,
                  **{ATTR_ENTITY_ID: entity_id,
                     ATTR_WEEKS: weeks,
@@ -123,7 +122,6 @@ def async_start(hass, entity_id,
                 hours=DEFAULT_DURATION, minutes=DEFAULT_DURATION,
                 seconds=DEFAULT_DURATION):
     """Start a timer."""
-    _LOGGER.warning("async_start")
     hass.async_add_job(hass.services.async_call(
         DOMAIN, SERVICE_START, {ATTR_ENTITY_ID: entity_id,
                                 ATTR_WEEKS: weeks,
@@ -300,8 +298,6 @@ class Timer(Entity):
         end = dt_util.as_local(self._end) if self._end else None
         return {
             ATTR_DURATION: self._duration.__str__(),
-            #ATTR_START: self._start,
-            #ATTR_END: self._end,
             ATTR_START: start,
             ATTR_END: end,
             ATTR_REMAINING: self._remaining.__str__()

--- a/homeassistant/components/timer.py
+++ b/homeassistant/components/timer.py
@@ -18,31 +18,16 @@ from homeassistant.const import (ATTR_ENTITY_ID, CONF_ICON, CONF_NAME)
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.restore_state import async_get_last_state
 from homeassistant.helpers.event import async_track_point_in_utc_time
-from homeassistant.util import Throttle
 
 from homeassistant.loader import bind_hass
 
 _LOGGER = logging.getLogger(__name__)
 
-UPDATE_INTERVAL = timedelta(minutes=1)
-
-EVENT_TIMER_STARTED = 'timer.started'
-EVENT_TIMER_PAUSED = 'timer.paused'
 EVENT_TIMER_FINISHED = 'timer.finished'
 EVENT_TIMER_CANCELLED = 'timer.cancelled'
 
-ATTR_STATUS = 'status'
 ATTR_DURATION = 'duration'
-ATTR_START = 'start'
-ATTR_END = 'end'
-ATTR_REMAINING = 'remaining'
-ATTR_WEEKS = 'weeks'
-ATTR_DAYS = 'days'
-ATTR_HOURS = 'hours'
-ATTR_MINUTES = 'minutes'
-ATTR_SECONDS = 'seconds'
 
 STATUS_IDLE = 0
 STATUS_ACTIVE = 1
@@ -54,11 +39,7 @@ STATUS_MAPPING = {
     STATUS_PAUSED: 'paused'
 }
 
-CONF_WEEKS = 'weeks'
-CONF_DAYS = 'days'
-CONF_HOURS = 'hours'
-CONF_MINUTES = 'minutes'
-CONF_SECONDS = 'seconds'
+CONF_DURATION = 'duration'
 
 DEFAULT_DURATION = 0
 DOMAIN = 'timer'
@@ -76,11 +57,8 @@ SERVICE_SCHEMA = vol.Schema({
 
 SERVICE_SCHEMA_DURATION = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Optional(ATTR_WEEKS): cv.positive_int,
-    vol.Optional(ATTR_DAYS): cv.positive_int,
-    vol.Optional(ATTR_HOURS): cv.positive_int,
-    vol.Optional(ATTR_MINUTES): cv.positive_int,
-    vol.Optional(ATTR_SECONDS): cv.positive_int,
+    vol.Optional(ATTR_DURATION,
+                 default=timedelta(DEFAULT_DURATION)): cv.time_period,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -88,50 +66,27 @@ CONFIG_SCHEMA = vol.Schema({
         cv.slug: vol.Any({
             vol.Optional(CONF_NAME): cv.string,
             vol.Optional(CONF_ICON): cv.icon,
-            vol.Optional(CONF_WEEKS, default=DEFAULT_DURATION):
-                cv.positive_int,
-            vol.Optional(CONF_DAYS, default=DEFAULT_DURATION):
-                cv.positive_int,
-            vol.Optional(CONF_HOURS, default=DEFAULT_DURATION):
-                cv.positive_int,
-            vol.Optional(CONF_MINUTES, default=DEFAULT_DURATION):
-                cv.positive_int,
-            vol.Optional(CONF_SECONDS, default=DEFAULT_DURATION):
-                cv.positive_int,
+            vol.Optional(CONF_DURATION, timedelta(DEFAULT_DURATION)):
+                cv.time_period,
         }, None)
     })
 }, extra=vol.ALLOW_EXTRA)
 
 
 @bind_hass
-def sync_start(hass, entity_id,
-               weeks=DEFAULT_DURATION, days=DEFAULT_DURATION,
-               hours=DEFAULT_DURATION, minutes=DEFAULT_DURATION,
-               seconds=DEFAULT_DURATION):
+def sync_start(hass, entity_id, duration):
     """Start a timer."""
-    hass.add_job(async_start, hass, entity_id,
-                 **{ATTR_ENTITY_ID: entity_id,
-                    ATTR_WEEKS: weeks,
-                    ATTR_DAYS: days,
-                    ATTR_HOURS: hours,
-                    ATTR_MINUTES: minutes,
-                    ATTR_SECONDS: seconds})
+    hass.add_job(async_start, hass, entity_id, {ATTR_ENTITY_ID: entity_id,
+                                                ATTR_DURATION: duration})
 
 
 @callback
 @bind_hass
-def async_start(hass, entity_id,
-                weeks=DEFAULT_DURATION, days=DEFAULT_DURATION,
-                hours=DEFAULT_DURATION, minutes=DEFAULT_DURATION,
-                seconds=DEFAULT_DURATION):
+def async_start(hass, entity_id, duration):
     """Start a timer."""
     hass.async_add_job(hass.services.async_call(
         DOMAIN, SERVICE_START, {ATTR_ENTITY_ID: entity_id,
-                                ATTR_WEEKS: weeks,
-                                ATTR_DAYS: days,
-                                ATTR_HOURS: hours,
-                                ATTR_MINUTES: minutes,
-                                ATTR_SECONDS: seconds}))
+                                ATTR_DURATION: duration}))
 
 
 @bind_hass
@@ -189,14 +144,9 @@ def async_setup(hass, config):
 
         name = cfg.get(CONF_NAME)
         icon = cfg.get(CONF_ICON)
-        weeks = cfg.get(CONF_WEEKS)
-        days = cfg.get(CONF_DAYS)
-        hours = cfg.get(CONF_HOURS)
-        minutes = cfg.get(CONF_MINUTES)
-        seconds = cfg.get(CONF_SECONDS)
+        duration = cfg.get(CONF_DURATION)
 
-        entities.append(Timer(hass, object_id, name, icon,
-                              weeks, days, hours, minutes, seconds))
+        entities.append(Timer(hass, object_id, name, icon, duration))
 
     if not entities:
         return False
@@ -218,39 +168,28 @@ def async_setup(hass, config):
         if service.service == SERVICE_START:
             for timer in target_timers:
                 tasks.append(
-                    timer.async_start(
-                        weeks=service.data.get(
-                            ATTR_WEEKS, DEFAULT_DURATION),
-                        days=service.data.get(
-                            ATTR_DAYS, DEFAULT_DURATION),
-                        hours=service.data.get(
-                            ATTR_HOURS, DEFAULT_DURATION),
-                        minutes=service.data.get(
-                            ATTR_MINUTES, DEFAULT_DURATION),
-                        seconds=service.data.get(
-                            ATTR_SECONDS, DEFAULT_DURATION),
-                    )
+                    timer.async_start(service.data.get(ATTR_DURATION))
                 )
         if tasks:
             yield from asyncio.wait(tasks, loop=hass.loop)
 
     descriptions = yield from hass.async_add_job(
         load_yaml_config_file, os.path.join(
-            os.path.dirname(__file__), 'services.yaml')
+            os.path.dirname(__file__), os.path.join(DOMAIN, 'services.yaml'))
     )
 
     hass.services.async_register(
         DOMAIN, SERVICE_START, async_handler_service,
-        descriptions[DOMAIN][SERVICE_START], SERVICE_SCHEMA_DURATION)
+        descriptions[SERVICE_START], SERVICE_SCHEMA_DURATION)
     hass.services.async_register(
         DOMAIN, SERVICE_PAUSE, async_handler_service,
-        descriptions[DOMAIN][SERVICE_PAUSE], SERVICE_SCHEMA)
+        descriptions[SERVICE_PAUSE], SERVICE_SCHEMA)
     hass.services.async_register(
         DOMAIN, SERVICE_CANCEL, async_handler_service,
-        descriptions[DOMAIN][SERVICE_CANCEL], SERVICE_SCHEMA)
+        descriptions[SERVICE_CANCEL], SERVICE_SCHEMA)
     hass.services.async_register(
         DOMAIN, SERVICE_FINISH, async_handler_service,
-        descriptions[DOMAIN][SERVICE_FINISH], SERVICE_SCHEMA)
+        descriptions[SERVICE_FINISH], SERVICE_SCHEMA)
 
     yield from component.async_add_entities(entities)
     return True
@@ -259,18 +198,15 @@ def async_setup(hass, config):
 class Timer(Entity):
     """Representation of a timer."""
 
-    def __init__(self, hass, object_id, name, icon,
-                 weeks, days, hours, minutes, seconds):
+    def __init__(self, hass, object_id, name, icon, duration):
         """Initialize a timer."""
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)
         self._name = name
         self._state = STATUS_IDLE
-        self._duration = timedelta(weeks=weeks, days=days, hours=hours,
-                                   minutes=minutes, seconds=seconds)
+        self._duration = duration
         self._remaining = self._duration
         self._icon = icon
         self._hass = hass
-        self._start = None
         self._end = None
         self._listener = None
 
@@ -297,20 +233,9 @@ class Timer(Entity):
     @property
     def state_attributes(self):
         """Return the state attributes."""
-        start = dt_util.as_local(self._start) if self._start else None
-        end = dt_util.as_local(self._end) if self._end else None
         return {
             ATTR_DURATION: self._duration.__str__(),
-            ATTR_START: start,
-            ATTR_END: end,
-            ATTR_REMAINING: self._remaining.__str__()
         }
-
-    @Throttle(UPDATE_INTERVAL)
-    def update(self):
-        """Calculate remaining time."""
-        if self._state == STATUS_ACTIVE:
-            self._remaining = self._end - dt_util.utcnow()
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -319,35 +244,35 @@ class Timer(Entity):
         if self._state is not None:
             return
 
-        state = yield from async_get_last_state(self.hass, self.entity_id)
+        # pylint: disable=undefined-variable
+        state = yield from hass.helpers.restore_state.async_get_last_state(
+            self.entity_id)
         self._state = state and state.state == state
 
     @asyncio.coroutine
-    def async_start(self, **kwargs):
+    def async_start(self, duration):
         """Start a timer."""
         if self._listener:
             self._listener()
             self._listener = None
         newduration = None
-        if any(bool(v) for v in kwargs.values()):
-            newduration = timedelta(**kwargs)
+        if duration:
+            newduration = duration
 
         self._state = STATUS_ACTIVE
-        self._start = dt_util.utcnow()
+        start = dt_util.utcnow()
         if self._remaining and newduration is None:
-            self._end = self._start + self._remaining
+            self._end = start + self._remaining
         else:
             if newduration:
                 self._duration = newduration
                 self._remaining = newduration
             else:
                 self._remaining = self._duration
-            self._end = self._start + self._duration
+            self._end = start + self._duration
         self._listener = async_track_point_in_utc_time(self._hass,
                                                        self.async_finished,
                                                        self._end)
-        self._hass.bus.async_fire(EVENT_TIMER_STARTED,
-                                  {"entity_id": self.entity_id})
         yield from self.async_update_ha_state()
 
     @asyncio.coroutine
@@ -359,8 +284,6 @@ class Timer(Entity):
             self._remaining = self._end - dt_util.utcnow()
             self._state = STATUS_PAUSED
             self._end = None
-            self._hass.bus.async_fire(EVENT_TIMER_PAUSED,
-                                      {"entity_id": self.entity_id})
             yield from self.async_update_ha_state()
 
     @asyncio.coroutine
@@ -370,7 +293,6 @@ class Timer(Entity):
             self._listener()
             self._listener = None
         self._state = STATUS_IDLE
-        self._start = None
         self._end = None
         self._remaining = timedelta()
         self._hass.bus.async_fire(EVENT_TIMER_CANCELLED,

--- a/homeassistant/components/timer/services.yaml
+++ b/homeassistant/components/timer/services.yaml
@@ -1,0 +1,34 @@
+start:
+  description: Start a timer.
+
+  fields:
+    entity_id:
+      description: Entity id of the timer to start. [optional]
+      example: 'timer.timer0'
+    duration:
+      description: Duration the timer requires to finish. [optional]
+      example: '00:01:00 or 60'
+
+pause:
+  description: Pause a timer.
+
+  fields:
+    entity_id:
+      description: Entity id of the timer to pause. [optional]
+      example: 'timer.timer0'
+
+cancel:
+  description: Cancel a timer.
+
+  fields:
+    entity_id:
+      description: Entity id of the timer to cancel. [optional]
+      example: 'timer.timer0'
+
+finish:
+  description: Finish a timer.
+
+  fields:
+    entity_id:
+      description: Entity id of the timer to finish. [optional]
+      example: 'timer.timer0'

--- a/tests/components/test_timer.py
+++ b/tests/components/test_timer.py
@@ -1,0 +1,135 @@
+"""The tests for the timer component."""
+# pylint: disable=protected-access
+import asyncio
+import unittest
+import logging
+
+from homeassistant.core import CoreState, State
+from homeassistant.setup import setup_component, async_setup_component
+from homeassistant.components.timer import (
+    DOMAIN, sync_start, pause, cancel, finish, CONF_SECONDS, CONF_NAME,
+    CONF_ICON)
+from homeassistant.const import (ATTR_ICON, ATTR_FRIENDLY_NAME)
+
+from tests.common import (get_test_home_assistant, mock_restore_cache)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TestTimer(unittest.TestCase):
+    """Test the timer component."""
+
+    # pylint: disable=invalid-name
+    def setUp(self):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    # pylint: disable=invalid-name
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_config(self):
+        """Test config."""
+        invalid_configs = [
+            None,
+            1,
+            {},
+            {'name with space': None},
+        ]
+
+        for cfg in invalid_configs:
+            self.assertFalse(
+                setup_component(self.hass, DOMAIN, {DOMAIN: cfg}))
+
+    def test_methods(self):
+        """Test start, pause, cancel and finish methods."""
+        config = {
+            DOMAIN: {
+                'test_1': {
+                    CONF_SECONDS: 10
+                },
+            }
+        }
+
+        assert setup_component(self.hass, 'timer', config)
+
+        entity_id = 'timer.test_1'
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(0, int(state.state))
+
+    def test_methods_with_config(self):
+        """Test increment, decrement, and reset methods with configuration."""
+        config = {
+            DOMAIN: {
+                'test_2': {
+                    CONF_NAME: 'MyTimer',
+                    CONF_SECONDS: 10,
+                }
+            }
+        }
+
+        assert setup_component(self.hass, 'timer', config)
+
+        entity_id = 'timer.test_2'
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(0, int(state.state))
+
+    def test_config_options(self):
+        """Test configuration options."""
+        count_start = len(self.hass.states.entity_ids())
+
+        _LOGGER.debug('ENTITIES @ start: %s', self.hass.states.entity_ids())
+
+        config = {
+            DOMAIN: {
+                'test_1': {},
+                'test_2': {
+                    CONF_NAME: 'Hello World',
+                    CONF_ICON: 'mdi:work',
+                    CONF_SECONDS: 10,
+                }
+            }
+        }
+
+        assert setup_component(self.hass, 'timer', config)
+        self.hass.block_till_done()
+
+        _LOGGER.debug('ENTITIES: %s', self.hass.states.entity_ids())
+
+        self.assertEqual(count_start + 2, len(self.hass.states.entity_ids()))
+        self.hass.block_till_done()
+
+        state_1 = self.hass.states.get('timer.test_1')
+        state_2 = self.hass.states.get('timer.test_2')
+
+        self.assertIsNotNone(state_1)
+        self.assertIsNotNone(state_2)
+
+        #self.assertEqual(0, int(state_1.state))
+        self.assertNotIn(ATTR_ICON, state_1.attributes)
+        self.assertNotIn(ATTR_FRIENDLY_NAME, state_1.attributes)
+
+        #self.assertEqual(10, int(state_2.state))
+        self.assertEqual('Hello World',
+                         state_2.attributes.get(ATTR_FRIENDLY_NAME))
+        self.assertEqual('mdi:work', state_2.attributes.get(ATTR_ICON))
+
+
+@asyncio.coroutine
+def test_no_initial_state_and_no_restore_state(hass):
+    """Ensure that entity is create without initial and restore feature."""
+    hass.state = CoreState.starting
+
+    yield from async_setup_component(hass, DOMAIN, {
+        DOMAIN: {
+            'test1': {
+                CONF_SECONDS: 5,
+            }
+        }})
+
+    state = hass.states.get('timer.test1')
+    assert state
+    assert int(state.state) == 0

--- a/tests/components/test_timer.py
+++ b/tests/components/test_timer.py
@@ -8,9 +8,10 @@ from datetime import timedelta
 from homeassistant.core import CoreState
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.timer import (
-    DOMAIN, CONF_DURATION, CONF_NAME, STATUS_ACTIVE, STATUS_IDLE, STATUS_PAUSED,
-    CONF_ICON, ATTR_DURATION, EVENT_TIMER_FINISHED, EVENT_TIMER_CANCELLED,
-    SERVICE_START, SERVICE_PAUSE, SERVICE_CANCEL, SERVICE_FINISH)
+    DOMAIN, CONF_DURATION, CONF_NAME, STATUS_ACTIVE, STATUS_IDLE,
+    STATUS_PAUSED, CONF_ICON, ATTR_DURATION, EVENT_TIMER_FINISHED,
+    EVENT_TIMER_CANCELLED, SERVICE_START, SERVICE_PAUSE, SERVICE_CANCEL,
+    SERVICE_FINISH)
 from homeassistant.const import (ATTR_ICON, ATTR_FRIENDLY_NAME, CONF_ENTITY_ID)
 from homeassistant.util.dt import utcnow
 


### PR DESCRIPTION
## Description:
As mentioned by @pvizeli in https://github.com/home-assistant/home-assistant/pull/9870 and https://github.com/home-assistant/home-assistant/pull/9680#issuecomment-335622062 a dedicated timer component would be a useful addition to Home Assistant. This is my attempt of doing that.

### Services:
1. `timer.start` to start a timer (optionally with a specific duration, else with default duration or the remaining time if it was paused)
2. `timer.pause` to pause a running timer
3. `timer.cancel` to stop the timer, event `timer.cancelled`
3. `timer.finish` to stop the timer, event `timer.finished`

### Events: 
1. `timer.cancelled` when a running timer has been cancelled
2. `timer.finished` when a timer has reached its expiration time

I have included a sample configuration with a counter that shows the elapsed time since the timer has started. Maybe there's s smarter way doing that with templates, but for now this works.

_Outdated information:
The current implementation for some reason runs slower than it should. I used `async_track_time_interval` with a timedelta of 1 second. In reality it's around 2 seconds it takes to update. How can this be fixed?_

This is a modification of the counter-component, hence the same look in the UI for now. Ideally the UI would have buttons for the services of course.

Comments and suggestions for improvements are very welcome. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3747

## Example entry for `configuration.yaml` (if applicable):
```yaml
timer:
  timer:
    duration: 30
  timer2:
    duration: '0:00:30'

counter:
  elapsed:
    initial: 0
    step: 1

automation:
  - alias: timerstarted
    trigger:
      platform: time
      seconds: '/1'
    condition:
      condition: state
      entity_id: 'timer.timer'
      state: 'active'
    action:
      service: counter.increment
      data:
        entity_id: counter.elapsed
  - alias: timerfinished
    trigger:
      platform: event
      event_type: timer.finished
      event_data:
        entity_id: 'timer.timer'
    action:
      service: counter.reset
      data:
        entity_id: counter.elapsed
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
