### PR TITLE
Changing handling for google_assistant groups to treat them as lights.

### DIFF
--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -132,7 +132,9 @@ class GoogleAssistantView(HomeAssistantView):
                 domain = eid.split('.')[0]
                 (service, service_data) = determine_service(
                     eid, execution.get('command'), execution.get('params'),
-                    hass.config.units)
+                    hass.config_units)
+                if domain == "group":
+                    domain = "switch"
                 success = yield from hass.services.async_call(
                     domain, service, service_data, blocking=True)
                 result = {"ids": [eid], "states": {}}

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -134,7 +134,7 @@ class GoogleAssistantView(HomeAssistantView):
                     eid, execution.get('command'), execution.get('params'),
                     hass.config_units)
                 if domain == "group":
-                    domain = "switch"
+                    domain = "homeassistant"
                 success = yield from hass.services.async_call(
                     domain, service, service_data, blocking=True)
                 result = {"ids": [eid], "states": {}}

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -132,7 +132,7 @@ class GoogleAssistantView(HomeAssistantView):
                 domain = eid.split('.')[0]
                 (service, service_data) = determine_service(
                     eid, execution.get('command'), execution.get('params'),
-                    hass.config_units)
+                    hass.config.units)
                 if domain == "group":
                     domain = "homeassistant"
                 success = yield from hass.services.async_call(

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -39,7 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 # Mapping is [actions schema, primary trait, optional features]
 # optional is SUPPORT_* = (trait, command)
 MAPPING_COMPONENT = {
-    group.DOMAIN: [TYPE_LIGHT, TRAIT_ONOFF, None],
+    group.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],
     scene.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     script.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     switch.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -39,7 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 # Mapping is [actions schema, primary trait, optional features]
 # optional is SUPPORT_* = (trait, command)
 MAPPING_COMPONENT = {
-    group.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],
+    group.DOMAIN: [TYPE_LIGHT, TRAIT_ONOFF, None],
     scene.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     script.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     switch.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -39,7 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 # Mapping is [actions schema, primary trait, optional features]
 # optional is SUPPORT_* = (trait, command)
 MAPPING_COMPONENT = {
-    group.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
+    group.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],
     scene.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     script.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     switch.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -39,7 +39,13 @@ _LOGGER = logging.getLogger(__name__)
 # Mapping is [actions schema, primary trait, optional features]
 # optional is SUPPORT_* = (trait, command)
 MAPPING_COMPONENT = {
-    group.DOMAIN: [TYPE_LIGHT, TRAIT_ONOFF, None],
+    group.DOMAIN: [
+        TYPE_LIGHT, TRAIT_ONOFF, {
+            light.SUPPORT_BRIGHTNESS: TRAIT_BRIGHTNESS,
+            light.SUPPORT_RGB_COLOR: TRAIT_RGB_COLOR,
+            light.SUPPORT_COLOR_TEMP: TRAIT_COLOR_TEMP,
+        }
+    ],
     scene.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     script.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     switch.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -39,13 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 # Mapping is [actions schema, primary trait, optional features]
 # optional is SUPPORT_* = (trait, command)
 MAPPING_COMPONENT = {
-    group.DOMAIN: [
-        TYPE_LIGHT, TRAIT_ONOFF, {
-            light.SUPPORT_BRIGHTNESS: TRAIT_BRIGHTNESS,
-            light.SUPPORT_RGB_COLOR: TRAIT_RGB_COLOR,
-            light.SUPPORT_COLOR_TEMP: TRAIT_COLOR_TEMP,
-        }
-    ],
+    group.DOMAIN: [TYPE_LIGHT, TRAIT_ONOFF, None],
     scene.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     script.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     switch.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -94,10 +94,11 @@ def entity_to_device(entity: Entity, units: UnitSystem):
 
     # use aliases
     aliases = entity.attributes.get(CONF_ALIASES)
-    if isinstance(aliases, list):
-        device['name']['nicknames'] = aliases
-    else:
-        _LOGGER.warning("%s must be a list", CONF_ALIASES)
+    if aliases:
+        if isinstance(aliases, list):
+            device['name']['nicknames'] = aliases
+        else:
+            _LOGGER.warning("%s must be a list", CONF_ALIASES)
 
     # add trait if entity supports feature
     if class_data[2]:

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -75,8 +75,8 @@ DEMO_DEVICES = [{
     'name': {
         'name': 'all lights'
     },
-    'traits': ['action.devices.traits.Scene'],
-    'type': 'action.devices.types.SCENE',
+    'traits': ['action.devices.traits.OnOff'],
+    'type': 'action.devices.types.LIGHT',
     'willReportState': False
 }, {
     'id': 'group.all_switches',
@@ -131,8 +131,8 @@ DEMO_DEVICES = [{
     'name': {
         'name': 'all covers'
     },
-    'traits': ['action.devices.traits.Scene'],
-    'type': 'action.devices.types.SCENE',
+    'traits': ['action.devices.traits.OnOff'],
+    'type': 'action.devices.types.LIGHT',
     'willReportState': False
 }, {
     'id':
@@ -199,8 +199,8 @@ DEMO_DEVICES = [{
     'name': {
         'name': 'all fans'
     },
-    'traits': ['action.devices.traits.Scene'],
-    'type': 'action.devices.types.SCENE',
+    'traits': ['action.devices.traits.OnOff'],
+    'type': 'action.devices.types.LIGHT',
     'willReportState': False
 }, {
     'id': 'climate.hvac',

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -76,15 +76,15 @@ DEMO_DEVICES = [{
         'name': 'all lights'
     },
     'traits': ['action.devices.traits.OnOff'],
-    'type': 'action.devices.types.LIGHT',
+    'type': 'action.devices.types.SWITCH',
     'willReportState': False
 }, {
     'id': 'group.all_switches',
     'name': {
         'name': 'all switches'
     },
-    'traits': ['action.devices.traits.Scene'],
-    'type': 'action.devices.types.SCENE',
+    'traits': ['action.devices.traits.OnOff'],
+    'type': 'action.devices.types.SWITCH',
     'willReportState': False
 }, {
     'id':
@@ -132,7 +132,7 @@ DEMO_DEVICES = [{
         'name': 'all covers'
     },
     'traits': ['action.devices.traits.OnOff'],
-    'type': 'action.devices.types.LIGHT',
+    'type': 'action.devices.types.SWITCH',
     'willReportState': False
 }, {
     'id':
@@ -200,7 +200,7 @@ DEMO_DEVICES = [{
         'name': 'all fans'
     },
     'traits': ['action.devices.traits.OnOff'],
-    'type': 'action.devices.types.LIGHT',
+    'type': 'action.devices.types.SWITCH',
     'willReportState': False
 }, {
     'id': 'climate.hvac',


### PR DESCRIPTION
## Description:

Currently the Google Assistant module treats Groups as Scenes when exposing the Groups to the Google Assistant API. There are 2 problems with the implementation.
1. Google Assistant/Home only allows turning Scenes "ON" ie activating them (and not off)
2. The code calls the turn_on, turn_off service for the domain. Groups do not support turn_on/turn_off which leads to an error in the logs and the groups is not turned on/off.

I solved this by making two changes:
1. Exposing groups as lights to the Google Assistant API so it will support on/off
2. When a request comes in for a group domain, it is switched to the light domain before calling the service. There may be a more elegant way to solve this but it definitely works for groups of lights.

