### PR TITLE
fix owntracks_http JSONDecodeError

### DIFF
--- a/homeassistant/components/device_tracker/owntracks_http.py
+++ b/homeassistant/components/device_tracker/owntracks_http.py
@@ -42,9 +42,12 @@ class OwnTracksView(HomeAssistantView):
     def post(self, request, user, device):
         """Handle an OwnTracks message."""
         hass = request.app['hass']
-
-        message = yield from request.json()
-        message['topic'] = 'owntracks/{}/{}'.format(user, device)
+        
+        try:
+            message = yield from request.json()
+            message['topic'] = 'owntracks/{}/{}'.format(user, device)
+        except JSONDecodeError:
+            return self.json([])
 
         try:
             yield from async_handle_message(hass, self.context, message)

--- a/homeassistant/components/device_tracker/owntracks_http.py
+++ b/homeassistant/components/device_tracker/owntracks_http.py
@@ -42,11 +42,11 @@ class OwnTracksView(HomeAssistantView):
     def post(self, request, user, device):
         """Handle an OwnTracks message."""
         hass = request.app['hass']
-        
+
         try:
             message = yield from request.json()
             message['topic'] = 'owntracks/{}/{}'.format(user, device)
-        except JSONDecodeError:
+        except:
             return self.json([])
 
         try:


### PR DESCRIPTION
## Description:
Fixes the JSONDecodeError in the [owntracks_http](https://home-assistant.io/components/device_tracker.owntracks_http/) component as [here](https://community.home-assistant.io/t/owntracks-http/28986/5) announced.

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: owntracks_http
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54