### PR TITLE
Fix Notifications for Android TV

### DIFF
--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -128,7 +128,7 @@ class NFAndroidTVNotificationService(BaseNotificationService):
                     self._icon_file = default_icon
             except ImportError:
                 _LOGGER.warning(
-                    "hass_frontend icon not found. " + \
+                    "hass_frontend icon not found. " +
                     "Provide an icon when calling the service.")
 
     def send_message(self, message="", **kwargs):

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -137,14 +137,11 @@ class NFAndroidTVNotificationService(BaseNotificationService):
                        offset='0', app=ATTR_TITLE_DEFAULT, force='true',
                        interrupt='%i' % self._default_interrupt)
 
+        icon_file = None
         data = kwargs.get(ATTR_DATA)
         if data:
             if ATTR_ICON in data:
                 icon_file = data.get(ATTR_ICON)
-                payload[ATTR_FILENAME] = ('icon.png',
-                                          open(icon_file, 'rb'),
-                                          'application/octet-stream',
-                                          {'Expires': '0'})
             if ATTR_DURATION in data:
                 duration = data.get(ATTR_DURATION)
                 try:
@@ -181,11 +178,12 @@ class NFAndroidTVNotificationService(BaseNotificationService):
                     _LOGGER.warning("Invalid interrupt-value: %s",
                                     str(interrupt))
 
-        if payload.get(ATTR_FILENAME, None) is None:
-            payload[ATTR_FILENAME] = ('icon.png',
-                                      open(self._icon_file, 'rb'),
-                                      'application/octet-stream',
-                                      {'Expires': '0'})
+        if icon_file is None:
+            icon_file = self._icon_file
+        payload[ATTR_FILENAME] = ('icon.png',
+                                  open(icon_file, 'rb'),
+                                  'application/octet-stream',
+                                  {'Expires': '0'})
 
         try:
             _LOGGER.debug("Payload: %s", str(payload))

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -116,12 +116,20 @@ class NFAndroidTVNotificationService(BaseNotificationService):
         self._default_color = color
         self._default_interrupt = interrupt
         self._timeout = timeout
+        self._icon_file = None
         if icon:
             self._icon_file = icon
         else:
-            self._icon_file = os.path.join(
-                os.path.dirname(__file__), '..', '..', '..', 'hass_frontend',
-                'icons', 'favicon-192x192.png')
+            try:
+                import hass_frontend
+                default_icon = os.path.join(
+                    hass_frontend.__path__[0], 'icons', 'favicon-192x192.png')
+                if os.path.exists(default_icon):
+                    self._icon_file = default_icon
+            except ImportError:
+                _LOGGER.warning(
+                    "hass_frontend icon not found. " + \
+                    "Provide an icon when calling the service.")
 
     def send_message(self, message="", **kwargs):
         """Send a message to a Android TV device."""
@@ -177,6 +185,9 @@ class NFAndroidTVNotificationService(BaseNotificationService):
                     _LOGGER.warning("Invalid interrupt-value: %s",
                                     str(interrupt))
 
+        if self._icon_file is None and icon_file is None:
+            _LOGGER.error("No icon available. Not sending notification.")
+            return
         if icon_file is None:
             icon_file = self._icon_file
         payload[ATTR_FILENAME] = ('icon.png',

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 from homeassistant.components.notify import (
     ATTR_TITLE, ATTR_TITLE_DEFAULT, ATTR_DATA, BaseNotificationService,
     PLATFORM_SCHEMA)
-from homeassistant.const import CONF_TIMEOUT
+from homeassistant.const import CONF_TIMEOUT, CONF_ICON
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,7 +24,6 @@ CONF_POSITION = 'position'
 CONF_TRANSPARENCY = 'transparency'
 CONF_COLOR = 'color'
 CONF_INTERRUPT = 'interrupt'
-CONF_ICON = 'icon'
 
 DEFAULT_DURATION = 5
 DEFAULT_POSITION = 'bottom-right'

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -83,7 +83,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.In(COLORS.keys()),
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(int),
     vol.Optional(CONF_INTERRUPT, default=DEFAULT_INTERRUPT): cv.boolean,
-    vol.Optional(CONF_ICON): cv.string,
+    vol.Optional(CONF_ICON, default=DEFAULT_ICON): cv.string,
 })
 
 

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -4,7 +4,6 @@ Notifications for Android TV notification service.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.nfandroidtv/
 """
-import os
 import logging
 import io
 import base64

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -15,7 +15,7 @@ import voluptuous as vol
 from homeassistant.components.notify import (
     ATTR_TITLE, ATTR_TITLE_DEFAULT, ATTR_DATA, BaseNotificationService,
     PLATFORM_SCHEMA)
-from homeassistant.const import CONF_TIMEOUT, CONF_ICON
+from homeassistant.const import CONF_TIMEOUT
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Description:
~~Fixing deprecated icon path (frontend/www_static), and while I'm at it adding optional dynamic icons.~~
Fixing the exception caused by the missing icon caused by frontend changes. Using an embedded image now.

**Related issue (if applicable):** fixes #10443

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/pull/4073)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
