### PR TITLE
Volvooncall: Support configuration of region (no service url neccessary

### DIFF
--- a/homeassistant/components/volvooncall.py
+++ b/homeassistant/components/volvooncall.py
@@ -22,13 +22,14 @@ DOMAIN = 'volvooncall'
 
 DATA_KEY = DOMAIN
 
-REQUIREMENTS = ['volvooncall==0.3.3']
+REQUIREMENTS = ['volvooncall==0.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_UPDATE_INTERVAL = 'update_interval'
 MIN_UPDATE_INTERVAL = timedelta(minutes=1)
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=1)
+CONF_REGION = 'region'
 CONF_SERVICE_URL = 'service_url'
 
 SIGNAL_VEHICLE_SEEN = '{}.vehicle_seen'.format(DOMAIN)
@@ -58,6 +59,7 @@ CONFIG_SCHEMA = vol.Schema({
             {cv.slug: cv.string}),
         vol.Optional(CONF_RESOURCES): vol.All(
             cv.ensure_list, [vol.In(RESOURCES)]),
+        vol.Optional(CONF_REGION): cv.string,
         vol.Optional(CONF_SERVICE_URL): cv.string,
     }),
 }, extra=vol.ALLOW_EXTRA)
@@ -65,11 +67,12 @@ CONFIG_SCHEMA = vol.Schema({
 
 def setup(hass, config):
     """Set up the Volvo On Call component."""
-    from volvooncall import Connection, DEFAULT_SERVICE_URL
+    from volvooncall import Connection
     connection = Connection(
         config[DOMAIN].get(CONF_USERNAME),
         config[DOMAIN].get(CONF_PASSWORD),
-        config[DOMAIN].get(CONF_SERVICE_URL, DEFAULT_SERVICE_URL))
+        config[DOMAIN].get(CONF_SERVICE_URL),
+        config[DOMAIN].get(CONF_REGION))
 
     interval = config[DOMAIN].get(CONF_UPDATE_INTERVAL)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1074,7 +1074,7 @@ upsmychoice==1.0.6
 uvcclient==0.10.1
 
 # homeassistant.components.volvooncall
-volvooncall==0.3.3
+volvooncall==0.4.0
 
 # homeassistant.components.verisure
 vsure==1.3.7


### PR DESCRIPTION
## Description:
Support configuration of region (e.g. `cn`, `na`).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3953

## Example entry for `configuration.yaml` (if applicable):
```yaml
volvooncall:
  username: foo
  password: bar
  region: na  # north-america
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
