### PR TITLE
Remove lag from Harmony remote platform

### DIFF
--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -141,25 +141,18 @@ def async_setup(hass, config):
     def async_handle_remote_service(service):
         """Handle calls to the remote services."""
         target_remotes = component.async_extract_from_service(service)
-
-        activity_id = service.data.get(ATTR_ACTIVITY)
-        device = service.data.get(ATTR_DEVICE)
-        command = service.data.get(ATTR_COMMAND)
-        num_repeats = service.data.get(ATTR_NUM_REPEATS)
-        delay_secs = service.data.get(ATTR_DELAY_SECS)
+        kwargs = service.data.copy()
 
         update_tasks = []
         for remote in target_remotes:
             if service.service == SERVICE_TURN_ON:
-                yield from remote.async_turn_on(activity=activity_id)
+                yield from remote.async_turn_on(**kwargs)
             elif service.service == SERVICE_TOGGLE:
-                yield from remote.async_toggle(activity=activity_id)
+                yield from remote.async_toggle(**kwargs)
             elif service.service == SERVICE_SEND_COMMAND:
-                yield from remote.async_send_command(
-                    device=device, command=command,
-                    num_repeats=num_repeats, delay_secs=delay_secs)
+                yield from remote.async_send_command(**kwargs)
             else:
-                yield from remote.async_turn_off(activity=activity_id)
+                yield from remote.async_turn_off(**kwargs)
 
             if not remote.should_poll:
                 continue

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -61,7 +61,7 @@ REMOTE_SERVICE_SEND_COMMAND_SCHEMA = REMOTE_SERVICE_SCHEMA.extend({
     vol.Optional(ATTR_DEVICE): cv.string,
     vol.Optional(
         ATTR_NUM_REPEATS, default=DEFAULT_NUM_REPEATS): cv.positive_int,
-    ATTR_DELAY_SECS: vol.Coerce(float),
+    vol.Optional(ATTR_DELAY_SECS): vol.Coerce(float),
 })
 
 

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -61,8 +61,7 @@ REMOTE_SERVICE_SEND_COMMAND_SCHEMA = REMOTE_SERVICE_SCHEMA.extend({
     vol.Optional(ATTR_DEVICE): cv.string,
     vol.Optional(
         ATTR_NUM_REPEATS, default=DEFAULT_NUM_REPEATS): cv.positive_int,
-    vol.Optional(
-        ATTR_DELAY_SECS, default=DEFAULT_DELAY_SECS): vol.Coerce(float)
+    ATTR_DELAY_SECS: vol.Coerce(float),
 })
 
 

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -21,9 +21,7 @@ from homeassistant.components.remote import (
 from homeassistant.util import slugify
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['https://github.com/amelchio/pyharmony/archive/'
-                '4bf627ef462c8e9a5d50b65e7523b54ed76e2b2a.zip'
-                '#pyharmony==1.0.17alpha1']
+REQUIREMENTS = ['pyharmony==1.0.17']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -148,7 +146,8 @@ class HarmonyRemote(remote.RemoteDevice):
         self._state = None
         self._current_activity = None
         self._default_activity = activity
-        self._client = pyharmony.get_client(host, port, self.new_activity)
+        self._client = pyharmony.get_client(host, port)
+        self._client.register_activity_callback(self.new_activity)
         self._config_path = out_path
         self._config = self._client.get_config()
         if not Path(self._config_path).is_file():

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -62,6 +62,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         port = DEFAULT_PORT
         if override:
             activity = override.get(ATTR_ACTIVITY)
+            delay_secs = override.get(ATTR_DELAY_SECS)
             port = override.get(CONF_PORT, DEFAULT_PORT)
 
         host = (
@@ -80,11 +81,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             config.get(CONF_PORT),
         )
         activity = config.get(ATTR_ACTIVITY)
+        delay_secs = config.get(ATTR_DELAY_SECS)
     else:
         hass.data[CONF_DEVICE_CACHE].append(config)
         return
-
-    delay_secs = config.get(ATTR_DELAY_SECS)
 
     name, address, port = host
     _LOGGER.info("Loading Harmony Platform: %s at %s:%s, startup activity: %s",

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -190,10 +190,7 @@ class HarmonyRemote(remote.RemoteDevice):
     def turn_on(self, **kwargs):
         """Start an activity from the Harmony device."""
         import pyharmony
-        if kwargs[ATTR_ACTIVITY]:
-            activity = kwargs[ATTR_ACTIVITY]
-        else:
-            activity = self._default_activity
+        activity = kwargs.get(ATTR_ACTIVITY, self._default_activity)
 
         if activity:
             pyharmony.ha_start_activity(
@@ -210,7 +207,7 @@ class HarmonyRemote(remote.RemoteDevice):
     def send_command(self, command, **kwargs):
         """Send a set of commands to one device."""
         import pyharmony
-        device = kwargs.pop(ATTR_DEVICE, None)
+        device = kwargs.get(ATTR_DEVICE)
         if device is None:
             _LOGGER.error("Missing required argument: device")
             return

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -98,7 +98,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         DEVICES.append(device)
         add_devices([device])
         register_services(hass)
-    except ValueError as err:
+    except ValueError:
         _LOGGER.warning("Failed to initialize remote: %s", name)
 
 

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -22,7 +22,8 @@ from homeassistant.util import slugify
 from homeassistant.config import load_yaml_config_file
 
 REQUIREMENTS = ['https://github.com/amelchio/pyharmony/archive/'
-                '4bf627ef462c8e9a5d50b65e7523b54ed76e2b2a.zip#pyharmony==1.0.17alpha1']
+                '4bf627ef462c8e9a5d50b65e7523b54ed76e2b2a.zip'
+                '#pyharmony==1.0.17alpha1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -21,7 +21,8 @@ from homeassistant.components.remote import (
 from homeassistant.util import slugify
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['pyharmony==1.0.16']
+REQUIREMENTS = ['https://github.com/amelchio/pyharmony/archive/'
+                '4bf627ef462c8e9a5d50b65e7523b54ed76e2b2a.zip#pyharmony==1.0.17alpha1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -21,7 +21,7 @@ from homeassistant.components.remote import (
 from homeassistant.util import slugify
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['pyharmony==1.0.17']
+REQUIREMENTS = ['pyharmony==1.0.18']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -146,8 +146,7 @@ class HarmonyRemote(remote.RemoteDevice):
         self._state = None
         self._current_activity = None
         self._default_activity = activity
-        self._client = pyharmony.get_client(host, port)
-        self._client.register_activity_callback(self.new_activity)
+        self._client = pyharmony.get_client(host, port, self.new_activity)
         self._config_path = out_path
         self._config = self._client.get_config()
         if not Path(self._config_path).is_file():

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -331,9 +331,6 @@ http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b89974819
 # homeassistant.components.sensor.dht
 # https://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.2
 
-# homeassistant.components.remote.harmony
-https://github.com/amelchio/pyharmony/archive/4bf627ef462c8e9a5d50b65e7523b54ed76e2b2a.zip#pyharmony==1.0.17alpha1
-
 # homeassistant.components.media_player.braviatv
 https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
 
@@ -654,6 +651,9 @@ pyflexit==0.3
 
 # homeassistant.components.ifttt
 pyfttt==0.3
+
+# homeassistant.components.remote.harmony
+pyharmony==1.0.17
 
 # homeassistant.components.binary_sensor.hikvision
 pyhik==0.1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -653,7 +653,7 @@ pyflexit==0.3
 pyfttt==0.3
 
 # homeassistant.components.remote.harmony
-pyharmony==1.0.17
+pyharmony==1.0.18
 
 # homeassistant.components.binary_sensor.hikvision
 pyhik==0.1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -331,6 +331,9 @@ http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b89974819
 # homeassistant.components.sensor.dht
 # https://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.2
 
+# homeassistant.components.remote.harmony
+https://github.com/amelchio/pyharmony/archive/4bf627ef462c8e9a5d50b65e7523b54ed76e2b2a.zip#pyharmony==1.0.17alpha1
+
 # homeassistant.components.media_player.braviatv
 https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
 
@@ -651,9 +654,6 @@ pyflexit==0.3
 
 # homeassistant.components.ifttt
 pyfttt==0.3
-
-# homeassistant.components.remote.harmony
-pyharmony==1.0.16
 
 # homeassistant.components.binary_sensor.hikvision
 pyhik==0.1.4


### PR DESCRIPTION
## Description:

The Harmony `remote` platform currently does a lengthy (3+ seconds) login procedure before any action. This makes e.g. consecutive  “channel up” commands almost unworkable and apparently it overloads the hub to an extent where `update` will frequently take more than 10 seconds:

```
2017-10-27 23:09:31 WARNING (MainThread) [homeassistant.helpers.entity] Update of remote.tv is taking over 10 seconds
2017-10-27 23:48:46 WARNING (MainThread) [homeassistant.helpers.entity] Update of remote.tv is taking over 10 seconds
2017-10-28 00:12:00 WARNING (MainThread) [homeassistant.helpers.entity] Update of remote.tv is taking over 10 seconds
```

This PR moves the platform over to using a persistent connection with push updates. Sending a command is now instantaneous. Also, changing activities using the physical Harmony remote will be picked up by Home Assistant immediately. Thus, light automations can execute right after turning on/off the TV and not some 20 seconds later ...

This is sort-of a breaking change because scripts with multiple `remote.send_command` calls now execute so fast that a target can miss some commands. This can be fixed by increasing the `delay_secs` parameter and to make that migration simpler I have added a platform way of changing the default.

CC @iandday <s>and pending iandday/pyharmony#10, iandday/pyharmony#11, iandday/pyharmony#12</s>.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3845

## Example entry for `configuration.yaml` (if applicable):
```yaml
remote:
  - platform: harmony
    name: TV
    host: 10.0.2.31
    delay_secs: 0.7
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54