### PR TITLE
Pin YARL

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,6 +6,7 @@ jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.3.1
+yarl==0.13
 async_timeout==2.0.0
 chardet==3.0.4
 astral==1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -7,6 +7,7 @@ jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.3.1
+yarl==0.13
 async_timeout==2.0.0
 chardet==3.0.4
 astral==1.4

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ REQUIRES = [
     'voluptuous==0.10.5',
     'typing>=3,<4',
     'aiohttp==2.3.1',
+    'yarl==0.13',  # Update this whenever you update aiohttp
     'async_timeout==2.0.0',
     'chardet==3.0.4',
     'astral==1.4',


### PR DESCRIPTION
## Description:
Pin YARL to version 0.13. From now on, no longer depend on aiohttp pulling in YARL but instead have our own version upgrades to make sure for a smooth upgrade.

I'll release hotfix 0.57.3 today. All previous installations of Home Assistant that use Google TTS will break 🤔 
