### PR TITLE
Telldus Live: Added sensor types from telldus server src

### DIFF
--- a/homeassistant/components/sensor/tellduslive.py
+++ b/homeassistant/components/sensor/tellduslive.py
@@ -11,26 +11,32 @@ from homeassistant.const import TEMP_CELSIUS
 
 _LOGGER = logging.getLogger(__name__)
 
-SENSOR_TYPE_TEMP = 'temp'
+SENSOR_TYPE_TEMPERATURE = 'temp'
 SENSOR_TYPE_HUMIDITY = 'humidity'
 SENSOR_TYPE_RAINRATE = 'rrate'
 SENSOR_TYPE_RAINTOTAL = 'rtot'
 SENSOR_TYPE_WINDDIRECTION = 'wdir'
 SENSOR_TYPE_WINDAVERAGE = 'wavg'
 SENSOR_TYPE_WINDGUST = 'wgust'
+SENSOR_TYPE_UV = 'uv'
 SENSOR_TYPE_WATT = 'watt'
 SENSOR_TYPE_LUMINANCE = 'lum'
+SENSOR_TYPE_DEW_POINT = 'dewp'
+SENSOR_TYPE_BAROMETRIC_PRESSURE = 'barpress'
 
 SENSOR_TYPES = {
-    SENSOR_TYPE_TEMP: ['Temperature', TEMP_CELSIUS, 'mdi:thermometer'],
+    SENSOR_TYPE_TEMPERATURE: ['Temperature', TEMP_CELSIUS, 'mdi:thermometer'],
     SENSOR_TYPE_HUMIDITY: ['Humidity', '%', 'mdi:water'],
-    SENSOR_TYPE_RAINRATE: ['Rain rate', 'mm', 'mdi:water'],
+    SENSOR_TYPE_RAINRATE: ['Rain rate', 'mm/h', 'mdi:water'],
     SENSOR_TYPE_RAINTOTAL: ['Rain total', 'mm', 'mdi:water'],
     SENSOR_TYPE_WINDDIRECTION: ['Wind direction', '', ''],
     SENSOR_TYPE_WINDAVERAGE: ['Wind average', 'm/s', ''],
     SENSOR_TYPE_WINDGUST: ['Wind gust', 'm/s', ''],
-    SENSOR_TYPE_WATT: ['Watt', 'W', ''],
+    SENSOR_TYPE_UV: ['UV', 'UV', ''],
+    SENSOR_TYPE_WATT: ['Power', 'W', ''],
     SENSOR_TYPE_LUMINANCE: ['Luminance', 'lx', ''],
+    SENSOR_TYPE_DEW_POINT: ['Dew Point', TEMP_CELSIUS, 'mdi:thermometer'],
+    SENSOR_TYPE_BAROMETRIC_PRESSURE: ['Barometric Pressure', 'kPa', ''],
 }
 
 
@@ -86,7 +92,7 @@ class TelldusLiveSensor(TelldusLiveEntity):
         """Return the state of the sensor."""
         if not self.available:
             return None
-        elif self._type == SENSOR_TYPE_TEMP:
+        elif self._type == SENSOR_TYPE_TEMPERATURE:
             return self._value_as_temperature
         elif self._type == SENSOR_TYPE_HUMIDITY:
             return self._value_as_humidity


### PR DESCRIPTION
## Description:
Added sensor types from https://github.com/telldus/tellstick-server/blob/master/telldus/src/telldus/Device.py

## Breaking change:
Sensor types previously not fully supported gets new entity names. Previously, for example, UV sensors got the entity `sensor.sensorname_`, now it's `sensor.sensorname_uv`.