### PR TITLE
Remove extra info from zwave entity states

### DIFF
--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -199,6 +199,8 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
 
         if self._attributes[ATTR_FAILED]:
             return 'dead'
+        if self._attributes[ATTR_QUERY_STAGE] != 'Complete':
+            return 'initializing'
         if not self._attributes[ATTR_AWAKE]:
             return 'sleeping'
         if self._attributes[ATTR_READY]:

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -69,11 +69,6 @@ class ZWaveBaseEntity(Entity):
         self.hass.loop.call_later(0.1, do_update)
 
 
-def sub_status(status, stage):
-    """Format sub-status."""
-    return '{} ({})'.format(status, stage) if stage else status
-
-
 class ZWaveNodeEntity(ZWaveBaseEntity):
     """Representation of a Z-Wave node."""
 
@@ -201,17 +196,15 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         """Return the state."""
         if ATTR_READY not in self._attributes:
             return None
-        stage = ''
-        if not self._attributes[ATTR_READY]:
-            # If node is not ready use stage as sub-status.
-            stage = self._attributes[ATTR_QUERY_STAGE]
+
         if self._attributes[ATTR_FAILED]:
-            return sub_status('Dead', stage)
+            return 'dead'
         if not self._attributes[ATTR_AWAKE]:
-            return sub_status('Sleeping', stage)
+            return 'sleeping'
         if self._attributes[ATTR_READY]:
-            return sub_status('Ready', stage)
-        return stage
+            return 'ready'
+
+        return None
 
     @property
     def should_poll(self):

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -330,38 +330,34 @@ class TestZWaveNodeEntity(unittest.TestCase):
         """Test state property."""
         self.node.is_ready = False
         self.entity.node_changed()
-        self.assertEqual('Dynamic', self.entity.state)
+        self.assertEqual('initializing', self.entity.state)
 
         self.node.is_failed = True
+        self.node.query_stage = 'Complete'
         self.entity.node_changed()
-        self.assertEqual('Dead (Dynamic)', self.entity.state)
+        self.assertEqual('dead', self.entity.state)
 
         self.node.is_failed = False
         self.node.is_awake = False
         self.entity.node_changed()
-        self.assertEqual('Sleeping (Dynamic)', self.entity.state)
+        self.assertEqual('sleeping', self.entity.state)
 
     def test_state_ready(self):
         """Test state property."""
+        self.node.query_stage = 'Complete'
         self.node.is_ready = True
         self.entity.node_changed()
-        self.assertEqual('Ready', self.entity.state)
+        self.assertEqual('ready', self.entity.state)
 
         self.node.is_failed = True
         self.entity.node_changed()
-        self.assertEqual('Dead', self.entity.state)
+        self.assertEqual('dead', self.entity.state)
 
         self.node.is_failed = False
         self.node.is_awake = False
         self.entity.node_changed()
-        self.assertEqual('Sleeping', self.entity.state)
+        self.assertEqual('sleeping', self.entity.state)
 
     def test_not_polled(self):
         """Test should_poll property."""
         self.assertFalse(self.entity.should_poll)
-
-
-def test_sub_status():
-    """Test sub_status function."""
-    assert node_entity.sub_status('Status', 'Stage') == 'Status (Stage)'
-    assert node_entity.sub_status('Status', '') == 'Status'


### PR DESCRIPTION
## Description:
Related to https://github.com/home-assistant/home-assistant-polymer/pull/575

Frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/584

We're currently attaching extra info to the state string for Z-Wave node entities. We should only include the primary state value, which is suitable for automations, conditions, etc. The query stage is still available in the state attributes.