### PR TITLE
Add away_mode_name to arlo alarm control panel

### DIFF
--- a/homeassistant/components/alarm_control_panel/arlo.py
+++ b/homeassistant/components/alarm_control_panel/arlo.py
@@ -22,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 ARMED = 'armed'
 
 CONF_HOME_MODE_NAME = 'home_mode_name'
+CONF_AWAY_MODE_NAME = 'away_mode_name'
 
 DEPENDENCIES = ['arlo']
 
@@ -31,6 +32,7 @@ ICON = 'mdi:security'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOME_MODE_NAME, default=ARMED): cv.string,
+    vol.Optional(CONF_AWAY_MODE_NAME, default=ARMED): cv.string,
 })
 
 
@@ -43,19 +45,21 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         return
 
     home_mode_name = config.get(CONF_HOME_MODE_NAME)
+    away_mode_name = config.get(CONF_AWAY_MODE_NAME)
     base_stations = []
     for base_station in data.base_stations:
-        base_stations.append(ArloBaseStation(base_station, home_mode_name))
+        base_stations.append(ArloBaseStation(base_station, home_mode_name, away_mode_name))
     async_add_devices(base_stations, True)
 
 
 class ArloBaseStation(AlarmControlPanel):
     """Representation of an Arlo Alarm Control Panel."""
 
-    def __init__(self, data, home_mode_name):
+    def __init__(self, data, home_mode_name, away_mode_name):
         """Initialize the alarm control panel."""
         self._base_station = data
         self._home_mode_name = home_mode_name
+        self._away_mode_name = away_mode_name
         self._state = None
 
     @property
@@ -89,8 +93,8 @@ class ArloBaseStation(AlarmControlPanel):
 
     @asyncio.coroutine
     def async_alarm_arm_away(self, code=None):
-        """Send arm away command."""
-        self._base_station.mode = ARMED
+        """Send arm away command. Uses custom mode."""
+        self._base_station.mode = self._home_mode_name
 
     @asyncio.coroutine
     def async_alarm_arm_home(self, code=None):
@@ -118,4 +122,6 @@ class ArloBaseStation(AlarmControlPanel):
             return STATE_ALARM_DISARMED
         elif mode == self._home_mode_name:
             return STATE_ALARM_ARMED_HOME
+        elif mode == self._away_mode_name:
+            return STATE_ALARM_ARMED_AWAY
         return None

--- a/homeassistant/components/alarm_control_panel/arlo.py
+++ b/homeassistant/components/alarm_control_panel/arlo.py
@@ -48,7 +48,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     away_mode_name = config.get(CONF_AWAY_MODE_NAME)
     base_stations = []
     for base_station in data.base_stations:
-        base_stations.append(ArloBaseStation(base_station, home_mode_name, away_mode_name))
+        base_stations.append(ArloBaseStation(base_station, home_mode_name, 
+                                             away_mode_name))
     async_add_devices(base_stations, True)
 
 

--- a/homeassistant/components/alarm_control_panel/arlo.py
+++ b/homeassistant/components/alarm_control_panel/arlo.py
@@ -95,7 +95,7 @@ class ArloBaseStation(AlarmControlPanel):
     @asyncio.coroutine
     def async_alarm_arm_away(self, code=None):
         """Send arm away command. Uses custom mode."""
-        self._base_station.mode = self._home_mode_name
+        self._base_station.mode = self._away_mode_name
 
     @asyncio.coroutine
     def async_alarm_arm_home(self, code=None):

--- a/homeassistant/components/alarm_control_panel/arlo.py
+++ b/homeassistant/components/alarm_control_panel/arlo.py
@@ -48,7 +48,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     away_mode_name = config.get(CONF_AWAY_MODE_NAME)
     base_stations = []
     for base_station in data.base_stations:
-        base_stations.append(ArloBaseStation(base_station, home_mode_name, 
+        base_stations.append(ArloBaseStation(base_station, home_mode_name,
                                              away_mode_name))
     async_add_devices(base_stations, True)
 


### PR DESCRIPTION
## Description:
Include variables for custom away mode specification

**Related issue (if applicable):** fixes #10794
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
home-assistant/home-assistant.github.io#4069

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: arlo
    home_mode_name: "ArmedHome"
    away_mode_name: "ArmedAway"
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
