### PR TITLE
Protect sensitive information for Amcrest cameras

### DIFF
--- a/homeassistant/components/amcrest.py
+++ b/homeassistant/components/amcrest.py
@@ -126,22 +126,47 @@ def setup(hass, config):
             else:
                 authentication = None
 
+        amcrest_hub = AmcrestHub(camera,
+                                 name,
+                                 authentication,
+                                 ffmpeg_arguments,
+                                 stream_source,
+                                 resolution)
+
         discovery.load_platform(
             hass, 'camera', DOMAIN, {
-                'device': camera,
-                CONF_AUTHENTICATION: authentication,
-                CONF_FFMPEG_ARGUMENTS: ffmpeg_arguments,
-                CONF_NAME: name,
-                CONF_RESOLUTION: resolution,
-                CONF_STREAM_SOURCE: stream_source,
+                'amcrest_hub': amcrest_hub,
             }, config)
 
         if sensors:
             discovery.load_platform(
                 hass, 'sensor', DOMAIN, {
-                    'device': camera,
-                    CONF_NAME: name,
+                    'amcrest_hub': amcrest_hub,
                     CONF_SENSORS: sensors,
                 }, config)
 
     return True
+
+
+class AmcrestHub(object):
+    """Representation of a base AmcrestHub discovery device."""
+
+    def __init__(self, camera, name, authentication, ffmpeg_arguments,
+                 stream_source, resolution):
+        """Initialize the entity."""
+        self.device = camera
+        self.name = name
+        self.authentication = authentication
+        self.ffmpeg_arguments = ffmpeg_arguments
+        self.stream_source = stream_source
+        self.resolution = resolution
+
+    def as_dict(self):
+        """Convert entry to a dict to be used within JSON."""
+        return {
+            'device': self.device,
+            'name': self.name,
+            'ffmpeg_arguments': self.ffmpeg_arguments,
+            'stream_source': self.stream_source,
+            'resolution': self.resolution,
+        }

--- a/homeassistant/components/amcrest.py
+++ b/homeassistant/components/amcrest.py
@@ -89,6 +89,7 @@ def setup(hass, config):
     """Set up the Amcrest IP Camera component."""
     from amcrest import AmcrestCamera
 
+    hass.data[DATA_AMCREST] = {}
     amcrest_cams = config[DOMAIN]
 
     for device in amcrest_cams:
@@ -133,15 +134,17 @@ def setup(hass, config):
                                  stream_source,
                                  resolution)
 
+        hass.data[DATA_AMCREST][name] = amcrest_hub
+
         discovery.load_platform(
             hass, 'camera', DOMAIN, {
-                'amcrest_hub': amcrest_hub,
+                CONF_NAME: name,
             }, config)
 
         if sensors:
             discovery.load_platform(
                 hass, 'sensor', DOMAIN, {
-                    'amcrest_hub': amcrest_hub,
+                    CONF_NAME: name,
                     CONF_SENSORS: sensors,
                 }, config)
 

--- a/homeassistant/components/amcrest.py
+++ b/homeassistant/components/amcrest.py
@@ -127,14 +127,9 @@ def setup(hass, config):
             else:
                 authentication = None
 
-        amcrest_hub = AmcrestHub(camera,
-                                 name,
-                                 authentication,
-                                 ffmpeg_arguments,
-                                 stream_source,
-                                 resolution)
-
-        hass.data[DATA_AMCREST][name] = amcrest_hub
+        hass.data[DATA_AMCREST][name] = AmcrestDevice(
+            camera, name, authentication, ffmpeg_arguments, stream_source,
+            resolution)
 
         discovery.load_platform(
             hass, 'camera', DOMAIN, {
@@ -151,8 +146,8 @@ def setup(hass, config):
     return True
 
 
-class AmcrestHub(object):
-    """Representation of a base AmcrestHub discovery device."""
+class AmcrestDevice(object):
+    """Representation of a base Amcrest discovery device."""
 
     def __init__(self, camera, name, authentication, ffmpeg_arguments,
                  stream_source, resolution):

--- a/homeassistant/components/amcrest.py
+++ b/homeassistant/components/amcrest.py
@@ -163,13 +163,3 @@ class AmcrestHub(object):
         self.ffmpeg_arguments = ffmpeg_arguments
         self.stream_source = stream_source
         self.resolution = resolution
-
-    def as_dict(self):
-        """Convert entry to a dict to be used within JSON."""
-        return {
-            'device': self.device,
-            'name': self.name,
-            'ffmpeg_arguments': self.ffmpeg_arguments,
-            'stream_source': self.stream_source,
-            'resolution': self.resolution,
-        }

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -26,21 +26,16 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    device = discovery_info['device']
-    authentication = discovery_info['authentication']
-    ffmpeg_arguments = discovery_info['ffmpeg_arguments']
-    name = discovery_info['name']
-    resolution = discovery_info['resolution']
-    stream_source = discovery_info['stream_source']
+    amcrest = discovery_info['amcrest_hub']
 
     async_add_devices([
         AmcrestCam(hass,
-                   name,
-                   device,
-                   authentication,
-                   ffmpeg_arguments,
-                   stream_source,
-                   resolution)], True)
+                   amcrest.name,
+                   amcrest.device,
+                   amcrest.authentication,
+                   amcrest.ffmpeg_arguments,
+                   amcrest.stream_source,
+                   amcrest.resolution)], True)
 
     return True
 

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -11,6 +11,7 @@ from homeassistant.components.amcrest import (
     DATA_AMCREST, STREAM_SOURCE_LIST, TIMEOUT)
 from homeassistant.components.camera import Camera
 from homeassistant.components.ffmpeg import DATA_FFMPEG
+from homeassistant.const import CONF_NAME
 from homeassistant.helpers.aiohttp_client import (
     async_get_clientsession, async_aiohttp_proxy_web,
     async_aiohttp_proxy_stream)
@@ -26,7 +27,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    device_name = discovery_info['name']
+    device_name = discovery_info[CONF_NAME]
     amcrest = hass.data[DATA_AMCREST][device_name]
 
     async_add_devices([

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 
 from homeassistant.components.amcrest import (
-    STREAM_SOURCE_LIST, TIMEOUT)
+    DATA_AMCREST, STREAM_SOURCE_LIST, TIMEOUT)
 from homeassistant.components.camera import Camera
 from homeassistant.components.ffmpeg import DATA_FFMPEG
 from homeassistant.helpers.aiohttp_client import (
@@ -26,7 +26,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    amcrest = discovery_info['amcrest_hub']
+    device_name = discovery_info['name']
+    amcrest = hass.data[DATA_AMCREST][device_name]
 
     async_add_devices([
         AmcrestCam(hass,

--- a/homeassistant/components/camera/amcrest.py
+++ b/homeassistant/components/camera/amcrest.py
@@ -30,14 +30,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     device_name = discovery_info[CONF_NAME]
     amcrest = hass.data[DATA_AMCREST][device_name]
 
-    async_add_devices([
-        AmcrestCam(hass,
-                   amcrest.name,
-                   amcrest.device,
-                   amcrest.authentication,
-                   amcrest.ffmpeg_arguments,
-                   amcrest.stream_source,
-                   amcrest.resolution)], True)
+    async_add_devices([AmcrestCam(hass, amcrest)], True)
 
     return True
 
@@ -45,18 +38,17 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class AmcrestCam(Camera):
     """An implementation of an Amcrest IP camera."""
 
-    def __init__(self, hass, name, camera, authentication,
-                 ffmpeg_arguments, stream_source, resolution):
+    def __init__(self, hass, amcrest):
         """Initialize an Amcrest camera."""
         super(AmcrestCam, self).__init__()
-        self._name = name
-        self._camera = camera
+        self._name = amcrest.name
+        self._camera = amcrest.device
         self._base_url = self._camera.get_base_url()
         self._ffmpeg = hass.data[DATA_FFMPEG]
-        self._ffmpeg_arguments = ffmpeg_arguments
-        self._stream_source = stream_source
-        self._resolution = resolution
-        self._token = self._auth = authentication
+        self._ffmpeg_arguments = amcrest.ffmpeg_arguments
+        self._stream_source = amcrest.stream_source
+        self._resolution = amcrest.resolution
+        self._token = self._auth = amcrest.authentication
 
     def camera_image(self):
         """Return a still image response from the camera."""

--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -8,7 +8,7 @@ import asyncio
 from datetime import timedelta
 import logging
 
-from homeassistant.components.amcrest import SENSORS
+from homeassistant.components.amcrest import DATA_AMCREST, SENSORS
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import STATE_UNKNOWN
 
@@ -25,8 +25,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    amcrest = discovery_info['amcrest_hub']
+    device_name = discovery_info['name']
     sensors = discovery_info['sensors']
+    amcrest = hass.data[DATA_AMCREST][device_name]
 
     amcrest_sensors = []
     for sensor_type in sensors:

--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -25,13 +25,13 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    device = discovery_info['device']
-    name = discovery_info['name']
+    amcrest = discovery_info['amcrest_hub']
     sensors = discovery_info['sensors']
 
     amcrest_sensors = []
     for sensor_type in sensors:
-        amcrest_sensors.append(AmcrestSensor(name, device, sensor_type))
+        amcrest_sensors.append(
+            AmcrestSensor(amcrest.name, amcrest.device, sensor_type))
 
     async_add_devices(amcrest_sensors, True)
     return True

--- a/homeassistant/components/sensor/amcrest.py
+++ b/homeassistant/components/sensor/amcrest.py
@@ -10,7 +10,7 @@ import logging
 
 from homeassistant.components.amcrest import DATA_AMCREST, SENSORS
 from homeassistant.helpers.entity import Entity
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import CONF_NAME, CONF_SENSORS, STATE_UNKNOWN
 
 DEPENDENCIES = ['amcrest']
 
@@ -25,8 +25,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    device_name = discovery_info['name']
-    sensors = discovery_info['sensors']
+    device_name = discovery_info[CONF_NAME]
+    sensors = discovery_info[CONF_SENSORS]
     amcrest = hass.data[DATA_AMCREST][device_name]
 
     amcrest_sensors = []


### PR DESCRIPTION
## Description:
Protect the Amcrest credentials (username, password) of being logged in `homeassistant.log`

**Before**
![30508079-73346c66-9a5c-11e7-97e9-b1c1698d9c93](https://user-images.githubusercontent.com/809840/32769680-e21d8fa6-c8ea-11e7-9c96-7a9a938ff704.png)

**NOW**

```bash
2017-11-22 01:08:07 INFO (MainThread) [homeassistant.core] Bus:Handling <Event platform_discovered[L]: service=load_platform.camera, platform=amcrest, discovered=name=Amcrest Backyard Gate>
2017-11-22 01:08:07 INFO (MainThread) [homeassistant.core] Bus:Handling <Event platform_discovered[L]: service=load_platform.camera, platform=amcrest, discovered=name=Amcrest Backyard>
2017-11-22 01:08:22 INFO (MainThread) [homeassistant.core] Bus:Handling <Event platform_discovered[L]: service=load_platform.sensor, platform=amcrest, discovered=name=Amcrest Backyard Gate, sensors=['motion_detector']>
2017-11-22 01:08:22 INFO (MainThread) [homeassistant.core] Bus:Handling <Event platform_discovered[L]: service=load_platform.sensor, platform=amcrest, discovered=name=Amcrest Backyard, sensors=['motion_detector']>
```
**Related issue (if applicable):** fixes #9444

## Example entry for `configuration.yaml` (if applicable):
```yaml
amcrest:
  - host: !secret amcrest_backyard_host
  name: "Amcrest Backyard"
  username: !secret amcrest_backyard_username
  password: !secret amcrest_backyard_password
  port: 80
  resolution: high
  stream_source: rtsp
  sensors:
    - motion_detector
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.