### PR TITLE
MPD now uses the filename if song doesn't have metadata

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -176,7 +176,7 @@ class MpdDevice(MediaPlayerDevice):
         """Return the title of current playing media."""
         name = self._currentsong.get('name', None)
         title = self._currentsong.get('title', None)
-        file_name = self._currentsong('file', None)
+        file_name = self._currentsong.get('file', None)
 
         if name is None and title is None:
             if file_name is None:

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -176,9 +176,13 @@ class MpdDevice(MediaPlayerDevice):
         """Return the title of current playing media."""
         name = self._currentsong.get('name', None)
         title = self._currentsong.get('title', None)
+        file_name = self._currentsong('file', None)
 
         if name is None and title is None:
-            return "None"
+            if file_name is None:
+                return "None"
+            else:
+                return file_name.split('/')[-1]
         elif name is None:
             return title
         elif title is None:

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.mpd/
 """
 import logging
+import os
 from datetime import timedelta
 
 import voluptuous as vol
@@ -182,7 +183,7 @@ class MpdDevice(MediaPlayerDevice):
             if file_name is None:
                 return "None"
             else:
-                return file_name.split('/')[-1]
+                return os.path.basename(file_name)
         elif name is None:
             return title
         elif title is None:


### PR DESCRIPTION
## Description:
Very small change, but it irritated me that MPD would write "None" when playing songs without meta-data.

Changes:
- MPD now shows file_name instead of "None" as the "media_title"


I only changed five lines in the MPD component, and, as far as i could see, no test-cases exist in regards to the MPD component, so i didn't actually run any test cases to make sure it works, but you are very welcome to test it locally in case i made some massive mistake, however it *should* work. 

