### PR TITLE
Added support for cover in tellstick

### DIFF
--- a/homeassistant/components/cover/tellstick.py
+++ b/homeassistant/components/cover/tellstick.py
@@ -2,7 +2,7 @@
 Support for Tellstick switches.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/switch.tellstick/
+https://home-assistant.io/components/cover.tellstick/
 """
 
 
@@ -50,11 +50,11 @@ class TellstickCover(TellstickDevice, CoverDevice):
 
     def _parse_tellcore_data(self, tellcore_data):
         """Turn the value received from tellcore into something useful."""
-        return None
+        pass
 
     def _parse_ha_data(self, kwargs):
         """Turn the value from HA into something useful."""
-        return None
+        pass
 
     def _update_model(self, new_state, data):
         """Update the device entity state to match the arguments."""

--- a/homeassistant/components/cover/tellstick.py
+++ b/homeassistant/components/cover/tellstick.py
@@ -1,0 +1,61 @@
+"""
+Support for Tellstick switches.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.tellstick/
+"""
+
+
+from homeassistant.components.cover import CoverDevice
+from homeassistant.components.tellstick import (
+    DEFAULT_SIGNAL_REPETITIONS, ATTR_DISCOVER_DEVICES, ATTR_DISCOVER_CONFIG,
+    DATA_TELLSTICK, TellstickDevice)
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Tellstick lights."""
+    if (discovery_info is None or
+            discovery_info[ATTR_DISCOVER_DEVICES] is None):
+        return
+
+    signal_repetitions = discovery_info.get(
+        ATTR_DISCOVER_CONFIG, DEFAULT_SIGNAL_REPETITIONS)
+
+    add_devices([TellstickCover(hass.data[DATA_TELLSTICK][tellcore_id],
+                                signal_repetitions)
+                 for tellcore_id in discovery_info[ATTR_DISCOVER_DEVICES]],
+                True)
+
+
+class TellstickCover(TellstickDevice, CoverDevice):
+    """Representation of a Tellstick switch."""
+
+    @property
+    def is_closed(self):
+        """Return the current position of the cover is not possible."""
+        return None
+
+    def close_cover(self, **kwargs):
+        """Close the cover."""
+        self._tellcore_device.down()
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        self._tellcore_device.up()
+
+    def stop_cover(self, **kwargs):
+        """Stop the cover."""
+        self._tellcore_device.stop()
+
+    def _parse_tellcore_data(self, tellcore_data):
+        """Turn the value received from tellcore into something useful."""
+        return None
+
+    def _parse_ha_data(self, kwargs):
+        """Turn the value from HA into something useful."""
+        return None
+
+    def _update_model(self, new_state, data):
+        """Update the device entity state to match the arguments."""
+        self._state = new_state

--- a/homeassistant/components/cover/tellstick.py
+++ b/homeassistant/components/cover/tellstick.py
@@ -1,5 +1,5 @@
 """
-Support for Tellstick switches.
+Support for Tellstick covers.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.tellstick/
@@ -12,9 +12,8 @@ from homeassistant.components.tellstick import (
     DATA_TELLSTICK, TellstickDevice)
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the Tellstick lights."""
+    """Set up the Tellstick covers."""
     if (discovery_info is None or
             discovery_info[ATTR_DISCOVER_DEVICES] is None):
         return
@@ -29,7 +28,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class TellstickCover(TellstickDevice, CoverDevice):
-    """Representation of a Tellstick switch."""
+    """Representation of a Tellstick cover."""
 
     @property
     def is_closed(self):

--- a/homeassistant/components/cover/tellstick.py
+++ b/homeassistant/components/cover/tellstick.py
@@ -35,6 +35,11 @@ class TellstickCover(TellstickDevice, CoverDevice):
         """Return the current position of the cover is not possible."""
         return None
 
+    @property
+    def assumed_state(self):
+        """Return True if unable to access real state of the entity."""
+        return True
+
     def close_cover(self, **kwargs):
         """Close the cover."""
         self._tellcore_device.down()
@@ -57,4 +62,4 @@ class TellstickCover(TellstickDevice, CoverDevice):
 
     def _update_model(self, new_state, data):
         """Update the device entity state to match the arguments."""
-        self._state = new_state
+        pass

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -66,7 +66,7 @@ def _discover(hass, config, component_name, found_tellcore_devices):
 
 def setup(hass, config):
     """Set up the Tellstick component."""
-    from tellcore.constants import TELLSTICK_DIM
+    from tellcore.constants import (TELLSTICK_DIM, TELLSTICK_UP)
     from tellcore.telldus import AsyncioCallbackDispatcher
     from tellcore.telldus import TelldusCore
     from tellcorenet import TellCoreClient
@@ -100,15 +100,21 @@ def setup(hass, config):
     hass.data[DATA_TELLSTICK] = {device.id: device for
                                  device in tellcore_devices}
 
-    # Discover the switches
-    _discover(hass, config, 'switch',
-              [device.id for device in tellcore_devices
-               if not device.methods(TELLSTICK_DIM)])
-
     # Discover the lights
     _discover(hass, config, 'light',
               [device.id for device in tellcore_devices
                if device.methods(TELLSTICK_DIM)])
+
+    # Discover the cover
+    _discover(hass, config, 'cover',
+              [device.id for device in tellcore_devices
+               if device.methods(TELLSTICK_UP)])
+
+    # Discover the switches
+    _discover(hass, config, 'switch',
+              [device.id for device in tellcore_devices
+               if (not device.methods(TELLSTICK_UP) and
+                   not device.methods(TELLSTICK_DIM))])
 
     @callback
     def async_handle_callback(tellcore_id, tellcore_command,


### PR DESCRIPTION
## Description:
New cover component for tellstick and fix for the main tellstick component to select the cover if it's not a switch or a light.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4096

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  platform: tellstick
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
