### PR TITLE
Return proper status when calling service via REST API

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -312,6 +312,8 @@ class APIDomainServicesView(HomeAssistantView):
         Returns a list of changed states.
         """
         hass = request.app['hass']
+        if not hass.services.has_service(domain, service):
+            return self.json_message('Service not found', HTTP_NOT_FOUND)
         body = yield from request.text()
         try:
             data = json.loads(body) if body else None
@@ -321,7 +323,6 @@ class APIDomainServicesView(HomeAssistantView):
 
         with AsyncTrackStates(hass) as changed_states:
             yield from hass.services.async_call(domain, service, data, True)
-
         return self.json(changed_states)
 
 

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -327,7 +327,7 @@ class APIDomainServicesView(HomeAssistantView):
         service_handler = hass.services._services[domain][service]
         try:
             if service_handler.schema:
-                service_data = service_handler.schema(data)
+                service_handler.schema(data)
         except vol.Invalid as ex:
             _LOGGER.error("Invalid service data for %s.%s: %s",
                           domain, service, humanize_error(data, ex))

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -324,6 +324,7 @@ class APIDomainServicesView(HomeAssistantView):
             return self.json_message('Data should be valid JSON',
                                      HTTP_BAD_REQUEST)
 
+        # pylint: disable=protected-access
         service_handler = hass.services._services[domain][service]
         try:
             if service_handler.schema:


### PR DESCRIPTION
This returns a 404 when calling a service if the service does not exist. It also throws a 400 if the provided data payload is invalid (along with the exact validation error using `humanize_error` just like the log line in core.py).
