### PR TITLE
Update __init__.py

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -234,7 +234,8 @@ class Entity(entity.Entity):
         ieeetail = ''.join([
             '%02x' % (o, ) for o in endpoint.device.ieee[-4:]
         ])
-        if manufacturer and model is not None:
+        # when using Ecosmart dimmable light bulbs, the value of model is not string type, it is a long byte array which throws an exception when calling slugify(model)
+        if manufacturer and model is not None and isinstance(manufacturer, str) and isinstance(model, str):
             self.entity_id = '%s.%s_%s_%s_%s' % (
                 self._domain,
                 slugify(manufacturer),


### PR DESCRIPTION
## Description:

When using Ecosmart dimmable light bulbs (link from home depot below), the value of model is not string type, it is a long byte array which throws an exception when calling slugify(model).

The only way to add/use the those Ecosmat Zigbee bulbs is using the above fix which I have to apply now as custom component to override the base ZHA component.

Bulbs:
https://www.homedepot.ca/en/home/p.connected-60w-equivalent-daylight-5000k-a19-dimmable-led-light-bulb.1000835496.html
