### PR TITLE
Recycle socket everytime new command to recover in case mochad restarted

### DIFF
--- a/homeassistant/components/switch/mochad.py
+++ b/homeassistant/components/switch/mochad.py
@@ -61,21 +61,29 @@ class MochadSwitch(SwitchDevice):
         """Turn the switch on."""
         self._state = True
         """Recycle socket everytime new command to recover in case mochad restarted"""
-        _LOGGER.debug("Reconnect to mochad {} : {} ".format(self._controller.server, self._controller.port))
+        _LOGGER.debug("Reconnect to mochad {} : {} ".format(self._controller.server, 
+                                                            self._controller.port))
         self._controller.socket.close()
         self._controller.__init__(self._controller.server, self._controller.port)
         self.device.send_cmd('on')
-        self._controller.read_data()
+        try:
+            self._controller.read_data()
+        except socket.error as e:
+            _LOGGER.error("Socket error when reading data from mochad {}".format(e.message))
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
         self._state = False
         """Recycle socket everytime new command to recover in case mochad restarted"""
-        _LOGGER.debug("Reconnect to mochad {} : {} ".format(self._controller.server, self._controller.port))
+        _LOGGER.debug("Reconnect to mochad {} : {} ".format(self._controller.server, 
+                                                            self._controller.port))
         self._controller.socket.close()
         self._controller.__init__(self._controller.server, self._controller.port)
         self.device.send_cmd('off')
-        self._controller.read_data()
+        try:
+            self._controller.read_data()
+        except socket.error as e:
+            _LOGGER.error("Socket error when reading data from mochad {}".format(e.message))
 
     def _get_device_status(self):
         """Get the status of the switch from mochad."""

--- a/homeassistant/components/switch/mochad.py
+++ b/homeassistant/components/switch/mochad.py
@@ -60,12 +60,20 @@ class MochadSwitch(SwitchDevice):
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         self._state = True
+        """Recycle socket everytime new command to recover in case mochad restarted"""
+        _LOGGER.debug("Reconnect to mochad {} : {} ".format(self._controller.server, self._controller.port))
+        self._controller.socket.close()
+        self._controller.__init__(self._controller.server, self._controller.port)
         self.device.send_cmd('on')
         self._controller.read_data()
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
         self._state = False
+        """Recycle socket everytime new command to recover in case mochad restarted"""
+        _LOGGER.debug("Reconnect to mochad {} : {} ".format(self._controller.server, self._controller.port))
+        self._controller.socket.close()
+        self._controller.__init__(self._controller.server, self._controller.port)
         self.device.send_cmd('off')
         self._controller.read_data()
 


### PR DESCRIPTION
Minor fix to re-connect the underlying socket in controller.PyMochad

There is a known issue for mochad to get locked up occasionally. e.g. as seen often on RPi.
https://sourceforge.net/p/mochad/discussion/1320003/thread/1c193f01/

When this happens, mochad can be recovered by restarting it. However, mochad.py components in home-assistant once connected on HA startup, won't ever reconnect.

This improvement allows to reconnect underlying socket in controller.PyMochad when X10 commands are sent to mochad. It's tested to work fine on my HA.