### PR TITLE
Fix yweather: need to cast to int

### DIFF
--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -115,7 +115,7 @@ class YahooWeatherWeather(WeatherEntity):
     @property
     def temperature(self):
         """Return the temperature."""
-        return self._data.yahoo.Now['temp']
+        return int(self._data.yahoo.Now['temp'])
 
     @property
     def temperature_unit(self):


### PR DESCRIPTION
## Description:

The `yahooweather` package returns the temperature as a string, but HA expects it to be an int. Casting helps. :) Is was probably broken by #10555 

**Related issue (if applicable):** fixes #10618