### PR TITLE
Convert configurator to use markdown

### DIFF
--- a/homeassistant/components/configurator.py
+++ b/homeassistant/components/configurator.py
@@ -50,15 +50,19 @@ def async_request_config(
 
     Will return an ID to be used for sequent calls.
     """
+    if link_name is not None and link_url is not None:
+        description += '\n\n[{}]({})'.format(link_name, link_url)
+
+    if description_image is not None:
+        description += '\n\n![Description image]({})'.format(description_image)
+
     instance = hass.data.get(_KEY_INSTANCE)
 
     if instance is None:
         instance = hass.data[_KEY_INSTANCE] = Configurator(hass)
 
     request_id = instance.async_request_config(
-        name, callback,
-        description, description_image, submit_caption,
-        fields, link_name, link_url, entity_picture)
+        name, callback, description, submit_caption, fields, entity_picture)
 
     if DATA_REQUESTS not in hass.data:
         hass.data[DATA_REQUESTS] = {}
@@ -137,9 +141,8 @@ class Configurator(object):
 
     @async_callback
     def async_request_config(
-            self, name, callback,
-            description, description_image, submit_caption,
-            fields, link_name, link_url, entity_picture):
+            self, name, callback, description, submit_caption, fields,
+            entity_picture):
         """Set up a request for configuration."""
         entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, name, hass=self.hass)
@@ -161,10 +164,7 @@ class Configurator(object):
         data.update({
             key: value for key, value in [
                 (ATTR_DESCRIPTION, description),
-                (ATTR_DESCRIPTION_IMAGE, description_image),
                 (ATTR_SUBMIT_CAPTION, submit_caption),
-                (ATTR_LINK_NAME, link_name),
-                (ATTR_LINK_URL, link_url),
             ] if value is not None
         })
 

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -85,6 +85,12 @@ SCENE_SCHEMA = vol.Schema({
 ATTR_IS_HUE_GROUP = "is_hue_group"
 GROUP_NAME_ALL_HUE_LIGHTS = "All Hue Lights"
 
+CONFIG_INSTRUCTIONS = """
+Press the button on the bridge to register Philips Hue with Home Assistant.
+
+![Location of button on bridge](/static/images/config_philips_hue.jpg)
+"""
+
 
 def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
     """Attempt to detect host based on existing configuration."""
@@ -298,10 +304,8 @@ def request_configuration(host, hass, add_devices, filename,
 
     _CONFIGURING[host] = configurator.request_config(
         "Philips Hue", hue_configuration_callback,
-        description=("Press the button on the bridge to register Philips Hue "
-                     "with Home Assistant."),
+        description=CONFIG_INSTRUCTIONS,
         entity_picture="/static/images/logo_philips_hue.png",
-        description_image="/static/images/config_philips_hue.jpg",
         submit_caption="I have pressed the button"
     )
 

--- a/tests/components/test_configurator.py
+++ b/tests/components/test_configurator.py
@@ -44,12 +44,13 @@ class TestConfigurator(unittest.TestCase):
         """Test request config with all possible info."""
         exp_attr = {
             ATTR_FRIENDLY_NAME: "Test Request",
-            configurator.ATTR_DESCRIPTION: "config description",
-            configurator.ATTR_DESCRIPTION_IMAGE: "config image url",
+            configurator.ATTR_DESCRIPTION: """config description
+
+[link name](link url)
+
+![Description image](config image url)""",
             configurator.ATTR_SUBMIT_CAPTION: "config submit caption",
             configurator.ATTR_FIELDS: [],
-            configurator.ATTR_LINK_NAME: "link name",
-            configurator.ATTR_LINK_URL: "link url",
             configurator.ATTR_ENTITY_PICTURE: "config entity picture",
             configurator.ATTR_CONFIGURE_ID: configurator.request_config(
                 self.hass,
@@ -70,7 +71,7 @@ class TestConfigurator(unittest.TestCase):
         state = states[0]
 
         self.assertEqual(configurator.STATE_CONFIGURE, state.state)
-        assert exp_attr == dict(state.attributes)
+        assert exp_attr == state.attributes
 
     def test_callback_called_on_configure(self):
         """Test if our callback gets called when configure service called."""


### PR DESCRIPTION
## Description:
Convert configurator to use markdown in the frontend to allow more flexibility how to render the content.

I have only converted the Hue configurator. Once all `request_config` calls have been converted to no longer use `link_name`, `link_url`, and `description_image` we can remove those options.

UI part: https://github.com/home-assistant/home-assistant-polymer/pull/644

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
