### PR TITLE
Clarify yamaha play_media parameters

### DIFF
--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -252,6 +252,20 @@ class YamahaDevice(MediaPlayerDevice):
         Yamaha to direct play certain kinds of media. media_type is
         treated as the input type that we are setting, and media id is
         specific to it.
+
+        For the NET RADIO mediatype the format for ``media_id`` is a
+        "path" in your vtuner hierarchy. For instance:
+        ``Bookmarks>Internet>Radio Paradise``. The separators are
+        ``>`` and the parts of this are navigated by name behind the
+        scenes. There is a looping construct built into the yamaha
+        library to do this with a fallback timeout if the vtuner
+        service is unresponsive.
+
+        NOTE: this might take a while, because the only API interface
+        for setting the net radio station emulates button pressing and
+        navigating through the net radio menu hiearchy. And each sub
+        menu must be fetched by the receiver from the vtuner service.
+
         """
         if media_type == "NET RADIO":
             self._receiver.net_radio(media_id)


### PR DESCRIPTION
The play_media parameters are a little bit black magic for the yamaha
platform, this explains what they are in a code comment instead of
having to go look at the yamaha platform itself.

Fixes Bug #10180