### PR TITLE
Change name on Android from "Assistant" to "Home Assistant"

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -47,7 +47,7 @@ MANIFEST_JSON = {
     'icons': [],
     'lang': 'en-US',
     'name': 'Home Assistant',
-    'short_name': 'Assistant',
+    'short_name': 'Home Assistant',
     'start_url': '/',
     'theme_color': DEFAULT_THEME_COLOR
 }


### PR DESCRIPTION
"Home Assistant" is not cut off in Launcher on my 3-4 year old HTC M7.
Also "Assistant" looks strange in notification title
![name](https://user-images.githubusercontent.com/11984118/33223855-0433785e-d164-11e7-9a78-b1bf7a016457.png)
