### PR TITLE
Add Facebook Notification tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -424,7 +424,6 @@ omit =
     homeassistant/components/notify/clicksend.py
     homeassistant/components/notify/clicksend_tts.py
     homeassistant/components/notify/discord.py
-    homeassistant/components/notify/facebook.py
     homeassistant/components/notify/free_mobile.py
     homeassistant/components/notify/gntp.py
     homeassistant/components/notify/group.py

--- a/tests/components/notify/test_facebook.py
+++ b/tests/components/notify/test_facebook.py
@@ -120,7 +120,6 @@ class TestFacebook(unittest.TestCase):
             expected_params
         )
 
-
     @requests_mock.Mocker()
     def test_send_targetless_message(self, mock):
         """Test sending a message without a target."""

--- a/tests/components/notify/test_facebook.py
+++ b/tests/components/notify/test_facebook.py
@@ -2,8 +2,6 @@
 import unittest
 import requests_mock
 
-from six.moves.urllib import parse as urlparse
-
 import homeassistant.components.notify.facebook as facebook
 
 
@@ -37,9 +35,8 @@ class TestFacebook(unittest.TestCase):
         }
         self.assertEqual(mock.last_request.json(), expected_body)
 
-        params = urlparse.parse_qs(mock.last_request.query)
         expected_params = {"access_token": ["page-access-token"]}
-        self.assertEqual(params, expected_params)
+        self.assertEqual(mock.last_request.qs, expected_params)
 
     @requests_mock.Mocker()
     def test_sending_multiple_messages(self, mock):
@@ -65,9 +62,8 @@ class TestFacebook(unittest.TestCase):
             }
             self.assertEqual(request.json(), expected_body)
 
-            params = urlparse.parse_qs(request.query)
             expected_params = {"access_token": ["page-access-token"]}
-            self.assertEqual(params, expected_params)
+            self.assertEqual(request.qs, expected_params)
 
     @requests_mock.Mocker()
     def test_send_message_attachment(self, mock):
@@ -97,9 +93,8 @@ class TestFacebook(unittest.TestCase):
         }
         self.assertEqual(mock.last_request.json(), expected_body)
 
-        params = urlparse.parse_qs(mock.last_request.query)
         expected_params = {"access_token": ["page-access-token"]}
-        self.assertEqual(params, expected_params)
+        self.assertEqual(mock.last_request.qs, expected_params)
 
     @requests_mock.Mocker()
     def test_send_targetless_message(self, mock):

--- a/tests/components/notify/test_facebook.py
+++ b/tests/components/notify/test_facebook.py
@@ -1,0 +1,154 @@
+"""The test for the Facebook notify module."""
+import unittest
+import requests_mock
+
+from six.moves.urllib import parse as urlparse
+
+import homeassistant.components.notify.facebook as facebook
+
+
+class TestFacebook(unittest.TestCase):
+    """Tests for Facebook notifification service."""
+
+    def setUp(self):
+        """Set up test variables."""
+
+        access_token = "page-access-token"
+        self.facebook = facebook.FacebookNotificationService(access_token)
+
+    @requests_mock.Mocker()
+    def test_send_simple_message(self, mock):
+        """Test sending a simple message with success."""
+        mock.register_uri(
+            requests_mock.POST,
+            facebook.BASE_URL,
+            status_code=200
+        )
+
+        message = "This is just a test"
+        target = ["+15555551234"]
+
+        self.facebook.send_message(message=message, target=target)
+        self.assertTrue(mock.called)
+        self.assertEqual(mock.call_count, 1)
+
+        expected_body = {
+            "recipient": {"phone_number": target[0]},
+            "message": {"text": message}
+        }
+        self.assertEqual(
+            mock.last_request.json(),
+            expected_body
+        )
+
+        params = urlparse.parse_qs(mock.last_request.query)
+        expected_params = {"access_token": ["page-access-token"]}
+        self.assertEqual(
+            params,
+            expected_params
+        )
+
+    @requests_mock.Mocker()
+    def test_sending_multiple_messages(self, mock):
+        """Test sending a message to multiple targets."""
+        mock.register_uri(
+            requests_mock.POST,
+            facebook.BASE_URL,
+            status_code=200
+        )
+
+        message = "This is just a test"
+        targets = ["+15555551234", "+15555551235"]
+
+        self.facebook.send_message(message=message, target=targets)
+        self.assertTrue(mock.called)
+        self.assertEqual(mock.call_count, 2)
+
+        for idx, target in enumerate(targets):
+            request = mock.request_history[idx]
+            expected_body = {
+                "recipient": {"phone_number": target},
+                "message": {"text": message}
+            }
+            self.assertEqual(
+                request.json(),
+                expected_body
+            )
+
+            params = urlparse.parse_qs(request.query)
+            expected_params = {"access_token": ["page-access-token"]}
+            self.assertEqual(
+                params,
+                expected_params
+            )
+
+    @requests_mock.Mocker()
+    def test_send_message_attachment(self, mock):
+        """Test sending a message with a remote attachment."""
+        mock.register_uri(
+            requests_mock.POST,
+            facebook.BASE_URL,
+            status_code=200
+        )
+
+        message = "This will be thrown away."
+        data = {
+            "attachment": {
+                "type": "image",
+                "payload": {"url": "http://www.example.com/image.jpg"}
+            }
+        }
+        target = ["+15555551234"]
+
+        self.facebook.send_message(message=message, data=data, target=target)
+        self.assertTrue(mock.called)
+        self.assertEqual(mock.call_count, 1)
+
+        expected_body = {
+            "recipient": {"phone_number": target[0]},
+            "message": data
+        }
+        self.assertEqual(
+            mock.last_request.json(),
+            expected_body
+        )
+
+        params = urlparse.parse_qs(mock.last_request.query)
+        expected_params = {"access_token": ["page-access-token"]}
+        self.assertEqual(
+            params,
+            expected_params
+        )
+
+
+    @requests_mock.Mocker()
+    def test_send_targetless_message(self, mock):
+        """Test sending a message without a target."""
+        mock.register_uri(
+            requests_mock.POST,
+            facebook.BASE_URL,
+            status_code=200
+        )
+
+        self.facebook.send_message(message="goin nowhere")
+        self.assertFalse(mock.called)
+
+    @requests_mock.Mocker()
+    def test_send_message_with_400(self, mock):
+        """Test sending a message with a 400 from Facebook."""
+        mock.register_uri(
+            requests_mock.POST,
+            facebook.BASE_URL,
+            status_code=400,
+            json={
+                "error": {
+                    "message": "Invalid OAuth access token.",
+                    "type": "OAuthException",
+                    "code": 190,
+                    "fbtrace_id": "G4Da2pFp2Dp"
+                }
+            }
+        )
+        self.facebook.send_message(message="nope!", target=["+15555551234"])
+        self.assertTrue(mock.called)
+        self.assertEqual(mock.call_count, 1)

--- a/tests/components/notify/test_facebook.py
+++ b/tests/components/notify/test_facebook.py
@@ -12,7 +12,6 @@ class TestFacebook(unittest.TestCase):
 
     def setUp(self):
         """Set up test variables."""
-
         access_token = "page-access-token"
         self.facebook = facebook.FacebookNotificationService(access_token)
 
@@ -36,17 +35,11 @@ class TestFacebook(unittest.TestCase):
             "recipient": {"phone_number": target[0]},
             "message": {"text": message}
         }
-        self.assertEqual(
-            mock.last_request.json(),
-            expected_body
-        )
+        self.assertEqual(mock.last_request.json(), expected_body)
 
         params = urlparse.parse_qs(mock.last_request.query)
         expected_params = {"access_token": ["page-access-token"]}
-        self.assertEqual(
-            params,
-            expected_params
-        )
+        self.assertEqual(params, expected_params)
 
     @requests_mock.Mocker()
     def test_sending_multiple_messages(self, mock):
@@ -70,17 +63,11 @@ class TestFacebook(unittest.TestCase):
                 "recipient": {"phone_number": target},
                 "message": {"text": message}
             }
-            self.assertEqual(
-                request.json(),
-                expected_body
-            )
+            self.assertEqual(request.json(), expected_body)
 
             params = urlparse.parse_qs(request.query)
             expected_params = {"access_token": ["page-access-token"]}
-            self.assertEqual(
-                params,
-                expected_params
-            )
+            self.assertEqual(params, expected_params)
 
     @requests_mock.Mocker()
     def test_send_message_attachment(self, mock):
@@ -108,17 +95,11 @@ class TestFacebook(unittest.TestCase):
             "recipient": {"phone_number": target[0]},
             "message": data
         }
-        self.assertEqual(
-            mock.last_request.json(),
-            expected_body
-        )
+        self.assertEqual(mock.last_request.json(), expected_body)
 
         params = urlparse.parse_qs(mock.last_request.query)
         expected_params = {"access_token": ["page-access-token"]}
-        self.assertEqual(
-            params,
-            expected_params
-        )
+        self.assertEqual(params, expected_params)
 
     @requests_mock.Mocker()
     def test_send_targetless_message(self, mock):


### PR DESCRIPTION
## Description:

I was about to add some functionality to the Facebook notify component but noticed that it was completely untested. This Pull request simply adds a few tests to cover the existing code.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
