### PR TITLE
Added sorted() to python_script

### DIFF
--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -140,6 +140,7 @@ def execute(hass, filename, source, data=None):
     builtins = safe_builtins.copy()
     builtins.update(utility_builtins)
     builtins['datetime'] = datetime
+    builtins['sorted'] = sorted
     builtins['time'] = TimeWrapper()
     builtins['dt_util'] = dt_util
     restricted_globals = {

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -208,6 +208,19 @@ hass.states.set('hello.ab_list', '{}'.format(ab_list))
     # No errors logged = good
     assert caplog.text == ''
 
+@asyncio.coroutine
+def test_execute_sorted(hass, caplog):
+    """Test sorted() function."""
+    caplog.set_level(logging.ERROR)
+    source = """
+a  = sorted([3,1,2])
+assert(a == [1,2,3])
+"""
+    hass.async_add_job(execute, hass, 'test.py', source, {})
+    yield from hass.async_block_till_done()
+
+    # No errors logged = good
+    assert caplog.text == ''
 
 @asyncio.coroutine
 def test_exposed_modules(hass, caplog):

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -208,6 +208,7 @@ hass.states.set('hello.ab_list', '{}'.format(ab_list))
     # No errors logged = good
     assert caplog.text == ''
 
+
 @asyncio.coroutine
 def test_execute_sorted(hass, caplog):
     """Test sorted() function."""
@@ -215,12 +216,19 @@ def test_execute_sorted(hass, caplog):
     source = """
 a  = sorted([3,1,2])
 assert(a == [1,2,3])
+hass.states.set('hello.a', a[0])
+hass.states.set('hello.b', a[1])
+hass.states.set('hello.c', a[2])
 """
     hass.async_add_job(execute, hass, 'test.py', source, {})
     yield from hass.async_block_till_done()
 
+    assert hass.states.is_state('hello.a', '1')
+    assert hass.states.is_state('hello.b', '2')
+    assert hass.states.is_state('hello.c', '3')
     # No errors logged = good
     assert caplog.text == ''
+
 
 @asyncio.coroutine
 def test_exposed_modules(hass, caplog):


### PR DESCRIPTION
## Description:

This PR adds functionality to sort iterables inside `python_script`

**Related issue (if applicable):** fixes #10002

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
