### PR TITLE
Improvement of KNX climate component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -64,6 +64,10 @@ homeassistant/components/xiaomi_aqara.py @danielhiversen @syssi
 
 homeassistant/components/*/broadlink.py @danielhiversen
 homeassistant/components/*/rfxtrx.py @danielhiversen
+homeassistant/components/velux.py @Julius2342
+homeassistant/components/*/velux.py @Julius2342
+homeassistant/components/knx.py @Julius2342
+homeassistant/components/*/knx.py @Julius2342
 homeassistant/components/tesla.py @zabuldon
 homeassistant/components/*/tesla.py @zabuldon
 homeassistant/components/*/tradfri.py @ggravlingen

--- a/homeassistant/components/climate/knx.py
+++ b/homeassistant/components/climate/knx.py
@@ -169,7 +169,7 @@ class KNXClimate(ClimateDevice):
     @property
     def target_temperature_step(self):
         """Return the supported step of target temperature."""
-        return  self.device.setpoint_shift_step
+        return self.device.setpoint_shift_step
 
     @property
     def target_temperature(self):

--- a/homeassistant/components/climate/knx.py
+++ b/homeassistant/components/climate/knx.py
@@ -42,8 +42,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
     vol.Optional(CONF_SETPOINT_SHIFT_ADDRESS): cv.string,
     vol.Optional(CONF_SETPOINT_SHIFT_STATE_ADDRESS): cv.string,
-    vol.Optional(CONF_SETPOINT_SHIFT_STEP, default=DEFAULT_SETPOINT_SHIFT_STEP):
-        vol.All(float, vol.Range(min=0, max=2)),
+    vol.Optional(CONF_SETPOINT_SHIFT_STEP,
+                 default=DEFAULT_SETPOINT_SHIFT_STEP): vol.All(
+                     float, vol.Range(min=0, max=2)),
     vol.Optional(CONF_SETPOINT_SHIFT_MAX, default=DEFAULT_SETPOINT_SHIFT_MAX):
         vol.All(int, vol.Range(min=-32, max=0)),
     vol.Optional(CONF_SETPOINT_SHIFT_MIN, default=DEFAULT_SETPOINT_SHIFT_MIN):

--- a/homeassistant/components/climate/knx.py
+++ b/homeassistant/components/climate/knx.py
@@ -10,12 +10,15 @@ import voluptuous as vol
 from homeassistant.components.knx import DATA_KNX, ATTR_DISCOVER_DEVICES
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.const import CONF_NAME, TEMP_CELSIUS, ATTR_TEMPERATURE
+from homeassistant.util.temperature import convert as convert_temperature
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
-CONF_SETPOINT_ADDRESS = 'setpoint_address'
 CONF_SETPOINT_SHIFT_ADDRESS = 'setpoint_shift_address'
 CONF_SETPOINT_SHIFT_STATE_ADDRESS = 'setpoint_shift_state_address'
+CONF_SETPOINT_SHIFT_STEP = 'setpoint_shift_step'
+CONF_SETPOINT_SHIFT_MAX = 'setpoint_shift_max'
+CONF_SETPOINT_SHIFT_MIN = 'setpoint_shift_min'
 CONF_TEMPERATURE_ADDRESS = 'temperature_address'
 CONF_TARGET_TEMPERATURE_ADDRESS = 'target_temperature_address'
 CONF_OPERATION_MODE_ADDRESS = 'operation_mode_address'
@@ -28,15 +31,23 @@ CONF_OPERATION_MODE_NIGHT_ADDRESS = 'operation_mode_night_address'
 CONF_OPERATION_MODE_COMFORT_ADDRESS = 'operation_mode_comfort_address'
 
 DEFAULT_NAME = 'KNX Climate'
+DEFAULT_SETPOINT_SHIFT_STEP = 0.5
+DEFAULT_SETPOINT_SHIFT_MAX = 6
+DEFAULT_SETPOINT_SHIFT_MIN = -6
 DEPENDENCIES = ['knx']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Required(CONF_SETPOINT_ADDRESS): cv.string,
     vol.Required(CONF_TEMPERATURE_ADDRESS): cv.string,
     vol.Required(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
     vol.Optional(CONF_SETPOINT_SHIFT_ADDRESS): cv.string,
     vol.Optional(CONF_SETPOINT_SHIFT_STATE_ADDRESS): cv.string,
+    vol.Optional(CONF_SETPOINT_SHIFT_STEP, default=DEFAULT_SETPOINT_SHIFT_STEP):
+        vol.All(float, vol.Range(min=0, max=2)),
+    vol.Optional(CONF_SETPOINT_SHIFT_MAX, default=DEFAULT_SETPOINT_SHIFT_MAX):
+        vol.All(int, vol.Range(min=-32, max=0)),
+    vol.Optional(CONF_SETPOINT_SHIFT_MIN, default=DEFAULT_SETPOINT_SHIFT_MIN):
+        vol.All(int, vol.Range(min=0, max=32)),
     vol.Optional(CONF_OPERATION_MODE_ADDRESS): cv.string,
     vol.Optional(CONF_OPERATION_MODE_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_CONTROLLER_STATUS_ADDRESS): cv.string,
@@ -77,6 +88,7 @@ def async_add_devices_discovery(hass, discovery_info, async_add_devices):
 def async_add_devices_config(hass, config, async_add_devices):
     """Set up climate for KNX platform configured within plattform."""
     import xknx
+
     climate = xknx.devices.Climate(
         hass.data[DATA_KNX].xknx,
         name=config.get(CONF_NAME),
@@ -84,12 +96,16 @@ def async_add_devices_config(hass, config, async_add_devices):
             CONF_TEMPERATURE_ADDRESS),
         group_address_target_temperature=config.get(
             CONF_TARGET_TEMPERATURE_ADDRESS),
-        group_address_setpoint=config.get(
-            CONF_SETPOINT_ADDRESS),
         group_address_setpoint_shift=config.get(
             CONF_SETPOINT_SHIFT_ADDRESS),
         group_address_setpoint_shift_state=config.get(
             CONF_SETPOINT_SHIFT_STATE_ADDRESS),
+        setpoint_shift_step=config.get(
+            CONF_SETPOINT_SHIFT_STEP),
+        setpoint_shift_max=config.get(
+            CONF_SETPOINT_SHIFT_MAX),
+        setpoint_shift_min=config.get(
+            CONF_SETPOINT_SHIFT_MIN),
         group_address_operation_mode=config.get(
             CONF_OPERATION_MODE_ADDRESS),
         group_address_operation_mode_state=config.get(
@@ -151,27 +167,30 @@ class KNXClimate(ClimateDevice):
         return self.device.temperature.value
 
     @property
+    def target_temperature_step(self):
+        """Return the supported step of target temperature."""
+        return  self.device.setpoint_shift_step
+
+    @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self.device.target_temperature_comfort
+        return self.device.target_temperature.value
 
     @property
-    def target_temperature_high(self):
-        """Return the highbound target temperature we try to reach."""
-        if self.device.target_temperature_comfort:
-            return max(
-                self.device.target_temperature_comfort,
-                self.device.target_temperature.value)
-        return None
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return convert_temperature(
+            self.device.target_temperature_min,
+            TEMP_CELSIUS,
+            self.temperature_unit)
 
     @property
-    def target_temperature_low(self):
-        """Return the lowbound target temperature we try to reach."""
-        if self.device.target_temperature_comfort:
-            return min(
-                self.device.target_temperature_comfort,
-                self.device.target_temperature.value)
-        return None
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return convert_temperature(
+            self.device.target_temperature_max,
+            TEMP_CELSIUS,
+            self.temperature_unit)
 
     @asyncio.coroutine
     def async_set_temperature(self, **kwargs):
@@ -179,7 +198,7 @@ class KNXClimate(ClimateDevice):
         temperature = kwargs.get(ATTR_TEMPERATURE)
         if temperature is None:
             return
-        yield from self.device.set_target_temperature_comfort(temperature)
+        yield from self.device.set_target_temperature(temperature)
         yield from self.async_update_ha_state()
 
     @property

--- a/homeassistant/components/climate/knx.py
+++ b/homeassistant/components/climate/knx.py
@@ -10,7 +10,6 @@ import voluptuous as vol
 from homeassistant.components.knx import DATA_KNX, ATTR_DISCOVER_DEVICES
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.const import CONF_NAME, TEMP_CELSIUS, ATTR_TEMPERATURE
-from homeassistant.util.temperature import convert as convert_temperature
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
@@ -135,8 +134,6 @@ class KNXClimate(ClimateDevice):
         self.async_register_callbacks()
 
         self._unit_of_measurement = TEMP_CELSIUS
-        self._away = False  # not yet supported
-        self._is_fan_on = False  # not yet supported
 
     def async_register_callbacks(self):
         """Register callbacks to update hass after device was changed."""
@@ -180,18 +177,12 @@ class KNXClimate(ClimateDevice):
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return convert_temperature(
-            self.device.target_temperature_min,
-            TEMP_CELSIUS,
-            self.temperature_unit)
+        return self.device.target_temperature_min
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return convert_temperature(
-            self.device.target_temperature_max,
-            TEMP_CELSIUS,
-            self.temperature_unit)
+        return self.device.target_temperature_max
 
     @asyncio.coroutine
     def async_set_temperature(self, **kwargs):

--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -36,7 +36,7 @@ ATTR_DISCOVER_DEVICES = 'devices'
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['xknx==0.7.16']
+REQUIREMENTS = ['xknx==0.7.18']
 
 TUNNELING_SCHEMA = vol.Schema({
     vol.Required(CONF_HOST): cv.string,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1131,7 +1131,7 @@ xbee-helper==0.0.7
 xboxapi==0.1.1
 
 # homeassistant.components.knx
-xknx==0.7.17
+xknx==0.7.18
 
 # homeassistant.components.media_player.bluesound
 # homeassistant.components.sensor.swiss_hydrological_data

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1131,7 +1131,7 @@ xbee-helper==0.0.7
 xboxapi==0.1.1
 
 # homeassistant.components.knx
-xknx==0.7.16
+xknx==0.7.17
 
 # homeassistant.components.media_player.bluesound
 # homeassistant.components.sensor.swiss_hydrological_data


### PR DESCRIPTION
## Description:

After some back and forth this should be final implementation of the KNX climate component. It now uses the setpoint-shift group address to set a target temperature.

The new setpoint shift is calculated out of current setpoint shift, current target temperature and desired target temperature.

**Related issue (if applicable):** https://github.com/XKNX/xknx/issues/48

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3903

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
   - platform: knx
     name: HASS-Kitchen.Temperature
     temperature_address: '5/1/1'
     setpoint_shift_address: '5/1/2'
     setpoint_shift_state_address: '5/1/3'
     target_temperature_address: '5/1/4'
     operation_mode_address: '5/1/5'
```


