### PR TITLE
added platform discovery code back into device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.components import group, zone
 from homeassistant.config import load_yaml_config_file, async_log_exception
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers import config_per_platform
+from homeassistant.helpers import config_per_platform, discovery
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.restore_state import async_get_last_state
@@ -174,6 +174,13 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
         yield from asyncio.wait(setup_tasks, loop=hass.loop)
 
     tracker.async_setup_group()
+
+    @asyncio.coroutine
+    def async_platform_discovered(platform, info):
+        """Load a platform."""
+        yield from async_setup_platform(platform, {}, disc_info=info)
+
+    discovery.async_listen_platform(hass, DOMAIN, async_platform_discovered)
 
     # Clean up stale devices
     async_track_utc_time_change(

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -11,6 +11,7 @@ import os
 from homeassistant.components import zone
 from homeassistant.core import callback, State
 from homeassistant.setup import setup_component
+from homeassistant.helpers import discovery
 from homeassistant.loader import get_component
 from homeassistant.util.async import run_coroutine_threadsafe
 import homeassistant.util.dt as dt_util
@@ -309,6 +310,23 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             assert aioclient_mock.call_count == 1, \
                 'No http request for macvendor made!'
         self.assertEqual(tracker.devices['b827eb000000'].vendor, vendor_string)
+
+    @patch(
+        'homeassistant.components.device_tracker.DeviceTracker.see')
+    @patch(
+        'homeassistant.components.device_tracker.demo.setup_scanner',
+        autospec=True)
+    def test_discover_platform(self, mock_demo_setup_scanner, mock_see):
+        """Test discovery of device_tracker demo platform."""
+        assert device_tracker.DOMAIN not in self.hass.config.components
+        discovery.load_platform(
+            self.hass, device_tracker.DOMAIN, 'demo', {'test_key': 'test_val'},
+            {})
+        self.hass.block_till_done()
+        assert device_tracker.DOMAIN in self.hass.config.components
+        assert mock_demo_setup_scanner.called
+        assert mock_demo_setup_scanner.call_args[0] == (
+            self.hass, {}, mock_see, {'test_key': 'test_val'})
 
     def test_update_stale(self):
         """Test stalled update."""


### PR DESCRIPTION
## Description:

Fixed platform discovery for `device_tracker` by reverting some of the changes (see #9683)

**Related issue (if applicable):** fixes #10124

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
