### PR TITLE
Upgrade pyhomematic to 0.1.34

### DIFF
--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['pyhomematic==0.1.33']
+REQUIREMENTS = ['pyhomematic==0.1.34']
 
 DOMAIN = 'homematic'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -632,7 +632,7 @@ pyharmony==1.0.16
 pyhik==0.1.4
 
 # homeassistant.components.homematic
-pyhomematic==0.1.33
+pyhomematic==0.1.34
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==1.2.0


### PR DESCRIPTION
## Description:
Upgrading pyhomematic dependency. This fixes the HMIP-PSM devices that broke with the last version. Additionally support for the HmIP-RC8 is added.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
