### PR TITLE
Use theme color in loading screen.

### DIFF
--- a/homeassistant/components/frontend/templates/index.html
+++ b/homeassistant/components/frontend/templates/index.html
@@ -38,7 +38,7 @@
         display: block;
         content: "";
         height: 48px;
-        background-color: #03A9F4;
+        background-color: {{ theme_color }};
       }
 
       #ha-init-skeleton .message {
@@ -52,7 +52,7 @@
       }
 
       #ha-init-skeleton a {
-        color: #03A9F4;
+        color: {{ theme_color }};
         text-decoration: none;
         font-weight: bold;
       }


### PR DESCRIPTION
## Description:

Use theme color in loading screen instead of hardcoded color.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.