### PR TITLE
Add hddtemp sensor device even if unreachable.

### DIFF
--- a/homeassistant/components/sensor/hddtemp.py
+++ b/homeassistant/components/sensor/hddtemp.py
@@ -67,6 +67,7 @@ class HddTempSensor(Entity):
         self._name = '{} {}'.format(name, disk)
         self._state = None
         self._details = None
+        self._unit = None
 
     @property
     def name(self):
@@ -81,9 +82,7 @@ class HddTempSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
-        if self._details is not None and self._details[3] == 'F':
-            return TEMP_FAHRENHEIT
-        return TEMP_CELSIUS
+        return self._unit
 
     @property
     def device_state_attributes(self):
@@ -101,6 +100,10 @@ class HddTempSensor(Entity):
         if self.hddtemp.data and self.disk in self.hddtemp.data:
             self._details = self.hddtemp.data[self.disk].split('|')
             self._state = self._details[2]
+            if self._details is not None and self._details[3] == 'F':
+                self._unit = TEMP_FAHRENHEIT
+            else:
+                self._unit = TEMP_CELSIUS
         else:
             self._state = None
 

--- a/homeassistant/components/sensor/hddtemp.py
+++ b/homeassistant/components/sensor/hddtemp.py
@@ -93,11 +93,6 @@ class HddTempSensor(Entity):
                 ATTR_DEVICE: self._details[0],
                 ATTR_MODEL: self._details[1],
                 }
-        # else:
-        #     return {
-        #         ATTR_DEVICE: '-',
-        #         ATTR_MODEL: '-',
-        #         }
 
     def update(self):
         """Get the latest data from HDDTemp daemon and updates the state."""

--- a/homeassistant/components/sensor/hddtemp.py
+++ b/homeassistant/components/sensor/hddtemp.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/sensor.hddtemp/
 import logging
 from datetime import timedelta
 from telnetlib import Telnet
+import socket
 
 import voluptuous as vol
 
@@ -46,16 +47,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     hddtemp = HddTempData(host, port)
     hddtemp.update()
 
-    if hddtemp.data is None:
-        return False
-
     if not disks:
         disks = [next(iter(hddtemp.data)).split('|')[0]]
 
     dev = []
     for disk in disks:
-        if disk in hddtemp.data:
-            dev.append(HddTempSensor(name, disk, hddtemp))
+        dev.append(HddTempSensor(name, disk, hddtemp))
 
     add_devices(dev, True)
 
@@ -84,17 +81,23 @@ class HddTempSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
-        if self._details[3] == 'C':
-            return TEMP_CELSIUS
-        return TEMP_FAHRENHEIT
+        if self._details is not None and self._details[3] == 'F':
+            return TEMP_FAHRENHEIT
+        return TEMP_CELSIUS
 
     @property
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
-        return {
-            ATTR_DEVICE: self._details[0],
-            ATTR_MODEL: self._details[1],
-        }
+        if self._details is not None:
+            return {
+                ATTR_DEVICE: self._details[0],
+                ATTR_MODEL: self._details[1],
+                }
+        # else:
+        #     return {
+        #         ATTR_DEVICE: '-',
+        #         ATTR_MODEL: '-',
+        #         }
 
     def update(self):
         """Get the latest data from HDDTemp daemon and updates the state."""
@@ -126,6 +129,9 @@ class HddTempData(object):
             self.data = {data[i].split('|')[0]: data[i]
                          for i in range(0, len(data), 1)}
         except ConnectionRefusedError:
-            _LOGGER.error(
-                "HDDTemp is not available at %s:%s", self.host, self.port)
+            _LOGGER.error("HDDTemp is not available at %s:%s",
+                          self.host, self.port)
+            self.data = None
+        except socket.gaierror:
+            _LOGGER.error("HDDTemp host not found %s:%s", self.host, self.port)
             self.data = None


### PR DESCRIPTION
## Description:
Add hddtemp device sensors even if the host is currently unreachable. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
