### PR TITLE
Fix Hikvision (motion) switch bug

### DIFF
--- a/homeassistant/components/switch/hikvisioncam.py
+++ b/homeassistant/components/switch/hikvisioncam.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.entity import ToggleEntity
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['hikvision==0.4']
+# This is the last working version, please test before updating
 
 _LOGGING = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/hikvisioncam.py
+++ b/homeassistant/components/switch/hikvisioncam.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import ToggleEntity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['hikvision==1.2']
+REQUIREMENTS = ['hikvision==0.4']
 
 _LOGGING = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -322,7 +322,7 @@ hbmqtt==0.8
 heatmiserV3==0.9.1
 
 # homeassistant.components.switch.hikvisioncam
-hikvision==1.2
+hikvision==0.4
 
 # homeassistant.components.notify.hipchat
 hipnotify==1.0.8


### PR DESCRIPTION
## Description:
The updated Hikvision 1.2 package breaks the camera switches. Reverting it to 0.4.

**Related issue (if applicable):** fixes #10440 #10606 

## Example entry for `configuration.yaml` (if applicable): Tested with 
```yaml
  - platform: hikvisioncam
    host: 192.168.2.91
    name: PorchMotion
    username: !secret hikvision_username
    password: !secret hikvision_password
```

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
