### PR TITLE
Remove model info from state

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 
 from homeassistant.core import callback
+from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_RGB_COLOR, ATTR_TRANSITION,
     SUPPORT_BRIGHTNESS, SUPPORT_TRANSITION, SUPPORT_COLOR_TEMP,
@@ -181,14 +182,12 @@ class TradfriLight(Light):
     def device_state_attributes(self):
         """Return the devices' state attributes."""
         info = self._light.device_info
-        attrs = {
-            'manufacturer': info.manufacturer,
-            'model_number': info.model_number,
-            'serial': info.serial,
-            'firmware_version': info.firmware_version,
-            'power_source': info.power_source_str,
-            'battery_level': info.battery_level
-        }
+
+        attrs = {}
+
+        if info.battery_level is not None:
+            attrs[ATTR_BATTERY_LEVEL] = info.battery_level
+
         return attrs
 
     @asyncio.coroutine


### PR DESCRIPTION
## Description:
Remove the model information from Tradfri states.

They should not be part of the state and attributes. 

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
