### PR TITLE
Added state attribute to light and switch .toggle service

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -17,8 +17,8 @@ from homeassistant.loader import bind_hass
 from homeassistant.components import group
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (
-    STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE,
-    ATTR_ENTITY_ID)
+    STATE_ON, STATE_OFF, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE,
+    ATTR_ENTITY_ID, ATTR_STATE)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
@@ -130,6 +130,7 @@ LIGHT_TURN_OFF_SCHEMA = vol.Schema({
 
 LIGHT_TOGGLE_SCHEMA = vol.Schema({
     ATTR_ENTITY_ID: cv.entity_ids,
+    ATTR_STATE: vol.In([STATE_ON, STATE_OFF]),
     ATTR_TRANSITION: VALID_TRANSITION,
 })
 
@@ -217,11 +218,12 @@ def async_turn_off(hass, entity_id=None, transition=None):
 
 
 @bind_hass
-def toggle(hass, entity_id=None, transition=None):
+def toggle(hass, entity_id=None, state=None, transition=None):
     """Toggle all or specified light."""
     data = {
         key: value for key, value in [
             (ATTR_ENTITY_ID, entity_id),
+            (ATTR_STATE, state),
             (ATTR_TRANSITION, transition),
         ] if value is not None
     }

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -71,8 +71,9 @@ toggle:
     state:
       description: Desired state
       values:
-        - on
-        - off
+        - 'on'
+        - 'off'
+      example: 'on'
     transition:
       description: Duration in seconds it takes to get to next state.
       example: 60

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -68,6 +68,11 @@ toggle:
     entity_id:
       description: Name(s) of entities to toggle.
       example: 'light.kitchen'
+    state:
+      description: Desired state
+      values:
+        - on
+        - off
     transition:
       description: Duration in seconds it takes to get to next state.
       example: 60

--- a/homeassistant/components/switch/services.yaml
+++ b/homeassistant/components/switch/services.yaml
@@ -23,8 +23,9 @@ toggle:
     state:
       description: Desired state
       values:
-        - on
-        - off
+        - 'on'
+        - 'off'
+      example: 'on'
 
 mysensors_send_ir_code:
   description: Set an IR code as a state attribute for a MySensors IR device switch and turn the switch on.

--- a/homeassistant/components/switch/services.yaml
+++ b/homeassistant/components/switch/services.yaml
@@ -20,6 +20,11 @@ toggle:
     entity_id:
       description: Name(s) of entities to toggle.
       example: 'switch.living_room'
+    state:
+      description: Desired state
+      values:
+        - on
+        - off
 
 mysensors_send_ir_code:
   description: Set an IR code as a state attribute for a MySensors IR device switch and turn the switch on.

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -7,7 +7,7 @@ from timeit import default_timer as timer
 from typing import Optional, List
 
 from homeassistant.const import (
-    ATTR_ASSUMED_STATE, ATTR_FRIENDLY_NAME, ATTR_HIDDEN, ATTR_ICON,
+    ATTR_ASSUMED_STATE, ATTR_FRIENDLY_NAME, ATTR_HIDDEN, ATTR_ICON, ATTR_STATE,
     ATTR_UNIT_OF_MEASUREMENT, DEVICE_DEFAULT_NAME, STATE_OFF, STATE_ON,
     STATE_UNAVAILABLE, STATE_UNKNOWN, TEMP_CELSIUS, TEMP_FAHRENHEIT,
     ATTR_ENTITY_PICTURE, ATTR_SUPPORTED_FEATURES, ATTR_DEVICE_CLASS)
@@ -393,16 +393,27 @@ class ToggleEntity(Entity):
 
     def toggle(self, **kwargs) -> None:
         """Toggle the entity."""
-        if self.is_on:
-            self.turn_off(**kwargs)
+        if ATTR_STATE in kwargs:
+            if kwargs[ATTR_STATE] == STATE_ON:
+                self.turn_on(**kwargs)
+            else:
+                self.turn_off(**kwargs)
         else:
-            self.turn_on(**kwargs)
+            if self.is_on:
+                self.turn_off(**kwargs)
+            else:
+                self.turn_on(**kwargs)
 
     def async_toggle(self, **kwargs):
         """Toggle the entity.
 
         This method must be run in the event loop and returns a coroutine.
         """
-        if self.is_on:
+        if ATTR_STATE in kwargs:
+            if kwargs[ATTR_STATE] == STATE_ON:
+                return self.async_turn_on(**kwargs)
             return self.async_turn_off(**kwargs)
-        return self.async_turn_on(**kwargs)
+        else:
+            if self.is_on:
+                return self.async_turn_off(**kwargs)
+            return self.async_turn_on(**kwargs)


### PR DESCRIPTION
## Description:

This adds the ability to set on/off state for lights and switches in one line instead of using conditional templates. This extends toggle service so that it accepts 'state' parameter. If this parameter is provided the state of light/switch is set to desired value irrespective of current light/switch state. See the example of below.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3847

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  - alias: 'Turn lights ON on presence'
    trigger:
    - platform: state
      entity_id: binary_sensor.presence
      to: 'on'
    - platform: state
      entity_id: binary_sensor.presence
      to: 'off'
      for: 10
    action:
    - service: light.toggle
      entity_id: light.light1
      data_template:
        state: '{{ states.input_boolean.test.state }}'
    - service: switch.toggle
      entity_id: switch.switch1
      data_template:
        state: '{{ states.input_boolean.test.state }}'
```
