### PR TITLE
Add System monitoring component

### DIFF
--- a/homeassistant/components/system_monitoring/__init__.py
+++ b/homeassistant/components/system_monitoring/__init__.py
@@ -1,0 +1,82 @@
+"""
+System monitoring component.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/system_monitoring/
+"""
+import asyncio
+import logging
+
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'system_monitoring'
+
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+CONF_SYSTEM = 'system'
+
+SENSOR_TYPES = {
+    'cpu_speed': ['CPU Speed', 'GHz', 'mdi:pulse'],
+    'disk_free': ['Disk free', 'GiB', 'mdi:harddisk'],
+    'disk_use': ['Disk used', 'GiB', 'mdi:harddisk'],
+    'load_15m': ['Average load (15m)', '', 'mdi:memory'],
+    'load_1m': ['Average load (1m)', '', 'mdi:memory'],
+    'memory_free': ['Memory free', 'MiB', 'mdi:memory'],
+    'memory_used': ['Memory used', 'MiB', 'mdi:memory'],
+}
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up the System monitoring component."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    yield from component.async_setup(config)
+    return True
+
+
+# pylint: disable=no-member, no-self-use
+class SystemMonitoring(Entity):
+    """ABC for System monitoring."""
+
+    @property
+    def name(self):
+        """Return the name of the resource."""
+        name = SENSOR_TYPES[self.resource][0]
+        if self.system is not None:
+            return '{} {}'.format(self.system, name)
+        return name
+
+    @property
+    def system(self):
+        """Return the name of the monitored system."""
+        return None
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return SENSOR_TYPES[self.resource][1]
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return SENSOR_TYPES[self.resource][2]
+
+    @property
+    def resource(self):
+        """Return the name of the resource."""
+        raise NotImplementedError()
+
+    @property
+    def value(self):
+        """Return the current value of the resource."""
+        raise NotImplementedError()
+
+    @property
+    def state(self):
+        """Return the current state."""
+        return self.value

--- a/homeassistant/components/system_monitoring/__init__.py
+++ b/homeassistant/components/system_monitoring/__init__.py
@@ -65,8 +65,7 @@ class SystemMonitoring(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
-        return None if str(self.value.units) == 'dimensionless' else \
-            self.value.units
+        return SENSOR_TYPES[self.resource][1]
 
     @property
     def icon(self):

--- a/homeassistant/components/system_monitoring/__init__.py
+++ b/homeassistant/components/system_monitoring/__init__.py
@@ -11,6 +11,8 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.helpers.entity import Entity
 
+REQUIREMENTS = ['pint==0.8.1']
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'system_monitoring'
@@ -28,6 +30,10 @@ SENSOR_TYPES = {
     'memory_free': ['Memory free', 'MiB', 'mdi:memory'],
     'memory_used': ['Memory used', 'MiB', 'mdi:memory'],
 }
+
+from pint import UnitRegistry
+
+unit_registry = UnitRegistry()
 
 
 @asyncio.coroutine
@@ -59,7 +65,8 @@ class SystemMonitoring(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
-        return SENSOR_TYPES[self.resource][1]
+        return None if str(self.value.units) == 'dimensionless' else \
+            self.value.units
 
     @property
     def icon(self):
@@ -79,4 +86,5 @@ class SystemMonitoring(Entity):
     @property
     def state(self):
         """Return the current state."""
-        return self.value
+        data = self.value.to(unit_registry(SENSOR_TYPES[self.resource][1]))
+        return round(data.magnitude, 2)

--- a/homeassistant/components/system_monitoring/const.py
+++ b/homeassistant/components/system_monitoring/const.py
@@ -1,0 +1,36 @@
+"""Constants used by Home Assistant System monitoring components."""
+# #### UNITS OF MEASUREMENT ####
+
+# Frequency units
+FREQUENCY_HZ = 'Hz'  # type: str
+FREQUENCY_MHZ = 'MHz'  # type: str
+FREQUENCY_GHZ = 'GHz'  # type: str
+FREQUENCY_THZ = 'THz'  # type: str
+
+# Disk units (SI)
+SIZE_KB = 'kB'  # type: str
+SIZE_MB = 'MB'  # type: str
+SIZE_GB = 'GB'  # type: str
+SIZE_TB = 'TB'  # type: str
+SIZE_PB = 'PB'  # type: str
+SIZE_EB = 'EB'  # type: str
+
+# Disk units (IEC)
+SIZE_KIB = 'KiB'  # type: str
+SIZE_MIB = 'MiB'  # type: str
+SIZE_GIB = 'GiB'  # type: str
+SIZE_TIB = 'TiB'  # type: str
+SIZE_PIB = 'PiB'  # type: str
+SIZE_EIB = 'EiB'  # type: str
+
+# Network speed/bandwidth
+SPEED_KBIT_S = 'kB/s'  # type: str
+SPEED_MBIT_S = 'Mbit/s'  # type: str
+SPEED_GBIT_S = 'Gbit/s'  # type: str
+SPEED_TBIT_S = 'Tbit/s'  # type: str
+
+# Disk throughput
+SPEED_KB_S = 'kB/s'  # type: str
+SPEED_MB_S = 'MB/s'  # type: str
+SPEED_GB_S = 'GB/s'  # type: str
+SPEED_TB_S = 'TB/s'  # type: str

--- a/homeassistant/components/system_monitoring/cpuspeed.py
+++ b/homeassistant/components/system_monitoring/cpuspeed.py
@@ -1,0 +1,79 @@
+"""
+Support for displaying the current CPU speed.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/system_monitoring.cpuspeed/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.system_monitoring import (
+    SystemMonitoring, PLATFORM_SCHEMA, CONF_SYSTEM)
+
+REQUIREMENTS = ['py-cpuinfo==3.3.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_BRAND = 'Brand'
+ATTR_HZ = 'GHz Advertised'
+ATTR_ARCH = 'arch'
+
+RESOURCE = 'cpu_speed'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_SYSTEM): cv.string,
+})
+
+
+# pylint: disable=unused-variable
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the CPU speed resource."""
+    system = config.get(CONF_SYSTEM)
+    resource = RESOURCE
+
+    add_devices([CpuSpeed(system, resource)], True)
+
+
+class CpuSpeed(SystemMonitoring):
+    """Representation of a CPU resource."""
+
+    def __init__(self, system, resource):
+        """Initialize the CPU resource."""
+        self._system = system
+        self._resource = resource
+        self._state = None
+        self.info = None
+
+    @property
+    def system(self):
+        """Return the name of the monitored system."""
+        return self._system
+
+    @property
+    def resource(self):
+        """Return the name of the resource."""
+        return self._resource
+
+    @property
+    def value(self):
+        """Return the current value of the resource."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self.info is not None:
+            return {
+                ATTR_ARCH: self.info['arch'],
+                ATTR_BRAND: self.info['brand'],
+                ATTR_HZ: round(self.info['hz_advertised_raw'][0]/10**9, 2)
+            }
+
+    def update(self):
+        """Get the latest data and updates the state."""
+        from cpuinfo import cpuinfo
+
+        self.info = cpuinfo.get_cpu_info()
+        self._state = round(float(self.info['hz_actual_raw'][0])/10**9, 2)

--- a/homeassistant/components/system_monitoring/cpuspeed.py
+++ b/homeassistant/components/system_monitoring/cpuspeed.py
@@ -18,8 +18,8 @@ REQUIREMENTS = ['py-cpuinfo==3.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_BRAND = 'Brand'
-ATTR_HZ = 'GHz Advertised'
+ATTR_BRAND = 'brand'
+ATTR_HZ = 'ghz_dvertised'
 ATTR_ARCH = 'arch'
 
 RESOURCE = 'cpu_speed'
@@ -70,7 +70,7 @@ class CpuSpeed(SystemMonitoring):
             return {
                 ATTR_ARCH: self.info['arch'],
                 ATTR_BRAND: self.info['brand'],
-                ATTR_HZ: self.info['hz_advertised_raw'][0]
+                ATTR_HZ: self.info['hz_advertised_raw'][0],
             }
 
     def update(self):

--- a/homeassistant/components/system_monitoring/cpuspeed.py
+++ b/homeassistant/components/system_monitoring/cpuspeed.py
@@ -11,6 +11,8 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.system_monitoring import (
     SystemMonitoring, PLATFORM_SCHEMA, CONF_SYSTEM)
+from homeassistant.components.system_monitoring.const import FREQUENCY_HZ
+from homeassistant.components.system_monitoring import unit_registry
 
 REQUIREMENTS = ['py-cpuinfo==3.3.0']
 
@@ -59,7 +61,7 @@ class CpuSpeed(SystemMonitoring):
     @property
     def value(self):
         """Return the current value of the resource."""
-        return self._state
+        return self._state * unit_registry(FREQUENCY_HZ)
 
     @property
     def device_state_attributes(self):
@@ -68,7 +70,7 @@ class CpuSpeed(SystemMonitoring):
             return {
                 ATTR_ARCH: self.info['arch'],
                 ATTR_BRAND: self.info['brand'],
-                ATTR_HZ: round(self.info['hz_advertised_raw'][0]/10**9, 2)
+                ATTR_HZ: self.info['hz_advertised_raw'][0]
             }
 
     def update(self):
@@ -76,4 +78,4 @@ class CpuSpeed(SystemMonitoring):
         from cpuinfo import cpuinfo
 
         self.info = cpuinfo.get_cpu_info()
-        self._state = round(float(self.info['hz_actual_raw'][0])/10**9, 2)
+        self._state = self.info['hz_actual_raw'][0]

--- a/homeassistant/components/system_monitoring/demo.py
+++ b/homeassistant/components/system_monitoring/demo.py
@@ -1,0 +1,45 @@
+"""
+Demo platform that offers fake system monitoring details.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/demo/
+"""
+from homeassistant.components.system_monitoring import SystemMonitoring
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Demo system monitoring resources."""
+    add_devices([
+        DemoSystemMonitoring(None, 'cpu_speed', 1.3),
+        DemoSystemMonitoring('Server', 'load_15m', 0.6),
+    ])
+
+
+class DemoSystemMonitoring(SystemMonitoring):
+    """Representation of a system monitoring resource."""
+
+    def __init__(self, system, resource, value):
+        """Initialize the Demo system monitoring resource."""
+        self._resource = resource
+        self._system = system
+        self._value = value
+
+    @property
+    def should_poll(self):
+        """No polling needed for a demo resource."""
+        return False
+
+    @property
+    def system(self):
+        """Return the name of the monitored system."""
+        return self._system
+
+    @property
+    def resource(self):
+        """Return the name of the resource."""
+        return self._resource
+
+    @property
+    def value(self):
+        """Return the value of the resource."""
+        return self._value

--- a/homeassistant/components/system_monitoring/demo.py
+++ b/homeassistant/components/system_monitoring/demo.py
@@ -5,23 +5,28 @@ For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/demo/
 """
 from homeassistant.components.system_monitoring import SystemMonitoring
+from homeassistant.components.system_monitoring.const import (
+    FREQUENCY_MHZ, SIZE_GB)
+from homeassistant.components.system_monitoring import unit_registry
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Demo system monitoring resources."""
     add_devices([
-        DemoSystemMonitoring(None, 'cpu_speed', 1.3),
-        DemoSystemMonitoring('Server', 'load_15m', 0.6),
+        DemoSystemMonitoring(None, 'cpu_speed', 1300, FREQUENCY_MHZ),
+        DemoSystemMonitoring('Server', 'load_15m', 0.6, None),
+        DemoSystemMonitoring('Desktop', 'disk_use', 900, SIZE_GB),
     ])
 
 
 class DemoSystemMonitoring(SystemMonitoring):
     """Representation of a system monitoring resource."""
 
-    def __init__(self, system, resource, value):
+    def __init__(self, system, resource, value, source_unit):
         """Initialize the Demo system monitoring resource."""
         self._resource = resource
         self._system = system
+        self._source_unit = source_unit
         self._value = value
 
     @property
@@ -42,4 +47,4 @@ class DemoSystemMonitoring(SystemMonitoring):
     @property
     def value(self):
         """Return the value of the resource."""
-        return self._value
+        return self._value * unit_registry(self._source_unit)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -292,8 +292,16 @@ ATTR_TEMPERATURE = 'temperature'
 
 # #### UNITS OF MEASUREMENT ####
 # Temperature units
-TEMP_CELSIUS = '°C'
-TEMP_FAHRENHEIT = '°F'
+TEMP_CELSIUS = '°C'  # type: str
+TEMP_FAHRENHEIT = '°F'  # type: str
+
+# Time & date units
+TIME_SECONDS = 's'  # type: str
+TIME_MINUTES = 'min'  # type: str
+TIME_HOURS = 'h'  # type: str
+TIME_DAYS = 'day'  # type: str
+TIME_MONTHS = 'month'  # type: str
+TIME_YEARS = 'year'  # type: str
 
 # Length units
 LENGTH_CENTIMETERS = 'cm'  # type: str

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -542,6 +542,9 @@ piglow==1.2.4
 # homeassistant.components.pilight
 pilight==0.1.1
 
+# homeassistant.components.system_monitoring
+pint==0.8.1
+
 # homeassistant.components.media_player.plex
 # homeassistant.components.sensor.plex
 plexapi==3.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -576,6 +576,7 @@ pushetta==1.0.15
 pwmled==1.2.1
 
 # homeassistant.components.sensor.cpuspeed
+# homeassistant.components.system_monitoring.cpuspeed
 py-cpuinfo==3.3.0
 
 # homeassistant.components.camera.synology

--- a/tests/components/system_monitoring/__init__.py
+++ b/tests/components/system_monitoring/__init__.py
@@ -1,0 +1,1 @@
+"""The tests for System monitoring platforms."""

--- a/tests/components/system_monitoring/test_system_monitoring.py
+++ b/tests/components/system_monitoring/test_system_monitoring.py
@@ -1,0 +1,46 @@
+"""The tests for the System Monitoring component."""
+import unittest
+
+from homeassistant.components import system_monitoring
+from homeassistant.components.weather import (
+    ATTR_WEATHER_ATTRIBUTION, ATTR_WEATHER_HUMIDITY, ATTR_WEATHER_OZONE,
+    ATTR_WEATHER_PRESSURE, ATTR_WEATHER_TEMPERATURE, ATTR_WEATHER_WIND_BEARING,
+    ATTR_WEATHER_WIND_SPEED, ATTR_FORECAST, ATTR_FORECAST_TEMP)
+from homeassistant.util.unit_system import METRIC_SYSTEM
+from homeassistant.setup import setup_component
+
+from tests.common import get_test_home_assistant
+
+
+class TestSystemMonitoring(unittest.TestCase):
+    """Test the System Monitoring component."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.config.units = METRIC_SYSTEM
+        self.assertTrue(setup_component(self.hass, system_monitoring.DOMAIN, {
+            'system_monitoring': {
+                'platform': 'demo',
+            }
+        }))
+
+    def tearDown(self):
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_value_to_state(self):
+        """Test system monitoring resource."""
+        state = self.hass.states.get('system_monitoring.cpu_speed')
+        assert state is not None
+
+        assert float(state.state) == 1.3
+
+        data = state.attributes
+        assert data.get('unit_of_measurement') == 'GHz'
+
+    def test_naming_with_system(self):
+        """Test system monitoring resource."""
+        state = self.hass.states.get(
+            'system_monitoring.server_average_load_15m')
+        assert state is not None

--- a/tests/components/system_monitoring/test_system_monitoring.py
+++ b/tests/components/system_monitoring/test_system_monitoring.py
@@ -2,10 +2,6 @@
 import unittest
 
 from homeassistant.components import system_monitoring
-from homeassistant.components.weather import (
-    ATTR_WEATHER_ATTRIBUTION, ATTR_WEATHER_HUMIDITY, ATTR_WEATHER_OZONE,
-    ATTR_WEATHER_PRESSURE, ATTR_WEATHER_TEMPERATURE, ATTR_WEATHER_WIND_BEARING,
-    ATTR_WEATHER_WIND_SPEED, ATTR_FORECAST, ATTR_FORECAST_TEMP)
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.setup import setup_component
 


### PR DESCRIPTION
## Description:
This is a limited prototype/proposal for a `system_monitoring` component. As mentioned in #10118 should this help us to avoid the issue with the naming as the names are handled by the component through a dict lookup. Also, units of measurement and icons would be identical across platforms.

**Depends on:** #10555

**Related issue (if applicable):** fixes #10118

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
system_monitoring:
  - platform: cpuspeed
  - platform: demo
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
