### PR TITLE
Rfxtrx set recv modes

### DIFF
--- a/homeassistant/components/binary_sensor/rfxtrx.py
+++ b/homeassistant/components/binary_sensor/rfxtrx.py
@@ -163,6 +163,8 @@ class RfxtrxBinarySensor(BinarySensorDevice):
             self._masked_id = rfxtrx.get_pt2262_deviceid(
                 event.device.id_string.lower(),
                 data_bits)
+        else:
+            self._masked_id = None
 
     def __str__(self):
         """Return the name of the sensor."""

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -4,6 +4,7 @@ Support for RFXtrx components.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/rfxtrx/
 """
+import asyncio
 import logging
 from collections import OrderedDict
 import voluptuous as vol

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -60,6 +60,7 @@ RFX_DEVICES = {}
 _LOGGER = logging.getLogger(__name__)
 RFXOBJECT = 'rfxobject'
 
+
 def _valid_device(value, device_type):
     """Validate a dictionary of devices definitions."""
     config = OrderedDict()

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -141,7 +141,7 @@ def _valid_light_switch(value):
 
 
 def valid_recvmode(value):
-    """Test if a recv_mode value is known by pyRFXTRX"""
+    """Test if a recv_mode value is known by pyRFXTRX."""
     if value in KNOWN_RECVMODES:
         return value
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -109,6 +109,15 @@ def _valid_light_switch(value):
     return _valid_device(value, "light_switch")
 
 
+def valid_recvmode(value):
+    """Test if a recv_mode value is known by pyRFXTRX"""
+    import RFXtrx
+    if RFXtrx.lowlevel.get_recmode_tuple(value) != (None, None):
+        return value
+
+    raise vol.Invalid('Recv_mode "{}" is unknown to RFXTRX.'.format(value))
+
+
 DEVICE_SCHEMA = vol.Schema({
     vol.Required(ATTR_NAME): cv.string,
     vol.Optional(ATTR_FIREEVENT, default=False): cv.boolean,
@@ -146,7 +155,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(ATTR_DEBUG, default=False): cv.boolean,
         vol.Optional(ATTR_DUMMY, default=False): cv.boolean,
         vol.Optional(ATTR_RECV_MODES, default=None):
-            vol.All(vol.All(cv.ensure_list, [cv.string]), vol.Length(min=1))
+            vol.All(vol.All(cv.ensure_list, [valid_recvmode]), vol.Length(min=1))
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -155,7 +155,8 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(ATTR_DEBUG, default=False): cv.boolean,
         vol.Optional(ATTR_DUMMY, default=False): cv.boolean,
         vol.Optional(ATTR_RECV_MODES, default=None):
-            vol.All(vol.All(cv.ensure_list, [valid_recvmode]), vol.Length(min=1))
+            vol.All(vol.All(cv.ensure_list, [valid_recvmode]),
+                    vol.Length(min=1))
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -370,6 +370,11 @@ class RfxtrxDevice(Entity):
         """Attach to callbacks."""
         self.hass.helpers.dispatcher.async_dispatcher_connect(
             SIGNAL_RFXTRX_EVENT, self._receive_command)
+    
+    @property
+    def unique_id(self):
+        """Return unique device id."""
+        return self._device_id
 
     @property
     def should_poll(self):

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -178,8 +178,9 @@ def setup(hass, config):
                       "".join("{0:02x}".format(x) for x in event.data))
 
         # Callback to HA registered components.
-        hass.helpers.dispatcher.dispatch_send(
-            SIGNAL_RFXTRX_EVENT, event)
+        device_id, slugify(event.device.id_string.lower())
+        hass.helpers.dispatcher.dispatcher_send(
+            SIGNAL_RFXTRX_EVENT, device_id, event)
 
     # Try to load the RFXtrx module.
     import RFXtrx as rfxtrxmod
@@ -366,7 +367,7 @@ class RfxtrxDevice(Entity):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Attach to callbacks."""
-        self.hass.helpers.dispatcher.async_dispatch_connect(
+        self.hass.helpers.dispatcher.async_dispatcher_connect(
             SIGNAL_RFXTRX_EVENT, self._receive_command)
 
     @property
@@ -403,11 +404,11 @@ class RfxtrxDevice(Entity):
         self._state = state
         self._brightness = brightness
         self.schedule_update_ha_state()
-    
-    def _received_command(event):
+
+    def _received_command(self, device_id, event):
         """Apply command from rfxtrx."""
         # Check if entity exists or previously added automatically
-        if slugify(event.device.id_string.lower()) != self._device_id:
+        if device_id != self._device_id:
             return
 
         if event.values['Command'] == 'On'\

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -178,7 +178,7 @@ def setup(hass, config):
                       "".join("{0:02x}".format(x) for x in event.data))
 
         # Callback to HA registered components.
-        device_id, slugify(event.device.id_string.lower())
+        device_id = slugify(event.device.id_string.lower())
         hass.helpers.dispatcher.dispatcher_send(
             SIGNAL_RFXTRX_EVENT, device_id, event)
 
@@ -321,17 +321,18 @@ def get_devices_from_config(config, device):
         datas = {ATTR_STATE: False, ATTR_FIREEVENT: fire_event}
 
         devices.append(device(
-            entity_info[ATTR_NAME], device_id, event, datas, signal_repetitions))
+            entity_info[ATTR_NAME], device_id, event, datas,
+            signal_repetitions)
+        )
 
     return devices
 
 
 def get_new_device(event, config, device):
     """Add entity if not exist and the automatic_add is True."""
-    device_id = slugify(event.device.id_string.lower())
-
     if not config[ATTR_AUTOMATIC_ADD]:
         return
+    device_id = slugify(event.device.id_string.lower())
 
     pkt_id = "".join("{0:02x}".format(x) for x in event.data)
     _LOGGER.info(

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -193,7 +193,7 @@ def setup(hass, config):
 
     if dummy_connection:
         hass.data[RFXOBJECT] =\
-            rfxtrxmod.Connect(device, handle_receive, debug=debug, 
+            rfxtrxmod.Connect(device, handle_receive, debug=debug,
                               transport_protocol=rfxtrxmod.DummyTransport2)
     else:
         hass.data[RFXOBJECT] = rfxtrxmod.Connect(
@@ -406,7 +406,7 @@ class RfxtrxDevice(Entity):
     def _received_command(event):
         """Apply command from rfxtrx."""
         # Check if entity exists or previously added automatically
-        if slugify(event.device.id_string.lower() != self._device_id:
+        if slugify(event.device.id_string.lower()) != self._device_id:
             return
 
         if event.values['Command'] == 'On'\

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -277,6 +277,8 @@ def find_possible_pt2262_device(device_id):
 
             if size is not None:
                 size = len(dev_id) - size - 1
+
+                # 6 tri-state bits = 729 values => 10 bits max.
                 if size <= 3:
                     _LOGGER.info("found possible device %s for %s "
                                  "with the following configuration:\n"

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -55,6 +55,36 @@ DATA_TYPES = OrderedDict([
     ('Counter value', ''),
     ('UV', 'uv')])
 
+KNOWN_RECVMODES = [
+    "ac",
+    "adlightwave",
+    "aeblyss",
+    "arc",
+    "ati",
+    "blindst0",
+    "blindst1234",
+    "byronsx",
+    "fineoffset",
+    "fs20",
+    "hideki",
+    "homeconfort",
+    "homeeasy",
+    "imagintronix",
+    "keeloq",
+    "lacrosse",
+    "lighting4",
+    "meiantech",
+    "mertik",
+    "oregon",
+    "proguard",
+    "rsl",
+    "rubicson",
+    "undecoded",
+    "visonic",
+    "x10"
+]
+
+
 RECEIVED_EVT_SUBSCRIBERS = []
 RFX_DEVICES = {}
 _LOGGER = logging.getLogger(__name__)
@@ -106,7 +136,16 @@ def valid_binary_sensor(value):
 
 
 def _valid_light_switch(value):
+    """Validate light switch configuration."""
     return _valid_device(value, "light_switch")
+
+
+def valid_recvmode(value):
+    """Test if a recv_mode value is known by pyRFXTRX"""
+    if value in KNOWN_RECVMODES:
+        return value
+
+    raise vol.Invalid('Recv_mode "{}" is unknown to RFXTRX.'.format(value))
 
 
 DEVICE_SCHEMA = vol.Schema({
@@ -146,7 +185,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(ATTR_DEBUG, default=False): cv.boolean,
         vol.Optional(ATTR_DUMMY, default=False): cv.boolean,
         vol.Optional(ATTR_RECV_MODES, default=None):
-            vol.All(vol.All(cv.ensure_list, [cv.string]),
+            vol.All(vol.All(cv.ensure_list, [valid_recvmode]),
                     vol.Length(min=1))
     }),
 }, extra=vol.ALLOW_EXTRA)

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -110,7 +110,7 @@ def _valid_light_switch(value):
 
 
 def valid_recvmode(value):
-    """Test if a recv_mode value is known by pyRFXTRX"""
+    """Test if a recv_mode value is known by pyRFXTRX."""
     import RFXtrx
     if RFXtrx.lowlevel.get_recmode_tuple(value) != (None, None):
         return value

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -108,6 +108,7 @@ def valid_binary_sensor(value):
 def _valid_light_switch(value):
     return _valid_device(value, "light_switch")
 
+
 DEVICE_SCHEMA = vol.Schema({
     vol.Required(ATTR_NAME): cv.string,
     vol.Optional(ATTR_FIREEVENT, default=False): cv.boolean,

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -254,6 +254,7 @@ def get_pt2262_device(device_id):
     """Look for the device which id matches the given device_id parameter."""
     for dev_id, device in RFX_DEVICES.items():
         if (hasattr(device, 'is_lighting4') and
+                device.data_bits is not None and
                 device.masked_id == get_pt2262_deviceid(device_id,
                                                         device.data_bits)):
             _LOGGER.info("rfxtrx: found matching device %s for %s",
@@ -276,16 +277,17 @@ def find_possible_pt2262_device(device_id):
 
             if size is not None:
                 size = len(dev_id) - size - 1
-                _LOGGER.info("found possible device %s for %s "
-                             "with the following configuration:\n"
-                             "data_bits=%d\n"
-                             "command_on=0x%s\n"
-                             "command_off=0x%s\n",
-                             device_id,
-                             dev_id,
-                             size * 4,
-                             dev_id[-size:], device_id[-size:])
-                return device
+                if size <= 3:
+                    _LOGGER.info("found possible device %s for %s "
+                                 "with the following configuration:\n"
+                                 "data_bits=%d\n"
+                                 "command_on=0x%s\n"
+                                 "command_off=0x%s\n",
+                                 device_id,
+                                 dev_id,
+                                 size * 4,
+                                 dev_id[-size:], device_id[-size:])
+                    return device
 
     return None
 

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -219,10 +219,6 @@ def setup(hass, config):
     recv_modes = config[DOMAIN][ATTR_RECV_MODES]
 
     if recv_modes is not None:
-        for mode in recv_modes:
-            if rfxtrxmod.lowlevel.get_recmode_tuple(mode) == (None, None):
-                _LOGGER.error('recv_mode "%s" is unknown to RFXTRX.', mode)
-                return False
         _LOGGER.debug("Receiving modes to be enabled: %s", recv_modes)
 
     if dummy_connection:

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -371,7 +371,7 @@ class RfxtrxDevice(Entity):
         """Attach to callbacks."""
         self.hass.helpers.dispatcher.async_dispatcher_connect(
             SIGNAL_RFXTRX_EVENT, self._receive_command)
-    
+
     @property
     def unique_id(self):
         """Return unique device id."""
@@ -445,7 +445,7 @@ class RfxtrxDevice(Entity):
     def _send_command(self, command, brightness=0):
         if not self._event:
             return
-        rfx_object = hass.data[DATA_RFXOBJECT]
+        rfx_object = self.hass.data[DATA_RFXOBJECT]
 
         if command == "turn_on":
             for _ in range(self.signal_repetitions):

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -182,10 +182,9 @@ def setup(hass, config):
     if recv_modes is not None:
         for mode in recv_modes:
             if rfxtrxmod.lowlevel.get_recmode_tuple(mode) == (None, None):
-                raise ValueError(
-                    'recv_mode "{}" is unknown to RFXTRX.'.format(mode)
-                )
-        _LOGGER.info("Receiving modes to be enabled: %s", recv_modes)
+                _LOGGER.error('recv_mode "%s" is unknown to RFXTRX.', mode)
+                return False
+        _LOGGER.debug("Receiving modes to be enabled: %s", recv_modes)
 
     if dummy_connection:
         hass.data[RFXOBJECT] =\

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -571,7 +571,7 @@ pyCEC==0.4.13
 pyHS100==0.3.0
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.20.1
+pyRFXtrx==0.21.1
 
 # homeassistant.components.sensor.tibber
 pyTibber==0.1.1

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -107,8 +107,8 @@ class TestRFXTRX(unittest.TestCase):
                        'devices':
                            {'0b1100cd0213c7f210010f51': {
                                'name': 'Test',
-                               rfxtrx.ATTR_FIREEVENT: True}
-        }}}))
+                               rfxtrx.ATTR_FIREEVENT: True}}}
+        }))
 
         calls = []
 
@@ -152,8 +152,8 @@ class TestRFXTRX(unittest.TestCase):
                        'devices':
                            {'0a520802060100ff0e0269': {
                                'name': 'Test',
-                               rfxtrx.ATTR_FIREEVENT: True}
-        }}}))
+                               rfxtrx.ATTR_FIREEVENT: True}}}
+        }))
 
         calls = []
 

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -59,7 +59,6 @@ class TestRFXTRX(unittest.TestCase):
                 'dummy': True,
                 'debug': True}}))
 
-
     def test_valid_config3(self):
         """Test configuration."""
         self.assertTrue(setup_component(self.hass, 'rfxtrx', {

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -108,7 +108,7 @@ class TestRFXTRX(unittest.TestCase):
                            {'0b1100cd0213c7f210010f51': {
                                'name': 'Test',
                                rfxtrx.ATTR_FIREEVENT: True}
-                           }}}))
+        }}}))
 
         calls = []
 
@@ -153,7 +153,7 @@ class TestRFXTRX(unittest.TestCase):
                            {'0a520802060100ff0e0269': {
                                'name': 'Test',
                                rfxtrx.ATTR_FIREEVENT: True}
-                           }}}))
+        }}}))
 
         calls = []
 

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -59,6 +59,17 @@ class TestRFXTRX(unittest.TestCase):
                 'dummy': True,
                 'debug': True}}))
 
+
+    def test_valid_config3(self):
+        """Test configuration."""
+        self.assertTrue(setup_component(self.hass, 'rfxtrx', {
+            'rfxtrx': {
+                'device': '/dev/serial/by-id/usb' +
+                          '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
+                'dummy': True,
+                'debug': False,
+                'recv_modes': ['hideki', 'oregon', 'ac']}}))
+
     def test_invalid_config(self):
         """Test configuration."""
         self.assertFalse(setup_component(self.hass, 'rfxtrx', {
@@ -70,6 +81,18 @@ class TestRFXTRX(unittest.TestCase):
                 'device': '/dev/serial/by-id/usb' +
                           '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
                 'invalid_key': True}}))
+
+    def test_invalid_config2(self):
+        """Test configuration."""
+        self.assertFalse(setup_component(self.hass, 'rfxtrx', {
+            'rfxtrx': {}
+        }))
+
+        self.assertFalse(setup_component(self.hass, 'rfxtrx', {
+            'rfxtrx': {
+                'device': '/dev/serial/by-id/usb' +
+                          '-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0',
+                'recv_modes': []}}))
 
     def test_fire_event(self):
         """Test fire event."""
@@ -86,7 +109,7 @@ class TestRFXTRX(unittest.TestCase):
                            {'0b1100cd0213c7f210010f51': {
                                'name': 'Test',
                                rfxtrx.ATTR_FIREEVENT: True}
-                            }}}))
+                           }}}))
 
         calls = []
 
@@ -131,7 +154,7 @@ class TestRFXTRX(unittest.TestCase):
                            {'0a520802060100ff0e0269': {
                                'name': 'Test',
                                rfxtrx.ATTR_FIREEVENT: True}
-                            }}}))
+                           }}}))
 
         calls = []
 


### PR DESCRIPTION
## Description:

Brings the possibility to set the decoded protocols on the RFX transceiver, using the latest version 0.21.1 of pyRFXTRX.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3824

## Example entry for `configuration.yaml` (if applicable):
```yaml
rfxtrx:
  device: /dev/ttyUSB0
  debug: True
  dummy: False
  recv_modes:
  - oregon
  - ac
  - lighting4
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
