### PR TITLE
add JSON processing capabilities to sensor_serial

### DIFF
--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -12,8 +12,8 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE, 
-    EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import (
+    CONF_NAME, CONF_VALUE_TEMPLATE, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['pyserial-asyncio==0.4']

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -114,9 +114,7 @@ class SerialSensor(Entity):
 
     @property
     def state_attributes(self):
-        """Return the attributes of the entity.
-
-           Provide the parsed JSON data (if any).
+        """Return the attributes of the entity (if any JSON present).
         """
 
         return self._attributes

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -114,9 +114,7 @@ class SerialSensor(Entity):
 
     @property
     def state_attributes(self):
-        """Return the attributes of the entity (if any JSON present).
-        """
-
+        """Return the attributes of the entity (if any JSON present)."""
         return self._attributes
 
     @property

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -84,11 +84,10 @@ class SerialSensor(Entity):
 
             try:
                 data = json.loads(line)
-            except json.JSONDecodeError:
-                _LOGGER.error("Invalid JSON data received: %s", data)
-
-            if isinstance(data, dict):
-                self._attributes = data
+                if isinstance(data, dict):
+                    self._attributes = data
+            except:
+                pass
 
             if self._template is not None:
                 line = self._template.async_render_with_possible_json_value(

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -12,7 +12,8 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE, 
+    EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['pyserial-asyncio==0.4']
@@ -80,8 +81,7 @@ class SerialSensor(Entity):
         while True:
             line = yield from reader.readline()
             line = line.decode('utf-8').strip()
-            
-            """ Parse the return text as JSON and save the json as an attribute. """
+
             try:
                 self._attributes = json.loads(line)
             except json.JSONDecodeError:

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -6,12 +6,13 @@ https://home-assistant.io/components/sensor.serial/
 """
 import asyncio
 import logging
+import json
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE, EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['pyserial-asyncio==0.4']
@@ -29,6 +30,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_BAUDRATE, default=DEFAULT_BAUDRATE):
         cv.positive_int,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
 })
 
 
@@ -39,7 +41,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     port = config.get(CONF_SERIAL_PORT)
     baudrate = config.get(CONF_BAUDRATE)
 
-    sensor = SerialSensor(name, port, baudrate)
+    value_template = config.get(CONF_VALUE_TEMPLATE)
+    if value_template is not None:
+        value_template.hass = hass
+
+    sensor = SerialSensor(name, port, baudrate, value_template)
 
     hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STOP, sensor.stop_serial_read())
@@ -49,13 +55,15 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class SerialSensor(Entity):
     """Representation of a Serial sensor."""
 
-    def __init__(self, name, port, baudrate):
+    def __init__(self, name, port, baudrate, value_template):
         """Initialize the Serial sensor."""
         self._name = name
         self._state = None
         self._port = port
         self._baudrate = baudrate
         self._serial_loop_task = None
+        self._template = value_template
+        self._attributes = []
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -71,7 +79,19 @@ class SerialSensor(Entity):
             url=device, baudrate=rate, **kwargs)
         while True:
             line = yield from reader.readline()
-            self._state = line.decode('utf-8').strip()
+            line = line.decode('utf-8').strip()
+            
+            """ Parse the return text as JSON and save the json as an attribute. """
+            try:
+                self._attributes = json.loads(line)
+            except json.JSONDecodeError:
+                self._attributes = []
+
+            if self._template is not None:
+                line = self._template.async_render_with_possible_json_value(
+                    line)
+
+            self._state = line
             self.async_schedule_update_ha_state()
 
     @asyncio.coroutine
@@ -89,6 +109,15 @@ class SerialSensor(Entity):
     def should_poll(self):
         """No polling needed."""
         return False
+
+    @property
+    def state_attributes(self):
+        """Return the attributes of the entity.
+
+           Provide the parsed JSON data (if any).
+        """
+
+        return self._attributes
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -86,7 +86,7 @@ class SerialSensor(Entity):
                 data = json.loads(line)
                 if isinstance(data, dict):
                     self._attributes = data
-            except:
+            except json.decoder.JSONDecodeError:
                 pass
 
             if self._template is not None:

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -83,9 +83,12 @@ class SerialSensor(Entity):
             line = line.decode('utf-8').strip()
 
             try:
-                self._attributes = json.loads(line)
+                data = json.loads(line)
             except json.JSONDecodeError:
-                self._attributes = []
+                _LOGGER.error("Invalid JSON data received: %s", data)
+
+            if isinstance(data, dict):
+                self._attributes = data
 
             if self._template is not None:
                 line = self._template.async_render_with_possible_json_value(

--- a/homeassistant/components/sensor/serial.py
+++ b/homeassistant/components/sensor/serial.py
@@ -86,7 +86,7 @@ class SerialSensor(Entity):
                 data = json.loads(line)
                 if isinstance(data, dict):
                     self._attributes = data
-            except json.decoder.JSONDecodeError:
+            except ValueError:
                 pass
 
             if self._template is not None:


### PR DESCRIPTION
## Description:

Reading from the serial line strings/numbers is OK, but most likely you will be reading something more complex. This pull request address devices that publish in JSON format through the serial interface adding the value_template optional configuration (which exists in other sensors) and copying into attributes the JSON values.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3942

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.


