### PR TITLE
Cleanup old stale restore feature

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -82,18 +82,6 @@ COLOR_GROUP = "Color descriptors"
 
 LIGHT_PROFILES_FILE = "light_profiles.csv"
 
-PROP_TO_ATTR = {
-    'brightness': ATTR_BRIGHTNESS,
-    'color_temp': ATTR_COLOR_TEMP,
-    'min_mireds': ATTR_MIN_MIREDS,
-    'max_mireds': ATTR_MAX_MIREDS,
-    'rgb_color': ATTR_RGB_COLOR,
-    'xy_color': ATTR_XY_COLOR,
-    'white_value': ATTR_WHITE_VALUE,
-    'effect_list': ATTR_EFFECT_LIST,
-    'effect': ATTR_EFFECT,
-}
-
 # Service call validation schemas
 VALID_TRANSITION = vol.All(vol.Coerce(float), vol.Clamp(min=0, max=6553))
 VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255))
@@ -137,14 +125,6 @@ PROFILE_SCHEMA = vol.Schema(
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def extract_info(state):
-    """Extract light parameters from a state object."""
-    params = {key: state.attributes[key] for key in PROP_TO_ATTR
-              if key in state.attributes}
-    params['is_on'] = state.state == STATE_ON
-    return params
 
 
 @bind_hass

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -82,6 +82,18 @@ COLOR_GROUP = "Color descriptors"
 
 LIGHT_PROFILES_FILE = "light_profiles.csv"
 
+PROP_TO_ATTR = {
+    'brightness': ATTR_BRIGHTNESS,
+    'color_temp': ATTR_COLOR_TEMP,
+    'min_mireds': ATTR_MIN_MIREDS,
+    'max_mireds': ATTR_MAX_MIREDS,
+    'rgb_color': ATTR_RGB_COLOR,
+    'xy_color': ATTR_XY_COLOR,
+    'white_value': ATTR_WHITE_VALUE,
+    'effect_list': ATTR_EFFECT_LIST,
+    'effect': ATTR_EFFECT,
+}
+
 # Service call validation schemas
 VALID_TRANSITION = vol.All(vol.Coerce(float), vol.Clamp(min=0, max=6553))
 VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255))

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -23,7 +23,6 @@ from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.restore_state import async_restore_state
 import homeassistant.util.color as color_util
 
 DOMAIN = "light"
@@ -431,9 +430,3 @@ class Light(ToggleEntity):
     def supported_features(self):
         """Flag supported features."""
         return 0
-
-    @asyncio.coroutine
-    def async_added_to_hass(self):
-        """Component added, restore_state using platforms."""
-        if hasattr(self, 'async_restore_state'):
-            yield from async_restore_state(self, extract_info)

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -4,7 +4,6 @@ Demo light platform that implements lights.
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/demo/
 """
-import asyncio
 import random
 
 from homeassistant.components.light import (

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -150,26 +150,3 @@ class DemoLight(Light):
         # As we have disabled polling, we need to inform
         # Home Assistant about updates in our state ourselves.
         self.schedule_update_ha_state()
-
-    @asyncio.coroutine
-    def async_restore_state(self, is_on, **kwargs):
-        """Restore the demo state."""
-        self._state = is_on
-
-        if 'brightness' in kwargs:
-            self._brightness = kwargs['brightness']
-
-        if 'color_temp' in kwargs:
-            self._ct = kwargs['color_temp']
-
-        if 'rgb_color' in kwargs:
-            self._rgb = kwargs['rgb_color']
-
-        if 'xy_color' in kwargs:
-            self._xy_color = kwargs['xy_color']
-
-        if 'white_value' in kwargs:
-            self._white = kwargs['white_value']
-
-        if 'effect' in kwargs:
-            self._effect = kwargs['effect']

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -79,36 +79,3 @@ class TestDemoLight(unittest.TestCase):
         light.turn_off(self.hass)
         self.hass.block_till_done()
         self.assertFalse(light.is_on(self.hass, ENTITY_LIGHT))
-
-
-@asyncio.coroutine
-def test_restore_state(hass):
-    """Test state gets restored."""
-    mock_component(hass, 'recorder')
-    hass.state = CoreState.starting
-    hass.data[DATA_RESTORE_CACHE] = {
-        'light.bed_light': State('light.bed_light', 'on', {
-            'brightness': 'value-brightness',
-            'color_temp': 'value-color_temp',
-            'rgb_color': 'value-rgb_color',
-            'xy_color': 'value-xy_color',
-            'white_value': 'value-white_value',
-            'effect': 'value-effect',
-        }),
-    }
-
-    yield from async_setup_component(hass, 'light', {
-        'light': {
-            'platform': 'demo',
-        }})
-
-    state = hass.states.get('light.bed_light')
-    assert state is not None
-    assert state.entity_id == 'light.bed_light'
-    assert state.state == 'on'
-    assert state.attributes.get('brightness') == 'value-brightness'
-    assert state.attributes.get('color_temp') == 'value-color_temp'
-    assert state.attributes.get('rgb_color') == 'value-rgb_color'
-    assert state.attributes.get('xy_color') == 'value-xy_color'
-    assert state.attributes.get('white_value') == 'value-white_value'
-    assert state.attributes.get('effect') == 'value-effect'

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -1,14 +1,11 @@
 """The tests for the demo light component."""
 # pylint: disable=protected-access
-import asyncio
 import unittest
 
-from homeassistant.core import State, CoreState
-from homeassistant.setup import setup_component, async_setup_component
+from homeassistant.setup import setup_component
 import homeassistant.components.light as light
-from homeassistant.helpers.restore_state import DATA_RESTORE_CACHE
 
-from tests.common import get_test_home_assistant, mock_component
+from tests.common import get_test_home_assistant
 
 ENTITY_LIGHT = 'light.bed_light'
 


### PR DESCRIPTION
## Description:

This was from first version but we remove this after some time while the restore is only available for device they assume his states. In this case we need not this function. We remove this but look like we forget the light platform.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
