### PR TITLE
Support script execution for Alexa

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF)
-from homeassistant.components import switch, light
+from homeassistant.components import switch, light, script
 import homeassistant.util.color as color_util
 from homeassistant.util.decorator import Registry
 
@@ -21,6 +21,7 @@ API_ENDPOINT = 'endpoint'
 
 
 MAPPING_COMPONENT = {
+    script.DOMAIN: ['ACTIVITY_TRIGGER', ('Alexa.SceneController',), None],
     switch.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
     light.DOMAIN: [
         'LIGHT', ('Alexa.PowerController',), {
@@ -167,6 +168,17 @@ def extract_entity(funct):
         return (yield from funct(hass, request, entity))
 
     return async_api_entity_wrapper
+
+
+@HANDLERS.register(('Alexa.SceneController', 'Activate'))
+@extract_entity
+@asyncio.coroutine
+def async_api_activate(hass, request, entity):
+    """Process an activate request."""
+    service = entity.entity_id.split('.')[1]
+    yield from hass.services.async_call(entity.domain, service, blocking=True)
+
+    return api_message(request)
 
 
 @HANDLERS.register(('Alexa.PowerController', 'TurnOn'))

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -21,7 +21,7 @@ API_ENDPOINT = 'endpoint'
 
 
 MAPPING_COMPONENT = {
-    script.DOMAIN: ['ACTIVITY_TRIGGER', ('Alexa.SceneController',), None],
+    script.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
     switch.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
     light.DOMAIN: [
         'LIGHT', ('Alexa.PowerController',), {
@@ -168,17 +168,6 @@ def extract_entity(funct):
         return (yield from funct(hass, request, entity))
 
     return async_api_entity_wrapper
-
-
-@HANDLERS.register(('Alexa.SceneController', 'Activate'))
-@extract_entity
-@asyncio.coroutine
-def async_api_activate(hass, request, entity):
-    """Process an activate request."""
-    service = entity.entity_id.split('.')[1]
-    yield from hass.services.async_call(entity.domain, service, blocking=True)
-
-    return api_message(request)
 
 
 @HANDLERS.register(('Alexa.PowerController', 'TurnOn'))

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -114,12 +114,15 @@ def test_discovery_request(hass):
             'friendly_name': "Test light 3", 'supported_features': 19
         })
 
+    hass.states.async_set(
+        'script.test', 'off', {'friendly_name': "Test script"})
+
     msg = yield from smart_home.async_handle_message(hass, request)
 
     assert 'event' in msg
     msg = msg['event']
 
-    assert len(msg['payload']['endpoints']) == 4
+    assert len(msg['payload']['endpoints']) == 5
     assert msg['header']['name'] == 'Discover.Response'
     assert msg['header']['namespace'] == 'Alexa.Discovery'
 
@@ -168,6 +171,14 @@ def test_discovery_request(hass):
             assert 'Alexa.ColorController' in caps
             assert 'Alexa.ColorTemperatureController' in caps
 
+            continue
+
+        if appliance['endpointId'] == 'script#test':
+            assert appliance['displayCategories'][0] == "ACTIVITY_TRIGGER"
+            assert appliance['friendlyName'] == "Test script"
+            assert len(appliance['capabilities']) == 1
+            assert appliance['capabilities'][-1]['interface'] == \
+                'Alexa.SceneController'
             continue
 
         raise AssertionError("Unknown appliance!")
@@ -458,4 +469,28 @@ def test_api_increase_color_temp(hass, result, initial):
     assert len(call_light) == 1
     assert call_light[0].data['entity_id'] == 'light.test'
     assert call_light[0].data['color_temp'] == result
+    assert msg['header']['name'] == 'Response'
+
+
+@asyncio.coroutine
+@pytest.mark.parametrize("domain", ['script'])
+def test_api_activate(hass, domain):
+    """Test api activate process."""
+    request = get_new_request(
+        'Alexa.SceneController', 'Activate', '{}#test'.format(domain))
+
+    # settup test devices
+    hass.states.async_set(
+        'script.test', 'off', {'friendly_name': "Test script"})
+
+    call = async_mock_service(hass, domain, 'test')
+
+    msg = yield from smart_home.async_handle_message(hass, request)
+
+    assert 'event' in msg
+    msg = msg['event']
+
+    assert len(call) == 1
+    assert call[0].domain == domain
+    assert call[0].service == 'test'
     assert msg['header']['name'] == 'Response'

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -174,11 +174,11 @@ def test_discovery_request(hass):
             continue
 
         if appliance['endpointId'] == 'script#test':
-            assert appliance['displayCategories'][0] == "ACTIVITY_TRIGGER"
+            assert appliance['displayCategories'][0] == "SWITCH"
             assert appliance['friendlyName'] == "Test script"
             assert len(appliance['capabilities']) == 1
             assert appliance['capabilities'][-1]['interface'] == \
-                'Alexa.SceneController'
+                'Alexa.PowerController'
             continue
 
         raise AssertionError("Unknown appliance!")
@@ -217,7 +217,7 @@ def test_api_function_not_implemented(hass):
 
 
 @asyncio.coroutine
-@pytest.mark.parametrize("domain", ['light', 'switch'])
+@pytest.mark.parametrize("domain", ['light', 'switch', 'script'])
 def test_api_turn_on(hass, domain):
     """Test api turn on process."""
     request = get_new_request(
@@ -242,7 +242,7 @@ def test_api_turn_on(hass, domain):
 
 
 @asyncio.coroutine
-@pytest.mark.parametrize("domain", ['light', 'switch'])
+@pytest.mark.parametrize("domain", ['light', 'switch', 'script'])
 def test_api_turn_off(hass, domain):
     """Test api turn on process."""
     request = get_new_request(
@@ -469,28 +469,4 @@ def test_api_increase_color_temp(hass, result, initial):
     assert len(call_light) == 1
     assert call_light[0].data['entity_id'] == 'light.test'
     assert call_light[0].data['color_temp'] == result
-    assert msg['header']['name'] == 'Response'
-
-
-@asyncio.coroutine
-@pytest.mark.parametrize("domain", ['script'])
-def test_api_activate(hass, domain):
-    """Test api activate process."""
-    request = get_new_request(
-        'Alexa.SceneController', 'Activate', '{}#test'.format(domain))
-
-    # settup test devices
-    hass.states.async_set(
-        'script.test', 'off', {'friendly_name': "Test script"})
-
-    call = async_mock_service(hass, domain, 'test')
-
-    msg = yield from smart_home.async_handle_message(hass, request)
-
-    assert 'event' in msg
-    msg = msg['event']
-
-    assert len(call) == 1
-    assert call[0].domain == domain
-    assert call[0].service == 'test'
     assert msg['header']['name'] == 'Response'


### PR DESCRIPTION
## Description:
Add script component support to Alexa smart home API

## Checklist:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
