### PR TITLE
Xiaomi Aqara: added interface and discovery_retry to the config validation

### DIFF
--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -25,7 +25,7 @@ def _validate_conf(config):
     res_config = []
     for gw_conf in config:
         for _conf in gw_conf.keys():
-            if _conf not in [CONF_MAC, CONF_HOST, CONF_PORT, 'key']:
+            if _conf not in [CONF_INTERFACE, CONF_DISCOVERY_RETRY, CONF_MAC, CONF_HOST, CONF_PORT, 'key']:
                 raise vol.Invalid('{} is not a valid config parameter'.
                                   format(_conf))
 

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -25,7 +25,8 @@ def _validate_conf(config):
     res_config = []
     for gw_conf in config:
         for _conf in gw_conf.keys():
-            if _conf not in [CONF_INTERFACE, CONF_DISCOVERY_RETRY, CONF_MAC, CONF_HOST, CONF_PORT, 'key']:
+            if _conf not in [CONF_INTERFACE, CONF_DISCOVERY_RETRY, CONF_MAC,
+                             CONF_HOST, CONF_PORT, 'key']:
                 raise vol.Invalid('{} is not a valid config parameter'.
                                   format(_conf))
 


### PR DESCRIPTION
## Description:
Xiaomi Aqara: added interface and discovery_retry to the config validation

**Related issue (if applicable):** fixes #10098 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
