### PR TITLE
Add unit test for wake on lan component.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -611,7 +611,6 @@ omit =
     homeassistant/components/switch/tplink.py
     homeassistant/components/switch/telnet.py
     homeassistant/components/switch/transmission.py
-    homeassistant/components/switch/wake_on_lan.py
     homeassistant/components/switch/xiaomi_miio.py
     homeassistant/components/telegram_bot/*
     homeassistant/components/thingspeak.py

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -164,6 +164,13 @@ statsd==3.2.1
 # homeassistant.components.camera.uvc
 uvcclient==0.10.1
 
+# homeassistant.components.wake_on_lan
+# homeassistant.components.media_player.panasonic_viera
+# homeassistant.components.media_player.samsungtv
+# homeassistant.components.media_player.webostv
+# homeassistant.components.switch.wake_on_lan
+wakeonlan==0.2.2
+
 # homeassistant.components.cloud
 warrant==0.5.0
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -81,7 +81,8 @@ TEST_REQUIREMENTS = (
     'uvcclient',
     'warrant',
     'yahoo-finance',
-    'pythonwhois'
+    'pythonwhois',
+    'wakeonlan'
 )
 
 IGNORE_PACKAGES = (

--- a/tests/components/switch/test_wake_on_lan.py
+++ b/tests/components/switch/test_wake_on_lan.py
@@ -1,0 +1,195 @@
+"""The tests for the wake on lan switch platform."""
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from homeassistant.setup import setup_component
+from homeassistant.const import STATE_ON, STATE_OFF
+import homeassistant.components.switch as switch
+#import homeassistant.components.switch.wake_on_lan as wake_on_lan
+
+from tests.common import get_test_home_assistant
+
+
+TEST_STATE = None
+
+
+def send_magic_packet(*macs, **kwargs):
+    """Fake call for sending magic packets."""
+    print("send_magic_packet", macs)
+    return
+
+
+def call(cmd, stdout, stderr):
+    """Return fake subprocess return codes."""
+    print("call(", cmd[5], ")")
+    if cmd[5] == 'validhostname' and TEST_STATE:
+        print("call_ok", TEST_STATE)
+        return 0
+    print("call_nook", TEST_STATE)
+    return 2
+
+
+def system():
+    """Fake system call to test the windows platform."""
+    return 'Windows'
+
+
+class TestWOLSwitch(unittest.TestCase):
+    """Test the wol switch."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @patch('wakeonlan.wol.send_magic_packet', new=send_magic_packet)
+    @patch('subprocess.call', new=call)
+    def test_valid_hostname(self):
+        """Test with valid hostname."""
+        global TEST_STATE
+        TEST_STATE = False
+        self.assertTrue(setup_component(self.hass, switch.DOMAIN, {
+            'switch': {
+                'platform': 'wake_on_lan',
+                'mac_address': '00-01-02-03-04-05',
+                'host': 'validhostname',
+            }
+        }))
+
+        state = self.hass.states.get('switch.wake_on_lan')
+        self.assertEqual(STATE_OFF, state.state)
+        
+        TEST_STATE = True
+
+        switch.turn_on(self.hass, 'switch.wake_on_lan')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.wake_on_lan')
+        self.assertEqual(STATE_ON, state.state)
+
+        switch.turn_off(self.hass, 'switch.wake_on_lan')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.wake_on_lan')
+        self.assertEqual(STATE_ON, state.state)
+
+    @patch('wakeonlan.wol.send_magic_packet', new=send_magic_packet)
+    @patch('subprocess.call', new=call)
+    @patch('platform.system', new=system)
+    def test_valid_hostname_windows(self):
+        """Test with valid hostname on windows."""
+        global TEST_STATE
+        TEST_STATE = False
+        self.assertTrue(setup_component(self.hass, switch.DOMAIN, {
+            'switch': {
+                'platform': 'wake_on_lan',
+                'mac_address': '00-01-02-03-04-05',
+                'host': 'validhostname',
+            }
+        }))
+
+        state = self.hass.states.get('switch.wake_on_lan')
+        self.assertEqual(STATE_OFF, state.state)
+        
+        TEST_STATE = True
+
+        switch.turn_on(self.hass, 'switch.wake_on_lan')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.wake_on_lan')
+        self.assertEqual(STATE_ON, state.state)
+
+    @patch('wakeonlan.wol.send_magic_packet', new=send_magic_packet)
+    def test_minimal_config(self):
+        """Test with minimal config."""
+        self.assertTrue(setup_component(self.hass, switch.DOMAIN, {
+            'switch': {
+                'platform': 'wake_on_lan',
+                'mac_address': '00-01-02-03-04-05',
+            }
+        }))
+
+    @patch('wakeonlan.wol.send_magic_packet', new=send_magic_packet)
+    @patch('subprocess.call', new=call)
+    def test_broadcast_config(self):
+        """Test with broadcast address config."""
+        self.assertTrue(setup_component(self.hass, switch.DOMAIN, {
+            'switch': {
+                'platform': 'wake_on_lan',
+                'mac_address': '00-01-02-03-04-05',
+                'broadcast_address': '255.255.255.255',
+            }
+        }))
+
+        state = self.hass.states.get('switch.wake_on_lan')
+        self.assertEqual(STATE_OFF, state.state)
+
+        switch.turn_on(self.hass, 'switch.wake_on_lan')
+        self.hass.block_till_done()
+
+    @patch('wakeonlan.wol.send_magic_packet', new=send_magic_packet)
+    @patch('subprocess.call', new=call)
+    def test_off_script(self):
+        """Test with turn off script."""
+        global TEST_STATE
+        TEST_STATE = False
+        self.assertTrue(setup_component(self.hass, switch.DOMAIN, {
+            'switch': {
+                'platform': 'wake_on_lan',
+                'mac_address': '00-01-02-03-04-05',
+                'host': 'validhostname',
+                'turn_off': {
+                    'service': 'shell_command.turn_off_TARGET',
+                },
+            }
+        }))
+
+        state = self.hass.states.get('switch.wake_on_lan')
+        self.assertEqual(STATE_OFF, state.state)
+        
+        TEST_STATE = True
+
+        switch.turn_on(self.hass, 'switch.wake_on_lan')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.wake_on_lan')
+        self.assertEqual(STATE_ON, state.state)
+        
+        TEST_STATE = False
+
+        switch.turn_off(self.hass, 'switch.wake_on_lan')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.wake_on_lan')
+        self.assertEqual(STATE_OFF, state.state)
+
+    @patch('wakeonlan.wol.send_magic_packet', new=send_magic_packet)
+    @patch('subprocess.call', new=call)
+    @patch('platform.system', new=system)
+    def test_invalid_hostname_windows(self):
+        """Test with invalid hostname on windows."""
+        global TEST_STATE
+        TEST_STATE = False
+        self.assertTrue(setup_component(self.hass, switch.DOMAIN, {
+            'switch': {
+                'platform': 'wake_on_lan',
+                'mac_address': '00-01-02-03-04-05',
+                'host': 'invalidhostname',
+            }
+        }))
+
+        state = self.hass.states.get('switch.wake_on_lan')
+        self.assertEqual(STATE_OFF, state.state)
+        
+        TEST_STATE = True
+
+        switch.turn_on(self.hass, 'switch.wake_on_lan')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.wake_on_lan')
+        self.assertEqual(STATE_OFF, state.state)

--- a/tests/components/switch/test_wake_on_lan.py
+++ b/tests/components/switch/test_wake_on_lan.py
@@ -56,7 +56,7 @@ class TestWOLSwitch(unittest.TestCase):
 
         state = self.hass.states.get('switch.wake_on_lan')
         self.assertEqual(STATE_OFF, state.state)
-        
+
         TEST_STATE = True
 
         switch.turn_on(self.hass, 'switch.wake_on_lan')
@@ -88,7 +88,7 @@ class TestWOLSwitch(unittest.TestCase):
 
         state = self.hass.states.get('switch.wake_on_lan')
         self.assertEqual(STATE_OFF, state.state)
-        
+
         TEST_STATE = True
 
         switch.turn_on(self.hass, 'switch.wake_on_lan')
@@ -144,7 +144,7 @@ class TestWOLSwitch(unittest.TestCase):
 
         state = self.hass.states.get('switch.wake_on_lan')
         self.assertEqual(STATE_OFF, state.state)
-        
+
         TEST_STATE = True
 
         switch.turn_on(self.hass, 'switch.wake_on_lan')
@@ -152,7 +152,7 @@ class TestWOLSwitch(unittest.TestCase):
 
         state = self.hass.states.get('switch.wake_on_lan')
         self.assertEqual(STATE_ON, state.state)
-        
+
         TEST_STATE = False
 
         switch.turn_off(self.hass, 'switch.wake_on_lan')
@@ -178,7 +178,7 @@ class TestWOLSwitch(unittest.TestCase):
 
         state = self.hass.states.get('switch.wake_on_lan')
         self.assertEqual(STATE_OFF, state.state)
-        
+
         TEST_STATE = True
 
         switch.turn_on(self.hass, 'switch.wake_on_lan')

--- a/tests/components/switch/test_wake_on_lan.py
+++ b/tests/components/switch/test_wake_on_lan.py
@@ -1,13 +1,10 @@
 """The tests for the wake on lan switch platform."""
-import json
-import os
 import unittest
 from unittest.mock import patch
 
 from homeassistant.setup import setup_component
 from homeassistant.const import STATE_ON, STATE_OFF
 import homeassistant.components.switch as switch
-#import homeassistant.components.switch.wake_on_lan as wake_on_lan
 
 from tests.common import get_test_home_assistant
 
@@ -17,17 +14,13 @@ TEST_STATE = None
 
 def send_magic_packet(*macs, **kwargs):
     """Fake call for sending magic packets."""
-    print("send_magic_packet", macs)
     return
 
 
 def call(cmd, stdout, stderr):
     """Return fake subprocess return codes."""
-    print("call(", cmd[5], ")")
     if cmd[5] == 'validhostname' and TEST_STATE:
-        print("call_ok", TEST_STATE)
         return 0
-    print("call_nook", TEST_STATE)
     return 2
 
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
