### PR TITLE
notify.xmpp - Add support for MUC

### DIFF
--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -83,7 +83,7 @@ def send_message(sender, password, recipient, use_tls,
             self.add_event_handler('failed_auth', self.check_credentials)
             self.add_event_handler('session_start', self.start)
             if room:
-                self.register_plugin('xep_0045') # MUC
+                self.register_plugin('xep_0045')  # MUC
             if not verify_certificate:
                 self.add_event_handler('ssl_invalid_cert',
                                        self.discard_ssl_invalid_cert)

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -22,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_TLS = 'tls'
 CONF_VERIFY = 'verify'
+CONF_ROOM = 'room'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SENDER): cv.string,
@@ -29,6 +30,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RECIPIENT): cv.string,
     vol.Optional(CONF_TLS, default=True): cv.boolean,
     vol.Optional(CONF_VERIFY, default=True): cv.boolean,
+    vol.Optional(CONF_ROOM, default=''): cv.string,
 })
 
 
@@ -37,31 +39,33 @@ def get_service(hass, config, discovery_info=None):
     return XmppNotificationService(
         config.get(CONF_SENDER), config.get(CONF_PASSWORD),
         config.get(CONF_RECIPIENT), config.get(CONF_TLS),
-        config.get(CONF_VERIFY))
+        config.get(CONF_VERIFY), config.get(CONF_ROOM))
 
 
 class XmppNotificationService(BaseNotificationService):
     """Implement the notification service for Jabber (XMPP)."""
 
-    def __init__(self, sender, password, recipient, tls, verify):
+    def __init__(self, sender, password, recipient, tls, verify, room):
         """Initialize the service."""
         self._sender = sender
         self._password = password
         self._recipient = recipient
         self._tls = tls
         self._verify = verify
+        self._room = room
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
         data = '{}: {}'.format(title, message) if title else message
 
-        send_message('{}/home-assistant'.format(self._sender), self._password,
-                     self._recipient, self._tls, self._verify, data)
+        send_message('{}/home-assistant'.format(self._sender),
+                     self._password, self._recipient, self._tls,
+                     self._verify, self._room, data)
 
 
 def send_message(sender, password, recipient, use_tls,
-                 verify_certificate, message):
+                 verify_certificate, room, message):
     """Send a message over XMPP."""
     import sleekxmpp
 
@@ -78,6 +82,8 @@ def send_message(sender, password, recipient, use_tls,
             self.use_ipv6 = False
             self.add_event_handler('failed_auth', self.check_credentials)
             self.add_event_handler('session_start', self.start)
+            if room:
+                self.register_plugin('xep_0045') # MUC
             if not verify_certificate:
                 self.add_event_handler('ssl_invalid_cert',
                                        self.discard_ssl_invalid_cert)
@@ -89,7 +95,13 @@ def send_message(sender, password, recipient, use_tls,
             """Start the communication and sends the message."""
             self.send_presence()
             self.get_roster()
-            self.send_message(mto=recipient, mbody=message, mtype='chat')
+
+            if room:
+                _LOGGER.debug("Joining room %s.", room)
+                self.plugin['xep_0045'].joinMUC(room, sender, wait=True)
+                self.send_message(mto=room, mbody=message, mtype='groupchat')
+            else:
+                self.send_message(mto=recipient, mbody=message, mtype='chat')
             self.disconnect(wait=True)
 
         def check_credentials(self, event):


### PR DESCRIPTION
## Description:
If user set the room variable, notification message will be sent to configured chatroom instead of direct message to recipient.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/pull/3664) with documentation.** https://github.com/home-assistant/home-assistant.github.io/pull/3664

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: xmpp
    name: jabber
    sender: bot@example.com
    password: !secret xmpp_password
    recipient: jdoe@example.com
    room: chatroom@conference.example.com
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
