### PR TITLE
Add support for logarithm in templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -4,6 +4,7 @@ import json
 import logging
 import random
 import re
+import math
 
 import jinja2
 from jinja2 import contextfilter
@@ -423,6 +424,17 @@ def multiply(value, amount):
         return value
 
 
+def logarithm(value, base=math.e):
+    """Filter to get logarithm of the value with a spesific base."""
+    try:
+        if base == 10:
+            return math.log10(float(value))
+        else:
+            return math.log(float(value), float(base))
+    except (ValueError, TypeError):
+        return value
+
+
 def timestamp_custom(value, date_format=DATE_STR_FORMAT, local=True):
     """Filter to convert given timestamp to format."""
     try:
@@ -508,6 +520,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
 ENV = TemplateEnvironment()
 ENV.filters['round'] = forgiving_round
 ENV.filters['multiply'] = multiply
+ENV.filters['log'] = logarithm
 ENV.filters['timestamp_custom'] = timestamp_custom
 ENV.filters['timestamp_local'] = timestamp_local
 ENV.filters['timestamp_utc'] = timestamp_utc

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -525,6 +525,7 @@ ENV.filters['is_defined'] = fail_when_undefined
 ENV.filters['max'] = max
 ENV.filters['min'] = min
 ENV.filters['random'] = random_every_time
+ENV.globals['log'] = logarithm
 ENV.globals['float'] = forgiving_float
 ENV.globals['now'] = dt_util.now
 ENV.globals['utcnow'] = dt_util.utcnow

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -427,10 +427,7 @@ def multiply(value, amount):
 def logarithm(value, base=math.e):
     """Filter to get logarithm of the value with a spesific base."""
     try:
-        if base == 10:
-            return math.log10(float(value))
-        else:
-            return math.log(float(value), float(base))
+        return math.log(float(value), float(base))
     except (ValueError, TypeError):
         return value
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -133,14 +133,15 @@ class TestHelpersTemplate(unittest.TestCase):
             (1000, 10, '3.0'),
             (math.e, '', '1.0'),
             ('"invalid"', '_', 'invalid'),
-            (10, '"invalid"', '10'),
+            (10, '"invalid"', '10.0'),
         ]
 
         for value, base, expected in tests:
             self.assertEqual(
                 expected,
-                template.Template('{{ %s | log(%s) }}' % (value, base),
-                                  self.hass).render())
+                template.Template(
+                    '{{ %s | log(%s) | round(1) }}' % (value, base),
+                    self.hass).render())
 
     def test_strptime(self):
         """Test the parse timestamp method."""

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -143,6 +143,12 @@ class TestHelpersTemplate(unittest.TestCase):
                     '{{ %s | log(%s) | round(1) }}' % (value, base),
                     self.hass).render())
 
+            self.assertEqual(
+                expected,
+                template.Template(
+                    '{{ log(%s, %s) | round(1) }}' % (value, base),
+                    self.hass).render())
+
     def test_strptime(self):
         """Test the parse timestamp method."""
         tests = [

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -3,6 +3,7 @@ import asyncio
 from datetime import datetime
 import unittest
 import random
+import math
 from unittest.mock import patch
 
 from homeassistant.components import group
@@ -123,6 +124,22 @@ class TestHelpersTemplate(unittest.TestCase):
             self.assertEqual(
                 out,
                 template.Template('{{ %s | multiply(10) | round }}' % inp,
+                                  self.hass).render())
+
+    def test_logarithm(self):
+        """Test logarithm."""
+        tests = [
+            (4, 2, '2.0'),
+            (1000, 10, '3.0'),
+            (math.e, '', '1.0'),
+            ('"invalid"', '_', 'invalid'),
+            (10, '"invalid"', '10'),
+        ]
+
+        for value, base, expected in tests:
+            self.assertEqual(
+                expected,
+                template.Template('{{ %s | log(%s) }}' % (value, base),
                                   self.hass).render())
 
     def test_strptime(self):


### PR DESCRIPTION
**TL;DR**: I needed to take the logarithm of a number in order to calculate a value, so I made this.

## Description:


This adds a 'log' filter that takes the logarithm of the given value,
with an optional base number. The base defaults to 'e' - the natural
logarithm

I can also add `pow` and `sqrt`, but that can also be achived with the `**` operator. Any thoughts?

## Todo
- Add docs to `home-assistant.github.io` if this PR sounds like a good idea


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4081

## Usage
Example template:

```text
{{ 8 | log(2) }} # yields 3
{{ log(8, 2) }}  # yields 3
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
