### PR TITLE
Add setup platform tests for the season sensor component.

### DIFF
--- a/tests/components/sensor/test_season.py
+++ b/tests/components/sensor/test_season.py
@@ -3,9 +3,37 @@
 import unittest
 from datetime import datetime
 
+from homeassistant.setup import setup_component
 import homeassistant.components.sensor.season as season
 
 from tests.common import get_test_home_assistant
+
+
+HEMISPHERE_NORTHERN = {
+    'homeassistant': {
+        'latitude': '48.864716',
+        'longitude': '2.349014',
+    }
+}
+
+HEMISPHERE_SOUTHERN = {
+    'homeassistant': {
+        'latitude': '-33.918861',
+        'longitude': '18.423300',
+    }
+}
+
+HEMISPHERE_EQUATOR = {
+    'homeassistant': {
+        'latitude': '0',
+        'longitude': '-51.065100',
+    }
+}
+
+HEMISPHERE_EMPTY = {
+    'homeassistant': {
+    }
+}
 
 
 # pylint: disable=invalid-name
@@ -181,3 +209,10 @@ class TestSeason(unittest.TestCase):
                                            season.EQUATOR,
                                            season.TYPE_ASTRONOMICAL)
         self.assertEqual(None, current_season)
+
+    def test_setup_hemisphere(self):
+        """Test platform setup of different hemispheres."""
+        assert setup_component(self.hass, 'sensor', HEMISPHERE_NORTHERN)
+        assert setup_component(self.hass, 'sensor', HEMISPHERE_SOUTHERN)
+        assert setup_component(self.hass, 'sensor', HEMISPHERE_EQUATOR)
+        assert setup_component(self.hass, 'sensor', HEMISPHERE_EMPTY)


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
