### PR TITLE
Cleanup async stuff on templates

### DIFF
--- a/homeassistant/components/cover/template.py
+++ b/homeassistant/components/cover/template.py
@@ -301,7 +301,7 @@ class CoverTemplate(CoverDevice):
     def async_stop_cover(self, **kwargs):
         """Fire the stop action."""
         if self._stop_script:
-            self.hass.async_add_job(self._stop_script.async_run())
+            yield from self._stop_script.async_run()
 
     @asyncio.coroutine
     def async_set_cover_position(self, **kwargs):

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -152,13 +152,15 @@ class SwitchTemplate(SwitchDevice):
         """Return the entity_picture to use in the frontend, if any."""
         return self._entity_picture
 
-    def turn_on(self, **kwargs):
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
         """Fire the on action."""
-        self._on_script.run()
+        yield from self._on_script.async_run()
 
-    def turn_off(self, **kwargs):
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
         """Fire the off action."""
-        self._off_script.run()
+        yield from self._off_script.async_run()
 
     @asyncio.coroutine
     def async_update(self):


### PR DESCRIPTION
## Description:
If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
