### PR TITLE
Bugfix trigger state with multible entities

### DIFF
--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -38,7 +38,7 @@ def async_trigger(hass, config, action):
     time_delta = config.get(CONF_FOR)
     value_template = config.get(CONF_VALUE_TEMPLATE)
     unsub_track_same = {}
-    entity_triggered = set()
+    entities_triggered = set()
 
     if value_template is not None:
         value_template.hass = hass
@@ -79,16 +79,16 @@ def async_trigger(hass, config, action):
 
         matching = check_numeric_state(entity, from_s, to_s)
 
-        if matching entity not in entity_triggered:
+        if matching and entity not in entities_triggered:
             if time_delta:
                 unsub_track_same[entity] = async_track_same_state(
                     hass, time_delta, call_action, entity_ids=entity_id,
                     async_check_same_func=check_numeric_state)
             else:
                 call_action()
-            entity_triggered.add(entity)
+            entities_triggered.add(entity)
 
-        entity_triggered.discard(entity)
+        entities_triggered.discard(entity)
 
     unsub = async_track_state_change(
         hass, entity_id, state_automation_listener)

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -86,9 +86,10 @@ def async_trigger(hass, config, action):
                     async_check_same_func=check_numeric_state)
             else:
                 call_action()
-            entities_triggered.add(entity)
 
-        entities_triggered.discard(entity)
+            entities_triggered.add(entity)
+        else:
+            entities_triggered.discard(entity)
 
     unsub = async_track_state_change(
         hass, entity_id, state_automation_listener)

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -79,7 +79,7 @@ def async_trigger(hass, config, action):
 
         matching = check_numeric_state(entity, from_s, to_s)
 
-        if matching or (matching and entity not in first_triggered:
+        if matching or (matching and entity not in first_triggered):
             if time_delta:
                 unsub_track_same[entity] = async_track_same_state(
                     hass, time_delta, call_action, entity_ids=entity_id,

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -79,17 +79,17 @@ def async_trigger(hass, config, action):
 
         matching = check_numeric_state(entity, from_s, to_s)
 
-        if matching and entity not in entities_triggered:
+        if not matching:
+            entities_triggered.discard(entity)
+        elif entity not in entities_triggered:
+            entities_triggered.add(entity)
+
             if time_delta:
                 unsub_track_same[entity] = async_track_same_state(
                     hass, time_delta, call_action, entity_ids=entity_id,
                     async_check_same_func=check_numeric_state)
             else:
                 call_action()
-
-            entities_triggered.add(entity)
-        elif matching:
-            entities_triggered.discard(entity)
 
     unsub = async_track_state_change(
         hass, entity_id, state_automation_listener)

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -88,7 +88,7 @@ def async_trigger(hass, config, action):
                 call_action()
 
             entities_triggered.add(entity)
-        else:
+        elif matching:
             entities_triggered.discard(entity)
 
     unsub = async_track_state_change(

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -86,8 +86,8 @@ def async_trigger(hass, config, action):
                     async_check_same_func=check_numeric_state)
             else:
                 call_action()
-        else:
-            first_triggered.discard(entity)
+
+        first_triggered.discard(entity)
 
     unsub = async_track_state_change(
         hass, entity_id, state_automation_listener)

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -38,7 +38,7 @@ def async_trigger(hass, config, action):
     time_delta = config.get(CONF_FOR)
     value_template = config.get(CONF_VALUE_TEMPLATE)
     unsub_track_same = {}
-    first_triggered = set(entity_id)
+    entity_triggered = set()
 
     if value_template is not None:
         value_template.hass = hass
@@ -79,15 +79,16 @@ def async_trigger(hass, config, action):
 
         matching = check_numeric_state(entity, from_s, to_s)
 
-        if matching or (matching and entity not in first_triggered):
+        if matching entity not in entity_triggered:
             if time_delta:
                 unsub_track_same[entity] = async_track_same_state(
                     hass, time_delta, call_action, entity_ids=entity_id,
                     async_check_same_func=check_numeric_state)
             else:
                 call_action()
+            entity_triggered.add(entity)
 
-        first_triggered.discard(entity)
+        entity_triggered.discard(entity)
 
     unsub = async_track_state_change(
         hass, entity_id, state_automation_listener)

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -37,7 +37,7 @@ def async_trigger(hass, config, action):
     above = config.get(CONF_ABOVE)
     time_delta = config.get(CONF_FOR)
     value_template = config.get(CONF_VALUE_TEMPLATE)
-    unsub_track_same = None
+    unsub_track_same = {}
     first_triggered = set(entity_id)
 
     if value_template is not None:

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -98,7 +98,7 @@ def async_trigger(hass, config, action):
     def async_remove():
         """Remove state listeners async."""
         unsub()
-        for async_remove in unsub_track_same:
+        for async_remove in unsub_track_same.values():
             async_remove()
 
     return async_remove

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -100,5 +100,6 @@ def async_trigger(hass, config, action):
         unsub()
         for async_remove in unsub_track_same.values():
             async_remove()
+        unsub_track_same.clear()
 
     return async_remove

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -74,7 +74,7 @@ def async_trigger(hass, config, action):
     def async_remove():
         """Remove state listeners async."""
         unsub()
-        for async_remove in unsub_track_same:
+        for async_remove in unsub_track_same.values():
             async_remove()
 
     return async_remove

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -35,13 +35,11 @@ def async_trigger(hass, config, action):
     to_state = config.get(CONF_TO, MATCH_ALL)
     time_delta = config.get(CONF_FOR)
     match_all = (from_state == MATCH_ALL and to_state == MATCH_ALL)
-    async_remove_track_same = None
+    unsub_track_same = {}
 
     @callback
     def state_automation_listener(entity, from_s, to_s):
         """Listen for state changes and calls action."""
-        nonlocal async_remove_track_same
-
         @callback
         def call_action():
             """Call action with right context."""
@@ -64,7 +62,7 @@ def async_trigger(hass, config, action):
             call_action()
             return
 
-        async_remove_track_same = async_track_same_state(
+        unsub_track_same[entity] = async_track_same_state(
             hass, time_delta, call_action,
             lambda _, _2, to_state: to_state.state == to_s.state,
             entity_ids=entity_id)
@@ -76,7 +74,7 @@ def async_trigger(hass, config, action):
     def async_remove():
         """Remove state listeners async."""
         unsub()
-        if async_remove_track_same:
-            async_remove_track_same()  # pylint: disable=not-callable
+        for async_remove in unsub_track_same:
+            async_remove()
 
     return async_remove

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -76,5 +76,6 @@ def async_trigger(hass, config, action):
         unsub()
         for async_remove in unsub_track_same.values():
             async_remove()
+        unsub_track_same.clear()
 
     return async_remove

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -84,6 +84,36 @@ class TestAutomationNumericState(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
 
+    def test_if_fires_on_entities_change_over_to_below(self):
+        """"Test the firing with changed entities."""
+        self.hass.states.set('test.entity_1', 11)
+        self.hass.states.set('test.entity_2', 11)
+        self.hass.block_till_done()
+
+        assert setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'numeric_state',
+                    'entity_id': [
+                        'test.entity_1',
+                        'test.entity_2',
+                    ],
+                    'below': 10,
+                },
+                'action': {
+                    'service': 'test.automation'
+                }
+            }
+        })
+
+        # 9 is below 10
+        self.hass.states.set('test.entity_1', 9)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        self.hass.states.set('test.entity_2', 9)
+        self.hass.block_till_done()
+        self.assertEqual(2, len(self.calls))
+
     def test_if_not_fires_on_entity_change_below_to_below(self):
         """"Test the firing with changed entity."""
         self.hass.states.set('test.entity', 11)

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -142,6 +142,11 @@ class TestAutomationNumericState(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
 
+        # still below so should not fire again
+        self.hass.states.set('test.entity', 3)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
     def test_if_not_below_fires_on_entity_change_to_equal(self):
         """"Test the firing with changed entity."""
         self.hass.states.set('test.entity', 11)

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -701,6 +701,48 @@ class TestAutomationNumericState(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
 
+    def test_if_not_fires_on_entities_change_with_for_afte_stop(self):
+        """Test for not firing on entities change with for after stop."""
+        assert setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'numeric_state',
+                    'entity_id': [
+                        'test.entity_1',
+                        'test.entity_2',
+                    ],
+                    'above': 8,
+                    'below': 12,
+                    'for': {
+                        'seconds': 5
+                    },
+                },
+                'action': {
+                    'service': 'test.automation'
+                }
+            }
+        })
+
+        self.hass.states.set('test.entity_1', 9)
+        self.hass.states.set('test.entity_2', 9)
+        self.hass.block_till_done()
+        fire_time_changed(self.hass, dt_util.utcnow() + timedelta(seconds=10))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(self.calls))
+
+        self.hass.states.set('test.entity_1', 15)
+        self.hass.states.set('test.entity_2', 15)
+        self.hass.block_till_done()
+        self.hass.states.set('test.entity_1', 9)
+        self.hass.states.set('test.entity_2', 9)
+        self.hass.block_till_done()
+        automation.turn_off(self.hass)
+        self.hass.block_till_done()
+
+        fire_time_changed(self.hass, dt_util.utcnow() + timedelta(seconds=10))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(self.calls))
+
     def test_if_fires_on_entity_change_with_for_attribute_change(self):
         """Test for firing on entity change with for and attribute change."""
         assert setup_component(self.hass, automation.DOMAIN, {

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -334,6 +334,47 @@ class TestAutomationState(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
 
+    def test_if_not_fires_on_entities_change_with_for_after_stop(self):
+        """Test for not firing on entity change with for after stop trigger."""
+        assert setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'state',
+                    'entity_id': [
+                        'test.entity_1',
+                        'test.entity_2',
+                    ],
+                    'to': 'world',
+                    'for': {
+                        'seconds': 5
+                    },
+                },
+                'action': {
+                    'service': 'test.automation'
+                }
+            }
+        })
+
+        self.hass.states.set('test.entity_1', 'world')
+        self.hass.states.set('test.entity_2', 'world')
+        self.hass.block_till_done()
+        fire_time_changed(self.hass, dt_util.utcnow() + timedelta(seconds=10))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(self.calls))
+
+        self.hass.states.set('test.entity_1', 'world_no')
+        self.hass.states.set('test.entity_2', 'world_no')
+        self.hass.block_till_done()
+        self.hass.states.set('test.entity_1', 'world')
+        self.hass.states.set('test.entity_2', 'world')
+        self.hass.block_till_done()
+        automation.turn_off(self.hass)
+        self.hass.block_till_done()
+
+        fire_time_changed(self.hass, dt_util.utcnow() + timedelta(seconds=10))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(self.calls))
+
     def test_if_fires_on_entity_change_with_for_attribute_change(self):
         """Test for firing on entity change with for and attribute change."""
         assert setup_component(self.hass, automation.DOMAIN, {


### PR DESCRIPTION
## Description:

This fix all problems with `state` and `numeric` trigger they can have multible entities and last changes on that trigger was not aware of that situation.

Fix: #10836

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
