### PR TITLE
Fix building Docker image on Docker for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure Docker script files uses LF to support Docker for Windows.
+setup_docker_prereqs    eol=lf
+/virtualization/Docker/scripts/*    eol=lf


### PR DESCRIPTION
## Description:
Building an image from the Home Assistant Dockerfile does not work using Docker for Windows if files needed to build the image have CRLF line endings. Git for Windows clones text files automatically as CRLF. A .gitattributes file can be used to ensure Git gives the Docker script files LF line endings when cloning the repo.

I tested this building both the Dockerfile and Dockerfile.dev images on Windows 10.