### PR TITLE
Fixes #10773: Demo Alarm Broken

### DIFF
--- a/homeassistant/components/alarm_control_panel/demo.py
+++ b/homeassistant/components/alarm_control_panel/demo.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/demo/
 import homeassistant.components.alarm_control_panel.manual as manual
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_NIGHT,
-    STATE_ALARM_TRIGGERED, CONF_PENDING_TIME)
+    STATE_ALARM_ARMED_CUSTOM_BYPASS, STATE_ALARM_TRIGGERED, CONF_PENDING_TIME)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -21,6 +21,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 CONF_PENDING_TIME: 5
             },
             STATE_ALARM_ARMED_NIGHT: {
+                CONF_PENDING_TIME: 5
+            },
+            STATE_ALARM_ARMED_CUSTOM_BYPASS: {
                 CONF_PENDING_TIME: 5
             },
             STATE_ALARM_TRIGGERED: {

--- a/tests/components/alarm_control_panel/test_manual.py
+++ b/tests/components/alarm_control_panel/test_manual.py
@@ -1,7 +1,9 @@
 """The tests for the manual Alarm Control Panel component."""
 from datetime import timedelta
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+from homeassistant.components.alarm_control_panel import demo
+
 
 from homeassistant.setup import setup_component
 from homeassistant.const import (
@@ -10,6 +12,8 @@ from homeassistant.const import (
     STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED)
 from homeassistant.components import alarm_control_panel
 import homeassistant.util.dt as dt_util
+
+from tests.common import assert_setup_component
 
 from tests.common import fire_time_changed, get_test_home_assistant
 
@@ -26,6 +30,13 @@ class TestAlarmControlPanelManual(unittest.TestCase):
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop down everything that was started."""
         self.hass.stop()
+
+    def test_setup_demo_platform(self):
+        """Test setup."""
+        mock = MagicMock();
+        add_devices = mock.MagicMock()
+        demo.setup_platform(self.hass, {}, add_devices)
+        add_devices.assert_called_once()
 
     def test_arm_home_no_pending(self):
         """Test arm home method."""

--- a/tests/components/alarm_control_panel/test_manual.py
+++ b/tests/components/alarm_control_panel/test_manual.py
@@ -31,7 +31,7 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
     def test_setup_demo_platform(self):
         """Test setup."""
-        mock = MagicMock();
+        mock = MagicMock()
         add_devices = mock.MagicMock()
         demo.setup_platform(self.hass, {}, add_devices)
         add_devices.assert_called_once()

--- a/tests/components/alarm_control_panel/test_manual.py
+++ b/tests/components/alarm_control_panel/test_manual.py
@@ -13,8 +13,6 @@ from homeassistant.const import (
 from homeassistant.components import alarm_control_panel
 import homeassistant.util.dt as dt_util
 
-from tests.common import assert_setup_component
-
 from tests.common import fire_time_changed, get_test_home_assistant
 
 CODE = 'HELLO_CODE'

--- a/tests/components/alarm_control_panel/test_manual.py
+++ b/tests/components/alarm_control_panel/test_manual.py
@@ -34,7 +34,7 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         mock = MagicMock()
         add_devices = mock.MagicMock()
         demo.setup_platform(self.hass, {}, add_devices)
-        add_devices.assert_called_once()
+        self.assertEquals(add_devices.call_count, 1)
 
     def test_arm_home_no_pending(self):
         """Test arm home method."""


### PR DESCRIPTION
## Description:
This PR fixes the broken demo alarm

**Related issue (if applicable):** fixes #10773 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel: 
  - platform: demo
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
