### PR TITLE
Remove warning component / Update event trigger for UI created

### DIFF
--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -31,7 +31,7 @@ def async_trigger(hass, config, action):
     event_type = config.get(CONF_EVENT_TYPE)
     event_data_schema = vol.Schema(
         config.get(CONF_EVENT_DATA),
-        extra=vol.ALLOW_EXTRA) if CONF_EVENT_DATA in config else None
+        extra=vol.ALLOW_EXTRA) if config.get(CONF_EVENT_DATA) else None
 
     @callback
     def handle_event(event):

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -370,12 +370,6 @@ class EntityPlatform(object):
 
     def add_entities(self, new_entities, update_before_add=False):
         """Add entities for a single platform."""
-        # That avoid deadlocks
-        if update_before_add:
-            self.component.logger.warning(
-                "Call 'add_entities' with update_before_add=True "
-                "only inside tests or you can run into a deadlock!")
-
         run_coroutine_threadsafe(
             self.async_add_entities(list(new_entities), update_before_add),
             self.component.hass.loop).result()


### PR DESCRIPTION
## Description:

I remove the warning while that is to hard. To run in a deadlock with that function is not easy and need a very wired configuration. I think we should make that function to not block in future for `component.add_entities` but for the moment we can run with it and maybe also in future.

I change the event trigger to trigger also with WebUI automation editor rules.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
