### PR TITLE
Limitlessled: restore previous state from database

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -4,6 +4,7 @@ Support for LimitlessLED bulbs.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.limitlessled/
 """
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -164,6 +165,12 @@ class LimitlessLEDGroup(Light):
         self._is_on = False
         self._brightness = None
         self.config = config
+
+    @asyncio.coroutine
+    def async_restore_state(self, is_on, **kwargs):
+        """Restore the state."""
+        if is_on:
+            yield from self.turn_on(**kwargs)
 
     @staticmethod
     def factory(group, config):

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -183,7 +183,7 @@ class LimitlessLEDGroup(Light):
         # We need to call turn_on here because the component turns the devices
         # off on init to achieve a known state.
         if old_state.state == STATE_ON:
-            yield from self.turn_on(**params)
+            yield from self.async_turn_on(**params)
 
     @staticmethod
     def factory(group, config):


### PR DESCRIPTION
## Description:

Restores the last known state from the database to limitlessled devices after HASS restart.


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
