### PR TITLE
Add presence device_class for binary_sensor

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -32,6 +32,7 @@ DEVICE_CLASSES = [
     'opening',       # Door, window, etc.
     'plug',          # On means plugged in, Off means unplugged
     'power',         # Power, over-current, etc
+    'presence',      # On means home, Off means away
     'safety',        # Generic on=unsafe, off=safe
     'smoke',         # Smoke detector
     'sound',         # On means sound detected, Off means no sound


### PR DESCRIPTION
## Description:
This should introduce a new device class for the binary sensor: "presence".

This has been frequently requested and used by folks to mark things home/away. 

**Related issue:** fixes https://community.home-assistant.io/t/presence-device-class/33186

Polymer PR: https://github.com/home-assistant/home-assistant-polymer/pull/659
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io):** home-assistant/home-assistant.github.io#4026

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
