### PR TITLE
Fix no data event triggers

### DIFF
--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -32,7 +32,7 @@ def async_trigger(hass, config, action):
     event_data_schema = vol.Schema(
         config.get(CONF_EVENT_DATA),
         extra=vol.ALLOW_EXTRA) if CONF_EVENT_DATA in config else \
-            vol.Schema(dict)
+        vol.Schema(dict)
 
     @callback
     def handle_event(event):

--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -31,17 +31,19 @@ def async_trigger(hass, config, action):
     event_type = config.get(CONF_EVENT_TYPE)
     event_data_schema = vol.Schema(
         config.get(CONF_EVENT_DATA),
-        extra=vol.ALLOW_EXTRA) if CONF_EVENT_DATA in config else \
-        vol.Schema(dict)
+        extra=vol.ALLOW_EXTRA) if CONF_EVENT_DATA in config else None
 
     @callback
     def handle_event(event):
         """Listen for events and calls the action when data matches."""
-        try:
-            event_data_schema(event.data)
-        except vol.Invalid:
-            # If event data doesn't match requested schema, skip event
-            return
+        if event_data_schema:
+            # Check that the event data matches the configured
+            # schema if one was provided
+            try:
+                event_data_schema(event.data)
+            except vol.Invalid:
+                # If event data doesn't match requested schema, skip event
+                return
 
         hass.async_run_job(action, {
             'trigger': {

--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 TRIGGER_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'event',
     vol.Required(CONF_EVENT_TYPE): cv.string,
-    vol.Optional(CONF_EVENT_DATA, default={}): dict,
+    vol.Optional(CONF_EVENT_DATA): dict,
 })
 
 
@@ -31,7 +31,8 @@ def async_trigger(hass, config, action):
     event_type = config.get(CONF_EVENT_TYPE)
     event_data_schema = vol.Schema(
         config.get(CONF_EVENT_DATA),
-        extra=vol.ALLOW_EXTRA)
+        extra=vol.ALLOW_EXTRA) if CONF_EVENT_DATA in config else \
+            vol.Schema(dict)
 
     @callback
     def handle_event(event):

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -43,7 +43,7 @@ class TestAutomationEvent(unittest.TestCase):
             }
         })
 
-        self.hass.bus.fire('test_event')
+        self.hass.bus.fire('test_event', {'extra_key': 'extra_data'})
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
 


### PR DESCRIPTION
## Description:
Allow extra on an empty dict isn't a valid voluptuous schema.

**Related issue (if applicable):** fixes #10046
