### PR TITLE
WIP: Add ability to check DD-WRT DHCP leases

### DIFF
--- a/homeassistant/components/device_tracker/ddwrt.py
+++ b/homeassistant/components/device_tracker/ddwrt.py
@@ -92,14 +92,20 @@ class DdWrtDeviceScanner(DeviceScanner):
 
         return self.mac2name.get(device)
 
-    def _update_info(self):
+    def _update_info(self, wireless=True):
         """Ensure the information from the DD-WRT router is up to date.
 
         Return boolean if scanning successful.
         """
-        _LOGGER.info("Checking ARP")
+        if wireless:
+            _LOGGER.info("Checking ARP")
+            url = 'http://{}/Status_Wireless.live.asp'.format(self.host)
+            extract_key = 'active_wireless'
+        else:
+            _LOGGER.info("Checking DHCP leases")
+            url = 'http://{}/Info.live.htm'.format(self.host)
+            extract_key = 'dhcp_leases'
 
-        url = 'http://{}/Status_Wireless.live.asp'.format(self.host)
         data = self.get_ddwrt_data(url)
 
         if not data:
@@ -107,7 +113,7 @@ class DdWrtDeviceScanner(DeviceScanner):
 
         self.last_results = []
 
-        active_clients = data.get('active_wireless', None)
+        active_clients = data.get(extract_key, None)
         if not active_clients:
             return False
 


### PR DESCRIPTION
## Description:

My use case is DD-WRT as a non-wifi router.
This allows the script to check DHCP leases on the router rather than just WIFI clients.
Setting the DHCP lease on DD-WRT fairly low makes this useful.

I tested this locally for now by changing the wireless=True parameter on the _update_info function.

This still needs additional changes to allow configuration in configuration.yaml to make its way to _update_info - wireless parameter, if anyone could help with that?


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: ddwrt
    host: 192.168.1.1
    interval_seconds: 5
    consider_home: 180
    track_new_devices: yes
    wireless: no
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
