### PR TITLE
Update tcp sensor to support json data

### DIFF
--- a/homeassistant/components/sensor/tcp.py
+++ b/homeassistant/components/sensor/tcp.py
@@ -127,13 +127,12 @@ class TcpSensor(Entity):
 
         if self._config[CONF_VALUE_TEMPLATE] is not None:
             try:
-                self._state = self._config[CONF_VALUE_TEMPLATE].render(
-                    value=value)
-                return
+                self._state = self._config[CONF_VALUE_TEMPLATE].\
+                    render_with_possible_json_value(value)
             except TemplateError as err:
                 _LOGGER.error(
                     "Unable to render template of %r with value: %r",
                     self._config[CONF_VALUE_TEMPLATE], value)
-                return
+            return
 
         self._state = value


### PR DESCRIPTION
## Description:

Updated tcp sensor to support automatic json parsing so 'value_json' can be used in addition to 'value'.

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: tcp                                                                                                                                                                                             
    name: Eth Mining Rate Local Test GPU0                                                                                                                                                                     
    host: localhost                                                                                                                                                                                           
    port: 3333                                                                                                                                                                                                
    payload: '{"id":0,"jsonrpc":"2.0","method":"miner_getstat1"}'                                                                                                                                             
    unit_of_measurement: 'MH/s'                                                                                                                                                                               
    value_template: '{{ (float(value_json.result[3].split(";")[0]) / 1000) | round(2) }}'
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
