### PR TITLE
Refactor hue to split bridge support from light platform

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -36,6 +36,7 @@ SERVICE_APPLE_TV = 'apple_tv'
 SERVICE_WINK = 'wink'
 SERVICE_XIAOMI_GW = 'xiaomi_gw'
 SERVICE_TELLDUSLIVE = 'tellstick'
+SERVICE_HUE = 'philips_hue'
 
 SERVICE_HANDLERS = {
     SERVICE_HASS_IOS_APP: ('ios', None),
@@ -48,7 +49,7 @@ SERVICE_HANDLERS = {
     SERVICE_WINK: ('wink', None),
     SERVICE_XIAOMI_GW: ('xiaomi_aqara', None),
     SERVICE_TELLDUSLIVE: ('tellduslive', None),
-    'philips_hue': ('light', 'hue'),
+    SERVICE_HUE: ('hue', None),
     'google_cast': ('media_player', 'cast'),
     'panasonic_viera': ('media_player', 'panasonic_viera'),
     'plex_mediaserver': ('media_player', 'plex'),

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -127,7 +127,6 @@ def setup_bridge(host, hass, filename=None, allow_unreachable=False,
 
     bridge = HueBridge(host, hass, filename, allow_unreachable,
                        allow_in_emulated_hue, allow_hue_groups)
-    hass.data[DOMAIN][socket.gethostbyname(host)] = bridge
     bridge.setup()
 
 
@@ -165,6 +164,8 @@ class HueBridge(object):
 
         self.configured = False
         self.config_request_id = None
+
+        hass.data[DOMAIN][socket.gethostbyname(host)] = self
 
     def setup(self):
         """Set up a phue bridge based on host parameter."""

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -84,10 +84,6 @@ def setup(hass, config):
         bridge_discovered(hass, service, discovery_info))
 
     bridges = config.get(CONF_BRIDGES, [])
-    if len(bridges) == 0:
-        _LOGGER.info("No bridges found in configuration")
-        return True
-
     for bridge in bridges:
         filename = bridge.get(CONF_FILENAME)
         allow_unreachable = bridge.get(CONF_ALLOW_UNREACHABLE)

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -107,6 +107,7 @@ def setup(hass, config):
     hass.data[DOMAIN][socket.gethostbyname(host)] = bridge
     bridge.setup()
 
+    discovery.load_platform(hass, 'light', DOMAIN, {}, config)
 
     return True
 
@@ -189,3 +190,15 @@ class HueBridge(object):
             entity_picture="/static/images/logo_philips_hue.png",
             submit_caption="I have pressed the button"
         )
+
+    def get_api(self):
+        """Returns the full api dictionary from phue."""
+        return self.bridge.get_api()
+
+    def set_light(self, light_id, command):
+        """Adjust properties of one or more lights. See phue for details."""
+        return self.bridge.set_light(light_id, command)
+
+    def set_group(self, light_id, command):
+        """Change light settings for a group. See phue for detail."""
+        return self.bridge.set_group(light_id, command)

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -1,0 +1,191 @@
+"""
+This component provides basic support for the Philips Hue system.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/hue/
+"""
+import json
+import logging
+import os
+import socket
+
+import voluptuous as vol
+
+from homeassistant.config import load_yaml_config_file
+from homeassistant.const import CONF_FILENAME, CONF_HOST
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import discovery
+
+REQUIREMENTS = ['phue==1.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "hue"
+SERVICE_HUE_SCENE = "hue_activate_scene"
+
+CONF_ALLOW_UNREACHABLE = 'allow_unreachable'
+DEFAULT_ALLOW_UNREACHABLE = False
+
+PHUE_CONFIG_FILE = 'phue.conf'
+
+CONF_ALLOW_IN_EMULATED_HUE = "allow_in_emulated_hue"
+DEFAULT_ALLOW_IN_EMULATED_HUE = True
+
+CONF_ALLOW_HUE_GROUPS = "allow_hue_groups"
+DEFAULT_ALLOW_HUE_GROUPS = True
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_ALLOW_UNREACHABLE): cv.boolean,
+        vol.Optional(CONF_FILENAME): cv.string,
+        vol.Optional(CONF_ALLOW_IN_EMULATED_HUE): cv.boolean,
+        vol.Optional(CONF_ALLOW_HUE_GROUPS,
+                     default=DEFAULT_ALLOW_HUE_GROUPS): cv.boolean,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+ATTR_GROUP_NAME = "group_name"
+ATTR_SCENE_NAME = "scene_name"
+SCENE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_GROUP_NAME): cv.string,
+    vol.Required(ATTR_SCENE_NAME): cv.string,
+})
+
+CONFIG_INSTRUCTIONS = """
+Press the button on the bridge to register Philips Hue with Home Assistant.
+
+![Location of button on bridge](/static/images/config_philips_hue.jpg)
+"""
+
+
+def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
+    """Attempt to detect host based on existing configuration."""
+    path = hass.config.path(filename)
+
+    if not os.path.isfile(path):
+        return None
+
+    try:
+        with open(path) as inp:
+            return next(json.loads(''.join(inp)).keys().__iter__())
+    except (ValueError, AttributeError, StopIteration):
+        # ValueError if can't parse as JSON
+        # AttributeError if JSON value is not a dict
+        # StopIteration if no keys
+        return None
+
+
+def setup(hass, config):
+    """Set up the Hue platform."""
+    # Default needed in case of discovery
+    config = config.get(DOMAIN)
+    if config is None:
+        config = {}
+    filename = config.get(CONF_FILENAME, PHUE_CONFIG_FILE)
+    allow_unreachable = config.get(CONF_ALLOW_UNREACHABLE,
+                                   DEFAULT_ALLOW_UNREACHABLE)
+    allow_in_emulated_hue = config.get(CONF_ALLOW_IN_EMULATED_HUE,
+                                       DEFAULT_ALLOW_IN_EMULATED_HUE)
+    allow_hue_groups = config.get(CONF_ALLOW_HUE_GROUPS,
+                                  DEFAULT_ALLOW_HUE_GROUPS)
+
+    host = config.get(CONF_HOST, None)
+
+    if host is None:
+        host = _find_host_from_config(hass, filename)
+
+    if host is None:
+        _LOGGER.error("No host found in configuration")
+        return False
+
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+
+    bridge = HueBridge(host, hass, filename, allow_unreachable,
+                       allow_in_emulated_hue, allow_hue_groups)
+    hass.data[DOMAIN][socket.gethostbyname(host)] = bridge
+    bridge.setup()
+
+
+    return True
+
+
+class HueBridge(object):
+    """Manages a single Hue bridge."""
+
+    def __init__(self, host, hass, filename, allow_unreachable=False,
+                 allow_in_emulated_hue=True, allow_hue_groups=True):
+        """Initialize the system."""
+        self.host = host
+        self.hass = hass
+        self.filename = filename
+        self.allow_unreachable = allow_unreachable
+        self.allow_in_emulated_hue = allow_in_emulated_hue
+        self.allow_hue_groups = allow_hue_groups
+
+        self.bridge = None
+
+        self.configured = False
+        self.config_request_id = None
+
+    def setup(self):
+        """Set up a phue bridge based on host parameter."""
+        import phue
+
+        try:
+            self.bridge = phue.Bridge(
+                self.host,
+                config_file_path=self.hass.config.path(self.filename))
+        except ConnectionRefusedError:  # Wrong host was given
+            _LOGGER.error("Error connecting to the Hue bridge at %s",
+                          self.host)
+            return
+        except phue.PhueRegistrationException:
+            _LOGGER.warning("Connected to Hue at %s but not registered.",
+                            self.host)
+            self.request_configuration()
+            return
+
+        # If we came here and configuring this host, mark as done
+        if self.config_request_id:
+            request_id = self.config_request_id
+            self.config_request_id = None
+            configurator = self.hass.components.configurator
+            configurator.request_done(request_id)
+
+        self.configured = True
+
+        # create a service for calling run_scene directly on the bridge,
+        # used to simplify automation rules.
+        def hue_activate_scene(call):
+            """Service to call directly into bridge to set scenes."""
+            group_name = call.data[ATTR_GROUP_NAME]
+            scene_name = call.data[ATTR_SCENE_NAME]
+            self.bridge.run_scene(group_name, scene_name)
+
+        descriptions = load_yaml_config_file(
+            os.path.join(os.path.dirname(__file__), 'services.yaml'))
+        self.hass.services.register(
+            DOMAIN, SERVICE_HUE_SCENE, hue_activate_scene,
+            descriptions.get(SERVICE_HUE_SCENE),
+            schema=SCENE_SCHEMA)
+
+    def request_configuration(self):
+        """Request configuration steps from the user."""
+        configurator = self.hass.components.configurator
+
+        # We got an error if this method is called while we are configuring
+        if self.config_request_id:
+            configurator.notify_errors(
+                self.config_request_id,
+                "Failed to register, please try again.")
+            return
+
+        self.config_request_id = configurator.request_config(
+            "Philips Hue",
+            lambda data: self.setup(),
+            description=CONFIG_INSTRUCTIONS,
+            entity_picture="/static/images/logo_philips_hue.png",
+            submit_caption="I have pressed the button"
+        )

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -106,8 +106,6 @@ def setup(hass, config):
         setup_bridge(host, hass, filename, allow_unreachable,
                      allow_in_emulated_hue, allow_hue_groups)
 
-    discovery.load_platform(hass, 'light', DOMAIN, {}, config)
-
     return True
 
 
@@ -118,8 +116,6 @@ def bridge_discovered(hass, service, discovery_info):
 
     filename = 'phue-{}.conf'.format(serial)
     setup_bridge(host, hass, filename)
-
-    discovery.load_platform(hass, 'light', DOMAIN, discovery_info, {})
 
 
 def setup_bridge(host, hass, filename=None, allow_unreachable=False,
@@ -196,6 +192,10 @@ class HueBridge(object):
             configurator.request_done(request_id)
 
         self.configured = True
+
+        discovery.load_platform(
+            self.hass, 'light', DOMAIN,
+            {'bridge_id': socket.gethostbyname(self.host)})
 
         # create a service for calling run_scene directly on the bridge,
         # used to simplify automation rules.

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -39,9 +39,11 @@ DEFAULT_ALLOW_HUE_GROUPS = True
 
 BRIDGE_CONFIG_SCHEMA = vol.Schema([{
     vol.Optional(CONF_HOST): cv.string,
-    vol.Optional(CONF_FILENAME): cv.string,
-    vol.Optional(CONF_ALLOW_UNREACHABLE): cv.boolean,
-    vol.Optional(CONF_ALLOW_IN_EMULATED_HUE): cv.boolean,
+    vol.Optional(CONF_FILENAME, default=PHUE_CONFIG_FILE): cv.string,
+    vol.Optional(CONF_ALLOW_UNREACHABLE,
+                 default=DEFAULT_ALLOW_UNREACHABLE): cv.boolean,
+    vol.Optional(CONF_ALLOW_IN_EMULATED_HUE,
+                 default=DEFAULT_ALLOW_IN_EMULATED_HUE): cv.boolean,
     vol.Optional(CONF_ALLOW_HUE_GROUPS,
                  default=DEFAULT_ALLOW_HUE_GROUPS): cv.boolean,
 }])
@@ -87,15 +89,12 @@ def setup(hass, config):
         return True
 
     for bridge in bridges:
-        filename = bridge.get(CONF_FILENAME, PHUE_CONFIG_FILE)
-        allow_unreachable = bridge.get(CONF_ALLOW_UNREACHABLE,
-                                       DEFAULT_ALLOW_UNREACHABLE)
-        allow_in_emulated_hue = bridge.get(CONF_ALLOW_IN_EMULATED_HUE,
-                                           DEFAULT_ALLOW_IN_EMULATED_HUE)
-        allow_hue_groups = bridge.get(CONF_ALLOW_HUE_GROUPS,
-                                      DEFAULT_ALLOW_HUE_GROUPS)
+        filename = bridge.get(CONF_FILENAME)
+        allow_unreachable = bridge.get(CONF_ALLOW_UNREACHABLE)
+        allow_in_emulated_hue = bridge.get(CONF_ALLOW_IN_EMULATED_HUE)
+        allow_hue_groups = bridge.get(CONF_ALLOW_HUE_GROUPS)
 
-        host = bridge.get(CONF_HOST, None)
+        host = bridge.get(CONF_HOST)
 
         if host is None:
             host = _find_host_from_config(hass, filename)
@@ -145,7 +144,7 @@ def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
 
     try:
         with open(path) as inp:
-            return next(json.loads(''.join(inp)).keys().__iter__())
+            return next(iter(json.load(inp).keys()))
     except (ValueError, AttributeError, StopIteration):
         # ValueError if can't parse as JSON
         # AttributeError if JSON value is not a dict

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -75,6 +75,9 @@ def unthrottled_update_lights(hass, bridge, add_devices):
     """Internal version of update_lights (intended for unit tests)."""
     import phue
 
+    if not bridge.configured:
+        return
+
     try:
         api = bridge.get_api()
     except phue.PhueRequestTimeout:

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -90,6 +90,9 @@ for more information.
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Hue lights."""
+    if discovery_info is None or 'bridge_id' not in discovery_info:
+        return True
+
     setup_data(hass)
 
     if config is not None and len(config) > 0:
@@ -102,8 +105,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             title=MIGRATION_TITLE,
             notification_id=MIGRATION_ID)
 
-    for bridge in hass.data[hue.DOMAIN].values():
-        update_lights(hass, bridge, add_devices)
+    bridge_id = discovery_info['bridge_id']
+    bridge = hass.data[hue.DOMAIN][bridge_id]
+    unthrottled_update_lights(hass, bridge, add_devices)
 
     return True
 
@@ -121,7 +125,7 @@ def update_lights(hass, bridge, add_devices):
 
 
 def unthrottled_update_lights(hass, bridge, add_devices):
-    """Internal version of update_lights (intended for unit tests)."""
+    """Internal version of update_lights."""
     import phue
 
     if not bridge.configured:

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -31,7 +31,7 @@ DEPENDENCIES = ['hue']
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_KEY = 'hue.lights'
+DATA_KEY = 'hue_lights'
 DATA_LIGHTS = 'lights'
 DATA_LIGHTGROUPS = 'lightgroups'
 
@@ -83,15 +83,15 @@ You have configured at least one bridge:
 {config}
 
 This configuration is deprecated, please check the
-[Hue component](https://home-assistant.io/components/hue/) page on the wiki
-for more information.
+[Hue component](https://home-assistant.io/components/hue/) page for more
+information.
 """
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Hue lights."""
     if discovery_info is None or 'bridge_id' not in discovery_info:
-        return True
+        return
 
     setup_data(hass)
 
@@ -108,8 +108,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     bridge_id = discovery_info['bridge_id']
     bridge = hass.data[hue.DOMAIN][bridge_id]
     unthrottled_update_lights(hass, bridge, add_devices)
-
-    return True
 
 
 def setup_data(hass):

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -1,17 +1,15 @@
 """
-Support for Hue lights.
+This component provides light support for the Philips Hue system.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.hue/
 """
-import json
+from datetime import timedelta
 import logging
-import os
 import random
 import socket
-from datetime import timedelta
 
-import voluptuous as vol
+import homeassistant.components.hue as hue
 
 import homeassistant.util as util
 import homeassistant.util.color as color_util
@@ -20,30 +18,18 @@ from homeassistant.components.light import (
     ATTR_TRANSITION, ATTR_XY_COLOR, EFFECT_COLORLOOP, EFFECT_RANDOM,
     FLASH_LONG, FLASH_SHORT, SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP,
     SUPPORT_EFFECT, SUPPORT_FLASH, SUPPORT_RGB_COLOR, SUPPORT_TRANSITION,
-    SUPPORT_XY_COLOR, Light, PLATFORM_SCHEMA)
-from homeassistant.config import load_yaml_config_file
-from homeassistant.const import (CONF_FILENAME, CONF_HOST, DEVICE_DEFAULT_NAME)
+    SUPPORT_XY_COLOR, Light)
+from homeassistant.const import DEVICE_DEFAULT_NAME
 from homeassistant.components.emulated_hue import ATTR_EMULATED_HUE_HIDDEN
-import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['phue==1.0']
+DEPENDENCIES = ['hue']
 
-# Track previously setup bridges
-_CONFIGURED_BRIDGES = {}
-# Map ip to request id for configuring
-_CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ALLOW_UNREACHABLE = 'allow_unreachable'
-
-DEFAULT_ALLOW_UNREACHABLE = False
-DOMAIN = "light"
-SERVICE_HUE_SCENE = "hue_activate_scene"
+DOMAIN = "hue.lights"
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
-
-PHUE_CONFIG_FILE = 'phue.conf'
 
 SUPPORT_HUE_ON_OFF = (SUPPORT_FLASH | SUPPORT_TRANSITION)
 SUPPORT_HUE_DIMMABLE = (SUPPORT_HUE_ON_OFF | SUPPORT_BRIGHTNESS)
@@ -60,251 +46,139 @@ SUPPORT_HUE = {
     'Color temperature light': SUPPORT_HUE_COLOR_TEMP
     }
 
-CONF_ALLOW_IN_EMULATED_HUE = "allow_in_emulated_hue"
-DEFAULT_ALLOW_IN_EMULATED_HUE = True
-
-CONF_ALLOW_HUE_GROUPS = "allow_hue_groups"
-DEFAULT_ALLOW_HUE_GROUPS = True
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_HOST): cv.string,
-    vol.Optional(CONF_ALLOW_UNREACHABLE): cv.boolean,
-    vol.Optional(CONF_FILENAME): cv.string,
-    vol.Optional(CONF_ALLOW_IN_EMULATED_HUE): cv.boolean,
-    vol.Optional(CONF_ALLOW_HUE_GROUPS,
-                 default=DEFAULT_ALLOW_HUE_GROUPS): cv.boolean,
-})
-
-ATTR_GROUP_NAME = "group_name"
-ATTR_SCENE_NAME = "scene_name"
-SCENE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_GROUP_NAME): cv.string,
-    vol.Required(ATTR_SCENE_NAME): cv.string,
-})
-
 ATTR_IS_HUE_GROUP = "is_hue_group"
-
-CONFIG_INSTRUCTIONS = """
-Press the button on the bridge to register Philips Hue with Home Assistant.
-
-![Location of button on bridge](/static/images/config_philips_hue.jpg)
-"""
-
-
-def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
-    """Attempt to detect host based on existing configuration."""
-    path = hass.config.path(filename)
-
-    if not os.path.isfile(path):
-        return None
-
-    try:
-        with open(path) as inp:
-            return next(json.loads(''.join(inp)).keys().__iter__())
-    except (ValueError, AttributeError, StopIteration):
-        # ValueError if can't parse as JSON
-        # AttributeError if JSON value is not a dict
-        # StopIteration if no keys
-        return None
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Hue lights."""
-    # Default needed in case of discovery
-    filename = config.get(CONF_FILENAME, PHUE_CONFIG_FILE)
-    allow_unreachable = config.get(CONF_ALLOW_UNREACHABLE,
-                                   DEFAULT_ALLOW_UNREACHABLE)
-    allow_in_emulated_hue = config.get(CONF_ALLOW_IN_EMULATED_HUE,
-                                       DEFAULT_ALLOW_IN_EMULATED_HUE)
-    allow_hue_groups = config.get(CONF_ALLOW_HUE_GROUPS)
+    setup_data(hass)
 
-    if discovery_info is not None:
-        if "HASS Bridge" in discovery_info.get('name', ''):
-            _LOGGER.info("Emulated hue found, will not add")
-            return False
+    for bridge in hass.data[hue.DOMAIN].values():
+        update_lights(hass, bridge, add_devices)
 
-        host = discovery_info.get('host')
-    else:
-        host = config.get(CONF_HOST, None)
-
-        if host is None:
-            host = _find_host_from_config(hass, filename)
-
-        if host is None:
-            _LOGGER.error("No host found in configuration")
-            return False
-
-    # Only act if we are not already configuring this host
-    if host in _CONFIGURING or \
-            socket.gethostbyname(host) in _CONFIGURED_BRIDGES:
-        return
-
-    setup_bridge(host, hass, add_devices, filename, allow_unreachable,
-                 allow_in_emulated_hue, allow_hue_groups)
+    return True
 
 
-def setup_bridge(host, hass, add_devices, filename, allow_unreachable,
-                 allow_in_emulated_hue, allow_hue_groups):
-    """Set up a phue bridge based on host parameter."""
+def setup_data(hass):
+    """Initialize internal data. Useful from tests."""
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {'lights': {}, 'lightgroups': {}}
+
+
+@util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
+def update_lights(hass, bridge, add_devices):
+    """Update the Hue light objects with latest info from the bridge."""
+    return unthrottled_update_lights(hass, bridge, add_devices)
+
+
+def unthrottled_update_lights(hass, bridge, add_devices):
+    """Internal version of update_lights (intended for unit tests)."""
     import phue
 
     try:
-        bridge = phue.Bridge(
-            host,
-            config_file_path=hass.config.path(filename))
-    except ConnectionRefusedError:  # Wrong host was given
-        _LOGGER.error("Error connecting to the Hue bridge at %s", host)
-
+        api = bridge.get_api()
+    except phue.PhueRequestTimeout:
+        _LOGGER.warning("Timeout trying to reach the bridge")
+        return
+    except ConnectionRefusedError:
+        _LOGGER.error("The bridge refused the connection")
+        return
+    except socket.error:
+        # socket.error when we cannot reach Hue
+        _LOGGER.exception("Cannot reach the bridge")
         return
 
-    except phue.PhueRegistrationException:
-        _LOGGER.warning("Connected to Hue at %s but not registered.", host)
+    bridge_type = get_bridge_type(api)
 
-        request_configuration(host, hass, add_devices, filename,
-                              allow_unreachable, allow_in_emulated_hue,
-                              allow_hue_groups)
+    new_lights = process_lights(
+        hass, api, bridge, bridge_type,
+        lambda **kw: update_lights(hass, bridge, add_devices, **kw))
+    if bridge.allow_hue_groups:
+        new_lightgroups = process_groups(
+            hass, api, bridge, bridge_type,
+            lambda **kw: update_lights(hass, bridge, add_devices, **kw))
+        new_lights = new_lights + new_lightgroups
 
-        return
+    if new_lights:
+        add_devices(new_lights)
 
-    # If we came here and configuring this host, mark as done
-    if host in _CONFIGURING:
-        request_id = _CONFIGURING.pop(host)
-        configurator = hass.components.configurator
-        configurator.request_done(request_id)
 
-    lights = {}
-    lightgroups = {}
-    skip_groups = not allow_hue_groups
+def get_bridge_type(api):
+    """Return the bridge type."""
+    api_name = api.get('config').get('name')
+    if api_name in ('RaspBee-GW', 'deCONZ-GW'):
+        return 'deconz'
+    else:
+        return 'hue'
 
-    @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
-    def update_lights():
-        """Update the Hue light objects with latest info from the bridge."""
-        nonlocal skip_groups
 
-        try:
-            api = bridge.get_api()
-        except phue.PhueRequestTimeout:
-            _LOGGER.warning("Timeout trying to reach the bridge")
-            return
-        except ConnectionRefusedError:
-            _LOGGER.error("The bridge refused the connection")
-            return
-        except socket.error:
-            # socket.error when we cannot reach Hue
-            _LOGGER.exception("Cannot reach the bridge")
-            return
+def process_lights(hass, api, bridge, bridge_type, update_lights_cb):
+    """Set up HueLight objects for all lights."""
+    api_lights = api.get('lights')
 
-        api_lights = api.get('lights')
+    if not isinstance(api_lights, dict):
+        _LOGGER.error("Got unexpected result from Hue API")
+        return []
 
-        if not isinstance(api_lights, dict):
-            _LOGGER.error("Got unexpected result from Hue API")
-            return
+    new_lights = []
 
-        if skip_groups:
-            api_groups = {}
+    for light_id, info in api_lights.items():
+        if light_id not in hass.data[DOMAIN]['lights']:
+            hass.data[DOMAIN]['lights'][light_id] = HueLight(
+                int(light_id), info, bridge,
+                update_lights_cb,
+                bridge_type, bridge.allow_unreachable,
+                bridge.allow_in_emulated_hue)
+            new_lights.append(hass.data[DOMAIN]['lights'][light_id])
         else:
-            api_groups = api.get('groups')
+            hass.data[DOMAIN]['lights'][light_id].info = info
+            hass.data[DOMAIN]['lights'][light_id].schedule_update_ha_state()
 
-        if not isinstance(api_groups, dict):
-            _LOGGER.error("Got unexpected result from Hue API")
-            return
+    return new_lights
 
-        new_lights = []
 
-        api_name = api.get('config').get('name')
-        if api_name in ('RaspBee-GW', 'deCONZ-GW'):
-            bridge_type = 'deconz'
+def process_groups(hass, api, bridge, bridge_type, update_lights_cb):
+    """Set up HueLight objects for all groups."""
+    api_groups = api.get('groups')
+
+    if not isinstance(api_groups, dict):
+        _LOGGER.error("Got unexpected result from Hue API")
+        return []
+
+    new_lights = []
+
+    for lightgroup_id, info in api_groups.items():
+        if 'state' not in info:
+            _LOGGER.warning("Group info does not contain state. "
+                            "Please update your hub.")
+            return []
+
+        if lightgroup_id not in hass.data[DOMAIN]['lightgroups']:
+            hass.data[DOMAIN]['lightgroups'][lightgroup_id] = HueLight(
+                int(lightgroup_id), info, bridge,
+                update_lights_cb,
+                bridge_type, bridge.allow_unreachable,
+                bridge.allow_in_emulated_hue, True)
+            new_lights.append(hass.data[DOMAIN]['lightgroups'][lightgroup_id])
         else:
-            bridge_type = 'hue'
+            hass.data[DOMAIN]['lightgroups'][lightgroup_id].info = info
+            hass.data[DOMAIN]['lightgroups'][
+                lightgroup_id].schedule_update_ha_state()
 
-        for light_id, info in api_lights.items():
-            if light_id not in lights:
-                lights[light_id] = HueLight(int(light_id), info,
-                                            bridge, update_lights,
-                                            bridge_type, allow_unreachable,
-                                            allow_in_emulated_hue)
-                new_lights.append(lights[light_id])
-            else:
-                lights[light_id].info = info
-                lights[light_id].schedule_update_ha_state()
-
-        for lightgroup_id, info in api_groups.items():
-            if 'state' not in info:
-                _LOGGER.warning("Group info does not contain state. "
-                                "Please update your hub.")
-                skip_groups = True
-                break
-
-            if lightgroup_id not in lightgroups:
-                lightgroups[lightgroup_id] = HueLight(
-                    int(lightgroup_id), info, bridge, update_lights,
-                    bridge_type, allow_unreachable, allow_in_emulated_hue,
-                    True)
-                new_lights.append(lightgroups[lightgroup_id])
-            else:
-                lightgroups[lightgroup_id].info = info
-                lightgroups[lightgroup_id].schedule_update_ha_state()
-
-        if new_lights:
-            add_devices(new_lights)
-
-    _CONFIGURED_BRIDGES[socket.gethostbyname(host)] = True
-
-    # create a service for calling run_scene directly on the bridge,
-    # used to simplify automation rules.
-    def hue_activate_scene(call):
-        """Service to call directly into bridge to set scenes."""
-        group_name = call.data[ATTR_GROUP_NAME]
-        scene_name = call.data[ATTR_SCENE_NAME]
-        bridge.run_scene(group_name, scene_name)
-
-    descriptions = load_yaml_config_file(
-        os.path.join(os.path.dirname(__file__), 'services.yaml'))
-    hass.services.register(DOMAIN, SERVICE_HUE_SCENE, hue_activate_scene,
-                           descriptions.get(SERVICE_HUE_SCENE),
-                           schema=SCENE_SCHEMA)
-
-    update_lights()
-
-
-def request_configuration(host, hass, add_devices, filename,
-                          allow_unreachable, allow_in_emulated_hue,
-                          allow_hue_groups):
-    """Request configuration steps from the user."""
-    configurator = hass.components.configurator
-
-    # We got an error if this method is called while we are configuring
-    if host in _CONFIGURING:
-        configurator.notify_errors(
-            _CONFIGURING[host], "Failed to register, please try again.")
-
-        return
-
-    # pylint: disable=unused-argument
-    def hue_configuration_callback(data):
-        """Set up actions to do when our configuration callback is called."""
-        setup_bridge(host, hass, add_devices, filename, allow_unreachable,
-                     allow_in_emulated_hue, allow_hue_groups)
-
-    _CONFIGURING[host] = configurator.request_config(
-        "Philips Hue", hue_configuration_callback,
-        description=CONFIG_INSTRUCTIONS,
-        entity_picture="/static/images/logo_philips_hue.png",
-        submit_caption="I have pressed the button"
-    )
+    return new_lights
 
 
 class HueLight(Light):
     """Representation of a Hue light."""
 
-    def __init__(self, light_id, info, bridge, update_lights,
+    def __init__(self, light_id, info, bridge, update_lights_cb,
                  bridge_type, allow_unreachable, allow_in_emulated_hue,
                  is_group=False):
         """Initialize the light."""
         self.light_id = light_id
         self.info = info
         self.bridge = bridge
-        self.update_lights = update_lights
+        self.update_lights = update_lights_cb
         self.bridge_type = bridge_type
         self.allow_unreachable = allow_unreachable
         self.is_group = is_group
@@ -382,8 +256,9 @@ class HueLight(Light):
 
         if ATTR_XY_COLOR in kwargs:
             if self.info.get('manufacturername') == "OSRAM":
-                hue, sat = color_util.color_xy_to_hs(*kwargs[ATTR_XY_COLOR])
-                command['hue'] = hue
+                color_hue, sat = color_util.color_xy_to_hs(
+                    *kwargs[ATTR_XY_COLOR])
+                command['hue'] = color_hue
                 command['sat'] = sat
             else:
                 command['xy'] = kwargs[ATTR_XY_COLOR]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -530,7 +530,7 @@ pdunehd==1.3
 # homeassistant.components.media_player.pandora
 pexpect==4.0.1
 
-# homeassistant.components.light.hue
+# homeassistant.components.hue
 phue==1.0
 
 # homeassistant.components.rpi_pfio

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -58,6 +58,7 @@ TEST_REQUIREMENTS = (
     'numpy',
     'paho-mqtt',
     'pexpect',
+    'phue',
     'pilight',
     'pmsensor',
     'prometheus_client',

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -58,7 +58,6 @@ TEST_REQUIREMENTS = (
     'numpy',
     'paho-mqtt',
     'pexpect',
-    'phue',
     'pilight',
     'pmsensor',
     'prometheus_client',

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -62,18 +62,18 @@ class TestSetup(unittest.TestCase):
         """Test setup_platform without discovery info."""
         self.hass.data[hue.DOMAIN] = {}
         mock_add_devices = MagicMock()
-        config = {}
-        self.assertTrue(
-            hue_light.setup_platform(self.hass, config, mock_add_devices))
+
+        hue_light.setup_platform(self.hass, {}, mock_add_devices)
+
         mock_add_devices.assert_not_called()
 
     def test_setup_platform_no_bridge_id(self):
         """Test setup_platform without a bridge."""
         self.hass.data[hue.DOMAIN] = {}
         mock_add_devices = MagicMock()
-        config = {}
-        self.assertTrue(
-            hue_light.setup_platform(self.hass, config, mock_add_devices, {}))
+
+        hue_light.setup_platform(self.hass, {}, mock_add_devices, {})
+
         mock_add_devices.assert_not_called()
 
     def test_setup_platform_one_bridge(self):
@@ -81,15 +81,12 @@ class TestSetup(unittest.TestCase):
         mock_bridge = MagicMock()
         self.hass.data[hue.DOMAIN] = {'10.0.0.1': mock_bridge}
         mock_add_devices = MagicMock()
-        config = {
-            }
 
         with patch('homeassistant.components.light.hue.' +
                    'unthrottled_update_lights') as mock_update_lights:
-            self.assertTrue(
-                hue_light.setup_platform(
-                    self.hass, config, mock_add_devices,
-                    {'bridge_id': '10.0.0.1'}))
+            hue_light.setup_platform(
+                self.hass, {}, mock_add_devices,
+                {'bridge_id': '10.0.0.1'})
             mock_update_lights.assert_called_once_with(
                 self.hass, mock_bridge, mock_add_devices)
 
@@ -102,17 +99,16 @@ class TestSetup(unittest.TestCase):
             '192.168.0.10': mock_bridge2,
         }
         mock_add_devices = MagicMock()
-        config = {
-            }
 
         with patch('homeassistant.components.light.hue.' +
                    'unthrottled_update_lights') as mock_update_lights:
-            self.assertTrue(hue_light.setup_platform(
-                self.hass, config, mock_add_devices,
-                {'bridge_id': '10.0.0.1'}))
-            self.assertTrue(hue_light.setup_platform(
-                self.hass, config, mock_add_devices,
-                {'bridge_id': '192.168.0.10'}))
+            hue_light.setup_platform(
+                self.hass, {}, mock_add_devices,
+                {'bridge_id': '10.0.0.1'})
+            hue_light.setup_platform(
+                self.hass, {}, mock_add_devices,
+                {'bridge_id': '192.168.0.10'})
+
             mock_update_lights.assert_has_calls([
                 call(self.hass, mock_bridge, mock_add_devices),
                 call(self.hass, mock_bridge2, mock_add_devices),

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -1,0 +1,454 @@
+"""Philips Hue lights platform tests."""
+
+import logging
+import unittest
+import unittest.mock as mock
+from unittest.mock import call, MagicMock, patch
+
+from homeassistant.components import hue
+import homeassistant.components.light.hue as hue_light
+
+from tests.common import get_test_home_assistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TestSetup(unittest.TestCase):
+    """Test the Hue light platform."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.skip_teardown_stop = False
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        if not self.skip_teardown_stop:
+            self.hass.stop()
+
+    def setup_mocks_for_update_lights(self):
+        """Set up all mocks for update_lights tests."""
+        self.mock_bridge = MagicMock()
+        self.mock_bridge.allow_hue_groups = False
+        self.mock_api = MagicMock()
+        self.mock_bridge.get_api.return_value = self.mock_api
+        self.mock_bridge_type = MagicMock()
+        self.mock_lights = []
+        self.mock_groups = []
+        self.mock_add_devices = MagicMock()
+        hue_light.setup_data(self.hass)
+
+    def setup_mocks_for_process_lights(self):
+        """Set up all mocks for process_lights tests."""
+        self.mock_bridge = MagicMock()
+        self.mock_api = MagicMock()
+        self.mock_api.get.return_value = {}
+        self.mock_bridge.get_api.return_value = self.mock_api
+        self.mock_bridge_type = MagicMock()
+        hue_light.setup_data(self.hass)
+
+    def setup_mocks_for_process_groups(self):
+        """Set up all mocks for process_groups tests."""
+        self.mock_bridge = MagicMock()
+        self.mock_bridge.get_group.return_value = {
+            'name': 'Group 0', 'state': {'any_on': True}}
+        self.mock_api = MagicMock()
+        self.mock_api.get.return_value = {}
+        self.mock_bridge.get_api.return_value = self.mock_api
+        self.mock_bridge_type = MagicMock()
+        hue_light.setup_data(self.hass)
+
+    def test_setup_platform_no_bridge(self):
+        """Test setup_platform without a bridge."""
+        self.hass.data[hue.DOMAIN] = {}
+        mock_add_devices = MagicMock()
+        config = {}
+        self.assertTrue(
+            hue_light.setup_platform(self.hass, config, mock_add_devices))
+        mock_add_devices.assert_not_called()
+
+    def test_setup_platform_one_bridge(self):
+        """Test setup_platform with one bridge."""
+        mock_bridge = MagicMock()
+        self.hass.data[hue.DOMAIN] = {'10.0.0.1': mock_bridge}
+        mock_add_devices = MagicMock()
+        config = {
+            }
+
+        with patch('homeassistant.components.light.hue.update_lights') \
+                as mock_update_lights:
+            self.assertTrue(
+                hue_light.setup_platform(self.hass, config, mock_add_devices))
+            mock_update_lights.assert_called_once_with(
+                self.hass, mock_bridge, mock_add_devices)
+
+    def test_setup_platform_multiple_bridges(self):
+        """Test setup_platform wuth multiple bridges."""
+        mock_bridge = MagicMock()
+        mock_bridge2 = MagicMock()
+        self.hass.data[hue.DOMAIN] = {
+            '10.0.0.1': mock_bridge,
+            '192.168.0.10': mock_bridge2,
+        }
+        mock_add_devices = MagicMock()
+        config = {
+            }
+
+        with patch('homeassistant.components.light.hue.update_lights') \
+                as mock_update_lights:
+            self.assertTrue(hue_light.setup_platform(
+                self.hass, config, mock_add_devices))
+            # We don't care about the order, different python versions will
+            # behave differently and that's ok.
+            mock_update_lights.assert_has_calls([
+                call(self.hass, mock_bridge, mock_add_devices),
+                call(self.hass, mock_bridge2, mock_add_devices),
+            ], any_order=True)
+
+    def test_update_lights_with_no_lights(self):
+        """Test the update_lights function when no lights are found."""
+        self.setup_mocks_for_update_lights()
+
+        with patch('homeassistant.components.light.hue.get_bridge_type',
+                   return_value=self.mock_bridge_type):
+            with patch('homeassistant.components.light.hue.process_lights',
+                       return_value=[]) as mock_process_lights:
+                with patch('homeassistant.components.light.hue.process_groups',
+                           return_value=self.mock_groups) \
+                        as mock_process_groups:
+                    hue_light.unthrottled_update_lights(
+                        self.hass, self.mock_bridge, self.mock_add_devices)
+
+                    mock_process_lights.assert_called_once_with(
+                        self.hass, self.mock_api, self.mock_bridge,
+                        self.mock_bridge_type, mock.ANY)
+                    mock_process_groups.assert_not_called()
+                    self.mock_add_devices.assert_not_called()
+
+    def test_update_lights_with_some_lights(self):
+        """Test the update_lights function with some lights."""
+        self.setup_mocks_for_update_lights()
+        self.mock_lights = ['some', 'light']
+
+        with patch('homeassistant.components.light.hue.get_bridge_type',
+                   return_value=self.mock_bridge_type):
+            with patch('homeassistant.components.light.hue.process_lights',
+                       return_value=self.mock_lights) as mock_process_lights:
+                with patch('homeassistant.components.light.hue.process_groups',
+                           return_value=self.mock_groups) \
+                        as mock_process_groups:
+                    hue_light.unthrottled_update_lights(
+                        self.hass, self.mock_bridge, self.mock_add_devices)
+
+                    mock_process_lights.assert_called_once_with(
+                        self.hass, self.mock_api, self.mock_bridge,
+                        self.mock_bridge_type, mock.ANY)
+                    mock_process_groups.assert_not_called()
+                    self.mock_add_devices.assert_called_once_with(
+                        self.mock_lights)
+
+    def test_update_lights_no_groups(self):
+        """Test the update_lights function when no groups are found."""
+        self.setup_mocks_for_update_lights()
+        self.mock_bridge.allow_hue_groups = True
+        self.mock_lights = ['some', 'light']
+
+        with patch('homeassistant.components.light.hue.get_bridge_type',
+                   return_value=self.mock_bridge_type):
+            with patch('homeassistant.components.light.hue.process_lights',
+                       return_value=self.mock_lights) as mock_process_lights:
+                with patch('homeassistant.components.light.hue.process_groups',
+                           return_value=self.mock_groups) \
+                        as mock_process_groups:
+                    hue_light.unthrottled_update_lights(
+                        self.hass, self.mock_bridge, self.mock_add_devices)
+
+                    mock_process_lights.assert_called_once_with(
+                        self.hass, self.mock_api, self.mock_bridge,
+                        self.mock_bridge_type, mock.ANY)
+                    mock_process_groups.assert_called_once_with(
+                        self.hass, self.mock_api, self.mock_bridge,
+                        self.mock_bridge_type, mock.ANY)
+                    self.mock_add_devices.assert_called_once_with(
+                        self.mock_lights)
+
+    def test_update_lights_with_lights_and_groups(self):
+        """Test the update_lights function with both lights and groups."""
+        self.setup_mocks_for_update_lights()
+        self.mock_bridge.allow_hue_groups = True
+        self.mock_lights = ['some', 'light']
+        self.mock_groups = ['and', 'groups']
+
+        with patch('homeassistant.components.light.hue.get_bridge_type',
+                   return_value=self.mock_bridge_type):
+            with patch('homeassistant.components.light.hue.process_lights',
+                       return_value=self.mock_lights) as mock_process_lights:
+                with patch('homeassistant.components.light.hue.process_groups',
+                           return_value=self.mock_groups) \
+                        as mock_process_groups:
+                    hue_light.unthrottled_update_lights(
+                        self.hass, self.mock_bridge, self.mock_add_devices)
+
+                    mock_process_lights.assert_called_once_with(
+                        self.hass, self.mock_api, self.mock_bridge,
+                        self.mock_bridge_type, mock.ANY)
+                    mock_process_groups.assert_called_once_with(
+                        self.hass, self.mock_api, self.mock_bridge,
+                        self.mock_bridge_type, mock.ANY)
+                    self.mock_add_devices.assert_called_once_with(
+                        self.mock_lights + self.mock_groups)
+
+    def test_process_lights_api_error(self):
+        """Test the process_lights function when the bridge errors out."""
+        self.setup_mocks_for_process_lights()
+        self.mock_api.get.return_value = None
+
+        ret = hue_light.process_lights(
+            self.hass, self.mock_api, self.mock_bridge, self.mock_bridge_type,
+            None)
+
+        self.assertEquals([], ret)
+        self.assertEquals({}, self.hass.data[hue_light.DOMAIN]['lights'])
+
+    def test_process_lights_no_lights(self):
+        """Test the process_lights function when bridge returns no lights."""
+        self.setup_mocks_for_process_lights()
+
+        ret = hue_light.process_lights(
+            self.hass, self.mock_api, self.mock_bridge, self.mock_bridge_type,
+            None)
+
+        self.assertEquals([], ret)
+        self.assertEquals({}, self.hass.data[hue_light.DOMAIN]['lights'])
+
+    @patch('homeassistant.components.light.hue.HueLight')
+    def test_process_lights_some_lights(self, mock_hue_light):
+        """Test the process_lights function with multiple groups."""
+        self.setup_mocks_for_process_lights()
+        self.mock_api.get.return_value = {
+            1: {'state': 'on'}, 2: {'state': 'off'}}
+
+        ret = hue_light.process_lights(
+            self.hass, self.mock_api, self.mock_bridge, self.mock_bridge_type,
+            None)
+
+        self.assertEquals(len(ret), 2)
+        mock_hue_light.assert_has_calls([
+            call(
+                1, {'state': 'on'}, self.mock_bridge, mock.ANY,
+                self.mock_bridge_type, self.mock_bridge.allow_unreachable,
+                self.mock_bridge.allow_in_emulated_hue),
+            call(
+                2, {'state': 'off'}, self.mock_bridge, mock.ANY,
+                self.mock_bridge_type, self.mock_bridge.allow_unreachable,
+                self.mock_bridge.allow_in_emulated_hue),
+        ])
+        self.assertEquals(
+            len(self.hass.data[hue_light.DOMAIN]['lights']),
+            2)
+
+    @patch('homeassistant.components.light.hue.HueLight')
+    def test_process_lights_new_light(self, mock_hue_light):
+        """
+        Test the process_lights function with new groups.
+
+        Test what happens when we already have a light and a new one shows up.
+        """
+        self.setup_mocks_for_process_lights()
+        self.mock_api.get.return_value = {
+            1: {'state': 'on'}, 2: {'state': 'off'}}
+        self.hass.data[hue_light.DOMAIN]['lights'][1] = MagicMock()
+
+        ret = hue_light.process_lights(
+            self.hass, self.mock_api, self.mock_bridge, self.mock_bridge_type,
+            None)
+
+        self.assertEquals(len(ret), 1)
+        mock_hue_light.assert_has_calls([
+            call(
+                2, {'state': 'off'}, self.mock_bridge, mock.ANY,
+                self.mock_bridge_type, self.mock_bridge.allow_unreachable,
+                self.mock_bridge.allow_in_emulated_hue),
+        ])
+        self.hass.data[hue_light.DOMAIN]['lights'][
+            1].schedule_update_ha_state.assert_called_once_with()
+        self.assertEquals(
+            len(self.hass.data[hue_light.DOMAIN]['lights']),
+            2)
+
+    def test_process_groups_api_error(self):
+        """Test the process_groups function when the bridge errors out."""
+        self.setup_mocks_for_process_groups()
+        self.mock_api.get.return_value = None
+
+        ret = hue_light.process_groups(
+            self.hass, self.mock_api, self.mock_bridge, self.mock_bridge_type,
+            None)
+
+        self.assertEquals([], ret)
+        self.assertEquals({}, self.hass.data[hue_light.DOMAIN]['lightgroups'])
+
+    def test_process_groups_no_state(self):
+        """Test the process_groups function when bridge returns no status."""
+        self.setup_mocks_for_process_groups()
+        self.mock_bridge.get_group.return_value = {'name': 'Group 0'}
+
+        ret = hue_light.process_groups(
+            self.hass, self.mock_api, self.mock_bridge, self.mock_bridge_type,
+            None)
+
+        self.assertEquals([], ret)
+        self.assertEquals({}, self.hass.data[hue_light.DOMAIN]['lightgroups'])
+
+    @patch('homeassistant.components.light.hue.HueLight')
+    def test_process_groups_some_groups(self, mock_hue_light):
+        """Test the process_groups function with multiple groups."""
+        self.setup_mocks_for_process_groups()
+        self.mock_api.get.return_value = {
+            1: {'state': 'on'}, 2: {'state': 'off'}}
+
+        ret = hue_light.process_groups(
+            self.hass, self.mock_api, self.mock_bridge, self.mock_bridge_type,
+            None)
+
+        self.assertEquals(len(ret), 2)
+        mock_hue_light.assert_has_calls([
+            call(
+                1, {'state': 'on'}, self.mock_bridge, mock.ANY,
+                self.mock_bridge_type, self.mock_bridge.allow_unreachable,
+                self.mock_bridge.allow_in_emulated_hue, True),
+            call(
+                2, {'state': 'off'}, self.mock_bridge, mock.ANY,
+                self.mock_bridge_type, self.mock_bridge.allow_unreachable,
+                self.mock_bridge.allow_in_emulated_hue, True),
+        ])
+        self.assertEquals(
+            len(self.hass.data[hue_light.DOMAIN]['lightgroups']),
+            2)
+
+    @patch('homeassistant.components.light.hue.HueLight')
+    def test_process_groups_new_group(self, mock_hue_light):
+        """
+        Test the process_groups function with new groups.
+
+        Test what happens when we already have a light and a new one shows up.
+        """
+        self.setup_mocks_for_process_groups()
+        self.mock_api.get.return_value = {
+            1: {'state': 'on'}, 2: {'state': 'off'}}
+        self.hass.data[hue_light.DOMAIN]['lightgroups'][1] = MagicMock()
+
+        ret = hue_light.process_groups(
+            self.hass, self.mock_api, self.mock_bridge, self.mock_bridge_type,
+            None)
+
+        self.assertEquals(len(ret), 1)
+        mock_hue_light.assert_has_calls([
+            call(
+                2, {'state': 'off'}, self.mock_bridge, mock.ANY,
+                self.mock_bridge_type, self.mock_bridge.allow_unreachable,
+                self.mock_bridge.allow_in_emulated_hue, True),
+        ])
+        self.hass.data[hue_light.DOMAIN]['lightgroups'][
+            1].schedule_update_ha_state.assert_called_once_with()
+        self.assertEquals(
+            len(self.hass.data[hue_light.DOMAIN]['lightgroups']),
+            2)
+
+
+class TestHueLight(unittest.TestCase):
+    """Test the HueLight class."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.skip_teardown_stop = False
+
+        self.light_id = 42
+        self.mock_info = MagicMock()
+        self.mock_bridge = MagicMock()
+        self.mock_update_lights = MagicMock()
+        self.mock_bridge_type = MagicMock()
+        self.mock_allow_unreachable = MagicMock()
+        self.mock_is_group = MagicMock()
+        self.mock_allow_in_emulated_hue = MagicMock()
+        self.mock_is_group = False
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        if not self.skip_teardown_stop:
+            self.hass.stop()
+
+    def buildLight(
+            self, light_id=None, info=None, update_lights=None, is_group=None):
+        """Helper to build a HueLight object with minimal fuss."""
+        return hue_light.HueLight(
+            light_id if light_id is not None else self.light_id,
+            info if info is not None else self.mock_info,
+            self.mock_bridge,
+            (update_lights
+             if update_lights is not None
+             else self.mock_update_lights),
+            self.mock_bridge_type,
+            self.mock_allow_unreachable, self.mock_allow_in_emulated_hue,
+            is_group if is_group is not None else self.mock_is_group)
+
+    def test_unique_id_for_light(self):
+        """Test the unique_id method with lights."""
+        class_name = "<class 'homeassistant.components.light.hue.HueLight'>"
+
+        light = self.buildLight(info={'uniqueid': 'foobar'})
+        self.assertEquals(
+            class_name+'.foobar',
+            light.unique_id)
+
+        light = self.buildLight(info={})
+        self.assertEquals(
+            class_name+'.Unnamed Device.Light.42',
+            light.unique_id)
+
+        light = self.buildLight(info={'name': 'my-name'})
+        self.assertEquals(
+            class_name+'.my-name.Light.42',
+            light.unique_id)
+
+        light = self.buildLight(info={'type': 'my-type'})
+        self.assertEquals(
+            class_name+'.Unnamed Device.my-type.42',
+            light.unique_id)
+
+        light = self.buildLight(info={'name': 'a name', 'type': 'my-type'})
+        self.assertEquals(
+            class_name+'.a name.my-type.42',
+            light.unique_id)
+
+    def test_unique_id_for_group(self):
+        """Test the unique_id method with groups."""
+        class_name = "<class 'homeassistant.components.light.hue.HueLight'>"
+
+        light = self.buildLight(info={'uniqueid': 'foobar'}, is_group=True)
+        self.assertEquals(
+            class_name+'.foobar',
+            light.unique_id)
+
+        light = self.buildLight(info={}, is_group=True)
+        self.assertEquals(
+            class_name+'.Unnamed Device.Group.42',
+            light.unique_id)
+
+        light = self.buildLight(info={'name': 'my-name'}, is_group=True)
+        self.assertEquals(
+            class_name+'.my-name.Group.42',
+            light.unique_id)
+
+        light = self.buildLight(info={'type': 'my-type'}, is_group=True)
+        self.assertEquals(
+            class_name+'.Unnamed Device.my-type.42',
+            light.unique_id)
+
+        light = self.buildLight(
+            info={'name': 'a name', 'type': 'my-type'},
+            is_group=True)
+        self.assertEquals(
+            class_name+'.a name.my-type.42',
+            light.unique_id)

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -196,7 +196,7 @@ class TestSetup(unittest.TestCase):
                         self.hass, self.mock_api, self.mock_bridge,
                         self.mock_bridge_type, mock.ANY)
                     self.mock_add_devices.assert_called_once_with(
-                        self.mock_lights + self.mock_groups)
+                        self.mock_lights)
 
     def test_process_lights_api_error(self):
         """Test the process_lights function when the bridge errors out."""
@@ -208,7 +208,9 @@ class TestSetup(unittest.TestCase):
             None)
 
         self.assertEquals([], ret)
-        self.assertEquals({}, self.hass.data[hue_light.DOMAIN]['lights'])
+        self.assertEquals(
+            {},
+            self.hass.data[hue_light.DATA_KEY][hue_light.DATA_LIGHTS])
 
     def test_process_lights_no_lights(self):
         """Test the process_lights function when bridge returns no lights."""
@@ -219,7 +221,9 @@ class TestSetup(unittest.TestCase):
             None)
 
         self.assertEquals([], ret)
-        self.assertEquals({}, self.hass.data[hue_light.DOMAIN]['lights'])
+        self.assertEquals(
+            {},
+            self.hass.data[hue_light.DATA_KEY][hue_light.DATA_LIGHTS])
 
     @patch('homeassistant.components.light.hue.HueLight')
     def test_process_lights_some_lights(self, mock_hue_light):
@@ -244,7 +248,7 @@ class TestSetup(unittest.TestCase):
                 self.mock_bridge.allow_in_emulated_hue),
         ])
         self.assertEquals(
-            len(self.hass.data[hue_light.DOMAIN]['lights']),
+            len(self.hass.data[hue_light.DATA_KEY][hue_light.DATA_LIGHTS]),
             2)
 
     @patch('homeassistant.components.light.hue.HueLight')
@@ -257,7 +261,8 @@ class TestSetup(unittest.TestCase):
         self.setup_mocks_for_process_lights()
         self.mock_api.get.return_value = {
             1: {'state': 'on'}, 2: {'state': 'off'}}
-        self.hass.data[hue_light.DOMAIN]['lights'][1] = MagicMock()
+        self.hass.data[
+            hue_light.DATA_KEY][hue_light.DATA_LIGHTS][1] = MagicMock()
 
         ret = hue_light.process_lights(
             self.hass, self.mock_api, self.mock_bridge, self.mock_bridge_type,
@@ -270,10 +275,10 @@ class TestSetup(unittest.TestCase):
                 self.mock_bridge_type, self.mock_bridge.allow_unreachable,
                 self.mock_bridge.allow_in_emulated_hue),
         ])
-        self.hass.data[hue_light.DOMAIN]['lights'][
+        self.hass.data[hue_light.DATA_KEY][hue_light.DATA_LIGHTS][
             1].schedule_update_ha_state.assert_called_once_with()
         self.assertEquals(
-            len(self.hass.data[hue_light.DOMAIN]['lights']),
+            len(self.hass.data[hue_light.DATA_KEY][hue_light.DATA_LIGHTS]),
             2)
 
     def test_process_groups_api_error(self):
@@ -286,7 +291,9 @@ class TestSetup(unittest.TestCase):
             None)
 
         self.assertEquals([], ret)
-        self.assertEquals({}, self.hass.data[hue_light.DOMAIN]['lightgroups'])
+        self.assertEquals(
+            {},
+            self.hass.data[hue_light.DATA_KEY][hue_light.DATA_LIGHTGROUPS])
 
     def test_process_groups_no_state(self):
         """Test the process_groups function when bridge returns no status."""
@@ -298,7 +305,9 @@ class TestSetup(unittest.TestCase):
             None)
 
         self.assertEquals([], ret)
-        self.assertEquals({}, self.hass.data[hue_light.DOMAIN]['lightgroups'])
+        self.assertEquals(
+            {},
+            self.hass.data[hue_light.DATA_KEY][hue_light.DATA_LIGHTGROUPS])
 
     @patch('homeassistant.components.light.hue.HueLight')
     def test_process_groups_some_groups(self, mock_hue_light):
@@ -323,7 +332,8 @@ class TestSetup(unittest.TestCase):
                 self.mock_bridge.allow_in_emulated_hue, True),
         ])
         self.assertEquals(
-            len(self.hass.data[hue_light.DOMAIN]['lightgroups']),
+            len(self.hass.data[
+                hue_light.DATA_KEY][hue_light.DATA_LIGHTGROUPS]),
             2)
 
     @patch('homeassistant.components.light.hue.HueLight')
@@ -336,7 +346,8 @@ class TestSetup(unittest.TestCase):
         self.setup_mocks_for_process_groups()
         self.mock_api.get.return_value = {
             1: {'state': 'on'}, 2: {'state': 'off'}}
-        self.hass.data[hue_light.DOMAIN]['lightgroups'][1] = MagicMock()
+        self.hass.data[
+            hue_light.DATA_KEY][hue_light.DATA_LIGHTGROUPS][1] = MagicMock()
 
         ret = hue_light.process_groups(
             self.hass, self.mock_api, self.mock_bridge, self.mock_bridge_type,
@@ -349,10 +360,11 @@ class TestSetup(unittest.TestCase):
                 self.mock_bridge_type, self.mock_bridge.allow_unreachable,
                 self.mock_bridge.allow_in_emulated_hue, True),
         ])
-        self.hass.data[hue_light.DOMAIN]['lightgroups'][
+        self.hass.data[hue_light.DATA_KEY][hue_light.DATA_LIGHTGROUPS][
             1].schedule_update_ha_state.assert_called_once_with()
         self.assertEquals(
-            len(self.hass.data[hue_light.DOMAIN]['lightgroups']),
+            len(self.hass.data[
+                hue_light.DATA_KEY][hue_light.DATA_LIGHTGROUPS]),
             2)
 
 

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -8,7 +8,7 @@ from unittest.mock import call, MagicMock, patch
 from homeassistant.components import hue
 import homeassistant.components.light.hue as hue_light
 
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, MockDependency
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,7 +114,8 @@ class TestSetup(unittest.TestCase):
                 call(self.hass, mock_bridge2, mock_add_devices),
             ])
 
-    def test_update_lights_with_no_lights(self):
+    @MockDependency('phue')
+    def test_update_lights_with_no_lights(self, mock_phue):
         """Test the update_lights function when no lights are found."""
         self.setup_mocks_for_update_lights()
 
@@ -134,7 +135,8 @@ class TestSetup(unittest.TestCase):
                     mock_process_groups.assert_not_called()
                     self.mock_add_devices.assert_not_called()
 
-    def test_update_lights_with_some_lights(self):
+    @MockDependency('phue')
+    def test_update_lights_with_some_lights(self, mock_phue):
         """Test the update_lights function with some lights."""
         self.setup_mocks_for_update_lights()
         self.mock_lights = ['some', 'light']
@@ -156,7 +158,8 @@ class TestSetup(unittest.TestCase):
                     self.mock_add_devices.assert_called_once_with(
                         self.mock_lights)
 
-    def test_update_lights_no_groups(self):
+    @MockDependency('phue')
+    def test_update_lights_no_groups(self, mock_phue):
         """Test the update_lights function when no groups are found."""
         self.setup_mocks_for_update_lights()
         self.mock_bridge.allow_hue_groups = True
@@ -181,7 +184,8 @@ class TestSetup(unittest.TestCase):
                     self.mock_add_devices.assert_called_once_with(
                         self.mock_lights)
 
-    def test_update_lights_with_lights_and_groups(self):
+    @MockDependency('phue')
+    def test_update_lights_with_lights_and_groups(self, mock_phue):
         """Test the update_lights function with both lights and groups."""
         self.setup_mocks_for_update_lights()
         self.mock_bridge.allow_hue_groups = True

--- a/tests/components/test_hue.py
+++ b/tests/components/test_hue.py
@@ -68,7 +68,13 @@ class TestSetup(unittest.TestCase):
                 mock_load.assert_called_once_with(
                     self.hass, 'light', hue.DOMAIN, {},
                     {'bridges': [
-                        {'host': 'localhost', 'allow_hue_groups': True}]})
+                        {
+                            'host': 'localhost',
+                            'filename': 'phue.conf',
+                            'allow_in_emulated_hue': True,
+                            'allow_hue_groups': True,
+                            'allow_unreachable': False,
+                        }]})
 
                 self.assertTrue(hue.DOMAIN in self.hass.data)
                 self.assertEquals(1, len(self.hass.data[hue.DOMAIN]))
@@ -96,8 +102,12 @@ class TestSetup(unittest.TestCase):
                     mock_load.assert_called_once_with(
                         self.hass, 'light', hue.DOMAIN, {},
                         {'bridges': [
-                            {'filename': 'phue.conf', 'allow_hue_groups': True}
-                        ]})
+                            {
+                                'filename': 'phue.conf',
+                                'allow_in_emulated_hue': True,
+                                'allow_hue_groups': True,
+                                'allow_unreachable': False,
+                            }]})
 
                     self.assertTrue(hue.DOMAIN in self.hass.data)
                     self.assertEquals(1, len(self.hass.data[hue.DOMAIN]))
@@ -128,8 +138,21 @@ class TestSetup(unittest.TestCase):
                 mock_load.assert_called_once_with(
                     self.hass, 'light', hue.DOMAIN, {},
                     {'bridges': [
-                        {'host': 'localhost', 'allow_hue_groups': True},
-                        {'host': '192.168.0.1', 'allow_hue_groups': True}]})
+                        {
+                            'host': 'localhost',
+                            'filename': 'phue.conf',
+                            'allow_in_emulated_hue': True,
+                            'allow_hue_groups': True,
+                            'allow_unreachable': False,
+                        },
+                        {
+                            'host': '192.168.0.1',
+                            'filename': 'phue.conf',
+                            'allow_in_emulated_hue': True,
+                            'allow_hue_groups': True,
+                            'allow_unreachable': False,
+                        },
+                    ]})
 
                 self.assertTrue(hue.DOMAIN in self.hass.data)
                 self.assertEquals(2, len(self.hass.data[hue.DOMAIN]))
@@ -182,8 +205,13 @@ class TestSetup(unittest.TestCase):
                     call(
                         self.hass, 'light', hue.DOMAIN, {},
                         {'bridges': [
-                            {'host': '192.168.1.10', 'allow_hue_groups': True}
-                        ]}),
+                            {
+                                'host': '192.168.1.10',
+                                'filename': 'phue.conf',
+                                'allow_in_emulated_hue': True,
+                                'allow_hue_groups': True,
+                                'allow_unreachable': False,
+                            }]}),
                 ]
                 mock_load.assert_has_calls(calls_to_mock_load)
 

--- a/tests/components/test_hue.py
+++ b/tests/components/test_hue.py
@@ -66,15 +66,8 @@ class TestSetup(unittest.TestCase):
                     'localhost',
                     config_file_path=get_test_config_dir(hue.PHUE_CONFIG_FILE))
                 mock_load.assert_called_once_with(
-                    self.hass, 'light', hue.DOMAIN, {},
-                    {'bridges': [
-                        {
-                            'host': 'localhost',
-                            'filename': 'phue.conf',
-                            'allow_in_emulated_hue': True,
-                            'allow_hue_groups': True,
-                            'allow_unreachable': False,
-                        }]})
+                    self.hass, 'light', hue.DOMAIN,
+                    {'bridge_id': '127.0.0.1'})
 
                 self.assertTrue(hue.DOMAIN in self.hass.data)
                 self.assertEquals(1, len(self.hass.data[hue.DOMAIN]))
@@ -100,14 +93,8 @@ class TestSetup(unittest.TestCase):
                         config_file_path=get_test_config_dir(
                             hue.PHUE_CONFIG_FILE))
                     mock_load.assert_called_once_with(
-                        self.hass, 'light', hue.DOMAIN, {},
-                        {'bridges': [
-                            {
-                                'filename': 'phue.conf',
-                                'allow_in_emulated_hue': True,
-                                'allow_hue_groups': True,
-                                'allow_unreachable': False,
-                            }]})
+                        self.hass, 'light', hue.DOMAIN,
+                        {'bridge_id': '127.0.0.1'})
 
                     self.assertTrue(hue.DOMAIN in self.hass.data)
                     self.assertEquals(1, len(self.hass.data[hue.DOMAIN]))
@@ -135,24 +122,15 @@ class TestSetup(unittest.TestCase):
                         '192.168.0.1',
                         config_file_path=get_test_config_dir(
                             hue.PHUE_CONFIG_FILE))])
-                mock_load.assert_called_once_with(
-                    self.hass, 'light', hue.DOMAIN, {},
-                    {'bridges': [
-                        {
-                            'host': 'localhost',
-                            'filename': 'phue.conf',
-                            'allow_in_emulated_hue': True,
-                            'allow_hue_groups': True,
-                            'allow_unreachable': False,
-                        },
-                        {
-                            'host': '192.168.0.1',
-                            'filename': 'phue.conf',
-                            'allow_in_emulated_hue': True,
-                            'allow_hue_groups': True,
-                            'allow_unreachable': False,
-                        },
-                    ]})
+                mock_load.mock_bridge.assert_not_called()
+                mock_load.assert_has_calls([
+                    call(
+                        self.hass, 'light', hue.DOMAIN,
+                        {'bridge_id': '127.0.0.1'}),
+                    call(
+                        self.hass, 'light', hue.DOMAIN,
+                        {'bridge_id': '192.168.0.1'}),
+                ], any_order=True)
 
                 self.assertTrue(hue.DOMAIN in self.hass.data)
                 self.assertEquals(2, len(self.hass.data[hue.DOMAIN]))
@@ -175,8 +153,7 @@ class TestSetup(unittest.TestCase):
                 config_file_path=get_test_config_dir('phue-foobar.conf'))
             mock_load.assert_called_once_with(
                 self.hass, 'light', hue.DOMAIN,
-                {'host': '192.168.0.10', 'serial': 'foobar'},
-                {})
+                {'bridge_id': '192.168.0.10'})
 
             self.assertTrue(hue.DOMAIN in self.hass.data)
             self.assertEquals(1, len(self.hass.data[hue.DOMAIN]))
@@ -203,15 +180,8 @@ class TestSetup(unittest.TestCase):
                         hue.PHUE_CONFIG_FILE))
                 calls_to_mock_load = [
                     call(
-                        self.hass, 'light', hue.DOMAIN, {},
-                        {'bridges': [
-                            {
-                                'host': '192.168.1.10',
-                                'filename': 'phue.conf',
-                                'allow_in_emulated_hue': True,
-                                'allow_hue_groups': True,
-                                'allow_unreachable': False,
-                            }]}),
+                        self.hass, 'light', hue.DOMAIN,
+                        {'bridge_id': '192.168.1.10'}),
                 ]
                 mock_load.assert_has_calls(calls_to_mock_load)
 
@@ -226,12 +196,6 @@ class TestSetup(unittest.TestCase):
                     '192.168.1.10',
                     config_file_path=get_test_config_dir(
                         hue.PHUE_CONFIG_FILE))
-                calls_to_mock_load.append(
-                    call(
-                        self.hass, 'light', hue.DOMAIN,
-                        {'host': '192.168.1.10', 'serial': 'foobar'},
-                        {}),
-                )
                 mock_load.assert_has_calls(calls_to_mock_load)
 
                 # Still only one

--- a/tests/components/test_hue.py
+++ b/tests/components/test_hue.py
@@ -1,0 +1,255 @@
+"""Generic Philips Hue component tests."""
+
+import logging
+import unittest
+from unittest.mock import call, patch
+
+import phue
+
+from homeassistant.components import configurator, hue
+from homeassistant.const import CONF_HOST
+from homeassistant.setup import setup_component
+
+from tests.common import (
+    assert_setup_component, get_test_home_assistant, get_test_config_dir,
+    MockDependency
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TestSetup(unittest.TestCase):
+    """Test the Hue component."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.skip_teardown_stop = False
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        if not self.skip_teardown_stop:
+            self.hass.stop()
+
+    @MockDependency('phue')
+    def test_setup_no_domain(self, mock_phue):
+        """If it's not in the config we won't even try."""
+        with assert_setup_component(0):
+            self.assertFalse(setup_component(
+                self.hass, hue.DOMAIN, {}))
+            mock_phue.Bridge.assert_not_called()
+            self.assertFalse(hue.DOMAIN in self.hass.data)
+
+    @MockDependency('phue')
+    def test_setup_no_host(self, mock_phue):
+        """No host specified in any way."""
+        with assert_setup_component(1):
+            self.assertFalse(setup_component(
+                self.hass, hue.DOMAIN, {hue.DOMAIN: {}}))
+            mock_phue.Bridge.assert_not_called()
+            self.assertFalse(hue.DOMAIN in self.hass.data)
+
+    @MockDependency('phue')
+    def test_setup_with_host(self, mock_phue):
+        """Host specified in the config file."""
+        mock_bridge = mock_phue.Bridge
+
+        with assert_setup_component(2):
+            self.assertTrue(setup_component(
+                self.hass, hue.DOMAIN,
+                {hue.DOMAIN: {CONF_HOST: 'localhost'}}))
+
+            mock_bridge.assert_called_once_with(
+                'localhost',
+                config_file_path=get_test_config_dir(hue.PHUE_CONFIG_FILE))
+
+            self.assertTrue(hue.DOMAIN in self.hass.data)
+
+    @MockDependency('phue')
+    def test_setup_with_phue_conf(self, mock_phue):
+        """No host in the config file, but one is cached in phue.conf."""
+        mock_bridge = mock_phue.Bridge
+
+        with assert_setup_component(1):
+            with patch(
+                    'homeassistant.components.hue._find_host_from_config',
+                    return_value='localhost'):
+                self.assertTrue(setup_component(
+                    self.hass, hue.DOMAIN, {hue.DOMAIN: {}}))
+
+                mock_bridge.assert_called_once_with(
+                    'localhost',
+                    config_file_path=get_test_config_dir(
+                        hue.PHUE_CONFIG_FILE))
+                mock_load.assert_called_once_with(
+                    self.hass, 'light', hue.DOMAIN, {},
+                    {'allow_hue_groups': True})
+
+                self.assertTrue(hue.DOMAIN in self.hass.data)
+
+
+class TestHue(unittest.TestCase):
+    """Test the Hue class."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.skip_teardown_stop = False
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        if not self.skip_teardown_stop:
+            self.hass.stop()
+
+    @MockDependency('phue')
+    def test_setup_bridge_connection_refused(self, mock_phue):
+        """Test a registration failed with a connection refused exception."""
+        mock_bridge = mock_phue.Bridge
+        mock_bridge.side_effect = ConnectionRefusedError()
+
+        bridge = hue.HueBridge('localhost', self.hass, hue.PHUE_CONFIG_FILE)
+        bridge.setup()
+        self.assertFalse(bridge.configured)
+        self.assertTrue(bridge.config_request_id is None)
+
+        mock_bridge.assert_called_once_with(
+            'localhost',
+            config_file_path=get_test_config_dir(hue.PHUE_CONFIG_FILE))
+
+    @MockDependency('phue')
+    def test_setup_bridge_registration_exception(self, mock_phue):
+        """Test a registration failed with an exception."""
+        mock_bridge = mock_phue.Bridge
+        mock_phue.PhueRegistrationException = phue.PhueRegistrationException
+        mock_bridge.side_effect = mock_phue.PhueRegistrationException(1, 2)
+
+        bridge = hue.HueBridge('localhost', self.hass, hue.PHUE_CONFIG_FILE)
+        bridge.setup()
+        self.assertFalse(bridge.configured)
+        self.assertFalse(bridge.config_request_id is None)
+        self.assertTrue(isinstance(bridge.config_request_id, str))
+
+        mock_bridge.assert_called_once_with(
+            'localhost',
+            config_file_path=get_test_config_dir(hue.PHUE_CONFIG_FILE))
+
+    @MockDependency('phue')
+    def test_setup_bridge_registration_succeeds(self, mock_phue):
+        """Test a registration success sequence."""
+        mock_bridge = mock_phue.Bridge
+        mock_phue.PhueRegistrationException = phue.PhueRegistrationException
+        mock_bridge.side_effect = [
+            # First call, raise because not registered
+            mock_phue.PhueRegistrationException(1, 2),
+            # Second call, registration is done
+            None,
+        ]
+
+        bridge = hue.HueBridge('localhost', self.hass, hue.PHUE_CONFIG_FILE)
+        bridge.setup()
+        self.assertFalse(bridge.configured)
+        self.assertFalse(bridge.config_request_id is None)
+
+        # Simulate the user confirming the registration
+        self.hass.services.call(
+            configurator.DOMAIN, configurator.SERVICE_CONFIGURE,
+            {configurator.ATTR_CONFIGURE_ID: bridge.config_request_id})
+
+        self.hass.block_till_done()
+        self.assertTrue(bridge.configured)
+        self.assertTrue(bridge.config_request_id is None)
+
+        # We should see a total of two identical calls
+        args = call(
+            'localhost',
+            config_file_path=get_test_config_dir(hue.PHUE_CONFIG_FILE))
+        mock_bridge.assert_has_calls([args, args])
+
+        # Make sure the request is done
+        self.assertEqual(1, len(self.hass.states.all()))
+        self.assertEqual('configured', self.hass.states.all()[0].state)
+
+    @MockDependency('phue')
+    def test_setup_bridge_registration_fails(self, mock_phue):
+        """
+        Test a registration failure sequence.
+
+        This may happen when we start the registration process, the user
+        responds to the request but the bridge has become unreachable.
+        """
+        mock_bridge = mock_phue.Bridge
+        mock_phue.PhueRegistrationException = phue.PhueRegistrationException
+        mock_bridge.side_effect = [
+            # First call, raise because not registered
+            mock_phue.PhueRegistrationException(1, 2),
+            # Second call, the bridge has gone away
+            ConnectionRefusedError(),
+        ]
+
+        bridge = hue.HueBridge('localhost', self.hass, hue.PHUE_CONFIG_FILE)
+        bridge.setup()
+        self.assertFalse(bridge.configured)
+        self.assertFalse(bridge.config_request_id is None)
+
+        # Simulate the user confirming the registration
+        self.hass.services.call(
+            configurator.DOMAIN, configurator.SERVICE_CONFIGURE,
+            {configurator.ATTR_CONFIGURE_ID: bridge.config_request_id})
+
+        self.hass.block_till_done()
+        self.assertFalse(bridge.configured)
+        self.assertFalse(bridge.config_request_id is None)
+
+        # We should see a total of two identical calls
+        args = call(
+            'localhost',
+            config_file_path=get_test_config_dir(hue.PHUE_CONFIG_FILE))
+        mock_bridge.assert_has_calls([args, args])
+
+        # The request should still be pending
+        self.assertEqual(1, len(self.hass.states.all()))
+        self.assertEqual('configure', self.hass.states.all()[0].state)
+
+    @MockDependency('phue')
+    def test_setup_bridge_registration_retry(self, mock_phue):
+        """
+        Test a registration retry sequence.
+
+        This may happen when we start the registration process, the user
+        responds to the request but we fail to confirm it with the bridge.
+        """
+        mock_bridge = mock_phue.Bridge
+        mock_phue.PhueRegistrationException = phue.PhueRegistrationException
+        mock_bridge.side_effect = [
+            # First call, raise because not registered
+            mock_phue.PhueRegistrationException(1, 2),
+            # Second call, for whatever reason authentication fails
+            mock_phue.PhueRegistrationException(1, 2),
+        ]
+
+        bridge = hue.HueBridge('localhost', self.hass, hue.PHUE_CONFIG_FILE)
+        bridge.setup()
+        self.assertFalse(bridge.configured)
+        self.assertFalse(bridge.config_request_id is None)
+
+        # Simulate the user confirming the registration
+        self.hass.services.call(
+            configurator.DOMAIN, configurator.SERVICE_CONFIGURE,
+            {configurator.ATTR_CONFIGURE_ID: bridge.config_request_id})
+
+        self.hass.block_till_done()
+        self.assertFalse(bridge.configured)
+        self.assertFalse(bridge.config_request_id is None)
+
+        # We should see a total of two identical calls
+        args = call(
+            'localhost',
+            config_file_path=get_test_config_dir(hue.PHUE_CONFIG_FILE))
+        mock_bridge.assert_has_calls([args, args])
+
+        # Make sure the request is done
+        self.assertEqual(1, len(self.hass.states.all()))
+        self.assertEqual('configure', self.hass.states.all()[0].state)
+        self.assertEqual(
+            'Failed to register, please try again.',
+            self.hass.states.all()[0].attributes.get(configurator.ATTR_ERRORS))

--- a/tests/components/test_hue.py
+++ b/tests/components/test_hue.py
@@ -335,7 +335,7 @@ class TestHueBridge(unittest.TestCase):
         responds to the request but we fail to confirm it with the bridge.
         """
         mock_bridge = mock_phue.Bridge
-        mock_phue.PhueRegistrationException = phue.PhueRegistrationException
+        mock_phue.PhueRegistrationException = Exception
         mock_bridge.side_effect = [
             # First call, raise because not registered
             mock_phue.PhueRegistrationException(1, 2),

--- a/tests/components/test_hue.py
+++ b/tests/components/test_hue.py
@@ -4,8 +4,6 @@ import logging
 import unittest
 from unittest.mock import call, MagicMock, patch
 
-import phue
-
 from homeassistant.components import configurator, hue
 from homeassistant.const import CONF_FILENAME, CONF_HOST
 from homeassistant.setup import setup_component
@@ -236,7 +234,7 @@ class TestHueBridge(unittest.TestCase):
     def test_setup_bridge_registration_exception(self, mock_phue):
         """Test a registration failed with an exception."""
         mock_bridge = mock_phue.Bridge
-        mock_phue.PhueRegistrationException = phue.PhueRegistrationException
+        mock_phue.PhueRegistrationException = Exception
         mock_bridge.side_effect = mock_phue.PhueRegistrationException(1, 2)
 
         bridge = hue.HueBridge('localhost', self.hass, hue.PHUE_CONFIG_FILE)
@@ -253,7 +251,7 @@ class TestHueBridge(unittest.TestCase):
     def test_setup_bridge_registration_succeeds(self, mock_phue):
         """Test a registration success sequence."""
         mock_bridge = mock_phue.Bridge
-        mock_phue.PhueRegistrationException = phue.PhueRegistrationException
+        mock_phue.PhueRegistrationException = Exception
         mock_bridge.side_effect = [
             # First call, raise because not registered
             mock_phue.PhueRegistrationException(1, 2),
@@ -294,7 +292,7 @@ class TestHueBridge(unittest.TestCase):
         responds to the request but the bridge has become unreachable.
         """
         mock_bridge = mock_phue.Bridge
-        mock_phue.PhueRegistrationException = phue.PhueRegistrationException
+        mock_phue.PhueRegistrationException = Exception
         mock_bridge.side_effect = [
             # First call, raise because not registered
             mock_phue.PhueRegistrationException(1, 2),

--- a/tests/components/test_hue.py
+++ b/tests/components/test_hue.py
@@ -55,15 +55,20 @@ class TestSetup(unittest.TestCase):
         mock_bridge = mock_phue.Bridge
 
         with assert_setup_component(2):
-            self.assertTrue(setup_component(
-                self.hass, hue.DOMAIN,
-                {hue.DOMAIN: {CONF_HOST: 'localhost'}}))
+            with patch('homeassistant.helpers.discovery.load_platform') \
+                    as mock_load:
+                self.assertTrue(setup_component(
+                    self.hass, hue.DOMAIN,
+                    {hue.DOMAIN: {CONF_HOST: 'localhost'}}))
 
-            mock_bridge.assert_called_once_with(
-                'localhost',
-                config_file_path=get_test_config_dir(hue.PHUE_CONFIG_FILE))
+                mock_bridge.assert_called_once_with(
+                    'localhost',
+                    config_file_path=get_test_config_dir(hue.PHUE_CONFIG_FILE))
+                mock_load.assert_called_once_with(
+                    self.hass, 'light', hue.DOMAIN, {},
+                    {'host': 'localhost', 'allow_hue_groups': True})
 
-            self.assertTrue(hue.DOMAIN in self.hass.data)
+                self.assertTrue(hue.DOMAIN in self.hass.data)
 
     @MockDependency('phue')
     def test_setup_with_phue_conf(self, mock_phue):
@@ -74,22 +79,24 @@ class TestSetup(unittest.TestCase):
             with patch(
                     'homeassistant.components.hue._find_host_from_config',
                     return_value='localhost'):
-                self.assertTrue(setup_component(
-                    self.hass, hue.DOMAIN, {hue.DOMAIN: {}}))
+                with patch('homeassistant.helpers.discovery.load_platform') \
+                        as mock_load:
+                    self.assertTrue(setup_component(
+                        self.hass, hue.DOMAIN, {hue.DOMAIN: {}}))
 
-                mock_bridge.assert_called_once_with(
-                    'localhost',
-                    config_file_path=get_test_config_dir(
-                        hue.PHUE_CONFIG_FILE))
-                mock_load.assert_called_once_with(
-                    self.hass, 'light', hue.DOMAIN, {},
-                    {'allow_hue_groups': True})
+                    mock_bridge.assert_called_once_with(
+                        'localhost',
+                        config_file_path=get_test_config_dir(
+                            hue.PHUE_CONFIG_FILE))
+                    mock_load.assert_called_once_with(
+                        self.hass, 'light', hue.DOMAIN, {},
+                        {'allow_hue_groups': True})
 
-                self.assertTrue(hue.DOMAIN in self.hass.data)
+                    self.assertTrue(hue.DOMAIN in self.hass.data)
 
 
-class TestHue(unittest.TestCase):
-    """Test the Hue class."""
+class TestHueBridge(unittest.TestCase):
+    """Test the HueBridge class."""
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""


### PR DESCRIPTION
## Description:

This is in preparation to supporting sensors.

**Related issue (if applicable):** fixes #10609

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4099

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:
  bridges:
    - host: 192.168.0.40
    - host: 192.168.0.80
    - filename: /tmp/phue.conf
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54