### PR TITLE
Bump AbodePy to 0.12.2 to fix urllib3 dependency

### DIFF
--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -21,7 +21,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 from requests.exceptions import HTTPError, ConnectTimeout
 
-REQUIREMENTS = ['abodepy==0.12.1']
+REQUIREMENTS = ['abodepy==0.12.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -58,7 +58,7 @@ TwitterAPI==2.4.6
 YesssSMS==0.1.1b3
 
 # homeassistant.components.abode
-abodepy==0.12.1
+abodepy==0.12.2
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.4


### PR DESCRIPTION
## Description:
Missing dependency in AbodePy 0.12.1 resulted in home-assistant complaining of missing a urllib3 dependency when using the Abode component. 0.12.2 adds the dependency and this should resolve the issue.

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**