### PR TITLE
WIP - add support for multiple passwords

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -86,7 +86,8 @@ def setup(hass, yaml_config):
         use_x_forwarded_for=False,
         trusted_networks=[],
         login_threshold=0,
-        is_ban_enabled=False
+        is_ban_enabled=False,
+        api_users=None
     )
 
     server.register_view(DescriptionXmlView(config))

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -21,7 +21,8 @@ import homeassistant.remote as rem
 import homeassistant.util as hass_util
 from homeassistant.const import (
     SERVER_PORT, CONTENT_TYPE_JSON, ALLOWED_CORS_HEADERS,
-    EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_START)
+    EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_START,
+    CONF_PASSWORD)
 from homeassistant.core import is_callback
 from homeassistant.util.logging import HideSensitiveDataFilter
 
@@ -40,6 +41,7 @@ REQUIREMENTS = ['aiohttp_cors==0.5.3']
 DOMAIN = 'http'
 
 CONF_API_PASSWORD = 'api_password'
+CONF_API_USERS = 'api_users'
 CONF_SERVER_HOST = 'server_host'
 CONF_SERVER_PORT = 'server_port'
 CONF_BASE_URL = 'base_url'
@@ -81,6 +83,7 @@ DEFAULT_LOGIN_ATTEMPT_THRESHOLD = -1
 
 HTTP_SCHEMA = vol.Schema({
     vol.Optional(CONF_API_PASSWORD, default=None): cv.string,
+    vol.Optional(CONF_API_USERS, default=None): dict,
     vol.Optional(CONF_SERVER_HOST, default=DEFAULT_SERVER_HOST): cv.string,
     vol.Optional(CONF_SERVER_PORT, default=SERVER_PORT): cv.port,
     vol.Optional(CONF_BASE_URL): cv.string,
@@ -111,6 +114,7 @@ def async_setup(hass, config):
         conf = HTTP_SCHEMA({})
 
     api_password = conf[CONF_API_PASSWORD]
+    api_users = conf[CONF_API_USERS]
     server_host = conf[CONF_SERVER_HOST]
     server_port = conf[CONF_SERVER_PORT]
     development = conf[CONF_DEVELOPMENT] == '1'
@@ -126,6 +130,12 @@ def async_setup(hass, config):
         logging.getLogger('aiohttp.access').addFilter(
             HideSensitiveDataFilter(api_password))
 
+    if api_users is not None:
+        for _, api_user in api_users.items():
+            if CONF_PASSWORD in api_user:
+                logging.getLogger('aiohttp.access').addFilter(
+                    HideSensitiveDataFilter(api_user[CONF_PASSWORD]))
+
     server = HomeAssistantWSGI(
         hass,
         development=development,
@@ -138,7 +148,8 @@ def async_setup(hass, config):
         use_x_forwarded_for=use_x_forwarded_for,
         trusted_networks=trusted_networks,
         login_threshold=login_threshold,
-        is_ban_enabled=is_ban_enabled
+        is_ban_enabled=is_ban_enabled,
+        api_users=api_users
     )
 
     @asyncio.coroutine
@@ -179,7 +190,7 @@ class HomeAssistantWSGI(object):
     def __init__(self, hass, development, api_password, ssl_certificate,
                  ssl_key, server_host, server_port, cors_origins,
                  use_x_forwarded_for, trusted_networks,
-                 login_threshold, is_ban_enabled):
+                 login_threshold, is_ban_enabled, api_users):
         """Initialize the WSGI Home Assistant server."""
         import aiohttp_cors
 
@@ -199,6 +210,7 @@ class HomeAssistantWSGI(object):
         self.hass = hass
         self.development = development
         self.api_password = api_password
+        self.api_users = api_users
         self.ssl_certificate = ssl_certificate
         self.ssl_key = ssl_key
         self.server_host = server_host

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -283,10 +283,12 @@ class ActiveConnection:
         try:
             if request[KEY_AUTHENTICATED]:
                 authenticated = True
+
             else:
                 yield from self.wsock.send_json(auth_required_message())
                 msg = yield from wsock.receive_json()
                 msg = AUTH_MESSAGE_SCHEMA(msg)
+
                 if validate_password(request, msg['api_password']):
                     authenticated = True
 
@@ -300,9 +302,12 @@ class ActiveConnection:
                 return wsock
 
             yield from self.wsock.send_json(auth_ok_message())
+
             # ---------- AUTH PHASE OVER ----------
+
             msg = yield from wsock.receive_json()
             last_id = 0
+
             while msg:
                 self.debug("Received", msg)
                 msg = BASE_COMMAND_MESSAGE_SCHEMA(msg)

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -283,12 +283,10 @@ class ActiveConnection:
         try:
             if request[KEY_AUTHENTICATED]:
                 authenticated = True
-
             else:
                 yield from self.wsock.send_json(auth_required_message())
                 msg = yield from wsock.receive_json()
                 msg = AUTH_MESSAGE_SCHEMA(msg)
-
                 if validate_password(request, msg['api_password']):
                     authenticated = True
 
@@ -302,12 +300,9 @@ class ActiveConnection:
                 return wsock
 
             yield from self.wsock.send_json(auth_ok_message())
-
             # ---------- AUTH PHASE OVER ----------
-
             msg = yield from wsock.receive_json()
             last_id = 0
-
             while msg:
                 self.debug("Received", msg)
                 msg = BASE_COMMAND_MESSAGE_SCHEMA(msg)

--- a/tests/common.py
+++ b/tests/common.py
@@ -261,9 +261,9 @@ def mock_state_change_event(hass, new_state, old_state=None):
     hass.bus.fire(EVENT_STATE_CHANGED, event_data)
 
 
-def mock_http_component(hass, api_password=None):
-    """Mock the HTTP component."""
-    hass.http = MagicMock(api_password=api_password)
+def mock_http_component(hass, api_password=None, api_users=None):
+    """Mock the HTTP component. Optionally an api user can be given."""
+    hass.http = MagicMock(api_password=api_password, api_users=api_users)
     mock_component(hass, 'http')
     hass.http.views = {}
 
@@ -278,10 +278,12 @@ def mock_http_component(hass, api_password=None):
     hass.http.register_view = mock_register_view
 
 
-def mock_http_component_app(hass, api_password=None):
+def mock_http_component_app(hass, api_password=None, api_users=None):
     """Create an aiohttp.web.Application instance for testing."""
     if 'http' not in hass.config.components:
-        mock_http_component(hass, api_password)
+        mock_http_component(hass,
+                            api_password=api_password,
+                            api_users=api_users)
     app = web.Application(middlewares=[auth_middleware])
     app['hass'] = hass
     app[KEY_USE_X_FORWARDED_FOR] = False

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -199,6 +199,7 @@ def test_basic_auth_works(mock_api_client, caplog):
     assert req.status == 200
     assert const.URL_API in caplog.text
 
+
 @asyncio.coroutine
 def test_basic_auth_api_user_works(mock_api_client, caplog):
     """Test access with basic authentication."""

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -15,6 +15,9 @@ from homeassistant.components.http.const import (
 
 API_PASSWORD = 'test1234'
 
+API_USER_NAME = 'user1'
+API_USER_PASS = 'pass1'
+
 # Don't add 127.0.0.1/::1 as trusted, as it may interfere with other test cases
 TRUSTED_NETWORKS = ['192.0.2.0/24', '2001:DB8:ABCD::/48', '100.64.0.1',
                     'FD01:DB8::1']
@@ -28,7 +31,12 @@ def mock_api_client(hass, test_client):
     """Start the Hass HTTP component."""
     hass.loop.run_until_complete(async_setup_component(hass, 'api', {
         'http': {
-            http.CONF_API_PASSWORD: API_PASSWORD,
+            http.CONF_API_USERS: {
+                API_USER_NAME: {
+                    const.CONF_PASSWORD: API_USER_PASS
+                }
+            },
+            http.CONF_API_PASSWORD: API_PASSWORD
         }
     }))
     return hass.loop.run_until_complete(test_client(hass.http.app))
@@ -125,6 +133,35 @@ def test_access_with_password_in_url(mock_api_client, caplog):
 
 
 @asyncio.coroutine
+def test_access_with_api_user_password_in_header(mock_api_client, caplog):
+    """Test access with password in URL."""
+    # Hide logging from requests package that we use to test logging
+    req = yield from mock_api_client.get(
+        const.URL_API, headers={const.HTTP_HEADER_HA_AUTH: API_USER_PASS})
+
+    assert req.status == 200
+
+    logs = caplog.text
+
+    assert const.URL_API in logs
+    assert API_USER_PASS not in logs
+
+
+@asyncio.coroutine
+def test_access_with_api_user_password_in_url(mock_api_client, caplog):
+    """Test access with password in URL."""
+    req = yield from mock_api_client.get(
+        const.URL_API, params={'api_password': API_USER_PASS})
+
+    assert req.status == 200
+
+    logs = caplog.text
+
+    assert const.URL_API in logs
+    assert API_USER_PASS not in logs
+
+
+@asyncio.coroutine
 def test_access_granted_with_x_forwarded_for(hass, mock_api_client, caplog,
                                              mock_trusted_networks):
     """Test access denied through the X-Forwarded-For http header."""
@@ -162,6 +199,16 @@ def test_basic_auth_works(mock_api_client, caplog):
     assert req.status == 200
     assert const.URL_API in caplog.text
 
+@asyncio.coroutine
+def test_basic_auth_api_user_works(mock_api_client, caplog):
+    """Test access with basic authentication."""
+    req = yield from mock_api_client.get(
+        const.URL_API,
+        auth=aiohttp.BasicAuth(API_USER_NAME, API_USER_PASS))
+
+    assert req.status == 200
+    assert const.URL_API in caplog.text
+
 
 @asyncio.coroutine
 def test_basic_auth_username_homeassistant(mock_api_client, caplog):
@@ -179,6 +226,16 @@ def test_basic_auth_wrong_password(mock_api_client, caplog):
     req = yield from mock_api_client.get(
         const.URL_API,
         auth=aiohttp.BasicAuth('homeassistant', 'wrong password'))
+
+    assert req.status == 401
+
+
+@asyncio.coroutine
+def test_basic_auth_api_user_wrong_password(mock_api_client, caplog):
+    """Test access with basic auth not allowed with wrong password."""
+    req = yield from mock_api_client.get(
+        const.URL_API,
+        auth=aiohttp.BasicAuth(API_USER_NAME, 'wrong password'))
 
     assert req.status == 401
 

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -14,7 +14,7 @@ class TestMQTT:
     def setup_method(self, method):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        mock_http_component(self.hass, 'super_secret')
+        mock_http_component(self.hass, api_password='super_secret')
 
     def teardown_method(self, method):
         """Stop everything that was started."""

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -177,6 +177,7 @@ class TestCheckConfig(unittest.TestCase):
 
             self.assertDictEqual({
                 'components': {'http': {'api_password': 'abc123',
+                                        'api_users': None,
                                         'cors_allowed_origins': [],
                                         'development': '0',
                                         'ip_ban_enabled': True,

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -308,6 +308,7 @@ class TestSecrets(unittest.TestCase):
 
         load_yaml(self._secret_path,
                   'http_pw: pwhttp\n'
+                  'user_http_pw: userpwhttp\n'
                   'comp1_un: un1\n'
                   'comp1_pw: pw1\n'
                   'stale_pw: not_used\n'
@@ -315,6 +316,9 @@ class TestSecrets(unittest.TestCase):
         self._yaml = load_yaml(self._yaml_path,
                                'http:\n'
                                '  api_password: !secret http_pw\n'
+                               '  api_users: \n'
+                               '    userhttp: \n'
+                               '      password: !secret user_http_pw\n'
                                'component:\n'
                                '  username: !secret comp1_un\n'
                                '  password: !secret comp1_pw\n'
@@ -327,7 +331,12 @@ class TestSecrets(unittest.TestCase):
 
     def test_secrets_from_yaml(self):
         """Did secrets load ok."""
-        expected = {'api_password': 'pwhttp'}
+        expected = {'api_password': 'pwhttp',
+                    'api_users': {
+                        'userhttp': {
+                            'password': 'userpwhttp'
+                        }
+                    }}
         self.assertEqual(expected, self._yaml['http'])
 
         expected = {


### PR DESCRIPTION
I've adding basic support for multiple users and am looking for feedback / thoughts on the general idea. 

In part it comes from the discussion from https://community.home-assistant.io/t/multiple-users-accounts/396. The basic structure of the user dict is based on some of the work from https://github.com/k-laus/home-assistant/commit/fc18173f519e88f3e03c6eeddca986a98e9c3f37. I only have a plaintext password but the dict could be expanded to later allow permissions or different password types.

I've no plan to add read / write / execute permissions as it would involve touching too much, but wanted a way to specify multiple passwords so that I can easily revoke one in the case the service using it is compromised. For example, If I'm using IFTTT and Stringify, each service can have it's own api_password and if one has a breach I can just revoke that password instead of having to change both. It could also be used to add a level of accountability for who triggered a service.




## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
  api_users: 
    ifttt:
      password: ifttt_password
    stringify:
      password: stringify_password
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
