### PR TITLE
Move temperature display helper from components to helpers

### DIFF
--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -9,12 +9,9 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.climate import (
-    ClimateDevice, PLATFORM_SCHEMA, PRECISION_HALVES,
-    STATE_AUTO, STATE_ON, STATE_OFF,
-)
+    STATE_ON, STATE_OFF, STATE_AUTO, PLATFORM_SCHEMA, ClimateDevice)
 from homeassistant.const import (
-    CONF_MAC, TEMP_CELSIUS, CONF_DEVICES, ATTR_TEMPERATURE)
-
+    CONF_MAC, CONF_DEVICES, TEMP_CELSIUS, ATTR_TEMPERATURE, PRECISION_HALVES)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['python-eq3bt==0.1.6']
@@ -58,15 +55,17 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
     def __init__(self, _mac, _name):
         """Initialize the thermostat."""
-        # we want to avoid name clash with this module..
+        # We want to avoid name clash with this module.
         import eq3bt as eq3
 
-        self.modes = {eq3.Mode.Open: STATE_ON,
-                      eq3.Mode.Closed: STATE_OFF,
-                      eq3.Mode.Auto: STATE_AUTO,
-                      eq3.Mode.Manual: STATE_MANUAL,
-                      eq3.Mode.Boost: STATE_BOOST,
-                      eq3.Mode.Away: STATE_AWAY}
+        self.modes = {
+            eq3.Mode.Open: STATE_ON,
+            eq3.Mode.Closed: STATE_OFF,
+            eq3.Mode.Auto: STATE_AUTO,
+            eq3.Mode.Manual: STATE_MANUAL,
+            eq3.Mode.Boost: STATE_BOOST,
+            eq3.Mode.Away: STATE_AWAY,
+        }
 
         self.reverse_modes = {v: k for k, v in self.modes.items()}
 
@@ -153,11 +152,11 @@ class EQ3BTSmartThermostat(ClimateDevice):
     def device_state_attributes(self):
         """Return the device specific state attributes."""
         dev_specific = {
+            ATTR_STATE_AWAY_END: self._thermostat.away_end,
             ATTR_STATE_LOCKED: self._thermostat.locked,
             ATTR_STATE_LOW_BAT: self._thermostat.low_battery,
             ATTR_STATE_VALVE: self._thermostat.valve_state,
             ATTR_STATE_WINDOW_OPEN: self._thermostat.window_open,
-            ATTR_STATE_AWAY_END: self._thermostat.away_end,
         }
 
         return dev_specific

--- a/homeassistant/components/weather/demo.py
+++ b/homeassistant/components/weather/demo.py
@@ -31,7 +31,7 @@ CONDITION_CLASSES = {
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Demo weather."""
     add_devices([
-        DemoWeather('South', 'Sunshine', 21, 92, 1099, 0.5, TEMP_CELSIUS,
+        DemoWeather('South', 'Sunshine', 21.6414, 92, 1099, 0.5, TEMP_CELSIUS,
                     [22, 19, 15, 12, 14, 18, 21]),
         DemoWeather('North', 'Shower rain', -12, 54, 987, 4.8, TEMP_FAHRENHEIT,
                     [-10, -13, -18, -23, -19, -14, -9])

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -417,3 +417,8 @@ SPEED_MS = 'speed_ms'  # type: str
 ILLUMINANCE = 'illuminance'  # type: str
 
 WEEKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
+
+# The degree of precision for platforms
+PRECISION_WHOLE = 1
+PRECISION_HALVES = 0.5
+PRECISION_TENTHS = 0.1

--- a/homeassistant/helpers/temperature.py
+++ b/homeassistant/helpers/temperature.py
@@ -1,0 +1,33 @@
+"""Temperature helpers for Home Assistant."""
+from numbers import Number
+
+from homeassistant.core import HomeAssistant
+from homeassistant.util.temperature import convert as convert_temperature
+
+
+def display_temp(hass: HomeAssistant, temperature: float, unit: str,
+                 precision: float) -> float:
+    """Convert temperature into preferred units for display purposes."""
+    temperature_unit = unit
+    ha_unit = hass.config.units.temperature_unit
+
+    if temperature is None:
+        return temperature
+
+    # If the temperature is not a number this can cause issues
+    # with Polymer components, so bail early there.
+    if not isinstance(temperature, Number):
+        raise TypeError(
+            "Temperature is not a number: {}".format(temperature))
+
+    if temperature_unit != ha_unit:
+        temperature = convert_temperature(
+            temperature, temperature_unit, ha_unit)
+
+    # Round in the units appropriate
+    if precision == 0.5:
+        return round(temperature * 2) / 2.0
+    elif precision == 0.1:
+        return round(temperature, 1)
+    # Integer as a fall back (PRECISION_WHOLE)
+    return round(temperature)

--- a/tests/components/weather/test_weather.py
+++ b/tests/components/weather/test_weather.py
@@ -37,7 +37,7 @@ class TestWeather(unittest.TestCase):
         assert state.state == 'sunny'
 
         data = state.attributes
-        assert data.get(ATTR_WEATHER_TEMPERATURE) == 21
+        assert data.get(ATTR_WEATHER_TEMPERATURE) == 21.6
         assert data.get(ATTR_WEATHER_HUMIDITY) == 92
         assert data.get(ATTR_WEATHER_PRESSURE) == 1099
         assert data.get(ATTR_WEATHER_WIND_SPEED) == 0.5
@@ -57,4 +57,4 @@ class TestWeather(unittest.TestCase):
         assert state.state == 'rainy'
 
         data = state.attributes
-        assert data.get(ATTR_WEATHER_TEMPERATURE) == -24.4
+        assert data.get(ATTR_WEATHER_TEMPERATURE) == -24

--- a/tests/helpers/test_temperature.py
+++ b/tests/helpers/test_temperature.py
@@ -1,0 +1,49 @@
+"""Tests Home Assistant temperature helpers."""
+import unittest
+
+from tests.common import get_test_home_assistant
+
+from homeassistant.const import (
+    TEMP_CELSIUS, PRECISION_WHOLE, TEMP_FAHRENHEIT, PRECISION_HALVES,
+    PRECISION_TENTHS)
+from homeassistant.helpers.temperature import display_temp
+from homeassistant.util.unit_system import METRIC_SYSTEM
+
+TEMP = 24.636626
+
+
+class TestHelpersTemperature(unittest.TestCase):
+    """Setup the temperature tests."""
+
+    def setUp(self):
+        """Setup the tests."""
+        self.hass = get_test_home_assistant()
+        self.hass.config.unit_system = METRIC_SYSTEM
+
+    def tearDown(self):
+        """Stop down stuff we started."""
+        self.hass.stop()
+
+    def test_temperature_not_a_number(self):
+        """Test that temperature is a number."""
+        temp = "Temperature"
+        with self.assertRaises(Exception) as context:
+            display_temp(self.hass, temp, TEMP_CELSIUS, PRECISION_HALVES)
+
+        self.assertTrue("Temperature is not a number: {}".format(temp)
+                        in str(context.exception))
+
+    def test_celsius_halves(self):
+        """Test temperature to celsius rounding to halves."""
+        self.assertEqual(24.5, display_temp(
+            self.hass, TEMP, TEMP_CELSIUS, PRECISION_HALVES))
+
+    def test_celsius_tenths(self):
+        """Test temperature to celsius rounding to tenths."""
+        self.assertEqual(24.6, display_temp(
+            self.hass, TEMP, TEMP_CELSIUS, PRECISION_TENTHS))
+
+    def test_fahrenheit_wholes(self):
+        """Test temperature to fahrenheit rounding to wholes."""
+        self.assertEqual(-4, display_temp(
+            self.hass, TEMP, TEMP_FAHRENHEIT, PRECISION_WHOLE))


### PR DESCRIPTION
## Description:
`convert_for_display` and `temp_for_display` were doing the same thing. Instead of copying the same to a third component (#10130) it's now a helper.

- Some constants needed to be moved. 
- Update of the Weather component. It's now more in sync with the Climate component in regard of displaying the temperature.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

