### PR TITLE
Fire numeric_state action when first state change matches criteria

### DIFF
--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -46,6 +46,9 @@ def async_trigger(hass, config, action):
     @callback
     def check_numeric_state(entity, from_s, to_s):
         """Return True if criteria are now met."""
+        if to_s is None:
+            return False
+
         variables = {
             'trigger': {
                 'platform': 'numeric_state',

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -55,7 +55,7 @@ def async_trigger(hass, config, action):
             }
         }
         return condition.async_numeric_state(
-                hass, to_s, below, above, value_template, variables)
+            hass, to_s, below, above, value_template, variables)
 
     @callback
     def state_automation_listener(entity, from_s, to_s):

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -38,16 +38,14 @@ def async_trigger(hass, config, action):
     time_delta = config.get(CONF_FOR)
     value_template = config.get(CONF_VALUE_TEMPLATE)
     async_remove_track_same = None
+    already_triggered = False
 
     if value_template is not None:
         value_template.hass = hass
 
     @callback
     def check_numeric_state(entity, from_s, to_s):
-        """Return True if they should trigger."""
-        if to_s is None:
-            return False
-
+        """Return True if criteria are now met."""
         variables = {
             'trigger': {
                 'platform': 'numeric_state',
@@ -56,51 +54,39 @@ def async_trigger(hass, config, action):
                 'above': above,
             }
         }
-
-        # If new one doesn't match, nothing to do
-        if not condition.async_numeric_state(
-                hass, to_s, below, above, value_template, variables):
-            return False
-
-        return True
+        return condition.async_numeric_state(
+                hass, to_s, below, above, value_template, variables)
 
     @callback
     def state_automation_listener(entity, from_s, to_s):
         """Listen for state changes and calls action."""
-        nonlocal async_remove_track_same
-
-        if not check_numeric_state(entity, from_s, to_s):
-            return
-
-        variables = {
-            'trigger': {
-                'platform': 'numeric_state',
-                'entity_id': entity,
-                'below': below,
-                'above': above,
-                'from_state': from_s,
-                'to_state': to_s,
-            }
-        }
-
-        # Only match if old didn't exist or existed but didn't match
-        # Written as: skip if old one did exist and matched
-        if from_s is not None and condition.async_numeric_state(
-                hass, from_s, below, above, value_template, variables):
-            return
+        nonlocal already_triggered, async_remove_track_same
 
         @callback
         def call_action():
             """Call action with right context."""
-            hass.async_run_job(action, variables)
+            hass.async_run_job(action, {
+                'trigger': {
+                    'platform': 'numeric_state',
+                    'entity_id': entity,
+                    'below': below,
+                    'above': above,
+                    'from_state': from_s,
+                    'to_state': to_s,
+                }
+            })
 
-        if not time_delta:
-            call_action()
-            return
+        matching = check_numeric_state(entity, from_s, to_s)
 
-        async_remove_track_same = async_track_same_state(
-            hass, time_delta, call_action, entity_ids=entity_id,
-            async_check_same_func=check_numeric_state)
+        if matching and not already_triggered:
+            if time_delta:
+                async_remove_track_same = async_track_same_state(
+                    hass, time_delta, call_action, entity_ids=entity_id,
+                    async_check_same_func=check_numeric_state)
+            else:
+                call_action()
+
+        already_triggered = matching
 
     unsub = async_track_state_change(
         hass, entity_id, state_automation_listener)


### PR DESCRIPTION
## Description:

This changes the `numeric_state` trigger to potentially fire on its first state change, even if the criteria were already met when the automation was created. That makes these two automations work in the same way:

```yaml
  - alias: 'Numeric state'
    trigger:
      platform: numeric_state
      entity_id: sensor.ram_used
      below: 11000
```
```yaml
  - alias: 'Template'
    trigger:
      platform: template
      value_template: "{{ states.sensor.ram_used.state | float < 11000 }}"
```

The current situation is that `template` will fire even without crossing the threshold but `numeric_state` will not. This inconsistency has caused severe confusion, like seen [in this forum post (with links to several more)](https://community.home-assistant.io/t/the-numeric-state-trigger-should-coerce-strings-to-numbers/30245).

I know this change is (once again) a bit controversial; you can easily argue that it should only fire when the threshold is actually passed. However, I think it is handy when developing automations to have it fire on startup and I definitely think the above two triggers should work in the same way.

There is a deeper problem that I do not know how to fix: when setting up sensors, the automations are not yet running. So, confusingly, things will not fire on startup but rather on the first change.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [X] Tests have been added to verify that the new code works.
