### PR TITLE
Google Assistant: make it possible to set a custom domain/type

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -5,6 +5,7 @@ GOOGLE_ASSISTANT_API_ENDPOINT = '/api/google_assistant'
 
 ATTR_GOOGLE_ASSISTANT = 'google_assistant'
 ATTR_GOOGLE_ASSISTANT_NAME = 'google_assistant_name'
+ATTR_GOOGLE_ASSISTANT_TYPE = 'google_assistant_type'
 
 CONF_EXPOSE_BY_DEFAULT = 'expose_by_default'
 CONF_EXPOSED_DOMAINS = 'exposed_domains'

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -19,7 +19,7 @@ from homeassistant.components import (
 )
 
 from .const import (
-    ATTR_GOOGLE_ASSISTANT_NAME,
+    ATTR_GOOGLE_ASSISTANT_NAME, ATTR_GOOGLE_ASSISTANT_TYPE,
     COMMAND_BRIGHTNESS, COMMAND_ONOFF, COMMAND_ACTIVATESCENE,
     TRAIT_ONOFF, TRAIT_BRIGHTNESS, TRAIT_COLOR_TEMP,
     TRAIT_RGB_COLOR, TRAIT_SCENE,
@@ -63,7 +63,8 @@ def make_actions_response(request_id: str, payload: dict) -> dict:
 
 def entity_to_device(entity: Entity):
     """Convert a hass entity into an google actions device."""
-    class_data = MAPPING_COMPONENT.get(entity.domain)
+    class_data = MAPPING_COMPONENT.get(
+        entity.attributes.get(ATTR_GOOGLE_ASSISTANT_TYPE) or entity.domain)
     if class_data is None:
         return None
 

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -24,7 +24,7 @@ DEMO_DEVICES = [{
     'traits': [
         'action.devices.traits.OnOff'
     ],
-    'type': 'action.devices.types.LIGHT',  # This is used for custom type
+    'type': 'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {
@@ -36,7 +36,7 @@ DEMO_DEVICES = [{
     'traits': [
         'action.devices.traits.OnOff'
     ],
-    'type': 'action.devices.types.SWITCH',
+    'type': 'action.devices.types.LIGHT',  # This is used for custom type
     'willReportState':
     False
 }, {

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -17,6 +17,30 @@ DEMO_DEVICES = [{
     False
 }, {
     'id':
+    'switch.ac',
+    'name': {
+        'name': 'AC'
+    },
+    'traits': [
+        'action.devices.traits.OnOff'
+    ],
+    'type': 'action.devices.types.LIGHT',  # This is used for custom type
+    'willReportState':
+    False
+}, {
+    'id':
+    'switch.decorative_lights',
+    'name': {
+        'name': 'Decorative Lights'
+    },
+    'traits': [
+        'action.devices.traits.OnOff'
+    ],
+    'type': 'action.devices.types.SWITCH',
+    'willReportState':
+    False
+}, {
+    'id':
     'light.ceiling_lights',
     'name': {
         'name': 'Roof Lights',
@@ -50,6 +74,14 @@ DEMO_DEVICES = [{
     'id': 'group.all_lights',
     'name': {
         'name': 'all lights'
+    },
+    'traits': ['action.devices.traits.Scene'],
+    'type': 'action.devices.types.SCENE',
+    'willReportState': False
+}, {
+    'id': 'group.all_switches',
+    'name': {
+        'name': 'all switches'
     },
     'traits': ['action.devices.traits.Scene'],
     'type': 'action.devices.types.SCENE',

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -101,7 +101,7 @@ def hass_fixture(loop, hass):
 
     # By setting the google_assistant_type = 'light'
     # we can override how a device is reported to GA
-    switch_light = hass.states.get('switch.ac')
+    switch_light = hass.states.get('switch.decorative_lights')
     attrs = dict(switch_light.attributes)
     attrs[ga.const.ATTR_GOOGLE_ASSISTANT_TYPE] = "light"
     hass.states.async_set(
@@ -205,6 +205,8 @@ def test_execute_request(hass_fixture, assistant_client):
                     "devices": [{
                         "id": "light.ceiling_lights",
                     }, {
+                        "id": "switch.decorative_lights",
+                    }, {
                         "id": "light.bed_light",
                     }],
                     "execution": [{
@@ -225,6 +227,7 @@ def test_execute_request(hass_fixture, assistant_client):
     body = yield from result.json()
     assert body.get('requestId') == reqid
     commands = body['payload']['commands']
-    assert len(commands) == 2
+    assert len(commands) == 3
     ceiling = hass_fixture.states.get('light.ceiling_lights')
     assert ceiling.state == 'off'
+    assert hass_fixture.states.get('switch.decorative_lights').state == 'off'

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant import setup, const, core
 from homeassistant.components import (
-    http, async_setup, light, cover, media_player, fan
+    http, async_setup, light, cover, media_player, fan, switch
 )
 from homeassistant.components import google_assistant as ga
 from tests.common import get_test_instance_port
@@ -63,6 +63,12 @@ def hass_fixture(loop, hass):
             }]
         }))
     loop.run_until_complete(
+        setup.async_setup_component(hass, switch.DOMAIN, {
+            'switch': [{
+                'platform': 'demo'
+            }]
+        }))
+    loop.run_until_complete(
         setup.async_setup_component(hass, cover.DOMAIN, {
             'cover': [{
                 'platform': 'demo'
@@ -91,6 +97,16 @@ def hass_fixture(loop, hass):
     hass.states.async_set(
         ceiling_lights_entity.entity_id,
         ceiling_lights_entity.state,
+        attributes=attrs)
+
+    # By setting the google_assistant_type = 'light'
+    # we can override how a device is reported to GA
+    switch_light = hass.states.get('switch.ac')
+    attrs = dict(switch_light.attributes)
+    attrs[ga.const.ATTR_GOOGLE_ASSISTANT_TYPE] = "light"
+    hass.states.async_set(
+        switch_light.entity_id,
+        switch_light.state,
         attributes=attrs)
 
     return hass

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -16,14 +16,14 @@ DETERMINE_SERVICE_TESTS = [{  # Test light brightness
         {'entity_id': 'light.test', 'brightness': 242}
     )
 }, {  # Test switch to light custom type
-    'entity_id': 'switch.ac',
+    'entity_id': 'switch.decorative_lights',
     'command': ga.const.COMMAND_ONOFF,
     'params': {
         'on': True
     },
     'expected': (
         const.SERVICE_TURN_ON,
-        {'entity_id': 'switch.ac'}
+        {'entity_id': 'switch.decorative_lights'}
     )
 }, {  # Test light on / off
     'entity_id': 'light.test',

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -15,6 +15,16 @@ DETERMINE_SERVICE_TESTS = [{  # Test light brightness
         const.SERVICE_TURN_ON,
         {'entity_id': 'light.test', 'brightness': 242}
     )
+}, {  # Test switch to light custom type
+    'entity_id': 'switch.ac',
+    'command': ga.const.COMMAND_ONOFF,
+    'params': {
+        'on': True
+    },
+    'expected': (
+        const.SERVICE_TURN_ON,
+        {'entity_id': 'switch.ac'}
+    )
 }, {  # Test light on / off
     'entity_id': 'light.test',
     'command': ga.const.COMMAND_ONOFF,


### PR DESCRIPTION
Makes it possible to map for example switch to light in Google Assistant.

Some wall switches which controls ceiling lights etc are reported as a `switch` in hass.

This makes it cumbersome to use Google Assistant as you need to issue to voice commands.
`hey google, turn off the lights in bedroom` or `hey google, turn off bedroom`. The latter would also turn off outlets etc.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3825

Example customize:
```
switch.bedroom_switch:
  friendly_name: "Bedroom, ceiling"
  google_assistant: true
  google_assistant_type: 'light'
```