### PR TITLE
Upgrade libnacl to 1.6.1

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -20,7 +20,7 @@ from homeassistant.const import STATE_HOME
 from homeassistant.core import callback
 from homeassistant.util import slugify, decorator
 
-REQUIREMENTS = ['libnacl==1.6.0']
+REQUIREMENTS = ['libnacl==1.6.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -394,7 +394,7 @@ keyring>=9.3,<10.0
 
 # homeassistant.components.device_tracker.owntracks
 # homeassistant.components.device_tracker.owntracks_http
-libnacl==1.6.0
+libnacl==1.6.1
 
 # homeassistant.components.dyson
 libpurecoollink==0.4.2


### PR DESCRIPTION
## Description
- Make sure that libnacl runs correctly on the 1.0.15 release of libsodium

## Example entry for `configuration.yaml` (if applicable):
``` yaml
device_tracker:
  - platform: owntracks
    secret: xyz
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
