### PR TITLE
Truncate sensor.rest to 255 characters. Parse JSON and store in attributes.

### DIFF
--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -120,17 +120,19 @@ class RestSensor(Entity):
             value = self._value_template.render_with_possible_json_value(
                 value, STATE_UNKNOWN)
 
-        # Limit the length of the state to less than 255 characters, otherwise HA > 0.57 complains.
+        # Limit the length of the state to less than 255 characters,
+        # otherwise HA > 0.57 complains.
         if len(value) >= 255:
-            value = value[0:255]    
+            value = value[0:255]
 
         self._state = value
 
-        """ Try parsing the return text as JSON and save the json items as an attributes. """
+        """Try parsing the return text as JSON and save
+            the JSON structure as attributes."""
         try:
             self._attributes = json.loads(value)
         except json.JSONDecodeError:
-            self._attributes = []  
+            self._attributes = []
 
 
 class RestData(object):

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -4,6 +4,7 @@ Support for RESTful API sensors.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.rest/
 """
+import json
 import logging
 import voluptuous as vol
 import requests
@@ -78,6 +79,7 @@ class RestSensor(Entity):
         self._hass = hass
         self.rest = rest
         self._name = name
+        self._attributes = []
         self._state = STATE_UNKNOWN
         self._unit_of_measurement = unit_of_measurement
         self._value_template = value_template
@@ -102,6 +104,11 @@ class RestSensor(Entity):
         """Return the state of the device."""
         return self._state
 
+    @property
+    def state_attributes(self):
+        """Return the attributes of the entity."""
+        return self._attributes
+
     def update(self):
         """Get the latest data from REST API and update the state."""
         self.rest.update()
@@ -118,6 +125,12 @@ class RestSensor(Entity):
             value = value[0:255]    
 
         self._state = value
+
+        """ Try parsing the return text as JSON and save the json items as an attributes. """
+        try:
+            self._attributes = json.loads(value)
+        except json.JSONDecodeError:
+            self._attributes = []  
 
 
 class RestData(object):

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.rest/
 """
 import logging
-
 import voluptuous as vol
 import requests
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
@@ -113,6 +112,10 @@ class RestSensor(Entity):
         elif self._value_template is not None:
             value = self._value_template.render_with_possible_json_value(
                 value, STATE_UNKNOWN)
+
+        # Limit the length of the state to less than 255 characters, otherwise HA > 0.57 complains.
+        if len(value) >= 255:
+            value = value[0:255]    
 
         self._state = value
 


### PR DESCRIPTION
## Description:

Truncates the state to 255 characters, to comply with https://github.com/home-assistant/home-assistant/pull/9696
Tries to automatically parse REST output as JSON, and if there are no parsing issues, stores all data inside attributes (even if the variable is templated).

Supporting documentation for this is a separate PR. I will reference it as soon as I get an ID.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) -- examples for clarity

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
