### PR TITLE
Fix the resource naming in the UI

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -23,28 +23,28 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ARG = 'arg'
 
 SENSOR_TYPES = {
-    'disk_free': ['Disk Free', 'GiB', 'mdi:harddisk'],
-    'disk_use': ['Disk Use', 'GiB', 'mdi:harddisk'],
-    'disk_use_percent': ['Disk Use', '%', 'mdi:harddisk'],
+    'disk_free': ['Disk free', 'GiB', 'mdi:harddisk'],
+    'disk_use': ['Disk used', 'GiB', 'mdi:harddisk'],
+    'disk_use_percent': ['Disk used', '%', 'mdi:harddisk'],
     'ipv4_address': ['IPv4 address', '', 'mdi:server-network'],
     'ipv6_address': ['IPv6 address', '', 'mdi:server-network'],
-    'last_boot': ['Last Boot', '', 'mdi:clock'],
-    'load_15m': ['Average Load (15m)', '', 'mdi:memory'],
-    'load_1m': ['Average Load (1m)', '', 'mdi:memory'],
-    'load_5m': ['Average Load (5m)', '', 'mdi:memory'],
-    'memory_free': ['RAM Free', 'MiB', 'mdi:memory'],
-    'memory_use': ['RAM Use', 'MiB', 'mdi:memory'],
-    'memory_use_percent': ['RAM Use', '%', 'mdi:memory'],
+    'last_boot': ['Last boot', '', 'mdi:clock'],
+    'load_15m': ['Average load (15m)', '', 'mdi:memory'],
+    'load_1m': ['Average load (1m)', '', 'mdi:memory'],
+    'load_5m': ['Average load (5m)', '', 'mdi:memory'],
+    'memory_free': ['RAM available', 'MiB', 'mdi:memory'],
+    'memory_use': ['RAM used', 'MiB', 'mdi:memory'],
+    'memory_use_percent': ['RAM used', '%', 'mdi:memory'],
     'network_in': ['Received', 'MiB', 'mdi:server-network'],
     'network_out': ['Sent', 'MiB', 'mdi:server-network'],
     'packets_in': ['Packets received', ' ', 'mdi:server-network'],
     'packets_out': ['Packets sent', ' ', 'mdi:server-network'],
     'process': ['Process', ' ', 'mdi:memory'],
-    'processor_use': ['CPU Use', '%', 'mdi:memory'],
-    'since_last_boot': ['Since Last Boot', '', 'mdi:clock'],
-    'swap_free': ['Swap Free', 'GiB', 'mdi:harddisk'],
-    'swap_use': ['Swap Use', 'GiB', 'mdi:harddisk'],
-    'swap_use_percent': ['Swap Use', '%', 'mdi:harddisk'],
+    'processor_use': ['CPU used', '%', 'mdi:memory'],
+    'since_last_boot': ['Since last boot', '', 'mdi:clock'],
+    'swap_free': ['Swap free', 'GiB', 'mdi:harddisk'],
+    'swap_use': ['Swap used', 'GiB', 'mdi:harddisk'],
+    'swap_use_percent': ['Swap used', '%', 'mdi:harddisk'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -126,8 +126,9 @@ class SystemMonitorSensor(Entity):
         elif self.type == 'memory_use_percent':
             self._state = psutil.virtual_memory().percent
         elif self.type == 'memory_use':
-            self._state = round((psutil.virtual_memory().total -
-                                 psutil.virtual_memory().available) /
+            virtual_memory = psutil.virtual_memory()
+            self._state = round((virtual_memory.total -
+                                 virtual_memory.available) /
                                 1024**2, 1)
         elif self.type == 'memory_free':
             self._state = round(psutil.virtual_memory().available / 1024**2, 1)


### PR DESCRIPTION
Use proper English for the UI representation without breaking the component.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
