### PR TITLE
Added cycles config option to LaMetric notifications

### DIFF
--- a/homeassistant/components/notify/lametric.py
+++ b/homeassistant/components/notify/lametric.py
@@ -63,7 +63,7 @@ class LaMetricNotificationService(BaseNotificationService):
         cycles = self._cycles
         sound = None
 
-        # Sound in data?
+        # Additional data?
         if data is not None:
             if "icon" in data:
                 icon = data["icon"]

--- a/homeassistant/components/notify/lametric.py
+++ b/homeassistant/components/notify/lametric.py
@@ -20,35 +20,39 @@ DEPENDENCIES = ['lametric']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_DISPLAY_TIME = "display_time"
+CONF_LIFETIME = "lifetime"
+CONF_CYCLES = "cycles"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ICON, default="i555"): cv.string,
-    vol.Optional(CONF_DISPLAY_TIME, default=10): cv.positive_int,
+    vol.Optional(CONF_LIFETIME, default=10): cv.positive_int,
+    vol.Optional(CONF_CYCLES, default=1): cv.positive_int,
 })
 
 
 # pylint: disable=unused-variable
 def get_service(hass, config, discovery_info=None):
-    """Get the Slack notification service."""
+    """Get the LaMetric notification service."""
     hlmn = hass.data.get(LAMETRIC_DOMAIN)
     return LaMetricNotificationService(hlmn,
                                        config[CONF_ICON],
-                                       config[CONF_DISPLAY_TIME] * 1000)
+                                       config[CONF_LIFETIME] * 1000,
+                                       config[CONF_CYCLES])
 
 
 class LaMetricNotificationService(BaseNotificationService):
     """Implement the notification service for LaMetric."""
 
-    def __init__(self, hasslametricmanager, icon, display_time):
+    def __init__(self, hasslametricmanager, icon, lifetime, cycles):
         """Initialize the service."""
         self.hasslametricmanager = hasslametricmanager
         self._icon = icon
-        self._display_time = display_time
+        self._lifetime = lifetime
+        self._cycles = cycles
 
     # pylint: disable=broad-except
     def send_message(self, message="", **kwargs):
-        """Send a message to some LaMetric deviced."""
+        """Send a message to some LaMetric device."""
         from lmnotify import SimpleFrame, Sound, Model
         from oauthlib.oauth2 import TokenExpiredError
 
@@ -56,12 +60,11 @@ class LaMetricNotificationService(BaseNotificationService):
         data = kwargs.get(ATTR_DATA)
         _LOGGER.debug("Targets/Data: %s/%s", targets, data)
         icon = self._icon
+        cycles = self._cycles
         sound = None
 
-        # User-defined icon?
+        # Sound in data?
         if data is not None:
-            if "icon" in data:
-                icon = data["icon"]
             if "sound" in data:
                 try:
                     sound = Sound(category="notifications",
@@ -73,12 +76,12 @@ class LaMetricNotificationService(BaseNotificationService):
                                   data["sound"])
 
         text_frame = SimpleFrame(icon, message)
-        _LOGGER.debug("Icon/Message/Duration: %s, %s, %d",
-                      icon, message, self._display_time)
+        _LOGGER.debug("Icon/Message/Cycles/Lifetime: %s, %s, %d, %d",
+                      icon, message, self._cycles, self._lifetime)
 
         frames = [text_frame]
 
-        model = Model(frames=frames, sound=sound)
+        model = Model(frames=frames, cycles=cycles, sound=sound)
         lmn = self.hasslametricmanager.manager
         try:
             devices = lmn.get_devices()
@@ -89,5 +92,5 @@ class LaMetricNotificationService(BaseNotificationService):
         for dev in devices:
             if targets is None or dev["name"] in targets:
                 lmn.set_device(dev)
-                lmn.send_notification(model, lifetime=self._display_time)
+                lmn.send_notification(model, lifetime=self._lifetime)
                 _LOGGER.debug("Sent notification to LaMetric %s", dev["name"])

--- a/homeassistant/components/notify/lametric.py
+++ b/homeassistant/components/notify/lametric.py
@@ -65,6 +65,8 @@ class LaMetricNotificationService(BaseNotificationService):
 
         # Sound in data?
         if data is not None:
+            if "icon" in data:
+                icon = data["icon"]
             if "sound" in data:
                 try:
                     sound = Sound(category="notifications",


### PR DESCRIPTION
## Description:

Added cycles config option, changed display_time to lifetime.

## Changes:

- Added cycles config option for how many times the notification is displayed on LaMetric.
- Changed display_time to lifetime, because LaMetric notification has no display_time. Lifetime is the time, how long a notification remains in the LaMetric notification queue. (Breaking change, if users have display_time in their config to show the notification more than once! Does not work without cycles).
- Changed some descriptions.

This is a breaking change: `display_time` config option is removed, because it is not what it is used for! Use `cycles` option to show notification more than once. See documentation.

## Example for configuration.yaml:

```
notify:
  name: lametric1
  platform: lametric
  lifetime: 20
  icon: a7956
  cycles: 3
```

Result: Notifications with Home Assistant animated icon, displayed three times on LaMetric and remains 20 seconds in the LaMetric queue.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
https://github.com/home-assistant/home-assistant.github.io/pull/4010 https://github.com/home-assistant/home-assistant.github.io/pull/4017