### PR TITLE
Add transmission rate

### DIFF
--- a/homeassistant/components/sensor/fritzbox_netmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_netmonitor.py
@@ -25,8 +25,8 @@ CONF_DEFAULT_IP = '169.254.1.1'  # This IP is valid for all FRITZ!Box routers.
 
 ATTR_BYTES_RECEIVED = 'bytes_received'
 ATTR_BYTES_SENT = 'bytes_sent'
-ATTR_TRANSMISSION_RATE_UPSTREAM = 'transmission_rate_upstream'
-ATTR_TRANSMISSION_RATE_DOWNSTREAM = 'transmission_rate_downstream'
+ATTR_TRANSMISSION_RATE_UP = 'transmission_rate_up'
+ATTR_TRANSMISSION_RATE_DOWN = 'transmission_rate_down'
 ATTR_EXTERNAL_IP = 'external_ip'
 ATTR_IS_CONNECTED = 'is_connected'
 ATTR_IS_LINKED = 'is_linked'
@@ -80,8 +80,8 @@ class FritzboxMonitorSensor(Entity):
         self._is_linked = self._is_connected = self._wan_access_type = None
         self._external_ip = self._uptime = None
         self._bytes_sent = self._bytes_received = None
-        self._transmission_rate_upstream = None
-        self._transmission_rate_downstream = None
+        self._transmission_rate_up = None
+        self._transmission_rate_down = None
         self._max_byte_rate_up = self._max_byte_rate_down = None
 
     @property
@@ -113,8 +113,8 @@ class FritzboxMonitorSensor(Entity):
             ATTR_UPTIME: self._uptime,
             ATTR_BYTES_SENT: self._bytes_sent,
             ATTR_BYTES_RECEIVED: self._bytes_received,
-            ATTR_TRANSMISSION_RATE_UPSTREAM: self._transmission_rate_upstream,
-            ATTR_TRANSMISSION_RATE_DOWNSTREAM: self._transmission_rate_downstream,
+            ATTR_TRANSMISSION_RATE_UP: self._transmission_rate_up,
+            ATTR_TRANSMISSION_RATE_DOWN: self._transmission_rate_down,
             ATTR_MAX_BYTE_RATE_UP: self._max_byte_rate_up,
             ATTR_MAX_BYTE_RATE_DOWN: self._max_byte_rate_down,
         }
@@ -132,8 +132,8 @@ class FritzboxMonitorSensor(Entity):
             self._bytes_sent = self._fstatus.bytes_sent
             self._bytes_received = self._fstatus.bytes_received
             transmission_rate = self._fstatus.transmission_rate
-            self._transmission_rate_upstream = transmission_rate[0]
-            self._transmission_rate_downstream = transmission_rate[1]
+            self._transmission_rate_up = transmission_rate[0]
+            self._transmission_rate_down = transmission_rate[1]
             self._max_byte_rate_up = self._fstatus.max_byte_rate[0]
             self._max_byte_rate_down = self._fstatus.max_byte_rate[1]
             self._state = STATE_ONLINE if self._is_connected else STATE_OFFLINE

--- a/homeassistant/components/sensor/fritzbox_netmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_netmonitor.py
@@ -25,6 +25,8 @@ CONF_DEFAULT_IP = '169.254.1.1'  # This IP is valid for all FRITZ!Box routers.
 
 ATTR_BYTES_RECEIVED = 'bytes_received'
 ATTR_BYTES_SENT = 'bytes_sent'
+ATTR_TRANSMISSION_RATE_UPSTREAM = 'transmission_rate_upstream'
+ATTR_TRANSMISSION_RATE_DOWNSTREAM = 'transmission_rate_downstream'
 ATTR_EXTERNAL_IP = 'external_ip'
 ATTR_IS_CONNECTED = 'is_connected'
 ATTR_IS_LINKED = 'is_linked'
@@ -78,6 +80,8 @@ class FritzboxMonitorSensor(Entity):
         self._is_linked = self._is_connected = self._wan_access_type = None
         self._external_ip = self._uptime = None
         self._bytes_sent = self._bytes_received = None
+        self._transmission_rate_upstream = None
+        self._transmission_rate_downstream = None
         self._max_byte_rate_up = self._max_byte_rate_down = None
 
     @property
@@ -109,6 +113,8 @@ class FritzboxMonitorSensor(Entity):
             ATTR_UPTIME: self._uptime,
             ATTR_BYTES_SENT: self._bytes_sent,
             ATTR_BYTES_RECEIVED: self._bytes_received,
+            ATTR_TRANSMISSION_RATE_UPSTREAM: self._transmission_rate_upstream,
+            ATTR_TRANSMISSION_RATE_DOWNSTREAM: self._transmission_rate_downstream,
             ATTR_MAX_BYTE_RATE_UP: self._max_byte_rate_up,
             ATTR_MAX_BYTE_RATE_DOWN: self._max_byte_rate_down,
         }
@@ -125,6 +131,9 @@ class FritzboxMonitorSensor(Entity):
             self._uptime = self._fstatus.uptime
             self._bytes_sent = self._fstatus.bytes_sent
             self._bytes_received = self._fstatus.bytes_received
+            transmission_rate = self._fstatus.transmission_rate
+            self._transmission_rate_upstream = transmission_rate[0]
+            self._transmission_rate_downstream = transmission_rate[1]
             self._max_byte_rate_up = self._fstatus.max_byte_rate[0]
             self._max_byte_rate_down = self._fstatus.max_byte_rate[1]
             self._state = STATE_ONLINE if self._is_connected else STATE_OFFLINE


### PR DESCRIPTION
## Description:
Add transmission rate as it was originally intended in #5469. For some reason, this was removed during refactoring. It works just fine and should be added for completeness as it's a very useful attribute to query.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4042

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: template
    internet_upstream:
      value_template: '{{ states.sensor.fritz_netmonitor.attributes.transmission_rate_up }}'
      friendly_name: 'Bytes sent per second'
      unit_of_measurement: 'bytes/s'
    internet_downstream:
      value_template: '{{ states.sensor.fritz_netmonitor.attributes.transmission_rate_down }}'
      friendly_name: 'Bytes receiving per second'
      unit_of_measurement: 'bytes/s'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
