### PR TITLE
Show current program thumbnail as media_image

### DIFF
--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -136,8 +136,11 @@ class LiveboxPlayTvDevice(MediaPlayerDevice):
     def media_title(self):
         """Title of current playing media."""
         if self._current_channel:
-            return '{}: {}'.format(self._current_channel,
-                                   self._current_program)
+            if self._current_program:
+                return '{}: {}'.format(self._current_channel,
+                                       self._current_program)
+            else:
+                return self._current_channel
 
     @property
     def supported_features(self):

--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -11,7 +11,6 @@ from datetime import timedelta
 import requests
 import voluptuous as vol
 
-import homeassistant.util as util
 from homeassistant.components.media_player import (
     SUPPORT_TURN_ON, SUPPORT_TURN_OFF, SUPPORT_PLAY,
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
@@ -44,8 +43,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Orange Livebox Play TV platform."""
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
@@ -59,7 +58,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     except IOError:
         _LOGGER.error("Failed to connect to Livebox Play TV at %s:%s. "
                       "Please check your configuration", host, port)
-    add_devices(livebox_devices, True)
+    async_add_devices(livebox_devices, True)
 
 
 class LiveboxPlayTvDevice(MediaPlayerDevice):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -401,7 +401,7 @@ lightify==1.0.6
 limitlessled==1.0.8
 
 # homeassistant.components.media_player.liveboxplaytv
-liveboxplaytv==1.5.0
+liveboxplaytv==2.0.0
 
 # homeassistant.components.lametric
 # homeassistant.components.notify.lametric


### PR DESCRIPTION
## Description:
This changes the media image that is displayed. It used to be the logo of the current channel, now a thumbnail of the current program is shown instead.
In case there is no thumbnail available it will default to the channel logo.

![Imgur](https://i.imgur.com/qDKU0dh.png)

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: liveboxplaytv
    host: 192.168.1.2
```