### PR TITLE
Upgrade pysnmp to 4.4.1

### DIFF
--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -16,7 +16,7 @@ from homeassistant.const import CONF_HOST
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pysnmp==4.3.10']
+REQUIREMENTS = ['pysnmp==4.4.1']
 
 CONF_COMMUNITY = 'community'
 CONF_AUTHKEY = 'authkey'
@@ -26,11 +26,11 @@ CONF_BASEOID = 'baseoid'
 DEFAULT_COMMUNITY = 'public'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_BASEOID): cv.string,
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
     vol.Inclusive(CONF_AUTHKEY, 'keys'): cv.string,
     vol.Inclusive(CONF_PRIVKEY, 'keys'): cv.string,
-    vol.Required(CONF_BASEOID): cv.string
 })
 
 

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PORT, CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN,
     CONF_VALUE_TEMPLATE)
 
-REQUIREMENTS = ['pysnmp==4.3.10']
+REQUIREMENTS = ['pysnmp==4.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,16 +41,15 @@ SCAN_INTERVAL = timedelta(seconds=10)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_BASEOID): cv.string,
+    vol.Optional(CONF_ACCEPT_ERRORS, default=False): cv.boolean,
     vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
+    vol.Optional(CONF_DEFAULT_VALUE): cv.string,
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
-    vol.Optional(CONF_VERSION, default=DEFAULT_VERSION):
-        vol.In(SNMP_VERSIONS),
-    vol.Optional(CONF_ACCEPT_ERRORS, default=False): cv.boolean,
-    vol.Optional(CONF_DEFAULT_VALUE): cv.string,
-    vol.Optional(CONF_VALUE_TEMPLATE): cv.template
+    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_VERSION, default=DEFAULT_VERSION): vol.In(SNMP_VERSIONS),
 })
 
 

--- a/homeassistant/components/switch/snmp.py
+++ b/homeassistant/components/switch/snmp.py
@@ -4,17 +4,16 @@ Support for SNMP enabled switch.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.snmp/
 """
-
 import logging
 
 import voluptuous as vol
 
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_PORT,
-                                 CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF)
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, CONF_PORT, CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pysnmp==4.3.10']
+REQUIREMENTS = ['pysnmp==4.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ CONF_BASEOID = 'baseoid'
 CONF_COMMUNITY = 'community'
 CONF_VERSION = 'version'
 
-DEFAULT_NAME = 'SNMPSwitch'
+DEFAULT_NAME = 'SNMP Switch'
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = '161'
 DEFAULT_COMMUNITY = 'private'
@@ -40,11 +39,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_VERSION, default=DEFAULT_VERSION):
-        vol.In(SNMP_VERSIONS),
+    vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
     vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
-    vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_VERSION, default=DEFAULT_VERSION): vol.In(SNMP_VERSIONS),
 })
 
 
@@ -59,9 +57,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     payload_on = config.get(CONF_PAYLOAD_ON)
     payload_off = config.get(CONF_PAYLOAD_OFF)
 
-    add_devices([SnmpSwitch(name, host, port, community,
-                            baseoid, version, payload_on,
-                            payload_off)], True)
+    add_devices(
+        [SnmpSwitch(name, host, port, community, baseoid, version, payload_on,
+                    payload_off)], True)
 
 
 class SnmpSwitch(SwitchDevice):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -765,7 +765,7 @@ pysma==0.1.3
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
 # homeassistant.components.switch.snmp
-pysnmp==4.3.10
+pysnmp==4.4.1
 
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner


### PR DESCRIPTION
## Description
- HMAC-SHA-2 Authentication Protocols support added (RFC-7860)
- The pycryptodome dependency replaced with pycryptodomex as it is recommended by the upstream to avoid unwanted interference with PyCrypto package should it also be installed
- Sphinx theme changed to Alabaster in the documentation
- Minor adjustments towards pyasn1 0.4.x compatibility
- Fixed ObjectIdentifier-into-ObjectIdentity casting at rfc1902.ObjectType MIB resolution harness
- Fixed NetworkAddress object handling in SNMP table indices
- Fixed MIB lookup by module:object.indices MIB object with InetAddressIPv{4,6} objects being in the index
- Fixed non-translated PDU being retries at CommandGenerator what leads to wrong PDU version being sent and even a crash on incompatible PDU/SNMP message combination

Tested with the following configuration:

``` yaml
sensor:
  - platform: snmp
    name: SNMP TEST String
    host: demo.snmplabs.com
    community: public
    baseoid: 1.3.6.1.4.1.2021.10.1.3.1
    unit_of_measurement: "load"
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.