### PR TITLE
Add minutes to Uptime sensor

### DIFF
--- a/homeassistant/components/sensor/uptime.py
+++ b/homeassistant/components/sensor/uptime.py
@@ -74,5 +74,5 @@ class UptimeSensor(Entity):
         if self.unit_of_measurement == 'days':
             div_factor *= 24
         delta = delta.total_seconds() / div_factor
-        self._state = round(delta, 2)
+        self._state = format(round(delta, 2), '.2f')
         _LOGGER.debug("New value: %s", delta)

--- a/homeassistant/components/sensor/uptime.py
+++ b/homeassistant/components/sensor/uptime.py
@@ -23,7 +23,7 @@ DEFAULT_NAME = 'Uptime'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT, default='days'):
-        vol.All(cv.string, vol.In(['hours', 'days']))
+        vol.All(cv.string, vol.In(['minutes', 'hours', 'days']))
 })
 
 
@@ -73,6 +73,8 @@ class UptimeSensor(Entity):
         div_factor = 3600
         if self.unit_of_measurement == 'days':
             div_factor *= 24
+        elif self.unit_of_measurement == 'minutes':
+            div_factor /= 60
         delta = delta.total_seconds() / div_factor
-        self._state = format(round(delta, 2), '.2f')
+        self._state = round(delta, 2)
         _LOGGER.debug("New value: %s", delta)

--- a/tests/components/sensor/test_uptime.py
+++ b/tests/components/sensor/test_uptime.py
@@ -59,14 +59,14 @@ class TestUptimeSensor(unittest.TestCase):
                 sensor.async_update(),
                 self.hass.loop
             ).result()
-            self.assertEqual(format(round(sensor.state, 2), '.2f'), 1.00)
+            self.assertEqual(sensor.state, 1.00)
         new_time = sensor.initial + timedelta(days=111.499)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             run_coroutine_threadsafe(
                 sensor.async_update(),
                 self.hass.loop
             ).result()
-            self.assertEqual(format(round(sensor.state, 2), '.2f'), 111.50)
+            self.assertEqual(sensor.state, 111.50)
 
     def test_uptime_sensor_hours_output(self):
         """Test uptime sensor output data."""
@@ -78,11 +78,11 @@ class TestUptimeSensor(unittest.TestCase):
                 sensor.async_update(),
                 self.hass.loop
             ).result()
-            self.assertEqual(format(round(sensor.state, 2), '.2f'), 16.00)
+            self.assertEqual(sensor.state, 16.00)
         new_time = sensor.initial + timedelta(hours=72.499)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             run_coroutine_threadsafe(
                 sensor.async_update(),
                 self.hass.loop
             ).result()
-            self.assertEqual(format(round(sensor.state, 2), '.2f'), 72.50)
+            self.assertEqual(sensor.state, 72.50)

--- a/tests/components/sensor/test_uptime.py
+++ b/tests/components/sensor/test_uptime.py
@@ -49,6 +49,16 @@ class TestUptimeSensor(unittest.TestCase):
         }
         assert setup_component(self.hass, 'sensor', config)
 
+    def test_uptime_sensor_config_minutes(self):
+        """Test uptime sensor with minutes defined in config."""
+        config = {
+            'sensor': {
+                'platform': 'uptime',
+                'unit_of_measurement': 'minutes',
+            }
+        }
+        assert setup_component(self.hass, 'sensor', config)
+
     def test_uptime_sensor_days_output(self):
         """Test uptime sensor output data."""
         sensor = UptimeSensor('test', 'days')
@@ -86,3 +96,22 @@ class TestUptimeSensor(unittest.TestCase):
                 self.hass.loop
             ).result()
             self.assertEqual(sensor.state, 72.50)
+
+    def test_uptime_sensor_minutes_output(self):
+        """Test uptime sensor output data."""
+        sensor = UptimeSensor('test', 'minutes')
+        self.assertEqual(sensor.unit_of_measurement, 'minutes')
+        new_time = sensor.initial + timedelta(minutes=16)
+        with patch('homeassistant.util.dt.now', return_value=new_time):
+            run_coroutine_threadsafe(
+                sensor.async_update(),
+                self.hass.loop
+            ).result()
+            self.assertEqual(sensor.state, 16.00)
+        new_time = sensor.initial + timedelta(minutes=12.499)
+        with patch('homeassistant.util.dt.now', return_value=new_time):
+            run_coroutine_threadsafe(
+                sensor.async_update(),
+                self.hass.loop
+            ).result()
+            self.assertEqual(sensor.state, 12.50)

--- a/tests/components/sensor/test_uptime.py
+++ b/tests/components/sensor/test_uptime.py
@@ -59,14 +59,14 @@ class TestUptimeSensor(unittest.TestCase):
                 sensor.async_update(),
                 self.hass.loop
             ).result()
-            self.assertEqual(sensor.state, 1.00)
+            self.assertEqual(format(round(sensor.state, 2), '.2f'), 1.00)
         new_time = sensor.initial + timedelta(days=111.499)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             run_coroutine_threadsafe(
                 sensor.async_update(),
                 self.hass.loop
             ).result()
-            self.assertEqual(sensor.state, 111.50)
+            self.assertEqual(format(round(sensor.state, 2), '.2f'), 111.50)
 
     def test_uptime_sensor_hours_output(self):
         """Test uptime sensor output data."""
@@ -78,11 +78,11 @@ class TestUptimeSensor(unittest.TestCase):
                 sensor.async_update(),
                 self.hass.loop
             ).result()
-            self.assertEqual(sensor.state, 16.00)
+            self.assertEqual(format(round(sensor.state, 2), '.2f'), 16.00)
         new_time = sensor.initial + timedelta(hours=72.499)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             run_coroutine_threadsafe(
                 sensor.async_update(),
                 self.hass.loop
             ).result()
-            self.assertEqual(sensor.state, 72.50)
+            self.assertEqual(format(round(sensor.state, 2), '.2f'), 72.50)


### PR DESCRIPTION
Added the option to use `minutes` in the uptime sensor to allow precise control over automations. 

**Pull request in home-assistant.github.io with documentation (if applicable):** home-assistant/home-assistant.github.io#3741