### PR TITLE
Google Assistant: Use homeassistant domain for handling group

### DIFF
--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -122,11 +122,10 @@ class GoogleAssistantView(HomeAssistantView):
             ent_ids = [ent.get('id') for ent in command.get('devices', [])]
             execution = command.get('execution')[0]
             for eid in ent_ids:
-                domain = eid.split('.')[0]
-                (service, service_data) = determine_service(
+                (service_domain, service, service_data) = determine_service(
                     eid, execution.get('command'), execution.get('params'))
                 success = yield from hass.services.async_call(
-                    domain, service, service_data, blocking=True)
+                    service_domain, service, service_data, blocking=True)
                 result = {"ids": [eid], "states": {}}
                 if success:
                     result['status'] = 'SUCCESS'

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -12,6 +12,7 @@ DETERMINE_SERVICE_TESTS = [{  # Test light brightness
         'brightness': 95
     },
     'expected': (
+        'light',
         const.SERVICE_TURN_ON,
         {'entity_id': 'light.test', 'brightness': 242}
     )
@@ -21,28 +22,34 @@ DETERMINE_SERVICE_TESTS = [{  # Test light brightness
     'params': {
         'on': False
     },
-    'expected': (const.SERVICE_TURN_OFF, {'entity_id': 'light.test'})
+    'expected': ('light', const.SERVICE_TURN_OFF, {'entity_id': 'light.test'})
 }, {
     'entity_id': 'light.test',
     'command': ga.const.COMMAND_ONOFF,
     'params': {
         'on': True
     },
-    'expected': (const.SERVICE_TURN_ON, {'entity_id': 'light.test'})
+    'expected': ('light', const.SERVICE_TURN_ON, {'entity_id': 'light.test'})
 }, {  # Test Cover open close
     'entity_id': 'cover.bedroom',
     'command': ga.const.COMMAND_ONOFF,
     'params': {
         'on': True
     },
-    'expected': (const.SERVICE_OPEN_COVER, {'entity_id': 'cover.bedroom'}),
+    'expected': (
+        'cover',
+        const.SERVICE_OPEN_COVER,
+        {'entity_id': 'cover.bedroom'}),
 }, {
     'entity_id': 'cover.bedroom',
     'command': ga.const.COMMAND_ONOFF,
     'params': {
         'on': False
     },
-    'expected': (const.SERVICE_CLOSE_COVER, {'entity_id': 'cover.bedroom'}),
+    'expected': (
+        'cover',
+        const.SERVICE_CLOSE_COVER,
+        {'entity_id': 'cover.bedroom'}),
 }, {  # Test cover position
     'entity_id': 'cover.bedroom',
     'command': ga.const.COMMAND_BRIGHTNESS,
@@ -50,6 +57,7 @@ DETERMINE_SERVICE_TESTS = [{  # Test light brightness
         'brightness': 50
     },
     'expected': (
+        'cover',
         const.SERVICE_SET_COVER_POSITION,
         {'entity_id': 'cover.bedroom', 'position': 50}
     ),
@@ -60,9 +68,19 @@ DETERMINE_SERVICE_TESTS = [{  # Test light brightness
         'brightness': 30
     },
     'expected': (
+        'media_player',
         const.SERVICE_VOLUME_SET,
         {'entity_id': 'media_player.living_room', 'volume_level': 0.3}
     ),
+}, {
+    'entity_id': 'group.my_switches',
+    'command': ga.const.COMMAND_ONOFF,
+    'params': {
+        'on': False
+    },
+    'expected': (
+        'homeassistant', const.SERVICE_TURN_OFF,
+        {'entity_id': 'group.my_switches'}),
 }]
 
 


### PR DESCRIPTION
## Description:
Modify determine_service to also determine the domain for the service. For group, use homeassistant as the domain.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A
## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
