### PR TITLE
Updated denon component to play nice with the 3808CI that doesn't sup…

### DIFF
--- a/homeassistant/components/media_player/denon.py
+++ b/homeassistant/components/media_player/denon.py
@@ -78,7 +78,9 @@ class DenonDevice(MediaPlayerDevice):
 
     def _setup_sources(self, telnet):
         # NSFRN - Network name
-        self._name = self.telnet_request(telnet, 'NSFRN ?')[len('NSFRN '):]
+        nsfrn = self.telnet_request(telnet, 'NSFRN ?')[len('NSFRN '):]
+        if nsfrn:
+            self._name = nsfrn
 
         # SSFUN - Configured sources with names
         self._source_list = {}
@@ -110,7 +112,7 @@ class DenonDevice(MediaPlayerDevice):
 
         if all_lines:
             return lines
-        return lines[0]
+        return lines[0] if lines else ''
 
     def telnet_command(self, command):
         """Establish a telnet connection and sends `command`."""


### PR DESCRIPTION
…port NSFRN command

## Description:


**Related issue (if applicable):** fixes #8884

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
