### PR TITLE
Bump ring_doorbell to 0.1.7

### DIFF
--- a/homeassistant/components/ring.py
+++ b/homeassistant/components/ring.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
 from requests.exceptions import HTTPError, ConnectTimeout
 
-REQUIREMENTS = ['ring_doorbell==0.1.6']
+REQUIREMENTS = ['ring_doorbell==0.1.7']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -951,7 +951,7 @@ restrictedpython==4.0b2
 rflink==0.0.34
 
 # homeassistant.components.ring
-ring_doorbell==0.1.6
+ring_doorbell==0.1.7
 
 # homeassistant.components.notify.rocketchat
 rocketchat-API==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -143,7 +143,7 @@ restrictedpython==4.0b2
 rflink==0.0.34
 
 # homeassistant.components.ring
-ring_doorbell==0.1.6
+ring_doorbell==0.1.7
 
 # homeassistant.components.media_player.yamaha
 rxv==0.5.1


### PR DESCRIPTION
## Description:
Bump `ring_doorbell` version to `0.1.7`

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/ring-doorbell/7943/340

Tests are OK.

## Example entry for `configuration.yaml` (if applicable):
```yaml
ring:
  username: foor
  password: bar

camera:
  - platform: ring

binary_sensor:
  - platform: ring

sensor:
  - platform: ring
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.