### PR TITLE
Add emeter attributes

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -26,8 +26,6 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_CURRENT_CONSUMPTION = 'current_consumption'
 ATTR_DAILY_CONSUMPTION = 'daily_consumption'
 ATTR_MONTHLY_CONSUMPTION = 'monthly_consumption'
-ATTR_VOLTAGE = 'voltage'
-ATTR_CURRENT = 'current'
 
 SUPPORT_TPLINK = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP)
 

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -138,25 +138,31 @@ class TPLinkSmartBulb(Light):
                 self.smartbulb.state == self.smartbulb.BULB_STATE_ON)
             if self._name is None:
                 self._name = self.smartbulb.alias
-            if self.smartbulb.is_dimmable:
+            if self._supported_features & SUPPORT_BRIGHTNESS:
                 self._brightness = brightness_from_percentage(
                     self.smartbulb.brightness)
-            if self.smartbulb.is_variable_color_temp:
+            if self._supported_features & SUPPORT_COLOR_TEMP:
                 if (self.smartbulb.color_temp is not None and
                         self.smartbulb.color_temp != 0):
                     self._color_temp = kelvin_to_mired(
                         self.smartbulb.color_temp)
-            if self.smartbulb.is_color:
+            if self._supported_features & SUPPORT_RGB_COLOR:
                 self._rgb = hsv_to_rgb(self.smartbulb.hsv)
             if self.smartbulb.has_emeter:
                 self._emeter_params[ATTR_CURRENT_CONSUMPTION] \
                     = "%.1f W" % self.smartbulb.current_consumption()
                 daily_statistics = self.smartbulb.get_emeter_daily()
                 monthly_statistics = self.smartbulb.get_emeter_monthly()
-                self._emeter_params[ATTR_DAILY_CONSUMPTION] \
-                    = "%.2f kW" % daily_statistics[int(time.strftime("%d"))]
-                self._emeter_params[ATTR_MONTHLY_CONSUMPTION] \
-                    = "%.2f kW" % monthly_statistics[int(time.strftime("%m"))]
+                try:
+                    self._emeter_params[ATTR_DAILY_CONSUMPTION] \
+                        = "%.2f kW" % daily_statistics[int(
+                            time.strftime("%d"))]
+                    self._emeter_params[ATTR_MONTHLY_CONSUMPTION] \
+                        = "%.2f kW" % monthly_statistics[int(
+                            time.strftime("%m"))]
+                except KeyError:
+                    # device returned no daily/monthly history
+                    pass
         except (SmartDeviceException, OSError) as ex:
             _LOGGER.warning('Could not read state for %s: %s', self._name, ex)
 


### PR DESCRIPTION
## Description:
This adds energy attributes (emeter) the the TP-Link LBxxx series bulbs.
Reworks the supported features so the bulb isn't queried each time supported_features is called.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - ~~[ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  - ~~[ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  - ~~[ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
  - ~~[ ] New files were added to `.coveragerc`.~~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
