### PR TITLE
Make recorder support including both entities and domains

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -303,8 +303,8 @@ class Recorder(threading.Thread):
                 # Included domains and entities
                 if self.include_d and self.include_e \
                         and domain not in self.include_d \
-                        and (entity_id not in self.include_e \
-                                and not self.exclude):
+                        and (entity_id not in self.include_e
+                             and not self.exclude):
                     self.queue.task_done()
                     continue
                 # Included domains only

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -300,11 +300,22 @@ class Recorder(threading.Thread):
                     self.queue.task_done()
                     continue
 
-                # Included domains only (excluded entities above) OR
-                # Include entities only, but only if no excludes
-                if (self.include_d and domain not in self.include_d) or \
-                        (self.include_e and entity_id not in self.include_e
-                         and not self.exclude):
+                # Included domains and entities
+                if self.include_d and self.include_e \
+                        and domain not in self.include_d \
+                        and (entity_id not in self.include_e \
+                                and not self.exclude):
+                    self.queue.task_done()
+                    continue
+                # Included domains only
+                elif self.include_d and not self.include_e \
+                        and domain not in self.include_d:
+                    self.queue.task_done()
+                    continue
+                # Included entities only
+                elif self.include_e and not self.include_d \
+                        and entity_id not in self.include_e \
+                        and not self.exclude:
                     self.queue.task_done()
                     continue
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -201,7 +201,9 @@ def test_saving_state_include_exclude_domains_entity(hass_recorder):
     hass = hass_recorder({
         'include': {'domains': 'test2', 'entities': 'test.recorder'},
         'exclude': {'domains': 'test', 'entities': 'test2.recorder2'}})
-    states = _add_entities(hass, ['test.recorder', 'test.recorder2', 'test2.recorder', 'test2.recorder2', 'test3.recorder'])
+    states = _add_entities(hass, ['test.recorder', 'test.recorder2',
+                                  'test2.recorder', 'test2.recorder2',
+                                  'test3.recorder'])
     assert len(states) == 3
     assert hass.states.get('test.recorder') == states[0]
     assert hass.states.get('test2.recorder') == states[1]

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -143,6 +143,14 @@ def test_saving_state_incl_entities(hass_recorder):
     assert hass.states.get('test2.recorder') == states[0]
 
 
+def test_saving_state_include_domain_include_entity(hass_recorder):
+    """Test saving and restoring a state."""
+    hass = hass_recorder({
+        'include': {'domains': 'test', 'entities': 'test2.recorder'}})
+    states = _add_entities(hass, ['test.recorder', 'test2.recorder'])
+    assert len(states) == 2
+
+
 def test_saving_event_exclude_event_type(hass_recorder):
     """Test saving and restoring an event."""
     hass = hass_recorder({'exclude': {'event_types': 'test'}})
@@ -186,6 +194,18 @@ def test_saving_state_include_domain_exclude_entity(hass_recorder):
     assert len(states) == 1
     assert hass.states.get('test.ok') == states[0]
     assert hass.states.get('test.ok').state == 'state2'
+
+
+def test_saving_state_include_exclude_domains_entity(hass_recorder):
+    """Test saving and restoring a state."""
+    hass = hass_recorder({
+        'include': {'domains': 'test2', 'entities': 'test.recorder'},
+        'exclude': {'domains': 'test', 'entities': 'test2.recorder2'}})
+    states = _add_entities(hass, ['test.recorder', 'test.recorder2', 'test2.recorder', 'test2.recorder2', 'test3.recorder'])
+    assert len(states) == 3
+    assert hass.states.get('test.recorder') == states[0]
+    assert hass.states.get('test2.recorder') == states[1]
+    assert hass.states.get('test3.recorder') == states[2]
 
 
 def test_recorder_setup_failure():


### PR DESCRIPTION
## Description:
Updates the Recorder component to allow specifying both domains and entities in the include list of the configuration.

**Related issue (if applicable):** fixes #7414

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
recorder:
    include:
      domains:
      - light
      entities:
      - switch.outlet
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
