### PR TITLE
Added rpi_servo component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -611,6 +611,7 @@ omit =
     homeassistant/components/switch/rainmachine.py
     homeassistant/components/switch/rest.py
     homeassistant/components/switch/rpi_rf.py
+    homeassistant/components/switch/rpi_servo.py
     homeassistant/components/switch/snmp.py
     homeassistant/components/switch/tplink.py
     homeassistant/components/switch/telnet.py

--- a/homeassistant/components/rpi_gpio.py
+++ b/homeassistant/components/rpi_gpio.py
@@ -49,7 +49,7 @@ def setup_input(port, pull_mode):
 
 
 def run_pwm(port, frequency, duty_cycle, duration):
-    """Run GPIO as PWM"""
+    """Run GPIO as PWM."""
     import RPi.GPIO as GPIO
     import time
     p = GPIO.PWM(port, frequency)

--- a/homeassistant/components/rpi_gpio.py
+++ b/homeassistant/components/rpi_gpio.py
@@ -48,6 +48,16 @@ def setup_input(port, pull_mode):
                GPIO.PUD_DOWN if pull_mode == 'DOWN' else GPIO.PUD_UP)
 
 
+def run_pwm(port, frequency, duty_cycle, duration):
+    """Run GPIO as PWM"""
+    import RPi.GPIO as GPIO
+    import time
+    p = GPIO.PWM(port, frequency)
+    p.start(duty_cycle)
+    time.sleep(duration)
+    p.stop()
+
+
 def write_output(port, value):
     """Write a value to a GPIO."""
     import RPi.GPIO as GPIO

--- a/homeassistant/components/rpi_gpio.py
+++ b/homeassistant/components/rpi_gpio.py
@@ -48,14 +48,16 @@ def setup_input(port, pull_mode):
                GPIO.PUD_DOWN if pull_mode == 'DOWN' else GPIO.PUD_UP)
 
 
-def run_pwm(port, frequency, duty_cycle, duration):
+def run_pwm(hass, port, frequency, duty_cycle, duration):
     """Run GPIO as PWM."""
     import RPi.GPIO as GPIO
-    import time
+    from homeassistant.helpers.event import track_point_in_time
     p = GPIO.PWM(port, frequency)
     p.start(duty_cycle)
-    time.sleep(duration)
-    p.stop()
+    def stop(*args):
+        """Call stop."""
+        p.stop()
+    track_point_in_time(hass, stop, duration)
 
 
 def write_output(port, value):

--- a/homeassistant/components/rpi_gpio.py
+++ b/homeassistant/components/rpi_gpio.py
@@ -54,9 +54,11 @@ def run_pwm(hass, port, frequency, duty_cycle, duration):
     from homeassistant.helpers.event import track_point_in_time
     p = GPIO.PWM(port, frequency)
     p.start(duty_cycle)
+
     def stop(*args):
         """Call stop."""
         p.stop()
+
     track_point_in_time(hass, stop, duration)
 
 

--- a/homeassistant/components/switch/rpi_servo.py
+++ b/homeassistant/components/switch/rpi_servo.py
@@ -32,12 +32,12 @@ _SWITCHES_SCHEMA = vol.Schema({
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PORTS): _SWITCHES_SCHEMA,
-    vol.Optional(CONF_INACTIVE_POSTION, default=DEFAULT_INACTIVE_POSITION):
-        cv.positive_int,
-    vol.Optional(CONF_POSITION_ON, default=DEFAULT_POSITION_ON):
-        cv.positive_int,
-    vol.Optional(CONF_POSITION_OFF, default=DEFAULT_POSITION_OFF)
-    : cv.positive_int,
+    vol.Optional(CONF_INACTIVE_POSTION,
+                 default=DEFAULT_INACTIVE_POSITION): cv.positive_int,
+    vol.Optional(CONF_POSITION_ON,
+                 default=DEFAULT_POSITION_ON): cv.positive_int,
+    vol.Optional(CONF_POSITION_OFF,
+                 default=DEFAULT_POSITION_OFF): cv.positive_int,
     vol.Optional(CONF_POSITION_DURATION,
                  default=DEFAULT_POSITION_DURATION): cv.positive_int,
 })
@@ -54,7 +54,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     ports = config.get(CONF_PORTS)
     for port, name in ports.items():
         switches.append(RPiGPIOServo(name, port, inactive_position,
-                                     position_on, position_off, enabled_duration))
+                                     position_on, position_off,
+                                     enabled_duration))
     add_devices(switches)
 
 

--- a/homeassistant/components/switch/rpi_servo.py
+++ b/homeassistant/components/switch/rpi_servo.py
@@ -26,21 +26,20 @@ DEFAULT_POSITION_ON = 180
 DEFAULT_POSITION_OFF = 0
 DEFAULT_POSITION_DURATION = 1
 
-
 _SWITCHES_SCHEMA = vol.Schema({
     cv.positive_int: cv.string,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-        vol.Required(CONF_PORTS): _SWITCHES_SCHEMA,
-        vol.Optional(CONF_INACTIVE_POSTION, default=DEFAULT_INACTIVE_POSITION):
+    vol.Required(CONF_PORTS): _SWITCHES_SCHEMA,
+    vol.Optional(CONF_INACTIVE_POSTION, default=DEFAULT_INACTIVE_POSITION):
         cv.positive_int,
-        vol.Optional(CONF_POSITION_ON, default=DEFAULT_POSITION_ON):
+    vol.Optional(CONF_POSITION_ON, default=DEFAULT_POSITION_ON):
         cv.positive_int,
-        vol.Optional(CONF_POSITION_OFF, default=DEFAULT_POSITION_OFF)
-        : cv.positive_int,
-        vol.Optional(CONF_POSITION_DURATION,
-            default=DEFAULT_POSITION_DURATION): cv.positive_int,
+    vol.Optional(CONF_POSITION_OFF, default=DEFAULT_POSITION_OFF)
+    : cv.positive_int,
+    vol.Optional(CONF_POSITION_DURATION,
+                 default=DEFAULT_POSITION_DURATION): cv.positive_int,
 })
 
 
@@ -55,7 +54,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     ports = config.get(CONF_PORTS)
     for port, name in ports.items():
         switches.append(RPiGPIOServo(name, port, inactive_position,
-            position_on, position_off, enabled_duration))
+                                     position_on, position_off, enabled_duration))
     add_devices(switches)
 
 
@@ -63,7 +62,7 @@ class RPiGPIOServo(ToggleEntity):
     """Representation of a  Raspberry Pi GPIO Servo."""
 
     def __init__(self, name, port, inactive_position, position_on,
-            position_off, enabled_duration):
+                 position_off, enabled_duration):
         """Initialize the servo"""
         self._name = name or DEVICE_DEFAULT_NAME
         self._port = port
@@ -117,4 +116,3 @@ class RPiGPIOServo(ToggleEntity):
 def get_duty(degrees):
     """Calculates the duty cycle given a number of degrees"""
     return float(degrees) / 18.0 + 2.5
-

--- a/homeassistant/components/switch/rpi_servo.py
+++ b/homeassistant/components/switch/rpi_servo.py
@@ -105,10 +105,7 @@ class RPiGPIOServo(ToggleEntity):
         self.schedule_update_ha_state()
 
     def _run_with_duty(self, duty):
-        """Turn the servo to the given duty.
-
-         Also turns it back to inactive unless duration is 0.
-         """
+        """Turn the servo to the given duty."""
         if self._enabled_duration == 0:
             GPIO.run_pwm(self._port, 50, duty, 2)
         else:

--- a/homeassistant/components/switch/rpi_servo.py
+++ b/homeassistant/components/switch/rpi_servo.py
@@ -1,0 +1,120 @@
+"""
+Allows to configure a switch using RPi GPIO Servos.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.rpi_gpio/
+"""
+import logging
+
+import voluptuous as vol
+import homeassistant.components.rpi_gpio as GPIO
+from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.helpers.entity import ToggleEntity
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['rpi_gpio']
+
+CONF_PORTS = 'ports'
+CONF_INACTIVE_POSTION = "default_position"
+CONF_POSITION_ON = "position_on"
+CONF_POSITION_OFF = "position_off"
+CONF_POSITION_DURATION = "enabled_duration"
+DEFAULT_INACTIVE_POSITION = 90
+DEFAULT_POSITION_ON = 180
+DEFAULT_POSITION_OFF = 0
+DEFAULT_POSITION_DURATION = 1
+
+
+_SWITCHES_SCHEMA = vol.Schema({
+    cv.positive_int: cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+        vol.Required(CONF_PORTS): _SWITCHES_SCHEMA,
+        vol.Optional(CONF_INACTIVE_POSTION, default=DEFAULT_INACTIVE_POSITION):
+        cv.positive_int,
+        vol.Optional(CONF_POSITION_ON, default=DEFAULT_POSITION_ON):
+        cv.positive_int,
+        vol.Optional(CONF_POSITION_OFF, default=DEFAULT_POSITION_OFF)
+        : cv.positive_int,
+        vol.Optional(CONF_POSITION_DURATION,
+            default=DEFAULT_POSITION_DURATION): cv.positive_int,
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Raspberry PI GPIO servo devices."""
+    inactive_position = config.get(CONF_INACTIVE_POSTION)
+    position_on = config.get(CONF_POSITION_ON)
+    position_off = config.get(CONF_POSITION_OFF)
+    enabled_duration = config.get(CONF_POSITION_DURATION)
+    switches = []
+    ports = config.get(CONF_PORTS)
+    for port, name in ports.items():
+        switches.append(RPiGPIOServo(name, port, inactive_position,
+            position_on, position_off, enabled_duration))
+    add_devices(switches)
+
+
+class RPiGPIOServo(ToggleEntity):
+    """Representation of a  Raspberry Pi GPIO Servo."""
+
+    def __init__(self, name, port, inactive_position, position_on,
+            position_off, enabled_duration):
+        """Initialize the servo"""
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._port = port
+        self._state = False
+        self._inactive_position = inactive_position
+        self._position_on = position_on
+        self._position_off = position_off
+        self._enabled_duration = enabled_duration
+        GPIO.setup_output(port)
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        duty = get_duty(self._position_on)
+        self._run_with_duty(duty)
+        self._state = True
+        self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn the switch off."""
+        duty = get_duty(self._position_off)
+        self._run_with_duty(duty)
+        self._state = False
+        self.schedule_update_ha_state()
+
+    def _run_with_duty(self, duty):
+        """Turn the servo to the given duty, and back to inactive unless
+        duration is 0"""
+        if self._enabled_duration == 0:
+            GPIO.run_pwm(self._port, 50, duty, 2)
+        else:
+            GPIO.run_pwm(self._port, 50, duty, self._enabled_duration)
+            duty = get_duty(self._inactive_position)
+            GPIO.run_pwm(self._port, 50, duty, self._enabled_duration)
+
+
+def get_duty(degrees):
+    """Calculates the duty cycle given a number of degrees"""
+    return float(degrees) / 18.0 + 2.5
+

--- a/homeassistant/components/switch/rpi_servo.py
+++ b/homeassistant/components/switch/rpi_servo.py
@@ -1,5 +1,6 @@
 """
 Allows to configure a switch using RPi GPIO Servos.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.rpi_gpio/
 """
@@ -64,7 +65,7 @@ class RPiGPIOServo(ToggleEntity):
 
     def __init__(self, name, port, inactive_position, position_on,
                  position_off, enabled_duration):
-        """Initialize the servo"""
+        """Initialize the servo."""
         self._name = name or DEVICE_DEFAULT_NAME
         self._port = port
         self._state = False
@@ -104,8 +105,10 @@ class RPiGPIOServo(ToggleEntity):
         self.schedule_update_ha_state()
 
     def _run_with_duty(self, duty):
-        """Turn the servo to the given duty, and back to inactive unless
-        duration is 0"""
+        """Turn the servo to the given duty.
+
+         Also turns it back to inactive unless duration is 0.
+         """
         if self._enabled_duration == 0:
             GPIO.run_pwm(self._port, 50, duty, 2)
         else:
@@ -115,5 +118,5 @@ class RPiGPIOServo(ToggleEntity):
 
 
 def get_duty(degrees):
-    """Calculates the duty cycle given a number of degrees"""
+    """Calculate the duty cycle given a number of degrees."""
     return float(degrees) / 18.0 + 2.5


### PR DESCRIPTION
This is a new request for the changes in #10215 since I were unable to cleanup the branch

## Description:
Created a servo component which uses the raspberry pi's GPIO pins. The component can for instance be used to push buttons on a tv-remote.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3827

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: rpi_gpio
    ports:
      12: Test Switch
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54