### PR TITLE
Add support for 'Send Current Position' feature in Geofency 5.1

### DIFF
--- a/homeassistant/components/device_tracker/geofency.py
+++ b/homeassistant/components/device_tracker/geofency.py
@@ -21,6 +21,9 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['http']
 
+ATTR_CURRENT_LATITUDE = 'currentLatitude'
+ATTR_CURRENT_LONGITUDE = 'currentLongitude'
+
 BEACON_DEV_PREFIX = 'beacon'
 CONF_MOBILE_BEACONS = 'mobile_beacons'
 
@@ -72,6 +75,9 @@ class GeofencyView(HomeAssistantView):
                 location_name = data['name']
             else:
                 location_name = STATE_NOT_HOME
+                if ATTR_CURRENT_LATITUDE in data:
+                    data[ATTR_LATITUDE] = data[ATTR_CURRENT_LATITUDE]
+                    data[ATTR_LONGITUDE] = data[ATTR_CURRENT_LONGITUDE]
 
             return (yield from self._set_location(hass, data, location_name))
 
@@ -96,8 +102,12 @@ class GeofencyView(HomeAssistantView):
         data['device'] = slugify(data['device'])
         data['name'] = slugify(data['name'])
 
-        data[ATTR_LATITUDE] = float(data[ATTR_LATITUDE])
-        data[ATTR_LONGITUDE] = float(data[ATTR_LONGITUDE])
+        gps_attributes = [ATTR_LATITUDE, ATTR_LONGITUDE,
+                          ATTR_CURRENT_LATITUDE, ATTR_CURRENT_LONGITUDE]
+
+        for attribute in gps_attributes:
+            if attribute in data:
+                data[attribute] = float(data[attribute])
 
         return data
 

--- a/tests/components/device_tracker/test_geofency.py
+++ b/tests/components/device_tracker/test_geofency.py
@@ -170,6 +170,21 @@ def test_gps_enter_and_exit_home(hass, geofency_client):
         'device_tracker', device_name)).state
     assert STATE_NOT_HOME == state_name
 
+    # Exit the Home zone with "Send Current Position" enabled
+    data = GPS_EXIT_HOME.copy()
+    data['currentLatitude'] = NOT_HOME_LATITUDE
+    data['currentLongitude'] = NOT_HOME_LONGITUDE
+
+    req = yield from geofency_client.post(URL, data=data)
+    assert req.status == HTTP_OK
+    device_name = slugify(GPS_EXIT_HOME['device'])
+    current_latitude = hass.states.get('{}.{}'.format(
+        'device_tracker', device_name)).attributes['latitude']
+    assert NOT_HOME_LATITUDE == current_latitude
+    current_longitude = hass.states.get('{}.{}'.format(
+        'device_tracker', device_name)).attributes['longitude']
+    assert NOT_HOME_LONGITUDE == current_longitude
+
 
 @asyncio.coroutine
 def test_beacon_enter_and_exit_home(hass, geofency_client):


### PR DESCRIPTION
## Description:

Add support for the 'Send Current Position' feature in Geofency 5.1. This feature ensures that the _current_ GPS coordinates are included in exit events instead of the coordinates of the (center of) the zone that was exited. This makes Geofency work better with the Proximity component.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#3704

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
