### PR TITLE
Store raw state of RF sensors from alarmdecoder

### DIFF
--- a/homeassistant/components/alarmdecoder.py
+++ b/homeassistant/components/alarmdecoder.py
@@ -29,6 +29,7 @@ CONF_DEVICE_TYPE = 'type'
 CONF_PANEL_DISPLAY = 'panel_display'
 CONF_ZONE_NAME = 'name'
 CONF_ZONE_TYPE = 'type'
+CONF_ZONE_RFID = 'rfid'
 CONF_ZONES = 'zones'
 
 DEFAULT_DEVICE_TYPE = 'socket'
@@ -48,6 +49,7 @@ SIGNAL_PANEL_DISARM = 'alarmdecoder.panel_disarm'
 
 SIGNAL_ZONE_FAULT = 'alarmdecoder.zone_fault'
 SIGNAL_ZONE_RESTORE = 'alarmdecoder.zone_restore'
+SIGNAL_RFX_MESSAGE = 'alarmdecoder.rfx_message'
 
 DEVICE_SOCKET_SCHEMA = vol.Schema({
     vol.Required(CONF_DEVICE_TYPE): 'socket',
@@ -64,7 +66,8 @@ DEVICE_USB_SCHEMA = vol.Schema({
 
 ZONE_SCHEMA = vol.Schema({
     vol.Required(CONF_ZONE_NAME): cv.string,
-    vol.Optional(CONF_ZONE_TYPE, default=DEFAULT_ZONE_TYPE): cv.string})
+    vol.Optional(CONF_ZONE_TYPE, default=DEFAULT_ZONE_TYPE): cv.string,
+    vol.Optional(CONF_ZONE_RFID, default=None): cv.string})
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -105,6 +108,10 @@ def setup(hass, config):
         hass.helpers.dispatcher.dispatcher_send(
             SIGNAL_PANEL_MESSAGE, message)
 
+    def handle_rfx_message(sender, message):
+        """Handle RFX message from AlarmDecoder."""
+        async_dispatcher_send(hass, SIGNAL_RFX_MESSAGE, message)
+
     def zone_fault_callback(sender, zone):
         """Handle zone fault from AlarmDecoder."""
         hass.helpers.dispatcher.dispatcher_send(
@@ -129,6 +136,7 @@ def setup(hass, config):
         return False
 
     controller.on_message += handle_message
+    controller.on_rfx_message += handle_rfx_message
     controller.on_zone_fault += zone_fault_callback
     controller.on_zone_restore += zone_restore_callback
 

--- a/homeassistant/components/alarmdecoder.py
+++ b/homeassistant/components/alarmdecoder.py
@@ -67,7 +67,7 @@ DEVICE_USB_SCHEMA = vol.Schema({
 ZONE_SCHEMA = vol.Schema({
     vol.Required(CONF_ZONE_NAME): cv.string,
     vol.Optional(CONF_ZONE_TYPE, default=DEFAULT_ZONE_TYPE): cv.string,
-    vol.Optional(CONF_ZONE_RFID, default=None): cv.string})
+    vol.Optional(CONF_ZONE_RFID): cv.string})
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -110,7 +110,8 @@ def setup(hass, config):
 
     def handle_rfx_message(sender, message):
         """Handle RFX message from AlarmDecoder."""
-        async_dispatcher_send(hass, SIGNAL_RFX_MESSAGE, message)
+        hass.helpers.dispatcher.dispatcher_send(
+            SIGNAL_RFX_MESSAGE, message)
 
     def zone_fault_callback(sender, zone):
         """Handle zone fault from AlarmDecoder."""

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -21,7 +21,14 @@ DEPENDENCIES = ['alarmdecoder']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_RF_STATE = 'rfstate'
+ATTR_RF_BIT0 = 'rf_bit0'
+ATTR_RF_LOW_BAT = 'rf_low_battery'
+ATTR_RF_SUPERVISED = 'rf_supervised'
+ATTR_RF_BIT3 = 'rf_bit3'
+ATTR_RF_LOOP3 = 'rf_loop3'
+ATTR_RF_LOOP2 = 'rf_loop2'
+ATTR_RF_LOOP4 = 'rf_loop4'
+ATTR_RF_LOOP1 = 'rf_loop1'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -50,11 +57,11 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
         """Initialize the binary_sensor."""
         self._zone_number = zone_number
         self._zone_type = zone_type
-        self._state = 0
+        self._state = None
         self._name = zone_name
         self._type = zone_type
         self._rfid = zone_rfid
-        self._rfstate = 0
+        self._rfstate = None
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -93,8 +100,15 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
     def device_state_attributes(self):
         """Return the state attributes."""
         attr = {}
-        if self._rfid:
-            attr[ATTR_RF_STATE] = self._rfstate
+        if self._rfid and self._rfstate is not None:
+            attr[ATTR_RF_BIT0] = True if self._rfstate & 0x01 else False
+            attr[ATTR_RF_LOW_BAT] = True if self._rfstate & 0x02 else False
+            attr[ATTR_RF_SUPERVISED] = True if self._rfstate & 0x04 else False
+            attr[ATTR_RF_BIT3] = True if self._rfstate & 0x08 else False
+            attr[ATTR_RF_LOOP3] = True if self._rfstate & 0x10 else False
+            attr[ATTR_RF_LOOP2] = True if self._rfstate & 0x20 else False
+            attr[ATTR_RF_LOOP4] = True if self._rfstate & 0x40 else False
+            attr[ATTR_RF_LOOP1] = True if self._rfstate & 0x80 else False
         return attr
 
     @property

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -8,14 +8,10 @@ import asyncio
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.components.alarmdecoder import (ZONE_SCHEMA,
-                                                   CONF_ZONES,
-                                                   CONF_ZONE_NAME,
-                                                   CONF_ZONE_TYPE,
-                                                   CONF_ZONE_RFID,
-                                                   SIGNAL_RFX_MESSAGE,
-                                                   SIGNAL_ZONE_FAULT,
-                                                   SIGNAL_ZONE_RESTORE)
+from homeassistant.components.alarmdecoder import (
+    ZONE_SCHEMA, CONF_ZONES, CONF_ZONE_NAME, CONF_ZONE_TYPE,
+    CONF_ZONE_RFID, SIGNAL_ZONE_FAULT, SIGNAL_ZONE_RESTORE,
+    SIGNAL_RFX_MESSAGE)
 
 DEPENDENCIES = ['alarmdecoder']
 

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -33,7 +33,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         device_config_data = ZONE_SCHEMA(configured_zones[zone_num])
         zone_type = device_config_data[CONF_ZONE_TYPE]
         zone_name = device_config_data[CONF_ZONE_NAME]
-        zone_rfid = device_config_data[CONF_ZONE_RFID]
+        zone_rfid = device_config_data.get(CONF_ZONE_RFID)
         device = AlarmDecoderBinarySensor(
             zone_num, zone_name, zone_type, zone_rfid)
         devices.append(device)
@@ -66,7 +66,7 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
             SIGNAL_ZONE_RESTORE, self._restore_callback)
 
         self.hass.helpers.dispatcher.async_dispatcher_connect(
-            self.hass, SIGNAL_RFX_MESSAGE, self._rfx_message_callback)
+            SIGNAL_RFX_MESSAGE, self._rfx_message_callback)
 
     @property
     def name(self):

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -8,13 +8,20 @@ import asyncio
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.components.alarmdecoder import (
-    ZONE_SCHEMA, CONF_ZONES, CONF_ZONE_NAME, CONF_ZONE_TYPE,
-    SIGNAL_ZONE_FAULT, SIGNAL_ZONE_RESTORE)
+from homeassistant.components.alarmdecoder import (ZONE_SCHEMA,
+                                                   CONF_ZONES,
+                                                   CONF_ZONE_NAME,
+                                                   CONF_ZONE_TYPE,
+                                                   CONF_ZONE_RFID,
+                                                   SIGNAL_RFX_MESSAGE,
+                                                   SIGNAL_ZONE_FAULT,
+                                                   SIGNAL_ZONE_RESTORE)
 
 DEPENDENCIES = ['alarmdecoder']
 
 _LOGGER = logging.getLogger(__name__)
+
+ATTR_RF_STATE = 'rfstate'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -26,7 +33,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         device_config_data = ZONE_SCHEMA(configured_zones[zone_num])
         zone_type = device_config_data[CONF_ZONE_TYPE]
         zone_name = device_config_data[CONF_ZONE_NAME]
-        device = AlarmDecoderBinarySensor(zone_num, zone_name, zone_type)
+        zone_rfid = device_config_data[CONF_ZONE_RFID]
+        device = AlarmDecoderBinarySensor(
+            zone_num, zone_name, zone_type, zone_rfid)
         devices.append(device)
 
     add_devices(devices)
@@ -37,13 +46,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AlarmDecoderBinarySensor(BinarySensorDevice):
     """Representation of an AlarmDecoder binary sensor."""
 
-    def __init__(self, zone_number, zone_name, zone_type):
+    def __init__(self, zone_number, zone_name, zone_type, zone_rfid):
         """Initialize the binary_sensor."""
         self._zone_number = zone_number
         self._zone_type = zone_type
         self._state = 0
         self._name = zone_name
         self._type = zone_type
+        self._rfid = zone_rfid
+        self._rfstate = 0
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -53,6 +64,9 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
 
         self.hass.helpers.dispatcher.async_dispatcher_connect(
             SIGNAL_ZONE_RESTORE, self._restore_callback)
+
+        self.hass.helpers.dispatcher.async_dispatcher_connect(
+            self.hass, SIGNAL_RFX_MESSAGE, self._rfx_message_callback)
 
     @property
     def name(self):
@@ -76,6 +90,14 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
         return False
 
     @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attr = {}
+        if self._rfid:
+            attr[ATTR_RF_STATE] = self._rfstate
+        return attr
+
+    @property
     def is_on(self):
         """Return true if sensor is on."""
         return self._state == 1
@@ -95,4 +117,10 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
         """Update the zone's state, if needed."""
         if zone is None or int(zone) == self._zone_number:
             self._state = 0
+            self.schedule_update_ha_state()
+
+    def _rfx_message_callback(self, message):
+        """Update RF state."""
+        if self._rfid and message and message.serial_number == self._rfid:
+            self._rfstate = message.value
             self.schedule_update_ha_state()


### PR DESCRIPTION
## Description:
Store the sensor state from RF sensors from alarmdecoder.
This allows visualization of how often supervision notifications are received, as well as direct access to low-battery indication.
This can be useful for detecting sensor issues before the alarm system flags them.  For instance sensors that are too far away from the receiver or have marginal battery may be unreliable, which can easily be detected by noticing that supervison pings (once per hour) are inconsistent.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4091

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarmdecoder:
  zones:
    20:
      name: 'Living Room Smoke Detector'
      type: 'smoke'
      rfid: '0531592'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
