### PR TITLE
Templating - Added get_state_changed, get_state_updated, get_state_attr

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -670,6 +670,24 @@ class StateMachine(object):
         return state_obj is not None and \
             state_obj.attributes.get(name, None) == value
 
+    def get_state_changed(self, entity_id):
+        """Test if entity exists and returns 'last_changed' value."""
+        state_obj = self.get(entity_id)
+        if state_obj is not None:
+            return state_obj.last_changed
+
+    def get_state_updated(self, entity_id):
+        """Test if entity exists and returns 'last_updated' value."""
+        state_obj = self.get(entity_id)
+        if state_obj is not None:
+            return state_obj.last_updated
+
+    def get_state_attr(self, entity_id, name):
+        """Test if entity exists and returns state attribute."""
+        state_obj = self.get(entity_id)
+        if state_obj is not None:
+            return state_obj.attributes.get(name, None)
+
     def remove(self, entity_id):
         """Remove the state of an entity.
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -25,7 +25,8 @@ DATE_STR_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 _RE_NONE_ENTITIES = re.compile(r"distance\(|closest\(", re.I | re.M)
 _RE_GET_ENTITIES = re.compile(
-    r"(?:(?:states\.|(?:is_state|is_state_attr|states)"
+    r"(?:(?:states\.|(?:is_state|is_state_attr|"
+    r"get_state_changed|get_state_updated|get_state_attr|states)"
     r"\((?:[\ \'\"]?))([\w]+\.[\w]+)|([\w]+))", re.I | re.M
 )
 
@@ -168,6 +169,9 @@ class Template(object):
             'distance': location_methods.distance,
             'is_state': self.hass.states.is_state,
             'is_state_attr': self.hass.states.is_state_attr,
+            'get_state_changed': self.hass.states.get_state_changed,
+            'get_state_updated': self.hass.states.get_state_updated,
+            'get_state_attr': self.hass.states.get_state_attr,
             'states': AllStates(self.hass),
         })
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -718,6 +718,21 @@ is_state_attr('device_tracker.phone_2', 'battery', 40)
             """))
 
         self.assertListEqual(
+            ['device_tracker.phone_2'],
+            template.extract_entities("""
+                get_state_changed('device_tracker.phone_2')"""))
+
+        self.assertListEqual(
+            ['device_tracker.phone_2'],
+            template.extract_entities("""
+                get_state_updated('device_tracker.phone_2')"""))
+
+        self.assertListEqual(
+            ['device_tracker.phone_2'],
+            template.extract_entities("""
+                get_state_attr('device_tracker.phone_2' 'battery')"""))
+
+        self.assertListEqual(
             sorted([
                 'device_tracker.phone_1',
                 'device_tracker.phone_2',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -502,6 +502,30 @@ class TestStateMachine(unittest.TestCase):
         self.assertFalse(
             self.states.is_state_attr('light.Non_existing', 'brightness', 100))
 
+    def test_get_state_changed(self):
+        """Test get_state_changed method."""
+        self.states.set("light.Bowl", "on", {"brightness": 100})
+        self.assertEqual(
+            self.states.get("light.Bowl").last_changed,
+            self.states.get_state_changed("light.Bowl"))
+
+    def test_get_state_updated(self):
+        """Test get_state_updated method."""
+        self.states.set("light.Bowl", "on", {"brightness": 100})
+        self.assertEqual(
+            self.states.get("light.Bowl").last_updated,
+            self.states.get_state_updated("light.Bowl"))
+
+    def test_get_state_attr(self):
+        """Test get_state_attr method."""
+        self.states.set("light.Bowl", "on", {"brightness": 100})
+        self.assertEqual(
+            100,
+            self.states.get_state_attr("light.Bowl", "brightness"))
+        self.assertEqual(
+            None,
+            self.states.get_state_attr("light.Bowl", "friendly_name"))
+
     def test_entity_ids(self):
         """Test get_entity_ids method."""
         ent_ids = self.states.entity_ids()


### PR DESCRIPTION
## Description:
- `get_state_changed('device_tracker.paulus')` will return time object of the time the state last changed.
- `get_state_updated('device_tracker.paulus')` will return time object of the time the state or attributes were last updated.
- `get_state_attr('device_tracker.pauls', 'battery')` will return value for a specific attribute of an entity.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3724

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
