### PR TITLE
Add panel build type

### DIFF
--- a/homeassistant/components/hassio.py
+++ b/homeassistant/components/hassio.py
@@ -49,7 +49,7 @@ NO_TIMEOUT = {
 }
 
 NO_AUTH = {
-    re.compile(r'^panel$'), re.compile(r'^addons/[^/]*/logo$')
+    re.compile(r'^panel_(es5|latest)$'), re.compile(r'^addons/[^/]*/logo$')
 }
 
 SCHEMA_ADDON = vol.Schema({

--- a/tests/components/test_hassio.py
+++ b/tests/components/test_hassio.py
@@ -231,7 +231,8 @@ def test_auth_required_forward_request(hassio_client):
 
 
 @asyncio.coroutine
-def test_forward_request_no_auth_for_panel(hassio_client):
+@pytest.mark.parametrize('build_type', ['es5', 'latest'])
+def test_forward_request_no_auth_for_panel(hassio_client, build_type):
     """Test no auth needed for ."""
     response = MagicMock()
     response.read.return_value = mock_coro('data')
@@ -240,7 +241,8 @@ def test_forward_request_no_auth_for_panel(hassio_client):
                Mock(return_value=mock_coro(response))), \
             patch('homeassistant.components.hassio._create_response') as mresp:
         mresp.return_value = 'response'
-        resp = yield from hassio_client.get('/api/hassio/panel')
+        resp = yield from hassio_client.get(
+            '/api/hassio/panel_{}'.format(build_type))
 
     # Check we got right response
     assert resp.status == 200


### PR DESCRIPTION
## Description:
Support the new 2 panel urls for Hass.io

Related PRs:
 - https://github.com/home-assistant/home-assistant-polymer/pull/630
 - https://github.com/home-assistant/hassio/pull/249
 - https://github.com/home-assistant/hassio-build/pull/47

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
