### PR TITLE
Restore target temperature for generic thermostat

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import condition
 from homeassistant.helpers.event import (
     async_track_state_change, async_track_time_interval)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.restore_state import async_get_last_state
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -116,6 +117,18 @@ class GenericThermostat(ClimateDevice):
         sensor_state = hass.states.get(sensor_entity_id)
         if sensor_state:
             self._async_update_temp(sensor_state)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Run when entity about to be added."""
+
+        # If we have an old state and no target temp, restore
+        if self._target_temp is None:
+            old_state = yield from async_get_last_state(self.hass,
+                                                        self.entity_id)
+            if old_state is not None:
+                self._target_temp = float(
+                    old_state.attributes[ATTR_TEMPERATURE])
 
     @property
     def should_poll(self):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -121,7 +121,6 @@ class GenericThermostat(ClimateDevice):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Run when entity about to be added."""
-
         # If we have an old state and no target temp, restore
         if self._target_temp is None:
             old_state = yield from async_get_last_state(self.hass,


### PR DESCRIPTION
## Description:

Since the generic thermostat does not have any physical device attached to it, it can't retrieve the set target temperature from it when hass starts. Thus, we should restore it from a previous state, if possible.

**Related issue (if applicable):**  I thought there was one, but I can't find it anymore…


## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
