### PR TITLE
Fix for time_date sensor

### DIFF
--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -90,7 +90,6 @@ class TimeDateSensor(Entity):
         if now is None:
             now = dt_util.utcnow()
         if self.type == 'date':
-            # now = dt_util.start_of_local_day()
             now = dt_util.start_of_local_day(dt_util.as_local(now))
             return now + timedelta(seconds=86400)
         elif self.type == 'beat':

--- a/homeassistant/components/sensor/time_date.py
+++ b/homeassistant/components/sensor/time_date.py
@@ -90,7 +90,8 @@ class TimeDateSensor(Entity):
         if now is None:
             now = dt_util.utcnow()
         if self.type == 'date':
-            now = dt_util.start_of_local_day(now)
+            # now = dt_util.start_of_local_day()
+            now = dt_util.start_of_local_day(dt_util.as_local(now))
             return now + timedelta(seconds=86400)
         elif self.type == 'beat':
             interval = 86.4

--- a/tests/components/sensor/test_time_date.py
+++ b/tests/components/sensor/test_time_date.py
@@ -1,6 +1,6 @@
 """The tests for Kira sensor platform."""
 import unittest
-from unittest import mock
+from unittest.mock import patch
 
 from homeassistant.components.sensor import time_date as time_date
 import homeassistant.util.dt as dt_util
@@ -91,12 +91,11 @@ class TestTimeDateSensor(unittest.TestCase):
         now = dt_util.parse_datetime('2017-11-13 19:47:19-07:00')
         device = time_date.TimeDateSensor(self.hass, 'date')
         next_time = device.get_next_interval(now)
-        assert next_time.timestamp() == \
-               dt_util.as_timestamp('2017-11-14 00:00:00-07:00')
+        assert (next_time.timestamp() ==
+                dt_util.as_timestamp('2017-11-14 00:00:00-07:00'))
 
-    @mock.patch('homeassistant.util.dt.utcnow',
-                return_value=
-                dt_util.parse_datetime('2017-11-14 02:47:19-00:00'))
+    @patch('homeassistant.util.dt.utcnow',
+           return_value=dt_util.parse_datetime('2017-11-14 02:47:19-00:00'))
     def test_timezone_intervals_empty_parameter(self, _):
         """Test get_interval() without parameters."""
         new_tz = dt_util.get_time_zone('America/Edmonton')
@@ -104,8 +103,8 @@ class TestTimeDateSensor(unittest.TestCase):
         dt_util.set_default_time_zone(new_tz)
         device = time_date.TimeDateSensor(self.hass, 'date')
         next_time = device.get_next_interval()
-        assert next_time.timestamp() == \
-               dt_util.as_timestamp('2017-11-14 00:00:00-07:00')
+        assert (next_time.timestamp() ==
+                dt_util.as_timestamp('2017-11-14 00:00:00-07:00'))
 
     def test_icons(self):
         """Test attributes of sensors."""

--- a/tests/components/sensor/test_time_date.py
+++ b/tests/components/sensor/test_time_date.py
@@ -1,11 +1,11 @@
 """The tests for Kira sensor platform."""
-import time
 import unittest
+from unittest import mock
 
 from homeassistant.components.sensor import time_date as time_date
 import homeassistant.util.dt as dt_util
 
-from common import get_test_home_assistant
+from tests.common import get_test_home_assistant
 
 
 class TestTimeDateSensor(unittest.TestCase):
@@ -36,18 +36,6 @@ class TestTimeDateSensor(unittest.TestCase):
         now = dt_util.utc_from_timestamp(45)
         next_time = device.get_next_interval(now)
         assert next_time == dt_util.utc_from_timestamp(60)
-
-        try:
-            t = time.time
-            time.time = lambda: 0
-            device = time_date.TimeDateSensor(self.hass, 'date')
-            now = dt_util.utc_from_timestamp(12345)
-            next_time = device.get_next_interval(now)
-            assert next_time == dt_util.utc_from_timestamp(86400)
-        finally:
-            time.time = t
-
-
 
         device = time_date.TimeDateSensor(self.hass, 'beat')
         now = dt_util.utc_from_timestamp(29)
@@ -96,6 +84,28 @@ class TestTimeDateSensor(unittest.TestCase):
         # start of local day in EST was 18000.0
         # so the second day was 18000 + 86400
         assert next_time.timestamp() == 104400
+
+        new_tz = dt_util.get_time_zone('America/Edmonton')
+        assert new_tz is not None
+        dt_util.set_default_time_zone(new_tz)
+        now = dt_util.parse_datetime('2017-11-13 19:47:19-07:00')
+        device = time_date.TimeDateSensor(self.hass, 'date')
+        next_time = device.get_next_interval(now)
+        assert next_time.timestamp() == \
+               dt_util.as_timestamp('2017-11-14 00:00:00-07:00')
+
+    @mock.patch('homeassistant.util.dt.utcnow',
+                return_value=
+                dt_util.parse_datetime('2017-11-14 02:47:19-00:00'))
+    def test_timezone_intervals_empty_parameter(self, _):
+        """Test get_interval() without parameters."""
+        new_tz = dt_util.get_time_zone('America/Edmonton')
+        assert new_tz is not None
+        dt_util.set_default_time_zone(new_tz)
+        device = time_date.TimeDateSensor(self.hass, 'date')
+        next_time = device.get_next_interval()
+        assert next_time.timestamp() == \
+               dt_util.as_timestamp('2017-11-14 00:00:00-07:00')
 
     def test_icons(self):
         """Test attributes of sensors."""

--- a/tests/components/sensor/test_time_date.py
+++ b/tests/components/sensor/test_time_date.py
@@ -1,10 +1,11 @@
 """The tests for Kira sensor platform."""
+import time
 import unittest
 
 from homeassistant.components.sensor import time_date as time_date
 import homeassistant.util.dt as dt_util
 
-from tests.common import get_test_home_assistant
+from common import get_test_home_assistant
 
 
 class TestTimeDateSensor(unittest.TestCase):
@@ -36,10 +37,17 @@ class TestTimeDateSensor(unittest.TestCase):
         next_time = device.get_next_interval(now)
         assert next_time == dt_util.utc_from_timestamp(60)
 
-        device = time_date.TimeDateSensor(self.hass, 'date')
-        now = dt_util.utc_from_timestamp(12345)
-        next_time = device.get_next_interval(now)
-        assert next_time == dt_util.utc_from_timestamp(86400)
+        try:
+            t = time.time
+            time.time = lambda: 0
+            device = time_date.TimeDateSensor(self.hass, 'date')
+            now = dt_util.utc_from_timestamp(12345)
+            next_time = device.get_next_interval(now)
+            assert next_time == dt_util.utc_from_timestamp(86400)
+        finally:
+            time.time = t
+
+
 
         device = time_date.TimeDateSensor(self.hass, 'beat')
         now = dt_util.utc_from_timestamp(29)


### PR DESCRIPTION
## Description:

This is a fix to `date` option of `time_date` sensor. 

**Related issue (if applicable):** fixes #10477

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
