### PR TITLE
Adds support for Tile® Bluetooth trackers

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -325,6 +325,7 @@ omit =
     homeassistant/components/device_tracker/thomson.py
     homeassistant/components/device_tracker/tomato.py
     homeassistant/components/device_tracker/tado.py
+    homeassistant/components/device_tracker/tile.py
     homeassistant/components/device_tracker/tplink.py
     homeassistant/components/device_tracker/trackr.py
     homeassistant/components/device_tracker/ubus.py

--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -1,0 +1,82 @@
+"""
+Support for Tile® Bluetooth trackers
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.tile/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker import (
+    PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.const import (
+    CONF_EMAIL, CONF_MONITORED_VARIABLES, CONF_PASSWORD)
+from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.util import slugify
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['pytile==1.0.0']
+
+DEVICE_TYPES = ['PHONE', 'TILE']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_EMAIL): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_MONITORED_VARIABLES):
+        vol.All(cv.ensure_list, [vol.In(DEVICE_TYPES)]),
+})
+
+
+def setup_scanner(hass, config: dict, see, discovery_info=None):
+    """Validate the configuration and return a Tile scanner."""
+    TileDeviceScanner(hass, config, see)
+    return True
+
+
+class TileDeviceScanner(DeviceScanner):
+    """Define a device scanner for Tiles."""
+
+    def __init__(self, hass, config, see):
+        """Initialize."""
+        from pytile import Client as TileAPI
+
+        self._client = TileAPI(
+            config[CONF_EMAIL],
+            config[CONF_PASSWORD])
+        self._types = config.get(CONF_MONITORED_VARIABLES)
+
+        self.devices = {}
+        self.hass = hass
+        self.see = see
+
+        track_utc_time_change(
+            self.hass, self._update_info, second=range(0, 60, 30))
+
+    def _update_info(self, now=None) -> None:
+        """Update the device info."""
+        device_data = self._client.get_tiles(type_whitelist=self._types)
+
+        try:
+            self.devices = device_data['result']
+        except KeyError:
+            _LOGGER.warning('No Tiles found')
+            return False
+
+        for _, info in self.devices.items():
+            dev_id = 'tile_{0}'.format(slugify(info['name']))
+            lat = info['tileState']['latitude']
+            lon = info['tileState']['longitude']
+
+            attrs = {
+                'altitude': info['tileState']['altitude'],
+                'is_lost': info['tileState']['is_lost'],
+                'last_seen': info['tileState']['timestamp'],
+                'last_updated': device_data['timestamp_ms'],
+            }
+
+            self.see(
+                dev_id=dev_id, gps=(lat, lon), attributes=attrs
+            )

--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
-    CONF_EMAIL, CONF_MONITORED_VARIABLES, CONF_PASSWORD)
+    CONF_USERNAME, CONF_MONITORED_VARIABLES, CONF_PASSWORD)
 from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.util import slugify
 from homeassistant.util.json import load_json, save_json
@@ -35,7 +35,7 @@ ATTR_RING_STATE = 'ring_state'
 ATTR_VOIP_STATE = 'voip_state'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_EMAIL): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_MONITORED_VARIABLES):
         vol.All(cv.ensure_list, [vol.In(DEVICE_TYPES)]),
@@ -62,13 +62,13 @@ class TileDeviceScanner(DeviceScanner):
         if config_data:
             _LOGGER.debug('Using existing client UUID')
             self._client = Client(
-                config[CONF_EMAIL],
+                config[CONF_USERNAME],
                 config[CONF_PASSWORD],
                 config_data['client_uuid'])
         else:
             _LOGGER.debug('Generating new client UUID')
             self._client = Client(
-                config[CONF_EMAIL],
+                config[CONF_USERNAME],
                 config[CONF_PASSWORD])
 
             if not save_json(
@@ -82,11 +82,10 @@ class TileDeviceScanner(DeviceScanner):
         self._types = config.get(CONF_MONITORED_VARIABLES)
 
         self.devices = {}
-        self.hass = hass
         self.see = see
 
         track_utc_time_change(
-            self.hass, self._update_info, second=range(0, 60, 30))
+            hass, self._update_info, second=range(0, 60, 30))
 
         self._update_info()
 
@@ -99,9 +98,9 @@ class TileDeviceScanner(DeviceScanner):
         except KeyError:
             _LOGGER.warning('No Tiles found')
             _LOGGER.debug(device_data)
-            return False
+            return
 
-        for _, info in self.devices.items():
+        for info in self.devices.values():
             dev_id = 'tile_{0}'.format(slugify(info['name']))
             lat = info['tileState']['latitude']
             lon = info['tileState']['longitude']

--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -1,5 +1,5 @@
 """
-Support for Tile® Bluetooth trackers
+Support for Tile® Bluetooth trackers.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.tile/
@@ -53,7 +53,7 @@ class TileDeviceScanner(DeviceScanner):
 
     def __init__(self, hass, config, see):
         """Initialize."""
-        from pytile import Client as TileAPI
+        from pytile import Client
 
         _LOGGER.debug('Received configuration data: %s', config)
 
@@ -61,13 +61,13 @@ class TileDeviceScanner(DeviceScanner):
         config_data = load_json(hass.config.path(CLIENT_UUID_CONFIG_FILE))
         if config_data:
             _LOGGER.debug('Using existing client UUID')
-            self._client = TileAPI(
+            self._client = Client(
                 config[CONF_EMAIL],
                 config[CONF_PASSWORD],
                 config_data['client_uuid'])
         else:
             _LOGGER.debug('Generating new client UUID')
-            self._client = TileAPI(
+            self._client = Client(
                 config[CONF_EMAIL],
                 config[CONF_PASSWORD])
 
@@ -87,6 +87,8 @@ class TileDeviceScanner(DeviceScanner):
 
         track_utc_time_change(
             self.hass, self._update_info, second=range(0, 60, 30))
+
+        self._update_info()
 
     def _update_info(self, now=None) -> None:
         """Update the device info."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -892,6 +892,9 @@ pythonegardia==1.0.22
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3
 
+# homeassistant.components.device_tracker.tile
+pytile==1.0.0
+
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5
 


### PR DESCRIPTION
## Description:
Adds support for Tile® Bluetooth trackers as a device tracker platform.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/3938

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: tile
    email: email@address.com
    password: MY_PASSWORD_123
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
