### PR TITLE
Upgrade credstash to 1.14.0

### DIFF
--- a/homeassistant/scripts/credstash.py
+++ b/homeassistant/scripts/credstash.py
@@ -4,7 +4,7 @@ import getpass
 
 from homeassistant.util.yaml import _SECRET_NAMESPACE
 
-REQUIREMENTS = ['credstash==1.13.3', 'botocore==1.7.34']
+REQUIREMENTS = ['credstash==1.14.0', 'botocore==1.7.34']
 
 
 def run(args):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -170,7 +170,7 @@ colorlog==3.0.1
 concord232==0.14
 
 # homeassistant.scripts.credstash
-# credstash==1.13.3
+# credstash==1.14.0
 
 # homeassistant.components.sensor.crimereports
 crimereports==1.0.0


### PR DESCRIPTION
## Description:
-  Fix for the incompatibilities with `cryptography` 2.1
- `AttributeError: module 'cryptography.hazmat` mentioned in #9893 started or will start to affect regular installations as well. 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
