### PR TITLE
Pin yarl

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,8 @@ pip>=8.0.3
 jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.3.1
+aiohttp==2.3.2
+yarl==0.14.0
 async_timeout==2.0.0
 chardet==3.0.4
 astral==1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,8 @@ pip>=8.0.3
 jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.3.1
+aiohttp==2.3.2
+yarl==0.14.0
 async_timeout==2.0.0
 chardet==3.0.4
 astral==1.4

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ REQUIRES = [
     'jinja2>=2.9.6',
     'voluptuous==0.10.5',
     'typing>=3,<4',
-    'aiohttp==2.3.1',
+    'aiohttp==2.3.2',   # If updated, check if yarl also needs an update!
+    'yarl==0.14.0',
     'async_timeout==2.0.0',
     'chardet==3.0.4',
     'astral==1.4',


### PR DESCRIPTION
## Description:

As discussed, pin yarl to a fixed version, together with aiohttp.

While I was at it, I updated aiohttp from 2.3.1 to 2.3.2, which is a bugfix release according to their description.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
