### PR TITLE
Shuffle support in Sonos

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -891,10 +891,7 @@ class SonosDevice(MediaPlayerDevice):
     def set_shuffle(self, shuffle):
         """Enable/Disable shuffle mode."""
         self._shuffle = shuffle
-        if shuffle is True:
-            self._player.play_mode = 'SHUFFLE'
-        else:
-            self._player.play_mode = 'NORMAL'
+        self._player.play_mode = 'SHUFFLE' if shuffle else 'NORMAL'
 
     @soco_error
     def mute_volume(self, mute):
@@ -995,7 +992,6 @@ class SonosDevice(MediaPlayerDevice):
     @soco_coordinator
     def media_play(self):
         """Send play command."""
-        self._player.play_mode = self.get_play_mode()
         self._player.play()
 
     @soco_error
@@ -1190,6 +1186,4 @@ class SonosDevice(MediaPlayerDevice):
 
     def get_play_mode(self):
         """Return play mode (only shuffle and normal is supported atm)."""
-        if self._shuffle is True:
-            return 'SHUFFLE'
-        return 'NORMAL'
+        return 'SHUFFLE' if self._shuffle else 'NORMAL'

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -890,8 +890,11 @@ class SonosDevice(MediaPlayerDevice):
     @soco_error
     def set_shuffle(self, shuffle):
         """Enable/Disable shuffle mode."""
-        self._shuffle = True
-        self._player.play_mode = 'SHUFFLE'
+        self._shuffle = shuffle
+        if shuffle is True:
+            self._player.play_mode = 'SHUFFLE'
+        else:
+            self._player.play_mode = 'NORMAL'
 
     @soco_error
     def mute_volume(self, mute):

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -313,7 +313,6 @@ class SonosDevice(MediaPlayerDevice):
         self._unique_id = player.uid
         self._player = player
         self._player_volume = None
-        self._shuffle = False
         self._player_volume_muted = None
         self._speaker_info = None
         self._name = None
@@ -772,7 +771,7 @@ class SonosDevice(MediaPlayerDevice):
     @property
     def shuffle(self):
         """Shuffling state."""
-        return self._shuffle
+        return True if self._player.play_mode == 'SHUFFLE' else False
 
     @property
     def media_content_id(self):
@@ -890,7 +889,6 @@ class SonosDevice(MediaPlayerDevice):
     @soco_error
     def set_shuffle(self, shuffle):
         """Enable/Disable shuffle mode."""
-        self._shuffle = shuffle
         self._player.play_mode = 'SHUFFLE' if shuffle else 'NORMAL'
 
     @soco_error
@@ -951,7 +949,6 @@ class SonosDevice(MediaPlayerDevice):
 
         self._player.stop()
         self._player.clear_queue()
-        self._player.play_mode = self.get_play_mode()
         self._player.add_to_queue(didl)
 
     @property
@@ -1183,7 +1180,3 @@ class SonosDevice(MediaPlayerDevice):
     def device_state_attributes(self):
         """Return device specific state attributes."""
         return {ATTR_IS_COORDINATOR: self.is_coordinator}
-
-    def get_play_mode(self):
-        """Return play mode (only shuffle and normal is supported atm)."""
-        return 'SHUFFLE' if self._shuffle else 'NORMAL'

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -293,7 +293,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
 
         device.set_shuffle(True)
         self.assertEqual(shuffle_set_mock.call_count, 1)
-        self.assertEqual(device.get_play_mode(), 'SHUFFLE')
+        self.assertEqual(device._player.play_mode, 'SHUFFLE')
 
     @mock.patch('soco.SoCo', new=SoCoMock)
     @mock.patch('socket.create_connection', side_effect=socket.error())

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -283,6 +283,20 @@ class TestSonosMediaPlayer(unittest.TestCase):
 
     @mock.patch('soco.SoCo', new=SoCoMock)
     @mock.patch('socket.create_connection', side_effect=socket.error())
+    def test_set_shuffle(self, shuffle_set_mock, *args):
+        """Ensuring soco methods called for sonos_snapshot service."""
+        sonos.setup_platform(self.hass, {}, fake_add_device, {
+            'host': '192.0.2.1'
+        })
+        device = self.hass.data[sonos.DATA_SONOS][-1]
+        device.hass = self.hass
+
+        device.set_shuffle(True)
+        self.assertEqual(shuffle_set_mock.call_count, 1)
+        self.assertEqual(device.get_play_mode(), 'SHUFFLE')
+
+    @mock.patch('soco.SoCo', new=SoCoMock)
+    @mock.patch('socket.create_connection', side_effect=socket.error())
     @mock.patch.object(SoCoMock, 'set_sleep_timer')
     def test_sonos_set_sleep_timer(self, set_sleep_timerMock, *args):
         """Ensuring soco methods called for sonos_set_sleep_timer service."""


### PR DESCRIPTION
## Description:
This PR adds support for Shuffle in Sonos. This is invoked by calling service shuffle_set.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ Will update ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ X ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ X ] Tests have been added to verify that the new code works.
