### PR TITLE
Change persistent notification to avoid long text in entity state

### DIFF
--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -43,6 +43,8 @@ SCHEMA_SERVICE_DISMISS = vol.Schema({
 DEFAULT_OBJECT_ID = 'notification'
 _LOGGER = logging.getLogger(__name__)
 
+STATE = 'notifying'
+
 
 @bind_hass
 def create(hass, message, title=None, notification_id=None):
@@ -115,7 +117,7 @@ def async_setup(hass, config):
 
         attr[ATTR_MESSAGE] = message
 
-        hass.states.async_set(entity_id, None, attr)
+        hass.states.async_set(entity_id, STATE, attr)
 
     @callback
     def dismiss_service(call):

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -113,7 +113,9 @@ def async_setup(hass, config):
             _LOGGER.error('Error rendering message %s: %s', message, ex)
             message = message.template
 
-        hass.states.async_set(entity_id, message, attr)
+        attr[ATTR_MESSAGE] = message
+
+        hass.states.async_set(entity_id, None, attr)
 
     @callback
     def dismiss_service(call):

--- a/tests/components/persistent_notification/test_init.py
+++ b/tests/components/persistent_notification/test_init.py
@@ -29,7 +29,7 @@ class TestPersistentNotification:
         assert len(entity_ids) == 1
 
         state = self.hass.states.get(entity_ids[0])
-        assert state.state == 'Hello World 2'
+        assert state.attributes.get('message') == 'Hello World 2'
         assert state.attributes.get('title') == '2 beers'
 
     def test_create_notification_id(self):
@@ -41,7 +41,7 @@ class TestPersistentNotification:
 
         assert len(self.hass.states.entity_ids()) == 1
         state = self.hass.states.get('persistent_notification.beer_2')
-        assert state.state == 'test'
+        assert state.attributes.get('message') == 'test'
 
         pn.create(self.hass, 'test 2', notification_id='Beer 2')
         self.hass.block_till_done()
@@ -49,7 +49,7 @@ class TestPersistentNotification:
         # We should have overwritten old one
         assert len(self.hass.states.entity_ids()) == 1
         state = self.hass.states.get('persistent_notification.beer_2')
-        assert state.state == 'test 2'
+        assert state.attributes.get('message') == 'test 2'
 
     def test_create_template_error(self):
         """Ensure we output templates if contain error."""
@@ -62,7 +62,7 @@ class TestPersistentNotification:
         assert len(entity_ids) == 1
 
         state = self.hass.states.get(entity_ids[0])
-        assert state.state == '{{ message + 1 }}'
+        assert state.attributes.get('message') == '{{ message + 1 }}'
         assert state.attributes.get('title') == '{{ title + 1 }}'
 
     def test_dismiss_notification(self):

--- a/tests/components/persistent_notification/test_init.py
+++ b/tests/components/persistent_notification/test_init.py
@@ -29,6 +29,7 @@ class TestPersistentNotification:
         assert len(entity_ids) == 1
 
         state = self.hass.states.get(entity_ids[0])
+        assert state.state == pn.STATE
         assert state.attributes.get('message') == 'Hello World 2'
         assert state.attributes.get('title') == '2 beers'
 


### PR DESCRIPTION
## Description:

Change persistent notification component to address long state issue, as discussed in PR:

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/pull/9696

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
