### PR TITLE
Change introduction card to use persistent notification

### DIFF
--- a/homeassistant/components/introduction.py
+++ b/homeassistant/components/introduction.py
@@ -4,6 +4,7 @@ Component that will help guide the user taking its first steps.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/introduction/
 """
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -15,7 +16,8 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-def setup(hass, config=None):
+@asyncio.coroutine
+def async_setup(hass, config=None):
     """Set up the introduction component."""
     log = logging.getLogger(__name__)
     log.info("""
@@ -45,5 +47,16 @@ def setup(hass, config=None):
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     """)
+
+    hass.components.persistent_notification.async_create("""
+Here are some resources to get started:
+
+ - [Configuring Home Assistant](https://home-assistant.io/getting-started/configuration/)
+ - [Available components](https://home-assistant.io/components/)
+ - [Troubleshooting your configuration](https://home-assistant.io/docs/configuration/troubleshooting/)
+ - [Getting help](https://home-assistant.io/help/)
+
+To not see this card popup in the future, edit your config in `configuration.yaml` and disable the `introduction` component.
+""", 'Welcome Home!')
 
     return True

--- a/homeassistant/components/introduction.py
+++ b/homeassistant/components/introduction.py
@@ -56,7 +56,8 @@ Here are some resources to get started:
  - [Troubleshooting your configuration](https://home-assistant.io/docs/configuration/troubleshooting/)
  - [Getting help](https://home-assistant.io/help/)
 
-To not see this card popup in the future, edit your config in `configuration.yaml` and disable the `introduction` component.
-""", 'Welcome Home!')
+To not see this card popup in the future, edit your config in
+`configuration.yaml` and disable the `introduction` component.
+""", 'Welcome Home!')  # noqa
 
     return True


### PR DESCRIPTION
## Description:
This makes the introduction component (part of the default config) create a persistent notification instead of relying on special treatment in the frontend.

![image](https://user-images.githubusercontent.com/1444314/32262315-308123a6-be91-11e7-8df5-e555b2dcae6b.png)
Old & New

Polymer PR: https://github.com/home-assistant/home-assistant-polymer/pull/543