### PR TITLE
Add an option to serve ES6 JS to clients

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.const import CONF_NAME, EVENT_THEMES_UPDATED
 from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['home-assistant-frontend==20171106.0']
+REQUIREMENTS = ['home-assistant-frontend==20171110.0']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http']

--- a/homeassistant/components/frontend/templates/index.html
+++ b/homeassistant/components/frontend/templates/index.html
@@ -78,11 +78,11 @@
         <a href='/'>TRY AGAIN</a>
       </div>
     </div>
-    <home-assistant icons='{{ icons }}'></home-assistant>
-    {# <script src='/static/home-assistant-polymer/build/_demo_data_compiled.js'></script> #}
+    <home-assistant></home-assistant>
+    {# <script src='/static/home-assistant-polymer/build/_demo_data_compiled.js'></script> -#}
+    {% if not es6 -%}
     <script>
-      var compatibilityRequired = (
-        typeof Object.assign != 'function');
+      var compatibilityRequired = (typeof Object.assign != 'function');
       if (compatibilityRequired) {
         var e = document.createElement('script');
         e.onerror = initError;
@@ -90,10 +90,11 @@
         document.head.appendChild(e);
       }
     </script>
+    {% endif -%}
     <script src='{{ core_url }}'></script>
-    {% if not dev_mode %}
+    {% if not dev_mode and not es6 -%}
     <script src='/static/custom-elements-es5-adapter.js'></script>
-    {% endif %}
+    {% endif -%}
     <script>
       var webComponentsSupported = (
         'customElements' in window &&
@@ -104,6 +105,11 @@
         e.onerror = initError;
         e.src = '/static/webcomponents-lite.js';
         document.head.appendChild(e);
+      }
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', function () {
+          navigator.serviceWorker.register('{{ service_worker_name }}');
+        });
       }
     </script>
     <link rel='import' href='{{ ui_url }}' onerror='initError()'>

--- a/homeassistant/components/frontend/templates/index.html
+++ b/homeassistant/components/frontend/templates/index.html
@@ -80,7 +80,7 @@
     </div>
     <home-assistant></home-assistant>
     {# <script src='/static/home-assistant-polymer/build/_demo_data_compiled.js'></script> -#}
-    {% if not es6 -%}
+    {% if not latest -%}
     <script>
       var compatibilityRequired = (typeof Object.assign != 'function');
       if (compatibilityRequired) {
@@ -92,7 +92,7 @@
     </script>
     {% endif -%}
     <script src='{{ core_url }}'></script>
-    {% if not dev_mode and not es6 -%}
+    {% if not dev_mode and not latest -%}
     <script src='/static/custom-elements-es5-adapter.js'></script>
     {% endif -%}
     <script>

--- a/homeassistant/components/frontend/templates/index.html
+++ b/homeassistant/components/frontend/templates/index.html
@@ -93,7 +93,7 @@
     {% endif -%}
     <script src='{{ core_url }}'></script>
     {% if not dev_mode and not latest -%}
-    <script src='/static/custom-elements-es5-adapter.js'></script>
+    <script src='/frontend_es5/custom-elements-es5-adapter.js'></script>
     {% endif -%}
     <script>
       var webComponentsSupported = (

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -262,7 +262,6 @@ class HomeAssistantWSGI(object):
                 resource = CachingStaticResource
             else:
                 resource = web.StaticResource
-
             self.app.router.register_resource(resource(url_path, path))
             return
 

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -65,7 +65,8 @@ class CachingFileResponse(FileResponse):
 @asyncio.coroutine
 def staticresource_middleware(request, handler):
     """Middleware to strip out fingerprint from fingerprinted assets."""
-    if not request.path.startswith('/static/'):
+    path = request.path
+    if not path.startswith('/static/') and not path.startswith('/frontend'):
         return handler(request)
 
     fingerprinted = _FINGERPRINT.match(request.match_info['filename'])

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -483,12 +483,14 @@ class ActiveConnection:
         Async friendly.
         """
         msg = GET_PANELS_MESSAGE_SCHEMA(msg)
+        panels = {
+            panel:
+            self.hass.data[frontend.DATA_PANELS][panel].to_response(self.hass,
+                                                                    request)
+            for panel in self.hass.data[frontend.DATA_PANELS]}
 
         self.to_write.put_nowait(result_message(
-            msg['id'], [
-                self.hass.data[frontend.DATA_PANELS][panel]
-                .to_response(self.hass, request)
-                for panel in self.hass.data[frontend.DATA_PANELS]]))
+            msg['id'], panels))
 
     def handle_ping(self, msg, _):
         """Handle ping command.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -330,7 +330,7 @@ hipnotify==1.0.8
 holidays==0.8.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20171106.0
+home-assistant-frontend==20171110.0
 
 # homeassistant.components.camera.onvif
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -74,7 +74,7 @@ hbmqtt==0.8
 holidays==0.8.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20171106.0
+home-assistant-frontend==20171110.0
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -63,7 +63,11 @@ def test_frontend_and_static(mock_http_client):
 @asyncio.coroutine
 def test_dont_cache_service_worker(mock_http_client):
     """Test that we don't cache the service worker."""
-    resp = yield from mock_http_client.get('/service_worker.js')
+    resp = yield from mock_http_client.get('/service_worker_es5.js')
+    assert resp.status == 200
+    assert 'cache-control' not in resp.headers
+
+    resp = yield from mock_http_client.get('/service_worker_es6.js')
     assert resp.status == 200
     assert 'cache-control' not in resp.headers
 

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -52,7 +52,7 @@ def test_frontend_and_static(mock_http_client):
 
     # Test we can retrieve frontend.js
     frontendjs = re.search(
-        r'(?P<app>\/static\/frontend-[A-Za-z0-9]{32}.html)', text)
+        r'(?P<app>\/frontend_es5\/frontend-[A-Za-z0-9]{32}.html)', text)
 
     assert frontendjs is not None
     resp = yield from mock_http_client.get(frontendjs.groups(0)[0])
@@ -67,7 +67,7 @@ def test_dont_cache_service_worker(mock_http_client):
     assert resp.status == 200
     assert 'cache-control' not in resp.headers
 
-    resp = yield from mock_http_client.get('/service_worker_es6.js')
+    resp = yield from mock_http_client.get('/service_worker.js')
     assert resp.status == 200
     assert 'cache-control' not in resp.headers
 

--- a/tests/components/test_panel_iframe.py
+++ b/tests/components/test_panel_iframe.py
@@ -33,7 +33,7 @@ class TestPanelIframe(unittest.TestCase):
                     'panel_iframe': conf
                 })
 
-    @patch.dict('hass_frontend.FINGERPRINTS',
+    @patch.dict('hass_frontend_es5.FINGERPRINTS',
                 {'panels/ha-panel-iframe.html': 'md5md5'})
     def test_correct_config(self):
         """Test correct config."""
@@ -55,20 +55,20 @@ class TestPanelIframe(unittest.TestCase):
 
         panels = self.hass.data[frontend.DATA_PANELS]
 
-        assert panels.get('router').as_dict() == {
+        assert panels.get('router').to_response(self.hass, None) == {
             'component_name': 'iframe',
             'config': {'url': 'http://192.168.1.1'},
             'icon': 'mdi:network-wireless',
             'title': 'Router',
-            'url': '/static/panels/ha-panel-iframe-md5md5.html',
+            'url': '/frontend_es5/panels/ha-panel-iframe-md5md5.html',
             'url_path': 'router'
         }
 
-        assert panels.get('weather').as_dict() == {
+        assert panels.get('weather').to_response(self.hass, None) == {
             'component_name': 'iframe',
             'config': {'url': 'https://www.wunderground.com/us/ca/san-diego'},
             'icon': 'mdi:weather',
             'title': 'Weather',
-            'url': '/static/panels/ha-panel-iframe-md5md5.html',
+            'url': '/frontend_es5/panels/ha-panel-iframe-md5md5.html',
             'url_path': 'weather',
         }

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -290,7 +290,7 @@ def test_get_panels(hass, websocket_client):
     """Test get_panels command."""
     yield from hass.components.frontend.async_register_built_in_panel(
         'map', 'Map', 'mdi:account-location')
-
+    hass.data[frontend.DATA_JS_VERSION] = 'es5'
     websocket_client.send_json({
         'id': 5,
         'type': wapi.TYPE_GET_PANELS,
@@ -300,8 +300,14 @@ def test_get_panels(hass, websocket_client):
     assert msg['id'] == 5
     assert msg['type'] == wapi.TYPE_RESULT
     assert msg['success']
-    assert msg['result'] == {url: panel.as_dict() for url, panel
-                             in hass.data[frontend.DATA_PANELS].items()}
+    assert msg['result'] == [{
+        'component_name': 'map',
+        'url_path': 'map',
+        'config': None,
+        'url': None,
+        'icon': 'mdi:account-location',
+        'title': 'Map',
+    }]
 
 
 @asyncio.coroutine

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -300,14 +300,14 @@ def test_get_panels(hass, websocket_client):
     assert msg['id'] == 5
     assert msg['type'] == wapi.TYPE_RESULT
     assert msg['success']
-    assert msg['result'] == [{
+    assert msg['result'] == {'map': {
         'component_name': 'map',
         'url_path': 'map',
         'config': None,
         'url': None,
         'icon': 'mdi:account-location',
         'title': 'Map',
-    }]
+    }}
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

Add an option to serve ES6 JS to clients
Frontend PR: home-assistant/home-assistant-polymer#596 home-assistant/home-assistant-polymer#608

`frontend` gets a new config attribute - `javascript_version` that get be `es5`, `latest`, and `auto`.
Meaning to serve es5 (like now), untranspiled, or to auto-detect supported JS by looking at useragent (to be implemented in a future PR)
`es5` is the default, so the behaviour users see shouldn't change by default.

The JS version served can also be overridden by using `latest` or `es5` in the URL.
For example: `localhost:8123/states?latest`
 
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3948

## Example entry for `configuration.yaml` (if applicable):
```yaml
frontend:
  javascript_version: latest
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
