### PR TITLE
Introducing multi-zone support for yamaha_musiccast devices

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,6 +51,7 @@ homeassistant/components/light/tplink.py @rytilahti
 homeassistant/components/light/yeelight.py @rytilahti
 homeassistant/components/media_player/kodi.py @armills
 homeassistant/components/media_player/monoprice.py @etsinko
+homeassistant/components/media_player/yamaha_musiccast.py @jalmeroth
 homeassistant/components/sensor/airvisual.py @bachya
 homeassistant/components/sensor/irish_rail_transport.py @ttroy50
 homeassistant/components/sensor/miflora.py @danielhiversen

--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -205,7 +205,8 @@ class YamahaDevice(MediaPlayerDevice):
         # call from constructor setup_platform()
         if not self.entity_id:
             _LOGGER.debug("First run")
-            self._recv.update_status(push=False)
+            self._recv.update_status()
+            self._zone.update_status()
         # call from regular polling
         else:
             # update_status_timer was set before
@@ -214,6 +215,7 @@ class YamahaDevice(MediaPlayerDevice):
                 if not self._recv.update_status_timer.is_alive():
                     _LOGGER.debug("Reinitializing")
                     self._recv.update_status()
+                    self._zone.update_status()
 
     def turn_on(self):
         """Turn on specified media player or all."""

--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -201,21 +201,8 @@ class YamahaDevice(MediaPlayerDevice):
     def update(self):
         """Get the latest details from the device."""
         _LOGGER.debug("update: %s", self.entity_id)
-
-        # call from constructor setup_platform()
-        if not self.entity_id:
-            _LOGGER.debug("First run")
-            self._recv.update_status()
-            self._zone.update_status()
-        # call from regular polling
-        else:
-            # update_status_timer was set before
-            if self._recv.update_status_timer:
-                # e.g. computer was suspended, while hass was running
-                if not self._recv.update_status_timer.is_alive():
-                    _LOGGER.debug("Reinitializing")
-                    self._recv.update_status()
-                    self._zone.update_status()
+        self._recv.update_status()
+        self._zone.update_status()
 
     def turn_on(self):
         """Turn on specified media player or all."""

--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -35,7 +35,7 @@ SUPPORTED_FEATURES = (
 KNOWN_HOSTS_KEY = 'data_yamaha_musiccast'
 INTERVAL_SECONDS = 'interval_seconds'
 
-REQUIREMENTS = ['pymusiccast==0.1.2']
+REQUIREMENTS = ['pymusiccast==0.1.3']
 
 DEFAULT_PORT = 5005
 DEFAULT_INTERVAL = 480

--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -2,7 +2,6 @@
 
 media_player:
   - platform: yamaha_musiccast
-    name: "Living Room"
     host: 192.168.xxx.xx
     port: 5005
 
@@ -13,7 +12,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant.const import (
-    CONF_NAME, CONF_HOST, CONF_PORT,
+    CONF_HOST, CONF_PORT,
     STATE_UNKNOWN, STATE_ON
 )
 from homeassistant.components.media_player import (
@@ -41,7 +40,6 @@ DEFAULT_NAME = "Yamaha Receiver"
 DEFAULT_PORT = 5005
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.positive_int,
 })
@@ -57,7 +55,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         known_hosts = hass.data[KNOWN_HOSTS_KEY] = []
     _LOGGER.debug("known_hosts: %s", known_hosts)
 
-    name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
 
@@ -92,7 +89,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 "receiver: %s / Port: %d / Zone: %s",
                 receiver, port, zone)
             add_devices(
-                [YamahaDevice(receiver, name, receiver.zones[zone])],
+                [YamahaDevice(receiver, receiver.zones[zone])],
                 True)
     else:
         known_hosts.remove(reg_host)
@@ -101,10 +98,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class YamahaDevice(MediaPlayerDevice):
     """Representation of a Yamaha MusicCast device."""
 
-    def __init__(self, recv, name, zone):
+    def __init__(self, recv, zone):
         """Initialize the Yamaha MusicCast device."""
         self._recv = recv
-        self._name = name
+        self._name = recv.name
         self._source = None
         self._source_list = []
         self._zone = zone

--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -210,9 +210,6 @@ class YamahaDevice(MediaPlayerDevice):
         else:
             # update_status_timer was set before
             if self._recv.update_status_timer:
-                _LOGGER.debug(
-                    "is_alive: %s",
-                    self._recv.update_status_timer.is_alive())
                 # e.g. computer was suspended, while hass was running
                 if not self._recv.update_status_timer.is_alive():
                     _LOGGER.debug("Reinitializing")

--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -33,15 +33,17 @@ SUPPORTED_FEATURES = (
 )
 
 KNOWN_HOSTS_KEY = 'data_yamaha_musiccast'
+INTERVAL_SECONDS = 'interval_seconds'
 
 REQUIREMENTS = ['pymusiccast==0.1.2']
 
-DEFAULT_NAME = "Yamaha Receiver"
 DEFAULT_PORT = 5005
+DEFAULT_INTERVAL = 480
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.positive_int,
+    vol.Optional(INTERVAL_SECONDS, default=DEFAULT_INTERVAL): cv.positive_int,
 })
 
 
@@ -57,6 +59,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
+    interval = config.get(INTERVAL_SECONDS)
 
     # Get IP of host to prevent duplicates
     try:
@@ -78,7 +81,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     known_hosts.append(reg_host)
 
     try:
-        receiver = pymusiccast.McDevice(ipaddr, udp_port=port)
+        receiver = pymusiccast.McDevice(
+            ipaddr, udp_port=port, mc_interval=interval)
     except pymusiccast.exceptions.YMCInitError as err:
         _LOGGER.error(err)
         receiver = None

--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -101,20 +101,20 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class YamahaDevice(MediaPlayerDevice):
     """Representation of a Yamaha MusicCast device."""
 
-    def __init__(self, receiver, name, zone):
+    def __init__(self, recv, name, zone):
         """Initialize the Yamaha MusicCast device."""
-        self._receiver = receiver
+        self._recv = recv
         self._name = name
-        self._zone = zone
-        self.power = STATE_UNKNOWN
-        self.volume = 0
-        self.volume_max = 0
-        self.mute = False
         self._source = None
         self._source_list = []
-        self.status = STATE_UNKNOWN
+        self._zone = zone
+        self.mute = False
         self.media_status = None
-        self._receiver.set_yamaha_device(self)
+        self.power = STATE_UNKNOWN
+        self.status = STATE_UNKNOWN
+        self.volume = 0
+        self.volume_max = 0
+        self._recv.set_yamaha_device(self)
         self._zone.set_yamaha_device(self)
 
     @property
@@ -208,18 +208,18 @@ class YamahaDevice(MediaPlayerDevice):
         # call from constructor setup_platform()
         if not self.entity_id:
             _LOGGER.debug("First run")
-            self._receiver.update_status(push=False)
+            self._recv.update_status(push=False)
         # call from regular polling
         else:
             # update_status_timer was set before
-            if self._receiver.update_status_timer:
+            if self._recv.update_status_timer:
                 _LOGGER.debug(
                     "is_alive: %s",
-                    self._receiver.update_status_timer.is_alive())
+                    self._recv.update_status_timer.is_alive())
                 # e.g. computer was suspended, while hass was running
-                if not self._receiver.update_status_timer.is_alive():
+                if not self._recv.update_status_timer.is_alive():
                     _LOGGER.debug("Reinitializing")
-                    self._receiver.update_status()
+                    self._recv.update_status()
 
     def turn_on(self):
         """Turn on specified media player or all."""
@@ -234,27 +234,27 @@ class YamahaDevice(MediaPlayerDevice):
     def media_play(self):
         """Send the media player the command for play/pause."""
         _LOGGER.debug("Play")
-        self._receiver.set_playback("play")
+        self._recv.set_playback("play")
 
     def media_pause(self):
         """Send the media player the command for pause."""
         _LOGGER.debug("Pause")
-        self._receiver.set_playback("pause")
+        self._recv.set_playback("pause")
 
     def media_stop(self):
         """Send the media player the stop command."""
         _LOGGER.debug("Stop")
-        self._receiver.set_playback("stop")
+        self._recv.set_playback("stop")
 
     def media_previous_track(self):
         """Send the media player the command for prev track."""
         _LOGGER.debug("Previous")
-        self._receiver.set_playback("previous")
+        self._recv.set_playback("previous")
 
     def media_next_track(self):
         """Send the media player the command for next track."""
         _LOGGER.debug("Next")
-        self._receiver.set_playback("next")
+        self._recv.set_playback("next")
 
     def mute_volume(self, mute):
         """Send mute command."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -717,7 +717,7 @@ pymodbus==1.3.1
 pymonoprice==0.2
 
 # homeassistant.components.media_player.yamaha_musiccast
-pymusiccast==0.1.2
+pymusiccast==0.1.3
 
 # homeassistant.components.cover.myq
 pymyq==0.0.8


### PR DESCRIPTION
## Description:
This release introduces multi-zone support for linked devices in `media_player.yamaha_musiccast` component.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3676

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: yamaha_musiccast
    host: 192.168.xxx.xx
    port: 5005
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

## Breaking change:
The name attribute was removed in favour of getting the name directly from the device. Devices will follow the naming scheme `deviceName_zone` from now on. Please update your configuration/automations accordingly.