### PR TITLE
Add baudrate option to Serial sensor

### DIFF
--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -25,7 +25,8 @@ DEFAULT_BAUDRATE = 9600
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SERIAL_PORT): cv.string,
-    vol.Optional(CONF_SERIAL_BAUDRATE, default=DEFAULT_BAUDRATE): cv.positive_int,
+    vol.Optional(CONF_SERIAL_BAUDRATE, default=DEFAULT_BAUDRATE): 
+        cv.positive_int,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -37,7 +37,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Serial sensor platform."""
     name = config.get(CONF_NAME)
     port = config.get(CONF_SERIAL_PORT)
-    baudrate = config.get(CONF_SERIAL_BAUDRATE)
+    baudrate = config.get(CONF_BAUDRATE)
 
     sensor = SerialSensor(name, port, baudrate)
 

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -1,6 +1,5 @@
 """
 Support for reading data from a serial port.
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.serial/
 """
@@ -19,11 +18,14 @@ REQUIREMENTS = ['pyserial-asyncio==0.4']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_SERIAL_PORT = 'serial_port'
+CONF_SERIAL_BAUDRATE = 'baudrate'
 
 DEFAULT_NAME = "Serial Sensor"
+DEFAULT_BAUDRATE = 9600
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SERIAL_PORT): cv.string,
+    vol.Optional(CONF_SERIAL_BAUDRATE, default=DEFAULT_BAUDRATE): cv.positive_int,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
@@ -33,8 +35,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Serial sensor platform."""
     name = config.get(CONF_NAME)
     port = config.get(CONF_SERIAL_PORT)
+    baudrate = config.get(CONF_SERIAL_BAUDRATE)
 
-    sensor = SerialSensor(name, port)
+    sensor = SerialSensor(name, port, baudrate)
 
     hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STOP, sensor.stop_serial_read())
@@ -44,25 +47,26 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class SerialSensor(Entity):
     """Representation of a Serial sensor."""
 
-    def __init__(self, name, port):
+    def __init__(self, name, port, baudrate):
         """Initialize the Serial sensor."""
         self._name = name
         self._state = None
         self._port = port
+        self._baudrate = baudrate
         self._serial_loop_task = None
 
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Handle when an entity is about to be added to Home Assistant."""
         self._serial_loop_task = self.hass.loop.create_task(
-            self.serial_read(self._port))
+            self.serial_read(self._port, self._baudrate))
 
     @asyncio.coroutine
-    def serial_read(self, device, **kwargs):
+    def serial_read(self, device, rate, **kwargs):
         """Read the data from the port."""
         import serial_asyncio
         reader, _ = yield from serial_asyncio.open_serial_connection(
-            url=device, **kwargs)
+            url=device, baudrate=rate, **kwargs)
         while True:
             line = yield from reader.readline()
             self._state = line.decode('utf-8').strip()

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -1,5 +1,6 @@
 """
 Support for reading data from a serial port.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.serial/
 """
@@ -18,14 +19,14 @@ REQUIREMENTS = ['pyserial-asyncio==0.4']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_SERIAL_PORT = 'serial_port'
-CONF_SERIAL_BAUDRATE = 'baudrate'
+CONF_BAUDRATE = 'baudrate'
 
 DEFAULT_NAME = "Serial Sensor"
 DEFAULT_BAUDRATE = 9600
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SERIAL_PORT): cv.string,
-    vol.Optional(CONF_SERIAL_BAUDRATE, default=DEFAULT_BAUDRATE):
+    vol.Optional(CONF_BAUDRATE, default=DEFAULT_BAUDRATE):
         cv.positive_int,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -25,7 +25,7 @@ DEFAULT_BAUDRATE = 9600
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SERIAL_PORT): cv.string,
-    vol.Optional(CONF_SERIAL_BAUDRATE, default=DEFAULT_BAUDRATE): 
+    vol.Optional(CONF_SERIAL_BAUDRATE, default=DEFAULT_BAUDRATE):
         cv.positive_int,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })


### PR DESCRIPTION
Baudrate is essential!

## Description:
Current version of the serial sensor does not include a configuration option to define baudrate of the serial port.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3926

## Example entry for `configuration.yaml` (if applicable):
```
sensor:
  - platform: serial
    serial_port: /dev/tty.usbmodem1421
    baudrate: 115200

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54