### PR TITLE
Properly initialize Harmony remote

### DIFF
--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -60,6 +60,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                         False)
 
         port = DEFAULT_PORT
+        delay_secs = DEFAULT_DELAY_SECS
         if override:
             activity = override.get(ATTR_ACTIVITY)
             delay_secs = override.get(ATTR_DELAY_SECS)


### PR DESCRIPTION
## Description:

This fixes a fallout from #10218 (merged in 0.58).

It would fail during initialization if `discovery:` was enabled and no `remote` configuration block existed to override the defaults. Thus, a workaround is to add a minimal configuration block.

CC @arsaboo

**Related issue (if applicable):** fixes #<home-assistant issue number goes here> (none yet, example traceback is below)

```
Traceback (most recent call last):
  File "/Users/am/home-assistant/homeassistant/helpers/entity_component.py", line 171, in _async_setup_platform
    SLOW_SETUP_MAX_WAIT, loop=self.hass.loop)
  File "/usr/local/Cellar/python3/3.6.3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/tasks.py", line 358, in wait_for
    return fut.result()
  File "/usr/local/Cellar/python3/3.6.3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/futures.py", line 245, in result
    raise self._exception
  File "/usr/local/Cellar/python3/3.6.3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/am/home-assistant/homeassistant/components/remote/harmony.py", line 97, in setup_platform
    name, address, port, activity, harmony_conf_file, delay_secs)
UnboundLocalError: local variable 'delay_secs' referenced before assignment
```
## Example entry for `configuration.yaml`:
```yaml
discovery:

# Uncomment the below to work around the error.
# The name must match the MyHarmony name exactly.
#remote:
#  - platform: harmony
#    name: Harmony Hub
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.