### PR TITLE
Allow unicode when dumping yaml

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -78,7 +78,8 @@ def load_yaml(fname: str) -> Union[List, Dict]:
 
 def dump(_dict: dict) -> str:
     """Dump YAML to a string and remove null."""
-    return yaml.safe_dump(_dict, default_flow_style=False) \
+    return yaml.safe_dump(
+        _dict, default_flow_style=False, allow_unicode=True) \
         .replace(': null\n', ':\n')
 
 

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -267,6 +267,10 @@ class TestYaml(unittest.TestCase):
         """The that the dump method returns empty None values."""
         assert yaml.dump({'a': None, 'b': 'b'}) == 'a:\nb: b\n'
 
+    def test_dump_unicode(self):
+        """The that the dump method returns empty None values."""
+        assert yaml.dump({'a': None, 'b': 'привет'}) == 'a:\nb: привет\n'
+
 
 FILES = {}
 


### PR DESCRIPTION
## Description:

Allow unicode when dumping yaml

When dumping `{'text': 'привет'}` it used to be:
`text: "\u043F\u0440\u0438\u0432\u0435\u0442" ` now it is `text: привет`

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
