### PR TITLE
Google assistant climate mode fix

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -124,7 +124,8 @@ def entity_to_device(entity: Entity, units: UnitSystem):
 
     if entity.domain == climate.DOMAIN:
         modes = ','.join(
-            m.lower() for m in entity.attributes.get(climate.ATTR_OPERATION_LIST, [])
+            m.lower() for m in entity.attributes.get(
+                climate.ATTR_OPERATION_LIST, [])
             if m.lower() in CLIMATE_SUPPORTED_MODES)
         device['attributes'] = {
             'availableThermostatModes': modes,
@@ -218,7 +219,6 @@ def determine_service(
     Attempt to return a tuple of service and service_data based on the entity
     and action requested.
     """
-
     _LOGGER.debug("Handling command %s with data %s", command, params)
     domain = entity_id.split('.')[0]
     service_data = {ATTR_ENTITY_ID: entity_id}  # type: Dict[str, Any]

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -124,14 +124,14 @@ def entity_to_device(entity: Entity, units: UnitSystem):
 
     if entity.domain == climate.DOMAIN:
         modes = ','.join(
-            m for m in entity.attributes.get(climate.ATTR_OPERATION_LIST, [])
-            if m in CLIMATE_SUPPORTED_MODES)
+            m.lower() for m in entity.attributes.get(climate.ATTR_OPERATION_LIST, [])
+            if m.lower() in CLIMATE_SUPPORTED_MODES)
         device['attributes'] = {
             'availableThermostatModes': modes,
             'thermostatTemperatureUnit':
             'F' if units.temperature_unit == TEMP_FAHRENHEIT else 'C',
         }
-
+        _LOGGER.debug('Thermostat attributes %s', device['attributes'])
     return device
 
 
@@ -143,7 +143,7 @@ def query_device(entity: Entity, units: UnitSystem) -> dict:
             return None
         return round(METRIC_SYSTEM.temperature(deg, units.temperature_unit), 1)
     if entity.domain == climate.DOMAIN:
-        mode = entity.attributes.get(climate.ATTR_OPERATION_MODE)
+        mode = entity.attributes.get(climate.ATTR_OPERATION_MODE).lower()
         if mode not in CLIMATE_SUPPORTED_MODES:
             mode = 'on'
         response = {
@@ -218,6 +218,8 @@ def determine_service(
     Attempt to return a tuple of service and service_data based on the entity
     and action requested.
     """
+
+    _LOGGER.debug("Handling command %s with data %s", command, params)
     domain = entity_id.split('.')[0]
     service_data = {ATTR_ENTITY_ID: entity_id}  # type: Dict[str, Any]
     # special media_player handling
@@ -260,7 +262,6 @@ def determine_service(
         service_data['brightness'] = int(brightness / 100 * 255)
         return (SERVICE_TURN_ON, service_data)
 
-    _LOGGER.debug("Handling command %s with data %s", command, params)
     if command == COMMAND_COLOR:
         color_data = params.get('color')
         if color_data is not None:


### PR DESCRIPTION
## Description:
Various thermostat sensors have a set of supported modes that differ from the globally supported Google Assistant climate modes in letter case only ("Cool" vs "cool"). The difference in case would prevent the Google Assistant component from reporting that those modes are supported and would typically cause it to report the thermostat as off. This fix converts all modes to lower case. 

**Related issue (if applicable):** fixes #10713

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
   Lint passed. Flake passed. Pydocstyle passed.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
