### PR TITLE
Add Random binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/random.py
+++ b/homeassistant/components/binary_sensor/random.py
@@ -1,0 +1,64 @@
+"""
+Support for showing random states.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.random/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA, DEVICE_CLASSES_SCHEMA)
+from homeassistant.const import CONF_NAME, CONF_DEVICE_CLASS
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Random Binary Sensor'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Random binary sensor."""
+    name = config.get(CONF_NAME)
+    device_class = config.get(CONF_DEVICE_CLASS)
+
+    async_add_devices([RandomSensor(name, device_class)], True)
+
+
+class RandomSensor(BinarySensorDevice):
+    """Representation of a Random binary sensor."""
+
+    def __init__(self, name, device_class):
+        """Initialize the Random binary sensor."""
+        self._name = name
+        self._device_class = device_class
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._state
+
+    @property
+    def device_class(self):
+        """Return the sensor class of the sensor."""
+        return self._device_class
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Get new state and update the sensor's state."""
+        from random import getrandbits
+        self._state = bool(getrandbits(1))

--- a/tests/components/binary_sensor/test_random.py
+++ b/tests/components/binary_sensor/test_random.py
@@ -1,0 +1,51 @@
+"""The test for the Random binary sensor platform."""
+import unittest
+from unittest.mock import patch
+
+from homeassistant.setup import setup_component
+
+from tests.common import get_test_home_assistant
+
+
+class TestRandomSensor(unittest.TestCase):
+    """Test the Random binary sensor."""
+
+    def setup_method(self, method):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @patch('random.getrandbits', return_value=1)
+    def test_random_binary_sensor_on(self, mocked):
+        """Test the Random binary sensor."""
+        config = {
+            'binary_sensor': {
+                'platform': 'random',
+                'name': 'test',
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        state = self.hass.states.get('binary_sensor.test')
+
+        self.assertEqual(state.state, 'on')
+
+    @patch('random.getrandbits', return_value=False)
+    def test_random_binary_sensor_off(self, mocked):
+        """Test the Random binary sensor."""
+        config = {
+            'binary_sensor': {
+                'platform': 'random',
+                'name': 'test',
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        state = self.hass.states.get('binary_sensor.test')
+
+        self.assertEqual(state.state, 'off')


### PR DESCRIPTION
## Description:
This is the equivalent to the [`random` sensor](https://home-assistant.io/components/sensor.random/) but in a binary form.

A [post on reddit](https://www.reddit.com/r/homeassistant/comments/78xpwk/need_some_help_with_demo_ideas_locally_connected/?st=j9905y2o&sh=56fcb2d4) basically "forced" me to create it because it allows one to run an interactive but very limited demo of Home Assistant within a minute.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3798

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: random
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

