### PR TITLE
Upgrade python_opendata_transport to 0.0.3

### DIFF
--- a/homeassistant/components/sensor/swiss_public_transport.py
+++ b/homeassistant/components/sensor/swiss_public_transport.py
@@ -17,7 +17,7 @@ from homeassistant.const import CONF_NAME, ATTR_ATTRIBUTION
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-REQUIREMENTS = ['python_opendata_transport==0.0.2']
+REQUIREMENTS = ['python_opendata_transport==0.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -859,7 +859,7 @@ python-vlc==1.1.2
 python-wink==1.7.0
 
 # homeassistant.components.sensor.swiss_public_transport
-python_opendata_transport==0.0.2
+python_opendata_transport==0.0.3
 
 # homeassistant.components.zwave
 python_openzwave==0.4.0.35


### PR DESCRIPTION
## Description:
- Fix command
- Fix docstrings and PEP8

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: swiss_public_transport
    name: Train
    from: Bern
    to: Biel
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
