### PR TITLE
GooglePlus profile image support

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -382,7 +382,7 @@ class Device(Entity):
 
     def __init__(self, hass: HomeAssistantType, consider_home: timedelta,
                  track: bool, dev_id: str, mac: str, name: str=None,
-                 picture: str=None, gravatar: str=None, icon: str=None,
+                 picture: str=None, gravatar: str=None, googleplus: str=None, icon: str=None,
                  hide_if_away: bool=False, vendor: str=None) -> None:
         """Initialize a device."""
         self.hass = hass
@@ -406,7 +406,11 @@ class Device(Entity):
         if gravatar is not None:
             self.config_picture = get_gravatar_for_email(gravatar)
         else:
-            self.config_picture = picture
+            # Attempt to use googleplus but revert to picture if it fails
+            if googleplus is not None:
+                googlepluspthumb = get_googlepluspthumb_from_email(googleplus)
+            if googlepluspthumb is None:
+                self.config_picture = picture
 
         self.icon = icon
 
@@ -640,6 +644,7 @@ def async_load_config(path: str, hass: HomeAssistantType,
             vol.Any(None, vol.All(cv.string, vol.Upper)),
         vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
         vol.Optional('gravatar', default=None): vol.Any(None, cv.string),
+        vol.Optional('googleplus', default=None): vol.Any(None, cv.string),
         vol.Optional('picture', default=None): vol.Any(None, cv.string),
         vol.Optional(CONF_CONSIDER_HOME, default=consider_home): vol.All(
             cv.time_period, cv.positive_timedelta),
@@ -744,3 +749,25 @@ def get_gravatar_for_email(email: str):
     import hashlib
     url = 'https://www.gravatar.com/avatar/{}.jpg?s=80&d=wavatar'
     return url.format(hashlib.md5(email.encode('utf-8').lower()).hexdigest())
+
+
+def get_googlepluspthumb_from_email(email: str):
+    """Return a thumbnail image of a user's google plus profile image"""
+    import urllib.request, urllib.parse
+    import re
+    
+    url = r'https://picasaweb.google.com/data/entry/api/user/'
+    url += urllib.parse.quote(email) + '?alt=json'
+    
+    print(url)
+    try:
+        jsontext = urllib.request.urlopen(url).read().decode('utf-8')
+    except:
+        print('"' + url + '" timeout or invalid email')
+        return None
+
+    thumbnail_pattern = r'gphoto\$thumbnail\"\:\{\"\$t\"\:\"([^\"]*?)\"'
+    thumbnail_url = re.search(thumbnail_pattern, jsontext).group(1)
+    if thumbnail_url == '':
+        return None
+    return thumbnail_url

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -193,6 +193,65 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                         "55502f40dc8b7c769880b10874abc9d0.jpg?s=80&d=wavatar")
         self.assertEqual(device.config_picture, gravatar_url)
 
+    def test_googleplus(self):
+        """Test the googleplus thumbnail generation."""
+		import re
+        dev_id = 'test'
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', googleplus='john@gmail.com')
+        googleplus_url_pattern = (r'https?\:\/\/[^\.\"]*?'
+                                  r'googleusercontent\.com\/[^\.\"]*?jpg')
+        self.assertNotEqual(re.search(googleplus_url_pattern,
+                                      device.config_picture), None)
+
+        """Test that googleplus returns empty
+        when a non-google or invalid account is used.
+        """
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', googleplus='test@example.com')
+        self.assertEqual(device.config_picture, None)
+
+    def test_googleplus_and_picture(self):
+        """Test the that GooglePlus overrides picture."""
+        dev_id = 'test'
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
+            googleplus='john@gmail.com')
+        googleplus_url_pattern = (r'https?\:\/\/[^\.\"]*?'
+                                  r'googleusercontent\.com\/[^\.\"]*?jpg')
+        self.assertNotEqual(re.search(googleplus_url_pattern,
+                                      device.config_picture), None)
+
+        """Test the that picture overrides googleplus when a non-google or invalid account is used."""
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
+            googleplus='test@example.com')
+        self.assertEqual(device.config_picture, 'http://test.picture')
+
+    def test_gravatar_googleplus_and_picture(self):
+        """Test the that googleplus overrides picture and gravatar"""
+        dev_id = 'test'
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
+            gravatar='test@example.com',
+            googleplus='john@gmail.com')
+        gravatar_url = ("https://www.gravatar.com/avatar/"
+                        "55502f40dc8b7c769880b10874abc9d0.jpg?s=80&d=wavatar")
+        self.assertEqual(device.config_picture, gravatar_url)
+
+        """Test the that gravatar overrides googleplus even when a non-google or invalid account is used."""
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
+            gravatar='test@example.com',
+            googleplus='test@example.com')
+        self.assertEqual(device.config_picture, gravatar_url)
+
     def test_mac_vendor_lookup(self):
         """Test if vendor string is lookup on macvendors API."""
         mac = 'B8:27:EB:00:00:00'


### PR DESCRIPTION
## Description:
adding support for getting a googleplus thumbnail image from their email. This is very similar to the existing gravitar support but can
fail if a non-google account or invalid email is used.
it currently prioritizes gravitar over googleplus over picture

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
