### PR TITLE
Support the OFF state for Kodi boxes running 24/7

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -588,23 +588,29 @@ class KodiDevice(MediaPlayerDevice):
     @asyncio.coroutine
     def async_turn_on(self):
         """Execute turn_on_action to turn on media player."""
-        self._flag_switch_off = False
         if self._turn_on_action is not None:
             yield from self._turn_on_action.async_run(
                 variables={"entity_id": self.entity_id})
         else:
             _LOGGER.warning("turn_on requested but turn_on_action is none")
+        if self._use_off_mode:
+            self._flag_switch_off = False
+            # Update HA state to reflect the new state
+            self.async_schedule_update_ha_state()
 
     @cmd
     @asyncio.coroutine
     def async_turn_off(self):
         """Execute turn_off_action to turn off media player."""
-        self._flag_switch_off = True
         if self._turn_off_action is not None:
             yield from self._turn_off_action.async_run(
                 variables={"entity_id": self.entity_id})
         else:
             _LOGGER.warning("turn_off requested but turn_off_action is none")
+        if self._use_off_mode:
+            self._flag_switch_off = True
+            # Update HA state to reflect the OFF state
+            self.async_schedule_update_ha_state()
 
     @cmd
     @asyncio.coroutine


### PR DESCRIPTION
## Introduction:

This is a custom mod that I'm using for some months now with one simple objective: **to show the OFF state** of my OSMC Kodi RPI3 that runs attached to my main TV in the living room.

These Kodi boxes run always and are CEC capable (the RPI is, and I understand the popular Android-based boxes are too), so they can turn on and off the TV and/or the home cinema (through the ARC HDMI port on the TV). This is great, because of the possibilities that the HA control of Kodi has. But there is a small problem: the Kodi state in HA, when nothing happens (no playing, etc.), is always the **idle state**. This is unfortunate because the frontend UI doesn't have 2 buttons to turn ON/OFF the device, but only the big one. When '_binarycing_' the state, the idle state is equal to 1/ON, so the problem is not the UI but the state. 

More problems arise derived from that. When exposing the HA `media_player` to `homebridge`, to control it with Siri, the equivalent switch is always on, so it's of no use. 
A few months ago, a new `homebridge` label was introduced to reflect the media players using the on_off state (`homebridge_media_player_switch: on_off`). That was the first piece needed for this little mod to work, and here I propose the second piece.

## Description:

This PR is _one-more-optional-configuration-parameter_ (sorry for that) for Kodi. A simple boolean (**`use_off_mode`**) to tell the Kodi component to use the off state even when it is present (because always is). 
The internals are solved with a flag that remembers the on_off state, and so, when turning off the media player, the reflected state will be off, instead of idle. When turning on or when Kodi starts doing anything, the state goes on (idle, playing or whatever). 

The config option and the internal flag are there to not make any change in existing Kodi configurations, so no breaking change of any type here. If you want the new behavior, just include `use_off_mode: true` in the config.

With this little mod I can **distinguish the idle state (between playings, for example) from the real off state of my media center**, and, with homebridge, totally control the TV from my watch (_Michael Knight style_), and make powerful automations, that I couldn't do with the actual behaviour.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml`:
I'm including here all pieces of, IMHO, the best Kodi configuration for an RPI3 running OSMC/OpenElec in a HomeKit scene:
- The homebridge custom label to work as on_off device
- The turn_on/off action scripts, based in the JSON-CEC Kodi addon to turn on and off the attached TV
- The new config parameter to activate the new behavior (`use_off_mode: true`)

```yaml
homeassistant:
  customize:
    media_player.kodi:
      homebridge_media_player_switch: on_off

media_player:
  - platform: kodi
    host: !secret kodi_host
    port: !secret kodi_port
    name: Kodi
    username: !secret kodi_user
    password: !secret kodi_pw
    enable_websocket: true
    use_off_mode: true
    turn_on_action:
    - service: media_player.kodi_call_method
      data:
        entity_id: media_player.kodi
        method: Addons.ExecuteAddon
        addonid: script.json-cec
        params:
          command: activate
    turn_off_action:
    - service: media_player.media_stop
      data:
        entity_id: media_player.kodi
    - service: media_player.kodi_call_method
      data:
        entity_id: media_player.kodi
        method: Addons.ExecuteAddon
        addonid: script.json-cec
        params:
          command: standby
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**