### PR TITLE
Microsoft Text-to-speech: Fixing missing en-gb support bug

### DIFF
--- a/homeassistant/components/tts/microsoft.py
+++ b/homeassistant/components/tts/microsoft.py
@@ -41,8 +41,8 @@ DEFAULT_LANG = 'en-us'
 DEFAULT_GENDER = 'Female'
 DEFAULT_TYPE = 'ZiraRUS'
 DEFAULT_OUTPUT = 'audio-16khz-128kbitrate-mono-mp3'
-DEFAULT_RATE = "+0%"
-DEFAULT_VOLUME = "+0%"
+DEFAULT_RATE = 0
+DEFAULT_VOLUME = 0
 DEFAULT_PITCH = "default"
 DEFAULT_CONTOUR = ""
 
@@ -51,8 +51,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORTED_LANGUAGES),
     vol.Optional(CONF_GENDER, default=DEFAULT_GENDER): vol.In(GENDERS),
     vol.Optional(CONF_TYPE, default=DEFAULT_TYPE): cv.string,
-    vol.Optional(CONF_RATE, default=DEFAULT_RATE): cv.string,
-    vol.Optional(CONF_VOLUME, default=DEFAULT_VOLUME): cv.string,
+    vol.Optional(CONF_RATE, default=DEFAULT_RATE):
+        vol.All(vol.Coerce(int), vol.Range(-100, 100)),
+    vol.Optional(CONF_VOLUME, default=DEFAULT_VOLUME):
+        vol.All(vol.Coerce(int), vol.Range(-100, 100)),
     vol.Optional(CONF_PITCH, default=DEFAULT_PITCH): cv.string,
     vol.Optional(CONF_CONTOUR, default=DEFAULT_CONTOUR): cv.string,
 })
@@ -77,8 +79,8 @@ class MicrosoftProvider(Provider):
         self._gender = gender
         self._type = ttype
         self._output = DEFAULT_OUTPUT
-        self._rate = rate
-        self._volume = volume
+        self._rate = "{}%".format(rate)
+        self._volume = "{}%".format(volume)
         self._pitch = pitch
         self._contour = contour
         self.name = 'Microsoft'

--- a/homeassistant/components/tts/microsoft.py
+++ b/homeassistant/components/tts/microsoft.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SUPPORTED_LANGUAGES = [
     'ar-eg', 'ar-sa', 'ca-es', 'cs-cz', 'da-dk', 'de-at', 'de-ch', 'de-de',
-    'el-gr', 'en-au', 'en-ca', 'en-ga', 'en-ie', 'en-in', 'en-us', 'es-es',
+    'el-gr', 'en-au', 'en-ca', 'en-gb', 'en-ie', 'en-in', 'en-us', 'es-es',
     'en-mx', 'fi-fi', 'fr-ca', 'fr-ch', 'fr-fr', 'he-il', 'hi-in', 'hu-hu',
     'id-id', 'it-it', 'ja-jp', 'ko-kr', 'nb-no', 'nl-nl', 'pl-pl', 'pt-br',
     'pt-pt', 'ro-ro', 'ru-ru', 'sk-sk', 'sv-se', 'th-th', 'tr-tr', 'zh-cn',

--- a/homeassistant/components/tts/microsoft.py
+++ b/homeassistant/components/tts/microsoft.py
@@ -63,8 +63,7 @@ def get_engine(hass, config):
     return MicrosoftProvider(config[CONF_API_KEY], config[CONF_LANG],
                              config[CONF_GENDER], config[CONF_TYPE],
                              config[CONF_RATE], config[CONF_VOLUME],
-                             config[CONF_PITCH], config[CONF_CONTOUR]
-                            )
+                             config[CONF_PITCH], config[CONF_CONTOUR])
 
 
 class MicrosoftProvider(Provider):

--- a/homeassistant/components/tts/microsoft.py
+++ b/homeassistant/components/tts/microsoft.py
@@ -15,8 +15,12 @@ import homeassistant.helpers.config_validation as cv
 
 CONF_GENDER = 'gender'
 CONF_OUTPUT = 'output'
+CONF_RATE = 'rate'
+CONF_VOLUME = 'volume'
+CONF_PITCH = 'pitch'
+CONF_CONTOUR = 'contour'
 
-REQUIREMENTS = ["pycsspeechtts==1.0.1"]
+REQUIREMENTS = ["pycsspeechtts==1.0.2"]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +28,7 @@ SUPPORTED_LANGUAGES = [
     'ar-eg', 'ar-sa', 'ca-es', 'cs-cz', 'da-dk', 'de-at', 'de-ch', 'de-de',
     'el-gr', 'en-au', 'en-ca', 'en-gb', 'en-ie', 'en-in', 'en-us', 'es-es',
     'en-mx', 'fi-fi', 'fr-ca', 'fr-ch', 'fr-fr', 'he-il', 'hi-in', 'hu-hu',
-    'id-id', 'it-it', 'ja-jp', 'ko-kr', 'nb-no', 'nl-nl', 'pl-pl', 'pt-br',
+    'id-id', 'it-it', 'ja-JP', 'ko-kr', 'nb-no', 'nl-nl', 'pl-pl', 'pt-br',
     'pt-pt', 'ro-ro', 'ru-ru', 'sk-sk', 'sv-se', 'th-th', 'tr-tr', 'zh-cn',
     'zh-hk', 'zh-tw',
 ]
@@ -37,31 +41,47 @@ DEFAULT_LANG = 'en-us'
 DEFAULT_GENDER = 'Female'
 DEFAULT_TYPE = 'ZiraRUS'
 DEFAULT_OUTPUT = 'audio-16khz-128kbitrate-mono-mp3'
+DEFAULT_RATE = "+0%"
+DEFAULT_VOLUME = "+0%"
+DEFAULT_PITCH = "default"
+DEFAULT_CONTOUR = ""
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORTED_LANGUAGES),
     vol.Optional(CONF_GENDER, default=DEFAULT_GENDER): vol.In(GENDERS),
     vol.Optional(CONF_TYPE, default=DEFAULT_TYPE): cv.string,
+    vol.Optional(CONF_RATE, default=DEFAULT_RATE): cv.string,
+    vol.Optional(CONF_VOLUME, default=DEFAULT_VOLUME): cv.string,
+    vol.Optional(CONF_PITCH, default=DEFAULT_PITCH): cv.string,
+    vol.Optional(CONF_CONTOUR, default=DEFAULT_CONTOUR): cv.string,
 })
 
 
 def get_engine(hass, config):
     """Set up Microsoft speech component."""
     return MicrosoftProvider(config[CONF_API_KEY], config[CONF_LANG],
-                             config[CONF_GENDER], config[CONF_TYPE])
+                             config[CONF_GENDER], config[CONF_TYPE],
+                             config[CONF_RATE], config[CONF_VOLUME],
+                             config[CONF_PITCH], config[CONF_CONTOUR]
+                            )
 
 
 class MicrosoftProvider(Provider):
     """The Microsoft speech API provider."""
 
-    def __init__(self, apikey, lang, gender, ttype):
+    def __init__(self, apikey, lang, gender, ttype, rate, volume,
+                 pitch, contour):
         """Init Microsoft TTS service."""
         self._apikey = apikey
         self._lang = lang
         self._gender = gender
         self._type = ttype
         self._output = DEFAULT_OUTPUT
+        self._rate = rate
+        self._volume = volume
+        self._pitch = pitch
+        self._contour = contour
         self.name = 'Microsoft'
 
     @property
@@ -81,8 +101,11 @@ class MicrosoftProvider(Provider):
         from pycsspeechtts import pycsspeechtts
         try:
             trans = pycsspeechtts.TTSTranslator(self._apikey)
-            data = trans.speak(language, self._gender, self._type,
-                               self._output, message)
+            data = trans.speak(language=language, gender=self._gender,
+                               voiceType=self._type, output=self._output,
+                               rate=self._rate, volume=self._volume,
+                               pitch=self._pitch, contour=self._contour,
+                               text=message)
         except HTTPException as ex:
             _LOGGER.error("Error occurred for Microsoft TTS: %s", ex)
             return(None, None)

--- a/homeassistant/components/tts/microsoft.py
+++ b/homeassistant/components/tts/microsoft.py
@@ -28,7 +28,7 @@ SUPPORTED_LANGUAGES = [
     'ar-eg', 'ar-sa', 'ca-es', 'cs-cz', 'da-dk', 'de-at', 'de-ch', 'de-de',
     'el-gr', 'en-au', 'en-ca', 'en-gb', 'en-ie', 'en-in', 'en-us', 'es-es',
     'en-mx', 'fi-fi', 'fr-ca', 'fr-ch', 'fr-fr', 'he-il', 'hi-in', 'hu-hu',
-    'id-id', 'it-it', 'ja-JP', 'ko-kr', 'nb-no', 'nl-nl', 'pl-pl', 'pt-br',
+    'id-id', 'it-it', 'ja-jp', 'ko-kr', 'nb-no', 'nl-nl', 'pl-pl', 'pt-br',
     'pt-pt', 'ro-ro', 'ru-ru', 'sk-sk', 'sv-se', 'th-th', 'tr-tr', 'zh-cn',
     'zh-hk', 'zh-tw',
 ]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -630,7 +630,7 @@ pycmus==0.1.0
 pycomfoconnect==0.3
 
 # homeassistant.components.tts.microsoft
-pycsspeechtts==1.0.1
+pycsspeechtts==1.0.2
 
 # homeassistant.components.sensor.cups
 # pycups==1.9.73


### PR DESCRIPTION
## Description:
There was a bug in the supported languages. Somehow 'en-gb' was missing and listed as 'en-ga', which is not a valid locale. No docs update necessary.

**Related issue (if applicable):** fixes #10375

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
tts:
  - platform: microsoft
    api_key: !secret
    language: en-gb
    gender: Male
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
