### PR TITLE
Only accept valid xiaomi sensor data

### DIFF
--- a/homeassistant/components/sensor/xiaomi_aqara.py
+++ b/homeassistant/components/sensor/xiaomi_aqara.py
@@ -67,9 +67,9 @@ class XiaomiSensor(XiaomiDevice):
         if value is None:
             return False
         value = float(value)
-        if self._data_key == 'temperature' and value == 10000:
+        if self._data_key == 'temperature' and (value < -20 or value > 60):
             return False
-        elif self._data_key == 'humidity' and value == 0:
+        elif self._data_key == 'humidity' and (value <= 0 or value > 100):
             return False
         elif self._data_key == 'illumination' and value == 0:
             return False


### PR DESCRIPTION
## Description:
Only accept xiaomi sensor values within range of the specifications: https://xiaomi-mi.com/sockets-and-sensors/xiaomi-mi-temperature-humidity-sensor/

**Related issue (if applicable):** fixes #9898


If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
