### PR TITLE
Fix for issue #9240

### DIFF
--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -186,7 +186,7 @@ class MqttFan(FanEntity):
             yield from mqtt.async_subscribe(
                 self.hass, self._topic[CONF_SPEED_STATE_TOPIC], speed_received,
                 self._qos)
-        self._speed = SPEED_OFF
+            self._speed = SPEED_OFF
 
         @callback
         def oscillation_received(topic, payload, qos):
@@ -202,7 +202,7 @@ class MqttFan(FanEntity):
             yield from mqtt.async_subscribe(
                 self.hass, self._topic[CONF_OSCILLATION_STATE_TOPIC],
                 oscillation_received, self._qos)
-        self._oscillation = False
+            self._oscillation = False
 
     @property
     def should_poll(self):


### PR DESCRIPTION
Changes for respecting mqtt fan config. If fan speed and oscillation is not configured they wouldn't be displayed in UI.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
