### PR TITLE
webostv: Reduce default timeout to prevent log spamming

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -57,7 +57,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_CUSTOMIZE, default={}): CUSTOMIZE_SCHEMA,
     vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string,
-    vol.Optional(CONF_TIMEOUT, default=10): cv.positive_int,
+    vol.Optional(CONF_TIMEOUT, default=8): cv.positive_int,
     vol.Optional(CONF_ON_ACTION): cv.SCRIPT_SCHEMA,
 })
 


### PR DESCRIPTION
## Description:
With the default timeout of 10 seconds, the log gets filled up with "component is taking more than 10 seconds" errors.
This should probably be fixed in some other way, but for now this reduces the problem a bit.

