### PR TITLE
Reduce album art flickering in media player UI

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -965,7 +965,7 @@ class MediaPlayerImageView(HomeAssistantView):
         if data is None:
             return web.Response(status=500)
 
-        headers = { hdrs.CACHE_CONTROL: 'max-age=3600' }
+        headers = {hdrs.CACHE_CONTROL: 'max-age=3600'}
         return web.Response(
             body=data,
             content_type=content_type,

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -12,7 +12,7 @@ import logging
 import os
 from random import SystemRandom
 
-from aiohttp import web
+from aiohttp import web, hdrs
 import async_timeout
 import voluptuous as vol
 
@@ -490,9 +490,8 @@ class MediaPlayerDevice(Entity):
     def media_image_hash(self):
         """Hash value for media image."""
         url = self.media_image_url
-
         if url is not None:
-            return hashlib.md5(url.encode('utf-8')).hexdigest()[:5]
+            return hashlib.sha256(url.encode('utf-8')).hexdigest()[:16]
 
         return None
 
@@ -966,4 +965,8 @@ class MediaPlayerImageView(HomeAssistantView):
         if data is None:
             return web.Response(status=500)
 
-        return web.Response(body=data, content_type=content_type)
+        headers = { hdrs.CACHE_CONTROL: 'max-age=3600' }
+        return web.Response(
+            body=data,
+            content_type=content_type,
+            headers=headers)


### PR DESCRIPTION
## Description:

With this change we tell the browser to cache the media art. Without the header, browsers will use heuristics that often lead to repeated downloads of the same image during play. This can cause a very visible flicker where the area with album art goes white for several seconds. Safari appears to be most affected by this issue (tested with Sonos).

As the images are now cached for longer, hash collisions are more likely. Thus, I have extended the cache buster key a bit. The URL already includes a very long token so this does not make it much more ugly.

**Related issue (if applicable):** There are some flickering issues logged but I am not sure that they are fixed by this change so I refrain from listing issue numbers. That is also why it says "reduce" in the title: the change fully fixes my particular issue but I want to keep expectations down because I think there are other issues to fix.

## Checklist:

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [ ] Tests have been added to verify that the new code works.