### PR TITLE
Remove async_update

### DIFF
--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -363,23 +363,17 @@ class MiroboVacuum(VacuumDevice):
             self._vacuum.manual_control_once,
             velocity=velocity, rotation=rotation, duration=duration)
 
-    @asyncio.coroutine
-    def async_update(self):
+    def update(self):
         """Fetch state from the device."""
         from mirobo import DeviceException
         try:
-            state = yield from self.hass.async_add_job(self._vacuum.status)
-            _LOGGER.debug("Got new state from the vacuum: %s", state.data)
+            state = self._vacuum.status()
             self.vacuum_state = state
-            self.consumable_state = yield from self.hass.async_add_job(
-                self._vacuum.consumable_status)
-            self.clean_history = yield from self.hass.async_add_job(
-                self._vacuum.clean_history)
+            self.consumable_state = self._vacuum.consumable_status()
+            self.clean_history = self._vacuum.clean_history()
             self._is_on = state.is_on
             self._available = True
         except OSError as exc:
             _LOGGER.error("Got OSError while fetching the state: %s", exc)
-            # self._available = False
         except DeviceException as exc:
             _LOGGER.warning("Got exception while fetching the state: %s", exc)
-            # self._available = False


### PR DESCRIPTION
## Description:

This code hit our executor pool. It's okay to run 1 add_job to wrap it async but not 3 times in one function. That is very bad.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
