### PR TITLE
[WIP] Add dewpoint template sensor

### DIFF
--- a/homeassistant/util/temperature.py
+++ b/homeassistant/util/temperature.py
@@ -1,4 +1,6 @@
 """Temperature util functions."""
+from math import log as ln
+
 from homeassistant.const import (
     TEMP_CELSIUS, TEMP_FAHRENHEIT, UNIT_NOT_RECOGNIZED_TEMPLATE, TEMPERATURE)
 
@@ -27,3 +29,21 @@ def convert(temperature: float, from_unit: str, to_unit: str) -> float:
     elif from_unit == TEMP_CELSIUS:
         return celsius_to_fahrenheit(temperature)
     return fahrenheit_to_celsius(temperature)
+
+
+def calculate_dewpoint(temperature: float, humidity: float,
+                       units: str) -> float:
+    """Calculate dewpoint from temperature and relative humidity.
+
+    Uses the Magnus formula approximation.
+    See https://en.wikipedia.org/wiki/Dew_point#Calculating_the_dew_point
+    """
+    if units not in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
+        raise ValueError(UNIT_NOT_RECOGNIZED_TEMPLATE.format(
+            units, TEMPERATURE))
+    temp = convert(temperature, units, TEMP_CELSIUS)
+    const_b = 17.67
+    const_c = 243.5
+    gamma = ln(humidity / 100) + (const_b * temp / (const_c + temp))
+    dewpoint = (const_c * gamma) / (const_b - gamma)
+    return convert(dewpoint, TEMP_CELSIUS, units)

--- a/homeassistant/util/temperature.py
+++ b/homeassistant/util/temperature.py
@@ -37,10 +37,17 @@ def calculate_dewpoint(temperature: float, humidity: float,
 
     Uses the Magnus formula approximation.
     See https://en.wikipedia.org/wiki/Dew_point#Calculating_the_dew_point
+
+    Humidity should be a percentage (0-100)
     """
     if units not in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
         raise ValueError(UNIT_NOT_RECOGNIZED_TEMPLATE.format(
             units, TEMPERATURE))
+    if humidity <= 0 or humidity > 100:
+        # Zero relative humidity doesn't work because natural log of zero
+        # is undefined
+        raise ValueError('Relative humidity value {} invalid, '
+                         'must be 0 < rh <= 100'.format(humidity))
     temp = convert(temperature, units, TEMP_CELSIUS)
     const_b = 17.67
     const_c = 243.5

--- a/tests/util/test_temperature.py
+++ b/tests/util/test_temperature.py
@@ -1,0 +1,47 @@
+"""Test temperature utility functions."""
+
+import unittest
+import homeassistant.util.temperature as temperature_util
+from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
+
+
+class TestTemperatureUtil(unittest.TestCase):
+    """Test the temperature utility functions."""
+
+    def test_convert_same_unit(self):
+        """Test conversion from any unit to same unit."""
+        self.assertEqual(20, temperature_util.convert(5, TEMP_CELSIUS,
+                                                      TEMP_CELSIUS))
+        self.assertEqual(20, temperature_util.convert(20, TEMP_FAHRENHEIT,
+                                                      TEMP_FAHRENHEIT))
+        # Try a repeating decimal to catch precision errors that might
+        # crop up from round-trip conversions
+        self.assertEqual(5/7, temperature_util.convert(5/7, TEMP_FAHRENHEIT,
+                                                       TEMP_FAHRENHEIT))
+
+    def test_convert_invalid_unit(self):
+        """Test exception is thrown for invalid units."""
+        with self.assertRaises(ValueError):
+            temperature_util.convert(5, 'hotnesses', TEMP_CELSIUS)
+
+        with self.assertRaises(ValueError):
+            temperature_util.convert(5, TEMP_CELSIUS, 'brrs')
+
+    def test_convert_nonnumeric_value(self):
+        """Test exception is thrown for nonnumeric type."""
+        with self.assertRaises(TypeError):
+            temperature_util.convert('cold', TEMP_CELSIUS, TEMP_FAHRENHEIT)
+
+    def test_convert_c_to_f(self):
+        """Test conversion from celsius to fahrenheit."""
+        self.assertEqual(
+            temperature_util.convert(20, TEMP_CELSIUS, TEMP_FAHRENHEIT), 68)
+        self.assertEqual(
+            temperature_util.convert(-40, TEMP_CELSIUS, TEMP_FAHRENHEIT), -40)
+
+    def test_convert_f_to_c(self):
+        """Test conversion from celsius to fahrenheit."""
+        self.assertEqual(
+            temperature_util.convert(68, TEMP_CELSIUS, TEMP_FAHRENHEIT), 20)
+        self.assertEqual(
+            temperature_util.convert(-40, TEMP_CELSIUS, TEMP_FAHRENHEIT), -40)

--- a/tests/util/test_temperature.py
+++ b/tests/util/test_temperature.py
@@ -10,7 +10,7 @@ class TestTemperatureUtil(unittest.TestCase):
 
     def test_convert_same_unit(self):
         """Test conversion from any unit to same unit."""
-        self.assertEqual(20, temperature_util.convert(5, TEMP_CELSIUS,
+        self.assertEqual(20, temperature_util.convert(20, TEMP_CELSIUS,
                                                       TEMP_CELSIUS))
         self.assertEqual(20, temperature_util.convert(20, TEMP_FAHRENHEIT,
                                                       TEMP_FAHRENHEIT))
@@ -42,6 +42,32 @@ class TestTemperatureUtil(unittest.TestCase):
     def test_convert_f_to_c(self):
         """Test conversion from celsius to fahrenheit."""
         self.assertEqual(
-            temperature_util.convert(68, TEMP_CELSIUS, TEMP_FAHRENHEIT), 20)
+            temperature_util.convert(68, TEMP_FAHRENHEIT, TEMP_CELSIUS), 20)
         self.assertEqual(
-            temperature_util.convert(-40, TEMP_CELSIUS, TEMP_FAHRENHEIT), -40)
+            temperature_util.convert(-40, TEMP_FAHRENHEIT, TEMP_CELSIUS), -40)
+
+    def test_dewpoint_invalid_unit(self):
+        """Test exception is thrown for invalid units."""
+        with self.assertRaises(ValueError):
+            temperature_util.calculate_dewpoint(5, 40, 'hotnesses')
+
+    def test_dewpoint_nonnumeric_value(self):
+        """Test exception is thrown for nonsense values."""
+        with self.assertRaises(TypeError):
+            temperature_util.calculate_dewpoint('hot', 'muggy', TEMP_CELSIUS)
+
+    def test_dewpoint_humidity_range(self):
+        """Test exception is thrown for humidity values out of range."""
+        with self.assertRaises(ValueError):
+            temperature_util.calculate_dewpoint(5, -40, TEMP_CELSIUS)
+        with self.assertRaises(ValueError):
+            temperature_util.calculate_dewpoint(5, 110, TEMP_CELSIUS)
+        with self.assertRaises(ValueError):
+            temperature_util.calculate_dewpoint(5, 0, TEMP_CELSIUS)
+
+    def test_dewpoint_calculation(self):
+        """Test that the dewpoint calculation produces correct answers."""
+        self.assertEqual(52.7, round(
+            temperature_util.calculate_dewpoint(68, 58, TEMP_FAHRENHEIT), 1))
+        self.assertEqual(11.5, round(
+            temperature_util.calculate_dewpoint(20, 58, TEMP_CELSIUS), 1))


### PR DESCRIPTION
## Description:

Adds a third sensor to the Ecobee component, using the temperature and humidity readings to calculate dew point.  Dew point is way more useful than relative humidity for assessing and predicting comfort (see e.g. [this explainer article](https://www.washingtonpost.com/news/capital-weather-gang/wp/2013/07/08/weather-weenies-prefer-dew-point-over-relative-humidity-and-you-should-too/)).

I tried to do this as a template sensor, but jinja2's math filters don't include a natural logarithm function.  And I don't see machinery for adding complex custom template filters directly to Home Assistant.  If there is such a thing and I missed it, this might make more sense as one.  That would make it easy for people to create dew point sensors from other temperature+humidity sources (either combined or independent).

No config changes needed.  No documentation changes needed, since the [Ecobee sensor documentation](https://home-assistant.io/components/sensor.ecobee/) just links to the general Ecobee page, and all the sensors get created automatically.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
