### PR TITLE
Extracted json saving and loading

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/media_player.plex/
 """
 import json
 import logging
-import os
 from datetime import timedelta
 
 import requests
@@ -22,6 +21,7 @@ from homeassistant.const import (
     DEVICE_DEFAULT_NAME, STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.util.json import load_json, save_json
 
 REQUIREMENTS = ['plexapi==3.0.3']
 
@@ -48,35 +48,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def config_from_file(filename, config=None):
-    """Small configuration file management function."""
-    if config:
-        # We're writing configuration
-        try:
-            with open(filename, 'w') as fdesc:
-                fdesc.write(json.dumps(config))
-        except IOError as error:
-            _LOGGER.error("Saving config file failed: %s", error)
-            return False
-        return True
-    else:
-        # We're reading config
-        if os.path.isfile(filename):
-            try:
-                with open(filename, 'r') as fdesc:
-                    return json.loads(fdesc.read())
-            except IOError as error:
-                _LOGGER.error("Reading config file failed: %s", error)
-                # This won't work yet
-                return False
-        else:
-            return {}
-
-
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up the Plex platform."""
     # get config from plex.conf
-    file_config = config_from_file(hass.config.path(PLEX_CONFIG_FILE))
+    file_config = load_json(hass.config.path(PLEX_CONFIG_FILE))
 
     if file_config:
         # Setup a configured PlexServer
@@ -146,7 +121,7 @@ def setup_plexserver(
         _LOGGER.info("Discovery configuration done")
 
     # Save config
-    if not config_from_file(
+    if not save_json(
             hass.config.path(PLEX_CONFIG_FILE), {host: {
                 'token': token,
                 'ssl': has_ssl,

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -1,0 +1,50 @@
+"""JSON utility functions."""
+import logging
+from typing import Union, List, Dict
+
+import json
+
+from homeassistant.exceptions import HomeAssistantError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def load_json(filename: str) -> Union[List, Dict]:
+    """Load JSON data from a file and return as dict or list.
+
+    Defaults to returning empty dict if file is not found.
+    """
+    try:
+        with open(filename, encoding='utf-8') as fdesc:
+            return json.loads(fdesc.read())
+    except FileNotFoundError:
+        # This is not a fatal error
+        _LOGGER.debug('JSON file not found: %s', filename)
+    except ValueError as error:
+        _LOGGER.exception('Could not parse JSON content: %s', filename)
+        raise HomeAssistantError(error)
+    except OSError as error:
+        _LOGGER.exception('JSON file reading failed: %s', filename)
+        raise HomeAssistantError(error)
+    return {}  # (also evaluates to False)
+
+
+def save_json(filename: str, config: Union[List, Dict]):
+    """Save JSON data to a file.
+
+    Returns True on success.
+    """
+    try:
+        data = json.dumps(config, sort_keys=True, indent=4)
+        with open(filename, 'w', encoding='utf-8') as fdesc:
+            fdesc.write(data)
+            return True
+    except TypeError as error:
+        _LOGGER.exception('Failed to serialize to JSON: %s',
+                          filename)
+        raise HomeAssistantError(error)
+    except OSError as error:
+        _LOGGER.exception('Saving JSON file failed: %s',
+                          filename)
+        raise HomeAssistantError(error)
+    return False


### PR DESCRIPTION
## Description:
Many components use json files to store custom configuration data.
All implements their own very basic code for loading and saving dicts as JSON files (`with open(filename) as f: json.loads(f)`). Some do error checking (checking if file exists or not), some do not. Some catch relevant exceptions, some do not.

It is obvious that in most places, the exact same logic is taking place, and in many places the same code is duplicated (a 20-line function `config_from_file(filename, config=None)` seems to be copied around a lot).

This PR provides basic functionality for loading and saving dicts as JSON (`load_json`, `save_json`, analogous with `load_yaml`) in core.

Benefits: Less code duplication, hopefully somewhat better error handling, better reporting in the logs, and easier testing/mocking.

The PR only contain changes in one component (`media_player/plex.py`) to use `load_json` and `save_json`, but at least the places mentioned in #10269 could possibly also benefit from this change.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
