### PR TITLE
media_title property now returns current source

### DIFF
--- a/homeassistant/components/media_player/monoprice.py
+++ b/homeassistant/components/media_player/monoprice.py
@@ -138,6 +138,11 @@ class MonopriceZone(MediaPlayerDevice):
         return SUPPORT_MONOPRICE
 
     @property
+    def media_title(self):
+        """Return the current source as medial title."""
+        return self._source
+
+    @property
     def source(self):
         """"Return the current input source of the device."""
         return self._source

--- a/tests/components/media_player/test_monoprice.py
+++ b/tests/components/media_player/test_monoprice.py
@@ -219,6 +219,12 @@ class TestMonopriceMediaPlayer(unittest.TestCase):
         self.media_player.update()
         self.assertEqual('one', self.media_player.source)
 
+    def test_media_title(self):
+        """Test media title property."""
+        self.assertIsNone(self.media_player.media_title)
+        self.media_player.update()
+        self.assertEqual('one', self.media_player.media_title)
+
     def test_source_list(self):
         """Test source list property."""
         # Note, the list is sorted!


### PR DESCRIPTION
## Description:

Small addition to the `monoprice` platform, `media_title` property now returns the current source so it can be displayed on a media player card.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
