### PR TITLE
Fix for telegram polling. (added pausing when error occurs)

### DIFF
--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -108,15 +108,15 @@ class TelegramPoll(BaseTelegramBotEntity):
         """Receiving and processing incoming messages."""
         try:
             _updates = yield from self.get_updates(self.update_id)
-        except WrongHttpStatus as _e:
+        except WrongHttpStatus as e:
             # WrongHttpStatus: Non-200 status code.
             # Occurs at times (mainly 502) and recovers
             # automatically. Pause for a while before retrying.
-            _LOGGER.error(_e)
+            _LOGGER.error(e)
             yield from asyncio.sleep(RETRY_SLEEP)
-        except ClientError as _e:
+        except ClientError as e:
             # ClientError: A client error has occurred. Pausing is advised.
-            _LOGGER.error(_e)
+            _LOGGER.error(e)
             yield from asyncio.sleep(RETRY_SLEEP)
         except asyncio.TimeoutError:
             # Long polling timeout. Nothing serious.

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -108,15 +108,15 @@ class TelegramPoll(BaseTelegramBotEntity):
         """Receiving and processing incoming messages."""
         try:
             _updates = yield from self.get_updates(self.update_id)
-        except WrongHttpStatus as e:
+        except WrongHttpStatus as err:
             # WrongHttpStatus: Non-200 status code.
             # Occurs at times (mainly 502) and recovers
             # automatically. Pause for a while before retrying.
-            _LOGGER.error(e)
+            _LOGGER.error(err)
             yield from asyncio.sleep(RETRY_SLEEP)
-        except ClientError as e:
+        except ClientError as err:
             # ClientError: A client error has occurred. Pausing is advised.
-            _LOGGER.error(e)
+            _LOGGER.error(err)
             yield from asyncio.sleep(RETRY_SLEEP)
         except asyncio.TimeoutError:
             # Long polling timeout. Nothing serious.

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -110,24 +110,16 @@ class TelegramPoll(BaseTelegramBotEntity):
             while True:
                 try:
                     _updates = yield from self.get_updates(self.update_id)
-                except WrongHttpStatus as err:
+                except (WrongHttpStatus, ClientError) as err:
                     # WrongHttpStatus: Non-200 status code.
                     # Occurs at times (mainly 502) and recovers
                     # automatically. Pause for a while before retrying.
                     _LOGGER.error(err)
                     yield from asyncio.sleep(RETRY_SLEEP)
-                except ClientError as err:
-                    # ClientError: A client error has occurred.
-                    # Pausing is advised.
-                    _LOGGER.error(err)
-                    yield from asyncio.sleep(RETRY_SLEEP)
-                except asyncio.TimeoutError:
+                except (asyncio.TimeoutError, ValueError):
                     # Long polling timeout. Nothing serious.
-                    _LOGGER.debug("Long polling timed out.")
-                except ValueError:
                     # Json error. Just retry for the next message.
-                    _LOGGER.debug(
-                        "Json decode error. Continuing without pause.")
+                    pass
                 else:
                     # no exception raised. update received data.
                     _updates = _updates.get('result')

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -117,7 +117,8 @@ class TelegramPoll(BaseTelegramBotEntity):
                     _LOGGER.error(err)
                     yield from asyncio.sleep(RETRY_SLEEP)
                 except ClientError as err:
-                    # ClientError: A client error has occurred. Pausing is advised.
+                    # ClientError: A client error has occurred.
+                    # Pausing is advised.
                     _LOGGER.error(err)
                     yield from asyncio.sleep(RETRY_SLEEP)
                 except asyncio.TimeoutError:


### PR DESCRIPTION
## Description:

Somehow, at times connecting to the telegram server returns an error (client connection or 502 status)
It also recovers from this automatically.
Polling runs in an infinite loop. When -for example- a 502 occurs, hass immediately retries connecting which keeps getting the 502 error and in the process fills the log (with +50 of the same error.)

Fixing the above with adding a pause before retrying.
