### PR TITLE
Tradfri support new psk

### DIFF
--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -115,20 +115,14 @@ def async_setup(hass, config):
                                                     allow_tradfri_groups)
         else:
             hass.async_add_job(request_configuration, hass, config, host)
+            return True
 
     discovery.async_listen(hass, SERVICE_IKEA_TRADFRI, gateway_discovered)
 
-    if not host:
-        return True
+    if host:
+        yield from gateway_discovered(None, {'host': host})
 
-    if host and known_hosts.get(host):
-        return (yield from _setup_gateway(hass, config, host, 
-                                                        known_hosts[host]['identity'], 
-                                                        known_hosts[host]['token'],
-                                                        allow_tradfri_groups))
-    else:
-        hass.async_add_job(request_configuration, hass, config, host)
-        return True
+    return True
 
 
 @asyncio.coroutine

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import CONF_HOST
 from homeassistant.components.discovery import SERVICE_IKEA_TRADFRI
 
-REQUIREMENTS = ['pytradfri==4.0.0',
+REQUIREMENTS = ['pytradfri==4.0.1',
                 'DTLSSocket==0.1.4',
                 'https://github.com/chrysn/aiocoap/archive/'
                 '3286f48f0b949901c8b5c04c0719dc54ab63d431.zip'

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -62,7 +62,7 @@ def request_configuration(hass, config, host):
             _LOGGER.exception("Looks like something isn't installed!")
             return
 
-        api_factory = APIFactory(host)
+        api_factory = APIFactory(host, psk_id=GATEWAY_IDENTITY)
         psk = yield from api_factory.generate_psk(callback_data.get('key'))
         res = yield from _setup_gateway(hass, config, host, psk,
                                         DEFAULT_ALLOW_TRADFRI_GROUPS)

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
-from homeassistant.const import CONF_HOST, CONF_API_KEY
+from homeassistant.const import CONF_HOST
 from homeassistant.components.discovery import SERVICE_IKEA_TRADFRI
 
 REQUIREMENTS = ['pytradfri==4.0.0',
@@ -35,7 +35,6 @@ DEFAULT_ALLOW_TRADFRI_GROUPS = True
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Inclusive(CONF_HOST, 'gateway'): cv.string,
-        vol.Inclusive(CONF_API_KEY, 'gateway'): cv.string,
         vol.Optional(CONF_ALLOW_TRADFRI_GROUPS,
                      default=DEFAULT_ALLOW_TRADFRI_GROUPS): cv.boolean,
     })

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -16,14 +16,15 @@ from homeassistant.helpers import discovery
 from homeassistant.const import CONF_HOST, CONF_API_KEY
 from homeassistant.components.discovery import SERVICE_IKEA_TRADFRI
 
-REQUIREMENTS = ['pytradfri==3.0.2',
+REQUIREMENTS = ['pytradfri==4.0.0',
                 'DTLSSocket==0.1.4',
                 'https://github.com/chrysn/aiocoap/archive/'
                 '3286f48f0b949901c8b5c04c0719dc54ab63d431.zip'
                 '#aiocoap==0.3']
 
 DOMAIN = 'tradfri'
-CONFIG_FILE = 'tradfri.conf'
+GATEWAY_IDENTITY = 'homeassistant'
+CONFIG_FILE = 'tradfri_psk.conf'
 KEY_CONFIG = 'tradfri_configuring'
 KEY_GATEWAY = 'tradfri_gateway'
 KEY_API = 'tradfri_api'
@@ -56,9 +57,11 @@ def request_configuration(hass, config, host):
     @asyncio.coroutine
     def configuration_callback(callback_data):
         """Handle the submitted configuration."""
-        res = yield from _setup_gateway(hass, config, host,
-                                        callback_data.get('key'),
+        api_factory = APIFactory(host)
+        psk = yield from api_factory.generate_psk(callback_data.get('key'))
+        res = yield from _setup_gateway(hass, config, host, psk,
                                         DEFAULT_ALLOW_TRADFRI_GROUPS)
+
         if not res:
             hass.async_add_job(configurator.notify_errors, instance,
                                "Unable to connect.")
@@ -67,7 +70,7 @@ def request_configuration(hass, config, host):
         def success():
             """Set up was successful."""
             conf = _read_config(hass)
-            conf[host] = {'key': callback_data.get('key')}
+            conf[host] = {'key': psk}
             _write_config(hass, conf)
             hass.async_add_job(configurator.request_done, instance)
 
@@ -122,13 +125,15 @@ def _setup_gateway(hass, hass_config, host, key, allow_tradfri_groups):
         return False
 
     try:
-        api = yield from api_factory(host, key, loop=hass.loop)
+        factory = APIFactory(host, psk_id=GATEWAY_IDENTITY, psk=key,
+                             loop=hass.loop)
+        api = factory.request
+        gateway = Gateway()
+        gateway_info_result = yield from api(gateway.get_gateway_info())
     except RequestError:
         _LOGGER.exception("Tradfri setup failed.")
         return False
 
-    gateway = Gateway()
-    gateway_info_result = yield from api(gateway.get_gateway_info())
     gateway_id = gateway_info_result.id
     hass.data.setdefault(KEY_API, {})
     hass.data.setdefault(KEY_GATEWAY, {})

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -24,7 +24,7 @@ REQUIREMENTS = ['pytradfri==4.0.1',
 
 DOMAIN = 'tradfri'
 GATEWAY_IDENTITY = 'homeassistant'
-CONFIG_FILE = 'tradfri_psk.conf'
+CONFIG_FILE = '.tradfri_psk.conf'
 KEY_CONFIG = 'tradfri_configuring'
 KEY_GATEWAY = 'tradfri_gateway'
 KEY_API = 'tradfri_api'

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -56,6 +56,13 @@ def request_configuration(hass, config, host):
     @asyncio.coroutine
     def configuration_callback(callback_data):
         """Handle the submitted configuration."""
+        from pytradfri import Gateway
+        try:
+            from pytradfri.api.aiocoap_api import APIFactory
+        except ImportError:
+            _LOGGER.exception("Looks like something isn't installed!")
+            return
+
         api_factory = APIFactory(host)
         psk = yield from api_factory.generate_psk(callback_data.get('key'))
         res = yield from _setup_gateway(hass, config, host, psk,
@@ -118,7 +125,7 @@ def _setup_gateway(hass, hass_config, host, key, allow_tradfri_groups):
     """Create a gateway."""
     from pytradfri import Gateway, RequestError
     try:
-        from pytradfri.api.aiocoap_api import api_factory
+        from pytradfri.api.aiocoap_api import APIFactory
     except ImportError:
         _LOGGER.exception("Looks like something isn't installed!")
         return False

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -56,7 +56,6 @@ def request_configuration(hass, config, host):
     @asyncio.coroutine
     def configuration_callback(callback_data):
         """Handle the submitted configuration."""
-        from pytradfri import Gateway
         try:
             from pytradfri.api.aiocoap_api import APIFactory
         except ImportError:

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -95,7 +95,6 @@ def async_setup(hass, config):
     """Set up the Tradfri component."""
     conf = config.get(DOMAIN, {})
     host = conf.get(CONF_HOST)
-    key = conf.get(CONF_API_KEY)
     allow_tradfri_groups = conf.get(CONF_ALLOW_TRADFRI_GROUPS)
 
     @asyncio.coroutine

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -893,7 +893,7 @@ pythonwhois==2.4.3
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-pytradfri==4.0.0
+pytradfri==4.0.1
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -893,7 +893,7 @@ pythonwhois==2.4.3
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-pytradfri==3.0.2
+pytradfri==4.0.0
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13


### PR DESCRIPTION
I changes the new Tradfri support to use dynamic identity strings on every new config attempt.
(else the gateway has to be reset for when coupling to a new home-assistant install)

Also refactored some code.

see also https://community.home-assistant.io/t/tradfri-identity-shouldnt-be-hardcoded/31388