### PR TITLE
Add spotify play_media playlist shuffle support

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -132,6 +132,7 @@ MEDIA_PLAYER_PLAY_MEDIA_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
     vol.Required(ATTR_MEDIA_CONTENT_TYPE): cv.string,
     vol.Required(ATTR_MEDIA_CONTENT_ID): cv.string,
     vol.Optional(ATTR_MEDIA_ENQUEUE): cv.boolean,
+    vol.Optional(ATTR_MEDIA_SHUFFLE): cv.boolean,
 })
 
 MEDIA_PLAYER_SET_SHUFFLE_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
@@ -317,7 +318,8 @@ def media_seek(hass, position, entity_id=None):
 
 
 @bind_hass
-def play_media(hass, media_type, media_id, entity_id=None, enqueue=None):
+def play_media(hass, media_type, media_id, entity_id=None,
+               enqueue=None, shuffle=None):
     """Send the media player the command for playing media."""
     data = {ATTR_MEDIA_CONTENT_TYPE: media_type,
             ATTR_MEDIA_CONTENT_ID: media_id}
@@ -327,6 +329,9 @@ def play_media(hass, media_type, media_id, entity_id=None, enqueue=None):
 
     if enqueue:
         data[ATTR_MEDIA_ENQUEUE] = enqueue
+
+    if shuffle:
+        data[ATTR_MEDIA_SHUFFLE] = shuffle
 
     hass.services.call(DOMAIN, SERVICE_PLAY_MEDIA, data)
 
@@ -396,6 +401,8 @@ def async_setup(hass, config):
             params['media_id'] = service.data.get(ATTR_MEDIA_CONTENT_ID)
             params[ATTR_MEDIA_ENQUEUE] = \
                 service.data.get(ATTR_MEDIA_ENQUEUE)
+            params[ATTR_MEDIA_SHUFFLE] = \
+                service.data.get(ATTR_MEDIA_SHUFFLE)
         elif service.service == SERVICE_SHUFFLE_SET:
             params[ATTR_MEDIA_SHUFFLE] = \
                 service.data.get(ATTR_MEDIA_SHUFFLE)

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -260,7 +260,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
                     playlist_user, playlist_id, fields='tracks')
                 playlist_total = playlist_data['tracks']['total']
                 play_args['offset'] = {'position':
-                                    _RND.randint(0, playlist_total - 1)}
+                                       _RND.randint(0, playlist_total - 1)}
         else:
             _LOGGER.error("media type %s is not supported", media_type)
             return

--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -28,6 +28,7 @@ REQUIREMENTS = ['https://github.com/happyleavesaoc/spotipy/'
 DEPENDENCIES = ['http']
 
 _LOGGER = logging.getLogger(__name__)
+_RND = SystemRandom()
 
 SUPPORT_SPOTIFY = SUPPORT_VOLUME_SET | SUPPORT_PAUSE | SUPPORT_PLAY |\
     SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK | SUPPORT_SELECT_SOURCE |\


### PR DESCRIPTION
## Description:
While it is possible to start a playlist and set it to shuffle in home assistant in Spotify using the available media_player calls, it is frustrating that you cannot match the normal Spotify client functionality. This PR adds consistent shuffle playback for Spotify playlists.

The current set of shuffle playlist actions would be:
* `media_player/play_media` with the required playlist. This will `ALWAYS` start with the first track.
* `media_player/shuffle_set` to turn on shuffle
* `media_player/media_next_track` to skip to the next track which be randomised as per the shuffle setting. *This is an optional step and does not stop at least a small portion of that first track from playing.*

Spotify does not expose starting playback shuffled via the API on first launch, so matching the existing normal clients isn't something that can be done out of the box.

**Proposed solution:**
* Add a `shuffle` option to `media_player/play_media` which uses the same existing attribute as `media_player/shuffle_set`
* When a playlist is used and shuffle is set, get the track data of the playlist in order to know the total track count
* Start playback at a random offset track *e.g. if there are 40 tracks, random number between 0 and 39*
* Call `shuffle_set` to set playback to shuffle as normal

**Example Call:**
```yaml
  - service: media_player.play_media
    entity_id: media_player.spotify
    data:
      media_content_type: playlist
      media_content_id: spotify:user:spotify:playlist:37i9dQZF1DWSkkUxEhrBdF
      shuffle: True
```

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** will update `media_player/play_media` if PR is accepted

## Example entry for `configuration.yaml` (if applicable): 
N/A

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - N/A [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - N/A [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - N/A [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - N/A [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
