### PR TITLE
Add include/exclude filter to mqtt_statestream

### DIFF
--- a/tests/components/test_mqtt_statestream.py
+++ b/tests/components/test_mqtt_statestream.py
@@ -25,7 +25,8 @@ class TestMqttStateStream(object):
         self.hass.stop()
 
     def add_statestream(self, base_topic=None, publish_attributes=None,
-                        publish_timestamps=None):
+                        publish_timestamps=None, publish_include=None,
+                        publish_exclude=None):
         """Add a mqtt_statestream component."""
         config = {}
         if base_topic:
@@ -34,7 +35,10 @@ class TestMqttStateStream(object):
             config['publish_attributes'] = publish_attributes
         if publish_timestamps:
             config['publish_timestamps'] = publish_timestamps
-            print("Publishing timestamps")
+        if publish_include:
+            config['include'] = publish_include
+        if publish_exclude:
+            config['exclude'] = publish_exclude
         return setup_component(self.hass, statestream.DOMAIN, {
             statestream.DOMAIN: config})
 
@@ -152,3 +156,237 @@ class TestMqttStateStream(object):
 
         mock_pub.assert_has_calls(calls, any_order=True)
         assert mock_pub.called
+
+    @patch('homeassistant.components.mqtt.async_publish')
+    @patch('homeassistant.core.dt_util.utcnow')
+    def test_state_changed_event_include_domain(self, mock_utcnow, mock_pub):
+        """"Test that filtering on included domain works as expected."""
+        base_topic = 'pub'
+
+        incl = {
+            'domains': ['fake']
+        }
+        excl = {}
+
+        # Add the statestream component for publishing state updates
+        # Set the filter to allow fake.* items
+        assert self.add_statestream(base_topic=base_topic,
+                                    publish_include=incl,
+                                    publish_exclude=excl)
+        self.hass.block_till_done()
+
+        # Reset the mock because it will have already gotten calls for the
+        # mqtt_statestream state change on initialization, etc.
+        mock_pub.reset_mock()
+
+        # Set a state of an entity
+        mock_state_change_event(self.hass, State('fake.entity', 'on'))
+        self.hass.block_till_done()
+
+        # Make sure 'on' was published to pub/fake/entity/state
+        mock_pub.assert_called_with(self.hass, 'pub/fake/entity/state', 'on',
+                                    1, True)
+        assert mock_pub.called
+
+        mock_pub.reset_mock()
+        # Set a state of an entity that shouldn't be included
+        mock_state_change_event(self.hass, State('fake2.entity', 'on'))
+        self.hass.block_till_done()
+
+        assert not mock_pub.called
+
+    @patch('homeassistant.components.mqtt.async_publish')
+    @patch('homeassistant.core.dt_util.utcnow')
+    def test_state_changed_event_include_entity(self, mock_utcnow, mock_pub):
+        """"Test that filtering on included entity works as expected."""
+        base_topic = 'pub'
+
+        incl = {
+            'entities': ['fake.entity']
+        }
+        excl = {}
+
+        # Add the statestream component for publishing state updates
+        # Set the filter to allow fake.* items
+        assert self.add_statestream(base_topic=base_topic,
+                                    publish_include=incl,
+                                    publish_exclude=excl)
+        self.hass.block_till_done()
+
+        # Reset the mock because it will have already gotten calls for the
+        # mqtt_statestream state change on initialization, etc.
+        mock_pub.reset_mock()
+
+        # Set a state of an entity
+        mock_state_change_event(self.hass, State('fake.entity', 'on'))
+        self.hass.block_till_done()
+
+        # Make sure 'on' was published to pub/fake/entity/state
+        mock_pub.assert_called_with(self.hass, 'pub/fake/entity/state', 'on',
+                                    1, True)
+        assert mock_pub.called
+
+        mock_pub.reset_mock()
+        # Set a state of an entity that shouldn't be included
+        mock_state_change_event(self.hass, State('fake.entity2', 'on'))
+        self.hass.block_till_done()
+
+        assert not mock_pub.called
+
+    @patch('homeassistant.components.mqtt.async_publish')
+    @patch('homeassistant.core.dt_util.utcnow')
+    def test_state_changed_event_exclude_domain(self, mock_utcnow, mock_pub):
+        """"Test that filtering on excluded domain works as expected."""
+        base_topic = 'pub'
+
+        incl = {}
+        excl = {
+            'domains': ['fake2']
+        }
+
+        # Add the statestream component for publishing state updates
+        # Set the filter to allow fake.* items
+        assert self.add_statestream(base_topic=base_topic,
+                                    publish_include=incl,
+                                    publish_exclude=excl)
+        self.hass.block_till_done()
+
+        # Reset the mock because it will have already gotten calls for the
+        # mqtt_statestream state change on initialization, etc.
+        mock_pub.reset_mock()
+
+        # Set a state of an entity
+        mock_state_change_event(self.hass, State('fake.entity', 'on'))
+        self.hass.block_till_done()
+
+        # Make sure 'on' was published to pub/fake/entity/state
+        mock_pub.assert_called_with(self.hass, 'pub/fake/entity/state', 'on',
+                                    1, True)
+        assert mock_pub.called
+
+        mock_pub.reset_mock()
+        # Set a state of an entity that shouldn't be included
+        mock_state_change_event(self.hass, State('fake2.entity', 'on'))
+        self.hass.block_till_done()
+
+        assert not mock_pub.called
+
+    @patch('homeassistant.components.mqtt.async_publish')
+    @patch('homeassistant.core.dt_util.utcnow')
+    def test_state_changed_event_exclude_entity(self, mock_utcnow, mock_pub):
+        """"Test that filtering on excluded entity works as expected."""
+        base_topic = 'pub'
+
+        incl = {}
+        excl = {
+            'entities': ['fake.entity2']
+        }
+
+        # Add the statestream component for publishing state updates
+        # Set the filter to allow fake.* items
+        assert self.add_statestream(base_topic=base_topic,
+                                    publish_include=incl,
+                                    publish_exclude=excl)
+        self.hass.block_till_done()
+
+        # Reset the mock because it will have already gotten calls for the
+        # mqtt_statestream state change on initialization, etc.
+        mock_pub.reset_mock()
+
+        # Set a state of an entity
+        mock_state_change_event(self.hass, State('fake.entity', 'on'))
+        self.hass.block_till_done()
+
+        # Make sure 'on' was published to pub/fake/entity/state
+        mock_pub.assert_called_with(self.hass, 'pub/fake/entity/state', 'on',
+                                    1, True)
+        assert mock_pub.called
+
+        mock_pub.reset_mock()
+        # Set a state of an entity that shouldn't be included
+        mock_state_change_event(self.hass, State('fake.entity2', 'on'))
+        self.hass.block_till_done()
+
+        assert not mock_pub.called
+
+    @patch('homeassistant.components.mqtt.async_publish')
+    @patch('homeassistant.core.dt_util.utcnow')
+    def test_state_changed_event_exclude_domain_include_entity(
+            self, mock_utcnow, mock_pub):
+        """"Test filtering with excluded domain and included entity."""
+        base_topic = 'pub'
+
+        incl = {
+            'entities': ['fake.entity']
+        }
+        excl = {
+            'domains': ['fake']
+        }
+
+        # Add the statestream component for publishing state updates
+        # Set the filter to allow fake.* items
+        assert self.add_statestream(base_topic=base_topic,
+                                    publish_include=incl,
+                                    publish_exclude=excl)
+        self.hass.block_till_done()
+
+        # Reset the mock because it will have already gotten calls for the
+        # mqtt_statestream state change on initialization, etc.
+        mock_pub.reset_mock()
+
+        # Set a state of an entity
+        mock_state_change_event(self.hass, State('fake.entity', 'on'))
+        self.hass.block_till_done()
+
+        # Make sure 'on' was published to pub/fake/entity/state
+        mock_pub.assert_called_with(self.hass, 'pub/fake/entity/state', 'on',
+                                    1, True)
+        assert mock_pub.called
+
+        mock_pub.reset_mock()
+        # Set a state of an entity that shouldn't be included
+        mock_state_change_event(self.hass, State('fake.entity2', 'on'))
+        self.hass.block_till_done()
+
+        assert not mock_pub.called
+
+    @patch('homeassistant.components.mqtt.async_publish')
+    @patch('homeassistant.core.dt_util.utcnow')
+    def test_state_changed_event_include_domain_exclude_entity(
+            self, mock_utcnow, mock_pub):
+        """"Test filtering with included domain and excluded entity."""
+        base_topic = 'pub'
+
+        incl = {
+            'domains': ['fake']
+        }
+        excl = {
+            'entities': ['fake.entity2']
+        }
+
+        # Add the statestream component for publishing state updates
+        # Set the filter to allow fake.* items
+        assert self.add_statestream(base_topic=base_topic,
+                                    publish_include=incl,
+                                    publish_exclude=excl)
+        self.hass.block_till_done()
+
+        # Reset the mock because it will have already gotten calls for the
+        # mqtt_statestream state change on initialization, etc.
+        mock_pub.reset_mock()
+
+        # Set a state of an entity
+        mock_state_change_event(self.hass, State('fake.entity', 'on'))
+        self.hass.block_till_done()
+
+        # Make sure 'on' was published to pub/fake/entity/state
+        mock_pub.assert_called_with(self.hass, 'pub/fake/entity/state', 'on',
+                                    1, True)
+        assert mock_pub.called
+
+        mock_pub.reset_mock()
+        # Set a state of an entity that shouldn't be included
+        mock_state_change_event(self.hass, State('fake.entity2', 'on'))
+        self.hass.block_till_done()
+
+        assert not mock_pub.called


### PR DESCRIPTION
## Description: 

This PR adds include/exclude configuration (via the EntityFilter helper) to mqtt_statestream.  This allows users to selectively configure what to publish to MQTT.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3893


## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt_statestream:
  base_topic: homeassistant
  publish_attributes: true
  include:
    domains:
      - sensor
  exclude:
    entities:
      - sun.sun
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
