### PR TITLE
Fix 10402: Axis - Don't start event stream without events configured

### DIFF
--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -269,7 +269,8 @@ def setup_device(hass, config, device_config):
                                     config)
 
     AXIS_DEVICES[device.serial_number] = device
-    hass.add_job(device.start)
+    if event_types:
+        hass.add_job(device.start)
     return True
 
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #10402 
