### PR TITLE
Adding "Queue count" sensor to SABnzdb

### DIFF
--- a/homeassistant/components/sensor/sabnzbd.py
+++ b/homeassistant/components/sensor/sabnzbd.py
@@ -41,6 +41,7 @@ SENSOR_TYPES = {
     'queue_remaining': ['Left', 'MB'],
     'disk_size': ['Disk', 'GB'],
     'disk_free': ['Disk Free', 'GB'],
+    'queue_count': ['Queue Count', None],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -212,6 +213,8 @@ class SabnzbdSensor(Entity):
                 self._state = self.sabnzb_client.queue.get('diskspacetotal1')
             elif self.type == 'disk_free':
                 self._state = self.sabnzb_client.queue.get('diskspace1')
+            elif self.type == 'queue_count':
+                self._state = self.sabnzb_client.queue.get('noofslots_total')
             else:
                 self._state = 'Unknown'
 


### PR DESCRIPTION
Adding another sensor to output the numeber of items in the SABnabd queue.  This is an alternative to displaying filesize, just a preference thing, as it is more meaningfull for me the way I use SABnzdb. 

Note this is my first time coding on github and I have no idea if I am doing things right, I assume that all I needed to do is add a couple of lines to the sensors available and also another line as to what to extract from the SABnzdb API, in this case I have called the sensor "queue_count" and it gets the value from the noofslots_total which as I understand - each slot is a separate download item. 

hope I did this correctly I did my best to follow the Pull request protocol - also I don't have a separate instance of home assistant running for testing so I have no way to test this code (and I don't know how I would switch to the dev channel either).  As I said I am a newb!

## Description:
Adds queue count as another sensor for SABnzdb sensor

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4034

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: sabnzbd
  host: YOUR_SABNZBD_HOST
  api_key: YOUR_API_KEY
  monitored_variables:
    - 'current_status'
    - 'speed'
    - 'queue_size'
    - 'queue_remaining'
    - 'disk_size'
    - 'disk_free'
    - 'queue_count'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
