### PR TITLE
Googleplus Image Support

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -766,18 +766,18 @@ def get_googlepluspthumb_from_email(email: str):
     from re import search
 
     url = r'https://picasaweb.google.com/data/entry/api/user/'
-    if email is None or email is False or email is True
+    if email is None or email is False or email is True:
         email = ''
     try:
         url += urllib.parse.quote(email) + r'?alt=json'
         jsontext = urllib.request.urlopen(url).read().decode('utf-8')
     except TypeError:
-        _LOGGER.error('http timeout or invalid email\r\n  '
-                      + email + '\r\n  ' + url)
+        _LOGGER.error('http timeout or invalid email\r\n  email: '
+                      + email + '\r\n  url: ' + url)
         return None
     except urllib.error.HTTPError:
-        _LOGGER.error('http timeout or invalid email\r\n  '
-                      + email + '\r\n  ' + url)
+        _LOGGER.error('http timeout or invalid email\r\n  email: '
+                      + email + '\r\n  url: ' + url)
         return None
 
     thumbnail_pattern = r'gphoto\$thumbnail\"\:\{\"\$t\"\:\"([^\"]*?)\"'

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -766,6 +766,8 @@ def get_googlepluspthumb_from_email(email: str):
     from re import search
 
     url = r'https://picasaweb.google.com/data/entry/api/user/'
+    if email is None or email is False or email is True
+        email = ''
     try:
         url += urllib.parse.quote(email) + r'?alt=json'
         jsontext = urllib.request.urlopen(url).read().decode('utf-8')

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -777,7 +777,7 @@ def get_googlepluspthumb_from_email(hass: HomeAssistantType, email: str):
             resp = yield from websession.get(url)
             if resp.status == 200:
                 jsontext = yield from resp.text()
-                debug_jsontext=yield from resp.json(encoding='utf-8')
+                debug_jsontext = yield from resp.json(encoding='utf-8')
     except (asyncio.TimeoutError, aiohttp.ClientError, TypeError):
         _LOGGER.error('http timeout or invalid email\r\n  email: '
                       + email + '\r\n  url: ' + url)

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -765,11 +765,8 @@ def get_googlepluspthumb_from_email(email: str):
     from re import search
 
     url = r'https://picasaweb.google.com/data/entry/api/user/'
-    url += urllib.parse.quote_from_bytes(str(email).encode('utf-8'))
-    url += r'?alt=json'
-
-    print(url)
     try:
+        url += urllib.parse.quote(email) + r'?alt=json'
         jsontext = urllib.request.urlopen(url).read().decode('utf-8')
     except:
         print('"' + url + '" timeout or invalid email')

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -760,7 +760,7 @@ def get_googlepluspthumb_from_email(email: str):
     """Return a thumbnail image of a user's google plus profile image"""
     import urllib.request
     import urllib.parse
-    import re
+    from re import search
 
     url = r'https://picasaweb.google.com/data/entry/api/user/'
     url += urllib.parse.quote(email) + '?alt=json'
@@ -773,7 +773,7 @@ def get_googlepluspthumb_from_email(email: str):
         return None
 
     thumbnail_pattern = r'gphoto\$thumbnail\"\:\{\"\$t\"\:\"([^\"]*?)\"'
-    thumbnail_url = re.search(thumbnail_pattern, jsontext).group(1)
+    thumbnail_url = search(thumbnail_pattern, jsontext).group(1)
     if thumbnail_url == '':
         return None
     return thumbnail_url

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -413,7 +413,8 @@ class Device(Entity):
             # Attempt to use googleplus but revert to picture if it fails
             googlepluspthumb = None
             if googleplus is not None:
-                googlepluspthumb = get_googlepluspthumb_from_email(hass, googleplus)
+                googlepluspthumb = get_googlepluspthumb_from_email(hass,
+                                                                   googleplus)
             if googlepluspthumb is not None:
                 self.config_picture = googlepluspthumb
             else:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -767,7 +767,7 @@ def get_googlepluspthumb_from_email(email: str):
     if email is None or email is False or email is True:
         email = ''
 
-    debug_jsontext=None
+    debug_jsontext={}
     try:
         url += urllib.parse.quote(email) + r'?alt=json'
 
@@ -776,7 +776,7 @@ def get_googlepluspthumb_from_email(email: str):
             resp = yield from websession.get(url)
             print('resp.status=' + resp.status)
             jsontext = yield from resp.text()
-            debug_jsontext=yield from resp.json(encoding = 'utf-8')
+            debug_jsontext=yield from resp.json()
     except (asyncio.TimeoutError, aiohttp.ClientError, TypeError):
         _LOGGER.error('http timeout or invalid email\r\n  email: '
                       + email + '\r\n  url: ' + url)

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -770,14 +770,12 @@ def get_googlepluspthumb_from_email(email: str):
         url += urllib.parse.quote(email) + r'?alt=json'
         jsontext = urllib.request.urlopen(url).read().decode('utf-8')
     except TypeError:
-        print(email)
-        print(url)
-        print('http timeout or invalid email')
+        _LOGGER.error('http timeout or invalid email\r\n  '
+                     + email + '\r\n  ' + url)
         return None
     except urllib.error.HTTPError:
-        print(email)
-        print(url)
-        print('http timeout or invalid email')
+        _LOGGER.error('http timeout or invalid email\r\n  '
+                     + email + '\r\n  ' + url)
         return None
 
     thumbnail_pattern = r'gphoto\$thumbnail\"\:\{\"\$t\"\:\"([^\"]*?)\"'

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -759,13 +759,16 @@ def get_gravatar_for_email(email: str):
 
 
 def get_googlepluspthumb_from_email(email: str):
-    """Return a thumbnail image of a user's google plus profile image"""
+    """Return a thumbnail image of a user's google plus profile image."""
     import urllib.request
     import urllib.parse
     from re import search
 
+    string_email = ''
+    if email is not None:
+        string_email = email
     url = r'https://picasaweb.google.com/data/entry/api/user/'
-    url += urllib.parse.quote(email) + '?alt=json'
+    url += urllib.parse.quote(string_email) + r'?alt=json'
 
     print(url)
     try:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -413,8 +413,8 @@ class Device(Entity):
             # Attempt to use googleplus but revert to picture if it fails
             googlepluspthumb = None
             if googleplus is not None:
-                googlepluspthumb = get_googlepluspthumb_from_email(hass,
-                                                                   googleplus)
+                googlepluspthumb = (yield from
+                                    get_googlepluspthumb_from_email(hass, googleplus))
             if googlepluspthumb is not None:
                 self.config_picture = googlepluspthumb
             else:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -768,7 +768,7 @@ def get_googlepluspthumb_from_email(hass: HomeAssistantType, email: str):
     if email is None or email is False or email is True:
         email = ''
 
-    #debug_jsontext = {}
+#    #debug_jsontext = {}
     jsontext = ''
     try:
         url += urllib.parse.quote(email) + r'?alt=json'
@@ -777,10 +777,9 @@ def get_googlepluspthumb_from_email(hass: HomeAssistantType, email: str):
         with async_timeout.timeout(5, loop=hass.loop):
             resp = yield from websession.get(url)
             if resp.status == 200:
-                jsongenerator = yield from resp.text()
-                jsontext = str(jsongenerator)
-                #debug_jsontext = yield from resp.json(encoding='utf-8')
-                #print(debug_jsontext.keys())
+                jsontext = str(resp.text())
+#                #debug_jsontext = resp.json(encoding='utf-8')
+#                #print(debug_jsontext.keys())
     except (asyncio.TimeoutError, aiohttp.ClientError, TypeError):
         _LOGGER.error('http timeout or invalid email\r\n  email: '
                       + email + '\r\n  url: ' + url)

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -748,7 +748,7 @@ def update_config(path: str, dev_id: str, device: Device):
         out.write(dump(device))
 
 
-def get_gravatar_for_email(hass: HomeAssistantType, email: str):
+def get_gravatar_for_email(email: str):
     """Return an 80px Gravatar for the given email address.
 
     Async friendly.
@@ -758,7 +758,7 @@ def get_gravatar_for_email(hass: HomeAssistantType, email: str):
     return url.format(hashlib.md5(email.encode('utf-8').lower()).hexdigest())
 
 
-def get_googlepluspthumb_from_email(email: str):
+def get_googlepluspthumb_from_email(hass: HomeAssistantType, email: str):
     """Return a thumbnail image of a user's google plus profile image."""
     import urllib.parse
     from re import search
@@ -767,16 +767,16 @@ def get_googlepluspthumb_from_email(email: str):
     if email is None or email is False or email is True:
         email = ''
 
-    debug_jsontext={}
+    debug_jsontext = {}
     try:
         url += urllib.parse.quote(email) + r'?alt=json'
 
         websession = async_get_clientsession(hass)
         with async_timeout.timeout(5, loop=hass.loop):
             resp = yield from websession.get(url)
-            print('resp.status=' + resp.status)
-            jsontext = yield from resp.text()
-            debug_jsontext=yield from resp.json(encoding = 'utf-8')
+            if resp.status == 200:
+                jsontext = yield from resp.text()
+                debug_jsontext=yield from resp.json(encoding='utf-8')
     except (asyncio.TimeoutError, aiohttp.ClientError, TypeError):
         _LOGGER.error('http timeout or invalid email\r\n  email: '
                       + email + '\r\n  url: ' + url)

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -771,11 +771,11 @@ def get_googlepluspthumb_from_email(email: str):
         jsontext = urllib.request.urlopen(url).read().decode('utf-8')
     except TypeError:
         _LOGGER.error('http timeout or invalid email\r\n  '
-                     + email + '\r\n  ' + url)
+                      + email + '\r\n  ' + url)
         return None
     except urllib.error.HTTPError:
         _LOGGER.error('http timeout or invalid email\r\n  '
-                     + email + '\r\n  ' + url)
+                      + email + '\r\n  ' + url)
         return None
 
     thumbnail_pattern = r'gphoto\$thumbnail\"\:\{\"\$t\"\:\"([^\"]*?)\"'

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -767,28 +767,29 @@ def get_googlepluspthumb_from_email(email: str):
     if email is None or email is False or email is True:
         email = ''
 
-	debug_jsontext=None
+    debug_jsontext=None
     try:
         url += urllib.parse.quote(email) + r'?alt=json'
 
         websession = async_get_clientsession(self.hass)
         with async_timeout.timeout(5, loop=self.hass.loop):
             resp = yield from websession.get(url)
-        print('resp.status=' + resp.status)
-        jsontext = yield from resp.text()
-        debug_jsontext=yield from resp.json(encoding='utf-8')
+            print('resp.status=' + resp.status)
+            jsontext = yield from resp.text()
+            debug_jsontext=yield from resp.json(encoding = 'utf-8')
     except (asyncio.TimeoutError, aiohttp.ClientError, TypeError):
         _LOGGER.error('http timeout or invalid email\r\n  email: '
                       + email + '\r\n  url: ' + url)
         return None
-	
-	try:
-		print('jsontext')
+
+    try:
+        print('jsontext')
         print(jsontext)
         print('debug_json.keys()')
         print(debug_json.keys())
-	except(TypeError): pass
-	
+    except(TypeError):
+        pass
+
     thumbnail_pattern = r'gphoto\$thumbnail\"\:\{\"\$t\"\:\"([^\"]*?)\"'
     thumbnail_url = search(thumbnail_pattern, jsontext).group(1)
     if thumbnail_url == '':

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -762,14 +762,22 @@ def get_googlepluspthumb_from_email(email: str):
     """Return a thumbnail image of a user's google plus profile image."""
     import urllib.request
     import urllib.parse
+    import urllib.error
     from re import search
 
     url = r'https://picasaweb.google.com/data/entry/api/user/'
     try:
         url += urllib.parse.quote(email) + r'?alt=json'
         jsontext = urllib.request.urlopen(url).read().decode('utf-8')
-    except:
-        print('"' + url + '" timeout or invalid email')
+    except TypeError:
+        print(email)
+        print(url)
+        print('http timeout or invalid email')
+        return None
+    except urllib.error.HTTPError:
+        print(email)
+        print(url)
+        print('http timeout or invalid email')
         return None
 
     thumbnail_pattern = r'gphoto\$thumbnail\"\:\{\"\$t\"\:\"([^\"]*?)\"'

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -385,7 +385,7 @@ class Device(Entity):
 
     def __init__(self, hass: HomeAssistantType, consider_home: timedelta,
                  track: bool, dev_id: str, mac: str, name: str=None,
-                 picture: str=None, gravatar: str=None, 
+                 picture: str=None, gravatar: str=None,
                  googleplus: str=None, icon: str=None,
                  hide_if_away: bool=False, vendor: str=None) -> None:
         """Initialize a device."""

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -765,7 +765,8 @@ def get_googlepluspthumb_from_email(email: str):
     from re import search
 
     url = r'https://picasaweb.google.com/data/entry/api/user/'
-    url += urllib.parse.quote_from_bytes(str(email).encode('utf-8')) + r'?alt=json'
+    url += urllib.parse.quote_from_bytes(str(email).encode('utf-8'))
+    url += r'?alt=json'
 
     print(url)
     try:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -411,6 +411,7 @@ class Device(Entity):
             self.config_picture = get_gravatar_for_email(gravatar)
         else:
             # Attempt to use googleplus but revert to picture if it fails
+            googlepluspthumb = None
             if googleplus is not None:
                 googlepluspthumb = get_googlepluspthumb_from_email(googleplus)
             if googlepluspthumb is None:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -408,12 +408,12 @@ class Device(Entity):
 
         # Configured picture
         if gravatar is not None:
-            self.config_picture = get_gravatar_for_email(hass, gravatar)
+            self.config_picture = get_gravatar_for_email(gravatar)
         else:
             # Attempt to use googleplus but revert to picture if it fails
             googlepluspthumb = None
             if googleplus is not None:
-                googlepluspthumb = get_googlepluspthumb_from_email(googleplus)
+                googlepluspthumb = get_googlepluspthumb_from_email(hass, googleplus)
             if googlepluspthumb is not None:
                 self.config_picture = googlepluspthumb
             else:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -765,7 +765,7 @@ def get_googlepluspthumb_from_email(email: str):
     from re import search
 
     url = r'https://picasaweb.google.com/data/entry/api/user/'
-    url += urllib.parse.quote_from_bytes(email.encode('utf-8')) + r'?alt=json'
+    url += urllib.parse.quote_from_bytes(str(email).encode('utf-8')) + r'?alt=json'
 
     print(url)
     try:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -414,7 +414,7 @@ class Device(Entity):
             googlepluspthumb = None
             if googleplus is not None:
                 googlepluspthumb = (get_googlepluspthumb_from_email(
-                                        hass,googleplus))
+                                        hass, googleplus))
             if googlepluspthumb is not None:
                 self.config_picture = googlepluspthumb
             else:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -769,6 +769,7 @@ def get_googlepluspthumb_from_email(hass: HomeAssistantType, email: str):
         email = ''
 
     debug_jsontext = {}
+    jsontext = ''
     try:
         url += urllib.parse.quote(email) + r'?alt=json'
 
@@ -776,7 +777,8 @@ def get_googlepluspthumb_from_email(hass: HomeAssistantType, email: str):
         with async_timeout.timeout(5, loop=hass.loop):
             resp = yield from websession.get(url)
             if resp.status == 200:
-                jsontext = ''.join(list(yield from resp.text()))
+                jsongenerator = yield from resp.text()
+                jsontext = str(jsongenerator)
                 debug_jsontext = yield from resp.json(encoding='utf-8')
     except (asyncio.TimeoutError, aiohttp.ClientError, TypeError):
         _LOGGER.error('http timeout or invalid email\r\n  email: '

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -408,7 +408,7 @@ class Device(Entity):
 
         # Configured picture
         if gravatar is not None:
-            self.config_picture = get_gravatar_for_email(gravatar)
+            self.config_picture = get_gravatar_for_email(hass, gravatar)
         else:
             # Attempt to use googleplus but revert to picture if it fails
             googlepluspthumb = None
@@ -748,7 +748,7 @@ def update_config(path: str, dev_id: str, device: Device):
         out.write(dump(device))
 
 
-def get_gravatar_for_email(email: str):
+def get_gravatar_for_email(hass: HomeAssistantType, email: str):
     """Return an 80px Gravatar for the given email address.
 
     Async friendly.
@@ -771,12 +771,12 @@ def get_googlepluspthumb_from_email(email: str):
     try:
         url += urllib.parse.quote(email) + r'?alt=json'
 
-        websession = async_get_clientsession(self.hass)
-        with async_timeout.timeout(5, loop=self.hass.loop):
+        websession = async_get_clientsession(hass)
+        with async_timeout.timeout(5, loop=hass.loop):
             resp = yield from websession.get(url)
             print('resp.status=' + resp.status)
             jsontext = yield from resp.text()
-            debug_jsontext=yield from resp.json()
+            debug_jsontext=yield from resp.json(encoding = 'utf-8')
     except (asyncio.TimeoutError, aiohttp.ClientError, TypeError):
         _LOGGER.error('http timeout or invalid email\r\n  email: '
                       + email + '\r\n  url: ' + url)
@@ -785,8 +785,8 @@ def get_googlepluspthumb_from_email(email: str):
     try:
         print('jsontext')
         print(jsontext)
-        print('debug_json.keys()')
-        print(debug_json.keys())
+        print('debug_jsontext.keys()')
+        print(debug_jsontext.keys())
     except(TypeError):
         pass
 

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -414,7 +414,8 @@ class Device(Entity):
             googlepluspthumb = None
             if googleplus is not None:
                 googlepluspthumb = (yield from
-                                    get_googlepluspthumb_from_email(hass, googleplus))
+                                    get_googlepluspthumb_from_email(
+                                        hass, googleplus))
             if googlepluspthumb is not None:
                 self.config_picture = googlepluspthumb
             else:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -768,7 +768,7 @@ def get_googlepluspthumb_from_email(hass: HomeAssistantType, email: str):
     if email is None or email is False or email is True:
         email = ''
 
-    debug_jsontext = {}
+    #debug_jsontext = {}
     jsontext = ''
     try:
         url += urllib.parse.quote(email) + r'?alt=json'
@@ -779,19 +779,12 @@ def get_googlepluspthumb_from_email(hass: HomeAssistantType, email: str):
             if resp.status == 200:
                 jsongenerator = yield from resp.text()
                 jsontext = str(jsongenerator)
-                debug_jsontext = yield from resp.json(encoding='utf-8')
+                #debug_jsontext = yield from resp.json(encoding='utf-8')
+                #print(debug_jsontext.keys())
     except (asyncio.TimeoutError, aiohttp.ClientError, TypeError):
         _LOGGER.error('http timeout or invalid email\r\n  email: '
                       + email + '\r\n  url: ' + url)
         return None
-
-    try:
-        print('jsontext')
-        print(jsontext)
-        print('debug_jsontext.keys()')
-        print(debug_jsontext.keys())
-    except(TypeError):
-        pass
 
     thumbnail_pattern = r'gphoto\$thumbnail\"\:\{\"\$t\"\:\"([^\"]*?)\"'
     thumbnail_url = search(thumbnail_pattern, jsontext).group(1)

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -760,26 +760,35 @@ def get_gravatar_for_email(email: str):
 
 def get_googlepluspthumb_from_email(email: str):
     """Return a thumbnail image of a user's google plus profile image."""
-    import urllib.request
     import urllib.parse
-    import urllib.error
     from re import search
 
     url = r'https://picasaweb.google.com/data/entry/api/user/'
     if email is None or email is False or email is True:
         email = ''
+
+	debug_jsontext=None
     try:
         url += urllib.parse.quote(email) + r'?alt=json'
-        jsontext = urllib.request.urlopen(url).read().decode('utf-8')
-    except TypeError:
-        _LOGGER.error('http timeout or invalid email\r\n  email: '
-                      + email + '\r\n  url: ' + url)
-        return None
-    except urllib.error.HTTPError:
-        _LOGGER.error('http timeout or invalid email\r\n  email: '
-                      + email + '\r\n  url: ' + url)
-        return None
 
+        websession = async_get_clientsession(self.hass)
+        with async_timeout.timeout(5, loop=self.hass.loop):
+            resp = yield from websession.get(url)
+        print('resp.status=' + resp.status)
+        jsontext = yield from resp.text()
+        debug_jsontext=yield from resp.json(encoding='utf-8')
+    except (asyncio.TimeoutError, aiohttp.ClientError, TypeError):
+        _LOGGER.error('http timeout or invalid email\r\n  email: '
+                      + email + '\r\n  url: ' + url)
+        return None
+	
+	try:
+		print('jsontext')
+        print(jsontext)
+        print('debug_json.keys()')
+        print(debug_json.keys())
+	except(TypeError): pass
+	
     thumbnail_pattern = r'gphoto\$thumbnail\"\:\{\"\$t\"\:\"([^\"]*?)\"'
     thumbnail_url = search(thumbnail_pattern, jsontext).group(1)
     if thumbnail_url == '':

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -414,7 +414,9 @@ class Device(Entity):
             googlepluspthumb = None
             if googleplus is not None:
                 googlepluspthumb = get_googlepluspthumb_from_email(googleplus)
-            if googlepluspthumb is None:
+            if googlepluspthumb is not None:
+                self.config_picture = googlepluspthumb
+            else:
                 self.config_picture = picture
 
         self.icon = icon

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -413,9 +413,8 @@ class Device(Entity):
             # Attempt to use googleplus but revert to picture if it fails
             googlepluspthumb = None
             if googleplus is not None:
-                googlepluspthumb = (yield from
-                                    get_googlepluspthumb_from_email(
-                                        hass, googleplus))
+                googlepluspthumb = (get_googlepluspthumb_from_email(
+                                        hass,googleplus))
             if googlepluspthumb is not None:
                 self.config_picture = googlepluspthumb
             else:
@@ -777,7 +776,7 @@ def get_googlepluspthumb_from_email(hass: HomeAssistantType, email: str):
         with async_timeout.timeout(5, loop=hass.loop):
             resp = yield from websession.get(url)
             if resp.status == 200:
-                jsontext = yield from resp.text()
+                jsontext = ''.join(list(yield from resp.text()))
                 debug_jsontext = yield from resp.json(encoding='utf-8')
     except (asyncio.TimeoutError, aiohttp.ClientError, TypeError):
         _LOGGER.error('http timeout or invalid email\r\n  email: '

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -764,11 +764,8 @@ def get_googlepluspthumb_from_email(email: str):
     import urllib.parse
     from re import search
 
-    string_email = ''
-    if email is not None:
-        string_email = email
     url = r'https://picasaweb.google.com/data/entry/api/user/'
-    url += urllib.parse.quote(string_email) + r'?alt=json'
+    url += urllib.parse.quote_from_bytes(email.encode('utf-8')) + r'?alt=json'
 
     print(url)
     try:

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -236,7 +236,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         self.assertEqual(device.config_picture, 'http://test.picture')
 
     def test_gravatar_googleplus_and_picture(self):
-        """Test the that googleplus overrides picture and gravatar"""
+        """Test the that googleplus overrides picture and gravatar."""
         dev_id = 'test'
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id,

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -203,7 +203,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         googleplus_url_pattern = (r'https?\:\/\/[^\.\"]*?'
                                   r'\.googleusercontent\.com\/[^\.\"]*?\.jpg')
         self.assertIsNotNone(match(googleplus_url_pattern,
-                                      device.config_picture))
+                                   device.config_picture))
 
         """Test that googleplus returns empty
         when a non-google or invalid account is used.
@@ -225,7 +225,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         googleplus_url_pattern = (r'https?\:\/\/[^\.\"]*?'
                                   r'\.googleusercontent\.com\/[^\.\"]*?\.jpg')
         self.assertIsNotNone(match(googleplus_url_pattern,
-                                      device.config_picture))
+                                   device.config_picture))
 
         """Test the that picture overrides googleplus when a
         non-google or invalid account is used."""

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -201,9 +201,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             self.hass, timedelta(seconds=180), True, dev_id,
             'AB:CD:EF:GH:IJ', 'Test name', googleplus='john@gmail.com')
         googleplus_url_pattern = (r'https?\:\/\/[^\.\"]*?'
-                                  r'googleusercontent\.com\/[^\.\"]*?jpg')
-        self.assertNotEqual(re.search(googleplus_url_pattern,
-                                      device.config_picture), None)
+                                  r'\.googleusercontent\.com\/[^\.\"]*?\.jpg')
+        self.assertIsNotNone(re.match(googleplus_url_pattern,
+                                      device.config_picture))
 
         """Test that googleplus returns empty
         when a non-google or invalid account is used.
@@ -211,7 +211,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id,
             'AB:CD:EF:GH:IJ', 'Test name', googleplus='test@example.com')
-        self.assertEqual(device.config_picture, None)
+        self.assertIsNone(device.config_picture)
 
     def test_googleplus_and_picture(self):
         """Test the that GooglePlus overrides picture."""
@@ -223,9 +223,9 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
             googleplus='john@gmail.com')
         googleplus_url_pattern = (r'https?\:\/\/[^\.\"]*?'
-                                  r'googleusercontent\.com\/[^\.\"]*?jpg')
-        self.assertNotEqual(re.search(googleplus_url_pattern,
-                                      device.config_picture), None)
+                                  r'\.googleusercontent\.com\/[^\.\"]*?\.jpg')
+        self.assertIsNotNone(re.match(googleplus_url_pattern,
+                                      device.config_picture))
 
         """Test the that picture overrides googleplus when a
         non-google or invalid account is used."""

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -195,14 +195,14 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
     def test_googleplus(self):
         """Test the googleplus thumbnail generation."""
-        import re
+        from re import match
         dev_id = 'test'
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id,
             'AB:CD:EF:GH:IJ', 'Test name', googleplus='john@gmail.com')
         googleplus_url_pattern = (r'https?\:\/\/[^\.\"]*?'
                                   r'\.googleusercontent\.com\/[^\.\"]*?\.jpg')
-        self.assertIsNotNone(re.match(googleplus_url_pattern,
+        self.assertIsNotNone(match(googleplus_url_pattern,
                                       device.config_picture))
 
         """Test that googleplus returns empty
@@ -215,7 +215,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
     def test_googleplus_and_picture(self):
         """Test the that GooglePlus overrides picture."""
-        import re
+        from re import match
 
         dev_id = 'test'
         device = device_tracker.Device(
@@ -224,7 +224,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             googleplus='john@gmail.com')
         googleplus_url_pattern = (r'https?\:\/\/[^\.\"]*?'
                                   r'\.googleusercontent\.com\/[^\.\"]*?\.jpg')
-        self.assertIsNotNone(re.match(googleplus_url_pattern,
+        self.assertIsNotNone(match(googleplus_url_pattern,
                                       device.config_picture))
 
         """Test the that picture overrides googleplus when a

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -193,6 +193,67 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                         "55502f40dc8b7c769880b10874abc9d0.jpg?s=80&d=wavatar")
         self.assertEqual(device.config_picture, gravatar_url)
 
+    def test_googleplus(self):
+        """Test the googleplus thumbnail generation."""
+        import re
+        dev_id = 'test'
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', googleplus='john@gmail.com')
+        googleplus_url_pattern = (r'https?\:\/\/[^\.\"]*?'
+                                  r'googleusercontent\.com\/[^\.\"]*?jpg')
+        self.assertNotEqual(re.search(googleplus_url_pattern,
+                                      device.config_picture), None)
+
+        """Test that googleplus returns empty
+        when a non-google or invalid account is used.
+        """
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', googleplus='test@example.com')
+        self.assertEqual(device.config_picture, None)
+
+    def test_googleplus_and_picture(self):
+        """Test the that GooglePlus overrides picture."""
+        dev_id = 'test'
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
+            googleplus='john@gmail.com')
+        googleplus_url_pattern = (r'https?\:\/\/[^\.\"]*?'
+                                  r'googleusercontent\.com\/[^\.\"]*?jpg')
+        self.assertNotEqual(re.search(googleplus_url_pattern,
+                                      device.config_picture), None)
+
+        """Test the that picture overrides googleplus when a 
+        non-google or invalid account is used."""
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
+            googleplus='test@example.com')
+        self.assertEqual(device.config_picture, 'http://test.picture')
+
+    def test_gravatar_googleplus_and_picture(self):
+        """Test the that googleplus overrides picture and gravatar"""
+        dev_id = 'test'
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
+            gravatar='test@example.com',
+            googleplus='john@gmail.com')
+        gravatar_url = ("https://www.gravatar.com/avatar/"
+                        "55502f40dc8b7c769880b10874abc9d0.jpg?s=80&d=wavatar")
+        self.assertEqual(device.config_picture, gravatar_url)
+
+        """Test the that gravatar overrides googleplus even when a 
+        non-google or invalid account is used."""
+        device = device_tracker.Device(
+            self.hass, timedelta(seconds=180), True, dev_id,
+            'AB:CD:EF:GH:IJ', 'Test name', picture='http://test.picture',
+            gravatar='test@example.com',
+            googleplus='test@example.com')
+        self.assertEqual(device.config_picture, gravatar_url)
+
     def test_mac_vendor_lookup(self):
         """Test if vendor string is lookup on macvendors API."""
         mac = 'B8:27:EB:00:00:00'

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -215,6 +215,8 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
     def test_googleplus_and_picture(self):
         """Test the that GooglePlus overrides picture."""
+        import re
+
         dev_id = 'test'
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id,
@@ -225,7 +227,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         self.assertNotEqual(re.search(googleplus_url_pattern,
                                       device.config_picture), None)
 
-        """Test the that picture overrides googleplus when a 
+        """Test the that picture overrides googleplus when a
         non-google or invalid account is used."""
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id,
@@ -245,7 +247,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                         "55502f40dc8b7c769880b10874abc9d0.jpg?s=80&d=wavatar")
         self.assertEqual(device.config_picture, gravatar_url)
 
-        """Test the that gravatar overrides googleplus even when a 
+        """Test the that gravatar overrides googleplus even when a
         non-google or invalid account is used."""
         device = device_tracker.Device(
             self.hass, timedelta(seconds=180), True, dev_id,


### PR DESCRIPTION
## Description:
Adding support for getting a googleplus thumbnail image from their email. This is very similar to the existing gravitar support but can fail if a non-google account or invalid email is used. it currently prioritizes gravitar over googleplus over picture

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#3999

## Example entry for `configuration.yaml` (if applicable):
```yaml
robbiesiphone:
  name: robbiesiphone
  googleplus: robbie@gmail.com
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
