### PR TITLE
Telldus Live: Device without methods is a binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/tellduslive.py
+++ b/homeassistant/components/binary_sensor/tellduslive.py
@@ -1,0 +1,34 @@
+"""
+Support for binary sensors using Tellstick Net.
+
+This platform uses the Telldus Live online service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.tellduslive/
+
+"""
+import logging
+
+from homeassistant.components.tellduslive import TelldusLiveEntity
+from homeassistant.components.binary_sensor import BinarySensorDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Tellstick sensors."""
+    if discovery_info is None:
+        return
+    add_devices(
+        TelldusLiveSensor(hass, binary_sensor)
+        for binary_sensor in discovery_info
+    )
+
+
+class TelldusLiveSensor(TelldusLiveEntity, BinarySensorDevice):
+    """Representation of a Tellstick sensor."""
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self.device.is_on

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -117,6 +117,8 @@ class TelldusLiveClient(object):
                 return 'cover'
             elif device.methods & TURNON:
                 return 'switch'
+            elif device.methods == 0:
+                return 'binary_sensor'
             _LOGGER.warning(
                 "Unidentified device type (methods: %d)", device.methods)
             return 'switch'


### PR DESCRIPTION
## Description:
Telldus Live reports binary sensors as devices without methods. This PR solves a problem where binary sensors is registered as switches in Home Assistant.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3753
