### PR TITLE
Support for Entity.available in sensor/rest

### DIFF
--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -68,10 +68,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     rest = RestData(method, resource, auth, headers, payload, verify_ssl)
     rest.update()
 
-    if rest.data is None:
-        _LOGGER.error("Unable to fetch REST data")
-        return False
-
     add_devices([RestSensor(hass, rest, name, unit, value_template)], True)
 
 
@@ -96,6 +92,11 @@ class RestSensor(Entity):
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return self._unit_of_measurement
+
+    @property
+    def available(self):
+        """Return if the sensor data are available."""
+        return self.rest.data is not None
 
     @property
     def state(self):

--- a/tests/components/sensor/test_rest.py
+++ b/tests/components/sensor/test_rest.py
@@ -45,18 +45,18 @@ class TestRestSensorSetup(unittest.TestCase):
            side_effect=requests.exceptions.ConnectionError())
     def test_setup_failed_connect(self, mock_req):
         """Test setup when connection error occurs."""
-        self.assertFalse(rest.setup_platform(self.hass, {
+        self.assertTrue(rest.setup_platform(self.hass, {
             'platform': 'rest',
             'resource': 'http://localhost',
-        }, None))
+        }, lambda devices, update=True: None) is None)
 
     @patch('requests.Session.send', side_effect=Timeout())
     def test_setup_timeout(self, mock_req):
         """Test setup when connection timeout occurs."""
-        self.assertFalse(rest.setup_platform(self.hass, {
+        self.assertTrue(rest.setup_platform(self.hass, {
             'platform': 'rest',
             'resource': 'http://localhost',
-        }, None))
+        }, lambda devices, update=True: None) is None)
 
     @requests_mock.Mocker()
     def test_setup_minimum(self, mock_req):
@@ -165,6 +165,7 @@ class TestRestSensor(unittest.TestCase):
             'rest.RestData.update', side_effect=self.update_side_effect(None))
         self.sensor.update()
         self.assertEqual(STATE_UNKNOWN, self.sensor.state)
+        self.assertFalse(self.sensor.available)
 
     def test_update_when_value_changed(self):
         """Test state gets updated when sensor returns a new status."""
@@ -173,6 +174,7 @@ class TestRestSensor(unittest.TestCase):
                                     '{ "key": "updated_state" }'))
         self.sensor.update()
         self.assertEqual('updated_state', self.sensor.state)
+        self.assertTrue(self.sensor.available)
 
     def test_update_with_no_template(self):
         """Test update when there is no value template."""
@@ -183,6 +185,7 @@ class TestRestSensor(unittest.TestCase):
             self.hass, self.rest, self.name, self.unit_of_measurement, None)
         self.sensor.update()
         self.assertEqual('plain_state', self.sensor.state)
+        self.assertTrue(self.sensor.available)
 
 
 class TestRestData(unittest.TestCase):


### PR DESCRIPTION
## Description:

Currently rest sensors that are not available when homeassistant is starting fail the initialization and are ingored untill after next restart. This change allows homeassistant to start first and pick-up the sensors later as they become available.

**Related issue (if applicable):** fixes #8109 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**  N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: rest
    resource: http://127.0.0.1:12345/
```
along with

```shell
while /bin/true; do echo -e "HTTP/1.0 200 OK\n\non" | nc -l -p 12345 ; done;
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
