### PR TITLE
Bump pyatv to 0.3.8

### DIFF
--- a/homeassistant/components/apple_tv.py
+++ b/homeassistant/components/apple_tv.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import discovery
 from homeassistant.components.discovery import SERVICE_APPLE_TV
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyatv==0.3.6']
+REQUIREMENTS = ['pyatv==0.3.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -613,7 +613,7 @@ pyasn1-modules==0.1.5
 pyasn1==0.3.7
 
 # homeassistant.components.apple_tv
-pyatv==0.3.6
+pyatv==0.3.8
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox


### PR DESCRIPTION
## Description:
Fixes AirPlay issues on newer versions of tvOS. Would be good if this could be merged to 0.58.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
