### PR TITLE
Addition of new binary sensor class 'plug'

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -35,6 +35,7 @@ DEVICE_CLASSES = [
     'smoke',         # Smoke detector
     'sound',         # On means sound detected, Off means no sound
     'vibration',     # On means vibration detected, Off means no vibration
+    'plug',          # On means plugged in, Off means plugged off
 ]
 
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))

--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -30,12 +30,12 @@ DEVICE_CLASSES = [
     'moving',        # On means moving, Off means stopped
     'occupancy',     # On means occupied, Off means not occupied
     'opening',       # Door, window, etc.
+    'plug',          # On means plugged in, Off means unplugged
     'power',         # Power, over-current, etc
     'safety',        # Generic on=unsafe, off=safe
     'smoke',         # Smoke detector
     'sound',         # On means sound detected, Off means no sound
     'vibration',     # On means vibration detected, Off means no vibration
-    'plug',          # On means plugged in, Off means unplugged
 ]
 
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))

--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -35,7 +35,7 @@ DEVICE_CLASSES = [
     'smoke',         # Smoke detector
     'sound',         # On means sound detected, Off means no sound
     'vibration',     # On means vibration detected, Off means no vibration
-    'plug',          # On means plugged in, Off means plugged off
+    'plug',          # On means plugged in, Off means unplugged
 ]
 
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))


### PR DESCRIPTION
## Description:
This should introduce a new deivce class for the binary sensor: "plug".

I will use it to monitor the state of pluged/unplugged sonoff switches but it could be used for other wireless switchable sockets.

**Related issue**: Frontend: https://github.com/home-assistant/home-assistant-polymer/issues/550

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3889

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
