### PR TITLE
Make host optional

### DIFF
--- a/homeassistant/components/namecheapdns.py
+++ b/homeassistant/components/namecheapdns.py
@@ -1,46 +1,55 @@
-"""Integrate with NamecheapDNS."""
+"""
+Integrate with namecheap DNS services.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/namecheapdns/
+"""
 import asyncio
-from datetime import timedelta
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_HOST, CONF_ACCESS_TOKEN, CONF_DOMAIN
 import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_DOMAIN
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-DOMAIN = 'namecheapdns'
-UPDATE_URL = 'https://dynamicdns.park-your-domain.com/update'
-INTERVAL = timedelta(minutes=5)
 _LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'namecheapdns'
+
+INTERVAL = timedelta(minutes=5)
+
+UPDATE_URL = 'https://dynamicdns.park-your-domain.com/update'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_HOST): cv.string,
         vol.Required(CONF_DOMAIN): cv.string,
-        vol.Required(CONF_ACCESS_TOKEN): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_HOST, default='@'): cv.string,
     })
 }, extra=vol.ALLOW_EXTRA)
 
 
 @asyncio.coroutine
 def async_setup(hass, config):
-    """Initialize the NamecheapDNS component."""
+    """Initialize the namecheap DNS component."""
     host = config[DOMAIN][CONF_HOST]
     domain = config[DOMAIN][CONF_DOMAIN]
-    token = config[DOMAIN][CONF_ACCESS_TOKEN]
+    password = config[DOMAIN][CONF_PASSWORD]
+
     session = async_get_clientsession(hass)
 
-    result = yield from _update_namecheapdns(session, host, domain, token)
+    result = yield from _update_namecheapdns(session, host, domain, password)
 
     if not result:
         return False
 
     @asyncio.coroutine
     def update_domain_interval(now):
-        """Update the NamecheapDNS entry."""
-        yield from _update_namecheapdns(session, host, domain, token)
+        """Update the namecheap DNS entry."""
+        yield from _update_namecheapdns(session, host, domain, password)
 
     async_track_time_interval(hass, update_domain_interval, INTERVAL)
 
@@ -48,14 +57,14 @@ def async_setup(hass, config):
 
 
 @asyncio.coroutine
-def _update_namecheapdns(session, host, domain, token):
-    """Update NamecheapDNS."""
+def _update_namecheapdns(session, host, domain, password):
+    """Update namecheap DNS entry."""
     import xml.etree.ElementTree as ET
 
     params = {
         'host': host,
         'domain': domain,
-        'password': token,
+        'password': password,
     }
 
     resp = yield from session.get(UPDATE_URL, params=params)
@@ -64,7 +73,7 @@ def _update_namecheapdns(session, host, domain, token):
     err_count = root.find('ErrCount').text
 
     if int(err_count) != 0:
-        _LOGGER.warning('Updating Namecheap domain %s failed', domain)
+        _LOGGER.warning("Updating namecheap domain failed: %s", domain)
         return False
 
     return True

--- a/tests/components/test_namecheapdns.py
+++ b/tests/components/test_namecheapdns.py
@@ -12,7 +12,7 @@ from tests.common import async_fire_time_changed
 
 HOST = 'test'
 DOMAIN = 'bla'
-TOKEN = 'abcdefgh'
+PASSWORD = 'abcdefgh'
 
 
 @pytest.fixture
@@ -21,7 +21,7 @@ def setup_namecheapdns(hass, aioclient_mock):
     aioclient_mock.get(namecheapdns.UPDATE_URL, params={
         'host': HOST,
         'domain': DOMAIN,
-        'password': TOKEN
+        'password': PASSWORD,
     }, text='<interface-response><ErrCount>0</ErrCount></interface-response>')
 
     hass.loop.run_until_complete(async_setup_component(
@@ -29,7 +29,7 @@ def setup_namecheapdns(hass, aioclient_mock):
             'namecheapdns': {
                 'host': HOST,
                 'domain': DOMAIN,
-                'access_token': TOKEN
+                'password': PASSWORD,
             }
         }))
 
@@ -40,14 +40,14 @@ def test_setup(hass, aioclient_mock):
     aioclient_mock.get(namecheapdns.UPDATE_URL, params={
         'host': HOST,
         'domain': DOMAIN,
-        'password': TOKEN
+        'password': PASSWORD
     }, text='<interface-response><ErrCount>0</ErrCount></interface-response>')
 
     result = yield from async_setup_component(hass, namecheapdns.DOMAIN, {
         'namecheapdns': {
             'host': HOST,
             'domain': DOMAIN,
-            'access_token': TOKEN
+            'password': PASSWORD,
         }
     })
     assert result
@@ -64,14 +64,14 @@ def test_setup_fails_if_update_fails(hass, aioclient_mock):
     aioclient_mock.get(namecheapdns.UPDATE_URL, params={
         'host': HOST,
         'domain': DOMAIN,
-        'password': TOKEN
+        'password': PASSWORD,
     }, text='<interface-response><ErrCount>1</ErrCount></interface-response>')
 
     result = yield from async_setup_component(hass, namecheapdns.DOMAIN, {
         'namecheapdns': {
             'host': HOST,
             'domain': DOMAIN,
-            'access_token': TOKEN
+            'password': PASSWORD,
         }
     })
     assert not result


### PR DESCRIPTION
## Description:
- Make `host` optional and set the `@` as default to avoid YAML issues. Was not addressed in #9821.
- Update docstrings
- Sync with namecheapdns naming of elements

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3733

## Example entry for `configuration.yaml` (if applicable):
```yaml
namecheapdns:
  domain: example.com
  password: thePassword
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
