### PR TITLE
Make configurator spinner spin again

### DIFF
--- a/homeassistant/components/configurator.py
+++ b/homeassistant/components/configurator.py
@@ -207,7 +207,7 @@ class Configurator(object):
 
         self.hass.bus.async_listen_once(EVENT_TIME_CHANGED, deferred_remove)
 
-    @async_callback
+    @asyncio.coroutine
     def async_handle_service_call(self, call):
         """Handle a configure service call."""
         request_id = call.data.get(ATTR_CONFIGURE_ID)
@@ -220,7 +220,8 @@ class Configurator(object):
 
         # field validation goes here?
         if callback:
-            self.hass.async_add_job(callback, call.data.get(ATTR_FIELDS, {}))
+            yield from self.hass.async_add_job(callback,
+                                               call.data.get(ATTR_FIELDS, {}))
 
     def _generate_unique_id(self):
         """Generate a unique configurator ID."""


### PR DESCRIPTION
This change will make the 'configure' service call from the configurator panel await the result of the callback. (for at most SERVICE_CALL_LIMIT in core.py = currently 10 seconds)

This improves the spinner behavior on the frontend. (the spinner is displayed until a response to the service call is received.)

The previous behaviour (as a callback) would add `async_handle_service_call` to the queue and return the service call immediately. (see core.py line 1027-1032)