### PR TITLE
Avoid Sonos error during startup

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -150,8 +150,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             _LOGGER.warning("No Sonos speakers found")
             return
 
-        hass.data[DATA_SONOS] = [SonosDevice(p) for p in players]
-        add_devices(hass.data[DATA_SONOS], True)
+        # Add coordinators first so they can be queried by slaves
+        coordinators = [SonosDevice(p) for p in players if p.is_coordinator]
+        slaves = [SonosDevice(p) for p in players if not p.is_coordinator]
+        hass.data[DATA_SONOS] = coordinators + slaves
+        add_devices(coordinators, True)
+        add_devices(slaves, True)
         _LOGGER.info("Added %s Sonos speakers", len(players))
 
     descriptions = load_yaml_config_file(

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -154,8 +154,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         coordinators = [SonosDevice(p) for p in players if p.is_coordinator]
         slaves = [SonosDevice(p) for p in players if not p.is_coordinator]
         hass.data[DATA_SONOS] = coordinators + slaves
-        add_devices(coordinators, True)
-        add_devices(slaves, True)
+        if coordinators:
+            add_devices(coordinators, True)
+        if slaves:
+            add_devices(slaves, True)
         _LOGGER.info("Added %s Sonos speakers", len(players))
 
     descriptions = load_yaml_config_file(


### PR DESCRIPTION
## Description:

This gets rid of an exception during startup when slaves query incomplete coordinators for their state.

The error is new in 0.56.x (which has no sonos.py changes) so @pvizeli I think it could be related to #9924. We probably used to `update` all entities before reading state from any of them?

I think it's fine to fix this in Sonos so I just mention it in case you want a more generic solution.

```
2017-10-25 20:15:26 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/lib/python3.6/asyncio/tasks.py", line 179, in _step
    result = coro.send(None)
  File "/usr/lib/python3.6/site-packages/homeassistant/helpers/entity_component.py", line 398, in async_process_entity
    new_entity, self, update_before_add=update_before_add
  File "/usr/lib/python3.6/site-packages/homeassistant/helpers/entity_component.py", line 246, in async_add_entity
    yield from entity.async_update_ha_state()
  File "/usr/lib/python3.6/site-packages/homeassistant/helpers/entity.py", line 222, in async_update_ha_state
    attr = self.state_attributes or {}
  File "/usr/lib/python3.6/site-packages/homeassistant/components/media_player/__init__.py", line 882, in state_attributes
    in ATTR_TO_PROPERTY if getattr(self, attr) is not None
  File "/usr/lib/python3.6/site-packages/homeassistant/components/media_player/__init__.py", line 882, in <dictcomp>
    in ATTR_TO_PROPERTY if getattr(self, attr) is not None
  File "/usr/lib/python3.6/site-packages/homeassistant/components/media_player/sonos.py", line 949, in source_list
    return self._coordinator.source_list
  File "/usr/lib/python3.6/site-packages/homeassistant/components/media_player/sonos.py", line 951, in source_list
    model_name = self._speaker_info['model_name']
TypeError: 'NoneType' object is not subscriptable
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
