### PR TITLE
Use <pre> instead of <p> for text to html convert

### DIFF
--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -204,7 +204,7 @@ def _build_multipart_msg(message, images):
     msg.attach(msg_alt)
     body_txt = MIMEText(message)
     msg_alt.attach(body_txt)
-    body_text = ['<p>{}</p><br>'.format(message)]
+    body_text = ['<pre>{}</pre><br>'.format(message)]
 
     for atch_num, atch_name in enumerate(images):
         cid = 'image{}'.format(atch_num)


### PR DESCRIPTION
Text messages with multiple lines and text based formatting or graphics (ascii art) are destroyed with the current p formatting. pre ensures that the formatting stays the same...

My text messages contain a lot of lines like this
```

Persons at home:

{% for state in states.device_tracker if '_phone_' in state.entity_id and state.state == 'home' -%}
- {{ state.name.split(' ',1)[1] }} seit {{ as_timestamp(state.last_changed) | timestamp_local }}

{% else %}
- nobody -

{% endfor %}

Active motion:

{% for state in states if state.attributes.device_class == 'motion' and state.state == 'on'  -%}
- {{ state.name.split(' ',1)[1] }}

{% else -%}
- none -

{% endfor %}

Open doors:

{% for state in states if state.attributes.device_class == 'opening' and 'Fenster' not in state.attributes.friendly_name and state.state == 'on' -%}
- {{ state.name.split(' ',1)[1] }} seit {{ as_timestamp(state.last_changed) | timestamp_local }}

{% else -%}
- none -

{% endfor %}
```

In a text message this looks perfect... but if you add attachments to the message home assistant also automatically creates a html part based on the text message. In this case all line breaks are removed...
