### PR TITLE
Dependency version bump.

### DIFF
--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -14,7 +14,7 @@ from homeassistant.components.device_tracker import (
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT)
 
-REQUIREMENTS = ['librouteros==1.0.2']
+REQUIREMENTS = ['librouteros==1.0.4']
 
 MTK_DEFAULT_API_PORT = '8728'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -386,7 +386,7 @@ libpurecoollink==0.4.2
 libpyfoscam==1.0
 
 # homeassistant.components.device_tracker.mikrotik
-librouteros==1.0.2
+librouteros==1.0.4
 
 # homeassistant.components.media_player.soundtouch
 libsoundtouch==0.7.2


### PR DESCRIPTION
## Description:
Version bump for mikrotik component dependency. 

**Related issue (if applicable):** 
fixes #8213 
fixes #7575.

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.