### PR TITLE
Add EntityFilter helper

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     CONF_INCLUDE, EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_START,
     EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entityfilter import EntityFilter
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 import homeassistant.util.dt as dt_util
@@ -178,10 +179,10 @@ class Recorder(threading.Thread):
         self.engine = None  # type: Any
         self.run_info = None  # type: Any
 
-        self.include_e = include.get(CONF_ENTITIES, [])
-        self.include_d = include.get(CONF_DOMAINS, [])
-        self.exclude = exclude.get(CONF_ENTITIES, []) + \
-            exclude.get(CONF_DOMAINS, [])
+        self.entity_filter = EntityFilter(include.get(CONF_DOMAINS, []),
+                                          include.get(CONF_ENTITIES, []),
+                                          exclude.get(CONF_DOMAINS, []),
+                                          exclude.get(CONF_ENTITIES, []))
         self.exclude_t = exclude.get(CONF_EVENT_TYPES, [])
 
         self.get_session = None
@@ -289,22 +290,8 @@ class Recorder(threading.Thread):
                 continue
 
             entity_id = event.data.get(ATTR_ENTITY_ID)
-            if entity_id is not None:
-                domain = split_entity_id(entity_id)[0]
-
-                # Exclude entities OR
-                # Exclude domains, but include specific entities
-                if (entity_id in self.exclude) or \
-                        (domain in self.exclude and
-                         entity_id not in self.include_e):
-                    self.queue.task_done()
-                    continue
-
-                # Included domains only (excluded entities above) OR
-                # Include entities only, but only if no excludes
-                if (self.include_d and domain not in self.include_d) or \
-                        (self.include_e and entity_id not in self.include_e
-                         and not self.exclude):
+            if entity_id is not None and \
+                not(self.entity_filter.check_entity(entity_id)):
                     self.queue.task_done()
                     continue
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -20,7 +20,7 @@ from typing import Optional, Dict
 import voluptuous as vol
 
 from homeassistant.core import (
-    HomeAssistant, callback, split_entity_id, CoreState)
+    HomeAssistant, callback, CoreState)
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_ENTITIES, CONF_EXCLUDE, CONF_DOMAINS,
     CONF_INCLUDE, EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_START,
@@ -290,8 +290,8 @@ class Recorder(threading.Thread):
                 continue
 
             entity_id = event.data.get(ATTR_ENTITY_ID)
-            if entity_id is not None and \
-                not(self.entity_filter.check_entity(entity_id)):
+            if entity_id is not None:
+                if not self.entity_filter.check_entity(entity_id):
                     self.queue.task_done()
                     continue
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
     CONF_INCLUDE, EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_START,
     EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entityfilter import EntityFilter
+from homeassistant.helpers.entityfilter import generate_filter
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 import homeassistant.util.dt as dt_util
@@ -179,10 +179,10 @@ class Recorder(threading.Thread):
         self.engine = None  # type: Any
         self.run_info = None  # type: Any
 
-        self.entity_filter = EntityFilter(include.get(CONF_DOMAINS, []),
-                                          include.get(CONF_ENTITIES, []),
-                                          exclude.get(CONF_DOMAINS, []),
-                                          exclude.get(CONF_ENTITIES, []))
+        self.entity_filter = generate_filter(include.get(CONF_DOMAINS, []),
+                                             include.get(CONF_ENTITIES, []),
+                                             exclude.get(CONF_DOMAINS, []),
+                                             exclude.get(CONF_ENTITIES, []))
         self.exclude_t = exclude.get(CONF_EVENT_TYPES, [])
 
         self.get_session = None
@@ -291,7 +291,7 @@ class Recorder(threading.Thread):
 
             entity_id = event.data.get(ATTR_ENTITY_ID)
             if entity_id is not None:
-                if not self.entity_filter.check_entity(entity_id):
+                if not self.entity_filter(entity_id):
                     self.queue.task_done()
                     continue
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -12,7 +12,8 @@ import voluptuous as vol
 
 from homeassistant.loader import get_platform
 from homeassistant.const import (
-    CONF_PLATFORM, CONF_SCAN_INTERVAL, TEMP_CELSIUS, TEMP_FAHRENHEIT,
+    CONF_DOMAINS, CONF_ENTITIES, CONF_EXCLUDE, CONF_INCLUDE, CONF_PLATFORM,
+    CONF_SCAN_INTERVAL, TEMP_CELSIUS, TEMP_FAHRENHEIT,
     CONF_ALIAS, CONF_ENTITY_ID, CONF_VALUE_TEMPLATE, WEEKDAYS,
     CONF_CONDITION, CONF_BELOW, CONF_ABOVE, CONF_TIMEOUT, SUN_EVENT_SUNSET,
     SUN_EVENT_SUNRISE, CONF_UNIT_SYSTEM_IMPERIAL, CONF_UNIT_SYSTEM_METRIC)
@@ -562,3 +563,16 @@ SCRIPT_SCHEMA = vol.All(
     [vol.Any(SERVICE_SCHEMA, _SCRIPT_DELAY_SCHEMA,
              _SCRIPT_WAIT_TEMPLATE_SCHEMA, EVENT_SCHEMA, CONDITION_SCHEMA)],
 )
+
+FILTER_SCHEMA = vol.Schema({
+    vol.Optional(CONF_EXCLUDE, default={}): vol.Schema({
+        vol.Optional(CONF_ENTITIES, default=[]): entity_ids,
+        vol.Optional(CONF_DOMAINS, default=[]):
+            vol.All(ensure_list, [string])
+    }),
+    vol.Optional(CONF_INCLUDE, default={}): vol.Schema({
+        vol.Optional(CONF_ENTITIES, default=[]): entity_ids,
+        vol.Optional(CONF_DOMAINS, default=[]):
+            vol.All(ensure_list, [string])
+    })
+})

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -5,7 +5,7 @@ from homeassistant.core import split_entity_id
 
 def generate_filter(include_domains, include_entities,
                     exclude_domains, exclude_entities):
-    """Returns a function that will filter entities based on the args."""
+    """Return a function that will filter entities based on the args."""
     include_d = set(include_domains)
     include_e = set(include_entities)
     exclude_d = set(exclude_domains)

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -3,62 +3,76 @@
 from homeassistant.core import split_entity_id
 
 
-class EntityFilter():
-    """Class that implements an include/exclude filter for entities/domains."""
+def generate_filter(include_domains, include_entities,
+                    exclude_domains, exclude_entities):
+    """Set up the filter."""
+    include_d = set(include_domains)
+    include_e = set(include_entities)
+    exclude_d = set(exclude_domains)
+    exclude_e = set(exclude_entities)
 
-    def __init__(self, include_domains, include_entities,
-                 exclude_domains, exclude_entities):
-        """Set up the filter."""
-        self.include_d = set(include_domains)
-        self.include_e = set(include_entities)
-        self.exclude_d = set(exclude_domains)
-        self.exclude_e = set(exclude_entities)
+    have_exclude = bool(exclude_e or exclude_d)
+    have_include = bool(include_e or include_d)
 
-        self.have_exclude = bool(self.exclude_e or self.exclude_d)
-        self.have_include = bool(self.include_e or self.include_d)
+    # Case 1 - no includes or excludes - pass all entities
+    if not have_include and not have_exclude:
+        return lambda entity_id: True
 
-    def check_entity(self, entity_id):
-        """Check if a given entity_id should be filtered."""
-        domain = split_entity_id(entity_id)[0]
+    # Case 2 - includes, no excludes - only include specified entities
+    if have_include and not have_exclude:
+        def entity_filter_2(entity_id):
+            """Return filter function for case 2."""
+            domain = split_entity_id(entity_id)[0]
+            return (entity_id in include_e or
+                    domain in include_d)
 
-        # Case 1 - no includes or excludes - pass all entities
-        if not self.have_include and not self.have_exclude:
-            return True
+        return entity_filter_2
 
-        # Case 2 - includes, no excludes - only include specified entities
-        if self.have_include and not self.have_exclude:
-            return entity_id in self.include_e or \
-                        domain in self.include_d
+    # Case 3 - excludes, no includes - only exclude specified entities
+    if not have_include and have_exclude:
+        def entity_filter_3(entity_id):
+            """Return filter function for case 3."""
+            domain = split_entity_id(entity_id)[0]
+            return (entity_id not in exclude_e and
+                    domain not in exclude_d)
 
-        # Case 3 - excludes, no includes - only exclude specified entities
-        if not self.have_include and self.have_exclude:
-            return entity_id not in self.exclude_e and \
-                        domain not in self.exclude_d
+        return entity_filter_3
 
-        # Case 4 - both includes and excludes specified
-        # Case 4a - include domain specified
-        #  - if domain is included, and entity not excluded, pass
-        #  - if domain is not included, and entity not included, fail
-        # note: if both include and exclude domains specified,
-        #   the exclude domains are ignored
-        if self.include_d:
-            if domain in self.include_d:
-                return entity_id not in self.exclude_e
+    # Case 4 - both includes and excludes specified
+    # Case 4a - include domain specified
+    #  - if domain is included, and entity not excluded, pass
+    #  - if domain is not included, and entity not included, fail
+    # note: if both include and exclude domains specified,
+    #   the exclude domains are ignored
+    if include_d:
+        def entity_filter_4a(entity_id):
+            """Return filter function for case 4a."""
+            domain = split_entity_id(entity_id)[0]
+            if domain in include_d:
+                return entity_id not in exclude_e
             else:
-                return entity_id in self.include_e
+                return entity_id in include_e
 
-        # Case 4b - exclude domain specified
-        #  - if domain is excluded, and entity not included, fail
-        #  - if domain is not excluded, and entity not excluded, pass
-        if self.exclude_d:
-            if domain in self.exclude_d:
-                return entity_id in self.include_e
+        return entity_filter_4a
+
+    # Case 4b - exclude domain specified
+    #  - if domain is excluded, and entity not included, fail
+    #  - if domain is not excluded, and entity not excluded, pass
+    if exclude_d:
+        def entity_filter_4b(entity_id):
+            """Return filter function for case 4b."""
+            domain = split_entity_id(entity_id)[0]
+            if domain in exclude_d:
+                return entity_id in include_e
             else:
-                return entity_id not in self.exclude_e
+                return entity_id not in exclude_e
 
-        # Case 4c - neither include or exclude domain specified
-        #  - Only pass if entity is included.  Ignore entity excludes.
-        if entity_id in self.include_e:
-            return True
+        return entity_filter_4b
 
-        return False
+    # Case 4c - neither include or exclude domain specified
+    #  - Only pass if entity is included.  Ignore entity excludes.
+    def entity_filter_4c(entity_id):
+        """Return filter function for case 4c."""
+        return entity_id in include_e
+
+    return entity_filter_4c

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -5,7 +5,7 @@ from homeassistant.core import split_entity_id
 
 def generate_filter(include_domains, include_entities,
                     exclude_domains, exclude_entities):
-    """Set up the filter."""
+    """Returns a function that will filter entities based on the args."""
     include_d = set(include_domains)
     include_e = set(include_entities)
     exclude_d = set(exclude_domains)

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -1,0 +1,74 @@
+"""Helper class to implement include/exclude of entities and domains."""
+
+from homeassistant.const import (
+    CONF_ENTITIES, CONF_DOMAINS)
+from homeassistant.core import split_entity_id
+
+
+class EntityFilter():
+    """Class that implements an include/exclude filter for entities/domains."""
+
+    def __init__(self, include_dict, exclude_dict):
+        """Set up the filter."""
+        self.include_e = include_dict.get(CONF_ENTITIES, [])
+        self.include_d = include_dict.get(CONF_DOMAINS, [])
+        self.exclude_e = exclude_dict.get(CONF_ENTITIES, [])
+        self.exclude_d = exclude_dict.get(CONF_DOMAINS, [])
+
+        if self.exclude_e + self.exclude_d == []:
+            self.have_exclude = False
+        else:
+            self.have_exclude = True
+
+        if self.include_e + self.include_d == []:
+            self.have_include = False
+        else:
+            self.have_include = True
+
+    def check_entity(self, entity_id):
+        """Check if a given entity_id should be filtered."""
+        domain = split_entity_id(entity_id)[0]
+
+        # Case 1 - no includes or excludes - pass all entities
+        if not self.have_include and not self.have_exclude:
+            return True
+
+        # Case 2 - includes, no excludes - only include specified entities
+        if self.have_include and not self.have_exclude:
+            return bool(entity_id in self.include_e or
+                        domain in self.include_d)
+
+        # Case 3 - excludes, no includes - only exclude specified entities
+        if not self.have_include and self.have_exclude:
+            if entity_id in self.exclude_e or domain in self.exclude_d:
+                return False
+            else:
+                return True
+
+        # Case 4 - both includes and excludes specified
+        # Case 4a - include domain specified
+        #  - if domain is included, and entity not excluded, pass
+        #  - if domain is not included, and entity not included, fail
+        # note: if both include and exclude domains specified,
+        #   the exclude domains are ignored
+        if self.include_d:
+            if domain in self.include_d:
+                return bool(entity_id not in self.exclude_e)
+            else:
+                return bool(entity_id in self.include_e)
+
+        # Case 4b - exclude domain specified
+        #  - if domain is excluded, and entity not included, fail
+        #  - if domain is not excluded, and entity not excluded, pass
+        if self.exclude_d:
+            if domain in self.exclude_d:
+                return bool(entity_id in self.include_e)
+            else:
+                return bool(entity_id not in self.exclude_e)
+
+        # Case 4c - neither include or exclude domain specified
+        #  - Only pass if entity is included.  Ignore entity excludes.
+        if entity_id in self.include_e:
+            return True
+
+        return False

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -1,29 +1,21 @@
 """Helper class to implement include/exclude of entities and domains."""
 
-from homeassistant.const import (
-    CONF_ENTITIES, CONF_DOMAINS)
 from homeassistant.core import split_entity_id
 
 
 class EntityFilter():
     """Class that implements an include/exclude filter for entities/domains."""
 
-    def __init__(self, include_dict, exclude_dict):
+    def __init__(self, include_domains, include_entities,
+                 exclude_domains, exclude_entities):
         """Set up the filter."""
-        self.include_e = include_dict.get(CONF_ENTITIES, [])
-        self.include_d = include_dict.get(CONF_DOMAINS, [])
-        self.exclude_e = exclude_dict.get(CONF_ENTITIES, [])
-        self.exclude_d = exclude_dict.get(CONF_DOMAINS, [])
+        self.include_d = set(include_domains)
+        self.include_e = set(include_entities)
+        self.exclude_d = set(exclude_domains)
+        self.exclude_e = set(exclude_entities)
 
-        if self.exclude_e + self.exclude_d == []:
-            self.have_exclude = False
-        else:
-            self.have_exclude = True
-
-        if self.include_e + self.include_d == []:
-            self.have_include = False
-        else:
-            self.have_include = True
+        self.have_exclude = bool(self.exclude_e or self.exclude_d)
+        self.have_include = bool(self.include_e or self.include_d)
 
     def check_entity(self, entity_id):
         """Check if a given entity_id should be filtered."""
@@ -35,15 +27,13 @@ class EntityFilter():
 
         # Case 2 - includes, no excludes - only include specified entities
         if self.have_include and not self.have_exclude:
-            return bool(entity_id in self.include_e or
-                        domain in self.include_d)
+            return entity_id in self.include_e or \
+                        domain in self.include_d
 
         # Case 3 - excludes, no includes - only exclude specified entities
         if not self.have_include and self.have_exclude:
-            if entity_id in self.exclude_e or domain in self.exclude_d:
-                return False
-            else:
-                return True
+            return entity_id not in self.exclude_e and \
+                        domain not in self.exclude_d
 
         # Case 4 - both includes and excludes specified
         # Case 4a - include domain specified
@@ -53,18 +43,18 @@ class EntityFilter():
         #   the exclude domains are ignored
         if self.include_d:
             if domain in self.include_d:
-                return bool(entity_id not in self.exclude_e)
+                return entity_id not in self.exclude_e
             else:
-                return bool(entity_id in self.include_e)
+                return entity_id in self.include_e
 
         # Case 4b - exclude domain specified
         #  - if domain is excluded, and entity not included, fail
         #  - if domain is not excluded, and entity not excluded, pass
         if self.exclude_d:
             if domain in self.exclude_d:
-                return bool(entity_id in self.include_e)
+                return entity_id in self.include_e
             else:
-                return bool(entity_id not in self.exclude_e)
+                return entity_id not in self.exclude_e
 
         # Case 4c - neither include or exclude domain specified
         #  - Only pass if entity is included.  Ignore entity excludes.

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -1,5 +1,5 @@
 """The tests for the EntityFitler component."""
-from homeassistant.helpers.entityfilter import EntityFilter
+from homeassistant.helpers.entityfilter import generate_filter
 
 
 def test_no_filters_case_1():
@@ -8,10 +8,10 @@ def test_no_filters_case_1():
     incl_ent = {}
     excl_dom = {}
     excl_ent = {}
-    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
+    testfilter = generate_filter(incl_dom, incl_ent, excl_dom, excl_ent)
 
     for value in ("sensor.test", "sun.sun", "light.test"):
-        assert testfilter.check_entity(value)
+        assert testfilter(value)
 
 
 def test_includes_only_case_2():
@@ -20,13 +20,13 @@ def test_includes_only_case_2():
     incl_ent = {'binary_sensor.working'}
     excl_dom = {}
     excl_ent = {}
-    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
+    testfilter = generate_filter(incl_dom, incl_ent, excl_dom, excl_ent)
 
-    assert testfilter.check_entity("sensor.test")
-    assert testfilter.check_entity("light.test")
-    assert testfilter.check_entity("binary_sensor.working")
-    assert testfilter.check_entity("binary_sensor.notworking") is False
-    assert testfilter.check_entity("sun.sun") is False
+    assert testfilter("sensor.test")
+    assert testfilter("light.test")
+    assert testfilter("binary_sensor.working")
+    assert testfilter("binary_sensor.notworking") is False
+    assert testfilter("sun.sun") is False
 
 
 def test_excludes_only_case_3():
@@ -35,13 +35,13 @@ def test_excludes_only_case_3():
     incl_ent = {}
     excl_dom = {'light', 'sensor'}
     excl_ent = {'binary_sensor.working'}
-    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
+    testfilter = generate_filter(incl_dom, incl_ent, excl_dom, excl_ent)
 
-    assert testfilter.check_entity("sensor.test") is False
-    assert testfilter.check_entity("light.test") is False
-    assert testfilter.check_entity("binary_sensor.working") is False
-    assert testfilter.check_entity("binary_sensor.another")
-    assert testfilter.check_entity("sun.sun") is True
+    assert testfilter("sensor.test") is False
+    assert testfilter("light.test") is False
+    assert testfilter("binary_sensor.working") is False
+    assert testfilter("binary_sensor.another")
+    assert testfilter("sun.sun") is True
 
 
 def test_with_include_domain_case4a():
@@ -50,15 +50,15 @@ def test_with_include_domain_case4a():
     incl_ent = {'binary_sensor.working'}
     excl_dom = {}
     excl_ent = {'light.ignoreme', 'sensor.notworking'}
-    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
+    testfilter = generate_filter(incl_dom, incl_ent, excl_dom, excl_ent)
 
-    assert testfilter.check_entity("sensor.test")
-    assert testfilter.check_entity("sensor.notworking") is False
-    assert testfilter.check_entity("light.test")
-    assert testfilter.check_entity("light.ignoreme") is False
-    assert testfilter.check_entity("binary_sensor.working")
-    assert testfilter.check_entity("binary_sensor.another") is False
-    assert testfilter.check_entity("sun.sun") is False
+    assert testfilter("sensor.test")
+    assert testfilter("sensor.notworking") is False
+    assert testfilter("light.test")
+    assert testfilter("light.ignoreme") is False
+    assert testfilter("binary_sensor.working")
+    assert testfilter("binary_sensor.another") is False
+    assert testfilter("sun.sun") is False
 
 
 def test_exclude_domain_case4b():
@@ -67,15 +67,15 @@ def test_exclude_domain_case4b():
     incl_ent = {'binary_sensor.working'}
     excl_dom = {'binary_sensor'}
     excl_ent = {'light.ignoreme', 'sensor.notworking'}
-    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
+    testfilter = generate_filter(incl_dom, incl_ent, excl_dom, excl_ent)
 
-    assert testfilter.check_entity("sensor.test")
-    assert testfilter.check_entity("sensor.notworking") is False
-    assert testfilter.check_entity("light.test")
-    assert testfilter.check_entity("light.ignoreme") is False
-    assert testfilter.check_entity("binary_sensor.working")
-    assert testfilter.check_entity("binary_sensor.another") is False
-    assert testfilter.check_entity("sun.sun") is True
+    assert testfilter("sensor.test")
+    assert testfilter("sensor.notworking") is False
+    assert testfilter("light.test")
+    assert testfilter("light.ignoreme") is False
+    assert testfilter("binary_sensor.working")
+    assert testfilter("binary_sensor.another") is False
+    assert testfilter("sun.sun") is True
 
 
 def testno_domain_case4c():
@@ -84,12 +84,12 @@ def testno_domain_case4c():
     incl_ent = {'binary_sensor.working'}
     excl_dom = {}
     excl_ent = {'light.ignoreme', 'sensor.notworking'}
-    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
+    testfilter = generate_filter(incl_dom, incl_ent, excl_dom, excl_ent)
 
-    assert testfilter.check_entity("sensor.test") is False
-    assert testfilter.check_entity("sensor.notworking") is False
-    assert testfilter.check_entity("light.test") is False
-    assert testfilter.check_entity("light.ignoreme") is False
-    assert testfilter.check_entity("binary_sensor.working")
-    assert testfilter.check_entity("binary_sensor.another") is False
-    assert testfilter.check_entity("sun.sun") is False
+    assert testfilter("sensor.test") is False
+    assert testfilter("sensor.notworking") is False
+    assert testfilter("light.test") is False
+    assert testfilter("light.ignoreme") is False
+    assert testfilter("binary_sensor.working")
+    assert testfilter("binary_sensor.another") is False
+    assert testfilter("sun.sun") is False

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -4,9 +4,11 @@ from homeassistant.helpers.entityfilter import EntityFilter
 
 def test_no_filters_case_1():
     """If include and exclude not included, pass everything."""
-    include_filter = {}
-    exclude_filter = {}
-    testfilter = EntityFilter(include_filter, exclude_filter)
+    incl_dom = {}
+    incl_ent = {}
+    excl_dom = {}
+    excl_ent = {}
+    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
 
     for value in ("sensor.test", "sun.sun", "light.test"):
         assert testfilter.check_entity(value)
@@ -14,17 +16,11 @@ def test_no_filters_case_1():
 
 def test_includes_only_case_2():
     """If include specified, only pass if specified (Case 2)."""
-    include_filter = {
-        'domains': [
-            'light',
-            'sensor'
-        ],
-        'entities': [
-            'binary_sensor.working'
-        ]
-    }
-    exclude_filter = {}
-    testfilter = EntityFilter(include_filter, exclude_filter)
+    incl_dom = {'light', 'sensor'}
+    incl_ent = {'binary_sensor.working'}
+    excl_dom = {}
+    excl_ent = {}
+    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
 
     assert testfilter.check_entity("sensor.test")
     assert testfilter.check_entity("light.test")
@@ -35,17 +31,11 @@ def test_includes_only_case_2():
 
 def test_excludes_only_case_3():
     """If exclude specified, pass all but specified (Case 3)."""
-    exclude_filter = {
-        'domains': [
-            'light',
-            'sensor'
-        ],
-        'entities': [
-            'binary_sensor.working'
-        ]
-    }
-    include_filter = {}
-    testfilter = EntityFilter(include_filter, exclude_filter)
+    incl_dom = {}
+    incl_ent = {}
+    excl_dom = {'light', 'sensor'}
+    excl_ent = {'binary_sensor.working'}
+    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
 
     assert testfilter.check_entity("sensor.test") is False
     assert testfilter.check_entity("light.test") is False
@@ -56,22 +46,11 @@ def test_excludes_only_case_3():
 
 def test_with_include_domain_case4a():
     """Test case 4a - include and exclude specified, with included domain."""
-    include_filter = {
-        'domains': [
-            'light',
-            'sensor'
-        ],
-        'entities': [
-            'binary_sensor.working'
-        ]
-    }
-    exclude_filter = {
-        'entities': [
-            'light.ignoreme',
-            'sensor.notworking'
-        ]
-    }
-    testfilter = EntityFilter(include_filter, exclude_filter)
+    incl_dom = {'light', 'sensor'}
+    incl_ent = {'binary_sensor.working'}
+    excl_dom = {}
+    excl_ent = {'light.ignoreme', 'sensor.notworking'}
+    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
 
     assert testfilter.check_entity("sensor.test")
     assert testfilter.check_entity("sensor.notworking") is False
@@ -84,21 +63,11 @@ def test_with_include_domain_case4a():
 
 def test_exclude_domain_case4b():
     """Test case 4b - include and exclude specified, with excluded domain."""
-    include_filter = {
-        'entities': [
-            'binary_sensor.working'
-        ]
-    }
-    exclude_filter = {
-        'domains': [
-            'binary_sensor'
-        ],
-        'entities': [
-            'light.ignoreme',
-            'sensor.notworking'
-        ]
-    }
-    testfilter = EntityFilter(include_filter, exclude_filter)
+    incl_dom = {}
+    incl_ent = {'binary_sensor.working'}
+    excl_dom = {'binary_sensor'}
+    excl_ent = {'light.ignoreme', 'sensor.notworking'}
+    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
 
     assert testfilter.check_entity("sensor.test")
     assert testfilter.check_entity("sensor.notworking") is False
@@ -111,18 +80,11 @@ def test_exclude_domain_case4b():
 
 def testno_domain_case4c():
     """Test case 4c - include and exclude specified, with no domains."""
-    include_filter = {
-        'entities': [
-            'binary_sensor.working'
-        ]
-    }
-    exclude_filter = {
-        'entities': [
-            'light.ignoreme',
-            'sensor.notworking'
-        ]
-    }
-    testfilter = EntityFilter(include_filter, exclude_filter)
+    incl_dom = {}
+    incl_ent = {'binary_sensor.working'}
+    excl_dom = {}
+    excl_ent = {'light.ignoreme', 'sensor.notworking'}
+    testfilter = EntityFilter(incl_dom, incl_ent, excl_dom, excl_ent)
 
     assert testfilter.check_entity("sensor.test") is False
     assert testfilter.check_entity("sensor.notworking") is False

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -1,0 +1,133 @@
+"""The tests for the EntityFitler component."""
+from homeassistant.helpers.entityfilter import EntityFilter
+
+
+def test_no_filters_case_1():
+    """If include and exclude not included, pass everything."""
+    include_filter = {}
+    exclude_filter = {}
+    testfilter = EntityFilter(include_filter, exclude_filter)
+
+    for value in ("sensor.test", "sun.sun", "light.test"):
+        assert testfilter.check_entity(value)
+
+
+def test_includes_only_case_2():
+    """If include specified, only pass if specified (Case 2)."""
+    include_filter = {
+        'domains': [
+            'light',
+            'sensor'
+        ],
+        'entities': [
+            'binary_sensor.working'
+        ]
+    }
+    exclude_filter = {}
+    testfilter = EntityFilter(include_filter, exclude_filter)
+
+    assert testfilter.check_entity("sensor.test")
+    assert testfilter.check_entity("light.test")
+    assert testfilter.check_entity("binary_sensor.working")
+    assert testfilter.check_entity("binary_sensor.notworking") is False
+    assert testfilter.check_entity("sun.sun") is False
+
+
+def test_excludes_only_case_3():
+    """If exclude specified, pass all but specified (Case 3)."""
+    exclude_filter = {
+        'domains': [
+            'light',
+            'sensor'
+        ],
+        'entities': [
+            'binary_sensor.working'
+        ]
+    }
+    include_filter = {}
+    testfilter = EntityFilter(include_filter, exclude_filter)
+
+    assert testfilter.check_entity("sensor.test") is False
+    assert testfilter.check_entity("light.test") is False
+    assert testfilter.check_entity("binary_sensor.working") is False
+    assert testfilter.check_entity("binary_sensor.another")
+    assert testfilter.check_entity("sun.sun") is True
+
+
+def test_with_include_domain_case4a():
+    """Test case 4a - include and exclude specified, with included domain."""
+    include_filter = {
+        'domains': [
+            'light',
+            'sensor'
+        ],
+        'entities': [
+            'binary_sensor.working'
+        ]
+    }
+    exclude_filter = {
+        'entities': [
+            'light.ignoreme',
+            'sensor.notworking'
+        ]
+    }
+    testfilter = EntityFilter(include_filter, exclude_filter)
+
+    assert testfilter.check_entity("sensor.test")
+    assert testfilter.check_entity("sensor.notworking") is False
+    assert testfilter.check_entity("light.test")
+    assert testfilter.check_entity("light.ignoreme") is False
+    assert testfilter.check_entity("binary_sensor.working")
+    assert testfilter.check_entity("binary_sensor.another") is False
+    assert testfilter.check_entity("sun.sun") is False
+
+
+def test_exclude_domain_case4b():
+    """Test case 4b - include and exclude specified, with excluded domain."""
+    include_filter = {
+        'entities': [
+            'binary_sensor.working'
+        ]
+    }
+    exclude_filter = {
+        'domains': [
+            'binary_sensor'
+        ],
+        'entities': [
+            'light.ignoreme',
+            'sensor.notworking'
+        ]
+    }
+    testfilter = EntityFilter(include_filter, exclude_filter)
+
+    assert testfilter.check_entity("sensor.test")
+    assert testfilter.check_entity("sensor.notworking") is False
+    assert testfilter.check_entity("light.test")
+    assert testfilter.check_entity("light.ignoreme") is False
+    assert testfilter.check_entity("binary_sensor.working")
+    assert testfilter.check_entity("binary_sensor.another") is False
+    assert testfilter.check_entity("sun.sun") is True
+
+
+def testno_domain_case4c():
+    """Test case 4c - include and exclude specified, with no domains."""
+    include_filter = {
+        'entities': [
+            'binary_sensor.working'
+        ]
+    }
+    exclude_filter = {
+        'entities': [
+            'light.ignoreme',
+            'sensor.notworking'
+        ]
+    }
+    testfilter = EntityFilter(include_filter, exclude_filter)
+
+    assert testfilter.check_entity("sensor.test") is False
+    assert testfilter.check_entity("sensor.notworking") is False
+    assert testfilter.check_entity("light.test") is False
+    assert testfilter.check_entity("light.ignoreme") is False
+    assert testfilter.check_entity("binary_sensor.working")
+    assert testfilter.check_entity("binary_sensor.another") is False
+    assert testfilter.check_entity("sun.sun") is False


### PR DESCRIPTION
## Description:
This PR adds a new `EntityFilter` helper class that implements a standardized include/exclude filter for use in components.  I plan to add capability to mqtt_statestream to select the items that are published, and I thought it made sense to break the code out so that it could be used in other modules.

It's inspired by the include/exclude options in the `recorder` component (if this is accepted, I'll submit a PR to update the component to use this class), but with the cases a little more formalized:

1. If there are no includes or excludes specified, return true.
2. If there are only includes (domain and/or entity), then only return true for the specified domains/entities, otherwise return false.
3. If there are only excludes (domain and/or entity), then only return false for the specified domains/entities, otherwise return true.
4. If both includes and excludes are specified:
  a. If included domains are specified:
    - If the entity's domain is included, and the entity is not excluded, return true.
    - If the entity's domain is not included, and then entity is not specifically included, return false.
  b. If excluded domains are specified:
    - If the entity's domain is excluded, and the entity is not specifically included, return false.
    - If the entity's domain is not excluded, and the entity is not specifically excluded, return true.
  c. Neither included or excluded domains are specified:
    - If the entity is specifically included, return true.

I've added a `FILTER_SCHEMA` to `config_validation` that can be used to set up the config parsing.

To get started:
```python
from homeassistant.helpers.entityfilter import EntityFilter
import homeassistant.helpers.config_validation as cv

CONFIG_SCHEMA = vol.Schema({
    DOMAIN: cv.FILTER_SCHEMA.extend({
      ...
    })
})
```

Then, in your component/platform setup:
```python
...
    conf = config.get(DOMAIN, {})
    my_filter = EntityFilter(conf.get(CONF_INCLUDE,{}), conf.get(CONF_EXCLUDE, {}))
...
```

When you want to check an entity:
```python
  if my_filter.check_entity(entity_id):
    """Do something here for valid entities."""
  else:
    """It returns False for ignored entities."""
```

I couldn't figure out where would be appropriate for documentation - if you let me know, I'll add a PR for home-assistant.github.io to add them.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
your_component:
  include:
    domains:
      - light
      - sensor
    entities:
      - binary_sensor.sensor1
  exclude:
    entities:
      - light.badlight
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
