### PR TITLE
Add option to set default hide if away for new devices

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -53,6 +53,7 @@ YAML_DEVICES = 'known_devices.yaml'
 
 CONF_TRACK_NEW = 'track_new_devices'
 DEFAULT_TRACK_NEW = True
+CONF_NEW_DEVICE_DEFAULTS = 'new_device_defaults'
 
 CONF_CONSIDER_HOME = 'consider_home'
 DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
@@ -81,13 +82,18 @@ ATTR_VENDOR = 'vendor'
 SOURCE_TYPE_GPS = 'gps'
 SOURCE_TYPE_ROUTER = 'router'
 
+NEW_DEVICE_DEFAULTS_SCHEMA = vol.Any(None, vol.Schema({
+    vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
+    vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
+}))
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
     vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
-    vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
     vol.Optional(CONF_CONSIDER_HOME,
                  default=DEFAULT_CONSIDER_HOME): vol.All(
-                     cv.time_period, cv.positive_timedelta)
+                     cv.time_period, cv.positive_timedelta),
+    vol.Optional(CONF_NEW_DEVICE_DEFAULTS,
+                 default={}): NEW_DEVICE_DEFAULTS_SCHEMA
 })
 
 
@@ -126,11 +132,11 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
     conf = conf[0] if conf else {}
     consider_home = conf.get(CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME)
     track_new = conf.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
-    hide_if_away = conf.get(CONF_AWAY_HIDE, DEFAULT_AWAY_HIDE)
+    defaults = conf.get(CONF_NEW_DEVICE_DEFAULTS, {})
 
     devices = yield from async_load_config(yaml_path, hass, consider_home)
     tracker = DeviceTracker(
-        hass, consider_home, track_new, hide_if_away, devices)
+        hass, consider_home, track_new, defaults, devices)
 
     @asyncio.coroutine
     def async_setup_platform(p_type, p_config, disc_info=None):
@@ -214,15 +220,15 @@ class DeviceTracker(object):
     """Representation of a device tracker."""
 
     def __init__(self, hass: HomeAssistantType, consider_home: timedelta,
-                 track_new: bool, hide_if_away: bool,
+                 track_new: bool, defaults: dict,
                  devices: Sequence) -> None:
         """Initialize a device tracker."""
         self.hass = hass
         self.devices = {dev.dev_id: dev for dev in devices}
         self.mac_to_dev = {dev.mac: dev for dev in devices if dev.mac}
         self.consider_home = consider_home
-        self.track_new = track_new
-        self.hide_if_away = hide_if_away
+        self.track_new = defaults.get(CONF_TRACK_NEW, track_new)
+        self.hide_if_away = defaults.get(CONF_AWAY_HIDE, DEFAULT_AWAY_HIDE)
         self.group = None
         self._is_updating = asyncio.Lock(loop=hass.loop)
 

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -228,7 +228,7 @@ class DeviceTracker(object):
         self.mac_to_dev = {dev.mac: dev for dev in devices if dev.mac}
         self.consider_home = consider_home
         self.track_new = defaults.get(CONF_TRACK_NEW, track_new)
-        self.hide_if_away = defaults.get(CONF_AWAY_HIDE, DEFAULT_AWAY_HIDE)
+        self.defaults = defaults
         self.group = None
         self._is_updating = asyncio.Lock(loop=hass.loop)
 
@@ -285,7 +285,8 @@ class DeviceTracker(object):
         device = Device(
             self.hass, self.consider_home, self.track_new,
             dev_id, mac, (host_name or dev_id).replace('_', ' '),
-            picture=picture, icon=icon, hide_if_away=self.hide_if_away)
+            picture=picture, icon=icon,
+            hide_if_away=self.defaults.get(CONF_AWAY_HIDE, DEFAULT_AWAY_HIDE))
         self.devices[dev_id] = device
         if mac is not None:
             self.mac_to_dev[mac] = device

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.components.device_tracker import (
-    CONF_CONSIDER_HOME, CONF_TRACK_NEW)
+    CONF_CONSIDER_HOME, CONF_TRACK_NEW, CONF_AWAY_HIDE)
 from homeassistant.components.device_tracker.asuswrt import (
     CONF_PROTOCOL, CONF_MODE, CONF_PUB_KEY, DOMAIN,
     CONF_PORT, PLATFORM_SCHEMA)
@@ -78,6 +78,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
                 CONF_USERNAME: 'fake_user',
                 CONF_PASSWORD: 'fake_pass',
                 CONF_TRACK_NEW: True,
+                CONF_AWAY_HIDE: False,
                 CONF_CONSIDER_HOME: timedelta(seconds=180)
             }
         }
@@ -104,6 +105,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
                 CONF_USERNAME: 'fake_user',
                 CONF_PUB_KEY: FAKEFILE,
                 CONF_TRACK_NEW: True,
+                CONF_AWAY_HIDE: True,
                 CONF_CONSIDER_HOME: timedelta(seconds=180)
             }
         }

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -9,7 +9,8 @@ import voluptuous as vol
 from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.components.device_tracker import (
-    CONF_CONSIDER_HOME, CONF_TRACK_NEW, CONF_AWAY_HIDE)
+    CONF_CONSIDER_HOME, CONF_TRACK_NEW, CONF_NEW_DEVICE_DEFAULTS,
+    CONF_AWAY_HIDE)
 from homeassistant.components.device_tracker.asuswrt import (
     CONF_PROTOCOL, CONF_MODE, CONF_PUB_KEY, DOMAIN,
     CONF_PORT, PLATFORM_SCHEMA)
@@ -78,8 +79,11 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
                 CONF_USERNAME: 'fake_user',
                 CONF_PASSWORD: 'fake_pass',
                 CONF_TRACK_NEW: True,
-                CONF_AWAY_HIDE: False,
-                CONF_CONSIDER_HOME: timedelta(seconds=180)
+                CONF_CONSIDER_HOME: timedelta(seconds=180),
+                CONF_NEW_DEVICE_DEFAULTS: {
+                    CONF_TRACK_NEW: True,
+                    CONF_AWAY_HIDE: False
+                }
             }
         }
 
@@ -105,8 +109,11 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
                 CONF_USERNAME: 'fake_user',
                 CONF_PUB_KEY: FAKEFILE,
                 CONF_TRACK_NEW: True,
-                CONF_AWAY_HIDE: True,
-                CONF_CONSIDER_HOME: timedelta(seconds=180)
+                CONF_CONSIDER_HOME: timedelta(seconds=180),
+                CONF_NEW_DEVICE_DEFAULTS: {
+                    CONF_TRACK_NEW: True,
+                    CONF_AWAY_HIDE: False
+                }
             }
         }
 

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -123,7 +123,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                                   'My device', None, None, False),
             device_tracker.Device(self.hass, True, True, 'your_device',
                                   'AB:01', 'Your device', None, None, False)]
-        device_tracker.DeviceTracker(self.hass, False, True, devices)
+        device_tracker.DeviceTracker(self.hass, False, True, False, devices)
         _LOGGER.debug(mock_warning.call_args_list)
         assert mock_warning.call_count == 1, \
             "The only warning call should be duplicates (check DEBUG)"
@@ -137,7 +137,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                                   'AB:01', 'My device', None, None, False),
             device_tracker.Device(self.hass, True, True, 'my_device',
                                   None, 'Your device', None, None, False)]
-        device_tracker.DeviceTracker(self.hass, False, True, devices)
+        device_tracker.DeviceTracker(self.hass, False, True, False, devices)
 
         _LOGGER.debug(mock_warning.call_args_list)
         assert mock_warning.call_count == 1, \
@@ -299,7 +299,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         vendor_string = 'Raspberry Pi Foundation'
 
         tracker = device_tracker.DeviceTracker(
-            self.hass, timedelta(seconds=60), 0, [])
+            self.hass, timedelta(seconds=60), 0, False, [])
 
         with mock_aiohttp_client() as aioclient_mock:
             aioclient_mock.get('http://api.macvendors.com/b8:27:eb',
@@ -622,7 +622,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     def test_see_failures(self, mock_warning):
         """Test that the device tracker see failures."""
         tracker = device_tracker.DeviceTracker(
-            self.hass, timedelta(seconds=60), 0, [])
+            self.hass, timedelta(seconds=60), 0, False, [])
 
         # MAC is not a string (but added)
         tracker.see(mac=567, host_name="Number MAC")
@@ -654,7 +654,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     def test_picture_and_icon_on_see_discovery(self):
         """Test that picture and icon are set in initial see."""
         tracker = device_tracker.DeviceTracker(
-            self.hass, timedelta(seconds=60), False, [])
+            self.hass, timedelta(seconds=60), False, False, [])
         tracker.see(dev_id=11, picture='pic_url', icon='mdi:icon')
         self.hass.block_till_done()
         config = device_tracker.load_config(self.yaml_devices, self.hass,

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -123,7 +123,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                                   'My device', None, None, False),
             device_tracker.Device(self.hass, True, True, 'your_device',
                                   'AB:01', 'Your device', None, None, False)]
-        device_tracker.DeviceTracker(self.hass, False, True, False, devices)
+        device_tracker.DeviceTracker(self.hass, False, True, {}, devices)
         _LOGGER.debug(mock_warning.call_args_list)
         assert mock_warning.call_count == 1, \
             "The only warning call should be duplicates (check DEBUG)"
@@ -137,7 +137,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                                   'AB:01', 'My device', None, None, False),
             device_tracker.Device(self.hass, True, True, 'my_device',
                                   None, 'Your device', None, None, False)]
-        device_tracker.DeviceTracker(self.hass, False, True, False, devices)
+        device_tracker.DeviceTracker(self.hass, False, True, {}, devices)
 
         _LOGGER.debug(mock_warning.call_args_list)
         assert mock_warning.call_count == 1, \
@@ -299,7 +299,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         vendor_string = 'Raspberry Pi Foundation'
 
         tracker = device_tracker.DeviceTracker(
-            self.hass, timedelta(seconds=60), 0, False, [])
+            self.hass, timedelta(seconds=60), 0, {}, [])
 
         with mock_aiohttp_client() as aioclient_mock:
             aioclient_mock.get('http://api.macvendors.com/b8:27:eb',
@@ -622,7 +622,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     def test_see_failures(self, mock_warning):
         """Test that the device tracker see failures."""
         tracker = device_tracker.DeviceTracker(
-            self.hass, timedelta(seconds=60), 0, False, [])
+            self.hass, timedelta(seconds=60), 0, {}, [])
 
         # MAC is not a string (but added)
         tracker.see(mac=567, host_name="Number MAC")
@@ -654,7 +654,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     def test_picture_and_icon_on_see_discovery(self):
         """Test that picture and icon are set in initial see."""
         tracker = device_tracker.DeviceTracker(
-            self.hass, timedelta(seconds=60), False, False, [])
+            self.hass, timedelta(seconds=60), False, {}, [])
         tracker.see(dev_id=11, picture='pic_url', icon='mdi:icon')
         self.hass.block_till_done()
         config = device_tracker.load_config(self.yaml_devices, self.hass,

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -663,6 +663,18 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         assert config[0].icon == 'mdi:icon'
         assert config[0].entity_picture == 'pic_url'
 
+    def test_default_hide_if_away_is_used(self):
+        """Test that picture and icon are set in initial see."""
+        tracker = device_tracker.DeviceTracker(
+            self.hass, timedelta(seconds=60), False,
+            {device_tracker.CONF_AWAY_HIDE: True}, [])
+        tracker.see(dev_id=12)
+        self.hass.block_till_done()
+        config = device_tracker.load_config(self.yaml_devices, self.hass,
+                                            timedelta(seconds=0))
+        assert len(config) == 1
+        assert config[0].hidden == True
+
 
 @asyncio.coroutine
 def test_async_added_to_hass(hass):

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -664,7 +664,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         assert config[0].entity_picture == 'pic_url'
 
     def test_default_hide_if_away_is_used(self):
-        """Test that picture and icon are set in initial see."""
+        """Test that default track_new is used."""
         tracker = device_tracker.DeviceTracker(
             self.hass, timedelta(seconds=60), False,
             {device_tracker.CONF_AWAY_HIDE: True}, [])
@@ -673,7 +673,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         config = device_tracker.load_config(self.yaml_devices, self.hass,
                                             timedelta(seconds=0))
         assert len(config) == 1
-        assert config[0].hidden == True
+        self.assertTrue(config[0].hidden)
 
 
 @asyncio.coroutine

--- a/tests/components/device_tracker/test_unifi_direct.py
+++ b/tests/components/device_tracker/test_unifi_direct.py
@@ -11,7 +11,8 @@ import voluptuous as vol
 from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.components.device_tracker import (
-    CONF_CONSIDER_HOME, CONF_TRACK_NEW, CONF_AWAY_HIDE)
+    CONF_CONSIDER_HOME, CONF_TRACK_NEW, CONF_AWAY_HIDE,
+    CONF_NEW_DEVICE_DEFAULTS)
 from homeassistant.components.device_tracker.unifi_direct import (
     DOMAIN, CONF_PORT, PLATFORM_SCHEMA, _response_to_json, get_scanner)
 from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
@@ -54,8 +55,11 @@ class TestComponentsDeviceTrackerUnifiDirect(unittest.TestCase):
                 CONF_USERNAME: 'fake_user',
                 CONF_PASSWORD: 'fake_pass',
                 CONF_TRACK_NEW: True,
-                CONF_AWAY_HIDE: True,
-                CONF_CONSIDER_HOME: timedelta(seconds=180)
+                CONF_CONSIDER_HOME: timedelta(seconds=180),
+                CONF_NEW_DEVICE_DEFAULTS: {
+                    CONF_TRACK_NEW: True,
+                    CONF_AWAY_HIDE: False
+                }
             }
         }
 

--- a/tests/components/device_tracker/test_unifi_direct.py
+++ b/tests/components/device_tracker/test_unifi_direct.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.components.device_tracker import (
-    CONF_CONSIDER_HOME, CONF_TRACK_NEW)
+    CONF_CONSIDER_HOME, CONF_TRACK_NEW, CONF_AWAY_HIDE)
 from homeassistant.components.device_tracker.unifi_direct import (
     DOMAIN, CONF_PORT, PLATFORM_SCHEMA, _response_to_json, get_scanner)
 from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
@@ -54,6 +54,7 @@ class TestComponentsDeviceTrackerUnifiDirect(unittest.TestCase):
                 CONF_USERNAME: 'fake_user',
                 CONF_PASSWORD: 'fake_pass',
                 CONF_TRACK_NEW: True,
+                CONF_AWAY_HIDE: True,
                 CONF_CONSIDER_HOME: timedelta(seconds=180)
             }
         }


### PR DESCRIPTION
## Description:
Add option to set default hide_if_away for new discovered devices. Currently it is always set to false

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4051

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: netgear
    host: 192.168.1.1
    username: admin
    password: YOUR_PASSWORD
    new_device_defaults:
      track_new_devices: True
      hide_if_away: False
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
`script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
