### PR TITLE
KNX: new config option to broadcast outside temperature to KNX bus.

### DIFF
--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -27,6 +27,7 @@ CONF_KNX_LOCAL_IP = "local_ip"
 CONF_KNX_FIRE_EVENT = "fire_event"
 CONF_KNX_FIRE_EVENT_FILTER = "fire_event_filter"
 CONF_KNX_STATE_UPDATER = "state_updater"
+CONF_KNX_TIME_ADDRESS = "time_address"
 
 SERVICE_KNX_SEND = "send"
 SERVICE_KNX_ATTR_ADDRESS = "address"
@@ -60,6 +61,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.All(
                 cv.ensure_list,
                 [cv.string]),
+        vol.Optional(CONF_KNX_TIME_ADDRESS): cv.string,
         vol.Optional(CONF_KNX_STATE_UPDATER, default=True): cv.boolean,
     })
 }, extra=vol.ALLOW_EXTRA)
@@ -97,12 +99,26 @@ def async_setup(hass, config):
                 ATTR_DISCOVER_DEVICES: found_devices
             }, config))
 
+    if CONF_KNX_TIME_ADDRESS in config[DOMAIN]:
+        _add_time_device(hass, config)
+
     hass.services.async_register(
         DOMAIN, SERVICE_KNX_SEND,
         hass.data[DATA_KNX].service_send_to_knx_bus,
         schema=SERVICE_KNX_SEND_SCHEMA)
 
     return True
+
+
+def _add_time_device(hass, config):
+    """Create time broadcasting device and add it to xknx device queue."""
+    import xknx
+    group_address_time = config[DOMAIN][CONF_KNX_TIME_ADDRESS]
+    time = xknx.devices.Time(
+        hass.data[DATA_KNX].xknx,
+        'Time',
+        group_address=group_address_time)
+    hass.data[DATA_KNX].xknx.devices.add(time)
 
 
 def _get_devices(hass, discovery_type):

--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -12,6 +12,7 @@ import asyncio
 import voluptuous as vol
 
 from homeassistant.helpers import discovery
+from homeassistant.helpers.event import async_track_state_change
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, \
     CONF_HOST, CONF_PORT
@@ -28,6 +29,8 @@ CONF_KNX_FIRE_EVENT = "fire_event"
 CONF_KNX_FIRE_EVENT_FILTER = "fire_event_filter"
 CONF_KNX_STATE_UPDATER = "state_updater"
 CONF_KNX_TIME_ADDRESS = "time_address"
+CONF_KNX_OUTSIDE_TEMPERATURE_SENSOR = "outside_temperature_sensor"
+CONF_KNX_OUTSIDE_TEMPERATURE_ADDRESS = "outside_temperature_address"
 
 SERVICE_KNX_SEND = "send"
 SERVICE_KNX_ATTR_ADDRESS = "address"
@@ -63,6 +66,10 @@ CONFIG_SCHEMA = vol.Schema({
                 [cv.string]),
         vol.Optional(CONF_KNX_TIME_ADDRESS): cv.string,
         vol.Optional(CONF_KNX_STATE_UPDATER, default=True): cv.boolean,
+        vol.Inclusive(CONF_KNX_OUTSIDE_TEMPERATURE_SENSOR, 'outside_temp'):
+            cv.string,
+        vol.Inclusive(CONF_KNX_OUTSIDE_TEMPERATURE_ADDRESS, 'outside_temp'):
+            cv.string,
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -223,6 +230,12 @@ class KNXModule(object):
             self.xknx.telegram_queue.register_telegram_received_cb(
                 self.telegram_received_cb, address_filters)
 
+        if CONF_KNX_OUTSIDE_TEMPERATURE_ADDRESS in self.config[DOMAIN]:
+            sensor_entity_id = \
+                self.config[DOMAIN][CONF_KNX_OUTSIDE_TEMPERATURE_SENSOR]
+            async_track_state_change(self.hass, sensor_entity_id,
+                                     self.async_broadcast_temperature)
+
     @asyncio.coroutine
     def telegram_received_cb(self, telegram):
         """Callback invoked after a KNX telegram was received."""
@@ -251,6 +264,20 @@ class KNXModule(object):
         telegram = Telegram()
         telegram.payload = payload
         telegram.group_address = address
+        yield from self.xknx.telegrams.put(telegram)
+
+    @asyncio.coroutine
+    def async_broadcast_temperature(self, entity_id, old_state, new_state):
+        """Broadcast new temperature of sensor to KNX bus."""
+        from xknx.knx import Telegram, Address, DPTArray, DPTFloat
+        if new_state is None:
+            return
+        address = Address(
+            self.config[DOMAIN][CONF_KNX_OUTSIDE_TEMPERATURE_ADDRESS])
+        payload = DPTArray(DPTFloat().to_knx(float(new_state.state)))
+        telegram = Telegram()
+        telegram.group_address = address
+        telegram.payload = payload
         yield from self.xknx.telegrams.put(telegram)
 
 


### PR DESCRIPTION
## Description:

*NOTE:* Plase merge after #10654 has been merged.

Added config option for broadcasting time to KNX bus. 

Some devices (e.g. [Gira Touch sensor 3 plus](https://www.gira.de/gebaeudetechnik/systeme/knx-eib_system/knx-produkte/bediengeraete/tastsensor3/tastsensor-plus.html) ) are able to display the outside temperature in the display. With this new feature you can specify a hass temperature sensor which value is broadcasted to the KNX bus with a given KNX group address. 

**Related issue (if applicable):** fixes https://github.com/XKNX/xknx/issues/12

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here> (WILL ADD TOMORROW)

## Example entry for `configuration.yaml` (if applicable):
```yaml
knx:
    outside_temperature_sensor: 'sensor.owm_temperature'
    outside_temperature_address: '0/0/2'
```
