### PR TITLE
Upgrade freesms to 0.1.2

### DIFF
--- a/homeassistant/components/notify/free_mobile.py
+++ b/homeassistant/components/notify/free_mobile.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['freesms==0.1.1']
+REQUIREMENTS = ['freesms==0.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -265,7 +265,7 @@ fixerio==0.1.1
 flux_led==0.20
 
 # homeassistant.components.notify.free_mobile
-freesms==0.1.1
+freesms==0.1.2
 
 # homeassistant.components.device_tracker.fritz
 # homeassistant.components.sensor.fritzbox_callmonitor


### PR DESCRIPTION
## Description:
Fix an insecure request warning when not using verify=True. Contributed by @nalepae

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
