### PR TITLE
Change fail2ban startup Fixes #10627

### DIFF
--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -64,7 +64,7 @@ class BanSensor(Entity):
         self._name = '{} {}'.format(name, jail)
         self.jail = jail
         self.ban_dict = {STATE_CURRENT_BANS: [], STATE_ALL_BANS: []}
-        self.last_ban = None
+        self.last_ban = ''
         self.log_parser = log_parser
         self.log_parser.ip_regex[self.jail] = re.compile(
             r"\[{}\].(Ban|Unban) ([\w+\.]{{3,}})".format(re.escape(self.jail))


### PR DESCRIPTION
Changed initial value to empty string so first read of fail2ban log file
will force a state change update. 

## Description:
The fail2ban sensor has an attribute that keeps track of the ten most recent bans that have happened on the system.  However, at home-assistant restart, if there is no active ban, this list will not get updated since the state in this mode was the same as the initial state ('None').  Changing the initial state will cause a state change at startup, allowing the ban list attributed to be correctly populated.

**Related issue (if applicable):** fixes #10627

## Checklist:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

