### PR TITLE
Google Assistant Script Support

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -34,7 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 MAPPING_COMPONENT = {
     group.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     scene.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
-	script.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
+    script.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     switch.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],
     fan.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],
     light.DOMAIN: [

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF, SERVICE_TURN_ON
 )
 from homeassistant.components import (
-    switch, light, cover, media_player, group, fan, scene
+    switch, light, cover, media_player, group, fan, scene, script
 )
 
 from .const import (

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -34,6 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 MAPPING_COMPONENT = {
     group.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     scene.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
+	script.DOMAIN: [TYPE_SCENE, TRAIT_SCENE, None],
     switch.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],
     fan.DOMAIN: [TYPE_SWITCH, TRAIT_ONOFF, None],
     light.DOMAIN: [


### PR DESCRIPTION
## Description:
Adds support to the Google Assistant component for handling scripts as scenes

## Example entry for `configuration.yaml` (if applicable):
```yaml
google_assistant:
  project_id: someproject-2d0b8
  client_id: [long URL safe random string]
  access_token: [a different long URL safe random string]
  exposed_domains:
    - script
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**