### PR TITLE
Tradfri unique identities

### DIFF
--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -102,7 +102,7 @@ def request_configuration(hass, config, host):
                     'your IKEA Trådfri Gateway.',
         submit_caption="Confirm",
         fields=[{'id': 'security_code', 'name': 'Security Code',
-                'type': 'password'}]
+                 'type': 'password'}]
     )
 
 

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -10,7 +10,6 @@ import logging
 import os
 
 import voluptuous as vol
-import uuid
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
@@ -59,6 +58,7 @@ def request_configuration(hass, config, host):
         """Handle the submitted configuration."""
         try:
             from pytradfri.api.aiocoap_api import APIFactory
+            import uuid
         except ImportError:
             _LOGGER.exception("Looks like something isn't installed!")
             return

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -5,9 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/ikea_tradfri/
 """
 import asyncio
-import json
 import logging
-import os
 
 import voluptuous as vol
 

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -91,7 +91,7 @@ def request_configuration(hass, config, host):
             conf[host] = {'identity': identity,
                           'key': key}
             save_json(hass.config.path(CONFIG_FILE), conf)
-            hass.async_add_job(configurator.request_done, instance)
+            hass.add_job(configurator.request_done, instance)
 
         hass.async_add_job(success)
 

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -91,7 +91,7 @@ def request_configuration(hass, config, host):
             conf[host] = {'identity': identity,
                           'key': key}
             save_json(hass.config.path(CONFIG_FILE), conf)
-            configurator.async_request_done(hass, instance)
+            hass.async_add_job(configurator.request_done, instance)
 
         hass.async_add_job(success)
 

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/ikea_tradfri/
 """
 import asyncio
 import logging
+from uuid import uuid4
 
 import voluptuous as vol
 
@@ -58,7 +59,6 @@ def request_configuration(hass, config, host):
         try:
             from pytradfri.api.aiocoap_api import APIFactory
             from pytradfri import RequestError
-            from uuid import uuid4
         except ImportError:
             _LOGGER.exception("Looks like something isn't installed!")
             return
@@ -91,7 +91,7 @@ def request_configuration(hass, config, host):
             conf[host] = {'identity': identity,
                           'key': key}
             save_json(hass.config.path(CONFIG_FILE), conf)
-            hass.add_job(configurator.request_done, instance)
+            configurator.request_done(instance)
 
         hass.async_add_job(success)
 

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -73,7 +73,7 @@ def request_configuration(hass, config, host):
         try:
             key = yield from api_factory.generate_psk(security_code)
         except RequestError:
-            configurator.async_notify_errors(instance,
+            configurator.async_notify_errors(hass, instance,
                                              "Security Code not accepted.")
             return
 
@@ -81,7 +81,8 @@ def request_configuration(hass, config, host):
                                         DEFAULT_ALLOW_TRADFRI_GROUPS)
 
         if not res:
-            configurator.async_notify_errors(instance, "Unable to connect.")
+            configurator.async_notify_errors(hass, instance,
+                                             "Unable to connect.")
             return
 
         def success():
@@ -90,7 +91,7 @@ def request_configuration(hass, config, host):
             conf[host] = {'identity': identity,
                           'key': key}
             save_json(hass.config.path(CONFIG_FILE), conf)
-            configurator.async_request_done(instance)
+            configurator.async_request_done(hass, instance)
 
         hass.async_add_job(success)
 

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -58,12 +58,13 @@ def request_configuration(hass, config, host):
         """Handle the submitted configuration."""
         try:
             from pytradfri.api.aiocoap_api import APIFactory
-            import uuid
+            from pytradfri import RequestError
+            from uuid import uuid4
         except ImportError:
             _LOGGER.exception("Looks like something isn't installed!")
             return
 
-        identity = uuid.uuid4().hex
+        identity = uuid4().hex
         security_code = callback_data.get('security_code')
 
         api_factory = APIFactory(host, psk_id=identity, loop=hass.loop)

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -73,16 +73,15 @@ def request_configuration(hass, config, host):
         try:
             key = yield from api_factory.generate_psk(security_code)
         except RequestError:
-            hass.async_add_job(configurator.notify_errors, instance,
-                               "Security Code not accepted.")
+            configurator.async_notify_errors(instance,
+                                             "Security Code not accepted.")
             return
 
         res = yield from _setup_gateway(hass, config, host, identity, key,
                                         DEFAULT_ALLOW_TRADFRI_GROUPS)
 
         if not res:
-            hass.async_add_job(configurator.notify_errors, instance,
-                               "Unable to connect.")
+            configurator.async_notify_errors(instance, "Unable to connect.")
             return
 
         def success():
@@ -91,7 +90,7 @@ def request_configuration(hass, config, host):
             conf[host] = {'identity': identity,
                           'key': key}
             save_json(hass.config.path(CONFIG_FILE), conf)
-            hass.async_add_job(configurator.request_done, instance)
+            configurator.async_request_done(instance)
 
         hass.async_add_job(success)
 


### PR DESCRIPTION
Using unique identities when pairing with a gateway.
This prevents people from needing to reset the gateway when the key gets missing and they want to pair with home-assistant again. 
For example when people 'start over', which probably happens quite a lot especially with new users.