### PR TITLE
0.57.3

### DIFF
--- a/homeassistant/components/binary_sensor/ring.py
+++ b/homeassistant/components/binary_sensor/ring.py
@@ -27,7 +27,7 @@ SCAN_INTERVAL = timedelta(seconds=5)
 
 # Sensor types: Name, category, device_class
 SENSOR_TYPES = {
-    'ding': ['Ding', ['doorbell', 'stickup_cams'], 'occupancy'],
+    'ding': ['Ding', ['doorbell'], 'occupancy'],
     'motion': ['Motion', ['doorbell', 'stickup_cams'], 'motion'],
 }
 

--- a/homeassistant/components/sensor/ring.py
+++ b/homeassistant/components/sensor/ring.py
@@ -34,7 +34,7 @@ SENSOR_TYPES = {
         'Last Activity', ['doorbell', 'stickup_cams'], None, 'history', None],
 
     'last_ding': [
-        'Last Ding', ['doorbell', 'stickup_cams'], None, 'history', 'ding'],
+        'Last Ding', ['doorbell'], None, 'history', 'ding'],
 
     'last_motion': [
         'Last Motion', ['doorbell', 'stickup_cams'], None,

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -4,15 +4,10 @@ Support for Tellstick switches.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.tellstick/
 """
-import voluptuous as vol
-
-from homeassistant.components.tellstick import (DEFAULT_SIGNAL_REPETITIONS,
-                                                ATTR_DISCOVER_DEVICES,
-                                                ATTR_DISCOVER_CONFIG,
-                                                DOMAIN, TellstickDevice)
+from homeassistant.components.tellstick import (
+    DEFAULT_SIGNAL_REPETITIONS, ATTR_DISCOVER_DEVICES,
+    ATTR_DISCOVER_CONFIG, DATA_TELLSTICK, TellstickDevice)
 from homeassistant.helpers.entity import ToggleEntity
-
-PLATFORM_SCHEMA = vol.Schema({vol.Required("platform"): DOMAIN})
 
 
 # pylint: disable=unused-argument
@@ -26,9 +21,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     signal_repetitions = discovery_info.get(ATTR_DISCOVER_CONFIG,
                                             DEFAULT_SIGNAL_REPETITIONS)
 
-    add_devices(TellstickSwitch(tellcore_id, hass.data['tellcore_registry'],
-                                signal_repetitions)
-                for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES])
+    add_devices([TellstickSwitch(hass.data[DATA_TELLSTICK][tellcore_id],
+                                 signal_repetitions)
+                 for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES]],
+                True)
 
 
 class TellstickSwitch(TellstickDevice, ToggleEntity):
@@ -36,11 +32,11 @@ class TellstickSwitch(TellstickDevice, ToggleEntity):
 
     def _parse_ha_data(self, kwargs):
         """Turn the value from HA into something useful."""
-        return None
+        pass
 
     def _parse_tellcore_data(self, tellcore_data):
         """Turn the value received from tellcore into something useful."""
-        return None
+        pass
 
     def _update_model(self, new_state, data):
         """Update the device entity state to match the arguments."""

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 57
-PATCH_VERSION = '2'
+PATCH_VERSION = '3'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,6 +6,7 @@ jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.2.5
+yarl==0.13
 async_timeout==2.0.0
 chardet==3.0.4
 astral==1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -7,6 +7,7 @@ jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.2.5
+yarl==0.13
 async_timeout==2.0.0
 chardet==3.0.4
 astral==1.4

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ REQUIRES = [
     'voluptuous==0.10.5',
     'typing>=3,<4',
     'aiohttp==2.2.5',
+    'yarl==0.13',  # Update this whenever you update aiohttp
     'async_timeout==2.0.0',
     'chardet==3.0.4',
     'astral==1.4',


### PR DESCRIPTION
- Tellstick Duo acync callback fix ([@stefan-jonasson] - [#10384]) ([tellstick docs])
- Fixed update() method and removed `ding` feature from stickupcams/floodlight ([@tchellomello] - [#10428]) ([binary_sensor.ring docs]) ([camera.ring docs]) ([sensor.ring docs])

[#10384]: https://github.com/home-assistant/home-assistant/pull/10384
[#10428]: https://github.com/home-assistant/home-assistant/pull/10428
[@stefan-jonasson]: https://github.com/stefan-jonasson
[@tchellomello]: https://github.com/tchellomello
[binary_sensor.ring docs]: https://home-assistant.io/components/binary_sensor.ring/
[camera.ring docs]: https://home-assistant.io/components/camera.ring/
[sensor.ring docs]: https://home-assistant.io/components/sensor.ring/
[tellstick docs]: https://home-assistant.io/components/tellstick/
