### PR TITLE
added Yesss SMS platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -447,6 +447,7 @@ omit =
     homeassistant/components/notify/telstra.py
     homeassistant/components/notify/twitter.py
     homeassistant/components/notify/xmpp.py
+    homeassistant/components/notify/yessssms.py
     homeassistant/components/nuimo_controller.py
     homeassistant/components/prometheus.py
     homeassistant/components/remote/harmony.py

--- a/homeassistant/components/notify/yessssms.py
+++ b/homeassistant/components/notify/yessssms.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_RECIPIENT
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['YesssSMS==0.1.1b2']
+REQUIREMENTS = ['YesssSMS==0.1.1b3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,9 +43,9 @@ class YesssSMSNotificationService(BaseNotificationService):
         """Send a SMS message via Yesss.at's website."""
         try:
             self.yesss.send(self._recipient, message)
-        except ValueError as e:
-            if str(e).startswith("YesssSMS:"):
-                _LOGGER.error(str(e))
-        except RuntimeError as e:
-            if str(e).startswith("YesssSMS:"):
-                _LOGGER.error(str(e))
+        except ValueError as ex:
+            if str(ex).startswith("YesssSMS:"):
+                _LOGGER.error(str(ex))
+        except RuntimeError as ex:
+            if str(ex).startswith("YesssSMS:"):
+                _LOGGER.error(str(ex))

--- a/homeassistant/components/notify/yessssms.py
+++ b/homeassistant/components/notify/yessssms.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_RECIPIENT
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['YesssSMS==0.1.1b']
+REQUIREMENTS = ['YesssSMS==0.1.1b2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,4 +41,11 @@ class YesssSMSNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a SMS message via Yesss.at's website."""
-        self.yesss.send(self._recipient, message)
+        try:
+            self.yesss.send(self._recipient, message)
+        except ValueError as e:
+            if str(e).startswith("YesssSMS:"):
+                _LOGGER.error(str(e))
+        except RuntimeError as e:
+            if str(e).startswith("YesssSMS:"):
+                _LOGGER.error(str(e))

--- a/homeassistant/components/notify/yessssms.py
+++ b/homeassistant/components/notify/yessssms.py
@@ -1,5 +1,5 @@
 """
-Support for the YesssSMS platform
+Support for the YesssSMS platform.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.yessssms/

--- a/homeassistant/components/notify/yessssms.py
+++ b/homeassistant/components/notify/yessssms.py
@@ -41,4 +41,4 @@ class YesssSMSNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a SMS message via Yesss.at's website."""
-        resp = self.yesss.send(self._recipient, message)
+        self.yesss.send(self._recipient, message)

--- a/homeassistant/components/notify/yessssms.py
+++ b/homeassistant/components/notify/yessssms.py
@@ -1,0 +1,44 @@
+"""
+Support for the YesssSMS platform
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.yessssms/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.notify import (
+    PLATFORM_SCHEMA, BaseNotificationService)
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_RECIPIENT
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['YesssSMS==0.1.1b']
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Required(CONF_RECIPIENT): cv.string,
+})
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the YesssSMS notification service."""
+    return YesssSMSNotificationService(
+        config[CONF_USERNAME], config[CONF_PASSWORD], config[CONF_RECIPIENT])
+
+
+class YesssSMSNotificationService(BaseNotificationService):
+    """Implement a notification service for the YesssSMS service."""
+
+    def __init__(self, username, password, recipient):
+        """Initialize the service."""
+        from YesssSMS import YesssSMS
+        self.yesss = YesssSMS(username, password)
+        self._recipient = recipient
+
+    def send_message(self, message="", **kwargs):
+        """Send a SMS message via Yesss.at's website."""
+        resp = self.yesss.send(self._recipient, message)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -51,6 +51,9 @@ TravisPy==0.3.5
 # homeassistant.components.notify.twitter
 TwitterAPI==2.4.6
 
+# homeassistant.components.notify.yessssms
+YesssSMS==0.1.1b
+
 # homeassistant.components.abode
 abodepy==0.12.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -52,7 +52,7 @@ TravisPy==0.3.5
 TwitterAPI==2.4.6
 
 # homeassistant.components.notify.yessssms
-YesssSMS==0.1.1b
+YesssSMS==0.1.1b2
 
 # homeassistant.components.abode
 abodepy==0.12.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -52,7 +52,7 @@ TravisPy==0.3.5
 TwitterAPI==2.4.6
 
 # homeassistant.components.notify.yessssms
-YesssSMS==0.1.1b2
+YesssSMS==0.1.1b3
 
 # homeassistant.components.abode
 abodepy==0.12.1


### PR DESCRIPTION
new component for sending SMS via yesss.at

requires YesssSMS==0.1.1b3

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3801

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: NOTIFIER_NAME
    platform: yessssms
    username: YOUR_PHONE_NUMBER
    password: YOUR_PASSWORD
    recipient: PHONE_NUMBER_TO_NOTIFY
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
