### PR TITLE
Don't use the 'id' field since it can be autogenerated (fixes #10551).

### DIFF
--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -155,9 +155,7 @@ class AlexaResponse(object):
                 if 'value' not in resolved:
                     continue
 
-                if 'id' in resolved['value']:
-                    self.variables[underscored_key] = resolved['value']['id']
-                elif 'name' in resolved['value']:
+                if 'name' in resolved['value']:
                     self.variables[underscored_key] = resolved['value']['name']
 
     def add_card(self, card_type, title, content):

--- a/tests/components/alexa/test_intent.py
+++ b/tests/components/alexa/test_intent.py
@@ -209,69 +209,6 @@ def test_intent_request_with_slots(alexa_client):
 
 
 @asyncio.coroutine
-def test_intent_request_with_slots_and_id_resolution(alexa_client):
-    """Test a request with slots and an id synonym."""
-    data = {
-        "version": "1.0",
-        "session": {
-            "new": False,
-            "sessionId": SESSION_ID,
-            "application": {
-                "applicationId": APPLICATION_ID
-            },
-            "attributes": {
-                "supportedHoroscopePeriods": {
-                    "daily": True,
-                    "weekly": False,
-                    "monthly": False
-                }
-            },
-            "user": {
-                "userId": "amzn1.account.AM3B00000000000000000000000"
-            }
-        },
-        "request": {
-            "type": "IntentRequest",
-            "requestId": REQUEST_ID,
-            "timestamp": "2015-05-13T12:34:56Z",
-            "intent": {
-                "name": "GetZodiacHoroscopeIntent",
-                "slots": {
-                    "ZodiacSign": {
-                        "name": "ZodiacSign",
-                        "value": "virgo",
-                        "resolutions": {
-                            "resolutionsPerAuthority": [
-                                {
-                                    "authority": AUTHORITY_ID,
-                                    "status": {
-                                        "code": "ER_SUCCESS_MATCH"
-                                    },
-                                    "values": [
-                                        {
-                                            "value": {
-                                                "name": "Virgo",
-                                                "id": "VIRGO"
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                }
-            }
-        }
-    }
-    req = yield from _intent_req(alexa_client, data)
-    assert req.status == 200
-    data = yield from req.json()
-    text = data.get("response", {}).get("outputSpeech",
-                                        {}).get("text")
-    assert text == "You told us your sign is VIRGO."
-
-
-@asyncio.coroutine
 def test_intent_request_with_slots_and_name_resolution(alexa_client):
     """Test a request with slots and a name synonym."""
     data = {


### PR DESCRIPTION
## Description:

Remove the use of the 'id' field since it is autogenerated if not set. 

**Related issue (if applicable):** fixes #10551 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
