### PR TITLE
Refactored WHOIS sensor to resolve assumed key errors

### DIFF
--- a/homeassistant/components/sensor/whois.py
+++ b/homeassistant/components/sensor/whois.py
@@ -71,7 +71,7 @@ class WhoisSensor(Entity):
         self._domain = domain
 
         self._state = None
-        self._attributes = {}
+        self._attributes = None
 
     @property
     def name(self):
@@ -119,20 +119,21 @@ class WhoisSensor(Entity):
                 _LOGGER.error("Whois response expiration_date empty.")
                 return
 
+            attrs = {}
+
             expiration_date = response['expiration_date'][0]
-            self._attributes[ATTR_EXPIRES] = expiration_date.isoformat()
+            attrs[ATTR_EXPIRES] = expiration_date.isoformat()
 
             if 'nameservers' in response:
-                self._attributes[ATTR_NAME_SERVERS] = \
-                    ' '.join(response['nameservers'])
+                attrs[ATTR_NAME_SERVERS] = ' '.join(response['nameservers'])
 
             if 'updated_date' in response:
-                self._attributes[ATTR_UPDATED] = \
-                    response['updated_date'][0].isoformat()
+                attrs[ATTR_UPDATED] = response['updated_date'][0].isoformat()
 
             if 'registrar' in response:
-                self._attributes[ATTR_REGISTRAR] = response['registrar'][0]
+                attrs[ATTR_REGISTRAR] = response['registrar'][0]
 
             time_delta = (expiration_date - expiration_date.now())
 
+            self._attributes = attrs
             self._state = time_delta.days

--- a/homeassistant/components/sensor/whois.py
+++ b/homeassistant/components/sensor/whois.py
@@ -71,7 +71,6 @@ class WhoisSensor(Entity):
         self._domain = domain
 
         self._state = None
-        self._data = None
         self._attributes = {}
 
     @property
@@ -120,21 +119,19 @@ class WhoisSensor(Entity):
                 _LOGGER.error("Whois response expiration_date empty.")
                 return
 
-            self._data = response
-
-            expiration_date = self._data['expiration_date'][0]
+            expiration_date = response['expiration_date'][0]
             self._attributes[ATTR_EXPIRES] = expiration_date.isoformat()
 
-            if 'nameservers' in self._data:
+            if 'nameservers' in response:
                 self._attributes[ATTR_NAME_SERVERS] = \
-                    ' '.join(self._data['nameservers'])
+                    ' '.join(response['nameservers'])
 
-            if 'updated_date' in self._data:
+            if 'updated_date' in response:
                 self._attributes[ATTR_UPDATED] = \
-                    self._data['updated_date'][0].isoformat()
+                    response['updated_date'][0].isoformat()
 
-            if 'registrar' in self._data:
-                self._attributes[ATTR_REGISTRAR] = self._data['registrar'][0]
+            if 'registrar' in response:
+                self._attributes[ATTR_REGISTRAR] = response['registrar'][0]
 
             time_delta = (expiration_date - expiration_date.now())
 


### PR DESCRIPTION
## Description:
Altered it to now set an attribute key and value only if the attribute is present in the WHOIS response. This prevents assumed keys (registrar) from raising a KeyError on WHOIS lookups that don't contain registrar information (onet.pl, wp.pl, for example).

**Related issue (if applicable):** fixes #10448

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensors:
  - platform: whois
    domain: github.com
    name: WHOIS GitHub
  - platform: whois
    domain: onet.pl
    name: WHOIS onet
  - platform: whois
    domain: wp.pl
    name: WHOIS wp
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
