### PR TITLE
KNX: Added config option for broadcasting current time to KNX bus.

### DIFF
--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -27,6 +27,7 @@ CONF_KNX_LOCAL_IP = "local_ip"
 CONF_KNX_FIRE_EVENT = "fire_event"
 CONF_KNX_FIRE_EVENT_FILTER = "fire_event_filter"
 CONF_KNX_STATE_UPDATER = "state_updater"
+CONF_KNX_TIME_ADDRESS = "time_address"
 
 SERVICE_KNX_SEND = "send"
 SERVICE_KNX_ATTR_ADDRESS = "address"
@@ -60,6 +61,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.All(
                 cv.ensure_list,
                 [cv.string]),
+        vol.Optional(CONF_KNX_TIME_ADDRESS): cv.string,
         vol.Optional(CONF_KNX_STATE_UPDATER, default=True): cv.boolean,
     })
 }, extra=vol.ALLOW_EXTRA)
@@ -97,12 +99,26 @@ def async_setup(hass, config):
                 ATTR_DISCOVER_DEVICES: found_devices
             }, config))
 
+    if CONF_KNX_TIME_ADDRESS in config[DOMAIN]:
+        _add_time_device(hass, config)
+
     hass.services.async_register(
         DOMAIN, SERVICE_KNX_SEND,
         hass.data[DATA_KNX].service_send_to_knx_bus,
         schema=SERVICE_KNX_SEND_SCHEMA)
 
     return True
+
+
+def _add_time_device(hass, config):
+    """Create time broadcasting device and add it to xknx device queue."""
+    import xknx
+    group_address_time = config[DOMAIN][CONF_KNX_TIME_ADDRESS]
+    time = xknx.devices.Time(
+        hass.data[DATA_KNX].xknx,
+        'Time',
+        group_address=group_address_time)
+    hass.data[DATA_KNX].xknx.devices.add(time)
 
 
 def _get_devices(hass, discovery_type):


### PR DESCRIPTION
## Description:

Added config option for broadcasting time to KNX bus. 

Some devices (e.g. [Gira Touch sensor 3 plus](https://www.gira.de/gebaeudetechnik/systeme/knx-eib_system/knx-produkte/bediengeraete/tastsensor3/tastsensor-plus.html) ) are able to display the time in the display. If this config option is set, the time is broadcasted to the KNX bus with the configured group address.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4007

## Example entry for `configuration.yaml`:
```yaml
knx:
    time_address: '0/0/1'
```

