### PR TITLE
Device model identification of the Xiaomi Philips Ceiling Lamp fixed

### DIFF
--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -64,7 +64,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             light = PhilipsEyecare(host, token)
             device = XiaomiPhilipsEyecareLamp(name, light, device_info)
             devices.append(device)
-        elif device_info.model == 'philips.light.ceil':
+        elif device_info.model == 'philips.light.ceiling':
             from miio import Ceil
             light = Ceil(host, token)
             device = XiaomiPhilipsCeilingLamp(name, light, device_info)


### PR DESCRIPTION
## Description:

The model was handled by a catch-all in the past. The code was replaced by an error message recently:

Unsupported device found! Please create an issue at https://github.com/rytilahti/python-miio/issues and provide the following data: philips.light.ceiling

The model name "philips.light.ceiling" will be handled now.

**Related issue (if applicable):** fixes #10398

Fixes https://github.com/rytilahti/python-miio/issues/112

