### PR TITLE
Fix recorder stop on SQLite vacuuming error

### DIFF
--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -2,8 +2,6 @@
 from datetime import timedelta
 import logging
 
-from sqlalchemy import exc
-
 import homeassistant.util.dt as dt_util
 
 from .util import session_scope
@@ -30,6 +28,8 @@ def purge_old_data(instance, purge_days):
     # Execute sqlite vacuum command to free up space on disk
     _LOGGER.debug("DB engine driver: %s", instance.engine.driver)
     if instance.engine.driver == 'pysqlite':
+        from sqlalchemy import exc
+
         _LOGGER.info("Vacuuming SQLite to free space")
         try:
             instance.engine.execute("VACUUM")

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 import logging
 
+from sqlalchemy import exc
+
 import homeassistant.util.dt as dt_util
 
 from .util import session_scope
@@ -29,4 +31,7 @@ def purge_old_data(instance, purge_days):
     _LOGGER.debug("DB engine driver: %s", instance.engine.driver)
     if instance.engine.driver == 'pysqlite':
         _LOGGER.info("Vacuuming SQLite to free space")
-        instance.engine.execute("VACUUM")
+        try:
+            instance.engine.execute("VACUUM")
+        except exc.OperationalError as err:
+            _LOGGER.error("Error vacuuming SQLite: %s.", err)


### PR DESCRIPTION
## Description:

Recorder thread stop recording if SQLite vacuum operation throws an exception, for example:
````
(sqlite3.OperationalError) database or disk is full [SQL: 'VACUUM'].
````
Main cause of the issue was insufficient space on tmp filesystem used by SQLite DB compact.

**Related issue (if applicable):** fixes #10299

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - N/A [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
