### PR TITLE
Remove STATE_UNKNOWN

### DIFF
--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -13,8 +13,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_HOST, CONF_PORT, STATE_UNKNOWN, CONF_NAME, CONF_RESOURCES,
-    TEMP_CELSIUS)
+    CONF_HOST, CONF_PORT, CONF_NAME, CONF_RESOURCES, TEMP_CELSIUS)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
@@ -81,7 +80,7 @@ class GlancesSensor(Entity):
         self.rest = rest
         self._name = name
         self.type = sensor_type
-        self._state = STATE_UNKNOWN
+        self._state = None
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
 
     @property
@@ -164,7 +163,7 @@ class GlancesData(object):
     def __init__(self, resource):
         """Initialize the data object."""
         self._resource = resource
-        self.data = dict()
+        self.data = {}
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):


### PR DESCRIPTION
## Description:
- Set `self._state = None` instead of using `STATE_UNKNOWN`.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: glances
    host: localhost
    resources:
      - 'disk_use_percent'
      - 'disk_use'
      - 'memory_use'
      - 'memory_use_percent'
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
