### PR TITLE
Add support for N600 to TPLink Device Tracker

### DIFF
--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -54,9 +54,11 @@ class TplinkDeviceScanner(DeviceScanner):
         username, password = config[CONF_USERNAME], config[CONF_PASSWORD]
 
         self.parse_macs_hyphens = re.compile('[0-9A-F]{2}-[0-9A-F]{2}-' +
-                     '[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}')
-        self.parse_macs_colons  = re.compile('[0-9A-F]{2}:[0-9A-F]{2}:' +
-                     '[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}')
+                                             '[0-9A-F]{2}-[0-9A-F]{2}-' +
+                                             '[0-9A-F]{2}-[0-9A-F]{2}')
+        self.parse_macs_colons = re.compile('[0-9A-F]{2}:[0-9A-F]{2}:' +
+                                            '[0-9A-F]{2}:[0-9A-F]{2}:' +
+                                            '[0-9A-F]{2}:[0-9A-F]{2}')
 
         self.host = host
         self.username = username
@@ -135,20 +137,26 @@ class Tplink1DeviceScanner(TplinkDeviceScanner):
         for clients_frequency in ('1', '2'):
 
             # Refresh associated clients.
-            page = requests.post( 'http://{}/cgi?7'.format(self.host),
+            page = requests.post(
+                'http://{}/cgi?7'.format(self.host),
                 headers={REFERER: referer, COOKIE: cookie},
-                data=('[ACT_WLAN_UPDATE_ASSOC#1,{},0,0,0,0#0,0,0,0,0,0]0,0\r\n'
-                ).format(clients_frequency), timeout=4)
+                data=(
+                  '[ACT_WLAN_UPDATE_ASSOC#1,{},0,0,0,0#0,0,0,0,0,0]0,0\r\n'
+                  ).format(clients_frequency),
+                timeout=4)
             if not page.status_code == 200:
                 _LOGGER.error("Error %s from router", page.status_code)
                 return False
 
             # Retrieve associated clients.
-            page = requests.post('http://{}/cgi?6'.format(self.host),
+            page = requests.post(
+                'http://{}/cgi?6'.format(self.host),
                 headers={REFERER: referer, COOKIE: cookie},
-                data=('[LAN_WLAN_ASSOC_DEV#0,0,0,0,0,0#1,{},0,0,0,0]0,1\r\n'
-                      'AssociatedDeviceMACAddress\r\n'
-                ).format(clients_frequency), timeout=4)
+                data=(
+                  '[LAN_WLAN_ASSOC_DEV#0,0,0,0,0,0#1,{},0,0,0,0]0,1\r\n'
+                  'AssociatedDeviceMACAddress\r\n'
+                  ).format(clients_frequency),
+                timeout=4)
             if not page.status_code == 200:
                 _LOGGER.error("Error %s from router", page.status_code)
                 return False

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -141,8 +141,8 @@ class Tplink1DeviceScanner(TplinkDeviceScanner):
                 'http://{}/cgi?7'.format(self.host),
                 headers={REFERER: referer, COOKIE: cookie},
                 data=(
-                  '[ACT_WLAN_UPDATE_ASSOC#1,{},0,0,0,0#0,0,0,0,0,0]0,0\r\n'
-                  ).format(clients_frequency),
+                    '[ACT_WLAN_UPDATE_ASSOC#1,{},0,0,0,0#0,0,0,0,0,0]0,0\r\n'
+                    ).format(clients_frequency),
                 timeout=4)
             if not page.status_code == 200:
                 _LOGGER.error("Error %s from router", page.status_code)
@@ -153,9 +153,9 @@ class Tplink1DeviceScanner(TplinkDeviceScanner):
                 'http://{}/cgi?6'.format(self.host),
                 headers={REFERER: referer, COOKIE: cookie},
                 data=(
-                  '[LAN_WLAN_ASSOC_DEV#0,0,0,0,0,0#1,{},0,0,0,0]0,1\r\n'
-                  'AssociatedDeviceMACAddress\r\n'
-                  ).format(clients_frequency),
+                    '[LAN_WLAN_ASSOC_DEV#0,0,0,0,0,0#1,{},0,0,0,0]0,1\r\n'
+                    'AssociatedDeviceMACAddress\r\n'
+                    ).format(clients_frequency),
                 timeout=4)
             if not page.status_code == 200:
                 _LOGGER.error("Error %s from router", page.status_code)


### PR DESCRIPTION
## Description:
I noticed that the existing TP-Link Device Tracker platform was not working with the TP-link N600 router, quite popular at least in Australia.
The protocol to access the list of connected clients is slightly different from the models supported by the platform today. Authentication is exactly the same but two HTTP post queries are needed (one to update the list and one to retrieve it). The HTTP response includes the list of MAC addresses as plain text (not JSON). 

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [n/a] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [n/a] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [n/a] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [n/a] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [n/a] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [n/a] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
