### PR TITLE
Fix async missing decorators

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, DEVICE_DEFAULT_NAME, STATE_OFF, STATE_ON,
     STATE_UNAVAILABLE, STATE_UNKNOWN, TEMP_CELSIUS, TEMP_FAHRENHEIT,
     ATTR_ENTITY_PICTURE, ATTR_SUPPORTED_FEATURES, ATTR_DEVICE_CLASS)
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.config import DATA_CUSTOMIZE
 from homeassistant.exceptions import NoEntitySpecifiedError
 from homeassistant.util import ensure_unique_string, slugify
@@ -41,6 +41,7 @@ def generate_entity_id(entity_id_format: str, name: Optional[str],
         entity_id_format.format(slugify(name)), current_ids)
 
 
+@callback
 def async_generate_entity_id(entity_id_format: str, name: Optional[str],
                              current_ids: Optional[List[str]]=None,
                              hass: Optional[HomeAssistant]=None) -> str:
@@ -271,10 +272,12 @@ class Entity(object):
         """
         self.hass.add_job(self.async_update_ha_state(force_refresh))
 
+    @callback
     def async_schedule_update_ha_state(self, force_refresh=False):
         """Schedule a update ha state change task."""
         self.hass.async_add_job(self.async_update_ha_state(force_refresh))
 
+    @asyncio.coroutine
     def async_device_update(self, warning=True):
         """Process 'update' or 'async_update' from entity.
 

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -97,6 +97,7 @@ class EntityComponent(object):
             expand_group
         ).result()
 
+    @callback
     def async_extract_from_service(self, service, expand_group=True):
         """Extract all known and available entities from a service call.
 


### PR DESCRIPTION
## Description:
This issue came up in chat a few days ago. The callbacks are just our own convention, but the missing coroutine means that `async_device_update` is really just a generator. It works with our current codebase, but when it's called from a Python 3.5 async function it causes an error.