### PR TITLE
Modbus switch register support

### DIFF
--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -122,10 +122,11 @@ class ModbusCoilSwitch(ToggleEntity):
                 'No response from modbus slave %s coil %s',
                 self._slave,
                 self._coil)
-                
+
+
 class ModbusRegisterSwitch(ModbusCoilSwitch):
     """Representation of a Modbus register switch."""
-    
+
     def __init__(self, name, slave, register, command_on,
         command_off, verify_state, verify_register, register_type,
         state_on, state_off):
@@ -144,7 +145,7 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
         self._state_off = (int(state_off) if
             state_off else self._command_off)
         self._is_on = None
-    
+
     def turn_on(self, **kwargs):
         """Set switch on."""
         modbus.HUB.write_register(
@@ -152,7 +153,7 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
             self._register,
             self._command_on)
         if not self._verify_state: self._is_on = True
-    
+
     def turn_off(self, **kwargs):
         """Set switch off."""
         modbus.HUB.write_register(
@@ -160,11 +161,11 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
             self._register,
             self._command_off)
         if not self._verify_state: self._is_on = False
-    
+
     def update(self):
         """Update the state of the switch."""
         if not self._verify_state: return
-    
+
         value = 0
         if self._register_type == REGISTER_TYPE_INPUT:
             result = modbus.HUB.read_input_registers(
@@ -176,7 +177,7 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
                 self._slave,
                 self._register,
                 1)
-                
+
         try:
             value = int(result.registers[0])
         except AttributeError:

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -133,18 +133,18 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
                  register_type, state_on, state_off):
         """Initialize the register switch."""
         self._name = name
-        self._slave = int(slave) if slave else None
-        self._register = int(register)
-        self._command_on = int(command_on)
-        self._command_off = int(command_off)
-        self._verify_state = bool(verify_state)
+        self._slave = slave
+        self._register = register
+        self._command_on = command_on
+        self._command_off = command_off
+        self._verify_state = verify_state
         self._verify_register = (
-            int(verify_register) if verify_register else self._register)
+            verify_register if verify_register else self._register)
         self._register_type = register_type
         self._state_on = (
-            int(state_on) if state_on else self._command_on)
+            state_on if state_on else self._command_on)
         self._state_off = (
-            int(state_off) if state_off else self._command_off)
+            state_off if state_off else self._command_off)
         self._is_on = None
 
     def turn_on(self, **kwargs):

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -88,7 +88,7 @@ class ModbusCoilSwitch(ToggleEntity):
     """Representation of a Modbus coil switch."""
 
     def __init__(self, name, slave, coil):
-        """Initialize the switch."""
+        """Initialize the coil switch."""
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
@@ -130,7 +130,7 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
     def __init__(self, name, slave, register, command_on,
                  command_off, verify_state, verify_register,
                  register_type, state_on, state_off):
-        """Initialize the switch."""
+        """Initialize the register switch."""
         self._name = name
         self._slave = int(slave) if slave else None
         self._register = int(register)

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -152,7 +152,8 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
             self._slave,
             self._register,
             self._command_on)
-        if not self._verify_state: self._is_on = True
+        if not self._verify_state:
+            self._is_on = True
 
     def turn_off(self, **kwargs):
         """Set switch off."""
@@ -160,11 +161,13 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
             self._slave,
             self._register,
             self._command_off)
-        if not self._verify_state: self._is_on = False
+        if not self._verify_state:
+            self._is_on = False
 
     def update(self):
         """Update the state of the switch."""
-        if not self._verify_state: return
+        if not self._verify_state:
+            return
 
         value = 0
         if self._register_type == REGISTER_TYPE_INPUT:

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -127,6 +127,7 @@ class ModbusCoilSwitch(ToggleEntity):
 class ModbusRegisterSwitch(ModbusCoilSwitch):
     """Representation of a Modbus register switch."""
 
+    # pylint: disable=super-init-not-called
     def __init__(self, name, slave, register, command_on,
                  command_off, verify_state, verify_register,
                  register_type, state_on, state_off):

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -8,8 +8,8 @@ import logging
 import voluptuous as vol
 
 import homeassistant.components.modbus as modbus
-from homeassistant.const import (CONF_NAME, CONF_SLAVE,
-    CONF_COMMAND_ON, CONF_COMMAND_OFF)
+from homeassistant.const import (
+    CONF_NAME, CONF_SLAVE, CONF_COMMAND_ON, CONF_COMMAND_OFF)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers import config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -45,7 +45,7 @@ REGISTERS_SCHEMA = vol.Schema({
     vol.Optional(CONF_STATE_OFF, default=None): cv.positive_int,
 })
 
-COILS_SCHEMA = vol.Schema ({
+COILS_SCHEMA = vol.Schema({
     vol.Required(CONF_COIL): cv.positive_int,
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_SLAVE): cv.positive_int,
@@ -128,8 +128,8 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
     """Representation of a Modbus register switch."""
 
     def __init__(self, name, slave, register, command_on,
-        command_off, verify_state, verify_register, register_type,
-        state_on, state_off):
+                 command_off, verify_state, verify_register,
+                 register_type, state_on, state_off):
         """Initialize the switch."""
         self._name = name
         self._slave = int(slave) if slave else None

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -137,13 +137,13 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
         self._command_on = int(command_on)
         self._command_off = int(command_off)
         self._verify_state = bool(verify_state)
-        self._verify_register = (int(verify_register) if
-            verify_register else self._register)
+        self._verify_register = (
+            int(verify_register) if verify_register else self._register)
         self._register_type = register_type
-        self._state_on = (int(state_on) if
-            state_on else self._command_on)
-        self._state_off = (int(state_off) if
-            state_off else self._command_off)
+        self._state_on = (
+            int(state_on) if state_on else self._command_on)
+        self._state_off = (
+            int(state_off) if state_off else self._command_off)
         self._is_on = None
 
     def turn_on(self, **kwargs):
@@ -185,7 +185,7 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
                 'No response from modbus slave %s register %s',
                 self._slave,
                 self._verify_register)
-                
+
         if value == self._state_on:
             self._is_on = True
         elif value == self._state_off:

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -8,7 +8,8 @@ import logging
 import voluptuous as vol
 
 import homeassistant.components.modbus as modbus
-from homeassistant.const import CONF_NAME, CONF_SLAVE
+from homeassistant.const import (CONF_NAME, CONF_SLAVE,
+    CONF_COMMAND_ON, CONF_COMMAND_OFF)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers import config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -18,29 +19,73 @@ DEPENDENCIES = ['modbus']
 
 CONF_COIL = "coil"
 CONF_COILS = "coils"
+CONF_REGISTER = "register"
+CONF_REGISTERS = "registers"
+CONF_VERIFY_STATE = "verify_state"
+CONF_VERIFY_REGISTER = "verify_register"
+CONF_REGISTER_TYPE = "register_type"
+CONF_STATE_ON = "state_on"
+CONF_STATE_OFF = "state_off"
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_COILS): [{
-        vol.Required(CONF_COIL): cv.positive_int,
-        vol.Required(CONF_NAME): cv.string,
-        vol.Optional(CONF_SLAVE): cv.positive_int,
-    }]
+REGISTER_TYPE_HOLDING = 'holding'
+REGISTER_TYPE_INPUT = 'input'
+
+REGISTERS_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_SLAVE): cv.positive_int,
+    vol.Required(CONF_REGISTER): cv.positive_int,
+    vol.Required(CONF_COMMAND_ON): cv.positive_int,
+    vol.Required(CONF_COMMAND_OFF): cv.positive_int,
+    vol.Optional(CONF_VERIFY_STATE, default=True): cv.boolean,
+    vol.Optional(CONF_VERIFY_REGISTER, default=None):
+        cv.positive_int,
+    vol.Optional(CONF_REGISTER_TYPE, default=REGISTER_TYPE_HOLDING):
+        vol.In([REGISTER_TYPE_HOLDING, REGISTER_TYPE_INPUT]),
+    vol.Optional(CONF_STATE_ON, default=None): cv.positive_int,
+    vol.Optional(CONF_STATE_OFF, default=None): cv.positive_int,
 })
+
+COILS_SCHEMA = vol.Schema ({
+    vol.Required(CONF_COIL): cv.positive_int,
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_SLAVE): cv.positive_int,
+})
+
+PLATFORM_SCHEMA = vol.All(
+    cv.has_at_least_one_key(CONF_COILS, CONF_REGISTERS),
+    PLATFORM_SCHEMA.extend({
+        vol.Optional(CONF_COILS): [COILS_SCHEMA],
+        vol.Optional(CONF_REGISTERS): [REGISTERS_SCHEMA]
+    }))
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Read configuration and create Modbus devices."""
     switches = []
-    for coil in config.get("coils"):
-        switches.append(ModbusCoilSwitch(
-            coil.get(CONF_NAME),
-            coil.get(CONF_SLAVE),
-            coil.get(CONF_COIL)))
+    if CONF_COILS in config:
+        for coil in config.get(CONF_COILS):
+            switches.append(ModbusCoilSwitch(
+                coil.get(CONF_NAME),
+                coil.get(CONF_SLAVE),
+                coil.get(CONF_COIL)))
+    if CONF_REGISTERS in config:
+        for register in config.get(CONF_REGISTERS):
+            switches.append(ModbusRegisterSwitch(
+                register.get(CONF_NAME),
+                register.get(CONF_SLAVE),
+                register.get(CONF_REGISTER),
+                register.get(CONF_COMMAND_ON),
+                register.get(CONF_COMMAND_OFF),
+                register.get(CONF_VERIFY_STATE),
+                register.get(CONF_VERIFY_REGISTER),
+                register.get(CONF_REGISTER_TYPE),
+                register.get(CONF_STATE_ON),
+                register.get(CONF_STATE_OFF)))
     add_devices(switches)
 
 
 class ModbusCoilSwitch(ToggleEntity):
-    """Representation of a Modbus switch."""
+    """Representation of a Modbus coil switch."""
 
     def __init__(self, name, slave, coil):
         """Initialize the switch."""
@@ -77,3 +122,77 @@ class ModbusCoilSwitch(ToggleEntity):
                 'No response from modbus slave %s coil %s',
                 self._slave,
                 self._coil)
+                
+class ModbusRegisterSwitch(ModbusCoilSwitch):
+    """Representation of a Modbus register switch."""
+    
+    def __init__(self, name, slave, register, command_on,
+        command_off, verify_state, verify_register, register_type,
+        state_on, state_off):
+        """Initialize the switch."""
+        self._name = name
+        self._slave = int(slave) if slave else None
+        self._register = int(register)
+        self._command_on = int(command_on)
+        self._command_off = int(command_off)
+        self._verify_state = bool(verify_state)
+        self._verify_register = (int(verify_register) if
+            verify_register else self._register)
+        self._register_type = register_type
+        self._state_on = (int(state_on) if
+            state_on else self._command_on)
+        self._state_off = (int(state_off) if
+            state_off else self._command_off)
+        self._is_on = None
+    
+    def turn_on(self, **kwargs):
+        """Set switch on."""
+        modbus.HUB.write_register(
+            self._slave,
+            self._register,
+            self._command_on)
+        if not self._verify_state: self._is_on = True
+    
+    def turn_off(self, **kwargs):
+        """Set switch off."""
+        modbus.HUB.write_register(
+            self._slave,
+            self._register,
+            self._command_off)
+        if not self._verify_state: self._is_on = False
+    
+    def update(self):
+        """Update the state of the switch."""
+        if not self._verify_state: return
+    
+        value = 0
+        if self._register_type == REGISTER_TYPE_INPUT:
+            result = modbus.HUB.read_input_registers(
+                self._slave,
+                self._register,
+                1)
+        else:
+            result = modbus.HUB.read_holding_registers(
+                self._slave,
+                self._register,
+                1)
+                
+        try:
+            value = int(result.registers[0])
+        except AttributeError:
+            _LOGGER.error(
+                'No response from modbus slave %s register %s',
+                self._slave,
+                self._verify_register)
+                
+        if value == self._state_on:
+            self._is_on = True
+        elif value == self._state_off:
+            self._is_on = False
+        else:
+            _LOGGER.error(
+                'Unexpected response from modbus slave %s '
+                'register %s, got 0x%2x',
+                self._slave,
+                self._verify_register,
+                value)


### PR DESCRIPTION
## Description:
Added support for modbus switch based on registers.

**Related issue (if applicable):** fixes #10432 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3978

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  platform: modbus
  slave: 1
  coils:
    - name: Switch1
      slave: 2
      coil: 14
  registers:
    - name: Register1
      slave: 1
      register: 11
      command_on: 1
      command_off: 0
      verify_state: True
      verify_register: 12
      register_type: holding
      state_on: 6
      state_off: 7
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
