### PR TITLE
Add fan and reduce I/O calls in radiotherm

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_ON, STATE_OFF, STATE_UNKNOWN,
-    TEMP_CELSIUS, PRECISION_WHOLE, PRECISION_HALVES, PRECISION_TENTHS)
+    TEMP_CELSIUS, PRECISION_WHOLE, PRECISION_TENTHS)
 
 DOMAIN = 'climate'
 

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_ON, STATE_OFF, STATE_UNKNOWN,
-    TEMP_CELSIUS, PRECISION_WHOLE, PRECISION_TENTHS)
+    TEMP_CELSIUS, PRECISION_WHOLE, PRECISION_HALVES, PRECISION_TENTHS)
 
 DOMAIN = 'climate'
 

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -281,9 +281,7 @@ class RadioThermostat(ClimateDevice):
 
     def set_operation_mode(self, operation_mode):
         """Set operation mode (auto, cool, heat, off)."""
-        if operation_mode == STATE_OFF:
-            self.device.tmode = TEMP_MODE_TO_CODE[operation_mode]
-        elif operation_mode == STATE_AUTO:
+        if operation_mode == STATE_OFF or operation_mode == STATE_AUTO:
             self.device.tmode = TEMP_MODE_TO_CODE[operation_mode]
 
         # Setting t_cool or t_heat automatically changes tmode.

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -31,9 +31,11 @@ CONF_AWAY_TEMPERATURE_COOL = 'away_temperature_cool'
 DEFAULT_AWAY_TEMPERATURE_HEAT = 60
 DEFAULT_AWAY_TEMPERATURE_COOL = 85
 
+STATE_CIRCULATE = "circulate"
+
 OPERATION_LIST = [STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_OFF]
 CT30_FAN_OPERATION_LIST = [STATE_ON, STATE_AUTO]
-CT80_FAN_OPERATION_LIST = [STATE_ON, "Circulate", STATE_AUTO]
+CT80_FAN_OPERATION_LIST = [STATE_ON, STATE_CIRCULATE, STATE_AUTO]
 
 # Mappings from radiotherm json data codes to and from HASS state
 # flags.  CODE is the thermostat integer code and these map to and
@@ -44,7 +46,7 @@ CODE_TO_TEMP_MODE = {0: STATE_OFF, 1: STATE_HEAT, 2: STATE_COOL, 3: STATE_AUTO}
 TEMP_MODE_TO_CODE = {v: k for k, v in CODE_TO_TEMP_MODE.items()}
 
 # Programmed fan mode (circulate is supported by CT80 models)
-CODE_TO_FAN_MODE = {0: STATE_AUTO, 1: "Circulate", 2: STATE_ON}
+CODE_TO_FAN_MODE = {0: STATE_AUTO, 1: STATE_CIRCULATE, 2: STATE_ON}
 FAN_MODE_TO_CODE = {v: k for k, v in CODE_TO_FAN_MODE.items()}
 
 # Active thermostat state (is it heating or cooling?).  In the future

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -11,8 +11,9 @@ import voluptuous as vol
 
 from homeassistant.components.climate import (
     STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_IDLE, STATE_ON, STATE_OFF,
-    ClimateDevice, PRECISION_HALVES, PLATFORM_SCHEMA)
-from homeassistant.const import CONF_HOST, TEMP_FAHRENHEIT, ATTR_TEMPERATURE
+    ClimateDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    CONF_HOST, TEMP_FAHRENHEIT, ATTR_TEMPERATURE, PRECISION_HALVES)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['radiotherm==1.3']

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -10,8 +10,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.climate import (
-    STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_IDLE, STATE_OFF,
-    ClimateDevice, PLATFORM_SCHEMA)
+    STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_IDLE, STATE_ON, STATE_OFF,
+    ClimateDevice, PRECISION_HALVES, PLATFORM_SCHEMA)
 from homeassistant.const import CONF_HOST, TEMP_FAHRENHEIT, ATTR_TEMPERATURE
 import homeassistant.helpers.config_validation as cv
 
@@ -28,6 +28,19 @@ CONF_AWAY_TEMPERATURE_COOL = 'away_temperature_cool'
 
 DEFAULT_AWAY_TEMPERATURE_HEAT = 60
 DEFAULT_AWAY_TEMPERATURE_COOL = 85
+
+# Mappings from radiotherm json data to HASS state flags.  Note that
+# the inverse mappings are also in the code below so they have to be
+# updated in two places if they ever change.
+
+# Temperature mode of the thermostat.
+NAME_TEMP_MODE = {0: STATE_OFF, 1: STATE_HEAT, 2: STATE_COOL, 3: STATE_AUTO}
+# Active state (is it heating or cooling?)
+NAME_TEMP_STATE = {0: STATE_IDLE, 1: STATE_HEAT, 2: STATE_COOL}
+# Fan mode
+NAME_FAN_MODE = {0: STATE_AUTO, 1: "circulate", 2: STATE_ON}
+# Active fan state
+NAME_FAN_STATE = {0: STATE_OFF, 1: STATE_ON}
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): vol.All(cv.ensure_list, [cv.string]),
@@ -77,6 +90,9 @@ class RadioThermostat(ClimateDevice):
     def __init__(self, device, hold_temp, away_temps):
         """Initialize the thermostat."""
         self.device = device
+        # It would be better if this was in update() since it triggers
+        # a network call but the thermostat will clear any temporary
+        # mode or temperature if this is called so we have to leave it here.
         self.set_time()
         self._target_temperature = None
         self._current_temperature = None
@@ -86,10 +102,12 @@ class RadioThermostat(ClimateDevice):
         self._tmode = None
         self._tstate = None
         self._hold_temp = hold_temp
+        self._hold_set = False
         self._away = False
-        self._away_temps = away_temps
+        self._away_temps = [self.round_temp(i) for i in away_temps]
         self._prev_temp = None
         self._operation_list = [STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_OFF]
+        self._fan_list = [STATE_ON, STATE_AUTO]
 
     @property
     def name(self):
@@ -102,12 +120,34 @@ class RadioThermostat(ClimateDevice):
         return TEMP_FAHRENHEIT
 
     @property
+    def precision(self):
+        """Return the precision of the system."""
+        return PRECISION_HALVES
+
+    @property
     def device_state_attributes(self):
         """Return the device specific state attributes."""
         return {
             ATTR_FAN: self._fmode,
             ATTR_MODE: self._tmode,
         }
+
+    @property
+    def fan_list(self):
+        """List of available fan modes."""
+        return self._fan_list
+
+    @property
+    def current_fan_mode(self):
+        """Return whether the fan is on."""
+        return self._fmode
+
+    def set_fan_mode(self, fan):
+        """Turn fan on/off."""
+        if fan == STATE_AUTO or fan == STATE_OFF:
+            self.device.fmode = 0
+        elif fan == STATE_ON:
+            self.device.fmode = 2
 
     @property
     def current_temperature(self):
@@ -136,53 +176,47 @@ class RadioThermostat(ClimateDevice):
 
     def update(self):
         """Update and validate the data from the thermostat."""
-        current_temp = self.device.temp['raw']
-        if current_temp == -1:
-            _LOGGER.error("Couldn't get valid temperature reading")
-            return
-        self._current_temperature = current_temp
-        self._name = self.device.name['raw']
-        try:
-            self._fmode = self.device.fmode['human']
-        except AttributeError:
-            _LOGGER.error("Couldn't get valid fan mode reading")
-        try:
-            self._tmode = self.device.tmode['human']
-        except AttributeError:
-            _LOGGER.error("Couldn't get valid thermostat mode reading")
-        try:
-            self._tstate = self.device.tstate['human']
-        except AttributeError:
-            _LOGGER.error("Couldn't get valid thermostat state reading")
+        # Radio thermostats are very slow, and sometimes don't respond
+        # very quickly.  So we need to keep the number of calls to them
+        # to a bare minimum or we'll hit the HASS 10 sec warning.  We
+        # have to make one call to /tstat to get temps but we'll try and
+        # keep the other calls to a minimum.  Even with this, these
+        # thermostats tend to time out sometimes when they're actively
+        # heating or cooling.
 
-        if self._tmode == 'Cool':
-            target_temp = self.device.t_cool['raw']
-            if target_temp == -1:
-                _LOGGER.error("Couldn't get target reading")
-                return
-            self._target_temperature = target_temp
-            self._current_operation = STATE_COOL
-        elif self._tmode == 'Heat':
-            target_temp = self.device.t_heat['raw']
-            if target_temp == -1:
-                _LOGGER.error("Couldn't get valid target reading")
-                return
-            self._target_temperature = target_temp
-            self._current_operation = STATE_HEAT
-        elif self._tmode == 'Auto':
-            if self._tstate == 'Cool':
-                target_temp = self.device.t_cool['raw']
-                if target_temp == -1:
-                    _LOGGER.error("Couldn't get valid target reading")
-                    return
-                self._target_temperature = target_temp
-            elif self._tstate == 'Heat':
-                target_temp = self.device.t_heat['raw']
-                if target_temp == -1:
-                    _LOGGER.error("Couldn't get valid target reading")
-                    return
-                self._target_temperature = target_temp
-            self._current_operation = STATE_AUTO
+        # First time - get the name from the thermostat.  This is
+        # normally set in the radio thermostat web app.
+        if self._name is None:
+            self._name = self.device.name['raw']
+
+        # Request the current state from the thermostat.
+        data = self.device.tstat['raw']
+
+        current_temp = data['temp']
+        if current_temp == -1:
+            _LOGGER.error('%s (%s) was busy (temp == -1)', self._name,
+                          self.device.host)
+            return
+
+        # Map thermostat values into various STATE_ flags.
+        self._current_temperature = current_temp
+        self._fmode = NAME_FAN_MODE[data['fmode']]
+        self._tmode = NAME_TEMP_MODE[data['tmode']]
+        self._tstate = NAME_TEMP_STATE[data['tstate']]
+
+        self._current_operation = self._tmode
+        if self._tmode == STATE_COOL:
+            self._target_temperature = data['t_cool']
+        elif self._tmode == STATE_HEAT:
+            self._target_temperature = data['t_heat']
+        elif self._tmode == STATE_AUTO:
+            # This doesn't really work - tstate is only set if the HVAC is
+            # active. If it's idle, we don't know what to do with the target
+            # temperature.
+            if self._tstate == STATE_COOL:
+                self._target_temperature = data['t_cool']
+            elif self._tstate == STATE_HEAT:
+                self._target_temperature = data['t_heat']
         else:
             self._current_operation = STATE_IDLE
 
@@ -191,23 +225,32 @@ class RadioThermostat(ClimateDevice):
         temperature = kwargs.get(ATTR_TEMPERATURE)
         if temperature is None:
             return
-        if self._current_operation == STATE_COOL:
-            self.device.t_cool = round(temperature * 2.0) / 2.0
-        elif self._current_operation == STATE_HEAT:
-            self.device.t_heat = round(temperature * 2.0) / 2.0
-        elif self._current_operation == STATE_AUTO:
-            if self._tstate == 'Cool':
-                self.device.t_cool = round(temperature * 2.0) / 2.0
-            elif self._tstate == 'Heat':
-                self.device.t_heat = round(temperature * 2.0) / 2.0
 
-        if self._hold_temp or self._away:
-            self.device.hold = 1
-        else:
-            self.device.hold = 0
+        temperature = self.round_temp(temperature)
+
+        if self._current_operation == STATE_COOL:
+            self.device.t_cool = temperature
+        elif self._current_operation == STATE_HEAT:
+            self.device.t_heat = temperature
+        elif self._current_operation == STATE_AUTO:
+            if self._tstate == STATE_COOL:
+                self.device.t_cool = temperature
+            elif self._tstate == STATE_HEAT:
+                self.device.t_heat = temperature
+
+        # Only change the hold if requested or if hold mode was turned
+        # on and we haven't set it yet.
+        if kwargs.get('hold_changed', False) or not self._hold_set:
+            if self._hold_temp or self._away:
+                self.device.hold = 1
+                self._hold_set = True
+            else:
+                self.device.hold = 0
 
     def set_time(self):
         """Set device time."""
+        # Calling this clears any local temperature override and
+        # reverts to the scheduled temperature.
         now = datetime.datetime.now()
         self.device.time = {
             'day': now.weekday(),
@@ -221,10 +264,12 @@ class RadioThermostat(ClimateDevice):
             self.device.tmode = 0
         elif operation_mode == STATE_AUTO:
             self.device.tmode = 3
+
+        # Setting t_cool or t_heat automatically changes tmode.
         elif operation_mode == STATE_COOL:
-            self.device.t_cool = round(self._target_temperature * 2.0) / 2.0
+            self.device.t_cool = self._target_temperature
         elif operation_mode == STATE_HEAT:
-            self.device.t_heat = round(self._target_temperature * 2.0) / 2.0
+            self.device.t_heat = self._target_temperature
 
     def turn_away_mode_on(self):
         """Turn away on.
@@ -238,10 +283,20 @@ class RadioThermostat(ClimateDevice):
                 away_temp = self._away_temps[0]
             elif self._current_operation == STATE_COOL:
                 away_temp = self._away_temps[1]
+
         self._away = True
-        self.set_temperature(temperature=away_temp)
+        self.set_temperature(temperature=away_temp, hold_changed=True)
 
     def turn_away_mode_off(self):
         """Turn away off."""
         self._away = False
-        self.set_temperature(temperature=self._prev_temp)
+        self.set_temperature(temperature=self._prev_temp, hold_changed=True)
+
+    @staticmethod
+    def round_temp(temperature):
+        """Round a temperature to the resolution of the thermostat.
+
+        RadioThermostats can handle 0.5 degree temps so the input
+        temperature is rounded to that value and returned.
+        """
+        return round(temperature * 2.0) / 2.0

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -42,6 +42,7 @@ NAME_FAN_MODE = {0: STATE_AUTO, 1: "circulate", 2: STATE_ON}
 # Active fan state
 NAME_FAN_STATE = {0: STATE_OFF, 1: STATE_ON}
 
+
 def round_temp(temperature):
     """Round a temperature to the resolution of the thermostat.
 
@@ -50,15 +51,16 @@ def round_temp(temperature):
     """
     return round(temperature * 2.0) / 2.0
 
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_HOLD_TEMP, default=False): cv.boolean,
     vol.Optional(CONF_AWAY_TEMPERATURE_HEAT,
                  default=DEFAULT_AWAY_TEMPERATURE_HEAT):
-                     vol.All(vol.Coerce(float), round_temp),
+                    vol.All(vol.Coerce(float), round_temp),
     vol.Optional(CONF_AWAY_TEMPERATURE_COOL,
-                 default=DEFAULT_AWAY_TEMPERATURE_COOL): 
-                     vol.All(vol.Coerce(float), round_temp),
+                 default=DEFAULT_AWAY_TEMPERATURE_COOL):
+                    vol.All(vol.Coerce(float), round_temp),
 })
 
 
@@ -301,4 +303,3 @@ class RadioThermostat(ClimateDevice):
         """Turn away off."""
         self._away = False
         self.set_temperature(temperature=self._prev_temp, hold_changed=True)
-


### PR DESCRIPTION
## Description:
See issue #8404 for most of the details.  The radiotherm underlying python module that the radiotherm climate component is using has a few issues.  Every state element access is implemented as a separate url call which the thermostat can't handle and there are no time outs supported.  I've reduced these as much as possible for now and reduce the number of url calls from ~7 per update() to 2-3 per update().   Given the constraint to use the existing library, a number of improvements that make this code work better (reducing calls even further to a single request, proper time outs, retry ability) can't be done.  The things I could fix include:
- fixed multiple web calls in update() to only use a minimum of calls for a large speed increase
- fixed constructor to defer web calls until update() to speed up start up times
- added correct temperature resolution
- added fan attributes so the web front end now allows for manual fan control.

There is still a lot of work to do for this component but there have been several requests for this fix by users so I'm putting this in as is for now.  Future work (which I'll open as a separate issue when I have time to finish it) includes:
- asyncio support
- automatic retry when set functions fail (which can happen sometimes)
- fix auto mode which isn't really working right now
- add proper hold mode as a switch that can be controlled from the web front end
- full set of unit tests w/ a mock thermostat (there are 0 test cases for this right now)
- move these fixes down to the 3rd party Python library.  The current package owner hasn't responded to issue posts since June so it's not clear whether changes can be merged down or not at this point.  Once I have a full set of fixes, I'll try and figure out how to get those propagated down or if the library should be forked.

NOTE: this was a previous PR that I closed because I somehow got my git branch into a strange state and could never fix it so I deleted the PR and the branch and started over.  There were a number of comments about using the existing 3rd party radiotherm library instead of moving that functionality into the HA component.  I disagreed with those since the only functionality being provided was a single web get/set call which tons of other components already do and they seem fine.  However I've changed the code to use the existing library as efficiently as it can given that constraint.  

**Related issue (if applicable):** fixes #8404 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

