### PR TITLE
fix gateway illumination sensor value

### DIFF
--- a/homeassistant/components/sensor/xiaomi_aqara.py
+++ b/homeassistant/components/sensor/xiaomi_aqara.py
@@ -75,8 +75,6 @@ class XiaomiSensor(XiaomiDevice):
             return False
         elif self._data_key == 'humidity' and (value <= 0 or value > 100):
             return False
-        elif self._data_key == 'illumination' and value == 0:
-            return False
         elif self._data_key == 'pressure' and value == 0:
             return False
         self._state = round(value, 2)


### PR DESCRIPTION
## Description:
My earlier PR https://github.com/home-assistant/home-assistant/pull/10024 broke gateway illumination sensor when illumination value is 0. There were two conditions to check the illumination value. I think that one is enough. 
