### PR TITLE
Add support for REQUEST_SYNC to will update devices in Google Assistant

### DIFF
--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/google_assistant/
 """
 import asyncio
 import logging
-
+import os
 import voluptuous as vol
 
 # Typing imports
@@ -15,11 +15,16 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant  # NOQA
 from typing import Dict, Any  # NOQA
 
+from homeassistant import config as conf_util
+from homeassistant.core import callback
+from homeassistant.loader import bind_hass
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     DOMAIN, CONF_PROJECT_ID, CONF_CLIENT_ID, CONF_ACCESS_TOKEN,
-    CONF_EXPOSE_BY_DEFAULT, CONF_EXPOSED_DOMAINS
+    CONF_EXPOSE_BY_DEFAULT, CONF_EXPOSED_DOMAINS,
+    CONF_AGENT_USER_ID, CONF_API_KEY
 )
 from .auth import GoogleAssistantAuthView
 from .http import GoogleAssistantView
@@ -28,12 +33,20 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['http']
 
+SERVICE_REQUEST_SYNC = "request_sync"
+BASE_REQUEST_SYNC_URL = \
+    "https://homegraph.googleapis.com/v1/devices:requestSync"
+
+REQUEST_SYNC_SERVICE_SCHEMA = vol.Schema({})
+
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: {
             vol.Required(CONF_PROJECT_ID): cv.string,
             vol.Required(CONF_CLIENT_ID): cv.string,
             vol.Required(CONF_ACCESS_TOKEN): cv.string,
+            vol.Optional(CONF_AGENT_USER_ID): cv.string,
+            vol.Optional(CONF_API_KEY): cv.string,
             vol.Optional(CONF_EXPOSE_BY_DEFAULT): cv.boolean,
             vol.Optional(CONF_EXPOSED_DOMAINS): cv.ensure_list,
         }
@@ -46,7 +59,43 @@ def async_setup(hass: HomeAssistant, yaml_config: Dict[str, Any]):
     """Activate Google Actions component."""
     config = yaml_config.get(DOMAIN, {})
 
+    descriptions = yield from hass.async_add_job(
+        conf_util.load_yaml_config_file, os.path.join(
+            os.path.dirname(__file__), 'services.yaml')
+    )
+
+    @asyncio.coroutine
+    def request_sync_service_handler(service):
+        """Request sync of devices."""
+        session = async_get_clientsession(hass)
+        yield from session.post(
+            BASE_REQUEST_SYNC_URL,
+            params={'key': config.get(CONF_API_KEY)},
+            json={'agent_user_id': config.get(CONF_AGENT_USER_ID)})
+
+        return
+
+    if config.get(CONF_AGENT_USER_ID) is not None and \
+       config.get(CONF_API_KEY) is not None:
+        hass.services.async_register(
+            DOMAIN, SERVICE_REQUEST_SYNC, request_sync_service_handler,
+            descriptions[SERVICE_REQUEST_SYNC],
+            schema=REQUEST_SYNC_SERVICE_SCHEMA)
+
     hass.http.register_view(GoogleAssistantAuthView(hass, config))
     hass.http.register_view(GoogleAssistantView(hass, config))
 
     return True
+
+
+@bind_hass
+def request_sync(hass):
+    """Request sync of devices."""
+    hass.add_job(async_request_sync, hass)
+
+
+@callback
+@bind_hass
+def async_request_sync(hass):
+    """Reload the automation from config."""
+    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_REQUEST_SYNC))

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -12,6 +12,8 @@ CONF_PROJECT_ID = 'project_id'
 CONF_ACCESS_TOKEN = 'access_token'
 CONF_CLIENT_ID = 'client_id'
 CONF_ALIASES = 'aliases'
+CONF_AGENT_USER_ID = 'agent_user_id'
+CONF_API_KEY = 'api_key'
 
 DEFAULT_EXPOSE_BY_DEFAULT = True
 DEFAULT_EXPOSED_DOMAINS = [

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -22,6 +22,8 @@ from homeassistant.const import (HTTP_BAD_REQUEST, HTTP_UNAUTHORIZED)
 from .const import (
     GOOGLE_ASSISTANT_API_ENDPOINT,
     CONF_ACCESS_TOKEN,
+    CONF_API_KEY,
+    CONF_AGENT_USER_ID,
     DEFAULT_EXPOSE_BY_DEFAULT,
     DEFAULT_EXPOSED_DOMAINS,
     CONF_EXPOSE_BY_DEFAULT,
@@ -48,6 +50,8 @@ class GoogleAssistantView(HomeAssistantView):
                                          DEFAULT_EXPOSE_BY_DEFAULT)
         self.exposed_domains = cfg.get(CONF_EXPOSED_DOMAINS,
                                        DEFAULT_EXPOSED_DOMAINS)
+        self.api_key = cfg.get(CONF_API_KEY)
+        self.agent_user_id = cfg.get(CONF_AGENT_USER_ID)
 
     def is_entity_exposed(self, entity) -> bool:
         """Determine if an entity should be exposed to Google Assistant."""
@@ -84,8 +88,12 @@ class GoogleAssistantView(HomeAssistantView):
 
             devices.append(device)
 
+        request_data = {'devices': devices}
+        if self.agent_user_id is not None:
+            request_data["agent_user_id"] = self.agent_user_id
+
         return self.json(
-            make_actions_response(request_id, {'devices': devices}))
+            make_actions_response(request_id, request_data))
 
     @asyncio.coroutine
     def handle_query(self,

--- a/homeassistant/components/google_assistant/services.yaml
+++ b/homeassistant/components/google_assistant/services.yaml
@@ -1,0 +1,2 @@
+request_sync:
+  description: "Request a sync of devices"


### PR DESCRIPTION
This adds support for REQUEST_SYNC which triggers a SYNC and updates devices.
It is added as a service under the google_assistant domain.

This requires two new configuration values.
The `agent_user_id` must be set when doing the first SYNC.

```
api_key: <key from console>
agent_user_id: <any string max 256 chars>
```
