### PR TITLE
Use translated panel names on frontend

### DIFF
--- a/homeassistant/components/hassio.py
+++ b/homeassistant/components/hassio.py
@@ -90,7 +90,7 @@ def async_setup(hass, config):
 
     if 'frontend' in hass.config.components:
         yield from hass.components.frontend.async_register_built_in_panel(
-            'hassio', 'Hass.io', 'mdi:access-point-network')
+            'hassio', 'hassio', 'mdi:access-point-network')
 
     if 'http' in config:
         yield from hassio.update_hass_api(config['http'])

--- a/homeassistant/components/hassio.py
+++ b/homeassistant/components/hassio.py
@@ -90,7 +90,7 @@ def async_setup(hass, config):
 
     if 'frontend' in hass.config.components:
         yield from hass.components.frontend.async_register_built_in_panel(
-            'hassio', 'hassio', 'mdi:access-point-network')
+            'hassio', 'Hass.io', 'mdi:access-point-network')
 
     if 'http' in config:
         yield from hassio.update_hass_api(config['http'])

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -36,7 +36,7 @@ def async_setup(hass, config):
     """Track states and offer events for mailboxes."""
     mailboxes = []
     yield from hass.components.frontend.async_register_built_in_panel(
-        'mailbox', 'Mailbox', 'mdi:mailbox')
+        'mailbox', 'mailbox', 'mdi:mailbox')
     hass.http.register_view(MailboxPlatformsView(mailboxes))
     hass.http.register_view(MailboxMessageView(mailboxes))
     hass.http.register_view(MailboxMediaView(mailboxes))

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -49,7 +49,7 @@ def async_setup(hass, config):
     ])
 
     yield from hass.components.frontend.async_register_built_in_panel(
-        'shopping-list', 'Shopping List', 'mdi:cart')
+        'shopping-list', 'shopping_list', 'mdi:cart')
 
     return True
 


### PR DESCRIPTION
## Description:
Use the newly available translation keys for the remaining built in panels. Depends on https://github.com/home-assistant/home-assistant-polymer/pull/539
