### PR TITLE
upgrade to new pylutron_caseta with TLS

### DIFF
--- a/homeassistant/components/cover/lutron_caseta.py
+++ b/homeassistant/components/cover/lutron_caseta.py
@@ -4,6 +4,7 @@ Support for Lutron Caseta shades.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.lutron_caseta/
 """
+import asyncio
 import logging
 
 from homeassistant.components.cover import (
@@ -18,7 +19,8 @@ DEPENDENCIES = ['lutron_caseta']
 
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Lutron Caseta shades as a cover device."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
@@ -48,21 +50,25 @@ class LutronCasetaCover(LutronCasetaDevice, CoverDevice):
         """Return the current position of cover."""
         return self._state['current_state']
 
-    def close_cover(self, **kwargs):
+    @asyncio.coroutine
+    def async_close_cover(self, **kwargs):
         """Close the cover."""
         self._smartbridge.set_value(self._device_id, 0)
 
-    def open_cover(self, **kwargs):
+    @asyncio.coroutine
+    def async_open_cover(self, **kwargs):
         """Open the cover."""
         self._smartbridge.set_value(self._device_id, 100)
 
-    def set_cover_position(self, **kwargs):
+    @asyncio.coroutine
+    def async_set_cover_position(self, **kwargs):
         """Move the shade to a specific position."""
         if ATTR_POSITION in kwargs:
             position = kwargs[ATTR_POSITION]
             self._smartbridge.set_value(self._device_id, position)
 
-    def update(self):
+    @asyncio.coroutine
+    def async_update(self):
         """Call when forcing a refresh of the device."""
         self._state = self._smartbridge.get_device_by_id(self._device_id)
         _LOGGER.debug(self._state)

--- a/homeassistant/components/cover/lutron_caseta.py
+++ b/homeassistant/components/cover/lutron_caseta.py
@@ -20,7 +20,7 @@ DEPENDENCIES = ['lutron_caseta']
 
 # pylint: disable=unused-argument
 @asyncio.coroutine
-def async_setup_platform(hass, config, add_devices, discovery_info=None):
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Lutron Caseta shades as a cover device."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
@@ -29,7 +29,7 @@ def async_setup_platform(hass, config, add_devices, discovery_info=None):
         dev = LutronCasetaCover(cover_device, bridge)
         devs.append(dev)
 
-    add_devices(devs, True)
+    async_add_devices(devs, True)
 
 
 class LutronCasetaCover(LutronCasetaDevice, CoverDevice):

--- a/homeassistant/components/light/lutron_caseta.py
+++ b/homeassistant/components/light/lutron_caseta.py
@@ -4,6 +4,7 @@ Support for Lutron Caseta lights.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.lutron_caseta/
 """
+import asyncio
 import logging
 
 from homeassistant.components.light import (
@@ -19,7 +20,8 @@ DEPENDENCIES = ['lutron_caseta']
 
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Lutron Caseta lights."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
@@ -44,7 +46,8 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
         """Return the brightness of the light."""
         return to_hass_level(self._state["current_state"])
 
-    def turn_on(self, **kwargs):
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
         """Turn the light on."""
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
@@ -53,7 +56,8 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
         self._smartbridge.set_value(self._device_id,
                                     to_lutron_level(brightness))
 
-    def turn_off(self, **kwargs):
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
         """Turn the light off."""
         self._smartbridge.set_value(self._device_id, 0)
 
@@ -62,7 +66,8 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
         """Return true if device is on."""
         return self._state["current_state"] > 0
 
-    def update(self):
+    @asyncio.coroutine
+    def async_update(self):
         """Call when forcing a refresh of the device."""
         self._state = self._smartbridge.get_device_by_id(self._device_id)
         _LOGGER.debug(self._state)

--- a/homeassistant/components/light/lutron_caseta.py
+++ b/homeassistant/components/light/lutron_caseta.py
@@ -21,7 +21,7 @@ DEPENDENCIES = ['lutron_caseta']
 
 # pylint: disable=unused-argument
 @asyncio.coroutine
-def async_setup_platform(hass, config, add_devices, discovery_info=None):
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Lutron Caseta lights."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
@@ -30,7 +30,7 @@ def async_setup_platform(hass, config, add_devices, discovery_info=None):
         dev = LutronCasetaLight(light_device, bridge)
         devs.append(dev)
 
-    add_devices(devs, True)
+    async_add_devices(devs, True)
 
 
 class LutronCasetaLight(LutronCasetaDevice, Light):

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -63,7 +63,8 @@ def async_setup(hass, base_config):
     _LOGGER.info("Connected to Lutron smartbridge at %s", config[CONF_HOST])
 
     for component in LUTRON_CASETA_COMPONENTS:
-        discovery.load_platform(hass, component, DOMAIN, {}, config)
+        hass.async_add_job(discovery.async_load_platform(hass, component,
+                                                         DOMAIN, {}, config))
 
     return True
 
@@ -87,13 +88,8 @@ class LutronCasetaDevice(Entity):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Register callbacks."""
-        self.hass.async_add_job(
-            self._smartbridge.add_subscriber, self._device_id,
-            self._update_callback
-        )
-
-    def _update_callback(self):
-        self.schedule_update_ha_state()
+        self._smartbridge.add_subscriber(self._device_id,
+                                         self.async_schedule_update_ha_state)
 
     @property
     def name(self):

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -22,9 +22,9 @@ LUTRON_CASETA_SMARTBRIDGE = 'lutron_smartbridge'
 
 DOMAIN = 'lutron_caseta'
 
-CONF_KEYFILE = 'key'
-CONF_CERTFILE = 'cert'
-CONF_CA_CERTS = 'ca'
+CONF_KEYFILE = 'keyfile'
+CONF_CERTFILE = 'certfile'
+CONF_CA_CERTS = 'ca_certs'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/scene/lutron_caseta.py
+++ b/homeassistant/components/scene/lutron_caseta.py
@@ -16,7 +16,7 @@ DEPENDENCIES = ['lutron_caseta']
 
 
 @asyncio.coroutine
-def async_setup_platform(hass, config, add_devices, discovery_info=None):
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Lutron Caseta lights."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
@@ -25,7 +25,7 @@ def async_setup_platform(hass, config, add_devices, discovery_info=None):
         dev = LutronCasetaScene(scenes[scene], bridge)
         devs.append(dev)
 
-    add_devices(devs, True)
+    async_add_devices(devs, True)
 
 
 class LutronCasetaScene(Scene):

--- a/homeassistant/components/scene/lutron_caseta.py
+++ b/homeassistant/components/scene/lutron_caseta.py
@@ -4,6 +4,7 @@ Support for Lutron Caseta scenes.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/scene.lutron_caseta/
 """
+import asyncio
 import logging
 
 from homeassistant.components.scene import Scene
@@ -14,7 +15,8 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['lutron_caseta']
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Lutron Caseta lights."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
@@ -50,6 +52,7 @@ class LutronCasetaScene(Scene):
         """There is no way of detecting if a scene is active (yet)."""
         return False
 
-    def activate(self, **kwargs):
+    @asyncio.coroutine
+    def async_activate(self, **kwargs):
         """Activate the scene."""
         self._bridge.activate_scene(self._scene_id)

--- a/homeassistant/components/switch/lutron_caseta.py
+++ b/homeassistant/components/switch/lutron_caseta.py
@@ -18,7 +18,7 @@ DEPENDENCIES = ['lutron_caseta']
 
 # pylint: disable=unused-argument
 @asyncio.coroutine
-def async_setup_platform(hass, config, add_devices, discovery_info=None):
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up Lutron switch."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
@@ -28,7 +28,7 @@ def async_setup_platform(hass, config, add_devices, discovery_info=None):
         dev = LutronCasetaLight(switch_device, bridge)
         devs.append(dev)
 
-    add_devices(devs, True)
+    async_add_devices(devs, True)
     return True
 
 

--- a/homeassistant/components/switch/lutron_caseta.py
+++ b/homeassistant/components/switch/lutron_caseta.py
@@ -4,6 +4,7 @@ Support for Lutron Caseta switches.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sitch.lutron_caseta/
 """
+import asyncio
 import logging
 
 from homeassistant.components.lutron_caseta import (
@@ -16,7 +17,8 @@ DEPENDENCIES = ['lutron_caseta']
 
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Lutron switch."""
     devs = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
@@ -33,11 +35,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class LutronCasetaLight(LutronCasetaDevice, SwitchDevice):
     """Representation of a Lutron Caseta switch."""
 
-    def turn_on(self, **kwargs):
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
         """Turn the switch on."""
         self._smartbridge.turn_on(self._device_id)
 
-    def turn_off(self, **kwargs):
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
         """Turn the switch off."""
         self._smartbridge.turn_off(self._device_id)
 
@@ -46,7 +50,8 @@ class LutronCasetaLight(LutronCasetaDevice, SwitchDevice):
         """Return true if device is on."""
         return self._state["current_state"] > 0
 
-    def update(self):
+    @asyncio.coroutine
+    def async_update(self):
         """Update when forcing a refresh of the device."""
         self._state = self._smartbridge.get_device_by_id(self._device_id)
         _LOGGER.debug(self._state)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -709,7 +709,7 @@ pylitejet==0.1
 pyloopenergy==0.0.17
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.2.8
+pylutron-caseta==0.3.0
 
 # homeassistant.components.lutron
 pylutron==0.1.0


### PR DESCRIPTION
## Description:

Lutron released a firmware updated for the Caseta system which removed our ability to connect to and control the bridge device over SSH, breaking compatibility with pylutron_caseta and Home Assistant. This is an update to pull in the new version of pylutron_caseta with support for connecting over TLS. See gurumitts/pylutron-caseta#15 and gurumitts/pylutron-caseta#16.

This should all be non-blocking now. I'm not sure if I updated all the appropriate lutron_caseta.py files in Home Assistant to take advantage of that but it seems to work.

The documentation does need to be updated but I'm not sure how best to do it. The setup process is a bit rough because it involves doing an OAuth login, but your Home Assistant instance is not a valid callback URI so the user isn't going to be able to click a link in Home Assistant and sign in to generate the key. What I did to get my instance running was to run the script referenced from the top of gurumitts/pylutron-caseta#15, separately use openssl to retrieve the CA certificate from the bridge (the parent certificate returned from the script is for your certificate chain and is not the certificate of the bridge itself), and collect the parts into the appropriate files. I don't know if there is some precedent for handling this sort of thing. Should Home Assistant have a UI that opens the OAuth login in a new tab and tells the user to copy the URL of the error page at the end? I don't see a way individual Home Assistant users could easily sign up with Lutron as developers and get their own proper OAuth clients registered and I don't know of any easier way of getting client keys.

**Related issue (if applicable):**
fixes #9730, fixes #9374 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
home-assistant/home-assistant.github.io#3883

## Example entry for `configuration.yaml` (if applicable):
```yaml
lutron_caseta:
  host: 192.168.86.49
  keyfile: caseta.key
  certfile: caseta.crt
  ca_certs: caseta-bridge.crt
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
