### PR TITLE
WIP: Missile Launcher new component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -385,6 +385,7 @@ omit =
     homeassistant/components/media_player/kodi.py
     homeassistant/components/media_player/lg_netcast.py
     homeassistant/components/media_player/liveboxplaytv.py
+	homeassistant/components/media_player/missile_launcher.py
     homeassistant/components/media_player/mpchc.py
     homeassistant/components/media_player/mpd.py
     homeassistant/components/media_player/nad.py

--- a/homeassistant/components/media_player/missile_launcher.py
+++ b/homeassistant/components/media_player/missile_launcher.py
@@ -1,0 +1,163 @@
+"""
+Support for interacting with USB Missile Launchers.
+Tested with those manufactured by Dream Cheeky.
+
+For more details about this platform, please refer to the documentation at
+@TODO
+
+USAGE:
+(Place below code in configuration.yaml)
+media_player:
+    platform: missile_launcher
+
+"""
+import sys
+import subprocess
+import time
+import platform
+import argparse
+import usb.core
+import usb.util
+import logging
+from homeassistant.components.media_player import (MediaPlayerDevice, SUPPORT_SELECT_SOURCE, PLATFORM_SCHEMA)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Protocol command bytes
+DOWN    = 0x01
+UP      = 0x02
+LEFT    = 0x04
+RIGHT   = 0x08
+FIRE    = 0x10
+STOP    = 0x20
+DEVICE = None
+DEVICE_TYPE = None
+REQUIREMENTS = []
+DOMAIN = 'missile_launcher'
+ICON = 'mdi:rocket'
+DEFAULT_NAME = 'Missile Launcher'
+SUPPORT_MISSILE = SUPPORT_SELECT_SOURCE
+
+# Set Up At Custom Component
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    name = config.get('name', DEFAULT_NAME)
+    # Initialize Device
+    add_devices([IMissileSensor(name)])
+
+# Missile Launcher Device
+class IMissileSensor(MediaPlayerDevice):
+    """Implementation of a Missile Launcher"""
+    def __init__(self, name):
+        """Initialize the sensor."""
+        self._name = name
+        # @TODO: The constants have slash from using telegram. Not sure what would be acceptable format or if there is a Standard to use.
+        self._source = '/none'
+        self._source_list = ['/none', '/right', '/left', '/up', '/down', '/fire']
+        # Setup USB
+        self.setup_usb()
+        # Lastly Do An Update
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon for the frontend."""
+        return ICON
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_MISSILE
+        
+    @property
+    def source(self):
+        """Return the current input source."""
+        return self._source
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+        return self._source_list
+    
+    @property
+    def media_image_url(self):
+        """Return the image URL of current playing media."""
+        # @TODO: for the image, I use Motion and place the image in home assistant www folder. Would this be acceptable solution?
+        # MAKE SURE THIS FILE HAS WRITE ACCESS
+        subprocess.Popen(['fswebcam', '/home/homeassistant/.homeassistant/www/missile_launcher.jpg'], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+        return 'http://127.0.0.1:8123/local/missile_launcher.jpg?1=1&t=%s' % (time.time())
+    
+    @property
+    def state(self):
+        """Return the date of the next event."""
+        return '/none'
+
+    def select_source(self, source):
+        """Set the input source."""
+        # @TODO: offer custom time in configuration for x and y movement duration.
+        self.run_command(source, 1000)
+        
+    def update(self):
+        """Get the latest update and set the state."""
+        self._source = "/none"
+
+    def setup_usb(_self):
+        # Tested only with the Cheeky Dream Thunder
+        # and original USB Launcher
+        # Make Sure USB Has Access by all users
+        # https://unix.stackexchange.com/questions/44308/understanding-udev-rules-and-permissions-in-libusb
+        global DEVICE 
+        global DEVICE_TYPE
+
+        DEVICE = usb.core.find(idVendor=0x2123, idProduct=0x1010)
+
+        if DEVICE is None:
+            DEVICE = usb.core.find(idVendor=0x0a81, idProduct=0x0701)
+            if DEVICE is None:
+                print('Missile device not found')
+            else:
+                DEVICE_TYPE = "Original"
+        else:
+            DEVICE_TYPE = "Thunder"
+        print(DEVICE_TYPE)
+        
+        # On Linux we need to detach usb HID first
+        try:
+            DEVICE.detach_kernel_driver(0)
+        except:
+            pass # already unregistered    
+
+    def send_cmd(_self, cmd):
+        if "Thunder" == DEVICE_TYPE:
+            DEVICE.ctrl_transfer(0x21, 0x09, 0, 0, [0x02, cmd, 0x00,0x00,0x00,0x00,0x00,0x00])
+        elif "Original" == DEVICE_TYPE:
+            DEVICE.ctrl_transfer(0x21, 0x09, 0x0200, 0, [cmd])
+
+    def send_move(_self, cmd, duration_ms):
+        _self.send_cmd(cmd)
+        time.sleep(duration_ms / 1000.0)
+        _self.send_cmd(STOP)
+
+    def run_command(_self, command, value):
+        command = command.lower()
+        if command == "/right":
+            _self.send_move(RIGHT, value)
+        elif command == "/left":
+            _self.send_move(LEFT, value)
+        elif command == "/up":
+            _self.send_move(UP, value)
+        elif command == "/down":
+            _self.send_move(DOWN, value)
+        elif command == "/fire" or command == "/shoot":
+            if value < 1 or value > 4:
+                value = 1
+            # Stabilize prior to the shot, then allow for reload time after.
+            time.sleep(0.5)
+            for i in range(value):
+                _self.send_cmd(FIRE)
+                time.sleep(4.5)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1057,6 +1057,9 @@ twilio==5.7.0
 # homeassistant.components.sensor.uber
 uber_rides==0.6.0
 
+# homeassistant.components.media_player.missile_launcher
+pyusb==1.0.2
+
 # homeassistant.components.sensor.ups
 upsmychoice==1.0.6
 


### PR DESCRIPTION
## Description:
In the spirit of hacktoberfest, I'm am submitting a custom component I've had implemented for a while.

It allows integration of a USB Missile Launcher (the foam ones) into HASS.

Since the missile launch can control the movements along with having a camera on it, I tried to figure out where to best implement it (as I didn't find any example of integrating a camera that you can also control.) So I implemented it as a media_player, which can show the image and the select source has the commands so that you can control it.

(I added a couple @TODO statements of areas that I need feedback on.)


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
media_player:
    platform: missile_launcher

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
