### PR TITLE
Fixed update() method and removed `ding` feature from stickupcams/floodlight

### DIFF
--- a/homeassistant/components/binary_sensor/ring.py
+++ b/homeassistant/components/binary_sensor/ring.py
@@ -27,7 +27,7 @@ SCAN_INTERVAL = timedelta(seconds=5)
 
 # Sensor types: Name, category, device_class
 SENSOR_TYPES = {
-    'ding': ['Ding', ['doorbell', 'stickup_cams'], 'occupancy'],
+    'ding': ['Ding', ['doorbell'], 'occupancy'],
     'motion': ['Motion', ['doorbell', 'stickup_cams'], 'motion'],
 }
 

--- a/homeassistant/components/camera/ring.py
+++ b/homeassistant/components/camera/ring.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/camera.ring/
 import asyncio
 import logging
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import voluptuous as vol
 

--- a/homeassistant/components/camera/ring.py
+++ b/homeassistant/components/camera/ring.py
@@ -84,8 +84,6 @@ class RingCam(Camera):
             'timezone': self._camera.timezone,
             'type': self._camera.family,
             'video_url': self._video_url,
-            'expires_at': self._expires_at,
-            'utcnow': self._utcnow,
             'video_id': self._last_video_id
         }
 

--- a/homeassistant/components/camera/ring.py
+++ b/homeassistant/components/camera/ring.py
@@ -23,6 +23,8 @@ CONF_FFMPEG_ARGUMENTS = 'ffmpeg_arguments'
 
 DEPENDENCIES = ['ring', 'ffmpeg']
 
+FORCE_REFRESH_INTERVAL = timedelta(minutes=45)
+
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=90)
@@ -63,8 +65,8 @@ class RingCam(Camera):
         self._ffmpeg_arguments = device_info.get(CONF_FFMPEG_ARGUMENTS)
         self._last_video_id = self._camera.last_recording_id
         self._video_url = self._camera.recording_url(self._last_video_id)
-        self._expires_at = None
-        self._utcnow = None
+        self._utcnow = dt_util.utcnow()
+        self._expires_at = FORCE_REFRESH_INTERVAL + self._utcnow
 
     @property
     def name(self):
@@ -82,6 +84,8 @@ class RingCam(Camera):
             'timezone': self._camera.timezone,
             'type': self._camera.family,
             'video_url': self._video_url,
+            'expires_at': self._expires_at,
+            'utcnow': self._utcnow,
             'video_id': self._last_video_id
         }
 
@@ -123,19 +127,19 @@ class RingCam(Camera):
 
     def update(self):
         """Update camera entity and refresh attributes."""
-        # extract the video expiration from URL
-        x_amz_expires = int(self._video_url.split('&')[0].split('=')[-1])
-        x_amz_date = self._video_url.split('&')[1].split('=')[-1]
+        _LOGGER.debug("Checking if Ring DoorBell needs to refresh video_url")
 
+        self._camera.update()
         self._utcnow = dt_util.utcnow()
-        self._expires_at = \
-            timedelta(seconds=x_amz_expires) + \
-            dt_util.as_utc(datetime.strptime(x_amz_date, "%Y%m%dT%H%M%SZ"))
 
-        if self._last_video_id != self._camera.last_recording_id:
-            _LOGGER.debug("Updated Ring DoorBell last_video_id")
+        last_recording_id = self._camera.last_recording_id
+
+        if self._last_video_id != last_recording_id or \
+           self._utcnow >= self._expires_at:
+
+            _LOGGER.info("Ring DoorBell properties refreshed")
+
+            # update attributes if new video or if URL has expired
             self._last_video_id = self._camera.last_recording_id
-
-        if self._utcnow >= self._expires_at:
-            _LOGGER.debug("Updated Ring DoorBell video_url")
             self._video_url = self._camera.recording_url(self._last_video_id)
+            self._expires_at = FORCE_REFRESH_INTERVAL + self._utcnow

--- a/homeassistant/components/sensor/ring.py
+++ b/homeassistant/components/sensor/ring.py
@@ -34,7 +34,7 @@ SENSOR_TYPES = {
         'Last Activity', ['doorbell', 'stickup_cams'], None, 'history', None],
 
     'last_ding': [
-        'Last Ding', ['doorbell', 'stickup_cams'], None, 'history', 'ding'],
+        'Last Ding', ['doorbell'], None, 'history', 'ding'],
 
     'last_motion': [
         'Last Motion', ['doorbell', 'stickup_cams'], None,


### PR DESCRIPTION
## Description:

Candidate for `0.57.3` errata

This PR will fix the issues below:

* https://community.home-assistant.io/t/upgraded-hass-io-from-0-56-2-to-0-57-1-getting-ring-doorbell-errors/31709 - Stickupcams/floodlight devices do not support `ding` event. This removes the support for that which was causing the logs to fill up. 

* https://github.com/home-assistant/home-assistant/issues/10407 - Fixes the error where the video was not being refreshed and hitting `AccessDenied` errors. Basically a couple of errors were happening (my apologies): 

  - The math used to expire the URL was not working as expected and it was also causing problems if the server's time was incorrect. We simplified the formula which should work fine now.

  - Even if a new video was detected, only the video_id was being replayed and not the URL. So the video URL would continue the same. So only restarting the HASS it would refresh.

  - Since the URL expiration math was incorrect, the video would be with a status as `Image not available` for a couple of hours. Only the image would be refreshed.

Many thanks to @ntalekt for helping troubleshooting and testing this issue.  And many thanks to @collse and @aptonline for reporting the `ding` issue. 

Fixes: https://github.com/home-assistant/home-assistant/issues/10407

## Example entry for `configuration.yaml` (if applicable):
```yaml
ring:
  username: foo
  password: bar

camera:
  - platform: ring

binary_sensor:
  - platform: ring

sensor:
  - platform: ring
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

