### PR TITLE
adding filter to allow parsing of JSON stored as a state or attribute

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -486,6 +486,12 @@ def forgiving_float(value):
     except (ValueError, TypeError):
         return value
 
+def as_json(value):
+    """Try to convert the value to a JSON object."""
+    try:
+        return json.loads(value)
+    except ValueError:
+        return value
 
 @contextfilter
 def random_every_time(context, values):
@@ -515,6 +521,7 @@ ENV.filters['is_defined'] = fail_when_undefined
 ENV.filters['max'] = max
 ENV.filters['min'] = min
 ENV.filters['random'] = random_every_time
+ENV.filters['as_json'] = as_json
 ENV.globals['float'] = forgiving_float
 ENV.globals['now'] = dt_util.now
 ENV.globals['utcnow'] = dt_util.utcnow

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -493,6 +493,7 @@ def as_json(value):
     except ValueError:
         return value
 
+
 @contextfilter
 def random_every_time(context, values):
     """Choose a random value.

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -486,6 +486,7 @@ def forgiving_float(value):
     except (ValueError, TypeError):
         return value
 
+
 def as_json(value):
     """Try to convert the value to a JSON object."""
     try:


### PR DESCRIPTION
## Problem Statement:
Right now there's no way to store complex data in a single sensor and have it available for others. For rate-limited APIs or other instances where there's a good deal of processing to go through returned JSON data, it would be great to store some subset of JSON as a string in a state and have another place, sensor/automation/script/whatever be able to re-constitute the JSON to easily access the contents.

## Example Use Case:
https://github.com/cribbstechnologies/ha_config/blob/master/packages/launch_sensor.yaml

There's a lot more information in the returned payload that would be useful to have when the automation is eventually triggered. Right now there's no way to have that information available other than to create multiple sensors that handle the individual pieces of data.

Using a template, a user could extract certain pieces of information and create their own, customized, JSON object and use that as the state for a sensor (line 38) and then reference the data to provide a more useful information/context to service(s) later (line 70)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here> I'll work on this if this PR seems like a good idea to others

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: template
    sensors:
      test_json:
        value_template: '{"prop1": "val1", "prop2": 3}'
```

Then in jinja you can do
{{(states('sensor.text_json') | as_json)['prop1']}}

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)