### PR TITLE
Corrects mistaken async items in RainMachine

### DIFF
--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -1,6 +1,5 @@
 """Implements a RainMachine sprinkler controller for Home Assistant."""
 
-import asyncio
 from datetime import timedelta
 from logging import getLogger
 
@@ -53,8 +52,7 @@ PLATFORM_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA)
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set this component up under its platform."""
     import regenmaschine as rm
 
@@ -114,7 +112,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                     zone_run_time,
                     device_name=rainmachine_device_name, ))
 
-        async_add_devices(entities)
+        add_devices(entities)
     except rm.exceptions.HTTPError as exc_info:
         _LOGGER.error('An HTTP error occurred while talking with RainMachine')
         _LOGGER.debug(exc_info)


### PR DESCRIPTION
## Description:
The RainMachine platform was incorrectly using `asyncio` (given that the underlying library doesn't utilize it) – the updates were fast enough to not mess with the scheduler too much, but still, it wasn't correct and could exacerbate things over time. This adjusts the platform to use the backwards-compatible API.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  platform: rainmachine
  ip_address: rainmachine.phil.lan
  password: password123
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
