### PR TITLE
Alexa improvements

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -5,8 +5,9 @@ import math
 from uuid import uuid4
 
 from homeassistant.const import (
-    ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF)
-from homeassistant.components import fan, light, scene, script, switch
+    ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID, SERVICE_TURN_ON,
+    SERVICE_TURN_OFF, SERVICE_LOCK, SERVICE_UNLOCK)
+from homeassistant.components import fan, light, lock, scene, script, switch
 import homeassistant.util.color as color_util
 from homeassistant.util.decorator import Registry
 
@@ -34,6 +35,7 @@ MAPPING_COMPONENT = {
             light.SUPPORT_COLOR_TEMP: 'Alexa.ColorTemperatureController',
         }
     ],
+    lock.DOMAIN: ['SMARTLOCK', ('Alexa.LockController',), None],
     scene.DOMAIN: ['SCENE', ('Alexa.SceneController',), None],
     script.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
     switch.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
@@ -399,3 +401,27 @@ def async_api_adjust_percentage(hass, request, entity):
 
     return api_message(request)
 
+
+@HANDLERS.register(('Alexa.LockController', 'Lock'))
+@extract_entity
+@asyncio.coroutine
+def async_api_lock(hass, request, entity):
+    """Process a lock request."""
+    yield from hass.services.async_call(entity.domain, SERVICE_LOCK, {
+        ATTR_ENTITY_ID: entity.entity_id
+    }, blocking=True)
+
+    return api_message(request)
+
+
+# Not supported by Alexa yet
+@HANDLERS.register(('Alexa.LockController', 'Unlock'))
+@extract_entity
+@asyncio.coroutine
+def async_api_unlock(hass, request, entity):
+    """Process a unlock request."""
+    yield from hass.services.async_call(entity.domain, SERVICE_UNLOCK, {
+        ATTR_ENTITY_ID: entity.entity_id
+    }, blocking=True)
+
+    return api_message(request)

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -36,7 +36,7 @@ MAPPING_COMPONENT = {
         }
     ],
     lock.DOMAIN: ['SMARTLOCK', ('Alexa.LockController',), None],
-    scene.DOMAIN: ['SCENE', ('Alexa.SceneController',), None],
+    scene.DOMAIN: ['ACTIVITY_TRIGGER', ('Alexa.SceneController',), None],
     script.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
     switch.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
 }
@@ -326,18 +326,6 @@ def async_api_increase_color_temp(hass, request, entity):
 def async_api_activate(hass, request, entity):
     """Process a activate request."""
     yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
-        ATTR_ENTITY_ID: entity.entity_id
-    }, blocking=True)
-
-    return api_message(request)
-
-
-@HANDLERS.register(('Alexa.SceneController', 'Deactivate'))
-@extract_entity
-@asyncio.coroutine
-def async_api_deactivate(hass, request, entity):
-    """Process a deactivate request."""
-    yield from hass.services.async_call(entity.domain, SERVICE_TURN_OFF, {
         ATTR_ENTITY_ID: entity.entity_id
     }, blocking=True)
 

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF)
-from homeassistant.components import switch, light, script, scene, fan
+from homeassistant.components import fan, light, scene, script, switch
 import homeassistant.util.color as color_util
 from homeassistant.util.decorator import Registry
 
@@ -21,14 +21,11 @@ API_ENDPOINT = 'endpoint'
 
 
 MAPPING_COMPONENT = {
-    scene.DOMAIN: ['SCENE', ('Alexa.SceneController',), None],
-    script.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
     fan.DOMAIN: [
         'SWITCH', ('Alexa.PowerController',), {
             fan.SUPPORT_SET_SPEED: 'Alexa.PercentageController',
         }
     ],
-    switch.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
     light.DOMAIN: [
         'LIGHT', ('Alexa.PowerController',), {
             light.SUPPORT_BRIGHTNESS: 'Alexa.BrightnessController',
@@ -37,6 +34,9 @@ MAPPING_COMPONENT = {
             light.SUPPORT_COLOR_TEMP: 'Alexa.ColorTemperatureController',
         }
     ],
+    scene.DOMAIN: ['SCENE', ('Alexa.SceneController',), None],
+    script.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
+    switch.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
 }
 
 
@@ -398,3 +398,4 @@ def async_api_adjust_percentage(hass, request, entity):
     }, blocking=True)
 
     return api_message(request)
+

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -10,7 +10,8 @@ from homeassistant.const import (
     SERVICE_MEDIA_STOP, SERVICE_MEDIA_PAUSE, SERVICE_MEDIA_PLAY,
     SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK)
 from homeassistant.components import (
-    fan, input_boolean, light, lock, media_player, scene, script, switch)
+    alert, automation, fan, group, input_boolean, light, lock,
+    media_player, scene, script, switch)
 import homeassistant.util.color as color_util
 from homeassistant.util.decorator import Registry
 
@@ -31,11 +32,14 @@ ATTR_ALEXA_SCENE_CATEGORY = 'alexa_scene_category'
 
 
 MAPPING_COMPONENT = {
+    alert.DOMAIN: ['OTHER', ('Alexa.PowerController',), None],
+    automation.DOMAIN: ['OTHER', ('Alexa.PowerController',), None],
     fan.DOMAIN: [
         'SWITCH', ('Alexa.PowerController',), {
             fan.SUPPORT_SET_SPEED: 'Alexa.PercentageController',
         }
     ],
+    group.DOMAIN: ['OTHER', ('Alexa.PowerController',), None],
     input_boolean.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
     light.DOMAIN: [
         'LIGHT', ('Alexa.PowerController',), {

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -27,8 +27,7 @@ API_ENDPOINT = 'endpoint'
 ATTR_ALEXA_HIDDEN = 'alexa_hidden'
 ATTR_ALEXA_NAME = 'alexa_name'
 ATTR_ALEXA_DESCRIPTION = 'alexa_description'
-ATTR_ALEXA_MEDIA_CATEGORY = 'alexa_media_category'
-ATTR_ALEXA_SCENE_CATEGORY = 'alexa_scene_category'
+ATTR_ALEXA_DISPLAY_CATEGORIES = 'alexa_display_categories'
 
 
 MAPPING_COMPONENT = {
@@ -157,16 +156,8 @@ def async_api_discovery(hass, request):
             scene_fmt = '%s (Scene connected via Home Assistant)'
             description = scene_fmt.format(description)
 
-        display_categories = class_data[0]
-
-        if entity.domain == media_player.DOMAIN:
-            cat_key = ATTR_ALEXA_MEDIA_CATEGORY
-            display_categories = entity.attributes.get(cat_key, 'TV')
-
-        if entity.domain == scene.DOMAIN:
-            cat_key = ATTR_ALEXA_SCENE_CATEGORY
-            display_categories = entity.attributes.get(cat_key,
-                                                       'ACTIVITY_TRIGGER')
+        cat_key = ATTR_ALEXA_DISPLAY_CATEGORIES
+        display_categories = entity.attributes.get(cat_key, class_data[0])
 
         endpoint = {
             'displayCategories': [display_categories],

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -451,7 +451,7 @@ def async_api_unlock(hass, request, entity):
 @asyncio.coroutine
 def async_api_set_volume(hass, request, entity):
     """Process a set volume request."""
-    volume = float(request[API_PAYLOAD]['volume'] * 100)
+    volume = round(float(request[API_PAYLOAD]['volume'] / 100), 2)
 
     data = {
         ATTR_ENTITY_ID: entity.entity_id,
@@ -469,17 +469,19 @@ def async_api_set_volume(hass, request, entity):
 @asyncio.coroutine
 def async_api_adjust_volume(hass, request, entity):
     """Process a adjust volume request."""
-    volume_delta = float(request[API_PAYLOAD]['volume'])
+    volume_delta = int(request[API_PAYLOAD]['volume'])
 
     current_level = entity.attributes.get(media_player.ATTR_MEDIA_VOLUME_LEVEL)
 
+    multiply = int(current_level * 100)
+
     # read current state
     try:
-        current = math.floor(float(current_level) * 100)
+        current = math.floor(int(current_level * 100))
     except ZeroDivisionError:
         current = 0
 
-    volume = max(0, volume_delta + current)
+    volume = float(max(0, volume_delta + current) / 100)
 
     data = {
         ATTR_ENTITY_ID: entity.entity_id,

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -21,6 +21,10 @@ API_HEADER = 'header'
 API_PAYLOAD = 'payload'
 API_ENDPOINT = 'endpoint'
 
+ATTR_ALEXA_HIDDEN = 'alexa_hidden'
+ATTR_ALEXA_NAME = 'alexa_name'
+ATTR_ALEXA_DESCRIPTION = 'alexa_description'
+
 
 MAPPING_COMPONENT = {
     fan.DOMAIN: [
@@ -118,17 +122,24 @@ def async_api_discovery(hass, request):
     discovery_endpoints = []
 
     for entity in hass.states.async_all():
+        if entity.attributes.get(ATTR_ALEXA_HIDDEN, False):
+            continue
+
         class_data = MAPPING_COMPONENT.get(entity.domain)
 
         if not class_data:
             continue
 
+        friendly_name = entity.attributes.get(ATTR_ALEXA_NAME, entity.name)
+        description = entity.attributes.get(ATTR_ALEXA_DESCRIPTION,
+                                            entity.entity_id)
+
         endpoint = {
             'displayCategories': [class_data[0]],
             'additionalApplianceDetails': {},
             'endpointId': entity.entity_id.replace('.', '#'),
-            'friendlyName': entity.name,
-            'description': '',
+            'friendlyName': friendly_name,
+            'description': description,
             'manufacturerName': 'Unknown',
         }
         actions = set()

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -6,7 +6,9 @@ from uuid import uuid4
 
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID, SERVICE_TURN_ON,
-    SERVICE_TURN_OFF, SERVICE_LOCK, SERVICE_UNLOCK, SERVICE_VOLUME_SET)
+    SERVICE_TURN_OFF, SERVICE_LOCK, SERVICE_UNLOCK, SERVICE_VOLUME_SET,
+    SERVICE_MEDIA_STOP, SERVICE_MEDIA_PAUSE, SERVICE_MEDIA_PLAY,
+    SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK)
 from homeassistant.components import (
     fan, input_boolean, light, lock, media_player, scene, script, switch)
 import homeassistant.util.color as color_util
@@ -46,6 +48,11 @@ MAPPING_COMPONENT = {
     media_player.DOMAIN: [
         'TV', ('Alexa.PowerController',), {
             media_player.SUPPORT_VOLUME_SET: 'Alexa.Speaker',
+            media_player.SUPPORT_PLAY: 'Alexa.PlaybackController',
+            media_player.SUPPORT_PAUSE: 'Alexa.PlaybackController',
+            media_player.SUPPORT_STOP: 'Alexa.PlaybackController',
+            media_player.SUPPORT_NEXT_TRACK: 'Alexa.PlaybackController',
+            media_player.SUPPORT_PREVIOUS_TRACK: 'Alexa.PlaybackController',
         }
     ],
     scene.DOMAIN: ['ACTIVITY_TRIGGER', ('Alexa.SceneController',), None],
@@ -501,6 +508,53 @@ def async_api_set_mute(hass, request, entity):
 
     yield from hass.services.async_call(entity.domain,
                                         media_player.SERVICE_VOLUME_MUTE,
+                                        data, blocking=True)
+
+    return api_message(request)
+
+@HANDLERS.register(('Alexa.PlaybackController', 'Play'))
+@extract_entity
+@asyncio.coroutine
+def async_api_play(hass, request, entity):
+    """Process a play request."""
+    data = {
+        ATTR_ENTITY_ID: entity.entity_id
+    }
+
+    yield from hass.services.async_call(entity.domain,
+                                        media_player.SERVICE_PLAY_MEDIA,
+                                        data, blocking=True)
+
+    return api_message(request)
+
+
+@HANDLERS.register(('Alexa.PlaybackController', 'Pause'))
+@extract_entity
+@asyncio.coroutine
+def async_api_pause(hass, request, entity):
+    """Process a pause request."""
+    data = {
+        ATTR_ENTITY_ID: entity.entity_id
+    }
+
+    yield from hass.services.async_call(entity.domain,
+                                        media_player.SERVICE_PAUSE_MEDIA,
+                                        data, blocking=True)
+
+    return api_message(request)
+
+
+@HANDLERS.register(('Alexa.PlaybackController', 'Stop'))
+@extract_entity
+@asyncio.coroutine
+def async_api_stop(hass, request, entity):
+    """Process a stop request."""
+    data = {
+        ATTR_ENTITY_ID: entity.entity_id
+    }
+
+    yield from hass.services.async_call(entity.domain,
+                                        media_player.SERVICE_STOP,
                                         data, blocking=True)
 
     return api_message(request)

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -473,8 +473,6 @@ def async_api_adjust_volume(hass, request, entity):
 
     current_level = entity.attributes.get(media_player.ATTR_MEDIA_VOLUME_LEVEL)
 
-    multiply = int(current_level * 100)
-
     # read current state
     try:
         current = math.floor(int(current_level * 100))

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -27,6 +27,7 @@ ATTR_ALEXA_HIDDEN = 'alexa_hidden'
 ATTR_ALEXA_NAME = 'alexa_name'
 ATTR_ALEXA_DESCRIPTION = 'alexa_description'
 ATTR_ALEXA_MEDIA_CATEGORY = 'alexa_media_category'
+ATTR_ALEXA_SCENE_CATEGORY = 'alexa_scene_category'
 
 
 MAPPING_COMPONENT = {
@@ -153,9 +154,15 @@ def async_api_discovery(hass, request):
             description = scene_fmt.format(description)
 
         display_categories = class_data[0]
+
         if entity.domain == media_player.DOMAIN:
             cat_key = ATTR_ALEXA_MEDIA_CATEGORY
             display_categories = entity.attributes.get(cat_key, 'TV')
+
+        if entity.domain == scene.DOMAIN:
+            cat_key = ATTR_ALEXA_SCENE_CATEGORY
+            display_categories = entity.attributes.get(cat_key,
+                                                       'ACTIVITY_TRIGGER')
 
         endpoint = {
             'displayCategories': [display_categories],

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -147,6 +147,11 @@ def async_api_discovery(hass, request):
         description = entity.attributes.get(ATTR_ALEXA_DESCRIPTION,
                                             entity.entity_id)
 
+        # Required description as per Amazon Scene docs
+        if entity.domain == scene.DOMAIN:
+            scene_fmt = '%s (Scene connected via Home Assistant)'
+            description = scene_fmt.format(description)
+
         display_categories = class_data[0]
         if entity.domain == media_player.DOMAIN:
             cat_key = ATTR_ALEXA_MEDIA_CATEGORY

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -458,8 +458,7 @@ def async_api_set_volume(hass, request, entity):
         media_player.ATTR_MEDIA_VOLUME_LEVEL: volume,
     }
 
-    yield from hass.services.async_call(entity.domain,
-                                        media_player.SERVICE_VOLUME_SET,
+    yield from hass.services.async_call(entity.domain, SERVICE_VOLUME_SET,
                                         data, blocking=True)
 
     return api_message(request)
@@ -512,6 +511,7 @@ def async_api_set_mute(hass, request, entity):
 
     return api_message(request)
 
+
 @HANDLERS.register(('Alexa.PlaybackController', 'Play'))
 @extract_entity
 @asyncio.coroutine
@@ -521,8 +521,7 @@ def async_api_play(hass, request, entity):
         ATTR_ENTITY_ID: entity.entity_id
     }
 
-    yield from hass.services.async_call(entity.domain,
-                                        media_player.SERVICE_PLAY_MEDIA,
+    yield from hass.services.async_call(entity.domain, SERVICE_MEDIA_PLAY,
                                         data, blocking=True)
 
     return api_message(request)
@@ -537,8 +536,7 @@ def async_api_pause(hass, request, entity):
         ATTR_ENTITY_ID: entity.entity_id
     }
 
-    yield from hass.services.async_call(entity.domain,
-                                        media_player.SERVICE_PAUSE_MEDIA,
+    yield from hass.services.async_call(entity.domain, SERVICE_MEDIA_PAUSE,
                                         data, blocking=True)
 
     return api_message(request)
@@ -553,8 +551,39 @@ def async_api_stop(hass, request, entity):
         ATTR_ENTITY_ID: entity.entity_id
     }
 
+    yield from hass.services.async_call(entity.domain, SERVICE_MEDIA_STOP,
+                                        data, blocking=True)
+
+    return api_message(request)
+
+
+@HANDLERS.register(('Alexa.PlaybackController', 'Next'))
+@extract_entity
+@asyncio.coroutine
+def async_api_next(hass, request, entity):
+    """Process a next request."""
+    data = {
+        ATTR_ENTITY_ID: entity.entity_id
+    }
+
     yield from hass.services.async_call(entity.domain,
-                                        media_player.SERVICE_STOP,
+                                        SERVICE_MEDIA_NEXT_TRACK,
+                                        data, blocking=True)
+
+    return api_message(request)
+
+
+@HANDLERS.register(('Alexa.PlaybackController', 'Previous'))
+@extract_entity
+@asyncio.coroutine
+def async_api_previous(hass, request, entity):
+    """Process a previous request."""
+    data = {
+        ATTR_ENTITY_ID: entity.entity_id
+    }
+
+    yield from hass.services.async_call(entity.domain,
+                                        SERVICE_MEDIA_PREVIOUS_TRACK,
                                         data, blocking=True)
 
     return api_message(request)

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -35,12 +35,12 @@ MAPPING_COMPONENT = {
     alert.DOMAIN: ['OTHER', ('Alexa.PowerController',), None],
     automation.DOMAIN: ['OTHER', ('Alexa.PowerController',), None],
     fan.DOMAIN: [
-        'SWITCH', ('Alexa.PowerController',), {
+        'OTHER', ('Alexa.PowerController',), {
             fan.SUPPORT_SET_SPEED: 'Alexa.PercentageController',
         }
     ],
     group.DOMAIN: ['OTHER', ('Alexa.PowerController',), None],
-    input_boolean.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
+    input_boolean.DOMAIN: ['OTHER', ('Alexa.PowerController',), None],
     light.DOMAIN: [
         'LIGHT', ('Alexa.PowerController',), {
             light.SUPPORT_BRIGHTNESS: 'Alexa.BrightnessController',
@@ -61,7 +61,7 @@ MAPPING_COMPONENT = {
         }
     ],
     scene.DOMAIN: ['ACTIVITY_TRIGGER', ('Alexa.SceneController',), None],
-    script.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
+    script.DOMAIN: ['OTHER', ('Alexa.PowerController',), None],
     switch.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
 }
 

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF)
-from homeassistant.components import switch, light, script
+from homeassistant.components import switch, light, script, scene
 import homeassistant.util.color as color_util
 from homeassistant.util.decorator import Registry
 
@@ -21,6 +21,7 @@ API_ENDPOINT = 'endpoint'
 
 
 MAPPING_COMPONENT = {
+    scene.DOMAIN: ['SCENE', ('Alexa.SceneController',), None],
     script.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
     switch.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
     light.DOMAIN: [
@@ -307,6 +308,30 @@ def async_api_increase_color_temp(hass, request, entity):
     yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
         ATTR_ENTITY_ID: entity.entity_id,
         light.ATTR_COLOR_TEMP: value,
+    }, blocking=True)
+
+    return api_message(request)
+
+
+@HANDLERS.register(('Alexa.SceneController', 'Activate'))
+@extract_entity
+@asyncio.coroutine
+def async_api_activate(hass, request, entity):
+    """Process a activate request."""
+    yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
+        ATTR_ENTITY_ID: entity.entity_id
+    }, blocking=True)
+
+    return api_message(request)
+
+
+@HANDLERS.register(('Alexa.SceneController', 'Deactivate'))
+@extract_entity
+@asyncio.coroutine
+def async_api_deactivate(hass, request, entity):
+    """Process a deactivate request."""
+    yield from hass.services.async_call(entity.domain, SERVICE_TURN_OFF, {
+        ATTR_ENTITY_ID: entity.entity_id
     }, blocking=True)
 
     return api_message(request)

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -158,7 +158,7 @@ def async_api_discovery(hass, request):
             'endpointId': entity.entity_id.replace('.', '#'),
             'friendlyName': friendly_name,
             'description': description,
-            'manufacturerName': 'Unknown',
+            'manufacturerName': 'Home Assistant',
         }
         actions = set()
 

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -7,7 +7,8 @@ from uuid import uuid4
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID, SERVICE_TURN_ON,
     SERVICE_TURN_OFF, SERVICE_LOCK, SERVICE_UNLOCK)
-from homeassistant.components import fan, light, lock, scene, script, switch
+from homeassistant.components import (
+    fan, input_boolean, light, lock, scene, script, switch)
 import homeassistant.util.color as color_util
 from homeassistant.util.decorator import Registry
 
@@ -27,6 +28,7 @@ MAPPING_COMPONENT = {
             fan.SUPPORT_SET_SPEED: 'Alexa.PercentageController',
         }
     ],
+    input_boolean.DOMAIN: ['SWITCH', ('Alexa.PowerController',), None],
     light.DOMAIN: [
         'LIGHT', ('Alexa.PowerController',), {
             light.SUPPORT_BRIGHTNESS: 'Alexa.BrightnessController',

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -5,11 +5,11 @@ import math
 from uuid import uuid4
 
 from homeassistant.const import (
-    ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID, SERVICE_TURN_ON,
-    SERVICE_TURN_OFF, SERVICE_LOCK, SERVICE_UNLOCK, SERVICE_VOLUME_SET,
-    SERVICE_MEDIA_STOP, SERVICE_MEDIA_PAUSE, SERVICE_MEDIA_PLAY,
-    SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK,
-    SERVICE_SET_COVER_POSITION)
+    ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES, SERVICE_LOCK,
+    SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PAUSE, SERVICE_MEDIA_PLAY,
+    SERVICE_MEDIA_PREVIOUS_TRACK, SERVICE_MEDIA_STOP,
+    SERVICE_SET_COVER_POSITION, SERVICE_TURN_OFF, SERVICE_TURN_ON,
+    SERVICE_UNLOCK, SERVICE_VOLUME_SET)
 from homeassistant.components import (
     alert, automation, cover, fan, group, input_boolean, light, lock,
     media_player, scene, script, switch)
@@ -20,15 +20,15 @@ HANDLERS = Registry()
 _LOGGER = logging.getLogger(__name__)
 
 API_DIRECTIVE = 'directive'
+API_ENDPOINT = 'endpoint'
 API_EVENT = 'event'
 API_HEADER = 'header'
 API_PAYLOAD = 'payload'
-API_ENDPOINT = 'endpoint'
 
-ATTR_ALEXA_HIDDEN = 'alexa_hidden'
-ATTR_ALEXA_NAME = 'alexa_name'
 ATTR_ALEXA_DESCRIPTION = 'alexa_description'
 ATTR_ALEXA_DISPLAY_CATEGORIES = 'alexa_display_categories'
+ATTR_ALEXA_HIDDEN = 'alexa_hidden'
+ATTR_ALEXA_NAME = 'alexa_name'
 
 
 MAPPING_COMPONENT = {

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -4,6 +4,7 @@ import logging
 import math
 from uuid import uuid4
 
+import homeassistant.core as ha
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES, SERVICE_LOCK,
     SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PAUSE, SERVICE_MEDIA_PLAY,
@@ -227,7 +228,7 @@ def extract_entity(funct):
 @asyncio.coroutine
 def async_api_turn_on(hass, request, entity):
     """Process a turn on request."""
-    yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
+    yield from hass.services.async_call(ha.DOMAIN, SERVICE_TURN_ON, {
         ATTR_ENTITY_ID: entity.entity_id
     }, blocking=True)
 
@@ -239,7 +240,7 @@ def async_api_turn_on(hass, request, entity):
 @asyncio.coroutine
 def async_api_turn_off(hass, request, entity):
     """Process a turn off request."""
-    yield from hass.services.async_call(entity.domain, SERVICE_TURN_OFF, {
+    yield from hass.services.async_call(ha.DOMAIN, SERVICE_TURN_OFF, {
         ATTR_ENTITY_ID: entity.entity_id
     }, blocking=True)
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -117,12 +117,15 @@ def test_discovery_request(hass):
     hass.states.async_set(
         'script.test', 'off', {'friendly_name': "Test script"})
 
+    hass.states.async_set(
+        'input_boolean.test', 'off', {'friendly_name': "Test input boolean"})
+
     msg = yield from smart_home.async_handle_message(hass, request)
 
     assert 'event' in msg
     msg = msg['event']
 
-    assert len(msg['payload']['endpoints']) == 5
+    assert len(msg['payload']['endpoints']) == 6
     assert msg['header']['name'] == 'Discover.Response'
     assert msg['header']['namespace'] == 'Alexa.Discovery'
 
@@ -181,6 +184,14 @@ def test_discovery_request(hass):
                 'Alexa.PowerController'
             continue
 
+        if appliance['endpointId'] == 'input_boolean#test':
+            assert appliance['displayCategories'][0] == "SWITCH"
+            assert appliance['friendlyName'] == "Test input boolean"
+            assert len(appliance['capabilities']) == 1
+            assert appliance['capabilities'][-1]['interface'] == \
+                'Alexa.PowerController'
+            continue
+
         raise AssertionError("Unknown appliance!")
 
 
@@ -217,7 +228,8 @@ def test_api_function_not_implemented(hass):
 
 
 @asyncio.coroutine
-@pytest.mark.parametrize("domain", ['light', 'switch', 'script'])
+@pytest.mark.parametrize("domain", ['light', 'switch',
+                                    'script', 'input_boolean'])
 def test_api_turn_on(hass, domain):
     """Test api turn on process."""
     request = get_new_request(
@@ -242,7 +254,8 @@ def test_api_turn_on(hass, domain):
 
 
 @asyncio.coroutine
-@pytest.mark.parametrize("domain", ['light', 'switch', 'script'])
+@pytest.mark.parametrize("domain", ['light', 'switch',
+                                    'script', 'input_boolean'])
 def test_api_turn_off(hass, domain):
     """Test api turn on process."""
     request = get_new_request(

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -151,12 +151,18 @@ def test_discovery_request(hass):
     hass.states.async_set(
         'group.test', 'off', {'friendly_name': "Test group"})
 
+    hass.states.async_set(
+        'cover.test', 'off', {
+            'friendly_name': "Test cover", 'supported_features': 255,
+            'position': 85
+        })
+
     msg = yield from smart_home.async_handle_message(hass, request)
 
     assert 'event' in msg
     msg = msg['event']
 
-    assert len(msg['payload']['endpoints']) == 14
+    assert len(msg['payload']['endpoints']) == 15
     assert msg['header']['name'] == 'Discover.Response'
     assert msg['header']['namespace'] == 'Alexa.Discovery'
 
@@ -295,6 +301,19 @@ def test_discovery_request(hass):
             assert len(appliance['capabilities']) == 1
             assert appliance['capabilities'][-1]['interface'] == \
                 'Alexa.PowerController'
+            continue
+
+        if appliance['endpointId'] == 'cover#test':
+            assert appliance['displayCategories'][0] == "DOOR"
+            assert appliance['friendlyName'] == "Test cover"
+            assert len(appliance['capabilities']) == 2
+
+            caps = set()
+            for feature in appliance['capabilities']:
+                caps.add(feature['interface'])
+
+            assert 'Alexa.PercentageController' in caps
+            assert 'Alexa.PowerController' in caps
             continue
 
         raise AssertionError("Unknown appliance!")
@@ -618,8 +637,8 @@ def test_api_activate(hass, domain):
 
 
 @asyncio.coroutine
-def test_api_set_percentage(hass):
-    """Test api set percentage process."""
+def test_api_set_percentage_fan(hass):
+    """Test api set percentage for fan process."""
     request = get_new_request(
         'Alexa.PercentageController', 'SetPercentage', 'fan#test_2')
 
@@ -644,10 +663,38 @@ def test_api_set_percentage(hass):
 
 
 @asyncio.coroutine
+def test_api_set_percentage_cover(hass):
+    """Test api set percentage for cover process."""
+    request = get_new_request(
+        'Alexa.PercentageController', 'SetPercentage', 'cover#test')
+
+    # add payload
+    request['directive']['payload']['percentage'] = '50'
+
+    # setup test devices
+    hass.states.async_set(
+        'cover.test', 'closed', {
+            'friendly_name': "Test cover"
+        })
+
+    call_cover = async_mock_service(hass, 'cover', 'set_cover_position')
+
+    msg = yield from smart_home.async_handle_message(hass, request)
+
+    assert 'event' in msg
+    msg = msg['event']
+
+    assert len(call_cover) == 1
+    assert call_cover[0].data['entity_id'] == 'cover.test'
+    assert call_cover[0].data['position'] == 50
+    assert msg['header']['name'] == 'Response'
+
+
+@asyncio.coroutine
 @pytest.mark.parametrize(
     "result,adjust", [('high', '-5'), ('off', '5'), ('low', '-80')])
-def test_api_adjust_percentage(hass, result, adjust):
-    """Test api adjust percentage process."""
+def test_api_adjust_percentage_fan(hass, result, adjust):
+    """Test api adjust percentage for fan process."""
     request = get_new_request(
         'Alexa.PercentageController', 'AdjustPercentage', 'fan#test_2')
 
@@ -670,6 +717,37 @@ def test_api_adjust_percentage(hass, result, adjust):
     assert len(call_fan) == 1
     assert call_fan[0].data['entity_id'] == 'fan.test_2'
     assert call_fan[0].data['speed'] == result
+    assert msg['header']['name'] == 'Response'
+
+
+@asyncio.coroutine
+@pytest.mark.parametrize(
+    "result,adjust", [(25, '-5'), (35, '5'), (0, '-80')])
+def test_api_adjust_percentage_cover(hass, result, adjust):
+    """Test api adjust percentage for cover process."""
+    request = get_new_request(
+        'Alexa.PercentageController', 'AdjustPercentage', 'cover#test')
+
+    # add payload
+    request['directive']['payload']['percentageDelta'] = adjust
+
+    # setup test devices
+    hass.states.async_set(
+        'cover.test', 'closed', {
+            'friendly_name': "Test cover",
+            'position': 30
+        })
+
+    call_cover = async_mock_service(hass, 'cover', 'set_cover_position')
+
+    msg = yield from smart_home.async_handle_message(hass, request)
+
+    assert 'event' in msg
+    msg = msg['event']
+
+    assert len(call_cover) == 1
+    assert call_cover[0].data['entity_id'] == 'cover.test'
+    assert call_cover[0].data['position'] == result
     assert msg['header']['name'] == 'Response'
 
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -99,7 +99,7 @@ def test_discovery_request(hass):
     """Test alexa discovery request."""
     request = get_new_request('Alexa.Discovery', 'Discover')
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'switch.test', 'on', {'friendly_name': "Test switch"})
 
@@ -307,7 +307,7 @@ def test_api_turn_on(hass, domain):
     request = get_new_request(
         'Alexa.PowerController', 'TurnOn', '{}#test'.format(domain))
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         '{}.test'.format(domain), 'off', {
             'friendly_name': "Test {}".format(domain)
@@ -333,7 +333,7 @@ def test_api_turn_off(hass, domain):
     request = get_new_request(
         'Alexa.PowerController', 'TurnOff', '{}#test'.format(domain))
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         '{}.test'.format(domain), 'on', {
             'friendly_name': "Test {}".format(domain)
@@ -360,7 +360,7 @@ def test_api_set_brightness(hass):
     # add payload
     request['directive']['payload']['brightness'] = '50'
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'light.test', 'off', {'friendly_name': "Test light"})
 
@@ -388,7 +388,7 @@ def test_api_adjust_brightness(hass, result, adjust):
     # add payload
     request['directive']['payload']['brightnessDelta'] = adjust
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'light.test', 'off', {
             'friendly_name': "Test light", 'brightness': '77'
@@ -420,7 +420,7 @@ def test_api_set_color_rgb(hass):
         'brightness': '0.342',
     }
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'light.test', 'off', {
             'friendly_name': "Test light",
@@ -453,7 +453,7 @@ def test_api_set_color_xy(hass):
         'brightness': '0.342',
     }
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'light.test', 'off', {
             'friendly_name': "Test light",
@@ -484,7 +484,7 @@ def test_api_set_color_temperature(hass):
     # add payload
     request['directive']['payload']['colorTemperatureInKelvin'] = '7500'
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'light.test', 'off', {'friendly_name': "Test light"})
 
@@ -509,7 +509,7 @@ def test_api_decrease_color_temp(hass, result, initial):
         'Alexa.ColorTemperatureController', 'DecreaseColorTemperature',
         'light#test')
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'light.test', 'off', {
             'friendly_name': "Test light", 'color_temp': initial,
@@ -537,7 +537,7 @@ def test_api_increase_color_temp(hass, result, initial):
         'Alexa.ColorTemperatureController', 'IncreaseColorTemperature',
         'light#test')
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'light.test', 'off', {
             'friendly_name': "Test light", 'color_temp': initial,
@@ -564,7 +564,7 @@ def test_api_activate(hass, domain):
     request = get_new_request(
         'Alexa.SceneController', 'Activate', '{}#test'.format(domain))
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         '{}.test'.format(domain), 'off', {
             'friendly_name': "Test {}".format(domain)
@@ -591,7 +591,7 @@ def test_api_set_percentage(hass):
     # add payload
     request['directive']['payload']['percentage'] = '50'
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'fan.test_2', 'off', {'friendly_name': "Test fan"})
 
@@ -619,7 +619,7 @@ def test_api_adjust_percentage(hass, result, adjust):
     # add payload
     request['directive']['payload']['percentageDelta'] = adjust
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'fan.test_2', 'on', {
             'friendly_name': "Test fan 2", 'speed': 'high'
@@ -645,7 +645,7 @@ def test_api_lock(hass, domain):
     request = get_new_request(
         'Alexa.LockController', 'Lock', '{}#test'.format(domain))
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         '{}.test'.format(domain), 'off', {
             'friendly_name': "Test {}".format(domain)
@@ -670,7 +670,7 @@ def test_api_play(hass, domain):
     request = get_new_request(
         'Alexa.PlaybackController', 'Play', '{}#test'.format(domain))
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         '{}.test'.format(domain), 'off', {
             'friendly_name': "Test {}".format(domain)
@@ -695,7 +695,7 @@ def test_api_pause(hass, domain):
     request = get_new_request(
         'Alexa.PlaybackController', 'Pause', '{}#test'.format(domain))
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         '{}.test'.format(domain), 'off', {
             'friendly_name': "Test {}".format(domain)
@@ -720,7 +720,7 @@ def test_api_stop(hass, domain):
     request = get_new_request(
         'Alexa.PlaybackController', 'Stop', '{}#test'.format(domain))
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         '{}.test'.format(domain), 'off', {
             'friendly_name': "Test {}".format(domain)
@@ -745,7 +745,7 @@ def test_api_next(hass, domain):
     request = get_new_request(
         'Alexa.PlaybackController', 'Next', '{}#test'.format(domain))
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         '{}.test'.format(domain), 'off', {
             'friendly_name': "Test {}".format(domain)
@@ -770,7 +770,7 @@ def test_api_previous(hass, domain):
     request = get_new_request(
         'Alexa.PlaybackController', 'Previous', '{}#test'.format(domain))
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         '{}.test'.format(domain), 'off', {
             'friendly_name': "Test {}".format(domain)
@@ -797,7 +797,7 @@ def test_api_set_volume(hass):
     # add payload
     request['directive']['payload']['volume'] = 50
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'media_player.test', 'off', {
             'friendly_name': "Test media player", 'volume_level': 0
@@ -827,7 +827,7 @@ def test_api_adjust_volume(hass, result, adjust):
     # add payload
     request['directive']['payload']['volume'] = adjust
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         'media_player.test', 'off', {
             'friendly_name': "Test media player", 'volume_level': 0.75
@@ -855,7 +855,7 @@ def test_api_mute(hass, domain):
 
     request['directive']['payload']['mute'] = True
 
-    # settup test devices
+    # setup test devices
     hass.states.async_set(
         '{}.test'.format(domain), 'off', {
             'friendly_name': "Test {}".format(domain)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -142,12 +142,21 @@ def test_discovery_request(hass):
             'volume_level': 1
         })
 
+    hass.states.async_set(
+        'alert.test', 'off', {'friendly_name': "Test alert"})
+
+    hass.states.async_set(
+        'automation.test', 'off', {'friendly_name': "Test automation"})
+
+    hass.states.async_set(
+        'group.test', 'off', {'friendly_name': "Test group"})
+
     msg = yield from smart_home.async_handle_message(hass, request)
 
     assert 'event' in msg
     msg = msg['event']
 
-    assert len(msg['payload']['endpoints']) == 11
+    assert len(msg['payload']['endpoints']) == 14
     assert msg['header']['name'] == 'Discover.Response'
     assert msg['header']['namespace'] == 'Alexa.Discovery'
 
@@ -264,6 +273,30 @@ def test_discovery_request(hass):
             assert 'Alexa.PlaybackController' in caps
             continue
 
+        if appliance['endpointId'] == 'alert#test':
+            assert appliance['displayCategories'][0] == "OTHER"
+            assert appliance['friendlyName'] == "Test alert"
+            assert len(appliance['capabilities']) == 1
+            assert appliance['capabilities'][-1]['interface'] == \
+                'Alexa.PowerController'
+            continue
+
+        if appliance['endpointId'] == 'automation#test':
+            assert appliance['displayCategories'][0] == "OTHER"
+            assert appliance['friendlyName'] == "Test automation"
+            assert len(appliance['capabilities']) == 1
+            assert appliance['capabilities'][-1]['interface'] == \
+                'Alexa.PowerController'
+            continue
+
+        if appliance['endpointId'] == 'group#test':
+            assert appliance['displayCategories'][0] == "OTHER"
+            assert appliance['friendlyName'] == "Test group"
+            assert len(appliance['capabilities']) == 1
+            assert appliance['capabilities'][-1]['interface'] == \
+                'Alexa.PowerController'
+            continue
+
         raise AssertionError("Unknown appliance!")
 
 
@@ -300,8 +333,9 @@ def test_api_function_not_implemented(hass):
 
 
 @asyncio.coroutine
-@pytest.mark.parametrize("domain", ['light', 'switch',
-                                    'script', 'input_boolean'])
+@pytest.mark.parametrize("domain", ['alert', 'automation', 'group',
+                                    'input_boolean', 'light', 'script',
+                                    'switch'])
 def test_api_turn_on(hass, domain):
     """Test api turn on process."""
     request = get_new_request(
@@ -326,8 +360,9 @@ def test_api_turn_on(hass, domain):
 
 
 @asyncio.coroutine
-@pytest.mark.parametrize("domain", ['light', 'switch',
-                                    'script', 'input_boolean'])
+@pytest.mark.parametrize("domain", ['alert', 'automation', 'group',
+                                    'input_boolean', 'light', 'script',
+                                    'switch'])
 def test_api_turn_off(hass, domain):
     """Test api turn on process."""
     request = get_new_request(

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -366,7 +366,7 @@ def test_api_turn_on(hass, domain):
             'friendly_name': "Test {}".format(domain)
         })
 
-    call = async_mock_service(hass, domain, 'turn_on')
+    call = async_mock_service(hass, 'homeassistant', 'turn_on')
 
     msg = yield from smart_home.async_handle_message(hass, request)
 
@@ -393,7 +393,7 @@ def test_api_turn_off(hass, domain):
             'friendly_name': "Test {}".format(domain)
         })
 
-    call = async_mock_service(hass, domain, 'turn_off')
+    call = async_mock_service(hass, 'homeassistant', 'turn_off')
 
     msg = yield from smart_home.async_handle_message(hass, request)
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -208,7 +208,7 @@ def test_discovery_request(hass):
             continue
 
         if appliance['endpointId'] == 'script#test':
-            assert appliance['displayCategories'][0] == "SWITCH"
+            assert appliance['displayCategories'][0] == "OTHER"
             assert appliance['friendlyName'] == "Test script"
             assert len(appliance['capabilities']) == 1
             assert appliance['capabilities'][-1]['interface'] == \
@@ -216,7 +216,7 @@ def test_discovery_request(hass):
             continue
 
         if appliance['endpointId'] == 'input_boolean#test':
-            assert appliance['displayCategories'][0] == "SWITCH"
+            assert appliance['displayCategories'][0] == "OTHER"
             assert appliance['friendlyName'] == "Test input boolean"
             assert len(appliance['capabilities']) == 1
             assert appliance['capabilities'][-1]['interface'] == \
@@ -232,7 +232,7 @@ def test_discovery_request(hass):
             continue
 
         if appliance['endpointId'] == 'fan#test_1':
-            assert appliance['displayCategories'][0] == "SWITCH"
+            assert appliance['displayCategories'][0] == "OTHER"
             assert appliance['friendlyName'] == "Test fan 1"
             assert len(appliance['capabilities']) == 1
             assert appliance['capabilities'][-1]['interface'] == \
@@ -240,7 +240,7 @@ def test_discovery_request(hass):
             continue
 
         if appliance['endpointId'] == 'fan#test_2':
-            assert appliance['displayCategories'][0] == "SWITCH"
+            assert appliance['displayCategories'][0] == "OTHER"
             assert appliance['friendlyName'] == "Test fan 2"
             assert len(appliance['capabilities']) == 2
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -132,12 +132,15 @@ def test_discovery_request(hass):
             'speed_list': ['low', 'medium', 'high']
         })
 
+    hass.states.async_set(
+        'lock.test', 'off', {'friendly_name': "Test lock"})
+
     msg = yield from smart_home.async_handle_message(hass, request)
 
     assert 'event' in msg
     msg = msg['event']
 
-    assert len(msg['payload']['endpoints']) == 9
+    assert len(msg['payload']['endpoints']) == 10
     assert msg['header']['name'] == 'Discover.Response'
     assert msg['header']['namespace'] == 'Alexa.Discovery'
 
@@ -231,6 +234,14 @@ def test_discovery_request(hass):
 
             assert 'Alexa.PercentageController' in caps
             assert 'Alexa.PowerController' in caps
+            continue
+
+        if appliance['endpointId'] == 'lock#test':
+            assert appliance['displayCategories'][0] == "SMARTLOCK"
+            assert appliance['friendlyName'] == "Test lock"
+            assert len(appliance['capabilities']) == 1
+            assert appliance['capabilities'][-1]['interface'] == \
+                'Alexa.LockController'
             continue
 
         raise AssertionError("Unknown appliance!")
@@ -604,4 +615,29 @@ def test_api_adjust_percentage(hass, result, adjust):
     assert len(call_fan) == 1
     assert call_fan[0].data['entity_id'] == 'fan.test_2'
     assert call_fan[0].data['speed'] == result
+    assert msg['header']['name'] == 'Response'
+
+
+@asyncio.coroutine
+@pytest.mark.parametrize("domain", ['lock'])
+def test_api_lock(hass, domain):
+    """Test api lock process."""
+    request = get_new_request(
+        'Alexa.LockController', 'Lock', '{}#test'.format(domain))
+
+    # settup test devices
+    hass.states.async_set(
+        '{}.test'.format(domain), 'off', {
+            'friendly_name': "Test {}".format(domain)
+        })
+
+    call = async_mock_service(hass, domain, 'lock')
+
+    msg = yield from smart_home.async_handle_message(hass, request)
+
+    assert 'event' in msg
+    msg = msg['event']
+
+    assert len(call) == 1
+    assert call[0].data['entity_id'] == '{}.test'.format(domain)
     assert msg['header']['name'] == 'Response'


### PR DESCRIPTION
## Description:

This is me trying to match the major functionality of Haaska and because @maddox begged and pleaded for me to do so 😝

- Adds support for the following domains:
  - `alert`
  - `automation`
  - `cover`
  - `fan`
    - supports on/off and set speed
  - `group`
  - `lock`
    - lock and unlock, but unlock is untested as Amazon [has disabled unlock for now](https://developer.amazon.com/docs/device-apis/alexa-lockcontroller.html#unlock)
  - `media_player`
    - play
    - pause
    - stop
    - set volume
    - adjust volume
    - next track
    - previous track
  - `scene`

- Adds customize attributes
  - Props to customize display/invocation
    - `alexa_hidden` - hide from Alexa
    - `alexa_name` - change name displayed/used by Alexa
    - `alexa_description` - change description shown in Alexa
  - Props to control [`displayCategories`](https://developer.amazon.com/docs/device-apis/alexa-discovery.html#display-categories)
    - `alexa_display_categories` - set displayCategories, useful for things like `media_player` (`TV`/`SPEAKERS`) or `scene` (`ACTIVITY_TRIGGER`/`SCENE_TRIGGER`)

- Change description to entity ID instead of empty string so it looks better in Alexa app
- Change manufacturer name from Unknown to Home Assiatant as per discovery recommendations and so it looks better in Alexa app
- Minor grammar/readability fixes

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.