### PR TITLE
Use new DoorBirdPy (v0.1.0)

### DIFF
--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['DoorBirdPy==0.0.4']
+REQUIREMENTS = ['DoorBirdPy==0.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -23,7 +23,7 @@ certifi>=2017.4.17
 # DTLSSocket==0.1.4
 
 # homeassistant.components.doorbird
-DoorBirdPy==0.0.4
+DoorBirdPy==0.1.0
 
 # homeassistant.components.isy994
 PyISY==1.0.8


### PR DESCRIPTION
## Description:

There was a bug in DoorBirdPy 0.0.4 that I fixed in 0.1.0, but Home Assistant does not yet use the new library.

**Related issue (if applicable):** No issue reported but the bug that was fixed causes this:

```
2017-11-21 13:39:45 ERROR (MainThread) [homeassistant.setup] Error during setup of component doorbird
Traceback (most recent call last):
  File "/home/pi/homeassistant/lib/python3.5/site-packages/homeassistant/setup.py", line 193, in _async_setup_component
    component.setup, hass, processed_config)
  File "/usr/lib/python3.5/asyncio/futures.py", line 380, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.5/asyncio/tasks.py", line 304, in _wakeup
    future.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 293, in result
    raise self._exception
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/pi/homeassistant/lib/python3.5/site-packages/homeassistant/components/doorbird.py", line 32, in setup
    status = device.ready()
  File "/home/pi/homeassistant/lib/python3.5/site-packages/doorbirdpy/__init__.py", line 35, in ready
    code = json.loads(content)["BHA"]["RETURNCODE"]
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
