### PR TITLE
Fix race condition for sync entities using throttle

### DIFF
--- a/homeassistant/components/sensor/bitcoin.py
+++ b/homeassistant/components/sensor/bitcoin.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_DISPLAY_OPTIONS, ATTR_ATTRIBUTION, CONF_CURRENCY)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
 
 REQUIREMENTS = ['blockchain==1.4.0']
 
@@ -178,6 +179,7 @@ class BitcoinData(object):
         self.stats = None
         self.ticker = None
 
+    @Throttle(SCAN_INTERVAL - timedelta(seconds=5))
     def update(self):
         """Get the latest data from blockchain.info."""
         from blockchain import statistics, exchangerates

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -374,6 +374,16 @@ class EntityPlatform(object):
         if not new_entities:
             return
 
+        hass = self.component.hass
+
+        # If the entities are not async, update them in sequence to avoid
+        # race conditions when component uses throttle.
+        if update_before_add and any(not hasattr(entity, 'async_update')
+                                     for entity in new_entities):
+            for entity in new_entities:
+                yield from hass.async_add_job(entity.update)
+            update_before_add = False
+
         @asyncio.coroutine
         def async_process_entity(new_entity):
             """Add entities to StateMachine."""
@@ -385,7 +395,7 @@ class EntityPlatform(object):
 
         tasks = [async_process_entity(entity) for entity in new_entities]
 
-        yield from asyncio.wait(tasks, loop=self.component.hass.loop)
+        yield from asyncio.wait(tasks, loop=hass.loop)
         self.component.async_update_group()
 
         if self._async_unsub_polling is not None or \
@@ -394,7 +404,7 @@ class EntityPlatform(object):
             return
 
         self._async_unsub_polling = async_track_time_interval(
-            self.component.hass, self._update_entity_states, self.scan_interval
+            hass, self._update_entity_states, self.scan_interval
         )
 
     @asyncio.coroutine


### PR DESCRIPTION
## Description:
I noticed that using the bitcoin sensor would lead to an exception on startup. After analyzing it I realized that `update_after_add` doesn't work as expected. We handle the situation correctly when `add_entities` is called on an entity component: we update all entities in sequence before passing adding them to Home Assistant.

However, we don't pass `add_entities` to `setup_platform` but instead give them `schedule_add_entities`. This method calls `async_schedule_add_entities` under the hood. `async_schedule_add_entities` will update the entities in parallel.

Updating entities in parallel that use a shared data resource with a throttle on the update function leads to updates being done before the actual data has been fetched:

 1. Call update on entity 1. Entity 1 calls shared_data.update() which makes a web request for 5s
 2. Call update on entity 2. Entity 2 calls shared_data.update() which returns immediately because it was called recently. However the web request is not done yet and thus the data has not been fetched.
 3. Entity 2 assumes update is done and writes to state machine. Since data is not fetched, blows up.
 4. shared_data.update() is done for Entity 1 and writes to state machine just fine. 

An alternative to this fix would be to update the throttle function to the following logic:

```
if called recently:
  return None

# This is new
if call in progress:
  wait till call done
  return None

call actual function()
```

CC @pvizeli 

## Exception without this fix

```
2017-10-15 17:21:13 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/tasks.py", line 182, in _step
    result = coro.throw(exc)
  File "/Users/paulus/dev/python/home-assistant/homeassistant/helpers/entity_component.py", line 391, in async_process_entity
    new_entity, self, update_before_add=update_before_add
  File "/Users/paulus/dev/python/home-assistant/homeassistant/helpers/entity_component.py", line 212, in async_add_entity
    yield from self.hass.async_add_job(entity.update)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/futures.py", line 332, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/tasks.py", line 250, in _wakeup
    future.result()
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/futures.py", line 245, in result
    raise self._exception
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/paulus/dev/python/home-assistant/homeassistant/components/sensor/bitcoin.py", line 130, in update
    self._state = '{0:.1f}'.format(stats.trade_volume_btc)
AttributeError: 'NoneType' object has no attribute 'trade_volume_btc'
```

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: bitcoin
    display_options:
      - exchangerate
      - trade_volume_btc
```
