### PR TITLE
Add transmission sensor: number of active torrents

### DIFF
--- a/homeassistant/components/sensor/transmission.py
+++ b/homeassistant/components/sensor/transmission.py
@@ -9,13 +9,13 @@ from datetime import timedelta
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_NAME, CONF_PORT,
-    CONF_MONITORED_VARIABLES, STATE_UNKNOWN, STATE_IDLE)
+    CONF_MONITORED_VARIABLES, STATE_IDLE)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['transmissionrpc==0.11']
 
@@ -26,10 +26,10 @@ DEFAULT_NAME = 'Transmission'
 DEFAULT_PORT = 9091
 
 SENSOR_TYPES = {
+    'active_torrents': ['Active Torrents', None],
     'current_status': ['Status', None],
     'download_speed': ['Down Speed', 'MB/s'],
     'upload_speed': ['Up Speed', 'MB/s'],
-    'active_torrents': ['Active Torrents', None]
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -81,7 +81,7 @@ class TransmissionSensor(Entity):
     def __init__(self, sensor_type, transmission_client, client_name):
         """Initialize the sensor."""
         self._name = SENSOR_TYPES[sensor_type][0]
-        self.transmission_client = transmission_client
+        self.tm_client = transmission_client
         self.type = sensor_type
         self.client_name = client_name
         self._state = None
@@ -118,9 +118,9 @@ class TransmissionSensor(Entity):
         self.refresh_transmission_data()
 
         if self.type == 'current_status':
-            if self.transmission_client.session:
-                upload = self.transmission_client.session.uploadSpeed
-                download = self.transmission_client.session.downloadSpeed
+            if self.tm_client.session:
+                upload = self.tm_client.session.uploadSpeed
+                download = self.tm_client.session.downloadSpeed
                 if upload > 0 and download > 0:
                     self._state = 'Up/Down'
                 elif upload > 0 and download == 0:
@@ -130,16 +130,16 @@ class TransmissionSensor(Entity):
                 else:
                     self._state = STATE_IDLE
             else:
-                self._state = STATE_UNKNOWN
+                self._state = None
 
-        if self.transmission_client.session:
+        if self.tm_client.session:
             if self.type == 'download_speed':
-                mb_spd = float(self.transmission_client.session.downloadSpeed)
+                mb_spd = float(self.tm_client.session.downloadSpeed)
                 mb_spd = mb_spd / 1024 / 1024
                 self._state = round(mb_spd, 2 if mb_spd < 0.1 else 1)
             elif self.type == 'upload_speed':
-                mb_spd = float(self.transmission_client.session.uploadSpeed)
+                mb_spd = float(self.tm_client.session.uploadSpeed)
                 mb_spd = mb_spd / 1024 / 1024
                 self._state = round(mb_spd, 2 if mb_spd < 0.1 else 1)
             elif self.type == 'active_torrents':
-                self._state = self.transmission_client.session.activeTorrentCount
+                self._state = self.tm_client.session.activeTorrentCount

--- a/homeassistant/components/sensor/transmission.py
+++ b/homeassistant/components/sensor/transmission.py
@@ -28,7 +28,8 @@ DEFAULT_PORT = 9091
 SENSOR_TYPES = {
     'current_status': ['Status', None],
     'download_speed': ['Down Speed', 'MB/s'],
-    'upload_speed': ['Up Speed', 'MB/s']
+    'upload_speed': ['Up Speed', 'MB/s'],
+    'active_torrents': ['Active Torrents', None]
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -140,3 +141,5 @@ class TransmissionSensor(Entity):
                 mb_spd = float(self.transmission_client.session.uploadSpeed)
                 mb_spd = mb_spd / 1024 / 1024
                 self._state = round(mb_spd, 2 if mb_spd < 0.1 else 1)
+            elif self.type == 'active_torrents':
+                self._state = self.transmission_client.session.activeTorrentCount


### PR DESCRIPTION
## Description:
This pull request adds a new sensor type for the transmission platform, to get the number of active torrents.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3655

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
   - platform: transmission
     host: IP_ADDRESS
     monitored_variables:
       - 'current_status'
       - 'download_speed'
       - 'upload_speed'
       - 'active_torrents'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)