### PR TITLE
Print entity type in "too slow" warnings

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -237,8 +237,8 @@ class Entity(object):
             self._slow_reported = True
             _LOGGER.warning("Updating state for %s (%s) took %.3f seconds. "
                             "Please report platform to the developers at "
-                            "https://goo.gl/Nvioub", self.entity_id, type(self),
-                            end - start)
+                            "https://goo.gl/Nvioub", self.entity_id,
+                            type(self), end - start)
 
         # Overwrite properties that have been set in the config file.
         if DATA_CUSTOMIZE in self.hass.data:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -235,9 +235,9 @@ class Entity(object):
 
         if not self._slow_reported and end - start > 0.4:
             self._slow_reported = True
-            _LOGGER.warning("Updating state for %s took %.3f seconds. "
+            _LOGGER.warning("Updating state for %s (%s) took %.3f seconds. "
                             "Please report platform to the developers at "
-                            "https://goo.gl/Nvioub", self.entity_id,
+                            "https://goo.gl/Nvioub", self.entity_id, type(self),
                             end - start)
 
         # Overwrite properties that have been set in the config file.


### PR DESCRIPTION
## Description:

Print entity type in "too slow" warnings

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
