### PR TITLE
Use real names when adding entities

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -210,6 +210,12 @@ class EntityComponent(object):
 
         entity.hass = self.hass
 
+        if update_before_add:
+            if hasattr(entity, 'async_update'):
+                yield from entity.async_update()
+            else:
+                yield from self.hass.async_add_job(entity.update)
+
         if getattr(entity, 'entity_id', None) is None:
             object_id = entity.name or DEVICE_DEFAULT_NAME
 
@@ -234,7 +240,7 @@ class EntityComponent(object):
         if hasattr(entity, 'async_added_to_hass'):
             yield from entity.async_added_to_hass()
 
-        yield from entity.async_update_ha_state(update_before_add)
+        yield from entity.async_update_ha_state()
 
         return True
 


### PR DESCRIPTION
## Description:

This reverts a small part of #9924 and seems to fix #10015 for me.

I did not have time to digest all of #9924 (or run tests) so I could be breaking something else. However, this seems like a big issue and I wanted to submit my findings as I will not be working more on this today.

CC @pvizeli 

**Related issue (if applicable):** fixes #10015, #10018, #10020

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
