### PR TITLE
Add option to overwrite file to the downloader component

### DIFF
--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -113,7 +113,7 @@ def setup(hass, config):
 
                     # If file exist append a number.
                     # We test filename, filename_2..
-                    if not overwrite:
+                    if overwrite is False:
                         tries = 1
                         final_path = path + ext
                         while os.path.isfile(final_path):

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -20,6 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_FILENAME = 'filename'
 ATTR_SUBDIR = 'subdir'
 ATTR_URL = 'url'
+ATTR_OVERWRITE = 'overwrite'
 
 CONF_DOWNLOAD_DIR = 'download_dir'
 
@@ -31,6 +32,7 @@ SERVICE_DOWNLOAD_FILE_SCHEMA = vol.Schema({
     vol.Required(ATTR_URL): cv.url,
     vol.Optional(ATTR_SUBDIR): cv.string,
     vol.Optional(ATTR_FILENAME): cv.string,
+    vol.Optional(ATTR_OVERWRITE, default=False): cv.boolean,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -65,6 +67,8 @@ def setup(hass, config):
                 subdir = service.data.get(ATTR_SUBDIR)
 
                 filename = service.data.get(ATTR_FILENAME)
+
+                overwrite = service.data.get(ATTR_OVERWRITE)
 
                 if subdir:
                     subdir = sanitize_filename(subdir)
@@ -109,14 +113,15 @@ def setup(hass, config):
 
                     # If file exist append a number.
                     # We test filename, filename_2..
-                    tries = 1
-                    final_path = path + ext
-                    while os.path.isfile(final_path):
-                        tries += 1
+                    if not overwrite:
+                        tries = 1
+                        final_path = path + ext
+                        while os.path.isfile(final_path):
+                            tries += 1
 
-                        final_path = "{}_{}.{}".format(path, tries, ext)
+                            final_path = "{}_{}.{}".format(path, tries, ext)
 
-                    _LOGGER.info("%s -> %s", url, final_path)
+                        _LOGGER.info("%s -> %s", url, final_path)
 
                     with open(final_path, 'wb') as fil:
                         for chunk in req.iter_content(1024):

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -113,7 +113,7 @@ def setup(hass, config):
 
                     # If file exist append a number.
                     # We test filename, filename_2..
-                    if overwrite is False:
+                    if not overwrite:
                         tries = 1
                         final_path = path + ext
                         while os.path.isfile(final_path):
@@ -121,7 +121,7 @@ def setup(hass, config):
 
                             final_path = "{}_{}.{}".format(path, tries, ext)
 
-                        _LOGGER.info("%s -> %s", url, final_path)
+                    _LOGGER.info("%s -> %s", url, final_path)
 
                     with open(final_path, 'wb') as fil:
                         for chunk in req.iter_content(1024):


### PR DESCRIPTION
## Description:
Added option to overwrite file to the `downloader` component. This is especially relevant when old files are not relevant and may take up precious space, e.g., recordings. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3876

## Example entry for `configuration.yaml` (if applicable):
```yaml
downloader:
  download_dir: downloads
```

`python_script` example used to test:
```yaml
# obtain ring doorbell camera object
# replace the camera.front_door by your camera entity
ring_cam = hass.states.get('camera.front_door')

subdir_name = 'ring_{}'.format(ring_cam.attributes.get('friendly_name'))

# get video URL
data = {
    'url': ring_cam.attributes.get('video_url'),
    'subdir': subdir_name,
    'overwrite': True,
    'filename': ring_cam.attributes.get('friendly_name')
}

# call downloader component to save the video
hass.services.call('downloader', 'download_file', data)
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**