### PR TITLE
Add support for onewire server.

### DIFF
--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -18,10 +18,19 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 
+REQUIREMENTS = ['pyownet==0.10.0']
+
 CONF_MOUNT_DIR = 'mount_dir'
 CONF_NAMES = 'names'
+CONF_SERVER_HOST = 'server'
+CONF_SERVER_PORT = 'port'
+CONF_SERVER_TIMEOUT = 'timeout'
 
 DEFAULT_MOUNT_DIR = '/sys/bus/w1/devices/'
+DEFAULT_SERVER_HOST = ''
+DEFAULT_SERVER_PORT = 4304
+DEFAULT_SERVER_TIMEOUT = 2
+
 DEVICE_SENSORS = {'10': {'temperature': 'temperature'},
                   '12': {'temperature': 'TAI8570/temperature',
                          'pressure': 'TAI8570/pressure'},
@@ -42,6 +51,10 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAMES): {cv.string: cv.string},
     vol.Optional(CONF_MOUNT_DIR, default=DEFAULT_MOUNT_DIR): cv.string,
+    vol.Optional(CONF_SERVER_HOST, default=DEFAULT_SERVER_HOST): cv.string,
+    vol.Optional(CONF_SERVER_PORT, default=DEFAULT_SERVER_PORT): cv.port,
+    vol.Optional(CONF_SERVER_TIMEOUT,
+                 default=DEFAULT_SERVER_TIMEOUT): cv.positive_int,
 })
 
 
@@ -49,13 +62,29 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the one wire Sensors."""
     base_dir = config.get(CONF_MOUNT_DIR)
+    server_host = config.get(CONF_SERVER_HOST)
+    server_port = config.get(CONF_SERVER_PORT)
+    server_timeout = config.get(CONF_SERVER_TIMEOUT)
     devs = []
     device_names = {}
     if 'names' in config:
         if isinstance(config['names'], dict):
             device_names = config['names']
 
-    if base_dir == DEFAULT_MOUNT_DIR:
+    if server_host:
+        import pyownet
+        proxy = pyownet.protocol.proxy(host=server_host, port=server_port)
+        for full_id in proxy.dir():
+            for device_family in DEVICE_SENSORS:
+                if full_id.startswith('/{}.'.format(device_family)):
+                    address_path = os.path.join(full_id, 'address')
+                    sensor_id = proxy.read(address_path).decode()
+                    sensor_name = device_names.get(sensor_id, sensor_id)
+                    for key, path in DEVICE_SENSORS[device_family].items():
+                        sensor_file = os.path.join(full_id, path)
+                        devs.append(OneWireOWNet(sensor_name, sensor_file, key,
+                                                 proxy, server_timeout))
+    elif base_dir == DEFAULT_MOUNT_DIR:
         for device_family in DEVICE_SENSORS:
             for device_folder in glob(os.path.join(base_dir, device_family +
                                                    '[.-]*')):
@@ -78,7 +107,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                                              sensor_id),
                                             device_file, sensor_key))
 
-    if devs == []:
+    if not devs:
         _LOGGER.error("No onewire sensor found. Check if dtoverlay=w1-gpio "
                       "is in your /boot/config.txt. "
                       "Check the mount_dir parameter if it's defined")
@@ -97,11 +126,15 @@ class OneWire(Entity):
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
         self._state = None
 
-    def _read_value_raw(self):
+    def _read_lines(self):
         """Read the value as it is returned by the sensor."""
         with open(self._device_file, 'r') as ds_device_file:
             lines = ds_device_file.readlines()
         return lines
+
+    def _read_value(self):
+        """Read the value from the sensor."""
+        raise NotImplementedError
 
     @property
     def name(self):
@@ -118,37 +151,72 @@ class OneWire(Entity):
         """Return the unit the value is expressed in."""
         return self._unit_of_measurement
 
+    def update(self):
+        """Get the latest data from the device."""
+        value = self._read_value()
+        if value is not None:
+            value = round(value, 1)
+        self._state = value
+
 
 class OneWireDirect(OneWire):
     """Implementation of an One wire Sensor directly connected to RPI GPIO."""
 
-    def update(self):
-        """Get the latest data from the device."""
+    def _read_value(self):
+        """Read the value from the sensor."""
         value = None
-        lines = self._read_value_raw()
+        lines = self._read_lines()
         while lines[0].strip()[-3:] != 'YES':
             time.sleep(0.2)
-            lines = self._read_value_raw()
+            lines = self._read_lines()
         equals_pos = lines[1].find('t=')
         if equals_pos != -1:
             value_string = lines[1][equals_pos + 2:]
-            value = round(float(value_string) / 1000.0, 1)
-        self._state = value
+            value = float(value_string) / 1000.0
+        return value
 
 
 class OneWireOWFS(OneWire):
     """Implementation of an One wire Sensor through owfs."""
 
-    def update(self):
-        """Get the latest data from the device."""
+    def _read_value(self):
+        """Read the value from the sensor."""
         value = None
         try:
-            value_read = self._read_value_raw()
+            value_read = self._read_lines()
             if len(value_read) == 1:
-                value = round(float(value_read[0]), 1)
+                value = float(value_read[0])
         except ValueError:
             _LOGGER.warning("Invalid value read from %s", self._device_file)
         except FileNotFoundError:
             _LOGGER.warning("Cannot read from sensor: %s", self._device_file)
+        return value
 
-        self._state = value
+
+class OneWireOWNet(OneWire):
+    """Implementation of an One wire Sensor through ownet."""
+
+    def __init__(self, name, device_file, sensor_type, proxy, timeout):
+        """Initialize the sensor."""
+        super().__init__(name, device_file, sensor_type)
+        self._proxy = proxy
+        self._timeout = timeout
+
+    def _read_value(self):
+        """Read the value as it is returned by the sensor."""
+        import pyownet
+        value = None
+        try:
+            value_read = self._proxy.read(self._device_file,
+                                          timeout=self._timeout).decode()
+            value = float(value_read)
+        except ValueError:
+            _LOGGER.warning("Invalid value read from %s", self._device_file)
+        except pyownet.protocol.OwnetTimeout:
+            _LOGGER.warning("Timeout exception from sensor: %s,"
+                            " please increase timeout in settings",
+                            self._device_file)
+        except pyownet.protocol.Error as ex:
+            _LOGGER.warning("Cannot read from sensor: %s (%s)",
+                            self._device_file, ex)
+        return value

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -755,6 +755,9 @@ pyotp==2.2.6
 # homeassistant.components.weather.openweathermap
 pyowm==2.7.1
 
+# homeassistant.components.sensor.onewire
+pyownet==0.10.0
+
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.4
 


### PR DESCRIPTION
## Description:

This add support for onewire sensor over ownet protocol. I have tested it against my [hassio addon](https://github.com/bestlibre/hassio-addons/tree/master/owserver)

I will add the documentation ASAP

## Example entry for `configuration.yaml`:
```yaml
sensor:
  - platform: onewire
    server: 192.168.0.10
    port: 4346
    timeout: 3
```
