### PR TITLE
Handle the new version of HydroQuebec website

### DIFF
--- a/homeassistant/components/sensor/hydroquebec.py
+++ b/homeassistant/components/sensor/hydroquebec.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyhydroquebec==1.2.0']
+REQUIREMENTS = ['pyhydroquebec==1.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +34,7 @@ DEFAULT_NAME = 'HydroQuebec'
 
 REQUESTS_TIMEOUT = 15
 MIN_TIME_BETWEEN_UPDATES = timedelta(hours=1)
+SCAN_INTERVAL = timedelta(hours=1)
 
 SENSOR_TYPES = {
     'balance':
@@ -115,7 +116,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for variable in config[CONF_MONITORED_VARIABLES]:
         sensors.append(HydroQuebecSensor(hydroquebec_data, variable, name))
 
-    add_devices(sensors, True)
+    add_devices(sensors)
 
 
 class HydroQuebecSensor(Entity):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -676,7 +676,7 @@ pyhik==0.1.4
 pyhomematic==0.1.34
 
 # homeassistant.components.sensor.hydroquebec
-pyhydroquebec==1.2.0
+pyhydroquebec==1.3.0
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.9.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -676,7 +676,7 @@ pyhik==0.1.4
 pyhomematic==0.1.34
 
 # homeassistant.components.sensor.hydroquebec
-pyhydroquebec==1.3.0
+pyhydroquebec==1.3.1
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.9.1


### PR DESCRIPTION
## Description:

HydroQuébec updated their website, this patch update the hydroquebec component to use the last version of pyhydroquebec

Also, this patch disabled the update on startup (this is useless) and set the default scan interval to 1 hour

Please merge also in the 0.58.1 (if this version is planned, Thanks !)

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
