### PR TITLE
OwnTracks Message Handling

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -369,6 +369,7 @@ def async_handle_transition_message(hass, context, message):
 
 @asyncio.coroutine
 def async_handle_waypoint(hass, name_base, waypoint):
+    """Handle a waypoint."""
     name = waypoint['desc']
     pretty_name = '{} - {}'.format(name_base, name)
     lat = waypoint['lat']
@@ -438,14 +439,16 @@ def async_handle_encrypted_message(hass, context, message):
 @HANDLERS.register('steps')
 @HANDLERS.register('card')
 @asyncio.coroutine
-def async_handle_not_implemented_message(hass, context, message):
+def async_handle_not_impl_msg(hass, context, message):
     """Handle valid but not implemented message types."""
     _LOGGER.debug('Not handling %s message: %s', message.get("_type"), message)
 
 
 @asyncio.coroutine
-def async_handle_unsupported_message(hass, context, message):
-    _LOGGER.warning('Received unsupported message type: %s.', message.get('_type'))
+def async_handle_unsupported_msg(hass, context, message):
+    """Handle an unsupported or invalid message type."""
+    _LOGGER.warning('Received unsupported message type: %s.',
+                    message.get('_type'))
 
 
 @asyncio.coroutine
@@ -453,6 +456,6 @@ def async_handle_message(hass, context, message):
     """Handle an OwnTracks message."""
     msgtype = message.get('_type')
 
-    handler = HANDLERS.get(msgtype, async_handle_unsupported_message)
+    handler = HANDLERS.get(msgtype, async_handle_unsupported_msg)
 
     yield from handler(hass, context, message)

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -367,6 +367,28 @@ def async_handle_transition_message(hass, context, message):
             message['event'])
 
 
+@asyncio.coroutine
+def async_handle_waypoint(hass, name_base, waypoint):
+    name = waypoint['desc']
+    pretty_name = '{} - {}'.format(name_base, name)
+    lat = waypoint['lat']
+    lon = waypoint['lon']
+    rad = waypoint['rad']
+
+    # check zone exists
+    entity_id = zone_comp.ENTITY_ID_FORMAT.format(slugify(pretty_name))
+
+    # Check if state already exists
+    if hass.states.get(entity_id) is not None:
+        return
+
+    zone = zone_comp.Zone(hass, pretty_name, lat, lon, rad,
+                          zone_comp.ICON_IMPORT, False)
+    zone.entity_id = entity_id
+    yield from zone.async_update_ha_state()
+
+
+@HANDLERS.register('waypoint')
 @HANDLERS.register('waypoints')
 @asyncio.coroutine
 def async_handle_waypoints_message(hass, context, message):
@@ -380,30 +402,17 @@ def async_handle_waypoints_message(hass, context, message):
         if user not in context.waypoint_whitelist:
             return
 
-    wayps = message['waypoints']
+    if 'waypoints' in message:
+        wayps = message['waypoints']
+    else:
+        wayps = [message]
 
     _LOGGER.info("Got %d waypoints from %s", len(wayps), message['topic'])
 
     name_base = ' '.join(_parse_topic(message['topic']))
 
     for wayp in wayps:
-        name = wayp['desc']
-        pretty_name = '{} - {}'.format(name_base, name)
-        lat = wayp['lat']
-        lon = wayp['lon']
-        rad = wayp['rad']
-
-        # check zone exists
-        entity_id = zone_comp.ENTITY_ID_FORMAT.format(slugify(pretty_name))
-
-        # Check if state already exists
-        if hass.states.get(entity_id) is not None:
-            continue
-
-        zone = zone_comp.Zone(hass, pretty_name, lat, lon, rad,
-                              zone_comp.ICON_IMPORT, False)
-        zone.entity_id = entity_id
-        yield from zone.async_update_ha_state()
+        yield from async_handle_waypoint(hass, name_base, wayp)
 
 
 @HANDLERS.register('encrypted')
@@ -423,10 +432,20 @@ def async_handle_encrypted_message(hass, context, message):
 
 
 @HANDLERS.register('lwt')
+@HANDLERS.register('configuration')
+@HANDLERS.register('beacon')
+@HANDLERS.register('cmd')
+@HANDLERS.register('steps')
+@HANDLERS.register('card')
 @asyncio.coroutine
-def async_handle_lwt_message(hass, context, message):
-    """Handle an lwt message."""
-    _LOGGER.debug('Not handling lwt message: %s', message)
+def async_handle_not_implemented_message(hass, context, message):
+    """Handle valid but not implemented message types."""
+    _LOGGER.debug('Not handling %s message: %s', message.get("_type"), message)
+
+
+@asyncio.coroutine
+def async_handle_unsupported_message(hass, context, message):
+    _LOGGER.warning('Received unsupported message type: %s.', message.get('_type'))
 
 
 @asyncio.coroutine
@@ -434,11 +453,6 @@ def async_handle_message(hass, context, message):
     """Handle an OwnTracks message."""
     msgtype = message.get('_type')
 
-    handler = HANDLERS.get(msgtype)
-
-    if handler is None:
-        _LOGGER.warning(
-            'Received unsupported message type: %s.', msgtype)
-        return
+    handler = HANDLERS.get(msgtype, async_handle_unsupported_message)
 
     yield from handler(hass, context, message)

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -18,10 +18,13 @@ DEVICE = 'phone'
 
 LOCATION_TOPIC = 'owntracks/{}/{}'.format(USER, DEVICE)
 EVENT_TOPIC = 'owntracks/{}/{}/event'.format(USER, DEVICE)
-WAYPOINT_TOPIC = 'owntracks/{}/{}/waypoints'.format(USER, DEVICE)
+WAYPOINTS_TOPIC = 'owntracks/{}/{}/waypoints'.format(USER, DEVICE)
+WAYPOINT_TOPIC = 'owntracks/{}/{}/waypoint'.format(USER, DEVICE)
 USER_BLACKLIST = 'ram'
-WAYPOINT_TOPIC_BLOCKED = 'owntracks/{}/{}/waypoints'.format(
+WAYPOINTS_TOPIC_BLOCKED = 'owntracks/{}/{}/waypoints'.format(
     USER_BLACKLIST, DEVICE)
+LWT_TOPIC = 'owntracks/{}/{}/lwt'.format(USER, DEVICE)
+BAD_TOPIC = 'owntracks/{}/{}/unsupported'.format(USER, DEVICE)
 
 DEVICE_TRACKER_STATE = 'device_tracker.{}_{}'.format(USER, DEVICE)
 
@@ -232,6 +235,15 @@ WAYPOINTS_UPDATED_MESSAGE = {
     ]
 }
 
+WAYPOINT_MESSAGE = {
+    "_type": "waypoint",
+    "tst": 4,
+    "lat": 9,
+    "lon": 47,
+    "rad": 50,
+    "desc": "exp_wayp1"
+}
+
 WAYPOINT_ENTITY_NAMES = [
     'zone.greg_phone__exp_wayp1',
     'zone.greg_phone__exp_wayp2',
@@ -239,8 +251,24 @@ WAYPOINT_ENTITY_NAMES = [
     'zone.ram_phone__exp_wayp2',
 ]
 
+LWT_MESSAGE = {
+    "_type": "lwt",
+    "tst": 1
+}
+
+BAD_MESSAGE = {
+    "_type": "unsupported",
+    "tst": 1
+}
+
 BAD_JSON_PREFIX = '--$this is bad json#--'
 BAD_JSON_SUFFIX = '** and it ends here ^^'
+
+
+# def raise_on_not_implemented(hass, context, message):
+def raise_on_not_implemented():
+    """Throw NotImplemented."""
+    raise NotImplementedError("oopsie")
 
 
 class BaseMQTT(unittest.TestCase):
@@ -1056,7 +1084,7 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
     def test_waypoint_import_simple(self):
         """Test a simple import of list of waypoints."""
         waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
-        self.send_message(WAYPOINT_TOPIC, waypoints_message)
+        self.send_message(WAYPOINTS_TOPIC, waypoints_message)
         # Check if it made it into states
         wayp = self.hass.states.get(WAYPOINT_ENTITY_NAMES[0])
         self.assertTrue(wayp is not None)
@@ -1066,7 +1094,7 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
     def test_waypoint_import_blacklist(self):
         """Test import of list of waypoints for blacklisted user."""
         waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
-        self.send_message(WAYPOINT_TOPIC_BLOCKED, waypoints_message)
+        self.send_message(WAYPOINTS_TOPIC_BLOCKED, waypoints_message)
         # Check if it made it into states
         wayp = self.hass.states.get(WAYPOINT_ENTITY_NAMES[2])
         self.assertTrue(wayp is None)
@@ -1088,7 +1116,7 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
         run_coroutine_threadsafe(owntracks.async_setup_scanner(
             self.hass, test_config, mock_see), self.hass.loop).result()
         waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
-        self.send_message(WAYPOINT_TOPIC_BLOCKED, waypoints_message)
+        self.send_message(WAYPOINTS_TOPIC_BLOCKED, waypoints_message)
         # Check if it made it into states
         wayp = self.hass.states.get(WAYPOINT_ENTITY_NAMES[2])
         self.assertTrue(wayp is not None)
@@ -1098,7 +1126,7 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
     def test_waypoint_import_bad_json(self):
         """Test importing a bad JSON payload."""
         waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
-        self.send_message(WAYPOINT_TOPIC, waypoints_message, True)
+        self.send_message(WAYPOINTS_TOPIC, waypoints_message, True)
         # Check if it made it into states
         wayp = self.hass.states.get(WAYPOINT_ENTITY_NAMES[2])
         self.assertTrue(wayp is None)
@@ -1108,14 +1136,39 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
     def test_waypoint_import_existing(self):
         """Test importing a zone that exists."""
         waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
-        self.send_message(WAYPOINT_TOPIC, waypoints_message)
+        self.send_message(WAYPOINTS_TOPIC, waypoints_message)
         # Get the first waypoint exported
         wayp = self.hass.states.get(WAYPOINT_ENTITY_NAMES[0])
         # Send an update
         waypoints_message = WAYPOINTS_UPDATED_MESSAGE.copy()
-        self.send_message(WAYPOINT_TOPIC, waypoints_message)
+        self.send_message(WAYPOINTS_TOPIC, waypoints_message)
         new_wayp = self.hass.states.get(WAYPOINT_ENTITY_NAMES[0])
         self.assertTrue(wayp == new_wayp)
+
+    def test_single_waypoint_import(self):
+        """Test single waypoint message."""
+        waypoint_message = WAYPOINT_MESSAGE.copy()
+        self.send_message(WAYPOINT_TOPIC, waypoint_message)
+        wayp = self.hass.states.get(WAYPOINT_ENTITY_NAMES[0])
+        self.assertTrue(wayp is not None)
+
+    def test_not_implemented_message(self):
+        """Handle not implemented message type."""
+        patch_handler = patch('homeassistant.components.device_tracker.owntracks.async_handle_not_implemented_message',
+                              return_value=mock_coro(False))
+        patch_handler.start()
+        self.assertFalse(self.send_message(LWT_TOPIC, LWT_MESSAGE))
+        patch_handler.stop()
+
+    @patch('homeassistant.components.device_tracker.owntracks.async_handle_unsupported_message',
+           raise_on_not_implemented)
+    def test_not_implemented_message(self):
+        """Handle not implemented message type."""
+        patch_handler = patch('homeassistant.components.device_tracker.owntracks.async_handle_unsupported_message',
+                              return_value=mock_coro(False))
+        patch_handler.start()
+        self.assertFalse(self.send_message(BAD_TOPIC, BAD_MESSAGE))
+        patch_handler.stop()
 
 
 def generate_ciphers(secret):
@@ -1143,7 +1196,7 @@ def generate_ciphers(secret):
              json.dumps(DEFAULT_LOCATION_MESSAGE).encode("utf-8"))
         )
     ).decode("utf-8")
-    return (ctxt, mctxt)
+    return ctxt, mctxt
 
 
 TEST_SECRET_KEY = 's3cretkey'
@@ -1172,7 +1225,7 @@ def mock_cipher():
         if key != mkey:
             raise ValueError()
         return plaintext
-    return (len(TEST_SECRET_KEY), mock_decrypt)
+    return len(TEST_SECRET_KEY), mock_decrypt
 
 
 class TestDeviceTrackerOwnTrackConfigs(BaseMQTT):

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -1154,17 +1154,17 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
 
     def test_not_implemented_message(self):
         """Handle not implemented message type."""
-        patch_handler = patch('homeassistant.components.device_tracker.owntracks.async_handle_not_implemented_message',
+        patch_handler = patch('homeassistant.components.device_tracker.'
+                              'owntracks.async_handle_not_impl_msg',
                               return_value=mock_coro(False))
         patch_handler.start()
         self.assertFalse(self.send_message(LWT_TOPIC, LWT_MESSAGE))
         patch_handler.stop()
 
-    @patch('homeassistant.components.device_tracker.owntracks.async_handle_unsupported_message',
-           raise_on_not_implemented)
-    def test_not_implemented_message(self):
+    def test_unsupported_message(self):
         """Handle not implemented message type."""
-        patch_handler = patch('homeassistant.components.device_tracker.owntracks.async_handle_unsupported_message',
+        patch_handler = patch('homeassistant.components.device_tracker.'
+                              'owntracks.async_handle_unsupported_msg',
                               return_value=mock_coro(False))
         patch_handler.start()
         self.assertFalse(self.send_message(BAD_TOPIC, BAD_MESSAGE))


### PR DESCRIPTION
## Description:

OwnTracks message types which the HA component does not handle are now logged DEBUG. A separate handler which logs as WARNING now reports unrecognized or invalid message types.

A single waypoint message is now supported in addition to the roll-up waypoints message. Waypoints is just a list of individual waypoint messages so the logic is the same. That has been pulled into its own function.

Test cases surrounding these new behaviors have been added.

**Related issue (if applicable):** fixes #10187 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  -  n/a Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [n/a] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [n/a] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [n/a] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [n/a] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
