### PR TITLE
Fix name collision when using multiple Hue bridges

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -83,7 +83,7 @@ SCENE_SCHEMA = vol.Schema({
 })
 
 ATTR_IS_HUE_GROUP = "is_hue_group"
-GROUP_NAME_ALL_HUE_LIGHTS_SUFFIX = " All Lights"
+GROUP_NAME_ALL_HUE_LIGHTS = "{} All Lights"
 
 
 def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
@@ -217,7 +217,7 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
                 return
             # Hue hub returns name of group 0 as "Group 0", so rename
             # for ease of use in HA.
-            all_lights['name'] = bridge_name + GROUP_NAME_ALL_HUE_LIGHTS_SUFFIX
+            all_lights['name'] = GROUP_NAME_ALL_HUE_LIGHTS.format(bridge_name)
             api_groups["0"] = all_lights
 
         new_lights = []

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -83,7 +83,7 @@ SCENE_SCHEMA = vol.Schema({
 })
 
 ATTR_IS_HUE_GROUP = "is_hue_group"
-GROUP_NAME_ALL_HUE_LIGHTS = "All Hue Lights"
+GROUP_NAME_ALL_HUE_LIGHTS_SUFFIX = " All Lights"
 
 
 def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
@@ -170,6 +170,7 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
     lights = {}
     lightgroups = {}
     skip_groups = not allow_hue_groups
+    bridge_name = bridge.name
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update_lights():
@@ -216,7 +217,7 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
                 return
             # Hue hub returns name of group 0 as "Group 0", so rename
             # for ease of use in HA.
-            all_lights['name'] = GROUP_NAME_ALL_HUE_LIGHTS
+            all_lights['name'] = bridge_name + GROUP_NAME_ALL_HUE_LIGHTS_SUFFIX
             api_groups["0"] = all_lights
 
         new_lights = []

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -83,7 +83,6 @@ SCENE_SCHEMA = vol.Schema({
 })
 
 ATTR_IS_HUE_GROUP = "is_hue_group"
-GROUP_NAME_ALL_HUE_LIGHTS = "{} All Lights"
 
 
 def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
@@ -170,7 +169,6 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
     lights = {}
     lightgroups = {}
     skip_groups = not allow_hue_groups
-    bridge_name = bridge.name
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update_lights():
@@ -204,21 +202,6 @@ def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
         if not isinstance(api_groups, dict):
             _LOGGER.error("Got unexpected result from Hue API")
             return
-
-        if not skip_groups:
-            # Group ID 0 is a special group in the hub for all lights, but it
-            # is not returned by get_api() so explicitly get it and include it.
-            # See https://developers.meethue.com/documentation/
-            #               groups-api#21_get_all_groups
-            _LOGGER.debug("Getting group 0 from bridge")
-            all_lights = bridge.get_group(0)
-            if not isinstance(all_lights, dict):
-                _LOGGER.error("Got unexpected result from Hue API for group 0")
-                return
-            # Hue hub returns name of group 0 as "Group 0", so rename
-            # for ease of use in HA.
-            all_lights['name'] = GROUP_NAME_ALL_HUE_LIGHTS.format(bridge_name)
-            api_groups["0"] = all_lights
 
         new_lights = []
 


### PR DESCRIPTION
## Description:
When you have more then one Hue bridge in your network it creates multiple 'All Hue Lights' light groups which seems to result in a naming conflict (I think).

In short it changes the name from 'All Hue Lights' to '{name of bridge} All Lights'.

This probably isn't the best solution for this, but I figured I atleast try to work towards a fix for this issue.

This also would be a breaking change for people using the `light.all_hue_lights` entity.

**Related issue (if applicable):**
fixes #9393, fixes #10031, fixes #10255 (maybe?)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
n/a

## Example entry for `configuration.yaml` (if applicable):
n/a

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

I didn't write a tests for this, sorry.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54