### PR TITLE
Allow offset for interval

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -379,8 +379,14 @@ def _process_time_match(parameter):
         return lambda _: True
 
     elif isinstance(parameter, str) and parameter.startswith('/'):
-        parameter = float(parameter[1:])
-        return lambda time: time % parameter == 0
+        plus_pos = parameter.find('+', 2)
+        if plus_pos > 0:
+            parameter = float(parameter[1:plus_pos])
+            remainder = int(parameter[plus_pos + 1:])
+        else:
+            parameter = float(parameter[1:])
+            remainder = 0
+        return lambda time: time % parameter == remainder
 
     elif isinstance(parameter, str) or not hasattr(parameter, '__iter__'):
         return lambda time: time == parameter

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -381,11 +381,11 @@ def _process_time_match(parameter):
     elif isinstance(parameter, str) and parameter.startswith('/'):
         plus_pos = parameter.find('+', 2)
         if plus_pos > 0:
+            remainder = float(parameter[plus_pos + 1:])
             parameter = float(parameter[1:plus_pos])
-            remainder = int(parameter[plus_pos + 1:])
         else:
-            parameter = float(parameter[1:])
             remainder = 0
+            parameter = float(parameter[1:])
         return lambda time: time % parameter == remainder
 
     elif isinstance(parameter, str) or not hasattr(parameter, '__iter__'):

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -631,6 +631,114 @@ class TestEventHelpers(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(2, len(specific_runs))
 
+    def test_periodic_task_minute_remainder(self):
+        """Test periodic tasks per minute, with remainder."""
+        specific_runs = []
+
+        unsub = track_utc_time_change(
+            self.hass, lambda x: specific_runs.append(1), minute='/5+3')
+
+        self._send_time_changed(datetime(2014, 5, 24, 12, 3, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 24, 12, 6, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 24, 12, 8, 0))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
+        unsub()
+
+        self._send_time_changed(datetime(2014, 5, 24, 12, 8, 0))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
+    def test_periodic_task_hour_remainder(self):
+        """Test periodic tasks per hour, with remainder."""
+        specific_runs = []
+
+        unsub = track_utc_time_change(
+            self.hass, lambda x: specific_runs.append(1), hour='/3+2')
+
+        self._send_time_changed(datetime(2014, 5, 24, 20, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 24, 21, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 24, 23, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 25, 1, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 25, 2, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(3, len(specific_runs))
+
+        unsub()
+
+        self._send_time_changed(datetime(2014, 5, 25, 2, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(3, len(specific_runs))
+
+    def test_periodic_task_day_remainder(self):
+        """Test periodic tasks per day, with remainder."""
+        specific_runs = []
+
+        unsub = track_utc_time_change(
+            self.hass, lambda x: specific_runs.append(1), day='/2+1')
+
+        self._send_time_changed(datetime(2014, 5, 3, 0, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 4, 12, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 5, 0, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
+        unsub()
+
+        self._send_time_changed(datetime(2014, 5, 5, 0, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
+    def test_periodic_task_year_remainder(self):
+        """Test periodic tasks per year, with remainder."""
+        specific_runs = []
+
+        unsub = track_utc_time_change(
+            self.hass, lambda x: specific_runs.append(1), year='/2+1')
+
+        self._send_time_changed(datetime(2015, 5, 2, 0, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2016, 5, 2, 0, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2017, 5, 2, 0, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
+        unsub()
+
+        self._send_time_changed(datetime(2017, 5, 2, 0, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
     def test_periodic_task_wrong_input(self):
         """Test periodic tasks with wrong input."""
         specific_runs = []


### PR DESCRIPTION
## Description:

Added support for `/n+m` time intervals, so it will be possible to use intervals not only for hours 0, 2, 4, 6, etc, but also for 1, 3, 5, 7, etc. Or you could use `minutes: '/30+15'`to get something to run at quarter to the hour and quarter past the hour.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3743

## Example entry for `configuration.yaml` (if applicable):
```yaml
trigger:
    platform: time
    minutes: '/15+5'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
