### PR TITLE
Added current_state to zwave state_changed event

### DIFF
--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -129,9 +129,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         """Retrieve current state of a binary switch"""
         if self.node.has_command_class(COMMAND_CLASS_SWITCH_BINARY):
             for value in self.node.get_values().values():
-                if value.data and value.is_polled:
-                    return None
-                else:
+                if value.data:
                     return value.data
 
     def node_changed(self):

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -126,7 +126,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
             self._network.home_id, self.node_id)
 
     def get_current_state(self):
-        """Retrieve current state of a binary switch"""
+        """Retrieve current state of a binary switch."""
         if self.node.has_command_class(COMMAND_CLASS_SWITCH_BINARY):
             for value in self.node.get_values().values():
                 if value.data:

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -2,14 +2,15 @@
 import logging
 
 from homeassistant.core import callback
-from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_WAKEUP, ATTR_ENTITY_ID, ATTR_CURRENT_STATE
+from homeassistant.const import (
+    ATTR_BATTERY_LEVEL, ATTR_WAKEUP, ATTR_ENTITY_ID, ATTR_CURRENT_STATE)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
 from .const import (
-    ATTR_NODE_ID, COMMAND_CLASS_WAKE_UP, COMMAND_CLASS_SWITCH_BINARY, ATTR_SCENE_ID, ATTR_SCENE_DATA,
-    ATTR_BASIC_LEVEL, EVENT_NODE_EVENT, EVENT_SCENE_ACTIVATED, DOMAIN,
-    COMMAND_CLASS_CENTRAL_SCENE)
+    ATTR_NODE_ID, COMMAND_CLASS_WAKE_UP, COMMAND_CLASS_SWITCH_BINARY,
+    ATTR_SCENE_ID, ATTR_SCENE_DATA, ATTR_BASIC_LEVEL, EVENT_NODE_EVENT,
+    EVENT_SCENE_ACTIVATED, DOMAIN, COMMAND_CLASS_CENTRAL_SCENE)
 from .util import node_name
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -244,6 +244,7 @@ ATTR_LOCATION = 'location'
 
 ATTR_BATTERY_LEVEL = 'battery_level'
 ATTR_WAKEUP = 'wake_up_interval'
+ATTR_CURRENT_STATE = 'current_state'
 
 # For devices which support a code attribute
 ATTR_CODE = 'code'


### PR DESCRIPTION
## Description:

This adds a ```current_state``` attribute for devices that are ```COMMAND_CLASS_SWITCH_BINARY```.  This will allow us to trigger automation on ZWave```state_changed``` events.  Since HA does not send duplicate switch on/off events, this opens up possibilities like toggling smart lights that are controlled by one switch as if they were controlled by multiple switches.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
