### PR TITLE
Fix device update / entity_id with names

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -200,34 +200,11 @@ class Entity(object):
 
         # update entity data
         if force_refresh:
-            if self._update_staged:
-                return
-            self._update_staged = True
-
-            # Process update sequential
-            if self.parallel_updates:
-                yield from self.parallel_updates.acquire()
-
-            update_warn = self.hass.loop.call_later(
-                SLOW_UPDATE_WARNING, _LOGGER.warning,
-                "Update of %s is taking over %s seconds", self.entity_id,
-                SLOW_UPDATE_WARNING
-            )
-
             try:
-                if hasattr(self, 'async_update'):
-                    # pylint: disable=no-member
-                    yield from self.async_update()
-                else:
-                    yield from self.hass.async_add_job(self.update)
+                yield from self.async_device_update()
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Update for %s fails", self.entity_id)
                 return
-            finally:
-                self._update_staged = False
-                update_warn.cancel()
-                if self.parallel_updates:
-                    self.parallel_updates.release()
 
         start = timer()
 
@@ -303,6 +280,39 @@ class Entity(object):
     def async_schedule_update_ha_state(self, force_refresh=False):
         """Schedule a update ha state change task."""
         self.hass.async_add_job(self.async_update_ha_state(force_refresh))
+
+    def async_device_update(self, warning=True):
+        """Process 'update' or 'async_update' from entity.
+
+        This method is a coroutine.
+        """
+        if self._update_staged:
+            return
+        self._update_staged = True
+
+        # Process update sequential
+        if self.parallel_updates:
+            yield from self.parallel_updates.acquire()
+
+        if warning:
+            update_warn = self.hass.loop.call_later(
+                SLOW_UPDATE_WARNING, _LOGGER.warning,
+                "Update of %s is taking over %s seconds", self.entity_id,
+                SLOW_UPDATE_WARNING
+            )
+
+        try:
+            if hasattr(self, 'async_update'):
+                # pylint: disable=no-member
+                yield from self.async_update()
+            else:
+                yield from self.hass.async_add_job(self.update)
+        finally:
+            self._update_staged = False
+            if warning:
+                update_warn.cancel()
+            if self.parallel_updates:
+                self.parallel_updates.release()
 
     def remove(self) -> None:
         """Remove entity from HASS."""

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -210,6 +210,15 @@ class EntityComponent(object):
 
         entity.hass = self.hass
 
+        # Update properties before we generate the entity_id
+        if update_before_add:
+            try:
+                yield from entity.async_device_update(warning=False)
+            except Exception:  # pylint: disable=broad-except
+                self.logger.exception("Error on device update!")
+                return False
+
+        # Write entity_id to entity
         if getattr(entity, 'entity_id', None) is None:
             object_id = entity.name or DEVICE_DEFAULT_NAME
 
@@ -234,7 +243,7 @@ class EntityComponent(object):
         if hasattr(entity, 'async_added_to_hass'):
             yield from entity.async_added_to_hass()
 
-        yield from entity.async_update_ha_state(update_before_add)
+        yield from entity.async_update_ha_state()
 
         return True
 
@@ -361,12 +370,14 @@ class EntityPlatform(object):
 
     def add_entities(self, new_entities, update_before_add=False):
         """Add entities for a single platform."""
+        # That avoid deadlocks
         if update_before_add:
-            for entity in new_entities:
-                entity.update()
+            self.component.logger.warning(
+                "Call 'add_entities' with update_before_add=True "
+                "only inside tests or you run into a deadlock!")
 
         run_coroutine_threadsafe(
-            self.async_add_entities(list(new_entities), False),
+            self.async_add_entities(list(new_entities), update_before_add),
             self.component.hass.loop).result()
 
     @asyncio.coroutine

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -374,7 +374,7 @@ class EntityPlatform(object):
         if update_before_add:
             self.component.logger.warning(
                 "Call 'add_entities' with update_before_add=True "
-                "only inside tests or you run into a deadlock!")
+                "only inside tests or you can run into a deadlock!")
 
         run_coroutine_threadsafe(
             self.async_add_entities(list(new_entities), update_before_add),

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -194,6 +194,30 @@ def test_warn_slow_update_with_exception(hass):
 
 
 @asyncio.coroutine
+def test_warn_slow_device_update_disabled(hass):
+    """Disable slow update warning with async_device_update."""
+    update_call = False
+
+    @asyncio.coroutine
+    def async_update():
+        """Mock async update."""
+        nonlocal update_call
+        update_call = True
+
+    mock_entity = entity.Entity()
+    mock_entity.hass = hass
+    mock_entity.entity_id = 'comp_test.test_entity'
+    mock_entity.async_update = async_update
+
+    with patch.object(hass.loop, 'call_later', MagicMock()) \
+            as mock_call:
+        yield from mock_entity.async_device_update(warning=False)
+
+        assert not mock_call.called
+        assert update_call
+
+
+@asyncio.coroutine
 def test_async_schedule_update_ha_state(hass):
     """Warn we log when entity update takes a long time and trow exception."""
     update_call = False


### PR DESCRIPTION
## Description:

With #9924 we forgeth that some device need call `update` before he provide the `name` that we read by `generate_entity_id`.

This PR call now the update like before but care about the `PARALLEL_UPDATES` settings of the platform. We do now also protect the add device callback if the update will raise a exception we don't break the hole platform like before. I remove also the update code inside `add_entities` and add a warning. We use this function now only inside tests and there we can't run into a deadlock and for custom component it's very hard to run into a real deadlock with new code. So we reduce a logic there.

Fix: #10028
Fix: #10015 
Fix: #10018 
Fix: #10020

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
