### PR TITLE
Docker healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,6 @@ RUN pip3 install --no-cache-dir -r requirements_all.txt && \
 # Copy source
 COPY . .
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=1m --retries=3 CMD curl -f http://localhost:8123 || exit 1
+
 CMD [ "python", "-m", "homeassistant", "--config", "/config" ]

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -53,4 +53,6 @@ RUN tox -e py36 --notest
 # Copy source
 COPY . .
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=1m --retries=3 CMD curl -f http://localhost:8123 || exit 1
+
 CMD [ "python", "-m", "homeassistant", "--config", "/config" ]


### PR DESCRIPTION
Perform Docker health checks every 30 seconds, with a startup delay of 1 minute. 
Requires Docker 1.12 (June 2016 ) or above.

Can be overridden in a Docker Compose file.