### PR TITLE
Fix load of components without any config from packages

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -123,7 +123,7 @@ http_password: welcome
 
 PACKAGES_CONFIG_SCHEMA = vol.Schema({
     cv.slug: vol.Schema(  # Package names are slugs
-        {cv.slug: vol.Any(dict, list)})  # Only slugs for component names
+        {cv.slug: vol.Any(dict, list, None)})  # Only slugs for component names
 })
 
 CUSTOMIZE_CONFIG_SCHEMA = vol.Schema({


### PR DESCRIPTION
## Description:

Add `None` to the **packages config schema validation**, to be able to load components without any additional configuration from yaml package files, like `wake_on_lan:`, `media_extractor:` and so on.

Now, these components only can be loaded when defined in the main `configuration.yaml` file.


