### PR TITLE
ping should add a -w5 flag so it works on hassio

### DIFF
--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -40,7 +40,7 @@ class Host(object):
         if sys.platform == 'win32':
             self._ping_cmd = ['ping', '-n 1', '-w', '1000', self.ip_address]
         else:
-            self._ping_cmd = ['ping', '-n', '-q', '-c1', '-W1',
+            self._ping_cmd = ['ping', '-n', '-q', '-c1', '-W1' '-w5',
                               self.ip_address]
 
     def ping(self):


### PR DESCRIPTION
## Description:

`ping` device tracker does not work on hassio since the defaults for ping there is set to wait forever. 
additional flag needs to be passed to ping so the wait time to receive packets is limited to 5s.
