### PR TITLE
Improve SSL certs used by aiohttp

### DIFF
--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -46,9 +46,6 @@ class CloudIoT:
         remove_hass_stop_listener = None
 
         session = async_get_clientsession(self.cloud.hass)
-        headers = {
-            hdrs.AUTHORIZATION: 'Bearer {}'.format(self.cloud.access_token)
-        }
 
         @asyncio.coroutine
         def _handle_hass_stop(event):
@@ -63,7 +60,10 @@ class CloudIoT:
             yield from hass.async_add_job(auth_api.check_token, self.cloud)
 
             self.client = client = yield from session.ws_connect(
-                self.cloud.relayer, headers=headers)
+                self.cloud.relayer, headers={
+                    hdrs.AUTHORIZATION:
+                        'Bearer {}'.format(self.cloud.access_token)
+                })
             self.tries = 0
 
             remove_hass_stop_listener = hass.bus.async_listen_once(

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -161,7 +161,7 @@ def _async_get_connector(hass, verify_ssl=True):
 
     if verify_ssl:
         if DATA_CONNECTOR not in hass.data:
-            ssl_context = ssl.SSLContext()
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             ssl_context.load_verify_locations(cafile=certifi.where(),
                                               capath=None)
             connector = aiohttp.TCPConnector(loop=hass.loop,

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -1,5 +1,6 @@
 """Helper for aiohttp webclient stuff."""
 import asyncio
+import ssl
 import sys
 
 import aiohttp
@@ -7,6 +8,7 @@ from aiohttp.hdrs import USER_AGENT, CONTENT_TYPE
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPGatewayTimeout, HTTPBadGateway
 import async_timeout
+import certifi
 
 from homeassistant.core import callback
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, __version__
@@ -159,7 +161,11 @@ def _async_get_connector(hass, verify_ssl=True):
 
     if verify_ssl:
         if DATA_CONNECTOR not in hass.data:
-            connector = aiohttp.TCPConnector(loop=hass.loop)
+            ssl_context = ssl.SSLContext()
+            ssl_context.load_verify_locations(cafile=certifi.where(),
+                                              capath=None)
+            connector = aiohttp.TCPConnector(loop=hass.loop,
+                                             ssl_context=ssl_context)
             hass.data[DATA_CONNECTOR] = connector
             is_new = True
         else:

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -9,6 +9,7 @@ aiohttp==2.2.5
 async_timeout==1.4.0
 chardet==3.0.4
 astral==1.4
+certifi>=2017.4.17
 
 # Breaks Python 3.6 and is not needed for our supported Pythons
 enum34==1000000000.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -10,6 +10,7 @@ aiohttp==2.2.5
 async_timeout==1.4.0
 chardet==3.0.4
 astral==1.4
+certifi>=2017.4.17
 
 # homeassistant.components.nuimo_controller
 --only-binary=all https://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ REQUIRES = [
     'async_timeout==1.4.0',
     'chardet==3.0.4',
     'astral==1.4',
+    'certifi>=2017.4.17',
 ]
 
 setup(


### PR DESCRIPTION
## Description:
Requests defaults to using a Mozilla curated cert bundle instead of the system default. This sets the same cert bundle for aiohttp.