### PR TITLE
Allow an empty MAC address at the Xiaomi Aqara Gateway configuration

### DIFF
--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -49,7 +49,7 @@ SERVICE_SCHEMA_REMOVE_DEVICE = vol.Schema({
 
 
 GATEWAY_CONFIG = vol.Schema({
-    vol.Optional(CONF_MAC): GW_MAC,
+    vol.Optional(CONF_MAC, default=None): vol.Any(GW_MAC, None),
     vol.Optional(CONF_KEY, default=None):
         vol.All(cv.string, vol.Length(min=16, max=16)),
     vol.Optional(CONF_HOST): cv.string,


### PR DESCRIPTION
The "one gateway setup" (https://home-assistant.io/components/xiaomi_aqara/) is very common and the documentation suggests an empty value for the MAC address.

Fixes: Invalid config for [xiaomi_aqara]: string value is None for dictionary value @ data['xiaomi_aqara']['gateways'][0]['mac']. Got None. (See /home/homeassistant/.homeassistant/configuration.yaml, line 1559). Please check the docs at https://home-assistant.io/components/xiaomi_aqara/
