### PR TITLE
add last_action for xiaomi cube

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -12,6 +12,7 @@ ATTR_OPEN_SINCE = 'Open since'
 
 MOTION = 'motion'
 NO_MOTION = 'no_motion'
+ATTR_LAST_ACTION = 'last_action'
 ATTR_NO_MOTION_SINCE = 'No motion since'
 
 DENSITY = 'density'
@@ -327,9 +328,17 @@ class XiaomiCube(XiaomiBinarySensor):
     def __init__(self, device, hass, xiaomi_hub):
         """Initialize the Xiaomi Cube."""
         self._hass = hass
+        self._last_action = None
         self._state = False
         XiaomiBinarySensor.__init__(self, device, 'Cube', xiaomi_hub,
                                     None, None)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attrs = {ATTR_LAST_ACTION: self._last_action}
+        attrs.update(super().device_state_attributes)
+        return attrs
 
     def parse_data(self, data):
         """Parse data sent by gateway."""
@@ -338,6 +347,7 @@ class XiaomiCube(XiaomiBinarySensor):
                 'entity_id': self.entity_id,
                 'action_type': data['status']
             })
+            self._last_action = data['status']
 
         if 'rotate' in data:
             self._hass.bus.fire('cube_action', {
@@ -345,4 +355,6 @@ class XiaomiCube(XiaomiBinarySensor):
                 'action_type': 'rotate',
                 'action_value': float(data['rotate'].replace(",", "."))
             })
-        return False
+            self._last_action = 'rotate'
+
+        return True


### PR DESCRIPTION
## Description:

Feature request from @arsaboo : https://community.home-assistant.io/t/last-action-on-xiaomi-cube/29590


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3643

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
