### PR TITLE
Wink external action tracking

### DIFF
--- a/homeassistant/components/alarm_control_panel/wink.py
+++ b/homeassistant/components/alarm_control_panel/wink.py
@@ -60,19 +60,22 @@ class WinkCameraDevice(WinkDevice, alarm.AlarmControlPanel):
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""
+        self.ha_state_fired()
         self.wink.set_mode("home")
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
+        self.ha_state_fired()
         self.wink.set_mode("night")
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
+        self.ha_state_fired()
         self.wink.set_mode("away")
 
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {
-            'private': self.wink.private()
-        }
+        attributes = super().device_state_attributes
+        attributes['private'] self.wink.private()
+        return attributes

--- a/homeassistant/components/alarm_control_panel/wink.py
+++ b/homeassistant/components/alarm_control_panel/wink.py
@@ -77,5 +77,5 @@ class WinkCameraDevice(WinkDevice, alarm.AlarmControlPanel):
     def device_state_attributes(self):
         """Return the state attributes."""
         attributes = super().device_state_attributes
-        attributes['private'] self.wink.private()
+        attributes['private'] = self.wink.private()
         return attributes

--- a/homeassistant/components/climate/wink.py
+++ b/homeassistant/components/climate/wink.py
@@ -81,34 +81,34 @@ class WinkThermostat(WinkDevice, ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return the optional state attributes."""
-        data = {}
+        attributes = super().device_state_attributes
         target_temp_high = self.target_temperature_high
         target_temp_low = self.target_temperature_low
         if target_temp_high is not None:
-            data[ATTR_TARGET_TEMP_HIGH] = self._convert_for_display(
+            attributes[ATTR_TARGET_TEMP_HIGH] = self._convert_for_display(
                 self.target_temperature_high)
         if target_temp_low is not None:
-            data[ATTR_TARGET_TEMP_LOW] = self._convert_for_display(
+            attributes[ATTR_TARGET_TEMP_LOW] = self._convert_for_display(
                 self.target_temperature_low)
 
         if self.external_temperature:
-            data[ATTR_EXTERNAL_TEMPERATURE] = self._convert_for_display(
+            attributes[ATTR_EXTERNAL_TEMPERATURE] = self._convert_for_display(
                 self.external_temperature)
 
         if self.smart_temperature:
-            data[ATTR_SMART_TEMPERATURE] = self.smart_temperature
+            attributes[ATTR_SMART_TEMPERATURE] = self.smart_temperature
 
         if self.occupied:
-            data[ATTR_OCCUPIED] = self.occupied
+            attributes[ATTR_OCCUPIED] = self.occupied
 
         if self.eco_target:
-            data[ATTR_ECO_TARGET] = self.eco_target
+            attributes[ATTR_ECO_TARGET] = self.eco_target
 
         current_humidity = self.current_humidity
         if current_humidity is not None:
-            data[ATTR_CURRENT_HUMIDITY] = current_humidity
+            attributes[ATTR_CURRENT_HUMIDITY] = current_humidity
 
-        return data
+        return attributes
 
     @property
     def current_temperature(self):
@@ -227,6 +227,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
             target_temp_low = target_temp_low
         if target_temp_high is not None:
             target_temp_high = target_temp_high
+        self.ha_state_fired()
         self.wink.set_temperature(target_temp_low, target_temp_high)
 
     def set_operation_mode(self, operation_mode):
@@ -235,6 +236,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
         # The only way to disable aux heat is with the toggle
         if self.is_aux_heat_on and op_mode_to_set == STATE_HEAT:
             return
+        self.ha_state_fired()
         self.wink.set_operation_mode(op_mode_to_set)
 
     @property
@@ -256,10 +258,12 @@ class WinkThermostat(WinkDevice, ClimateDevice):
 
     def turn_away_mode_on(self):
         """Turn away on."""
+        self.ha_state_fired()
         self.wink.set_away_mode()
 
     def turn_away_mode_off(self):
         """Turn away off."""
+        self.ha_state_fired()
         self.wink.set_away_mode(False)
 
     @property
@@ -281,14 +285,17 @@ class WinkThermostat(WinkDevice, ClimateDevice):
 
     def set_fan_mode(self, fan):
         """Turn fan on/off."""
+        self.ha_state_fired()
         self.wink.set_fan_mode(fan.lower())
 
     def turn_aux_heat_on(self):
         """Turn auxiliary heater on."""
+        self.ha_state_fired()
         self.wink.set_operation_mode('aux')
 
     def turn_aux_heat_off(self):
         """Turn auxiliary heater off."""
+        self.ha_state_fired()
         self.set_operation_mode(STATE_HEAT)
 
     @property
@@ -356,19 +363,19 @@ class WinkAC(WinkDevice, ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return the optional state attributes."""
-        data = {}
+        attributes = super().device_state_attributes
         target_temp_high = self.target_temperature_high
         target_temp_low = self.target_temperature_low
         if target_temp_high is not None:
-            data[ATTR_TARGET_TEMP_HIGH] = self._convert_for_display(
+            attributes[ATTR_TARGET_TEMP_HIGH] = self._convert_for_display(
                 self.target_temperature_high)
         if target_temp_low is not None:
-            data[ATTR_TARGET_TEMP_LOW] = self._convert_for_display(
+            attributes[ATTR_TARGET_TEMP_LOW] = self._convert_for_display(
                 self.target_temperature_low)
-        data["total_consumption"] = self.wink.total_consumption()
-        data["schedule_enabled"] = self.wink.schedule_enabled()
+        attributes["total_consumption"] = self.wink.total_consumption()
+        attributes["schedule_enabled"] = self.wink.schedule_enabled()
 
-        return data
+        return attributes
 
     @property
     def current_temperature(self):
@@ -404,6 +411,7 @@ class WinkAC(WinkDevice, ClimateDevice):
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
         target_temp = kwargs.get(ATTR_TEMPERATURE)
+        self.ha_state_fired()
         self.wink.set_temperature(target_temp)
 
     def set_operation_mode(self, operation_mode):
@@ -411,6 +419,7 @@ class WinkAC(WinkDevice, ClimateDevice):
         op_mode_to_set = HA_STATE_TO_WINK.get(operation_mode)
         if op_mode_to_set == 'eco':
             op_mode_to_set = 'auto_eco'
+        self.ha_state_fired()
         self.wink.set_operation_mode(op_mode_to_set)
 
     @property
@@ -443,6 +452,7 @@ class WinkAC(WinkDevice, ClimateDevice):
             speed = 0.8
         elif fan == SPEED_HIGH:
             speed = 1.0
+        self.ha_state_fired()
         self.wink.set_ac_fan_speed(speed)
 
 
@@ -458,11 +468,11 @@ class WinkWaterHeater(WinkDevice, ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return the optional state attributes."""
-        data = {}
-        data["vacation_mode"] = self.wink.vacation_mode_enabled()
-        data["rheem_type"] = self.wink.rheem_type()
+        attributes = super().device_state_attributes
+        attributes["vacation_mode"] = self.wink.vacation_mode_enabled()
+        attributes["rheem_type"] = self.wink.rheem_type()
 
-        return data
+        return attributes
 
     @property
     def current_operation(self):
@@ -500,11 +510,13 @@ class WinkWaterHeater(WinkDevice, ClimateDevice):
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
         target_temp = kwargs.get(ATTR_TEMPERATURE)
+        self.ha_state_fired()
         self.wink.set_temperature(target_temp)
 
     def set_operation_mode(self, operation_mode):
         """Set operation mode."""
         op_mode_to_set = HA_STATE_TO_WINK.get(operation_mode)
+        self.ha_state_fired()
         self.wink.set_operation_mode(op_mode_to_set)
 
     @property
@@ -514,10 +526,12 @@ class WinkWaterHeater(WinkDevice, ClimateDevice):
 
     def turn_away_mode_on(self):
         """Turn away on."""
+        self.ha_state_fired()
         self.wink.set_vacation_mode(True)
 
     def turn_away_mode_off(self):
         """Turn away off."""
+        self.ha_state_fired()
         self.wink.set_vacation_mode(False)
 
     @property

--- a/homeassistant/components/cover/wink.py
+++ b/homeassistant/components/cover/wink.py
@@ -36,14 +36,17 @@ class WinkCoverDevice(WinkDevice, CoverDevice):
 
     def close_cover(self, **kwargs):
         """Close the shade."""
+        self.ha_state_fired()
         self.wink.set_state(0)
 
     def open_cover(self, **kwargs):
         """Open the shade."""
+        self.ha_state_fired()
         self.wink.set_state(1)
 
     def set_cover_position(self, position, **kwargs):
         """Move the roller shutter to a specific position."""
+        self.ha_state_fired()
         self.wink.set_state(float(position)/100)
 
     @property

--- a/homeassistant/components/fan/wink.py
+++ b/homeassistant/components/fan/wink.py
@@ -43,18 +43,22 @@ class WinkFanDevice(WinkDevice, FanEntity):
 
     def set_direction(self: ToggleEntity, direction: str) -> None:
         """Set the direction of the fan."""
+        self.ha_state_fired()
         self.wink.set_fan_direction(direction)
 
     def set_speed(self: ToggleEntity, speed: str) -> None:
         """Set the speed of the fan."""
+        self.ha_state_fired()
         self.wink.set_state(True, speed)
 
     def turn_on(self: ToggleEntity, speed: str=None, **kwargs) -> None:
         """Turn on the fan."""
+        self.ha_state_fired()
         self.wink.set_state(True, speed)
 
     def turn_off(self: ToggleEntity, **kwargs) -> None:
         """Turn off the fan."""
+        self.ha_state_fired()
         self.wink.set_state(False)
 
     @property

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -116,8 +116,10 @@ class WinkLight(WinkDevice, Light):
         if brightness:
             state_kwargs['brightness'] = brightness / 255.0
 
+        self.ha_state_fired()
         self.wink.set_state(True, **state_kwargs)
 
     def turn_off(self):
         """Turn the switch off."""
+        self.ha_state_fired()
         self.wink.set_state(False)

--- a/homeassistant/components/lock/wink.py
+++ b/homeassistant/components/lock/wink.py
@@ -148,26 +148,32 @@ class WinkLockDevice(WinkDevice, LockDevice):
 
     def lock(self, **kwargs):
         """Lock the device."""
+        self.ha_state_fired()
         self.wink.set_state(True)
 
     def unlock(self, **kwargs):
         """Unlock the device."""
+        self.ha_state_fired()
         self.wink.set_state(False)
 
     def set_alarm_state(self, enabled):
         """Set lock's alarm state."""
+        self.ha_state_fired()
         self.wink.set_alarm_state(enabled)
 
     def set_vacation_mode(self, enabled):
         """Set lock's vacation mode."""
+        self.ha_state_fired()
         self.wink.set_vacation_mode(enabled)
 
     def set_beeper_state(self, enabled):
         """Set lock's beeper mode."""
+        self.ha_state_fired()
         self.wink.set_beeper_mode(enabled)
 
     def add_new_key(self, code, name):
         """Add a new user key code."""
+        self.ha_state_fired()
         self.wink.add_new_key(code, name)
 
     def set_alarm_sensitivity(self, sensitivity):
@@ -177,6 +183,7 @@ class WinkLockDevice(WinkDevice, LockDevice):
         Valid sensitivities:
             0.2, 0.4, 0.6, 0.8, 1.0
         """
+        self.ha_state_fired()
         self.wink.set_alarm_sensitivity(sensitivity)
 
     def set_alarm_mode(self, mode):
@@ -189,6 +196,7 @@ class WinkLockDevice(WinkDevice, LockDevice):
             forced_entry - 3 min alarm when significant force applied
                            to door when locked.
         """
+        self.ha_state_fired()
         self.wink.set_alarm_mode(mode)
 
     @property

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -52,10 +52,12 @@ class WinkToggleDevice(WinkDevice, ToggleEntity):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
+        self.ha_state_fired()
         self.wink.set_state(True)
 
     def turn_off(self):
         """Turn the device off."""
+        self.ha_state_fired()
         self.wink.set_state(False)
 
     @property

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -669,7 +669,7 @@ class WinkDevice(Entity):
                 self.schedule_update_ha_state()
                 current_time = datetime.now()
                 difference = current_time - self.last_ha_change
-                if difference.total_seconds() > 10:
+                if difference.total_seconds() > 15:
                     self.external_change = True
         except (ValueError, KeyError, AttributeError):
             _LOGGER.error("Error in pubnub JSON for %s "

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -691,6 +691,7 @@ class WinkDevice(Entity):
         self.wink.update_state()
 
     def ha_state_fired(self):
+        """Used to document when HA issues a Wink state change."""
         self.external_change = False
         self.last_ha_change = datetime.now()
 

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -9,7 +9,7 @@ import logging
 import time
 import json
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import voluptuous as vol
 import requests
@@ -650,6 +650,9 @@ class WinkDevice(Entity):
         """Initialize the Wink device."""
         self.hass = hass
         self.wink = wink
+        current_time = datetime.now()
+        self.external_change = False
+        self.last_ha_change = current_time
         hass.data[DOMAIN]['pubnub'].add_subscription(
             self.wink.pubnub_channel, self._pubnub_update)
         hass.data[DOMAIN]['unique_ids'].append(self.wink.object_id() +
@@ -664,6 +667,10 @@ class WinkDevice(Entity):
             else:
                 self.wink.pubnub_update(message)
                 self.schedule_update_ha_state()
+                current_time = datetime.now()
+                difference = current_time - self.last_ha_change
+                if difference.total_seconds() > 10:
+                    self.external_change = True
         except (ValueError, KeyError, AttributeError):
             _LOGGER.error("Error in pubnub JSON for %s "
                           "polling API for current state", self.name)
@@ -682,6 +689,10 @@ class WinkDevice(Entity):
     def update(self):
         """Update state of the device."""
         self.wink.update_state()
+
+    def ha_state_fired(self):
+        self.external_change = False
+        self.last_ha_change = datetime.now()
 
     @property
     def should_poll(self):
@@ -710,6 +721,7 @@ class WinkDevice(Entity):
         tamper = self._tamper
         if tamper is not None:
             attributes["tamper_detected"] = tamper
+        attributes["external_change"] = self.external_change
         return attributes
 
     @property


### PR DESCRIPTION
## Description:
This adds a new attribute to all non-sensor Wink devices called "external_change" this attribute is calculated by checking the last update time of the device (set by HA) and if the state change was was greater than 15 seconds ago, and the state change came from PubNub the attribute will be set to true. 

So what this means is, if the user changes a device via the official Wink app, or turns on a switch by the physical switch, this attribute will be set to true. Any time a state is changed via HA the attribute is set back to false. This could be useful in making complex automations around how a device was changed. If my front door was manually unlocked don't autolock it, but if it was unlocked via an automation automatically lock it again"

My use case is, I have a light that gets turned on automatically, and it gets turned back off automatically via an HA automation. If I turn that light on manually I don't want the delayed script to get executed and make the light automatically turn off again. So I can check this attribute in the automation and if it isn't false don't execute.

This doesn't work for all Wink devices. It doesn't seem to work for powerstrips/outlets because to wink they are all one device. It also doesn't seem to work on a generic zwave switch I have that doesn't report it's state quick enough. Everything else seems to work as expected... 

This also fixes some Wink attributes that weren't getting pulled from the base Wink device. (Climate and Alarms)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
