### PR TITLE
Wink strip white space from configurator input

### DIFF
--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -160,7 +160,6 @@ def _request_app_setup(hass, config):
     hass.data[DOMAIN]['configurator'] = True
     configurator = hass.components.configurator
 
-    # pylint: disable=unused-argument
     def wink_configuration_callback(callback_data):
         """Handle configuration updates."""
         _config_path = hass.config.path(WINK_CONFIG_FILE)
@@ -168,8 +167,8 @@ def _request_app_setup(hass, config):
             setup(hass, config)
             return
 
-        client_id = callback_data.get('client_id')
-        client_secret = callback_data.get('client_secret')
+        client_id = callback_data.get('client_id').strip()
+        client_secret = callback_data.get('client_secret').strip()
         if None not in (client_id, client_secret):
             save_json(_config_path,
                       {ATTR_CLIENT_ID: client_id,


### PR DESCRIPTION
## Description:
This will remove leading and trailing white space form client ID and client secret input made on the Wink configurator.

Multiple users have reported getting errors similar to "Client is not authorized or could not be found." this has been because when copying the ID and secret from the Wink developer site they are accidentally grabbing a leading or trailing space.  

@balloob Can this get added to the next release? Since this will now be the only way new users can authenticate starting in 0.57 I would like to prevent as many issues as possible.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
