### PR TITLE
Verisure: Added option to set installation giid

### DIFF
--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -27,6 +27,7 @@ ATTR_DEVICE_SERIAL = 'device_serial'
 CONF_ALARM = 'alarm'
 CONF_CODE_DIGITS = 'code_digits'
 CONF_DOOR_WINDOW = 'door_window'
+CONF_GIID = 'giid'
 CONF_HYDROMETERS = 'hygrometers'
 CONF_LOCKS = 'locks'
 CONF_MOUSE = 'mouse'
@@ -47,6 +48,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_ALARM, default=True): cv.boolean,
         vol.Optional(CONF_CODE_DIGITS, default=4): cv.positive_int,
         vol.Optional(CONF_DOOR_WINDOW, default=True): cv.boolean,
+        vol.Optional(CONF_GIID, default=None): cv.string,
         vol.Optional(CONF_HYDROMETERS, default=True): cv.boolean,
         vol.Optional(CONF_LOCKS, default=True): cv.boolean,
         vol.Optional(CONF_MOUSE, default=True): cv.boolean,
@@ -110,6 +112,8 @@ class VerisureHub(object):
             domain_config[CONF_USERNAME],
             domain_config[CONF_PASSWORD])
 
+        self.giid = domain_config[CONF_GIID]
+
         import jsonpath
         self.jsonpath = jsonpath.jsonpath
 
@@ -120,6 +124,8 @@ class VerisureHub(object):
         except self._verisure.Error as ex:
             _LOGGER.error('Could not log in to verisure, %s', ex)
             return False
+        if self.giid:
+            return self.set_giid()
         return True
 
     def logout(self):
@@ -128,6 +134,15 @@ class VerisureHub(object):
             self.session.logout()
         except self._verisure.Error as ex:
             _LOGGER.error('Could not log out from verisure, %s', ex)
+            return False
+        return True
+
+    def set_giid(self):
+        """Set installation GIID."""
+        try:
+            self.session.set_giid(self.giid)
+        except self._verisure.Error as ex:
+            _LOGGER.error('Could not set installation GIID, %s', ex)
             return False
         return True
 

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -112,10 +112,7 @@ class VerisureHub(object):
             domain_config[CONF_USERNAME],
             domain_config[CONF_PASSWORD])
 
-        try:
-            self.giid = domain_config[CONF_GIID]
-        except KeyError:
-            self.giid = None
+        self.giid = domain_config.get(CONF_GIID)
 
         import jsonpath
         self.jsonpath = jsonpath.jsonpath

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -48,7 +48,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_ALARM, default=True): cv.boolean,
         vol.Optional(CONF_CODE_DIGITS, default=4): cv.positive_int,
         vol.Optional(CONF_DOOR_WINDOW, default=True): cv.boolean,
-        vol.Optional(CONF_GIID, default=None): cv.string,
+        vol.Optional(CONF_GIID): cv.string,
         vol.Optional(CONF_HYDROMETERS, default=True): cv.boolean,
         vol.Optional(CONF_LOCKS, default=True): cv.boolean,
         vol.Optional(CONF_MOUSE, default=True): cv.boolean,
@@ -111,8 +111,10 @@ class VerisureHub(object):
         self.session = verisure.Session(
             domain_config[CONF_USERNAME],
             domain_config[CONF_PASSWORD])
-
-        self.giid = domain_config[CONF_GIID]
+        try:
+            self.giid = domain_config[CONF_GIID]
+        except KeyError:
+            self.giid = None
 
         import jsonpath
         self.jsonpath = jsonpath.jsonpath

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -111,6 +111,7 @@ class VerisureHub(object):
         self.session = verisure.Session(
             domain_config[CONF_USERNAME],
             domain_config[CONF_PASSWORD])
+
         try:
             self.giid = domain_config[CONF_GIID]
         except KeyError:


### PR DESCRIPTION
## Description:
Added new feature to Verisure component that makes it possible to choose alarm installation if you have more then one connected to your Verisure account (like multiple houses).
An optional configuration variable "giid" is added. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#3946

## Example entry for `configuration.yaml`:
```yaml
verisure:
  username: USERNAME
  password: PASSWORD
  giid: INSTALLATION_GIID
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
