### PR TITLE
Fixed fail2ban sensor config : scan_interval was missing

### DIFF
--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -37,6 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, vol.Length(min=1)),
     vol.Optional(CONF_FILE_PATH, default=DEFAULT_LOG): cv.isfile,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL): cv.time_period
 })
 
 


### PR DESCRIPTION
## Description:

Fixed fail2ban sensor config schema : scan_interval variable was not declared

**Related issue :** fixes #10497


If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

