### PR TITLE
fixing Trådfri dependency Cython

### DIFF
--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -17,8 +17,9 @@ from homeassistant.const import CONF_HOST, CONF_API_KEY
 from homeassistant.components.discovery import SERVICE_IKEA_TRADFRI
 
 REQUIREMENTS = ['pytradfri==3.0.2',
-                'Cython==0.27.2',
-                'DTLSSocket==0.1.3',
+                'https://github.com/flowolf/tinydtls-cython/raw/'
+                '432c4b014936cbce655a0c0f271d16bc74602c47/DTLSSocket.tar.gz'
+                '#DTLSSocket==0.1.3',
                 'https://github.com/chrysn/aiocoap/archive/'
                 '3286f48f0b949901c8b5c04c0719dc54ab63d431.zip'
                 '#aiocoap==0.3']

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -17,9 +17,7 @@ from homeassistant.const import CONF_HOST, CONF_API_KEY
 from homeassistant.components.discovery import SERVICE_IKEA_TRADFRI
 
 REQUIREMENTS = ['pytradfri==3.0.2',
-                'https://github.com/flowolf/tinydtls-cython/raw/'
-                '432c4b014936cbce655a0c0f271d16bc74602c47/DTLSSocket.tar.gz'
-                '#DTLSSocket==0.1.3',
+                'DTLSSocket==0.1.4',
                 'https://github.com/chrysn/aiocoap/archive/'
                 '3286f48f0b949901c8b5c04c0719dc54ab63d431.zip'
                 '#aiocoap==0.3']

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -17,6 +17,7 @@ from homeassistant.const import CONF_HOST, CONF_API_KEY
 from homeassistant.components.discovery import SERVICE_IKEA_TRADFRI
 
 REQUIREMENTS = ['pytradfri==3.0.2',
+                'Cython==0.27.2',
                 'DTLSSocket==0.1.3',
                 'https://github.com/chrysn/aiocoap/archive/'
                 '3286f48f0b949901c8b5c04c0719dc54ab63d431.zip'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -18,6 +18,9 @@ certifi>=2017.4.17
 # homeassistant.components.bbb_gpio
 # Adafruit_BBIO==1.0.0
 
+# homeassistant.components.tradfri
+# DTLSSocket==0.1.4
+
 # homeassistant.components.doorbird
 DoorBirdPy==0.0.4
 
@@ -329,9 +332,6 @@ https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
 
 # homeassistant.components.tradfri
 # https://github.com/chrysn/aiocoap/archive/3286f48f0b949901c8b5c04c0719dc54ab63d431.zip#aiocoap==0.3
-
-# homeassistant.components.tradfri
-# https://github.com/flowolf/tinydtls-cython/raw/432c4b014936cbce655a0c0f271d16bc74602c47/DTLSSocket.tar.gz#DTLSSocket==0.1.3
 
 # homeassistant.components.media_player.spotify
 https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f86c90aa26b2.zip#spotipy==2.4.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -18,12 +18,6 @@ certifi>=2017.4.17
 # homeassistant.components.bbb_gpio
 # Adafruit_BBIO==1.0.0
 
-# homeassistant.components.tradfri
-# Cython==0.27.2
-
-# homeassistant.components.tradfri
-# DTLSSocket==0.1.3
-
 # homeassistant.components.doorbird
 DoorBirdPy==0.0.4
 
@@ -335,6 +329,9 @@ https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
 
 # homeassistant.components.tradfri
 # https://github.com/chrysn/aiocoap/archive/3286f48f0b949901c8b5c04c0719dc54ab63d431.zip#aiocoap==0.3
+
+# homeassistant.components.tradfri
+# https://github.com/flowolf/tinydtls-cython/raw/432c4b014936cbce655a0c0f271d16bc74602c47/DTLSSocket.tar.gz#DTLSSocket==0.1.3
 
 # homeassistant.components.media_player.spotify
 https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f86c90aa26b2.zip#spotipy==2.4.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -19,7 +19,7 @@ certifi>=2017.4.17
 # Adafruit_BBIO==1.0.0
 
 # homeassistant.components.tradfri
-Cython==0.27.2
+# Cython==0.27.2
 
 # homeassistant.components.tradfri
 # DTLSSocket==0.1.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -19,6 +19,9 @@ certifi>=2017.4.17
 # Adafruit_BBIO==1.0.0
 
 # homeassistant.components.tradfri
+Cython==0.27.2
+
+# homeassistant.components.tradfri
 # DTLSSocket==0.1.3
 
 # homeassistant.components.doorbird


### PR DESCRIPTION
fixing Trådfri issue, where setup of component fails.
Cython is needed by DTLSSocket.

fixes issue #10022

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**