### PR TITLE
Use states.last_updated to determine age of state

### DIFF
--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -111,8 +111,7 @@ class StatisticsSensor(Entity):
         try:
             self.states.append(float(new_state.state))
             if self._max_age is not None:
-                now = dt_util.utcnow()
-                self.ages.append(now)
+                self.ages.append(new_state.last_updated)
             self.count = self.count + 1
         except ValueError:
             self.count = self.count + 1


### PR DESCRIPTION
Previously, as each state was added to the list of state values for calculating the statistics the current UTC time was added to the corresponding `self.ages`, and this was used to determine if a value fell outside of `max_age`.

The limitation of this approach is as such: upon initialization, all historic state values that are loaded are given the current time and only values that are recorded since initialization get accurate times. Thus, if I'd like to monitor the statistics over the last 24 hours and I supply an arbitrarily large `sampling_size`, when I initialize the component all of the values (up to `n=sampling_size`) are included, not values for the last 24 hours. The component would have to be loaded for a full 24 hours before this would be the case.

Here, I use each state value's `last_changed` parameter to determine if it should be excluded based on the `max_age` parameter. I think this is a better representation of what the `max_age` parameter is meant to achieve.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
