### PR TITLE
Upgrade apns2 to 0.3.0

### DIFF
--- a/homeassistant/components/notify/apns.py
+++ b/homeassistant/components/notify/apns.py
@@ -17,7 +17,7 @@ from homeassistant.const import CONF_NAME, CONF_PLATFORM
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import template as template_helper
 
-REQUIREMENTS = ['apns2==0.1.1']
+REQUIREMENTS = ['apns2==0.3.0']
 
 APNS_DEVICES = 'apns.yaml'
 CONF_CERTFILE = 'cert_file'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -95,7 +95,7 @@ anthemav==1.1.8
 apcaccess==0.0.13
 
 # homeassistant.components.notify.apns
-apns2==0.1.1
+apns2==0.3.0
 
 # homeassistant.components.asterisk_mbox
 asterisk_mbox==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -34,7 +34,7 @@ aioautomatic==0.6.4
 aiohttp_cors==0.5.3
 
 # homeassistant.components.notify.apns
-apns2==0.1.1
+apns2==0.3.0
 
 # homeassistant.components.sensor.coinmarketcap
 coinmarketcap==4.1.1


### PR DESCRIPTION
## Description:
Version bump to 0.3.0

### Version 0.3.0
- Update list of exceptions
- Added capability to pass in cert-key tuple instead of chain certificate file to the APNs client
- load certificate with password
- Enable JWT authentication in addition to old certificate authentication
- Add parameter collapse_id
- Make server and port easier to override in subclasses
- load_cert_chain support to pass password parameter

### Version 0.2.1
- Implement thread-id option

### Version 0.2.0
- Add support for Safari Push Notifications
- Remove stub files
- Support sending notifications in batch
- Fix classifiers in setup.py

### Version 0.1.3
- Fix payload behaviour for empty strings / 0 values
- Allow using custom JSON conversion class
- Update Apple doc reference
- Fix memory leak of Stream objects in HTTP20Connection

### Version 0.1.2
- support for apns-expiration header
- Fixing bug in automatic casting of PayloadAlert to dict
- Add support for iOS 10 "mutable-content" flag

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
