### PR TITLE
Tellduslive: Accurate implementation of battery level

### DIFF
--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -343,8 +343,17 @@ class TelldusLiveEntity(Entity):
     @property
     def _battery_level(self):
         """Return the battery level of a device."""
-        return round(self.device.battery * 100 / 255) \
-            if self.device.battery else None
+        from tellduslive import (BATTERY_LOW,
+                                 BATTERY_UNKNOWN,
+                                 BATTERY_OK)
+        if self.device.battery == BATTERY_LOW:
+            return 1
+        elif self.device.battery == BATTERY_UNKNOWN:
+            return None
+        elif self.device.battery == BATTERY_OK:
+            return 100
+        else:
+            return self.device.battery  # Percentage
 
     @property
     def _last_updated(self):


### PR DESCRIPTION
Use magic Tellduslive constants instead of erroneous formula for reporting battery level.

Not sure about the best way of translating `BATTERY_LOW` and `BATTERY_OK`, for now they are translated to 1% and 100% respectively. (The `icon_for_battery_level` function (https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/helpers/icon.py#L5) doesn't seem to be used for sensors in general, but at least it would be compatible with that function in the future if it were to be used for displaying sensor battery level attributes.)

N.B This PR depends on https://github.com/home-assistant/home-assistant/pull/10435 being merged, since that PR upgrades the external library (which provides the used constants).

## Description:

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
