### PR TITLE
Add Alpha Vantage sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -472,6 +472,7 @@ omit =
     homeassistant/components/scene/hunterdouglas_powerview.py
     homeassistant/components/scene/lifx_cloud.py
     homeassistant/components/sensor/airvisual.py
+    homeassistant/components/sensor/alpha_vantage.py
     homeassistant/components/sensor/arest.py
     homeassistant/components/sensor/arwn.py
     homeassistant/components/sensor/bbox.py
@@ -482,8 +483,8 @@ omit =
     homeassistant/components/sensor/bom.py
     homeassistant/components/sensor/broadlink.py
     homeassistant/components/sensor/buienradar.py
-    homeassistant/components/sensor/citybikes.py
     homeassistant/components/sensor/cert_expiry.py
+    homeassistant/components/sensor/citybikes.py
     homeassistant/components/sensor/comed_hourly_pricing.py
     homeassistant/components/sensor/cpuspeed.py
     homeassistant/components/sensor/crimereports.py

--- a/homeassistant/components/sensor/alpha_vantage.py
+++ b/homeassistant/components/sensor/alpha_vantage.py
@@ -1,0 +1,125 @@
+"""
+Stock market information from Alpha Vantage.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.alpha_vantage/
+"""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['alpha_vantage==1.3.6']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_CLOSE = 'close'
+ATTR_HIGH = 'high'
+ATTR_OPEN = 'open'
+ATTR_LOW = 'low'
+ATTR_VOLUME = 'volume'
+
+CONF_ATTRIBUTION = "Stock market information provided by Alpha Vantage."
+CONF_SYMBOLS = 'symbols'
+
+DEFAULT_SYMBOL = 'GOOGL'
+
+ICON = 'mdi:currency-usd'
+
+SCAN_INTERVAL = timedelta(minutes=5)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_SYMBOLS, default=[DEFAULT_SYMBOL]):
+        vol.All(cv.ensure_list, [cv.string]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Alpha Vantage sensor."""
+    from alpha_vantage.timeseries import TimeSeries
+
+    api_key = config.get(CONF_API_KEY)
+    symbols = config.get(CONF_SYMBOLS)
+
+    timeserie = TimeSeries(key=api_key)
+
+    dev = []
+    for symbol in symbols:
+        try:
+            data = AlphaVantageData(timeserie, symbol)
+            data.update()
+        except ValueError:
+            _LOGGER.error("API Key is not valid or symbol not known")
+            return False
+        dev.append(AlphaVantageSensor(data, symbol))
+
+    add_devices(dev)
+
+
+class AlphaVantageSensor(Entity):
+    """Representation of a Alpha Vantage sensor."""
+
+    def __init__(self, data, symbol):
+        """Initialize the sensor."""
+        self._name = symbol
+        self.data = data
+        self._symbol = symbol
+        self._state = None
+        self._unit_of_measurement = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._symbol
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self.data.values['1. open']
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self.data is not None:
+            return {
+                ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+                ATTR_CLOSE: self.data.values['4. close'],
+                ATTR_HIGH: self.data.values['2. high'],
+                ATTR_LOW: self.data.values['3. low'],
+                ATTR_VOLUME: self.data.values['5. volume'],
+            }
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return ICON
+
+    def update(self):
+        """Get the latest data and updates the states."""
+        self.data.update()
+
+
+class AlphaVantageData(object):
+    """Get data from Alpha Vantage."""
+
+    def __init__(self, timeserie, symbol):
+        """Initialize the data object."""
+        self._symbol = symbol
+        self._timeserie = timeserie
+        self.values = None
+
+    def update(self):
+        """Get the latest data and updates the states."""
+        all_values, _ = self._timeserie.get_intraday(self._symbol)
+        self.values = next(iter(all_values.values()))

--- a/homeassistant/components/sensor/alpha_vantage.py
+++ b/homeassistant/components/sensor/alpha_vantage.py
@@ -46,17 +46,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     api_key = config.get(CONF_API_KEY)
     symbols = config.get(CONF_SYMBOLS)
 
-    timeserie = TimeSeries(key=api_key)
+    timeseries = TimeSeries(key=api_key)
 
     dev = []
     for symbol in symbols:
         try:
-            timeserie.get_intraday(symbol)
+            timeseries.get_intraday(symbol)
         except ValueError:
             _LOGGER.error(
                 "API Key is not valid or symbol '%s' not known", symbol)
             return
-        dev.append(AlphaVantageSensor(timeserie, symbol))
+        dev.append(AlphaVantageSensor(timeseries, symbol))
 
     add_devices(dev, True)
 
@@ -64,10 +64,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AlphaVantageSensor(Entity):
     """Representation of a Alpha Vantage sensor."""
 
-    def __init__(self, timeserie, symbol):
+    def __init__(self, timeseries, symbol):
         """Initialize the sensor."""
         self._name = symbol
-        self._timeserie = timeserie
+        self._timeseries = timeseries
         self._symbol = symbol
         self.values = None
         self._unit_of_measurement = None
@@ -106,5 +106,5 @@ class AlphaVantageSensor(Entity):
 
     def update(self):
         """Get the latest data and updates the states."""
-        all_values, _ = self._timeserie.get_intraday(self._symbol)
+        all_values, _ = self._timeseries.get_intraday(self._symbol)
         self.values = next(iter(all_values.values()))

--- a/homeassistant/components/sensor/alpha_vantage.py
+++ b/homeassistant/components/sensor/alpha_vantage.py
@@ -20,7 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_CLOSE = 'close'
 ATTR_HIGH = 'high'
-ATTR_OPEN = 'open'
 ATTR_LOW = 'low'
 ATTR_VOLUME = 'volume'
 
@@ -56,7 +55,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         except ValueError:
             _LOGGER.error(
                 "API Key is not valid or symbol '%s' not known", symbol)
-            return False
+            return
         dev.append(AlphaVantageSensor(timeserie, symbol))
 
     add_devices(dev, True)
@@ -70,7 +69,6 @@ class AlphaVantageSensor(Entity):
         self._name = symbol
         self._timeserie = timeserie
         self._symbol = symbol
-        self._state = None
         self.values = None
         self._unit_of_measurement = None
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -83,6 +83,9 @@ aiopvapi==1.5.4
 # homeassistant.components.alarmdecoder
 alarmdecoder==0.12.3
 
+# homeassistant.components.sensor.alpha_vantage
+alpha_vantage==1.3.6
+
 # homeassistant.components.amcrest
 amcrest==1.2.1
 


### PR DESCRIPTION
## Description:
Alpha Vantage sensor for stock details. It's a replacement for the [Yahoo! Finance](https://home-assistant.io/components/sensor.yahoo_finance/) which will no longer work as the service was decommissioned.

**Related issue (if applicable):** #9144, #10334

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4122

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: alpha_vantage
    api_key: !secret av_api
    symbols:
      - RHT
      - GOOGL
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
