### PR TITLE
Load Ring camera only with Ring Protect plan activated

### DIFF
--- a/homeassistant/components/camera/ring.py
+++ b/homeassistant/components/camera/ring.py
@@ -59,8 +59,12 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             cams_no_plan.append(camera)
 
     # show notification for all cameras without an active subscription
-    for camera in cams_no_plan:
-        err_msg = "A Ring Protect plan is required for {}.".format(camera.name)
+    if cams_no_plan:
+        cameras = str(', '.join([camera for camera in cams_no_plan]))
+
+        err_msg = '''A Ring Protect Plan is required for the''' \
+                  ''' following cameras: {}.'''.format(cameras)
+
         _LOGGER.error(err_msg)
         hass.components.persistent_notification.create(
             'Error: {}<br />'

--- a/homeassistant/components/camera/ring.py
+++ b/homeassistant/components/camera/ring.py
@@ -60,7 +60,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     # show notification for all cameras without an active subscription
     if cams_no_plan:
-        cameras = str(', '.join([camera for camera in cams_no_plan]))
+        cameras = str(', '.join([camera.name for camera in cams_no_plan]))
 
         err_msg = '''A Ring Protect Plan is required for the''' \
                   ''' following cameras: {}.'''.format(cameras)

--- a/homeassistant/components/camera/ring.py
+++ b/homeassistant/components/camera/ring.py
@@ -66,7 +66,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                   ''' following cameras: {}.'''.format(cameras)
 
         _LOGGER.error(err_msg)
-        hass.components.persistent_notification.create(
+        hass.components.persistent_notification.async_create(
             'Error: {}<br />'
             'You will need to restart hass after fixing.'
             ''.format(err_msg),

--- a/homeassistant/components/camera/ring.py
+++ b/homeassistant/components/camera/ring.py
@@ -12,7 +12,8 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.helpers import config_validation as cv
-from homeassistant.components.ring import DATA_RING, CONF_ATTRIBUTION
+from homeassistant.components.ring import (
+    DATA_RING, CONF_ATTRIBUTION, NOTIFICATION_ID)
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.components.ffmpeg import DATA_FFMPEG
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_SCAN_INTERVAL
@@ -26,6 +27,8 @@ DEPENDENCIES = ['ring', 'ffmpeg']
 FORCE_REFRESH_INTERVAL = timedelta(minutes=45)
 
 _LOGGER = logging.getLogger(__name__)
+
+NOTIFICATION_TITLE = 'Ring Camera Setup'
 
 SCAN_INTERVAL = timedelta(seconds=90)
 
@@ -42,11 +45,29 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     ring = hass.data[DATA_RING]
 
     cams = []
+    cams_no_plan = []
     for camera in ring.doorbells:
-        cams.append(RingCam(hass, camera, config))
+        if camera.has_subscription:
+            cams.append(RingCam(hass, camera, config))
+        else:
+            cams_no_plan.append(camera)
 
     for camera in ring.stickup_cams:
-        cams.append(RingCam(hass, camera, config))
+        if camera.has_subscription:
+            cams.append(RingCam(hass, camera, config))
+        else:
+            cams_no_plan.append(camera)
+
+    # show notification for all cameras without an active subscription
+    for camera in cams_no_plan:
+        err_msg = "A Ring Protect plan is required for {}.".format(camera.name)
+        _LOGGER.error(err_msg)
+        hass.components.persistent_notification.create(
+            'Error: {}<br />'
+            'You will need to restart hass after fixing.'
+            ''.format(err_msg),
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID)
 
     async_add_devices(cams, True)
     return True
@@ -84,7 +105,6 @@ class RingCam(Camera):
             'timezone': self._camera.timezone,
             'type': self._camera.family,
             'video_url': self._video_url,
-            'video_id': self._last_video_id
         }
 
     @asyncio.coroutine

--- a/homeassistant/components/ring.py
+++ b/homeassistant/components/ring.py
@@ -12,14 +12,14 @@ from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
 from requests.exceptions import HTTPError, ConnectTimeout
 
-REQUIREMENTS = ['ring_doorbell==0.1.7']
+REQUIREMENTS = ['ring_doorbell==0.1.8']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ATTRIBUTION = "Data provided by Ring.com"
 
 NOTIFICATION_ID = 'ring_notification'
-NOTIFICATION_TITLE = 'Ring Sensor Setup'
+NOTIFICATION_TITLE = 'Ring Setup'
 
 DATA_RING = 'ring'
 DOMAIN = 'ring'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -952,7 +952,7 @@ restrictedpython==4.0b2
 rflink==0.0.34
 
 # homeassistant.components.ring
-ring_doorbell==0.1.7
+ring_doorbell==0.1.8
 
 # homeassistant.components.notify.rocketchat
 rocketchat-API==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -144,7 +144,7 @@ restrictedpython==4.0b2
 rflink==0.0.34
 
 # homeassistant.components.ring
-ring_doorbell==0.1.7
+ring_doorbell==0.1.8
 
 # homeassistant.components.media_player.yamaha
 rxv==0.5.1


### PR DESCRIPTION
## Description:
The company Ring.com now enforces its users to have a valid subscription plan called *Ring Protect plan*  in order to be able to see the videos. 

This PR make sure that the Ring camera component will be only loaded if the device/account has a valid subscription.

 _Note that a subscription is not required for Ring sensors component._

**Related issue (if applicable):** fixes #10736
**HASS Forums**: https://community.home-assistant.io/t/ring-doorbell/7943/35

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4040  Many thanks to @arsaboo 


## Example entry for `configuration.yaml` (if applicable):
```yaml
ring:
   username: foor@bar
   password: secret

camera:
   - platform: ring
```
Here we can see a screenshot of 2 Ring cameras. One has a subscription and the other does not. 

![image](https://user-images.githubusercontent.com/809840/33157803-b5f8cf00-cfd2-11e7-82dd-325b4c1c591f.png)


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) Many thanks to @arsaboo 

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.