### PR TITLE
Add fail2ban sensor

### DIFF
--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -127,10 +127,11 @@ class BanLogParser(object):
         """Check if we are allowed to update."""
         boundary = dt_util.now() - self.interval
         if boundary > self.last_update:
-            last_update = dt_util.now()
+            self.last_update = dt_util.now()
             return True
 
     def read_log(self, jail):
+        """Read the fail2ban log and find entries for jail."""
         self.data = list()
         try:
             with open(self.log_file, 'r', encoding='utf-8') as file_data:

--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -87,7 +87,6 @@ class BanSensor(Entity):
         if self.log_parser.timer():
             self.log_parser.read_log(self.jail)
 
-        self.last_ban = 'None'
         if self.log_parser.data:
             for entry in self.log_parser.data:
                 _LOGGER.debug(entry)

--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -1,0 +1,115 @@
+"""
+Support for displaying IPs banned by fail2ban.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.fail2ban/
+"""
+import os
+import asyncio
+from datetime import timedelta
+import logging
+
+import voluptuous as voluptuous
+
+import homeassistant.helper.config_validation as cv
+import homeassistant.util.dt as dt_util
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME, CONF_SCAN_INTERVAL, CONF_FILE_PATH
+)
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_JAILS = 'jails'
+
+DEFAULT_NAME = 'fail2ban'
+DEFAULT_LOG = '/var/log/syslog'
+DEFAULT_SCAN_INTERVAL = 120
+
+STATE_BANS = 'current_bans'
+STATE_COUNT = 'total_bans'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_JAILS, default=[]): 
+        vol.All(cv.ensure_list, vol.Length(min=1)),
+    vol.Optional(CONF_FILE_PATH, default=DEFAULT_LOG): cv.isfile,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SCAN_INTERVAL,default=DEFAULT_SCAN_INTERVAL): 
+        cv.positive_int,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the fail2ban sensor."""
+    name = config.get(CONF_NAME)
+    jails = config.get(CONF_JAILS)
+    scan_interval = config.get(CONF_SCAN_INTERVAL)
+    log_file = config.get(CONF_FILE_PATH)
+
+    device_list = []
+    for jail in jails:
+        device_list.append(BanSensor(name, jail, scan_interval, log_file))
+
+    async_add_devices(device_list, True)
+
+
+class BanSensor(Entity):
+    """Implementation of a fail2ban sensor."""
+
+    def __init__(self, name, jail, scan_interval, log_file):
+        """Initialize the sensor."""
+        self._name = name
+        self.jail = jail
+        self.interval = timedelta(seconds=scan_interval)
+        self.log_file = log_file
+        self.ban_dict = {STATE_BANS: [], STATE_COUNT: 0}
+        self.last_ban = None
+        self.last_update = dt_util.now()
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the fail2ban sensor."""
+        return self.ban_dict
+
+    @property
+    def state(self):
+        """Return the most recently banned IP Address."""
+        return self.last_ban
+
+    def update(self):
+        """Update the list of banned ips."""
+        boundary = dt_util.now() - self.interval
+        jail_data = list()
+        if boundary > self.last_update:
+            _LOGGER.info("Checking log for ip bans in %s", self.jail)
+            try:
+                with open(self.log_file, 'r', encoding='utf-8') as file_data:
+                    for line in file_data:
+                        if self.jail and 'fail2ban.action' in line:
+                            jail_data.append(line)
+            except (IndexError, FileNotFoundError, IsADirectoryError,
+                    UnboundLocalError):
+                _LOGGER.warning("File or data not present at the moment: %s",
+                                os.path.basename(self._file_path))
+                return
+        if jail_data:
+            for entry in jail_data:
+                _LOGGER.debug(entry)
+                split_entry = entry.split()
+                if 'Ban' in split_entry:
+                    ip_index = split_entry.index('Ban') + 1
+                    this_ban = split_entry[ip_index]
+                    if this_ban not in self.ban_dict[STATE_BANS]:
+                        self.last_ban = this_ban
+                        self.ban_dict[STATE_BANS].append(self.last_ban)
+                        self.ban_dict[STATE_COUNT] += 1
+                elif 'Unban' in split_entry:
+                    ip_index = split_entry.index('Unban') + 1
+                    this_unban = split_entry[ip_index]
+                    if this_unban in self.ban_dict[STATE_BANS]:
+                        self.ban_dict[STATE_BANS].remove(this_unban)
+        else:
+            self.last_ban = 'None'
+    

--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -8,8 +8,9 @@ import os
 import asyncio
 import logging
 
-import re
+from datetime import timedelta
 
+import re
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -26,7 +27,7 @@ CONF_JAILS = 'jails'
 
 DEFAULT_NAME = 'fail2ban'
 DEFAULT_LOG = '/var/log/fail2ban.log'
-SCAN_INTERVAL = 120
+SCAN_INTERVAL = timedelta(seconds=120)
 
 STATE_CURRENT_BANS = 'current_bans'
 STATE_ALL_BANS = 'total_bans'

--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -26,7 +26,7 @@ CONF_JAILS = 'jails'
 
 DEFAULT_NAME = 'fail2ban'
 DEFAULT_LOG = '/var/log/fail2ban.log'
-DEFAULT_SCAN_INTERVAL = 120
+SCAN_INTERVAL = 120
 
 STATE_CURRENT_BANS = 'current_bans'
 STATE_ALL_BANS = 'total_bans'
@@ -36,8 +36,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, vol.Length(min=1)),
     vol.Optional(CONF_FILE_PATH, default=DEFAULT_LOG): cv.isfile,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
-        cv.positive_timedelta,
 })
 
 

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -3,7 +3,6 @@ import unittest
 from unittest.mock import Mock, patch
 
 from datetime import timedelta
-
 from mock_open import MockOpen
 
 from homeassistant.setup import setup_component

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -1,0 +1,146 @@
+"""The tests for local file sensor platform."""
+import unittest
+from unittest import mock
+from unittest.mock import Mock, patch
+
+from mock_open import MockOpen
+
+from datetime import timedelta
+
+from homeassistant.setup import setup_component
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.components.sensor.fail2ban import (
+    BanSensor, STATE_CURRENT_BANS, STATE_ALL_BANS
+)
+
+from tests.common import get_test_home_assistant, assert_setup_component
+
+
+class TestBanSensor(unittest.TestCase):
+    """Test the fail2ban sensor."""
+
+    def setUp(self):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def fake_log(self, log_key):
+        """Return a fake fail2ban log."""
+        fake_log_dict = {
+            'single_ban': '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 111.111.111.111',
+            'multi_ban': 
+                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 111.111.111.111\n' \
+                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 222.222.222.222',
+            'multi_jail':
+                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 111.111.111.111\n' \
+                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_two] Ban 222.222.222.222',
+            'unban_all': 
+                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 111.111.111.111\n' \
+                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Unban 111.111.111.111\n' \
+                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 222.222.222.222\n' \
+                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Unban 222.222.222.222',
+            'unban_one': 
+                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 111.111.111.111\n' \
+                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 222.222.222.222\n' \
+                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Unban 111.111.111.111',
+        }
+        return fake_log_dict[log_key]
+
+    @patch('os.path.isfile', Mock(return_value=True))
+    def test_setup(self):
+        """Test that sensor can be setup."""
+        config = {
+            'sensor': {
+                'platform': 'fail2ban',
+                'jails': ['jail_one']
+            }
+        }
+        mock_fh = MockOpen()
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+            assert setup_component(self.hass, 'sensor', config)
+            self.hass.block_till_done()
+        assert_setup_component(1, 'sensor')
+
+    @patch('os.path.isfile', Mock(return_value=True))
+    def test_multi_jails(self):
+        """Test that multiple jails can be set up as sensors.."""
+        config = {
+            'sensor': {
+                'platform': 'fail2ban',
+                'jails': ['jail_one', 'jail_two']
+            }
+        }
+        mock_fh = MockOpen()
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+            assert setup_component(self.hass, 'sensor', config)
+            self.hass.block_till_done()
+        assert_setup_component(2, 'sensor')
+
+    def test_single_ban(self):
+        """Tests that log is parsed correctly for single ban."""
+        sensor = BanSensor('fail2ban', 'jail_one', timedelta(seconds=-1), '/tmp')
+        self.assertEqual(sensor.name, 'fail2ban jail_one')
+        mock_fh = MockOpen(read_data=self.fake_log('single_ban'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+            sensor.update()
+
+        self.assertEqual(sensor.state, '111.111.111.111')
+        self.assertEqual(sensor.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111'])
+        self.assertEqual(sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111'])
+
+    def test_multiple_ban(self):
+        """Tests that log is parsed correctly for multiple ban."""
+        sensor = BanSensor('fail2ban', 'jail_one', timedelta(seconds=-1), '/tmp')
+        self.assertEqual(sensor.name, 'fail2ban jail_one')
+        mock_fh = MockOpen(read_data=self.fake_log('multi_ban'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+            sensor.update()
+
+        self.assertEqual(sensor.state, '222.222.222.222')
+        self.assertEqual(sensor.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111', '222.222.222.222'])
+        self.assertEqual(sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111', '222.222.222.222'])
+
+    def test_unban_all(self):
+        """Tests that log is parsed correctly when unbanning."""
+        sensor = BanSensor('fail2ban', 'jail_one', timedelta(seconds=-1), '/tmp')
+        self.assertEqual(sensor.name, 'fail2ban jail_one')
+        mock_fh = MockOpen(read_data=self.fake_log('unban_all'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+            sensor.update()
+
+        self.assertEqual(sensor.state, 'None')
+        self.assertEqual(sensor.state_attributes[STATE_CURRENT_BANS], [])
+        self.assertEqual(sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111', '222.222.222.222'])
+
+    def test_unban_one(self):
+        """Tests that log is parsed correctly when unbanning one ip."""
+        sensor = BanSensor('fail2ban', 'jail_one', timedelta(seconds=-1), '/tmp')
+        self.assertEqual(sensor.name, 'fail2ban jail_one')
+        mock_fh = MockOpen(read_data=self.fake_log('unban_one'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+            sensor.update()
+
+        self.assertEqual(sensor.state, '222.222.222.222')
+        self.assertEqual(sensor.state_attributes[STATE_CURRENT_BANS], ['222.222.222.222'])
+        self.assertEqual(sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111', '222.222.222.222'])
+
+    def test_multi_jail(self):
+        """Tests that log is parsed correctly when using multiple jails."""
+        sensor1 = BanSensor('fail2ban', 'jail_one', timedelta(seconds=-1), '/tmp')
+        sensor2 = BanSensor('fail2ban', 'jail_two', timedelta(seconds=-1), '/tmp')
+        self.assertEqual(sensor1.name, 'fail2ban jail_one')
+        self.assertEqual(sensor2.name, 'fail2ban jail_two')
+        mock_fh = MockOpen(read_data=self.fake_log('multi_jail'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+            sensor1.update()
+            sensor2.update()
+        
+        self.assertEqual(sensor1.state, '111.111.111.111')
+        self.assertEqual(sensor1.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111'])
+        self.assertEqual(sensor1.state_attributes[STATE_ALL_BANS], ['111.111.111.111'])
+        self.assertEqual(sensor2.state, '222.222.222.222')
+        self.assertEqual(sensor2.state_attributes[STATE_CURRENT_BANS], ['222.222.222.222'])
+        self.assertEqual(sensor2.state_attributes[STATE_ALL_BANS], ['222.222.222.222'])

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 from homeassistant.setup import setup_component
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.components.sensor.fail2ban import (
-    BanSensor, STATE_CURRENT_BANS, STATE_ALL_BANS
+    BanSensor, BanLogParser, STATE_CURRENT_BANS, STATE_ALL_BANS
 )
 
 from tests.common import get_test_home_assistant, assert_setup_component
@@ -81,7 +81,8 @@ class TestBanSensor(unittest.TestCase):
 
     def test_single_ban(self):
         """Tests that log is parsed correctly for single ban."""
-        sensor = BanSensor('fail2ban', 'jail_one', timedelta(seconds=-1), '/tmp')
+        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        sensor = BanSensor('fail2ban', 'jail_one', log_parser)
         self.assertEqual(sensor.name, 'fail2ban jail_one')
         mock_fh = MockOpen(read_data=self.fake_log('single_ban'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
@@ -93,7 +94,8 @@ class TestBanSensor(unittest.TestCase):
 
     def test_multiple_ban(self):
         """Tests that log is parsed correctly for multiple ban."""
-        sensor = BanSensor('fail2ban', 'jail_one', timedelta(seconds=-1), '/tmp')
+        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        sensor = BanSensor('fail2ban', 'jail_one', log_parser)
         self.assertEqual(sensor.name, 'fail2ban jail_one')
         mock_fh = MockOpen(read_data=self.fake_log('multi_ban'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
@@ -105,7 +107,8 @@ class TestBanSensor(unittest.TestCase):
 
     def test_unban_all(self):
         """Tests that log is parsed correctly when unbanning."""
-        sensor = BanSensor('fail2ban', 'jail_one', timedelta(seconds=-1), '/tmp')
+        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        sensor = BanSensor('fail2ban', 'jail_one', log_parser)
         self.assertEqual(sensor.name, 'fail2ban jail_one')
         mock_fh = MockOpen(read_data=self.fake_log('unban_all'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
@@ -117,7 +120,8 @@ class TestBanSensor(unittest.TestCase):
 
     def test_unban_one(self):
         """Tests that log is parsed correctly when unbanning one ip."""
-        sensor = BanSensor('fail2ban', 'jail_one', timedelta(seconds=-1), '/tmp')
+        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        sensor = BanSensor('fail2ban', 'jail_one', log_parser)
         self.assertEqual(sensor.name, 'fail2ban jail_one')
         mock_fh = MockOpen(read_data=self.fake_log('unban_one'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
@@ -129,8 +133,9 @@ class TestBanSensor(unittest.TestCase):
 
     def test_multi_jail(self):
         """Tests that log is parsed correctly when using multiple jails."""
-        sensor1 = BanSensor('fail2ban', 'jail_one', timedelta(seconds=-1), '/tmp')
-        sensor2 = BanSensor('fail2ban', 'jail_two', timedelta(seconds=-1), '/tmp')
+        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        sensor1 = BanSensor('fail2ban', 'jail_one', log_parser)
+        sensor2 = BanSensor('fail2ban', 'jail_two', log_parser)
         self.assertEqual(sensor1.name, 'fail2ban jail_one')
         self.assertEqual(sensor2.name, 'fail2ban jail_two')
         mock_fh = MockOpen(read_data=self.fake_log('multi_jail'))

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -18,37 +18,37 @@ def fake_log(log_key):
     """Return a fake fail2ban log."""
     fake_log_dict = {
         'single_ban': (
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Ban 111.111.111.111'
         ),
         'multi_ban': (
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Ban 111.111.111.111\n'
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Ban 222.222.222.222'
         ),
         'multi_jail': (
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Ban 111.111.111.111\n'
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_two] Ban 222.222.222.222'
         ),
         'unban_all': (
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Ban 111.111.111.111\n'
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Unban 111.111.111.111\n'
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Ban 222.222.222.222\n'
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Unban 222.222.222.222'
         ),
         'unban_one': (
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Ban 111.111.111.111\n'
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Ban 222.222.222.222\n'
-            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Unban 111.111.111.111'
         )
     }

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -1,19 +1,58 @@
 """The tests for local file sensor platform."""
 import unittest
-from unittest import mock
 from unittest.mock import Mock, patch
-
-from mock_open import MockOpen
 
 from datetime import timedelta
 
+from mock_open import MockOpen
+
 from homeassistant.setup import setup_component
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.components.sensor.fail2ban import (
     BanSensor, BanLogParser, STATE_CURRENT_BANS, STATE_ALL_BANS
 )
 
 from tests.common import get_test_home_assistant, assert_setup_component
+
+
+def fake_log(log_key):
+    """Return a fake fail2ban log."""
+    fake_log_dict = {
+        'single_ban': (
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_one] Ban 111.111.111.111'
+        ),
+        'multi_ban': (
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_one] Ban 111.111.111.111\n'
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_one] Ban 222.222.222.222'
+        ),
+        'multi_jail': (
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_one] Ban 111.111.111.111\n'
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_two] Ban 222.222.222.222'
+        ),
+        'unban_all': (
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_one] Ban 111.111.111.111\n'
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_one] Unban 111.111.111.111\n'
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_one] Ban 222.222.222.222\n'
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_one] Unban 222.222.222.222'
+        ),
+        'unban_one': (
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_one] Ban 111.111.111.111\n'
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_one] Ban 222.222.222.222\n'
+            '2017-01-01 12:23:35 fail2ban.actions [111]:'
+            'NOTICE [jail_one] Unban 111.111.111.111'
+        )
+    }
+    return fake_log_dict[log_key]
 
 
 class TestBanSensor(unittest.TestCase):
@@ -27,28 +66,6 @@ class TestBanSensor(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def fake_log(self, log_key):
-        """Return a fake fail2ban log."""
-        fake_log_dict = {
-            'single_ban': '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 111.111.111.111',
-            'multi_ban': 
-                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 111.111.111.111\n' \
-                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 222.222.222.222',
-            'multi_jail':
-                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 111.111.111.111\n' \
-                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_two] Ban 222.222.222.222',
-            'unban_all': 
-                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 111.111.111.111\n' \
-                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Unban 111.111.111.111\n' \
-                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 222.222.222.222\n' \
-                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Unban 222.222.222.222',
-            'unban_one': 
-                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 111.111.111.111\n' \
-                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Ban 222.222.222.222\n' \
-                '2017-01-01 12:23:35 fail2ban.actions [111]: NOTICE [jail_one] Unban 111.111.111.111',
-        }
-        return fake_log_dict[log_key]
-
     @patch('os.path.isfile', Mock(return_value=True))
     def test_setup(self):
         """Test that sensor can be setup."""
@@ -59,7 +76,8 @@ class TestBanSensor(unittest.TestCase):
             }
         }
         mock_fh = MockOpen()
-        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
+                   create=True):
             assert setup_component(self.hass, 'sensor', config)
             self.hass.block_till_done()
         assert_setup_component(1, 'sensor')
@@ -74,78 +92,111 @@ class TestBanSensor(unittest.TestCase):
             }
         }
         mock_fh = MockOpen()
-        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
+                   create=True):
             assert setup_component(self.hass, 'sensor', config)
             self.hass.block_till_done()
         assert_setup_component(2, 'sensor')
 
     def test_single_ban(self):
-        """Tests that log is parsed correctly for single ban."""
+        """Test that log is parsed correctly for single ban."""
         log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
         self.assertEqual(sensor.name, 'fail2ban jail_one')
-        mock_fh = MockOpen(read_data=self.fake_log('single_ban'))
-        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+        mock_fh = MockOpen(read_data=fake_log('single_ban'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
+                   create=True):
             sensor.update()
 
         self.assertEqual(sensor.state, '111.111.111.111')
-        self.assertEqual(sensor.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111'])
-        self.assertEqual(sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111'])
+        self.assertEqual(
+            sensor.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111']
+        )
+        self.assertEqual(
+            sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111']
+        )
 
     def test_multiple_ban(self):
-        """Tests that log is parsed correctly for multiple ban."""
+        """Test that log is parsed correctly for multiple ban."""
         log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
         self.assertEqual(sensor.name, 'fail2ban jail_one')
-        mock_fh = MockOpen(read_data=self.fake_log('multi_ban'))
-        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+        mock_fh = MockOpen(read_data=fake_log('multi_ban'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
+                   create=True):
             sensor.update()
 
         self.assertEqual(sensor.state, '222.222.222.222')
-        self.assertEqual(sensor.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111', '222.222.222.222'])
-        self.assertEqual(sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111', '222.222.222.222'])
+        self.assertEqual(
+            sensor.state_attributes[STATE_CURRENT_BANS],
+            ['111.111.111.111', '222.222.222.222']
+        )
+        self.assertEqual(
+            sensor.state_attributes[STATE_ALL_BANS],
+            ['111.111.111.111', '222.222.222.222']
+        )
 
     def test_unban_all(self):
-        """Tests that log is parsed correctly when unbanning."""
+        """Test that log is parsed correctly when unbanning."""
         log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
         self.assertEqual(sensor.name, 'fail2ban jail_one')
-        mock_fh = MockOpen(read_data=self.fake_log('unban_all'))
-        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+        mock_fh = MockOpen(read_data=fake_log('unban_all'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
+                   create=True):
             sensor.update()
 
         self.assertEqual(sensor.state, 'None')
         self.assertEqual(sensor.state_attributes[STATE_CURRENT_BANS], [])
-        self.assertEqual(sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111', '222.222.222.222'])
+        self.assertEqual(
+            sensor.state_attributes[STATE_ALL_BANS],
+            ['111.111.111.111', '222.222.222.222']
+        )
 
     def test_unban_one(self):
-        """Tests that log is parsed correctly when unbanning one ip."""
+        """Test that log is parsed correctly when unbanning one ip."""
         log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
         self.assertEqual(sensor.name, 'fail2ban jail_one')
-        mock_fh = MockOpen(read_data=self.fake_log('unban_one'))
-        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+        mock_fh = MockOpen(read_data=fake_log('unban_one'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
+                   create=True):
             sensor.update()
 
         self.assertEqual(sensor.state, '222.222.222.222')
-        self.assertEqual(sensor.state_attributes[STATE_CURRENT_BANS], ['222.222.222.222'])
-        self.assertEqual(sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111', '222.222.222.222'])
+        self.assertEqual(
+            sensor.state_attributes[STATE_CURRENT_BANS],
+            ['222.222.222.222']
+        )
+        self.assertEqual(
+            sensor.state_attributes[STATE_ALL_BANS],
+            ['111.111.111.111', '222.222.222.222']
+        )
 
     def test_multi_jail(self):
-        """Tests that log is parsed correctly when using multiple jails."""
+        """Test that log is parsed correctly when using multiple jails."""
         log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
         sensor1 = BanSensor('fail2ban', 'jail_one', log_parser)
         sensor2 = BanSensor('fail2ban', 'jail_two', log_parser)
         self.assertEqual(sensor1.name, 'fail2ban jail_one')
         self.assertEqual(sensor2.name, 'fail2ban jail_two')
-        mock_fh = MockOpen(read_data=self.fake_log('multi_jail'))
-        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh, create=True):
+        mock_fh = MockOpen(read_data=fake_log('multi_jail'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
+                   create=True):
             sensor1.update()
             sensor2.update()
-        
+
         self.assertEqual(sensor1.state, '111.111.111.111')
-        self.assertEqual(sensor1.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111'])
-        self.assertEqual(sensor1.state_attributes[STATE_ALL_BANS], ['111.111.111.111'])
+        self.assertEqual(
+            sensor1.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111']
+        )
+        self.assertEqual(
+            sensor1.state_attributes[STATE_ALL_BANS], ['111.111.111.111']
+        )
         self.assertEqual(sensor2.state, '222.222.222.222')
-        self.assertEqual(sensor2.state_attributes[STATE_CURRENT_BANS], ['222.222.222.222'])
-        self.assertEqual(sensor2.state_attributes[STATE_ALL_BANS], ['222.222.222.222'])
+        self.assertEqual(
+            sensor2.state_attributes[STATE_CURRENT_BANS], ['222.222.222.222']
+        )
+        self.assertEqual(
+            sensor2.state_attributes[STATE_ALL_BANS], ['222.222.222.222']
+        )

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -200,3 +200,22 @@ class TestBanSensor(unittest.TestCase):
         self.assertEqual(
             sensor2.state_attributes[STATE_ALL_BANS], ['222.222.222.222']
         )
+
+    def test_ban_active_after_update(self):
+        """Test that ban persists after subsequent update."""
+        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        sensor = BanSensor('fail2ban', 'jail_one', log_parser)
+        self.assertEqual(sensor.name, 'fail2ban jail_one')
+        mock_fh = MockOpen(read_data=fake_log('single_ban'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
+                   create=True):
+            sensor.update()
+            self.assertEqual(sensor.state, '111.111.111.111')
+            sensor.update()
+            self.assertEqual(sensor.state, '111.111.111.111')
+        self.assertEqual(
+            sensor.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111']
+        )
+        self.assertEqual(
+            sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111']
+        )


### PR DESCRIPTION
## Description:
I was looking for an easy way to display active and historical bans on my system within home-assistant, and decided to add this platform as a solution.  Please let me know if you think there is a better way to implement this.

### What it does
Each 'jail' set up within fail2ban can be added as a sensor within homeassistant.  This component will access the fail2ban log (which you provide via the config) and scan it for any IPs that have been banned within each specified jail.  Any IP that is found will be added to a list within `sensor.state_attributes` to keep a running tab on each IP _currently_ banned.  Each uniquely banned IP will also be added to a permanent list to keep track of all IPs banned for that jail, up to a total of 10 (any more and the oldest banned IP is removed, to prevent the list from becoming too long).  The `state` displayed within home-assistant is the most recently banned IP for the given jail.  

### Tested platforms
I've tested this with the following setups:
- Custom homeassistant filter (using [this](https://home-assistant.io/cookbook/fail2ban/) guide) running on Debian 9
- Same filter running in a homeassistant docker on an unRAID server behind nginx 

For both those platforms, fail2ban still needs to be manually configured to work correctly.  For the docker in unRAID behind nginx, there were some extra steps needed but it's working great for me right now.  I plan on adding the latter to the documentation when I get to it.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3679

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: fail2ban
    name: fail2ban
    jails:
      - hass-iptables
      - ssh
    file_path: /var/log/fail2ban.log
    scan_interval: 120
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

