### PR TITLE
Added capability to pass a filename to the downloader component

### DIFF
--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -17,6 +17,7 @@ from homeassistant.util import sanitize_filename
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_FILENAME = 'filename'
 ATTR_SUBDIR = 'subdir'
 ATTR_URL = 'url'
 
@@ -29,6 +30,7 @@ SERVICE_DOWNLOAD_FILE = 'download_file'
 SERVICE_DOWNLOAD_FILE_SCHEMA = vol.Schema({
     vol.Required(ATTR_URL): cv.url,
     vol.Optional(ATTR_SUBDIR): cv.string,
+    vol.Optional(ATTR_FILENAME): cv.string,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -62,6 +64,8 @@ def setup(hass, config):
 
                 subdir = service.data.get(ATTR_SUBDIR)
 
+                friendly_name = service.data.get(ATTR_FILENAME)
+
                 if subdir:
                     subdir = sanitize_filename(subdir)
 
@@ -78,6 +82,9 @@ def setup(hass, config):
 
                         if match:
                             filename = match[0].strip("'\" ")
+
+                    if friendly_name:
+                        filename = friendly_name
 
                     if not filename:
                         filename = os.path.basename(

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -64,7 +64,7 @@ def setup(hass, config):
 
                 subdir = service.data.get(ATTR_SUBDIR)
 
-                friendly_name = service.data.get(ATTR_FILENAME)
+                filename = service.data.get(ATTR_FILENAME)
 
                 if subdir:
                     subdir = sanitize_filename(subdir)
@@ -74,21 +74,17 @@ def setup(hass, config):
                 req = requests.get(url, stream=True, timeout=10)
 
                 if req.status_code == 200:
-                    filename = None
 
-                    if 'content-disposition' in req.headers:
+                    if filename is None and \
+                       'content-disposition' in req.headers:
                         match = re.findall(r"filename=(\S+)",
                                            req.headers['content-disposition'])
 
                         if match:
                             filename = match[0].strip("'\" ")
 
-                    if friendly_name:
-                        filename = friendly_name
-
                     if not filename:
-                        filename = os.path.basename(
-                            url).strip()
+                        filename = os.path.basename(url).strip()
 
                     if not filename:
                         filename = 'ha_download'


### PR DESCRIPTION
## Description:

Added capability to pass a filename to the downloader component

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/3705#issuecomment-338500800

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3730

## Example entry for `configuration.yaml` (if applicable):
```yaml
downloader:
  download_dir: downloads
```
* `python_script` example used on this test
```python
# obtain ring doorbell camera object
# replace the camera.front_door by your camera entity
ring_cam = hass.states.get('camera.front_door')

subdir_name = 'ring_{}'.format(ring_cam.attributes.get('friendly_name'))
filename = 'test.mp4'

# get video URL
data = {
    'url': ring_cam.attributes.get('video_url'),
    'subdir': subdir_name,
    'filename': filename,
}

# call downloader component to save the video
hass.services.call('downloader', 'download_file', data)
```

* Result
```bash
(python:ha-py36) ↪ tree ~/.homeassistant_tests/downloads/
/home/mdemello/.homeassistant_tests/downloads/
└── ring_FrontDoor
    └── test.mp4
```


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.