### PR TITLE
Introduce media progress for Yamaha Musiccast devices

### DIFF
--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -36,7 +36,7 @@ SUPPORTED_FEATURES = (
 KNOWN_HOSTS_KEY = 'data_yamaha_musiccast'
 INTERVAL_SECONDS = 'interval_seconds'
 
-REQUIREMENTS = ['pymusiccast==0.1.4']
+REQUIREMENTS = ['pymusiccast==0.1.5']
 
 DEFAULT_PORT = 5005
 DEFAULT_INTERVAL = 480

--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -210,8 +210,6 @@ class YamahaDevice(MediaPlayerDevice):
         if self.media_status and self.state in \
                 [STATE_PLAYING, STATE_PAUSED, STATE_IDLE]:
             return self.media_status.media_position
-        else:
-            return None
 
     @property
     def media_position_updated_at(self):
@@ -229,10 +227,7 @@ class YamahaDevice(MediaPlayerDevice):
 
     def update_hass(self):
         """Push updates to HASS"""
-        if not self.entity_id:
-            _LOGGER.debug("update_hass: not pushing yet")
-            return False
-        else:
+        if self.entity_id:
             _LOGGER.debug("update_hass: pushing updates")
             self.schedule_update_ha_state()
             return True

--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -226,7 +226,7 @@ class YamahaDevice(MediaPlayerDevice):
         self._zone.update_status()
 
     def update_hass(self):
-        """Push updates to HASS"""
+        """Push updates to HASS."""
         if self.entity_id:
             _LOGGER.debug("update_hass: pushing updates")
             self.schedule_update_ha_state()

--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -208,6 +208,16 @@ class YamahaDevice(MediaPlayerDevice):
         self._recv.update_status()
         self._zone.update_status()
 
+    def update_hass(self):
+        """Push updates to HASS"""
+        if not self.entity_id:
+            _LOGGER.debug("update_hass: not pushing yet")
+            return False
+        else:
+            _LOGGER.debug("update_hass: pushing updates")
+            self.schedule_update_ha_state()
+            return True
+
     def turn_on(self):
         """Turn on specified media player or all."""
         _LOGGER.debug("Turn device: on")

--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -36,7 +36,7 @@ SUPPORTED_FEATURES = (
 KNOWN_HOSTS_KEY = 'data_yamaha_musiccast'
 INTERVAL_SECONDS = 'interval_seconds'
 
-REQUIREMENTS = ['pymusiccast==0.1.3']
+REQUIREMENTS = ['pymusiccast==0.1.4']
 
 DEFAULT_PORT = 5005
 DEFAULT_INTERVAL = 480

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -730,7 +730,7 @@ pymodbus==1.3.1
 pymonoprice==0.2
 
 # homeassistant.components.media_player.yamaha_musiccast
-pymusiccast==0.1.4
+pymusiccast==0.1.5
 
 # homeassistant.components.cover.myq
 pymyq==0.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -730,7 +730,7 @@ pymodbus==1.3.1
 pymonoprice==0.2
 
 # homeassistant.components.media_player.yamaha_musiccast
-pymusiccast==0.1.3
+pymusiccast==0.1.4
 
 # homeassistant.components.cover.myq
 pymyq==0.0.8


### PR DESCRIPTION
## Description:
Provide media progress info (media_position/media_duration) to calculate media progress bar.

**Related issue (if applicable):**
- fixes https://github.com/jalmeroth/pymusiccast/issues/6
- fixes https://github.com/jalmeroth/pymusiccast/issues/7

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
