### PR TITLE
Upgrade HomeMatic, add new devices

### DIFF
--- a/homeassistant/components/binary_sensor/homematic.py
+++ b/homeassistant/components/binary_sensor/homematic.py
@@ -25,6 +25,7 @@ SENSOR_TYPES_CLASS = {
     'RemoteMotion': None,
     'WeatherSensor': None,
     'TiltSensor': None,
+    'PresenceIP': 'motion',
 }
 
 

--- a/homeassistant/components/homematic.py
+++ b/homeassistant/components/homematic.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.config import load_yaml_config_file
 
-REQUIREMENTS = ['pyhomematic==0.1.34']
+REQUIREMENTS = ['pyhomematic==0.1.35']
 
 DOMAIN = 'homematic'
 
@@ -56,7 +56,7 @@ SERVICE_SET_DEV_VALUE = 'set_dev_value'
 
 HM_DEVICE_TYPES = {
     DISCOVER_SWITCHES: [
-        'Switch', 'SwitchPowermeter', 'IOSwitch', 'IPSwitch',
+        'Switch', 'SwitchPowermeter', 'IOSwitch', 'IPSwitch', 'RFSiren',
         'IPSwitchPowermeter', 'KeyMatic', 'HMWIOSwitch', 'Rain', 'EcoLogic'],
     DISCOVER_LIGHTS: ['Dimmer', 'KeyDimmer', 'IPKeyDimmer'],
     DISCOVER_SENSORS: [
@@ -66,7 +66,7 @@ HM_DEVICE_TYPES = {
         'WeatherStation', 'ThermostatWall2', 'TemperatureDiffSensor',
         'TemperatureSensor', 'CO2Sensor', 'IPSwitchPowermeter', 'HMWIOSwitch',
         'FillingLevel', 'ValveDrive', 'EcoLogic', 'IPThermostatWall',
-        'IPSmoke'],
+        'IPSmoke', 'RFSiren', 'PresenceIP'],
     DISCOVER_CLIMATE: [
         'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2',
         'MAXWallThermostat', 'IPThermostat', 'IPThermostatWall',
@@ -74,7 +74,8 @@ HM_DEVICE_TYPES = {
     DISCOVER_BINARY_SENSORS: [
         'ShutterContact', 'Smoke', 'SmokeV2', 'Motion', 'MotionV2',
         'RemoteMotion', 'WeatherSensor', 'TiltSensor', 'IPShutterContact',
-        'HMWIOSwitch', 'MaxShutterContact', 'Rain', 'WiredSensor'],
+        'HMWIOSwitch', 'MaxShutterContact', 'Rain', 'WiredSensor',
+        'PresenceIP'],
     DISCOVER_COVER: ['Blind', 'KeyBlind']
 }
 

--- a/homeassistant/components/sensor/homematic.py
+++ b/homeassistant/components/sensor/homematic.py
@@ -13,10 +13,23 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['homematic']
 
 HM_STATE_HA_CAST = {
-    'RotaryHandleSensor': {0: 'closed', 1: 'tilted', 2: 'open'},
-    'WaterSensor': {0: 'dry', 1: 'wet', 2: 'water'},
-    'CO2Sensor': {0: 'normal', 1: 'added', 2: 'strong'},
-    'IPSmoke': {0: 'off', 1: 'primary', 2: 'intrusion', 3: 'secondary'}
+    'RotaryHandleSensor': {0: 'closed',
+                           1: 'tilted',
+                           2: 'open'},
+    'WaterSensor': {0: 'dry',
+                    1: 'wet',
+                    2: 'water'},
+    'CO2Sensor': {0: 'normal',
+                  1: 'added',
+                  2: 'strong'},
+    'IPSmoke': {0: 'off',
+                1: 'primary',
+                2: 'intrusion',
+                3: 'secondary'},
+    'RFSiren': {0: 'disarmed',
+                1: 'extsens_armed',
+                2: 'allsens_armed',
+                3: 'alarm_blocked'},
 }
 
 HM_UNIT_HA_CAST = {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -674,7 +674,7 @@ pyhik==0.1.4
 pyhiveapi==0.2.5
 
 # homeassistant.components.homematic
-pyhomematic==0.1.34
+pyhomematic==0.1.35
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==1.3.1


### PR DESCRIPTION
## Description:
Upgrade pyhomematic dependency, add support for new devices.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
