### PR TITLE
Cover - Updated config schema

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -59,6 +59,10 @@ ATTR_TILT_POSITION = 'tilt_position'
 
 COVER_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_POSITION):
+        vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
+    vol.Optional(ATTR_TILT_POSITION):
+        vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
 })
 
 COVER_SET_COVER_POSITION_SCHEMA = COVER_SERVICE_SCHEMA.extend({

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -59,11 +59,7 @@ ATTR_TILT_POSITION = 'tilt_position'
 
 COVER_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Optional(ATTR_POSITION):
-        vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
-    vol.Optional(ATTR_TILT_POSITION):
-        vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
-})
+}, extra=vol.REMOVE_EXTRA)
 
 COVER_SET_COVER_POSITION_SCHEMA = COVER_SERVICE_SCHEMA.extend({
     vol.Required(ATTR_POSITION):


### PR DESCRIPTION
## Description:
As follow up to #9756. @pvizeli suggested to use `data_template` instead. As far as I know this wouldn't work (see example below). Since `extra=vol.ALLOW_EXTRA` is pretty broad I figured that allowing the `position` parameter as `optional` could be a solution.

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Use case
cover:
  sequence:
    - service_template: "cover.{{action}}"
         # action beeing the service name
         # (start_cover, stop_cover, close_cover, set_cover_position)
      data_template:
        position: "{{position}}"

# Using data_template
cover:
  sequence:
    - service_template: "cover.{{action}}"
         # action beeing the service name
         # (start_cover, stop_cover, close_cover, set_cover_position)
      data_template:
        {% if {{action}} != 'stop_cover' %}
        position: "{{position}}"
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**