### PR TITLE
fix a import in test causing vs code to fail to discover

### DIFF
--- a/tests/components/media_player/test_monoprice.py
+++ b/tests/components/media_player/test_monoprice.py
@@ -9,8 +9,8 @@ from homeassistant.components.media_player import (
     SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP, SUPPORT_SELECT_SOURCE)
 from homeassistant.const import STATE_ON, STATE_OFF
 
-from homeassistant.components.media_player.monoprice import \
-    MonopriceZone, PLATFORM_SCHEMA
+from homeassistant.components.media_player.monoprice import (
+    MonopriceZone, PLATFORM_SCHEMA)
 
 
 class MockState(object):

--- a/tests/components/media_player/test_monoprice.py
+++ b/tests/components/media_player/test_monoprice.py
@@ -9,7 +9,8 @@ from homeassistant.components.media_player import (
     SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP, SUPPORT_SELECT_SOURCE)
 from homeassistant.const import STATE_ON, STATE_OFF
 
-from components.media_player.monoprice import MonopriceZone, PLATFORM_SCHEMA
+from homeassistant.components.media_player.monoprice import \
+    MonopriceZone, PLATFORM_SCHEMA
 
 
 class MockState(object):


### PR DESCRIPTION
vscode/pytest failed to discover tests due to import statement missing `homeassistant`