### PR TITLE
tellstick fix DEPENDENCIES and update tellcore-net

### DIFF
--- a/homeassistant/components/sensor/tellstick.py
+++ b/homeassistant/components/sensor/tellstick.py
@@ -14,7 +14,7 @@ from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['tellcore-py==1.1.2']
+DEPENDENCIES = ['homematic']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/tellstick.py
+++ b/homeassistant/components/sensor/tellstick.py
@@ -14,7 +14,7 @@ from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-DEPENDENCIES = ['homematic']
+DEPENDENCIES = ['tellstick']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['tellcore-py==1.1.2', 'tellcore-net==0.1']
+REQUIREMENTS = ['tellcore-py==1.1.2', 'tellcore-net==0.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -77,7 +77,7 @@ def setup(hass, config):
     net_ports = conf.get(CONF_PORT)
 
     # Initialize remote tellcore client
-    if net_host and net_port:
+    if net_host:
         net_client = TellCoreClient(
             host=net_host, port_client=net_ports[0], port_events=net_ports[1])
         net_client.start()

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -43,7 +43,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Inclusive(CONF_HOST, 'tellcore-net'): cv.string,
         vol.Inclusive(CONF_PORT, 'tellcore-net'):
-            vol.All(cv.ensure_list, [cv.port]),
+            vol.All(cv.ensure_list, [cv.port], vol.Length(min=2, max=2)),
         vol.Optional(CONF_SIGNAL_REPETITIONS,
                      default=DEFAULT_SIGNAL_REPETITIONS): vol.Coerce(int),
     }),

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['tellcore-py==1.1.2', 'tellcore-net==0.2']
+REQUIREMENTS = ['tellcore-py==1.1.2', 'tellcore-net==0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -42,7 +42,7 @@ TELLCORE_REGISTRY = None
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Inclusive(CONF_HOST, 'tellcore-net'): cv.string,
-        vol.Inclusive(CONF_PORT, 'tellcore-net'): 
+        vol.Inclusive(CONF_PORT, 'tellcore-net'):
             vol.All(cv.ensure_list, [cv.port]),
         vol.Optional(CONF_SIGNAL_REPETITIONS,
                      default=DEFAULT_SIGNAL_REPETITIONS): vol.Coerce(int),

--- a/homeassistant/components/tellstick.py
+++ b/homeassistant/components/tellstick.py
@@ -42,7 +42,8 @@ TELLCORE_REGISTRY = None
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Inclusive(CONF_HOST, 'tellcore-net'): cv.string,
-        vol.Inclusive(CONF_PORT, 'tellcore-net'): cv.port,
+        vol.Inclusive(CONF_PORT, 'tellcore-net'): 
+            vol.All(cv.ensure_list, [cv.port]),
         vol.Optional(CONF_SIGNAL_REPETITIONS,
                      default=DEFAULT_SIGNAL_REPETITIONS): vol.Coerce(int),
     }),
@@ -73,11 +74,12 @@ def setup(hass, config):
 
     conf = config.get(DOMAIN, {})
     net_host = conf.get(CONF_HOST)
-    net_port = conf.get(CONF_PORT)
+    net_ports = conf.get(CONF_PORT)
 
     # Initialize remote tellcore client
     if net_host and net_port:
-        net_client = TellCoreClient(net_host, net_port)
+        net_client = TellCoreClient(
+            host=net_host, port_client=net_ports[0], port_events=net_ports[1])
         net_client.start()
 
         def stop_tellcore_net(event):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1057,7 +1057,7 @@ tank_utility==1.4.0
 tapsaff==0.1.3
 
 # homeassistant.components.tellstick
-tellcore-net==0.1
+tellcore-net==0.2
 
 # homeassistant.components.tellstick
 # homeassistant.components.sensor.tellstick

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1060,7 +1060,6 @@ tapsaff==0.1.3
 tellcore-net==0.2
 
 # homeassistant.components.tellstick
-# homeassistant.components.sensor.tellstick
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1057,7 +1057,7 @@ tank_utility==1.4.0
 tapsaff==0.1.3
 
 # homeassistant.components.tellstick
-tellcore-net==0.2
+tellcore-net==0.3
 
 # homeassistant.components.tellstick
 tellcore-py==1.1.2


### PR DESCRIPTION
## Description:

- fix sensor DEPENDENCIES
- use new tellcore-net library

```yaml
tellstick:
  host: core-tellstick
  port: 50800, 50801
```

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
