### PR TITLE
Script - Added support for states.trigger.entity_id.state

### DIFF
--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -794,3 +794,37 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(
             'numeric_state - test.entity - 12',
             self.calls[0].data['some'])
+
+    def test_wait_template_with_trigger_states(self):
+        """Test using wait template with 'states.trigger.entity_id'."""
+        assert setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'numeric_state',
+                    'entity_id': 'test.entity',
+                    'above': 10,
+                },
+                'action': [
+                    {'wait_template':
+                        "{{ states.trigger.entity_id.state | int < 10 }}"},
+                    {'service': 'test.automation',
+                     'data_template': {
+                        'some':
+                        '{{ trigger.%s }}' % '}} - {{ trigger.'.join((
+                            'platform', 'entity_id', 'to_state.state'))
+                        }}
+                ],
+            }
+        })
+
+        self.hass.block_till_done()
+        self.calls = []
+
+        self.hass.states.set('test.entity', '12')
+        self.hass.block_till_done()
+        self.hass.states.set('test.entity', '8')
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        self.assertEqual(
+            'numeric_state - test.entity - 12',
+            self.calls[0].data['some'])

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -380,6 +380,41 @@ class TestScriptHelper(unittest.TestCase):
         assert not script_obj.is_running
         assert len(events) == 2
 
+    def test_wait_template_variables_states(self):
+        """Test the wait template with variables and states."""
+        event = 'test_event'
+        events = []
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        self.hass.states.set('switch.test', 'on')
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
+            {'event': event},
+            {'wait_template': "{{ states.data.state == 'off' }}"},
+            {'event': event}]))
+
+        script_obj.run({
+            'data': 'switch.test'
+        })
+        self.hass.block_till_done()
+
+        assert script_obj.is_running
+        assert script_obj.can_cancel
+        assert script_obj.last_action == event
+        assert len(events) == 1
+
+        self.hass.states.set('switch.test', 'off')
+        self.hass.block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 2
+
     def test_passing_variables_to_script(self):
         """Test if we can pass variables to script."""
         calls = []


### PR DESCRIPTION
* Added support for states.trigger.entity_id.state
* Added support for states.[data].state with [data] being an entity_id
* Added tests

## Description:
As an alternative to #10052 and #10081. When rendering a template with `async_render` I call a function to replace `trigger.entity_id` or `data` which act as placeholders.

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  - alias: 'Test'
    hide_entity: true
    trigger:
      - platform: state
        entity_id: input_boolean.test
        from: 'off'
        to: 'on'
    action:
      - service: input_text.set_value
        data_template:
          entity_id: 'input_text.text'
          value: 'Start'
      - wait_template: "{{ states.input_boolean.test.state == 'off' }}" #  [1]
      - wait_template: "{{ states.trigger.entity_id.state == 'off' }}" # [2]
      - service: script.test_data
        data_template:
          data: "{{ trigger.entity_id }}"

script:
  test_data:
    sequence:
      - wait_template: "{{ states.data.state == 'off' }}" # [3]
      - service: input_text.set_value
        data_template:
          entity_id: 'input_text.text'
          value: 'End'
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.