### PR TITLE
Random Identity for new Tradfri Gateway pairings.

### DIFF
--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -63,16 +63,16 @@ def request_configuration(hass, config, host):
             return
 
         # use an unique identity to pair with gateway on every config attempt
-        # using the same id would make it unable to pair with a 
+        # using the same id would make it unable to pair with a
         # new (or another) hass instance.
         identity = uuid.uuid4().hex
 
         try:
             api_factory = APIFactory(host, psk_id=identity)
             token = yield from api_factory.generate_psk(callback_data.get('key'))
-            res = yield from _setup_gateway(hass, config, host, 
+            res = yield from _setup_gateway(hass, config, host,
                                                           identity,
-                                                          token, 
+                                                          token,
                                                           DEFAULT_ALLOW_TRADFRI_GROUPS)
             if not res:
                 raise

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -24,17 +24,21 @@ REQUIREMENTS = ['pytradfri==4.0.1',
                 '#aiocoap==0.3']
 
 DOMAIN = 'tradfri'
-CONFIG_FILE = '.tradfri_identity.conf'
-KEY_CONFIG = 'tradfri_configuring'
+CONFIG_FILE = '.tradfri_identities.conf'
+KEY_CONFIGURING = 'tradfri_configuring'
 KEY_GATEWAY = 'tradfri_gateway'
 KEY_API = 'tradfri_api'
 KEY_TRADFRI_GROUPS = 'tradfri_allow_tradfri_groups'
 CONF_ALLOW_TRADFRI_GROUPS = 'allow_tradfri_groups'
 DEFAULT_ALLOW_TRADFRI_GROUPS = True
+CONF_HOSTNAME = 'custom_hostname'
+DEFAULT_HOSTNAME = 'my_Tradfri_gateway'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Inclusive(CONF_HOST, 'gateway'): cv.string,
+        vol.Optional(CONF_HOSTNAME,
+                     default=DEFAULT_HOSTNAME): cv.boolean,
         vol.Optional(CONF_ALLOW_TRADFRI_GROUPS,
                      default=DEFAULT_ALLOW_TRADFRI_GROUPS): cv.boolean,
     })
@@ -43,15 +47,10 @@ CONFIG_SCHEMA = vol.Schema({
 _LOGGER = logging.getLogger(__name__)
 
 
-def request_configuration(hass, config, host):
+def request_configuration(hass, config, host, hostname):
     """Request configuration steps from the user."""
     configurator = hass.components.configurator
-    hass.data.setdefault(KEY_CONFIG, {})
-    instance = hass.data[KEY_CONFIG].get(host)
-
-    # Configuration already in progress
-    if instance:
-        return
+    hass.data.setdefault(KEY_CONFIGURING, [])
 
     @asyncio.coroutine
     def configuration_callback(callback_data):
@@ -67,29 +66,44 @@ def request_configuration(hass, config, host):
         # new (or another) hass instance.
         identity = uuid.uuid4().hex
 
+        api_factory = APIFactory(host, psk_id=identity, loop=hass.loop)
+
+        # FIXME: currently entering a wrong security code sends
+        # pytradfri aiocoap API into an entless loop.
+        # posibly because of non standard response from gateway
+        # but there's no clear Error/Exception being raised.
         try:
-            api_factory = APIFactory(host, psk_id=identity)
             token = yield from api_factory.generate_psk(
                                             callback_data.get('key'))
-            res = yield from _setup_gateway(hass, config, host,
-                                            identity, token,
-                                            DEFAULT_ALLOW_TRADFRI_GROUPS)
-            if not res:
-                raise
-        except:
+        except CancelledError():
             hass.async_add_job(configurator.notify_errors, instance,
-                               "Unable to connect.")
+                               "Security Code not accepted.")
+            return
+
+        res = yield from _setup_gateway(hass, config, host, hostname,
+                                        identity, token,
+                                        DEFAULT_ALLOW_TRADFRI_GROUPS)
+        if not res:
+            hass.async_add_job(configurator.notify_errors, instance,
+                               "Gateway setup failed.")
             return
 
         def success():
             """Set up was successful."""
             conf = _read_config(hass)
-            conf[host] = {'identity': identity, 'token': token}
+            conf[hostname] = {'host': host,
+                              'identity': identity,
+                              'token': token}
             _write_config(hass, conf)
             hass.async_add_job(configurator.request_done, instance)
 
         hass.async_add_job(success)
 
+    # Configuration already in progress
+    if host in hass.data[KEY_CONFIGURING]:
+        return
+
+    hass.data[KEY_CONFIGURING].append(host)
     instance = configurator.request_config(
         "IKEA Trådfri", configuration_callback,
         description='Please enter the security code written at the bottom of '
@@ -104,6 +118,7 @@ def async_setup(hass, config):
     """Set up the Tradfri component."""
     conf = config.get(DOMAIN, {})
     host = conf.get(CONF_HOST)
+    hostname = conf.get(CONF_HOSTNAME)
     allow_tradfri_groups = conf.get(CONF_ALLOW_TRADFRI_GROUPS)
     known_hosts = yield from hass.async_add_job(_read_config, hass)
 
@@ -111,27 +126,29 @@ def async_setup(hass, config):
     def gateway_discovered(service, info):
         """Run when a gateway is discovered."""
         host = info['host']
-
-        if host in known_hosts:
-            yield from _setup_gateway(hass, config, host,
-                                        known_hosts[host]['identity'],
-                                        known_hosts[host]['token'],
-                                        allow_tradfri_groups)
+        hostname = info['hostname']
+        if hostname in known_hosts:
+            yield from _setup_gateway(hass, config, host, hostname,
+                                      known_hosts[host]['identity'],
+                                      known_hosts[host]['token'],
+                                      allow_tradfri_groups)
         else:
-            hass.async_add_job(request_configuration, hass, config, host)
-            return True
+            hass.async_add_job(request_configuration, hass,
+                               config, host, hostname)
 
     discovery.async_listen(hass, SERVICE_IKEA_TRADFRI, gateway_discovered)
 
     if host:
-        yield from gateway_discovered(None, {'host': host})
+        yield from gateway_discovered(None,
+                                      {'host': host,
+                                       'hostname': hostname})
 
     return True
 
 
 @asyncio.coroutine
-def _setup_gateway(hass, hass_config, host,
-                    identity, token, allow_tradfri_groups):
+def _setup_gateway(hass, hass_config, host, hostname,
+                   identity, token, allow_tradfri_groups):
     """Create a gateway."""
     from pytradfri import Gateway, RequestError
     try:
@@ -145,9 +162,10 @@ def _setup_gateway(hass, hass_config, host,
         api = factory.request
         gateway = Gateway()
         gateway_info_result = yield from api(gateway.get_gateway_info())
-    except:
+    except RequestError:
         _LOGGER.exception("Tradfri setup failed. Requesting reconfiguration.")
-        hass.async_add_job(request_configuration, hass, hass_config, host)
+        hass.async_add_job(request_configuration, hass, hass_config,
+                           host, hostname)
         return False
 
     gateway_id = gateway_info_result.id

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -57,7 +57,7 @@ def request_configuration(hass, config, host, hostname):
         """Handle the submitted configuration."""
         try:
             from pytradfri.api.aiocoap_api import APIFactory
-        except ImportError:
+        except RequestError:
             _LOGGER.exception("Looks like something isn't installed!")
             return
 
@@ -72,10 +72,11 @@ def request_configuration(hass, config, host, hostname):
         # pytradfri aiocoap API into an entless loop.
         # posibly because of non standard response from gateway
         # but there's no clear Error/Exception being raised.
+        # the only thing that shows up in the logs is an OSError
         try:
             token = yield from api_factory.generate_psk(
                                             callback_data.get('key'))
-        except UnknownError:
+        except ConnctionError:
             hass.async_add_job(configurator.notify_errors, instance,
                                "Security Code not accepted.")
             return

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -69,11 +69,11 @@ def request_configuration(hass, config, host):
 
         try:
             api_factory = APIFactory(host, psk_id=identity)
-            token = yield from api_factory.generate_psk(callback_data.get('key'))
+            token = yield from api_factory.generate_psk(
+                                            callback_data.get('key'))
             res = yield from _setup_gateway(hass, config, host,
-                                                          identity,
-                                                          token,
-                                                          DEFAULT_ALLOW_TRADFRI_GROUPS)
+                                            identity, token,
+                                            DEFAULT_ALLOW_TRADFRI_GROUPS)
             if not res:
                 raise
         except:
@@ -96,7 +96,7 @@ def request_configuration(hass, config, host):
                     'your IKEA Trådfri Gateway.',
         submit_caption="Confirm",
         fields=[{'id': 'key', 'name': 'Security Code'}]
-    )
+        )
 
 
 @asyncio.coroutine
@@ -114,9 +114,9 @@ def async_setup(hass, config):
 
         if host in known_hosts:
             yield from _setup_gateway(hass, config, host,
-                                                    known_hosts[host]['identity'],
-                                                    known_hosts[host]['token'],
-                                                    allow_tradfri_groups)
+                                        known_hosts[host]['identity'],
+                                        known_hosts[host]['token'],
+                                        allow_tradfri_groups)
         else:
             hass.async_add_job(request_configuration, hass, config, host)
             return True
@@ -130,7 +130,8 @@ def async_setup(hass, config):
 
 
 @asyncio.coroutine
-def _setup_gateway(hass, hass_config, host, identity, token, allow_tradfri_groups):
+def _setup_gateway(hass, hass_config, host,
+                    identity, token, allow_tradfri_groups):
     """Create a gateway."""
     from pytradfri import Gateway, RequestError
     try:

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -75,7 +75,7 @@ def request_configuration(hass, config, host, hostname):
         try:
             token = yield from api_factory.generate_psk(
                                             callback_data.get('key'))
-        except CancelledError():
+        except UnknownError:
             hass.async_add_job(configurator.notify_errors, instance,
                                "Security Code not accepted.")
             return

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import os
+import uuid
 
 import voluptuous as vol
 
@@ -23,8 +24,7 @@ REQUIREMENTS = ['pytradfri==4.0.1',
                 '#aiocoap==0.3']
 
 DOMAIN = 'tradfri'
-GATEWAY_IDENTITY = 'homeassistant'
-CONFIG_FILE = '.tradfri_psk.conf'
+CONFIG_FILE = '.tradfri_identity.conf'
 KEY_CONFIG = 'tradfri_configuring'
 KEY_GATEWAY = 'tradfri_gateway'
 KEY_API = 'tradfri_api'
@@ -62,12 +62,21 @@ def request_configuration(hass, config, host):
             _LOGGER.exception("Looks like something isn't installed!")
             return
 
-        api_factory = APIFactory(host, psk_id=GATEWAY_IDENTITY)
-        psk = yield from api_factory.generate_psk(callback_data.get('key'))
-        res = yield from _setup_gateway(hass, config, host, psk,
-                                        DEFAULT_ALLOW_TRADFRI_GROUPS)
+        # use an unique identity to pair with gateway on every config attempt
+        # using the same id would make it unable to pair with a 
+        # new (or another) hass instance.
+        identity = uuid.uuid4().hex
 
-        if not res:
+        try:
+            api_factory = APIFactory(host, psk_id=identity)
+            token = yield from api_factory.generate_psk(callback_data.get('key'))
+            res = yield from _setup_gateway(hass, config, host, 
+                                                          identity,
+                                                          token, 
+                                                          DEFAULT_ALLOW_TRADFRI_GROUPS)
+            if not res:
+                raise
+        except:
             hass.async_add_job(configurator.notify_errors, instance,
                                "Unable to connect.")
             return
@@ -75,7 +84,7 @@ def request_configuration(hass, config, host):
         def success():
             """Set up was successful."""
             conf = _read_config(hass)
-            conf[host] = {'key': psk}
+            conf[host] = {'identity': identity, 'token': token}
             _write_config(hass, conf)
             hass.async_add_job(configurator.request_done, instance)
 
@@ -86,7 +95,7 @@ def request_configuration(hass, config, host):
         description='Please enter the security code written at the bottom of '
                     'your IKEA Trådfri Gateway.',
         submit_caption="Confirm",
-        fields=[{'id': 'key', 'name': 'Security Code', 'type': 'password'}]
+        fields=[{'id': 'key', 'name': 'Security Code'}]
     )
 
 
@@ -96,35 +105,32 @@ def async_setup(hass, config):
     conf = config.get(DOMAIN, {})
     host = conf.get(CONF_HOST)
     allow_tradfri_groups = conf.get(CONF_ALLOW_TRADFRI_GROUPS)
-    keys = yield from hass.async_add_job(_read_config, hass)
+    known_hosts = yield from hass.async_add_job(_read_config, hass)
 
     @asyncio.coroutine
     def gateway_discovered(service, info):
         """Run when a gateway is discovered."""
         host = info['host']
 
-        if host in keys:
-            yield from _setup_gateway(hass, config, host, keys[host]['key'],
-                                      allow_tradfri_groups)
+        if host in known_hosts:
+            yield from _setup_gateway(hass, config, host,
+                                                    known_hosts[host]['identity'],
+                                                    known_hosts[host]['token'],
+                                                    allow_tradfri_groups)
         else:
             hass.async_add_job(request_configuration, hass, config, host)
+            return True
 
     discovery.async_listen(hass, SERVICE_IKEA_TRADFRI, gateway_discovered)
 
-    if not host:
-        return True
+    if host:
+        yield from gateway_discovered(None, {'host': host})
 
-    if host and keys.get(host):
-        return (yield from _setup_gateway(hass, config, host,
-                                          keys[host]['key'],
-                                          allow_tradfri_groups))
-    else:
-        hass.async_add_job(request_configuration, hass, config, host)
-        return True
+    return True
 
 
 @asyncio.coroutine
-def _setup_gateway(hass, hass_config, host, key, allow_tradfri_groups):
+def _setup_gateway(hass, hass_config, host, identity, token, allow_tradfri_groups):
     """Create a gateway."""
     from pytradfri import Gateway, RequestError
     try:
@@ -134,13 +140,13 @@ def _setup_gateway(hass, hass_config, host, key, allow_tradfri_groups):
         return False
 
     try:
-        factory = APIFactory(host, psk_id=GATEWAY_IDENTITY, psk=key,
-                             loop=hass.loop)
+        factory = APIFactory(host, psk_id=identity, psk=token, loop=hass.loop)
         api = factory.request
         gateway = Gateway()
         gateway_info_result = yield from api(gateway.get_gateway_info())
-    except RequestError:
-        _LOGGER.exception("Tradfri setup failed.")
+    except:
+        _LOGGER.exception("Tradfri setup failed. Requesting reconfiguration.")
+        hass.async_add_job(request_configuration, hass, hass_config, host)
         return False
 
     gateway_id = gateway_info_result.id


### PR DESCRIPTION
!! There’s a bug I can’t get rid of: entering the wrong security code in the configurator sends the connection into an endless loop.

Using the same identity across all home-assistant instlallations means you need to reset the gateway to be able to connect it to a new installation or another (development) instance of home-assistance.

see here: https://community.home-assistant.io/t/tradfri-identity-shouldnt-be-hardcoded/31388