### PR TITLE
Added support for Plum Lightpad

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -366,6 +366,7 @@ omit =
     homeassistant/components/light/osramlightify.py
     homeassistant/components/light/rpi_gpio_pwm.py
     homeassistant/components/light/piglow.py
+    homeassistant/components/light/plum_lightpad.py
     homeassistant/components/light/sensehat.py
     homeassistant/components/light/tikteck.py
     homeassistant/components/light/tplink.py

--- a/homeassistant/components/light/plum_lightpad.py
+++ b/homeassistant/components/light/plum_lightpad.py
@@ -1,0 +1,102 @@
+"""
+Support for Plum Lightpad switches.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/light.plum_lightpad
+"""
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.light import (
+    PLATFORM_SCHEMA, ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
+
+REQUIREMENTS = ['plumlightpad==0.0.5']
+
+CONF_USER = 'username'
+CONF_PASSWORD = 'password'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_USER, default=None): cv.string,
+    vol.Optional(CONF_PASSWORD, default=None): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Setup the demo light platform."""
+    from plumlightpad import Plum
+
+    if (config.get(CONF_USER) is not None and
+            config.get(CONF_PASSWORD) is not None):
+        plum = Plum(config.get(CONF_USER), config.get(CONF_PASSWORD))
+        for key, value in plum.get_logical_loads().items():
+            add_devices_callback([
+                LogicalLoad(plum, key, value)
+            ])
+
+
+class LogicalLoad(Light):
+    """Represenation of a demo light."""
+
+    def __init__(
+            self, plum, llid, load):
+        """Initialize the light."""
+        self._plum = plum
+        self._llid = llid
+        self._name = load['name']
+
+        metrics = plum.get_metrics(self._llid)
+
+        self._brightness = metrics['level']
+        self._state = self._brightness > 0
+
+        # sign up for events from all of the LightPads.
+        for lpid in load['lightpads']:
+            plum.register_event_listener(lpid, self.__process_event)
+
+    def __process_event(self, event):
+        if event['type'] == 'dimmerchange':
+            self._brightness = event['level']
+            self._state = self._brightness != 0
+            self.schedule_update_ha_state()
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the light if any."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return self._brightness
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._state
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_BRIGHTNESS
+
+    def turn_on(self, **kwargs):
+        """Turn the light on."""
+        self._state = True
+
+        if ATTR_BRIGHTNESS in kwargs:
+            self._brightness = kwargs[ATTR_BRIGHTNESS]
+            self._plum.set_level(self._llid, self._brightness)
+        else:
+            self._plum.turn_on(self._llid)
+
+        self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn the light off."""
+        self._state = False
+        self._plum.turn_off(self._llid)
+        self.schedule_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -546,6 +546,9 @@ pizzapi==0.0.3
 # homeassistant.components.sensor.plex
 plexapi==3.0.3
 
+# homeassistant.components.light.plum_lightpad
+plumlightpad==0.0.5
+
 # homeassistant.components.sensor.mhz19
 # homeassistant.components.sensor.serial_pm
 pmsensor==0.4


### PR DESCRIPTION
## Description:
Added new plum lightpad component.

**Related issue (if applicable):** fixes N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4030
https://github.com/home-assistant/home-assistant.github.io/pull/4030

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: plum_lightpad
    username: xxxxxx
    password: xxxxxxx
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [N/A] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [N/A] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
