### PR TITLE
Various IKEA tradfri gateway enhancements

### DIFF
--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -85,7 +85,7 @@ def request_configuration(hass, config, host, name, allow_tradfri_groups):
                                "Security Code not accepted.")
             return
 
-        res = yield from _setup_gateway(hass, config, host,
+        res = yield from _setup_gateway(hass, config, host, name,
                                         identity, token,
                                         allow_tradfri_groups)
         if not res:
@@ -153,7 +153,7 @@ def async_setup(hass, config):
             token = known_hosts[host].get('token',
                                           known_hosts[host].get('key'))
 
-            yield from _setup_gateway(hass, config, host,
+            yield from _setup_gateway(hass, config, host, name,
                                       identity,
                                       token,
                                       allow_tradfri_groups)
@@ -175,7 +175,7 @@ def async_setup(hass, config):
 
 
 @asyncio.coroutine
-def _setup_gateway(hass, hass_config, host,
+def _setup_gateway(hass, hass_config, host, name,
                    identity, token,
                    allow_tradfri_groups):
     """Create a gateway."""
@@ -194,7 +194,7 @@ def _setup_gateway(hass, hass_config, host,
     except RequestError:
         _LOGGER.exception("Tradfri setup failed. Requesting reconfiguration.")
         hass.async_add_job(request_configuration, hass, hass_config,
-                           host, allow_tradfri_groups)
+                           host, name, allow_tradfri_groups)
         return False
 
     gateway_id = gateway_info_result.id

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -205,6 +205,13 @@ def _setup_gateway(hass, hass_config, host, name,
         _LOGGER.warning("Timeout on setting up Tradfri gateway: %s "
                         "at %s. Host probably not reachable",
                         name, host)
+        hass.components.persistent_notification.create(
+            'Could not setup your IKEA Trådfri gateway: {} @ {}.<br>'
+            'The connection timed out. <br>'
+            'Please check that your gateway is connected and reachable on the '
+            'network.'.format(name, host),
+            title='IKEA Trådfri setup error'
+            )
         return False
 
     gateway_id = gateway_info_result.id

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import os
+import uuid
 
 import voluptuous as vol
 
@@ -23,8 +24,7 @@ REQUIREMENTS = ['pytradfri==4.0.1',
                 '#aiocoap==0.3']
 
 DOMAIN = 'tradfri'
-GATEWAY_IDENTITY = 'homeassistant'
-CONFIG_FILE = '.tradfri_psk.conf'
+CONFIG_FILE = '.tradfri_identity.conf'
 KEY_CONFIG = 'tradfri_configuring'
 KEY_GATEWAY = 'tradfri_gateway'
 KEY_API = 'tradfri_api'
@@ -62,12 +62,21 @@ def request_configuration(hass, config, host):
             _LOGGER.exception("Looks like something isn't installed!")
             return
 
-        api_factory = APIFactory(host, psk_id=GATEWAY_IDENTITY)
-        psk = yield from api_factory.generate_psk(callback_data.get('key'))
-        res = yield from _setup_gateway(hass, config, host, psk,
-                                        DEFAULT_ALLOW_TRADFRI_GROUPS)
+        # use an unique identity to pair with gateway on every config attempt
+        # using the same id would make it unable to pair with a
+        # new (or another) hass instance.
+        identity = uuid.uuid4().hex
 
-        if not res:
+        try:
+            api_factory = APIFactory(host, psk_id=identity)
+            token = yield from api_factory.generate_psk(
+                                            callback_data.get('key'))
+            res = yield from _setup_gateway(hass, config, host,
+                                            identity, token,
+                                            DEFAULT_ALLOW_TRADFRI_GROUPS)
+            if not res:
+                raise
+        except:
             hass.async_add_job(configurator.notify_errors, instance,
                                "Unable to connect.")
             return
@@ -75,7 +84,7 @@ def request_configuration(hass, config, host):
         def success():
             """Set up was successful."""
             conf = _read_config(hass)
-            conf[host] = {'key': psk}
+            conf[host] = {'identity': identity, 'token': token}
             _write_config(hass, conf)
             hass.async_add_job(configurator.request_done, instance)
 
@@ -86,8 +95,8 @@ def request_configuration(hass, config, host):
         description='Please enter the security code written at the bottom of '
                     'your IKEA Trådfri Gateway.',
         submit_caption="Confirm",
-        fields=[{'id': 'key', 'name': 'Security Code', 'type': 'password'}]
-    )
+        fields=[{'id': 'key', 'name': 'Security Code'}]
+        )
 
 
 @asyncio.coroutine
@@ -96,35 +105,33 @@ def async_setup(hass, config):
     conf = config.get(DOMAIN, {})
     host = conf.get(CONF_HOST)
     allow_tradfri_groups = conf.get(CONF_ALLOW_TRADFRI_GROUPS)
-    keys = yield from hass.async_add_job(_read_config, hass)
+    known_hosts = yield from hass.async_add_job(_read_config, hass)
 
     @asyncio.coroutine
     def gateway_discovered(service, info):
         """Run when a gateway is discovered."""
         host = info['host']
 
-        if host in keys:
-            yield from _setup_gateway(hass, config, host, keys[host]['key'],
-                                      allow_tradfri_groups)
+        if host in known_hosts:
+            yield from _setup_gateway(hass, config, host,
+                                        known_hosts[host]['identity'],
+                                        known_hosts[host]['token'],
+                                        allow_tradfri_groups)
         else:
             hass.async_add_job(request_configuration, hass, config, host)
+            return True
 
     discovery.async_listen(hass, SERVICE_IKEA_TRADFRI, gateway_discovered)
 
-    if not host:
-        return True
+    if host:
+        yield from gateway_discovered(None, {'host': host})
 
-    if host and keys.get(host):
-        return (yield from _setup_gateway(hass, config, host,
-                                          keys[host]['key'],
-                                          allow_tradfri_groups))
-    else:
-        hass.async_add_job(request_configuration, hass, config, host)
-        return True
+    return True
 
 
 @asyncio.coroutine
-def _setup_gateway(hass, hass_config, host, key, allow_tradfri_groups):
+def _setup_gateway(hass, hass_config, host,
+                    identity, token, allow_tradfri_groups):
     """Create a gateway."""
     from pytradfri import Gateway, RequestError
     try:
@@ -134,13 +141,13 @@ def _setup_gateway(hass, hass_config, host, key, allow_tradfri_groups):
         return False
 
     try:
-        factory = APIFactory(host, psk_id=GATEWAY_IDENTITY, psk=key,
-                             loop=hass.loop)
+        factory = APIFactory(host, psk_id=identity, psk=token, loop=hass.loop)
         api = factory.request
         gateway = Gateway()
         gateway_info_result = yield from api(gateway.get_gateway_info())
-    except RequestError:
-        _LOGGER.exception("Tradfri setup failed.")
+    except:
+        _LOGGER.exception("Tradfri setup failed. Requesting reconfiguration.")
+        hass.async_add_job(request_configuration, hass, hass_config, host)
         return False
 
     gateway_id = gateway_info_result.id

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -170,7 +170,7 @@ def async_setup(hass, config):
         allow_groups = gateway_conf.get(CONF_ALLOW_TRADFRI_GROUPS)
 
         yield from gateway_discovered(None, {'hostname': host, 'name': name},
-                           allow_groups)
+                                      allow_groups)
 
     return True
 

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -82,7 +82,7 @@ def request_configuration(hass, config, host, hostname):
                                "Security Code not accepted.")
             return
 
-        res = yield from _setup_gateway(hass, config, host, hostname,
+        res = yield from _setup_gateway(hass, config, host,
                                         identity, token,
                                         DEFAULT_ALLOW_TRADFRI_GROUPS)
         if not res:
@@ -129,14 +129,22 @@ def async_setup(hass, config):
         """Run when a gateway is discovered."""
         host = info['host']
         hostname = info['hostname']
+
         if hostname in known_hosts:
+            known_host = hostname
+        else if host in known_hosts:
+            known_host = hostname
+        else:
+            known_host = False
+
+        if known_host
             yield from _setup_gateway(hass, config, host, hostname,
                                       known_hosts[hostname]['identity'],
                                       known_hosts[hostname]['token'],
                                       allow_tradfri_groups)
         else:
             hass.async_add_job(request_configuration, hass,
-                               config, host, hostname)
+                               config, hostname)
 
     discovery.async_listen(hass, SERVICE_IKEA_TRADFRI, gateway_discovered)
 

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -24,7 +24,7 @@ REQUIREMENTS = ['pytradfri==4.0.1',
                 '#aiocoap==0.3']
 
 DOMAIN = 'tradfri'
-CONFIG_FILE = '.tradfri_identities.conf'
+CONFIG_FILE = '.tradfri_psk.conf'
 KEY_CONFIGURING = 'tradfri_configuring'
 KEY_GATEWAY = 'tradfri_gateway'
 KEY_API = 'tradfri_api'

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -5,13 +5,13 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/ikea_tradfri/
 """
 import asyncio
-import async_timeout
 import json
 import logging
 import os
 import uuid
 
 import voluptuous as vol
+import async_timeout
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -131,8 +131,8 @@ def async_setup(hass, config):
         hostname = info['hostname']
         if hostname in known_hosts:
             yield from _setup_gateway(hass, config, host, hostname,
-                                      known_hosts[host]['identity'],
-                                      known_hosts[host]['token'],
+                                      known_hosts[hostname]['identity'],
+                                      known_hosts[hostname]['token'],
                                       allow_tradfri_groups)
         else:
             hass.async_add_job(request_configuration, hass,

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -140,9 +140,9 @@ def async_setup(hass, config):
         host = info['hostname']
         name = info.get('name', DEFAULT_NAME)
 
-        # try to keep old autoconf setups working
+        # try to keep old autoconf setups working, but prefer newer config
         discovered_host = info.get('host', None)
-        if discovered_host:
+        if (host not in known_hosts) and (discovered_host in known_hosts):
             host = discovered_host
 
         if host in known_hosts:

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -140,7 +140,8 @@ def async_setup(hass, config):
         if host in known_hosts:
             yield from _setup_gateway(hass, config, host,
                                       known_hosts[host]['identity'],
-                                      known_hosts[host]['token'])
+                                      known_hosts[host]['token'],
+                                      allow_groups)
         else:
             hass.async_add_job(request_configuration, hass,
                                config, host, name)

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -139,18 +139,23 @@ def async_setup(hass, config):
         host = info['hostname']
         name = info.get('name', DEFAULT_NAME)
 
+        # try to keep old autoconf setups working
+        discovered_host = info.get('host', None)
+        if discovered_host:
+            host = discovered_host
+
         if host in known_hosts:
             # fallback for old config style
             # identity was hard coded
             # GATEWAY_IDENTITY = 'homeassistant'
             # token was called 'key'
             identity = known_hosts[host].get('identity', 'homeassistant')
-            token = known_hosts[host].get('tokem',
+            token = known_hosts[host].get('token',
                                           known_hosts[host].get('key'))
 
             yield from _setup_gateway(hass, config, host,
                                       identity,
-                                      known_hosts[host]['token'],
+                                      token,
                                       allow_tradfri_groups)
         else:
             hass.async_add_job(request_configuration, hass,

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -169,7 +169,7 @@ def async_setup(hass, config):
         name = gateway_conf.get(CONF_NAME)
         allow_groups = gateway_conf.get(CONF_ALLOW_TRADFRI_GROUPS)
 
-        gateway_discovered(None, {'hostname': host, 'name': name},
+        yield from gateway_discovered(None, {'hostname': host, 'name': name},
                            allow_groups)
 
     return True

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -113,16 +113,17 @@ def request_configuration(hass, config, host, name, allow_tradfri_groups):
     if name:
         title = "{} ({})".format(title, name)
 
+    security_code_field = {'id': 'security_code', 'name': 'Security Code'}
     checbox_field = {'id': 'allow_tradfri_groups',
-                     'name': 'use Tradfri groups', 'type': 'checkbox'}
-    if allow_tradfri_groups:
-        checbox_field['checked'] = 'checked'
+                     'name': 'use Tradfri groups',
+                     'type': 'checkbox',
+                     'checked': allow_tradfri_groups}
     instance = configurator.request_config(
         title, configuration_callback,
         description='Please enter the security code written at the bottom of '
                     'your IKEA Trådfri Gateway.',
         submit_caption="Confirm",
-        fields=[{'id': 'security_code', 'name': 'Security Code'}]
+        fields=[security_code_field, checbox_field]
         )
 
 


### PR DESCRIPTION
- Use a random identity on new setups
- Alow multiple gateways to be set up, either in the config file or auto discovered
- configuration.yaml now accepts a list of gateways. (required attribute: host, optional attributes: name, allow_tradfri_groups)
- configuration panel now includes a checkbox for 'allow_tradfri_groups' (depends on: https://github.com/home-assistant/home-assistant-polymer/pull/581)
- gateway setup timeouts after 10 seconds and then shows a persistent notification
- allow_tradfri_groups is written to the .tradfri_psk.conf (which actually should've just been named .tradfri.conf, but for backward compatibility we'll leave it there)
- all changes should be backward compatible with current configurations (both manual config or autodiscovered configs)