### PR TITLE
Snapcast: bump version and enable reconnect.

### DIFF
--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['snapcast==2.0.7']
+REQUIREMENTS = ['snapcast==2.0.8']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     try:
         server = yield from snapcast.control.create_server(
-            hass.loop, host, port)
+            hass.loop, host, port, reconnect=True)
     except socket.gaierror:
         _LOGGER.error('Could not connect to Snapcast server at %s:%d',
                       host, port)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1022,7 +1022,7 @@ sleepyq==0.6
 # smbus-cffi==0.5.1
 
 # homeassistant.components.media_player.snapcast
-snapcast==2.0.7
+snapcast==2.0.8
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.4.1


### PR DESCRIPTION
## Description:

This bumps the used snapcast version to 2.0.8 and enables the new
reconnect feature that causes the component to reconnect to a server if
the connection was lost.

This fixes the need to restart Home Assistant after a snapcast reboot, as
described in issue #10264.

**Related issue (if applicable):** fixes #10264 


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
