### PR TITLE
Remove http.development

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -76,7 +76,6 @@ def setup(hass, yaml_config):
 
     server = HomeAssistantWSGI(
         hass,
-        development=False,
         server_host=config.host_ip_addr,
         server_port=config.listen_port,
         api_password=None,

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -210,7 +210,10 @@ class ExternalPanel(AbstractPanel):
             URL_PANEL_COMPONENT_FP.format(self.component_name, self.md5)
 
         if self.component_name not in self.REGISTERED_COMPONENTS:
-            hass.http.register_static_path(self.webcomponent_url, self.path)
+            hass.http.register_static_path(
+                self.webcomponent_url, self.path,
+                # if path is None, we're in prod mode, so cache static assets
+                frontend_repository_path is None)
             self.REGISTERED_COMPONENTS.add(self.component_name)
 
 
@@ -272,10 +275,11 @@ def async_setup(hass, config):
     is_dev = repo_path is not None
 
     if is_dev:
-        hass.http.register_static_path("/home-assistant-polymer", repo_path)
+        hass.http.register_static_path(
+            "/home-assistant-polymer", repo_path, False)
         hass.http.register_static_path(
             "/static/translations",
-            os.path.join(repo_path, "build/translations"))
+            os.path.join(repo_path, "build/translations"), False)
         sw_path = os.path.join(repo_path, "build/service_worker.js")
         static_path = os.path.join(repo_path, 'hass_frontend')
     else:
@@ -285,13 +289,13 @@ def async_setup(hass, config):
         static_path = frontend_path
 
     hass.http.register_static_path("/service_worker.js", sw_path, False)
-    hass.http.register_static_path("/robots.txt",
-                                   os.path.join(static_path, "robots.txt"))
-    hass.http.register_static_path("/static", static_path)
+    hass.http.register_static_path(
+        "/robots.txt", os.path.join(static_path, "robots.txt"), not is_dev)
+    hass.http.register_static_path("/static", static_path, not is_dev)
 
     local = hass.config.path('www')
     if os.path.isdir(local):
-        hass.http.register_static_path("/local", local)
+        hass.http.register_static_path("/local", local, not is_dev)
 
     index_view = IndexView(is_dev)
     hass.http.register_view(index_view)

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -43,7 +43,6 @@ CONF_API_PASSWORD = 'api_password'
 CONF_SERVER_HOST = 'server_host'
 CONF_SERVER_PORT = 'server_port'
 CONF_BASE_URL = 'base_url'
-CONF_DEVELOPMENT = 'development'
 CONF_SSL_CERTIFICATE = 'ssl_certificate'
 CONF_SSL_KEY = 'ssl_key'
 CONF_CORS_ORIGINS = 'cors_allowed_origins'
@@ -84,7 +83,6 @@ HTTP_SCHEMA = vol.Schema({
     vol.Optional(CONF_SERVER_HOST, default=DEFAULT_SERVER_HOST): cv.string,
     vol.Optional(CONF_SERVER_PORT, default=SERVER_PORT): cv.port,
     vol.Optional(CONF_BASE_URL): cv.string,
-    vol.Optional(CONF_DEVELOPMENT, default=DEFAULT_DEVELOPMENT): cv.string,
     vol.Optional(CONF_SSL_CERTIFICATE, default=None): cv.isfile,
     vol.Optional(CONF_SSL_KEY, default=None): cv.isfile,
     vol.Optional(CONF_CORS_ORIGINS, default=[]):
@@ -113,7 +111,6 @@ def async_setup(hass, config):
     api_password = conf[CONF_API_PASSWORD]
     server_host = conf[CONF_SERVER_HOST]
     server_port = conf[CONF_SERVER_PORT]
-    development = conf[CONF_DEVELOPMENT] == '1'
     ssl_certificate = conf[CONF_SSL_CERTIFICATE]
     ssl_key = conf[CONF_SSL_KEY]
     cors_origins = conf[CONF_CORS_ORIGINS]
@@ -128,7 +125,6 @@ def async_setup(hass, config):
 
     server = HomeAssistantWSGI(
         hass,
-        development=development,
         server_host=server_host,
         server_port=server_port,
         api_password=api_password,
@@ -176,7 +172,7 @@ def async_setup(hass, config):
 class HomeAssistantWSGI(object):
     """WSGI server for Home Assistant."""
 
-    def __init__(self, hass, development, api_password, ssl_certificate,
+    def __init__(self, hass, api_password, ssl_certificate,
                  ssl_key, server_host, server_port, cors_origins,
                  use_x_forwarded_for, trusted_networks,
                  login_threshold, is_ban_enabled):
@@ -194,10 +190,8 @@ class HomeAssistantWSGI(object):
         self.app[KEY_TRUSTED_NETWORKS] = trusted_networks
         self.app[KEY_BANS_ENABLED] = is_ban_enabled
         self.app[KEY_LOGIN_THRESHOLD] = login_threshold
-        self.app[KEY_DEVELOPMENT] = development
 
         self.hass = hass
-        self.development = development
         self.api_password = api_password
         self.ssl_certificate = ssl_certificate
         self.ssl_key = ssl_key

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -28,9 +28,8 @@ from homeassistant.util.logging import HideSensitiveDataFilter
 from .auth import auth_middleware
 from .ban import ban_middleware
 from .const import (
-    KEY_USE_X_FORWARDED_FOR, KEY_TRUSTED_NETWORKS,
-    KEY_BANS_ENABLED, KEY_LOGIN_THRESHOLD,
-    KEY_DEVELOPMENT, KEY_AUTHENTICATED)
+    KEY_USE_X_FORWARDED_FOR, KEY_TRUSTED_NETWORKS, KEY_BANS_ENABLED,
+    KEY_LOGIN_THRESHOLD, KEY_AUTHENTICATED)
 from .static import (
     staticresource_middleware, CachingFileResponse, CachingStaticResource)
 from .util import get_real_ip

--- a/homeassistant/components/http/const.py
+++ b/homeassistant/components/http/const.py
@@ -7,6 +7,5 @@ KEY_BANS_ENABLED = 'ha_bans_enabled'
 KEY_BANNED_IPS = 'ha_banned_ips'
 KEY_FAILED_LOGIN_ATTEMPTS = 'ha_failed_login_attempts'
 KEY_LOGIN_THRESHOLD = 'ha_login_threshold'
-KEY_DEVELOPMENT = 'ha_development'
 
 HTTP_HEADER_X_FORWARDED_FOR = 'X-Forwarded-For'

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -8,8 +8,6 @@ from aiohttp.web_exceptions import HTTPNotFound
 from aiohttp.web_urldispatcher import StaticResource
 from yarl import unquote
 
-from .const import KEY_DEVELOPMENT
-
 _FINGERPRINT = re.compile(r'^(.+)-[a-z0-9]{32}\.(\w+)$', re.IGNORECASE)
 
 
@@ -53,10 +51,9 @@ class CachingFileResponse(FileResponse):
         @asyncio.coroutine
         def sendfile(request, fobj, count):
             """Sendfile that includes a cache header."""
-            if not request.app[KEY_DEVELOPMENT]:
-                cache_time = 31 * 86400  # = 1 month
-                self.headers[hdrs.CACHE_CONTROL] = "public, max-age={}".format(
-                    cache_time)
+            cache_time = 31 * 86400  # = 1 month
+            self.headers[hdrs.CACHE_CONTROL] = "public, max-age={}".format(
+                cache_time)
 
             yield from orig_sendfile(request, fobj, count)
 

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -22,9 +22,9 @@ BASE_CONFIG = (
 
 
 def change_yaml_files(check_dict):
-    """Change the ['yaml_files'] property and remove the config path.
+    """Change the ['yaml_files'] property and remove the configuration path.
 
-    Also removes other files like service.yaml that gets loaded
+    Also removes other files like service.yaml that gets loaded.
     """
     root = get_test_config_dir()
     keys = check_dict['yaml_files'].keys()
@@ -178,7 +178,6 @@ class TestCheckConfig(unittest.TestCase):
             self.assertDictEqual({
                 'components': {'http': {'api_password': 'abc123',
                                         'cors_allowed_origins': [],
-                                        'development': '0',
                                         'ip_ban_enabled': True,
                                         'login_attempts_threshold': -1,
                                         'server_host': '0.0.0.0',


### PR DESCRIPTION
## Description:
HTTP development mode was once added for frontend development. This is no longer needed as frontend now has it's own development mode.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3856
