### PR TITLE
Correct input_datetime initial value parsing

### DIFF
--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -46,7 +46,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Required(CONF_HAS_DATE): cv.boolean,
             vol.Required(CONF_HAS_TIME): cv.boolean,
             vol.Optional(CONF_ICON): cv.icon,
-            vol.Optional(CONF_INITIAL): cv.datetime,
+            vol.Optional(CONF_INITIAL): cv.string,
         }, cv.has_at_least_one_key_value((CONF_HAS_DATE, True),
                                          (CONF_HAS_TIME, True)))})
 }, extra=vol.ALLOW_EXTRA)
@@ -137,15 +137,15 @@ class InputDatetime(Entity):
             old_state = yield from async_get_last_state(self.hass,
                                                         self.entity_id)
             if old_state is not None:
-                restore_val = dt_util.parse_datetime(old_state.state)
+                restore_val = old_state.state
 
         if restore_val is not None:
             if not self._has_date:
-                self._current_datetime = restore_val.time()
+                self._current_datetime = dt_util.parse_time(restore_val)
             elif not self._has_time:
-                self._current_datetime = restore_val.date()
+                self._current_datetime = dt_util.parse_date(restore_val)
             else:
-                self._current_datetime = restore_val
+                self._current_datetime = dt_util.parse_datetime(restore_val)
 
     def has_date(self):
         """Return whether the input datetime carries a date."""

--- a/tests/components/test_input_datetime.py
+++ b/tests/components/test_input_datetime.py
@@ -102,7 +102,7 @@ def test_set_datetime_time(hass):
 @asyncio.coroutine
 def test_set_invalid(hass):
     """Test set_datetime method with only time."""
-    initial = datetime.datetime(2017, 1, 1, 0, 0)
+    initial = '2017-01-01'
     yield from async_setup_component(hass, DOMAIN, {
         DOMAIN: {
             'test_date': {
@@ -124,7 +124,7 @@ def test_set_invalid(hass):
     yield from hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
-    assert state.state == str(initial.date())
+    assert state.state == initial
 
 
 @asyncio.coroutine
@@ -159,8 +159,8 @@ def test_set_datetime_date(hass):
 def test_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(hass, (
-        State('input_datetime.test_time', '2017-09-07 19:46:00'),
-        State('input_datetime.test_date', '2017-09-07 19:46:00'),
+        State('input_datetime.test_time', '19:46:00'),
+        State('input_datetime.test_date', '2017-09-07'),
         State('input_datetime.test_datetime', '2017-09-07 19:46:00'),
         State('input_datetime.test_bogus_data', 'this is not a date'),
     ))


### PR DESCRIPTION
## Description:
Fixes an issue with both initial value and state restore for input_datetime where if a time or date was used setting values neither way worked. datetime values were working fine.

Tests were adjusted accordingly

**Related issue (if applicable):** fixes #10245

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A, bugfix only

## Example entry for `configuration.yaml` (if applicable):
N/A Bugfix only

## Checklist:

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
