### PR TITLE
Zwave save cache to file now.

### DIFF
--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -34,14 +34,14 @@ def async_setup(hass):
 
 
 class ZWaveConfigWriteView(HomeAssistantView):
-    """View to save the ZWave configuration to zwcfg_xxxxx.xml"""
+    """View to save the ZWave configuration to zwcfg_xxxxx.xml."""
 
     url = "/api/zwave/saveconfig"
     name = "api:zwave:saveconfig"
 
     @ha.callback
     def post(self, request):
-        """Save cache configuration to zwcfg_xxxxx.xml"""
+        """Save cache configuration to zwcfg_xxxxx.xml."""
         hass = request.app['hass']
         network = hass.data.get(const.DATA_NETWORK)
         if network is None:

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -27,8 +27,26 @@ def async_setup(hass):
     hass.http.register_view(ZWaveUserCodeView)
     hass.http.register_static_path(
         URL_API_OZW_LOG, hass.config.path(OZW_LOG_FILENAME), False)
+    hass.http.register_view(ZWaveConfigWriteView)
 
     return True
+
+
+class ZWaveConfigWriteView(HomeAssistantView):
+    """View to save the ZWave configuration to zwcfg_xxxxxx.xml"""
+
+    url = "/api/zwave/saveconfig"
+    name = "api:zwave:saveconfig"
+
+    @ha.callback
+    def post(self, request):
+        """Save cache configuration to zwcfg_xxxxx.xml"""
+        hass = request.app['hass']
+        network = hass.data.get(const.DATA_NETWORK)
+        if network is None:
+            return self.json_message('No Z-Wave network data found',
+                                     HTTP_NOT_FOUND)
+        network.write_config()
 
 
 class ZWaveNodeValueView(HomeAssistantView):

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -49,7 +49,8 @@ class ZWaveConfigWriteView(HomeAssistantView):
                                      HTTP_NOT_FOUND)
         _LOGGER.info("Z-Wave configuration written to file.")
         network.write_config()
-        return self.json_message('Z-Wave configuration saved to file.', HTTP_OK)
+        return self.json_message('Z-Wave configuration saved to file.',
+                                 HTTP_OK)
 
 
 class ZWaveNodeValueView(HomeAssistantView):

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -1,14 +1,15 @@
 """Provide configuration end points for Z-Wave."""
 import asyncio
+import logging
 
 import homeassistant.core as ha
-from homeassistant.const import HTTP_NOT_FOUND
+from homeassistant.const import HTTP_NOT_FOUND, HTTP_OK
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.config import EditKeyBasedConfigView
 from homeassistant.components.zwave import const, DEVICE_CONFIG_SCHEMA_ENTRY
 import homeassistant.helpers.config_validation as cv
 
-
+_LOGGER = logging.getLogger(__name__)
 CONFIG_PATH = 'zwave_device_config.yaml'
 OZW_LOG_FILENAME = 'OZW_Log.txt'
 URL_API_OZW_LOG = '/api/zwave/ozwlog'
@@ -33,7 +34,7 @@ def async_setup(hass):
 
 
 class ZWaveConfigWriteView(HomeAssistantView):
-    """View to save the ZWave configuration to zwcfg_xxxxxx.xml"""
+    """View to save the ZWave configuration to zwcfg_xxxxx.xml"""
 
     url = "/api/zwave/saveconfig"
     name = "api:zwave:saveconfig"
@@ -46,7 +47,9 @@ class ZWaveConfigWriteView(HomeAssistantView):
         if network is None:
             return self.json_message('No Z-Wave network data found',
                                      HTTP_NOT_FOUND)
+        _LOGGER.info("Z-Wave configuration written to file.")
         network.write_config()
+        return self.json_message('Z-Wave configuration saved to file.', HTTP_OK)
 
 
 class ZWaveNodeValueView(HomeAssistantView):

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -9,7 +9,7 @@ from homeassistant.components import config
 from homeassistant.components.zwave import DATA_NETWORK, const
 from homeassistant.components.config.zwave import (
     ZWaveNodeValueView, ZWaveNodeGroupView, ZWaveNodeConfigView,
-    ZWaveUserCodeView)
+    ZWaveUserCodeView, ZWaveConfigWriteView)
 from tests.common import mock_http_component_app
 from tests.mock.zwave import MockNode, MockValue, MockEntityValues
 
@@ -417,3 +417,37 @@ def test_get_usercodes_no_genreuser(hass, test_client):
     result = yield from resp.json()
 
     assert result == {}
+
+@asyncio.coroutine
+def test_save_config_no_network(hass, test_client):
+    """Test saving configuration without network data."""
+    app = mock_http_component_app(hass)
+    ZWaveConfigWriteView().register(app.router)
+
+    network = hass.data[DATA_NETWORK] = None
+
+    client = yield from test_client(app)
+
+    resp = yield from client.post('/api/zwave/saveconfig')
+
+    assert resp.status == 404
+    result = yield from resp.json()
+
+    assert result == {'message': 'No Z-Wave network data found'}
+
+@asyncio.coroutine
+def test_save_config(hass, test_client):
+    """Test saving configuration."""
+    app = mock_http_component_app(hass)
+    ZWaveConfigWriteView().register(app.router)
+
+    network = hass.data[DATA_NETWORK] = MagicMock()
+
+    client = yield from test_client(app)
+
+    resp = yield from client.post('/api/zwave/saveconfig')
+
+    assert resp.status == 200
+    result = yield from resp.json()
+
+    assert result == {'message': 'Z-Wave configuration saved to file.'}

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -425,8 +425,6 @@ def test_save_config_no_network(hass, test_client):
     app = mock_http_component_app(hass)
     ZWaveConfigWriteView().register(app.router)
 
-    network = hass.data[DATA_NETWORK] = None
-
     client = yield from test_client(app)
 
     resp = yield from client.post('/api/zwave/saveconfig')

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -418,6 +418,7 @@ def test_get_usercodes_no_genreuser(hass, test_client):
 
     assert result == {}
 
+
 @asyncio.coroutine
 def test_save_config_no_network(hass, test_client):
     """Test saving configuration without network data."""
@@ -432,8 +433,8 @@ def test_save_config_no_network(hass, test_client):
 
     assert resp.status == 404
     result = yield from resp.json()
-
     assert result == {'message': 'No Z-Wave network data found'}
+
 
 @asyncio.coroutine
 def test_save_config(hass, test_client):
@@ -449,5 +450,5 @@ def test_save_config(hass, test_client):
 
     assert resp.status == 200
     result = yield from resp.json()
-
+    assert network.write_config.called
     assert result == {'message': 'Z-Wave configuration saved to file.'}


### PR DESCRIPTION
## Description:
API call to save Z-Wave cache to file on runtime instead of at network stop.

**Related issue (if applicable):** fixes #10240

Frontend: https://github.com/home-assistant/home-assistant-polymer/pull/568