### PR TITLE
Allow to pass YandexTTS options via service call

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -286,10 +286,11 @@ class SpeechManager(object):
         options = options or provider.default_options
         if options is not None:
             invalid_opts = [opt_name for opt_name in options.keys()
-                            if opt_name not in provider.supported_options]
+                            if opt_name not in (provider.supported_options or
+                                                [])]
             if invalid_opts:
                 raise HomeAssistantError(
-                    "Invalid options found: %s", invalid_opts)
+                    "Invalid options found: {}".format(invalid_opts))
             options_key = ctypes.c_size_t(hash(frozenset(options))).value
         else:
             options_key = '-'

--- a/homeassistant/components/tts/yandextts.py
+++ b/homeassistant/components/tts/yandextts.py
@@ -63,6 +63,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Range(min=MIN_SPEED, max=MAX_SPEED)
 })
 
+SUPPORTED_OPTIONS = [
+    CONF_CODEC,
+    CONF_VOICE,
+    CONF_EMOTION,
+    CONF_SPEED,
+]
+
 
 @asyncio.coroutine
 def async_get_engine(hass, config):
@@ -94,11 +101,17 @@ class YandexSpeechKitProvider(Provider):
         """Return list of supported languages."""
         return SUPPORT_LANGUAGES
 
+    @property
+    def supported_options(self):
+        """Return list of supported options."""
+        return SUPPORTED_OPTIONS
+
     @asyncio.coroutine
     def async_get_tts_audio(self, message, language, options=None):
         """Load TTS from yandex."""
         websession = async_get_clientsession(self.hass)
         actual_language = language
+        options = options or {}
 
         try:
             with async_timeout.timeout(10, loop=self.hass.loop):
@@ -106,10 +119,10 @@ class YandexSpeechKitProvider(Provider):
                     'text': message,
                     'lang': actual_language,
                     'key': self._key,
-                    'speaker': self._speaker,
-                    'format': self._codec,
-                    'emotion': self._emotion,
-                    'speed': self._speed
+                    'speaker': options.get(CONF_VOICE, self._speaker),
+                    'format': options.get(CONF_CODEC, self._codec),
+                    'emotion': options.get(CONF_EMOTION, self._emotion),
+                    'speed': options.get(CONF_SPEED, self._speed)
                 }
 
                 request = yield from websession.get(

--- a/tests/components/tts/test_yandextts.py
+++ b/tests/components/tts/test_yandextts.py
@@ -363,3 +363,40 @@ class TestTTSYandexPlatform(object):
 
         assert len(aioclient_mock.mock_calls) == 1
         assert len(calls) == 1
+
+    def test_service_say_specified_options(self, aioclient_mock):
+        """Test service call say with options."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        url_param = {
+            'text': 'HomeAssistant',
+            'lang': 'en-US',
+            'key': '1234567xx',
+            'speaker': 'zahar',
+            'format': 'mp3',
+            'emotion': 'evil',
+            'speed': 2
+        }
+        aioclient_mock.get(
+            self._base_url, status=200, content=b'test', params=url_param)
+        config = {
+            tts.DOMAIN: {
+                'platform': 'yandextts',
+                'api_key': '1234567xx',
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'yandextts_say', {
+            tts.ATTR_MESSAGE: "HomeAssistant",
+            'options': {
+                'emotion': 'evil',
+                'speed': 2,
+            }
+        })
+        self.hass.block_till_done()
+
+        assert len(aioclient_mock.mock_calls) == 1
+        assert len(calls) == 1


### PR DESCRIPTION
## Description:

Allow to pass YandexTTS options via service call

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
