### PR TITLE
Fix PEP8 and PEP257 issues

### DIFF
--- a/homeassistant/components/climate/toon.py
+++ b/homeassistant/components/climate/toon.py
@@ -3,23 +3,20 @@ Toon van Eneco Thermostat Support.
 
 This provides a component for the rebranded Quby thermostat as provided by
 Eneco.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/climate.toon/
 """
-
-from homeassistant.components.climate import (ClimateDevice,
-                                              ATTR_TEMPERATURE,
-                                              STATE_PERFORMANCE,
-                                              STATE_HEAT,
-                                              STATE_ECO,
-                                              STATE_COOL)
-from homeassistant.const import TEMP_CELSIUS
-
 import homeassistant.components.toon as toon_main
+from homeassistant.components.climate import (
+    ClimateDevice, ATTR_TEMPERATURE, STATE_PERFORMANCE, STATE_HEAT, STATE_ECO,
+    STATE_COOL)
+from homeassistant.const import TEMP_CELSIUS
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup thermostat."""
-    # Add toon
-    add_devices((ThermostatDevice(hass), ), True)
+    """Set up the Toon thermostat."""
+    add_devices([ThermostatDevice(hass)], True)
 
 
 class ThermostatDevice(ClimateDevice):
@@ -31,24 +28,20 @@ class ThermostatDevice(ClimateDevice):
         self.hass = hass
         self.thermos = hass.data[toon_main.TOON_HANDLE]
 
-        # set up internal state vars
         self._state = None
         self._temperature = None
         self._setpoint = None
-        self._operation_list = [STATE_PERFORMANCE,
-                                STATE_HEAT,
-                                STATE_ECO,
-                                STATE_COOL]
+        self._operation_list = [
+            STATE_PERFORMANCE,
+            STATE_HEAT,
+            STATE_ECO,
+            STATE_COOL,
+        ]
 
     @property
     def name(self):
         """Name of this Thermostat."""
         return self._name
-
-    @property
-    def should_poll(self):
-        """Polling is required."""
-        return True
 
     @property
     def temperature_unit(self):
@@ -83,10 +76,12 @@ class ThermostatDevice(ClimateDevice):
 
     def set_operation_mode(self, operation_mode):
         """Set new operation mode as toonlib requires it."""
-        toonlib_values = {STATE_PERFORMANCE: 'Comfort',
-                          STATE_HEAT: 'Home',
-                          STATE_ECO: 'Away',
-                          STATE_COOL: 'Sleep'}
+        toonlib_values = {
+            STATE_PERFORMANCE: 'Comfort',
+            STATE_HEAT: 'Home',
+            STATE_ECO: 'Away',
+            STATE_COOL: 'Sleep',
+        }
 
         self.thermos.set_state(toonlib_values[operation_mode])
 

--- a/homeassistant/components/sensor/toon.py
+++ b/homeassistant/components/sensor/toon.py
@@ -1,8 +1,8 @@
 """
-Toon van Eneco Utility Gages.
+Component for the rebranded Quby thermostat as provided by Eneco.
 
-This provides a component for the rebranded Quby thermostat as provided by
-Eneco.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.toon/
 """
 import logging
 import datetime as datetime
@@ -12,46 +12,33 @@ import homeassistant.components.toon as toon_main
 
 _LOGGER = logging.getLogger(__name__)
 
-STATE_ATTR_DEVICE_TYPE = "device_type"
-STATE_ATTR_LAST_CONNECTED_CHANGE = "last_connected_change"
+STATE_ATTR_DEVICE_TYPE = 'device_type'
+STATE_ATTR_LAST_CONNECTED_CHANGE = 'last_connected_change'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup sensors."""
+    """Set up the Toon sensors."""
     _toon_main = hass.data[toon_main.TOON_HANDLE]
 
     sensor_items = []
-    sensor_items.extend([ToonSensor(hass,
-                                    'Power_current',
-                                    'power-plug',
-                                    'Watt'),
-                         ToonSensor(hass,
-                                    'Power_today',
-                                    'power-plug',
-                                    'kWh')])
+    sensor_items.extend([
+        ToonSensor(hass, 'Power_current', 'power-plug', 'Watt'),
+        ToonSensor(hass, 'Power_today', 'power-plug', 'kWh'),
+    ])
 
     if _toon_main.gas:
-        sensor_items.extend([ToonSensor(hass,
-                                        'Gas_current',
-                                        'gas-cylinder',
-                                        'CM3'),
-                             ToonSensor(hass,
-                                        'Gas_today',
-                                        'gas-cylinder',
-                                        'M3')])
+        sensor_items.extend([
+            ToonSensor(hass, 'Gas_current', 'gas-cylinder', 'CM3'),
+            ToonSensor(hass, 'Gas_today', 'gas-cylinder', 'M3'),
+        ])
 
     for plug in _toon_main.toon.smartplugs:
         sensor_items.extend([
-            FibaroSensor(hass,
-                         '{}_current_power'.format(plug.name),
-                         plug.name,
-                         'power-socket-eu',
-                         'Watt'),
-            FibaroSensor(hass,
-                         '{}_today_energy'.format(plug.name),
-                         plug.name,
-                         'power-socket-eu',
-                         'kWh')])
+            FibaroSensor(hass, '{}_current_power'.format(plug.name),
+                         plug.name, 'power-socket-eu', 'Watt'),
+            FibaroSensor(hass, '{}_today_energy'.format(plug.name),
+                         plug.name, 'power-socket-eu', 'kWh'),
+        ])
 
     if _toon_main.toon.solar.produced or _toon_main.solar:
         sensor_items.extend([
@@ -61,35 +48,29 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             SolarSensor(hass, 'Solar_average_produced', 'kWh'),
             SolarSensor(hass, 'Solar_meter_reading_low_produced', 'kWh'),
             SolarSensor(hass, 'Solar_meter_reading_produced', 'kWh'),
-            SolarSensor(hass, 'Solar_daily_cost_produced', 'Euro')
+            SolarSensor(hass, 'Solar_daily_cost_produced', 'Euro'),
         ])
 
     for smokedetector in _toon_main.toon.smokedetectors:
         sensor_items.append(
-            FibaroSmokeDetector(hass,
-                                '{}_smoke_detector'.format(smokedetector.name),
-                                smokedetector.device_uuid,
-                                'alarm-bell',
-                                '%'))
+            FibaroSmokeDetector(
+                hass, '{}_smoke_detector'.format(smokedetector.name),
+                smokedetector.device_uuid, 'alarm-bell', '%')
+        )
 
     add_devices(sensor_items)
 
 
 class ToonSensor(Entity):
-    """Representation of a sensor."""
+    """Representation of a Toon sensor."""
 
     def __init__(self, hass, name, icon, unit_of_measurement):
-        """Initialize the sensor."""
+        """Initialize the Toon sensor."""
         self._name = name
         self._state = None
-        self._icon = "mdi:" + icon
+        self._icon = 'mdi:{}'.format(icon)
         self._unit_of_measurement = unit_of_measurement
         self.thermos = hass.data[toon_main.TOON_HANDLE]
-
-    @property
-    def should_poll(self):
-        """Polling required."""
-        return True
 
     @property
     def name(self):
@@ -117,21 +98,16 @@ class ToonSensor(Entity):
 
 
 class FibaroSensor(Entity):
-    """Representation of a sensor."""
+    """Representation of a Fibaro sensor."""
 
     def __init__(self, hass, name, plug_name, icon, unit_of_measurement):
-        """Initialize the sensor."""
+        """Initialize the Fibaro sensor."""
         self._name = name
         self._plug_name = plug_name
         self._state = None
-        self._icon = "mdi:" + icon
+        self._icon = 'mdi:{}'.format(icon)
         self._unit_of_measurement = unit_of_measurement
         self.toon = hass.data[toon_main.TOON_HANDLE]
-
-    @property
-    def should_poll(self):
-        """Polling required."""
-        return True
 
     @property
     def name(self):
@@ -160,20 +136,15 @@ class FibaroSensor(Entity):
 
 
 class SolarSensor(Entity):
-    """Representation of a sensor."""
+    """Representation of a Solar sensor."""
 
     def __init__(self, hass, name, unit_of_measurement):
-        """Initialize the sensor."""
+        """Initialize the Solar sensor."""
         self._name = name
         self._state = None
-        self._icon = "mdi:weather-sunny"
+        self._icon = 'mdi:weather-sunny'
         self._unit_of_measurement = unit_of_measurement
         self.toon = hass.data[toon_main.TOON_HANDLE]
-
-    @property
-    def should_poll(self):
-        """Polling required."""
-        return True
 
     @property
     def name(self):
@@ -201,21 +172,16 @@ class SolarSensor(Entity):
 
 
 class FibaroSmokeDetector(Entity):
-    """Representation of a smoke detector."""
+    """Representation of a Fibaro smoke detector."""
 
     def __init__(self, hass, name, uid, icon, unit_of_measurement):
-        """Initialize the sensor."""
+        """Initialize the Fibaro smoke sensor."""
         self._name = name
         self._uid = uid
         self._state = None
-        self._icon = "mdi:" + icon
+        self._icon = 'mdi:{}'.format(icon)
         self._unit_of_measurement = unit_of_measurement
         self.toon = hass.data[toon_main.TOON_HANDLE]
-
-    @property
-    def should_poll(self):
-        """Polling required."""
-        return True
 
     @property
     def name(self):
@@ -235,9 +201,9 @@ class FibaroSmokeDetector(Entity):
         ).strftime('%Y-%m-%d %H:%M:%S')
 
         return {
-            STATE_ATTR_DEVICE_TYPE: self.toon.get_data('device_type',
-                                                       self.name),
-            STATE_ATTR_LAST_CONNECTED_CHANGE: value
+            STATE_ATTR_DEVICE_TYPE:
+                self.toon.get_data('device_type', self.name),
+            STATE_ATTR_LAST_CONNECTED_CHANGE: value,
         }
 
     @property

--- a/homeassistant/components/switch/toon.py
+++ b/homeassistant/components/switch/toon.py
@@ -1,18 +1,19 @@
 """
 Support for Eneco Slimmer stekkers (Smart Plugs).
 
-This provides controlls for the z-wave smart plugs Toon can control.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.toon/
 """
 import logging
 
-from homeassistant.components.switch import SwitchDevice
 import homeassistant.components.toon as toon_main
+from homeassistant.components.switch import SwitchDevice
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
-    """Setup discovered Smart Plugs."""
+    """Set up the discovered Toon Smart Plugs."""
     _toon_main = hass.data[toon_main.TOON_HANDLE]
     switch_items = []
     for plug in _toon_main.toon.smartplugs:
@@ -22,17 +23,12 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 
 
 class EnecoSmartPlug(SwitchDevice):
-    """Representation of a Smart Plug."""
+    """Representation of a Toon Smart Plug."""
 
     def __init__(self, hass, plug):
         """Initialize the Smart Plug."""
         self.smartplug = plug
         self.toon_data_store = hass.data[toon_main.TOON_HANDLE]
-
-    @property
-    def should_poll(self):
-        """No polling needed with subscriptions."""
-        return True
 
     @property
     def unique_id(self):

--- a/homeassistant/components/toon.py
+++ b/homeassistant/components/toon.py
@@ -1,32 +1,33 @@
 """
 Toon van Eneco Support.
 
-This provides a component for the rebranded Quby thermostat as provided by
-Eneco.
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/toon/
 """
 import logging
 from datetime import datetime, timedelta
+
 import voluptuous as vol
 
-# Import the device class from the component that you want to support
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
 from homeassistant.helpers.discovery import load_platform
-import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-# Home Assistant depends on 3rd party packages for API specific code.
 REQUIREMENTS = ['toonlib==1.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_GAS = 'gas'
+CONF_SOLAR = 'solar'
+
+DEFAULT_GAS = True
+DEFAULT_SOLAR = False
+DOMAIN = 'toon'
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
-DOMAIN = 'toon'
 TOON_HANDLE = 'toon_handle'
-CONF_GAS = 'gas'
-DEFAULT_GAS = True
-CONF_SOLAR = 'solar'
-DEFAULT_SOLAR = False
 
 # Validation of the user's configuration
 CONFIG_SCHEMA = vol.Schema({
@@ -40,36 +41,31 @@ CONFIG_SCHEMA = vol.Schema({
 
 
 def setup(hass, config):
-    """Setup toon."""
+    """Set up the Toon component."""
     from toonlib import InvalidCredentials
-    gas = config['toon']['gas']
-    solar = config['toon']['solar']
+    gas = config[DOMAIN][CONF_GAS]
+    solar = config[DOMAIN][CONF_SOLAR]
+    username = config[DOMAIN][CONF_USERNAME]
+    password = config[DOMAIN][CONF_PASSWORD]
 
     try:
-        hass.data[TOON_HANDLE] = ToonDataStore(config['toon']['username'],
-                                               config['toon']['password'],
-                                               gas,
-                                               solar)
+        hass.data[TOON_HANDLE] = ToonDataStore(username, password, gas, solar)
     except InvalidCredentials:
         return False
 
-    # Load all platforms
     for platform in ('climate', 'sensor', 'switch'):
         load_platform(hass, platform, DOMAIN, {}, config)
 
-    # Initialization successfull
     return True
 
 
-class ToonDataStore:
-    """An object to store the toon data."""
+class ToonDataStore(object):
+    """An object to store the Toon data."""
 
     def __init__(self, username, password, gas=DEFAULT_GAS,
                  solar=DEFAULT_SOLAR):
-        """Initialize toon."""
+        """Initialize Toon."""
         from toonlib import Toon
-
-        # Creating the class
 
         toon = Toon(username, password)
 
@@ -83,7 +79,7 @@ class ToonDataStore:
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        """Update toon data."""
+        """Update Toon data."""
         self.last_update = datetime.now()
 
         self.data['power_current'] = self.toon.power.value
@@ -104,11 +100,12 @@ class ToonDataStore:
                                        1000, 2)
 
         for plug in self.toon.smartplugs:
-            self.data[plug.name] = {'current_power': plug.current_usage,
-                                    'today_energy': round(
-                                        float(plug.daily_usage) / 1000, 2),
-                                    'current_state': plug.current_state,
-                                    'is_connected': plug.is_connected}
+            self.data[plug.name] = {
+                'current_power': plug.current_usage,
+                'today_energy': round(float(plug.daily_usage) / 1000, 2),
+                'current_state': plug.current_state,
+                'is_connected': plug.is_connected,
+            }
 
         self.data['solar_maximum'] = self.toon.solar.maximum
         self.data['solar_produced'] = self.toon.solar.produced
@@ -123,11 +120,12 @@ class ToonDataStore:
 
         for detector in self.toon.smokedetectors:
             value = '{}_smoke_detector'.format(detector.name)
-            self.data[value] = {'smoke_detector': detector.battery_level,
-                                'device_type': detector.device_type,
-                                'is_connected': detector.is_connected,
-                                'last_connected_change':
-                                detector.last_connected_change}
+            self.data[value] = {
+                'smoke_detector': detector.battery_level,
+                'device_type': detector.device_type,
+                'is_connected': detector.is_connected,
+                'last_connected_change': detector.last_connected_change,
+            }
 
     def set_state(self, state):
         """Push a new state to the Toon unit."""


### PR DESCRIPTION
## Description:
- Fix docstrings according PEP257
- Update ordering (PEP8)
- Use defined constants
- Add link to docs
- Update brand name
- Remove `def should_poll(self)`

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3752

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

