### PR TITLE
Fix lametric sound

### DIFF
--- a/homeassistant/components/lametric.py
+++ b/homeassistant/components/lametric.py
@@ -51,13 +51,7 @@ def setup(hass, config):
 
 
 class HassLaMetricManager():
-    """
-    A class that encapsulated requests to the LaMetric manager.
-
-    As the original class does not have a re-connect feature that is needed
-    for applications running for a long time as the OAuth tokens expire. This
-    class implements this reconnect() feature.
-    """
+    """A class that encapsulated requests to the LaMetric manager."""
 
     def __init__(self, client_id, client_secret):
         """Initialize HassLaMetricManager and connect to LaMetric."""
@@ -67,13 +61,3 @@ class HassLaMetricManager():
         self.manager = LaMetricManager(client_id, client_secret)
         self._client_id = client_id
         self._client_secret = client_secret
-
-    def reconnect(self):
-        """
-        Reconnect to LaMetric.
-
-        This is usually necessary when the OAuth token is expired.
-        """
-        from lmnotify import LaMetricManager
-        _LOGGER.debug("Reconnecting to LaMetric")
-        self.manager = LaMetricManager(self._client_id, self._client_secret)

--- a/homeassistant/components/notify/lametric.py
+++ b/homeassistant/components/notify/lametric.py
@@ -78,12 +78,7 @@ class LaMetricNotificationService(BaseNotificationService):
 
         frames = [text_frame]
 
-        if sound is not None:
-            frames.append(sound)
-
-        _LOGGER.debug(frames)
-
-        model = Model(frames=frames)
+        model = Model(frames=frames, sound=sound)
         lmn = self.hasslametricmanager.manager
         try:
             devices = lmn.get_devices()


### PR DESCRIPTION
## Description:
* Make sound work for lametric notifications.
* Remove not needed method `reconnect` from lametric component. If token has expired, there's the `get_token` method available on the `LaMetricManager` instance, to fetch new token.

**Related issue (if applicable):**
fixes #10561 
Issue reported here initally:
https://github.com/home-assistant/home-assistant/pull/10391#issuecomment-344039790

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
Although this is a fix, we should really update the docs for this platform. Current docs are very sparse.

## Checklist:
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**