### PR TITLE
Follow-up: Replace emulated_hue: with emulated_hue_hidden

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -23,7 +23,7 @@ from homeassistant.components.light import (
     SUPPORT_XY_COLOR, Light, PLATFORM_SCHEMA)
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (CONF_FILENAME, CONF_HOST, DEVICE_DEFAULT_NAME)
-from homeassistant.components.emulated_hue import ATTR_EMULATED_HUE
+from homeassistant.components.emulated_hue import ATTR_EMULATED_HUE_HIDDEN
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['phue==1.0']
@@ -471,7 +471,8 @@ class HueLight(Light):
         """Return the device state attributes."""
         attributes = {}
         if not self.allow_in_emulated_hue:
-            attributes[ATTR_EMULATED_HUE] = self.allow_in_emulated_hue
+            attributes[ATTR_EMULATED_HUE_HIDDEN] = \
+                not self.allow_in_emulated_hue
         if self.is_group:
             attributes[ATTR_IS_HUE_GROUP] = self.is_group
         return attributes


### PR DESCRIPTION
## Description:
Follow-up to PR #9382 

When lights in the hue component are used with the emulated hue component ATTR_EMULATED_HUE is still being used, which was deprecated by #9382. This updates ATTR_EMULATED_HUE to ATTR_EMULATED_HUE_HIDDEN to improve consistency and stop the deprecation warnings.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io #9382 

## Checklist:

dev branch currently does not pass `tox`: also note there is no test for hue.py

If the code communicates with devices, web services, or third-party tools:
  - [] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
