### PR TITLE
Add last action to xiaomi aqara button

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -282,8 +282,16 @@ class XiaomiButton(XiaomiBinarySensor):
     def __init__(self, device, name, data_key, hass, xiaomi_hub):
         """Initialize the XiaomiButton."""
         self._hass = hass
+        self._last_action = None
         XiaomiBinarySensor.__init__(self, device, name, xiaomi_hub,
                                     data_key, None)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attrs = {ATTR_LAST_ACTION: self._last_action}
+        attrs.update(super().device_state_attributes)
+        return attrs
 
     def parse_data(self, data):
         """Parse data sent by gateway."""
@@ -310,6 +318,8 @@ class XiaomiButton(XiaomiBinarySensor):
             'entity_id': self.entity_id,
             'click_type': click_type
         })
+        self._last_action = click_type
+
         if value in ['long_click_press', 'long_click_release']:
             return True
         return False


### PR DESCRIPTION
## Description:
Add last action to xiaomi aqara button

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/xiaomi-aqara-double-button-support-for-double-clicks/30527

## Checklist:


If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
