### PR TITLE
[WIP] Move flux out of the switch domain

### DIFF
--- a/homeassistant/components/flux.py
+++ b/homeassistant/components/flux.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 
 from homeassistant.components.light import (
     is_on, turn_on, VALID_TRANSITION, ATTR_TRANSITION)
-from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_LIGHTS
+from homeassistant.const import CONF_NAME, CONF_MODE, CONF_LIGHTS
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.sun import get_astral_event_date
 from homeassistant.util import slugify
@@ -36,7 +36,6 @@ CONF_SUNSET_CT = 'sunset_colortemp'
 CONF_STOP_CT = 'stop_colortemp'
 CONF_BRIGHTNESS = 'brightness'
 CONF_DISABLE_BRIGTNESS_ADJUST = 'disable_brightness_adjust'
-CONF_MODE = 'mode'
 CONF_INTERVAL = 'interval'
 CONF_ACTIVE_BY_DEFAULT = 'active_by_default'
 

--- a/homeassistant/components/flux.py
+++ b/homeassistant/components/flux.py
@@ -15,7 +15,7 @@ import voluptuous as vol
 from homeassistant.components.light import (
     is_on, turn_on, VALID_TRANSITION, ATTR_TRANSITION)
 from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_LIGHTS
-from homeassistant.helpers.event import track_time_change
+from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.sun import get_astral_event_date
 from homeassistant.util import slugify
 from homeassistant.util.color import (
@@ -62,7 +62,8 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_DISABLE_BRIGTNESS_ADJUST): cv.boolean,
         vol.Optional(CONF_MODE, default=DEFAULT_MODE):
             vol.Any(MODE_XY, MODE_MIRED, MODE_RGB),
-        vol.Optional(CONF_INTERVAL, default=30): cv.positive_int,
+        vol.Optional(CONF_INTERVAL, default=datetime.timedelta(seconds=30)):
+            cv.time_period,
         vol.Optional(ATTR_TRANSITION, default=30): VALID_TRANSITION,
         vol.Optional(CONF_ACTIVE_BY_DEFAULT, default=True): cv.boolean
     }),
@@ -173,8 +174,8 @@ class FluxSwitch:
         # Make initial update
         self.flux_update()
 
-        self.unsub_tracker = track_time_change(
-            self.hass, self.flux_update, second=[0, self._interval])
+        self.unsub_tracker = track_time_interval(
+            self.hass, self.flux_update, self._interval)
 
     def turn_off(self):
         """Turn off flux."""

--- a/homeassistant/components/flux.py
+++ b/homeassistant/components/flux.py
@@ -24,7 +24,7 @@ from homeassistant.util.color import (
 from homeassistant.util.dt import now as dt_now
 import homeassistant.helpers.config_validation as cv
 
-DOMAIN = 'device_sun_light_trigger'
+DOMAIN = 'flux'
 DEPENDENCIES = ['light']
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,9 +45,8 @@ MODE_MIRED = 'mired'
 MODE_RGB = 'rgb'
 DEFAULT_MODE = MODE_XY
 
-PLATFORM_SCHEMA = vol.Schema({
+CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_PLATFORM): 'flux',
         vol.Required(CONF_LIGHTS): cv.entity_ids,
         vol.Optional(CONF_NAME, default="Flux"): cv.string,
         vol.Optional(CONF_START_TIME): cv.time,
@@ -101,19 +100,20 @@ def set_lights_rgb(hass, lights, rgb, transition):
 
 def setup(hass, config):
     """Set up the Flux switches."""
-    name = config.get(CONF_NAME)
-    lights = config.get(CONF_LIGHTS)
-    start_time = config.get(CONF_START_TIME)
-    stop_time = config.get(CONF_STOP_TIME)
-    start_colortemp = config.get(CONF_START_CT)
-    sunset_colortemp = config.get(CONF_SUNSET_CT)
-    stop_colortemp = config.get(CONF_STOP_CT)
-    brightness = config.get(CONF_BRIGHTNESS)
-    disable_brightness_adjust = config.get(CONF_DISABLE_BRIGTNESS_ADJUST)
-    mode = config.get(CONF_MODE)
-    interval = config.get(CONF_INTERVAL)
-    transition = config.get(ATTR_TRANSITION)
-    active = config.get(CONF_ACTIVE_BY_DEFAULT)
+    domain_cfg = config[DOMAIN]
+    name = domain_cfg.get(CONF_NAME)
+    lights = domain_cfg.get(CONF_LIGHTS)
+    start_time = domain_cfg.get(CONF_START_TIME)
+    stop_time = domain_cfg.get(CONF_STOP_TIME)
+    start_colortemp = domain_cfg.get(CONF_START_CT)
+    sunset_colortemp = domain_cfg.get(CONF_SUNSET_CT)
+    stop_colortemp = domain_cfg.get(CONF_STOP_CT)
+    brightness = domain_cfg.get(CONF_BRIGHTNESS)
+    disable_brightness_adjust = domain_cfg.get(CONF_DISABLE_BRIGTNESS_ADJUST)
+    mode = domain_cfg.get(CONF_MODE)
+    interval = domain_cfg.get(CONF_INTERVAL)
+    transition = domain_cfg.get(ATTR_TRANSITION)
+    active = domain_cfg.get(CONF_ACTIVE_BY_DEFAULT)
     flux = FluxSwitch(name, hass, lights, start_time, stop_time,
                       start_colortemp, sunset_colortemp, stop_colortemp,
                       brightness, disable_brightness_adjust, mode, interval,


### PR DESCRIPTION
## Description:

As requested by @pvizeli, moves the flux component out of switch domain.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

