### PR TITLE
Change deprecated use of maintainer tag in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # This way, the development image and the production image are kept in sync.
 
 FROM python:3.6
-MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
+LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 
 # Uncomment any of the following lines to disable the installation.
 #ENV INSTALL_TELLSTICK no

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -3,7 +3,7 @@
 # Keep this file as close as possible to the production Dockerfile, so the environments match.
 
 FROM python:3.6
-MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
+LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 
 # Uncomment any of the following lines to disable the installation.
 #ENV INSTALL_TELLSTICK no


### PR DESCRIPTION
## Description:
The use of the maintainer tag in a Dockerfile has been deprecated. The Docker documentation states a label called maintainer can be used instead (https://docs.docker.com/engine/reference/builder/#maintainer-deprecated). I changed the Dockerfile and Dockerfile.dev to use the new label notation.