### PR TITLE
Support for AppliedSensors iAQStick

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -516,6 +516,7 @@ omit =
     homeassistant/components/sensor/hp_ilo.py
     homeassistant/components/sensor/htu21d.py
     homeassistant/components/sensor/hydroquebec.py
+    homeassistant/components/sensor/iaqstick.py
     homeassistant/components/sensor/imap.py
     homeassistant/components/sensor/imap_email_content.py
     homeassistant/components/sensor/influxdb.py

--- a/homeassistant/components/sensor/iaqstick.py
+++ b/homeassistant/components/sensor/iaqstick.py
@@ -14,7 +14,7 @@ import logging
 
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyusb>=1.0.0']
+REQUIREMENTS = ['pyusb==1.0.0']
 
 logger = logging.getLogger('iAQStick')
 

--- a/homeassistant/components/sensor/iaqstick.py
+++ b/homeassistant/components/sensor/iaqstick.py
@@ -113,7 +113,6 @@ class iAQStick(Entity):
             logger.error("update failed - {}".format(e))
             self._state = 99
 
-
     def state_string(self):
         if self.ppm > 1500:
             return 'Bad'

--- a/homeassistant/components/sensor/iaqstick.py
+++ b/homeassistant/components/sensor/iaqstick.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# vim: set encoding=utf-8 tabstop=4 softtabstop=4 shiftwidth=4 expandtab
+#########################################################################
+#  Copyright 2013 Robert Budde                       robert@projekt131.de
+#  Copyright 2017 Sebastian Kügler                          sebas@kde.org
+#########################################################################
+#  based on iAQ-Stick plugin for SmartHome.py.
+#                                        http://mknx.github.io/smarthome/
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########################################################################
+
+#/etc/udev/rules.d/99-iaqstick.rules
+#SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="2013", MODE="666"
+#udevadm trigger
+
+from homeassistant.helpers.entity import Entity
+
+import logging
+import usb.core
+import usb.util
+
+logger = logging.getLogger('iAQStick')
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the air sensor platform"""
+    add_devices([iAQStick()])
+
+
+class iAQStick(Entity):
+
+    initialized = False
+
+    ppm = 0
+
+    def __init__(self):
+        self._dev = usb.core.find(idVendor=0x03eb, idProduct=0x2013)
+        if self._dev is None:
+            logger.error('iaqstick: iAQ Stick not found')
+            return
+        self._intf = 0
+        #self._type1_seq = 0x0001
+        self._type2_seq = 0x67
+
+        try:
+            if self._dev.is_kernel_driver_active(self._intf):
+                self._dev.detach_kernel_driver(self._intf)
+
+            self._dev.set_configuration(0x01)
+            usb.util.claim_interface(self._dev, self._intf)
+            self._dev.set_interface_altsetting(self._intf, 0x00)
+            logger.error("iaqstick: initialized")
+
+        except Exception as e:
+            logger.error("iaqstick: init interface failed - {}".format(e))
+        self.initialized = True
+        self._state = None
+        self.update()
+
+    @property
+    def name(self):
+        """Returns ame of the sensor"""
+        return "AppliedSensor iAQStick"
+
+    @property
+    def state(self):
+        """Returns the state of the sensor"""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Returns the unit of measurement: parts per million"""
+        return "ppm"
+
+    @property
+    def should_poll(self):
+        return True
+
+    def xfer_type2(self, msg):
+        out_data = bytes('@', 'utf-8') + self._type2_seq.to_bytes(1, byteorder='big') + bytes('{}\n@@@@@@@@@@@@@'.format(msg), 'utf-8')
+        self._type2_seq = (self._type2_seq + 1) if (self._type2_seq < 0xFF) else 0x67
+        ret = self._dev.write(0x02, out_data[:16])
+        in_data = bytes()
+        while True:
+            ret = bytes(self._dev.read(0x81, 0x10))
+            if len(ret) == 0:
+                break
+            in_data += ret
+        return in_data
+
+    def stop(self):
+        if not self.initialized:
+            return
+        self.alive = False
+        try:
+            usb.util.release_interface(self._dev, self._intf)
+        except Exception as e:
+            logger.error("iaqstick: releasing interface failed - {}".format(e))
+
+    def update(self):
+
+        if not self.initialized:
+            return
+        try:
+            meas = self.xfer_type2('*TR')
+            ppm = int.from_bytes(meas[2:4], byteorder='little')
+            self.ppm = ppm
+            self._state = ppm
+        except Exception as e:
+            logger.error("iaqstick: update failed - {}".format(e))
+            self._state = 99
+
+
+    def state_string(self):
+        if self.ppm > 1500:
+            return "Bad"
+        elif self.ppm > 1000:
+            return "Mediocre"
+        elif self.ppm > 500:
+            return "Decent"
+        elif self.ppm > 400:
+            return "Good"
+        else:
+            return "Invalid Measurement"

--- a/homeassistant/components/sensor/iaqstick.py
+++ b/homeassistant/components/sensor/iaqstick.py
@@ -75,9 +75,11 @@ class iAQStick(Entity):
         return True
 
     def xfer_type2(self, msg):
-        out_data = bytes('@', 'utf-8') + self._type2_seq.to_bytes(1,
-                    byteorder='big') + bytes('{}\n@@@@@@@@@@@@@'.format(msg),
-                                                                      'utf-8')
+        out_data = bytes('@', 'utf-8') + \
+            self._type2_seq.to_bytes(1,
+                                    byteorder='big') + \
+                                    bytes('{}\n@@@@@@@@@@@@@'.format(msg),
+                                    'utf-8')
         self._type2_seq = (self._type2_seq + 1) if (self._type2_seq < 0xFF) \
             else 0x67
         ret = self._dev.write(0x02, out_data[:16])

--- a/homeassistant/components/sensor/iaqstick.py
+++ b/homeassistant/components/sensor/iaqstick.py
@@ -38,7 +38,6 @@ class iAQStick(Entity):
             logger.error("iAQ Stick not found")
             return
         self._intf = 0
-        #self._type1_seq = 0x0001
         self._type2_seq = 0x67
 
         try:
@@ -76,8 +75,9 @@ class iAQStick(Entity):
         return True
 
     def xfer_type2(self, msg):
-        out_data = bytes('@', 'utf-8') + self._type2_seq.to_bytes(1, \
-            byteorder='big') + bytes('{}\n@@@@@@@@@@@@@'.format(msg), 'utf-8')
+        out_data = bytes('@', 'utf-8') + self._type2_seq.to_bytes(1,
+                    byteorder='big') + bytes('{}\n@@@@@@@@@@@@@'.format(msg),
+                                                                      'utf-8')
         self._type2_seq = (self._type2_seq + 1) if (self._type2_seq < 0xFF) \
             else 0x67
         ret = self._dev.write(0x02, out_data[:16])

--- a/homeassistant/components/sensor/iaqstick.py
+++ b/homeassistant/components/sensor/iaqstick.py
@@ -1,28 +1,14 @@
-#!/usr/bin/env python3
-# vim: set encoding=utf-8 tabstop=4 softtabstop=4 shiftwidth=4 expandtab
-#########################################################################
-#  Copyright 2013 Robert Budde                       robert@projekt131.de
-#  Copyright 2017 Sebastian Kügler                          sebas@kde.org
-#########################################################################
-#  based on iAQ-Stick plugin for SmartHome.py.
-#                                        http://mknx.github.io/smarthome/
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#########################################################################
+"""
+Support for AppliedSensor iAQStick
 
-#/etc/udev/rules.d/99-iaqstick.rules
-#SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="2013", MODE="666"
-#udevadm trigger
+On Linux, a custom udev rule is needed, add a file
+/etc/udev/rules.d/99-iaqstick.rules containing
+
+SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="2013", MODE="666"
+
+and run # udevadm control --reload-rules && udevadm trigger or reboot.
+
+"""
 
 import logging
 import usb.core
@@ -30,7 +16,7 @@ import usb.util
 
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyusb<=1.0.0']
+REQUIREMENTS = ['pyusb>=1.0.0']
 
 logger = logging.getLogger('iAQStick')
 

--- a/homeassistant/components/sensor/iaqstick.py
+++ b/homeassistant/components/sensor/iaqstick.py
@@ -11,8 +11,6 @@ and run # udevadm control --reload-rules && udevadm trigger or reboot.
 """
 
 import logging
-import usb.core
-import usb.util
 
 from homeassistant.helpers.entity import Entity
 
@@ -33,6 +31,10 @@ class iAQStick(Entity):
     ppm = 0
 
     def __init__(self):
+
+        import usb.core
+        import usb.util
+
         self._dev = usb.core.find(idVendor=0x03eb, idProduct=0x2013)
         if self._dev is None:
             logger.error("iAQ Stick not found")
@@ -92,6 +94,9 @@ class iAQStick(Entity):
         return in_data
 
     def stop(self):
+
+        import usb.util
+
         if not self.initialized:
             return
         self.alive = False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -906,6 +906,9 @@ pytradfri==4.0.1
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13
 
+# homeassistant.components.sensor.iaqstick
+pyusb==1.0.0
+
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11
 


### PR DESCRIPTION
## Description:
This PR adds support for AppliedSensors air quality sensors. A sensor measuring volatice organic compounds in the surrounding air. It comes as a handy USB stick. Support is implemented as a simple sensor.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: iaqstick
    name: Air Quality
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
