### PR TITLE
Small fix to be able to use mac and vendor in "device_tracker_new_device" event.

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -76,6 +76,7 @@ ATTR_LOCATION_NAME = 'location_name'
 ATTR_MAC = 'mac'
 ATTR_NAME = 'name'
 ATTR_SOURCE_TYPE = 'source_type'
+ATTR_VENDOR = 'vendor'
 
 SOURCE_TYPE_GPS = 'gps'
 SOURCE_TYPE_ROUTER = 'router'
@@ -285,11 +286,6 @@ class DeviceTracker(object):
         if device.track:
             yield from device.async_update_ha_state()
 
-        self.hass.bus.async_fire(EVENT_NEW_DEVICE, {
-            ATTR_ENTITY_ID: device.entity_id,
-            ATTR_HOST_NAME: device.host_name,
-        })
-
         # During init, we ignore the group
         if self.group and self.track_new:
             self.group.async_set_group(
@@ -298,6 +294,13 @@ class DeviceTracker(object):
 
         # lookup mac vendor string to be stored in config
         yield from device.set_vendor_for_mac()
+
+        self.hass.bus.async_fire(EVENT_NEW_DEVICE, {
+            ATTR_ENTITY_ID: device.entity_id,
+            ATTR_HOST_NAME: device.host_name,
+            ATTR_MAC: device.mac,
+            ATTR_VENDOR: device.vendor,
+        })
 
         # update known_devices.yaml
         self.hass.async_add_job(

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -481,6 +481,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         assert test_events[0].data == {
             'entity_id': 'device_tracker.hello',
             'host_name': 'hello',
+            'mac': 'MAC_1',
+            'vendor': 'unknown',
         }
 
     # pylint: disable=invalid-name


### PR DESCRIPTION
## Description:

I had an automation to notify me when a new device is found on the network, but because NMAP can't find a `host_name` the notification can only contain the entity id, which isn't very informative. With this patch i can also add the properly formatted MAC address and vendor to the notification.

This does make the  `device_tracker_new_device` event fire slightly later because it has to wait for the vendor lookup, but that <0.2s delay is worth the added clarity in my opinion.

## Checklist:

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
