### PR TITLE
telegram_bot: Support for sending videos

### DIFF
--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -64,7 +64,7 @@ class TelegramNotificationService(BaseNotificationService):
             keys = keys if isinstance(keys, list) else [keys]
             service_data.update(inline_keyboard=keys)
 
-        # Send a photo, a video, a document or a location
+        # Send a photo, video, document, or location
         if data is not None and ATTR_PHOTO in data:
             photos = data.get(ATTR_PHOTO, None)
             photos = photos if isinstance(photos, list) else [photos]

--- a/homeassistant/components/notify/telegram.py
+++ b/homeassistant/components/notify/telegram.py
@@ -21,6 +21,7 @@ DEPENDENCIES = [DOMAIN]
 ATTR_KEYBOARD = 'keyboard'
 ATTR_INLINE_KEYBOARD = 'inline_keyboard'
 ATTR_PHOTO = 'photo'
+ATTR_VIDEO = 'video'
 ATTR_DOCUMENT = 'document'
 
 CONF_CHAT_ID = 'chat_id'
@@ -63,7 +64,7 @@ class TelegramNotificationService(BaseNotificationService):
             keys = keys if isinstance(keys, list) else [keys]
             service_data.update(inline_keyboard=keys)
 
-        # Send a photo, a document or a location
+        # Send a photo, a video, a document or a location
         if data is not None and ATTR_PHOTO in data:
             photos = data.get(ATTR_PHOTO, None)
             photos = photos if isinstance(photos, list) else [photos]
@@ -71,6 +72,14 @@ class TelegramNotificationService(BaseNotificationService):
                 service_data.update(photo_data)
                 self.hass.services.call(
                     DOMAIN, 'send_photo', service_data=service_data)
+            return
+        elif data is not None and ATTR_VIDEO in data:
+            videos = data.get(ATTR_VIDEO, None)
+            videos = videos if isinstance(videos, list) else [videos]
+            for video_data in videos:
+                service_data.update(video_data)
+                self.hass.services.call(
+                    DOMAIN, 'send_video', service_data=service_data)
             return
         elif data is not None and ATTR_LOCATION in data:
             service_data.update(data.get(ATTR_LOCATION))

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -65,6 +65,7 @@ DOMAIN = 'telegram_bot'
 
 SERVICE_SEND_MESSAGE = 'send_message'
 SERVICE_SEND_PHOTO = 'send_photo'
+SERVICE_SEND_VIDEO = 'send_video'
 SERVICE_SEND_DOCUMENT = 'send_document'
 SERVICE_SEND_LOCATION = 'send_location'
 SERVICE_EDIT_MESSAGE = 'edit_message'
@@ -154,6 +155,7 @@ SERVICE_SCHEMA_DELETE_MESSAGE = vol.Schema({
 SERVICE_MAP = {
     SERVICE_SEND_MESSAGE: SERVICE_SCHEMA_SEND_MESSAGE,
     SERVICE_SEND_PHOTO: SERVICE_SCHEMA_SEND_FILE,
+    SERVICE_SEND_VIDEO: SERVICE_SCHEMA_SEND_FILE,
     SERVICE_SEND_DOCUMENT: SERVICE_SCHEMA_SEND_FILE,
     SERVICE_SEND_LOCATION: SERVICE_SCHEMA_SEND_LOCATION,
     SERVICE_EDIT_MESSAGE: SERVICE_SCHEMA_EDIT_MESSAGE,
@@ -277,12 +279,11 @@ def async_setup(hass, config):
         if msgtype == SERVICE_SEND_MESSAGE:
             yield from hass.async_add_job(
                 partial(notify_service.send_message, **kwargs))
-        elif msgtype == SERVICE_SEND_PHOTO:
+        elif msgtype == SERVICE_SEND_PHOTO or \
+             msgtype == SERVICE_SEND_VIDEO or \
+             msgtype == SERVICE_SEND_DOCUMENT:
             yield from hass.async_add_job(
-                partial(notify_service.send_file, True, **kwargs))
-        elif msgtype == SERVICE_SEND_DOCUMENT:
-            yield from hass.async_add_job(
-                partial(notify_service.send_file, False, **kwargs))
+                partial(notify_service.send_file, msgtype, **kwargs))
         elif msgtype == SERVICE_SEND_LOCATION:
             yield from hass.async_add_job(
                 partial(notify_service.send_location, **kwargs))
@@ -518,11 +519,15 @@ class TelegramNotificationService:
                        callback_query_id,
                        text=message, show_alert=show_alert, **params)
 
-    def send_file(self, is_photo=True, target=None, **kwargs):
-        """Send a photo or a document."""
+    def send_file(self, file_type=SERVICE_SEND_PHOTO, target=None, **kwargs):
+        """Send a photo or video or document."""
         params = self._get_msg_kwargs(kwargs)
         caption = kwargs.get(ATTR_CAPTION)
-        func_send = self.bot.sendPhoto if is_photo else self.bot.sendDocument
+        func_send = {
+            SERVICE_SEND_PHOTO: self.bot.sendPhoto,
+            SERVICE_SEND_VIDEO: self.bot.sendVideo,
+            SERVICE_SEND_DOCUMENT: self.bot.sendDocument
+        }.get(file_type)
         file_content = load_data(
             self.hass,
             url=kwargs.get(ATTR_URL),

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -279,9 +279,9 @@ def async_setup(hass, config):
         if msgtype == SERVICE_SEND_MESSAGE:
             yield from hass.async_add_job(
                 partial(notify_service.send_message, **kwargs))
-        elif msgtype == SERVICE_SEND_PHOTO or \
-             msgtype == SERVICE_SEND_VIDEO or \
-             msgtype == SERVICE_SEND_DOCUMENT:
+        elif (msgtype == SERVICE_SEND_PHOTO or
+              msgtype == SERVICE_SEND_VIDEO or
+              msgtype == SERVICE_SEND_DOCUMENT):
             yield from hass.async_add_job(
                 partial(notify_service.send_file, msgtype, **kwargs))
         elif msgtype == SERVICE_SEND_LOCATION:

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -520,7 +520,7 @@ class TelegramNotificationService:
                        text=message, show_alert=show_alert, **params)
 
     def send_file(self, file_type=SERVICE_SEND_PHOTO, target=None, **kwargs):
-        """Send a photo or video or document."""
+        """Send a photo, video, or document."""
         params = self._get_msg_kwargs(kwargs)
         caption = kwargs.get(ATTR_CAPTION)
         func_send = {

--- a/homeassistant/components/telegram_bot/services.yaml
+++ b/homeassistant/components/telegram_bot/services.yaml
@@ -59,6 +59,37 @@ send_photo:
       description: List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with asociated callback data.
       example: '["/button1, /button2", "/button3"] or [[["Text button1", "/button1"], ["Text button2", "/button2"]], [["Text button3", "/button3"]]]'
 
+send_video:
+  description: Send a video.
+  fields:
+    url:
+      description: Remote path to a video.
+      example: 'http://example.org/path/to/the/video.mp4'
+    file:
+      description: Local path to an image.
+      example: '/path/to/the/video.mp4'
+    caption:
+      description: The title of the video.
+      example: 'My video'
+    username:
+      description: Username for a URL which require HTTP basic authentication.
+      example: myuser
+    password:
+      description: Password for a URL which require HTTP basic authentication.
+      example: myuser_pwd
+    target:
+      description: An array of pre-authorized chat_ids to send the document to. If not present, first allowed chat_id is the default.
+      example: '[12345, 67890] or 12345'
+    disable_notification:
+      description: Sends the message silently. iOS users and Web users will not receive a notification, Android users will receive a notification with no sound.
+      example: true
+    keyboard:
+      description: List of rows of commands, comma-separated, to make a custom keyboard.
+      example: '["/command1, /command2", "/command3"]'
+    inline_keyboard:
+      description: List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with asociated callback data.
+      example: '["/button1, /button2", "/button3"] or [[["Text button1", "/button1"], ["Text button2", "/button2"]], [["Text button3", "/button3"]]]'
+
 send_document:
   description: Send a document.
   fields:


### PR DESCRIPTION
## Description:

Telegram python library has a sendVideo function that can be used
similar to sending photos and documents.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/3936

## Example entry for `configuration.yaml` (if applicable):
```yaml
...
action:
  service: notify.NOTIFIER_NAME
  data:
    title: Send a video
    message: That's an example that sends a video.
    data:
      video:
        - url: http://192.168.1.28/camera.mp4
          username: admin
          password: secrete
        - file: /tmp/video.mp4
          caption: Video Title xy
        - url: http://somebla.ie/video.mp4
          caption: I.e. for a Title
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
