### PR TITLE
Tellstick Duo acync callback fix

### DIFF
--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -7,12 +7,11 @@ https://home-assistant.io/components/light.tellstick/
 import voluptuous as vol
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light, PLATFORM_SCHEMA)
 from homeassistant.components.tellstick import (
     DEFAULT_SIGNAL_REPETITIONS, ATTR_DISCOVER_DEVICES, ATTR_DISCOVER_CONFIG,
-    DOMAIN, TellstickDevice)
+    DATA_TELLSTICK, TellstickDevice)
 
-PLATFORM_SCHEMA = vol.Schema({vol.Required("platform"): DOMAIN})
 
 SUPPORT_TELLSTICK = SUPPORT_BRIGHTNESS
 
@@ -27,9 +26,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     signal_repetitions = discovery_info.get(
         ATTR_DISCOVER_CONFIG, DEFAULT_SIGNAL_REPETITIONS)
 
-    add_devices(TellstickLight(tellcore_id, hass.data['tellcore_registry'],
+    add_devices(TellstickLight(tellcore_id, hass.data[DATA_TELLSTICK],
                                signal_repetitions)
-                for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES])
+                for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES], True)
 
 
 class TellstickLight(TellstickDevice, Light):

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -4,10 +4,9 @@ Support for Tellstick lights.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.tellstick/
 """
-import voluptuous as vol
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light, PLATFORM_SCHEMA)
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
 from homeassistant.components.tellstick import (
     DEFAULT_SIGNAL_REPETITIONS, ATTR_DISCOVER_DEVICES, ATTR_DISCOVER_CONFIG,
     DATA_TELLSTICK, TellstickDevice)

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -58,8 +58,7 @@ class TellstickLight(TellstickDevice, Light):
     def _parse_tellcore_data(self, tellcore_data):
         """Turn the value received from tellcore into something useful."""
         if tellcore_data is not None:
-            brightness = int(tellcore_data)
-            return brightness
+            return int(tellcore_data)  # brightness
         return None
 
     def _update_model(self, new_state, data):

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -26,9 +26,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     signal_repetitions = discovery_info.get(
         ATTR_DISCOVER_CONFIG, DEFAULT_SIGNAL_REPETITIONS)
 
-    add_devices(TellstickLight(tellcore_id, hass.data[DATA_TELLSTICK],
-                               signal_repetitions)
-                for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES], True)
+    add_devices([TellstickLight(tellcore_id, hass.data[DATA_TELLSTICK],
+                                signal_repetitions)
+                 for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES]],
+                True)
 
 
 class TellstickLight(TellstickDevice, Light):

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -56,7 +56,7 @@ class TellstickLight(TellstickDevice, Light):
 
     def _parse_tellcore_data(self, tellcore_data):
         """Turn the value received from tellcore into something useful."""
-        if tellcore_data is not None:
+        if tellcore_data:
             return int(tellcore_data)  # brightness
         return None
 

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -34,9 +34,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class TellstickLight(TellstickDevice, Light):
     """Representation of a Tellstick light."""
 
-    def __init__(self, tellcore_id, tellcore_registry, signal_repetitions):
+    def __init__(self, tellcore_device, signal_repetitions):
         """Initialize the Tellstick light."""
-        super().__init__(tellcore_id, tellcore_registry, signal_repetitions)
+        super().__init__(tellcore_device, signal_repetitions)
 
         self._brightness = 255
 

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -25,7 +25,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     signal_repetitions = discovery_info.get(
         ATTR_DISCOVER_CONFIG, DEFAULT_SIGNAL_REPETITIONS)
 
-    add_devices([TellstickLight(tellcore_id, hass.data[DATA_TELLSTICK],
+    add_devices([TellstickLight(hass.data[DATA_TELLSTICK][tellcore_id],
                                 signal_repetitions)
                  for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES]],
                 True)

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -36,11 +36,11 @@ class TellstickSwitch(TellstickDevice, ToggleEntity):
 
     def _parse_ha_data(self, kwargs):
         """Turn the value from HA into something useful."""
-        return None
+        pass
 
     def _parse_tellcore_data(self, tellcore_data):
         """Turn the value received from tellcore into something useful."""
-        return None
+        pass
 
     def _update_model(self, new_state, data):
         """Update the device entity state to match the arguments."""

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -24,9 +24,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     signal_repetitions = discovery_info.get(ATTR_DISCOVER_CONFIG,
                                             DEFAULT_SIGNAL_REPETITIONS)
 
-    add_devices(TellstickSwitch(tellcore_id, hass.data[DATA_TELLSTICK],
-                                signal_repetitions)
-                for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES], True)
+    add_devices([TellstickSwitch(tellcore_id, hass.data[DATA_TELLSTICK],
+                                 signal_repetitions)
+                 for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES]],
+                True)
 
 
 class TellstickSwitch(TellstickDevice, ToggleEntity):

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -4,12 +4,9 @@ Support for Tellstick switches.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.tellstick/
 """
-import voluptuous as vol
-
-from homeassistant.components.switch import PLATFORM_SCHEMA
 from homeassistant.components.tellstick import (
-  DEFAULT_SIGNAL_REPETITIONS, ATTR_DISCOVER_DEVICES,
-  ATTR_DISCOVER_CONFIG, DATA_TELLSTICK, TellstickDevice)
+    DEFAULT_SIGNAL_REPETITIONS, ATTR_DISCOVER_DEVICES,
+    ATTR_DISCOVER_CONFIG, DATA_TELLSTICK, TellstickDevice)
 from homeassistant.helpers.entity import ToggleEntity
 
 

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -21,7 +21,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     signal_repetitions = discovery_info.get(ATTR_DISCOVER_CONFIG,
                                             DEFAULT_SIGNAL_REPETITIONS)
 
-    add_devices([TellstickSwitch(tellcore_id, hass.data[DATA_TELLSTICK],
+    add_devices([TellstickSwitch(hass.data[DATA_TELLSTICK][tellcore_id],
                                  signal_repetitions)
                  for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES]],
                 True)

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -6,13 +6,11 @@ https://home-assistant.io/components/switch.tellstick/
 """
 import voluptuous as vol
 
-from homeassistant.components.tellstick import (DEFAULT_SIGNAL_REPETITIONS,
-                                                ATTR_DISCOVER_DEVICES,
-                                                ATTR_DISCOVER_CONFIG,
-                                                DOMAIN, TellstickDevice)
+from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.components.tellstick import (
+  DEFAULT_SIGNAL_REPETITIONS, ATTR_DISCOVER_DEVICES,
+  ATTR_DISCOVER_CONFIG, DATA_TELLSTICK, TellstickDevice)
 from homeassistant.helpers.entity import ToggleEntity
-
-PLATFORM_SCHEMA = vol.Schema({vol.Required("platform"): DOMAIN})
 
 
 # pylint: disable=unused-argument
@@ -26,9 +24,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     signal_repetitions = discovery_info.get(ATTR_DISCOVER_CONFIG,
                                             DEFAULT_SIGNAL_REPETITIONS)
 
-    add_devices(TellstickSwitch(tellcore_id, hass.data['tellcore_registry'],
+    add_devices(TellstickSwitch(tellcore_id, hass.data[DATA_TELLSTICK],
                                 signal_repetitions)
-                for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES])
+                for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES], True)
 
 
 class TellstickSwitch(TellstickDevice, ToggleEntity):

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -62,7 +62,7 @@ def _discover(hass, config, component_name, found_tellcore_devices):
 def setup(hass, config):
     """Set up the Tellstick component."""
     from tellcore.constants import TELLSTICK_DIM
-    from tellcore.telldus import QueuedCallbackDispatcher
+    from tellcore.telldus import AsyncioCallbackDispatcher
     from tellcore.telldus import TelldusCore
     from tellcorenet import TellCoreClient
 
@@ -83,7 +83,7 @@ def setup(hass, config):
 
     try:
         tellcore_lib = TelldusCore(
-            callback_dispatcher=QueuedCallbackDispatcher())
+            callback_dispatcher=AsyncioCallbackDispatcher(hass.loop))
     except OSError:
         _LOGGER.exception("Could not initialize Tellstick")
         return False

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -28,7 +28,8 @@ CONF_SIGNAL_REPETITIONS = 'signal_repetitions'
 DEFAULT_SIGNAL_REPETITIONS = 1
 DOMAIN = 'tellstick'
 
-DATA_TELLSTICK = 'tellcore_registry'
+DATA_TELLSTICK = 'tellstick_device'
+SIGNAL_TELLCORE_CALLBACK = 'tellstick_callback'
 
 # Use a global tellstick domain lock to avoid getting Tellcore errors when
 # calling concurrently.
@@ -93,84 +94,42 @@ def setup(hass, config):
         return False
 
     # Get all devices, switches and lights alike
-    all_tellcore_devices = tellcore_lib.devices()
+    tellcore_devices = tellcore_lib.devices()
 
     # Register devices
-    tellcore_registry = TellstickRegistry(hass, tellcore_lib)
-    tellcore_registry.register_tellcore_devices(all_tellcore_devices)
-    hass.data[DATA_TELLSTICK] = tellcore_registry
+    hass.data[DATA_TELLSTICK] = {device.id: device for 
+                                 device in tellcore_devices}
 
     # Discover the switches
     _discover(hass, config, 'switch',
-              [tellcore_device.id for tellcore_device in all_tellcore_devices
-               if not tellcore_device.methods(TELLSTICK_DIM)])
+              [device.id for device in tellcore_devices
+               if not device.methods(TELLSTICK_DIM)])
 
     # Discover the lights
     _discover(hass, config, 'light',
-              [tellcore_device.id for tellcore_device in all_tellcore_devices
-               if tellcore_device.methods(TELLSTICK_DIM)])
-
-    return True
-
-
-class TellstickRegistry(object):
-    """Handle everything around Tellstick callbacks.
-
-    Keeps a map device ids to the tellcore device object, and
-    another to the HA device objects (entities).
-
-    Also responsible for registering / cleanup of callbacks, and for
-    dispatching the callbacks to the corresponding HA device object.
-
-    All device specific logic should be elsewhere (Entities).
-    """
-
-    def __init__(self, hass, tellcore_lib):
-        """Initialize the Tellstick mappings and callbacks."""
-        # used when map callback device id to ha entities.
-        self.hass = hass
-        self._id_to_ha_device_map = {}
-        self._id_to_tellcore_device_map = {}
-        self._setup_tellcore_callback(tellcore_lib)
+              [device.id for device in tellcore_devices
+               if device.methods(TELLSTICK_DIM)])
 
     @callback
-    def _async_tellcore_event_callback(self, tellcore_id, tellcore_command,
-                                       tellcore_data, cid):
+    def async_handle_callback(tellcore_id, tellcore_command,
+                              tellcore_data, cid):
         """Handle the actual callback from Tellcore."""
-        ha_device = self._id_to_ha_device_map.get(tellcore_id, None)
-        if ha_device is not None:
-            # Pass it on to the HA device object
-            self.hass.async_add_job(
-                ha_device.update_from_callback, tellcore_command,
-                tellcore_data)
+            hass.helpers.dispatcher.async_dispatcher_send(
+                SIGNAL_TELLCORE_CALLBACK, tellcore_id,
+                tellcore_command, tellcore_data)
 
-    def _setup_tellcore_callback(self, tellcore_lib):
-        """Register the callback handler."""
-        callback_id = tellcore_lib.register_device_event(
-            self._async_tellcore_event_callback)
+    # Register callback
+    callback_id = tellcore_lib.register_device_event(
+        async_handle_callback)
 
-        def clean_up_callback(event):
-            """Unregister the callback bindings."""
-            if callback_id is not None:
-                tellcore_lib.unregister_callback(callback_id)
-                _LOGGER.debug("Tellstick callback unregistered")
+    def clean_up_callback(event):
+        """Unregister the callback bindings."""
+        if callback_id is not None:
+            tellcore_lib.unregister_callback(callback_id)
 
-        self.hass.bus.listen_once(
-            EVENT_HOMEASSISTANT_STOP, clean_up_callback)
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, clean_up_callback)
 
-    def register_ha_device(self, tellcore_id, ha_device):
-        """Register a new HA device to receive callback updates."""
-        self._id_to_ha_device_map[tellcore_id] = ha_device
-
-    def register_tellcore_devices(self, tellcore_devices):
-        """Register a list of devices."""
-        self._id_to_tellcore_device_map.update(
-            {tellcore_device.id: tellcore_device for tellcore_device
-             in tellcore_devices})
-
-    def get_tellcore_device(self, tellcore_id):
-        """Return a device by tellcore_id."""
-        return self._id_to_tellcore_device_map.get(tellcore_id, None)
+    return True
 
 
 class TellstickDevice(Entity):
@@ -179,7 +138,7 @@ class TellstickDevice(Entity):
     Contains the common logic for all Tellstick devices.
     """
 
-    def __init__(self, tellcore_id, tellcore_registry, signal_repetitions):
+    def __init__(self, tellcore_device, signal_repetitions):
         """Init the Tellstick device."""
         self._signal_repetitions = signal_repetitions
         self._state = None
@@ -188,19 +147,16 @@ class TellstickDevice(Entity):
         self._repeats_left = 0
 
         # Look up our corresponding tellcore device
-        self._tellcore_device = tellcore_registry.get_tellcore_device(
-            tellcore_id)
-        self._name = self._tellcore_device.name
+        self._tellcore_device = tellcore_device
+        self._name = tellcore_device.name
 
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Register callbacks."""
-        tellcore_registry = self.hass.data[DATA_TELLSTICK]
-
-        # Add ourselves to the mapping for callbacks
-        self.hass.async_add_job(
-            tellcore_registry.register_ha_device,
-            self._tellcore_device.id, self)
+        self.hass.helpers.dispatcher.async_dispatcher_connect(
+            SIGNAL_TELLCORE_CALLBACK,
+            self.update_from_callback
+        )
 
     @property
     def should_poll(self):
@@ -290,15 +246,19 @@ class TellstickDevice(Entity):
         self._update_model(tellcore_command != TELLSTICK_TURNOFF,
                            self._parse_tellcore_data(tellcore_data))
 
-    def update_from_callback(self, tellcore_command, tellcore_data):
+    def update_from_callback(self, tellcore_id, tellcore_command,
+                             tellcore_data):
         """Handle updates from the tellcore callback."""
+        if tellcore_id != self._tellcore_device.id:
+            return
+
         self._update_model_from_command(tellcore_command, tellcore_data)
         self.schedule_update_ha_state()
 
         # This is a benign race on _repeats_left -- it's checked with the lock
         # in _send_repeated_command.
         if self._repeats_left > 0:
-            self.hass.add_job(self._send_repeated_command)
+            self._send_repeated_command()
 
     def _update_from_tellcore(self):
         """Read the current state of the device from the tellcore library."""

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -144,10 +144,10 @@ class TellstickRegistry(object):
                 ha_device.update_from_callback, tellcore_command,
                 tellcore_data)
 
-    def _setup_tellcore_callback(self, hass, tellcore_lib):
+    def _setup_tellcore_callback(self, tellcore_lib):
         """Register the callback handler."""
         callback_id = tellcore_lib.register_device_event(
-            self._tellcore_event_callback)
+            self._async_tellcore_event_callback)
 
         def clean_up_callback(event):
             """Unregister the callback bindings."""

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -128,7 +128,7 @@ class TellstickRegistry(object):
         self.hass = hass
         self._id_to_ha_device_map = {}
         self._id_to_tellcore_device_map = {}
-        self._setup_tellcore_callback(hass, tellcore_lib)
+        self._setup_tellcore_callback(tellcore_lib)
 
     @callback
     def _async_tellcore_event_callback(self, tellcore_id, tellcore_command,
@@ -152,7 +152,8 @@ class TellstickRegistry(object):
                 tellcore_lib.unregister_callback(callback_id)
                 _LOGGER.debug("Tellstick callback unregistered")
 
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, clean_up_callback)
+        self.hass.bus.listen_once(
+            EVENT_HOMEASSISTANT_STOP, clean_up_callback)
 
     def register_ha_device(self, tellcore_id, ha_device):
         """Register a new HA device to receive callback updates."""

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -4,6 +4,7 @@ Tellstick Component.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/tellstick/
 """
+import asyncio
 import logging
 import threading
 

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -97,7 +97,7 @@ def setup(hass, config):
     tellcore_devices = tellcore_lib.devices()
 
     # Register devices
-    hass.data[DATA_TELLSTICK] = {device.id: device for 
+    hass.data[DATA_TELLSTICK] = {device.id: device for
                                  device in tellcore_devices}
 
     # Discover the switches
@@ -114,9 +114,9 @@ def setup(hass, config):
     def async_handle_callback(tellcore_id, tellcore_command,
                               tellcore_data, cid):
         """Handle the actual callback from Tellcore."""
-            hass.helpers.dispatcher.async_dispatcher_send(
-                SIGNAL_TELLCORE_CALLBACK, tellcore_id,
-                tellcore_command, tellcore_data)
+        hass.helpers.dispatcher.async_dispatcher_send(
+            SIGNAL_TELLCORE_CALLBACK, tellcore_id,
+            tellcore_command, tellcore_data)
 
     # Register callback
     callback_id = tellcore_lib.register_device_event(

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -125,7 +125,7 @@ class TellstickRegistry(object):
     def __init__(self, hass, tellcore_lib):
         """Initialize the Tellstick mappings and callbacks."""
         # used when map callback device id to ha entities.
-        self.hass
+        self.hass = hass
         self._id_to_ha_device_map = {}
         self._id_to_tellcore_device_map = {}
         self._setup_tellcore_callback(hass, tellcore_lib)


### PR DESCRIPTION
## Description:

This is a revert back to the old asyncio callback for tellstick.
The original commit that has been reverted said that the asycio callback was unnecessary, 
It's not for the tellstick duo.

**Related issue ** 
Fixes #10329

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
 
