### PR TITLE
Use feed name assigned in EmonCMS if there is one

### DIFF
--- a/homeassistant/components/sensor/emoncms.py
+++ b/homeassistant/components/sensor/emoncms.py
@@ -112,8 +112,13 @@ class EmonCmsSensor(Entity):
                  unit_of_measurement, sensorid, elem):
         """Initialize the sensor."""
         if name is None:
-            self._name = "emoncms{}_feedid_{}".format(
-                sensorid, elem["id"])
+            # Suppress ID in sensor name if it's 1, since most people won't
+            # have more than one EmonCMS source and it's redundant to show the
+            # ID if there's only one.
+            id_for_name = '' if str(sensorid) == '1' else sensorid
+            # Use the feed name assigned in EmonCMS or fall back to the feed ID
+            feed_name = elem.get('name') or 'Feed {}'.format(elem['id'])
+            self._name = "EmonCMS{} {}".format(id_for_name, feed_name)
         else:
             self._name = name
         self._identifier = get_id(


### PR DESCRIPTION
## Description:

The default names for the feeds created by the EmonCMS component are like 'emoncms1_feedid_10', but
- This is the display name. The ID should be lowercase and underscored, but the display name should be readable. The ID gets derived from it and comes out formatted correctly.
- EmonCMS lets you assign names to feeds, so it makes sense to use those if they exist, rather than feed IDs. The ID is pretty meaningless and basically means you have to override every name to make it readable.
- Including the ID identifying the EmonCMS instance (i.e. the '1') makes the name clunkier and would only be useful for people with multiple EmonCMS instances, which is likely to be an extremely small group since one hub can run as many feeds as you need it to.

This changes the default behavior but still uses configured 'name' if it's set, so it won't break the configuration of people who have customized their feed names in HA config.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3708


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
