### PR TITLE
 Add basic support for Alexa intent slot synonyms.

### DIFF
--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -138,9 +138,27 @@ class AlexaResponse(object):
         # Intent is None if request was a LaunchRequest or SessionEndedRequest
         if intent_info is not None:
             for key, value in intent_info.get('slots', {}).items():
+                underscored_key = key.replace('.', '_')
+
                 if 'value' in value:
-                    underscored_key = key.replace('.', '_')
                     self.variables[underscored_key] = value['value']
+
+                if 'resolutions' in value:
+                    self._populate_resolved_values(underscored_key, value)
+
+    def _populate_resolved_values(self, underscored_key, value):
+        for resolution in value['resolutions']['resolutionsPerAuthority']:
+            if 'values' not in resolution:
+                continue
+
+            for resolved in resolution['values']:
+                if 'value' not in resolved:
+                    continue
+
+                if 'id' in resolved['value']:
+                    self.variables[underscored_key] = resolved['value']['id']
+                elif 'name' in resolved['value']:
+                    self.variables[underscored_key] = resolved['value']['name']
 
     def add_card(self, card_type, title, content):
         """Add a card to the response."""

--- a/tests/components/alexa/test_intent.py
+++ b/tests/components/alexa/test_intent.py
@@ -13,6 +13,7 @@ from homeassistant.components.alexa import intent
 SESSION_ID = "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000"
 APPLICATION_ID = "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
 REQUEST_ID = "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000"
+AUTHORITY_ID = "amzn1.er-authority.000000-d0ed-0000-ad00-000000d00ebe.ZODIAC"
 
 # pylint: disable=invalid-name
 calls = []
@@ -90,7 +91,7 @@ def alexa_client(loop, hass, test_client):
                         "type": "plain",
                         "text": "LaunchRequest has been received.",
                     }
-                }
+                },
             }
         }))
     return loop.run_until_complete(test_client(hass.http.app))
@@ -205,6 +206,131 @@ def test_intent_request_with_slots(alexa_client):
     text = data.get("response", {}).get("outputSpeech",
                                         {}).get("text")
     assert text == "You told us your sign is virgo."
+
+
+@asyncio.coroutine
+def test_intent_request_with_slots_and_id_resolution(alexa_client):
+    """Test a request with slots and an id synonym."""
+    data = {
+        "version": "1.0",
+        "session": {
+            "new": False,
+            "sessionId": SESSION_ID,
+            "application": {
+                "applicationId": APPLICATION_ID
+            },
+            "attributes": {
+                "supportedHoroscopePeriods": {
+                    "daily": True,
+                    "weekly": False,
+                    "monthly": False
+                }
+            },
+            "user": {
+                "userId": "amzn1.account.AM3B00000000000000000000000"
+            }
+        },
+        "request": {
+            "type": "IntentRequest",
+            "requestId": REQUEST_ID,
+            "timestamp": "2015-05-13T12:34:56Z",
+            "intent": {
+                "name": "GetZodiacHoroscopeIntent",
+                "slots": {
+                    "ZodiacSign": {
+                        "name": "ZodiacSign",
+                        "value": "virgo",
+                        "resolutions": {
+                            "resolutionsPerAuthority": [
+                                {
+                                    "authority": AUTHORITY_ID,
+                                    "status": {
+                                        "code": "ER_SUCCESS_MATCH"
+                                    },
+                                    "values": [
+                                        {
+                                            "value": {
+                                                "name": "Virgo",
+                                                "id": "VIRGO"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+    req = yield from _intent_req(alexa_client, data)
+    assert req.status == 200
+    data = yield from req.json()
+    text = data.get("response", {}).get("outputSpeech",
+                                        {}).get("text")
+    assert text == "You told us your sign is VIRGO."
+
+
+@asyncio.coroutine
+def test_intent_request_with_slots_and_name_resolution(alexa_client):
+    """Test a request with slots and a name synonym."""
+    data = {
+        "version": "1.0",
+        "session": {
+            "new": False,
+            "sessionId": SESSION_ID,
+            "application": {
+                "applicationId": APPLICATION_ID
+            },
+            "attributes": {
+                "supportedHoroscopePeriods": {
+                    "daily": True,
+                    "weekly": False,
+                    "monthly": False
+                }
+            },
+            "user": {
+                "userId": "amzn1.account.AM3B00000000000000000000000"
+            }
+        },
+        "request": {
+            "type": "IntentRequest",
+            "requestId": REQUEST_ID,
+            "timestamp": "2015-05-13T12:34:56Z",
+            "intent": {
+                "name": "GetZodiacHoroscopeIntent",
+                "slots": {
+                    "ZodiacSign": {
+                        "name": "ZodiacSign",
+                        "value": "virgo",
+                        "resolutions": {
+                            "resolutionsPerAuthority": [
+                                {
+                                    "authority": AUTHORITY_ID,
+                                    "status": {
+                                        "code": "ER_SUCCESS_MATCH"
+                                    },
+                                    "values": [
+                                        {
+                                            "value": {
+                                                "name": "Virgo"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+    req = yield from _intent_req(alexa_client, data)
+    assert req.status == 200
+    data = yield from req.json()
+    text = data.get("response", {}).get("outputSpeech",
+                                        {}).get("text")
+    assert text == "You told us your sign is Virgo."
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

Adds basic support for [synonyms](https://developer.amazon.com/docs/custom-skills/define-synonyms-and-ids-for-slot-type-values-entity-resolution.html).

It's not clear (to me) in which case(s) there will be either multiple "resolutionsPerAuthority" or multiple "values" so the implementation will currently use the last value it finds which admittedly will be somewhat undefined behaviour if it occurs. 

Since the "id" is optional in the UI it's prioritised over the "name" (original value) if specified as it's presumed to be what the implementer wants returned to home assistant (e.g. this could be an entity_id I'd think).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
