### PR TITLE
Fix ValueError exception

### DIFF
--- a/homeassistant/components/sensor/modbus.py
+++ b/homeassistant/components/sensor/modbus.py
@@ -165,7 +165,7 @@ class ModbusRegisterSensor(Entity):
             if self._reverse_order:
                 registers.reverse()
         except AttributeError:
-            _LOGGER.error("No response from modbus slave %s register %s",
+            _LOGGER.error("No response from modbus slave %s, register %s",
                           self._slave, self._register)
             return
         byte_string = b''.join(

--- a/homeassistant/components/sensor/modbus.py
+++ b/homeassistant/components/sensor/modbus.py
@@ -70,7 +70,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         structure = '>i'
         if register.get(CONF_DATA_TYPE) != DATA_TYPE_CUSTOM:
             try:
-                structure = '>{:c}'.format(data_types[
+                structure = '>{}'.format(data_types[
                     register.get(CONF_DATA_TYPE)][register.get(CONF_COUNT)])
             except KeyError:
                 _LOGGER.error("Unable to detect data type for %s sensor, "


### PR DESCRIPTION
## Description:
prevous code:
structure = '>{:c}'.format(data_types[register.get(CONF_DATA_TYPE)][register.get(CONF_COUNT)])
give:
ValueError: Unknown format code 'c' for object of type 'str'



If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
