### PR TITLE
Reload groups after saving a change via config API

### DIFF
--- a/homeassistant/components/config/group.py
+++ b/homeassistant/components/config/group.py
@@ -1,8 +1,8 @@
 """Provide configuration end points for Groups."""
 import asyncio
-
+from homeassistant.const import SERVICE_RELOAD
 from homeassistant.components.config import EditKeyBasedConfigView
-from homeassistant.components.group import GROUP_SCHEMA
+from homeassistant.components.group import DOMAIN, GROUP_SCHEMA
 import homeassistant.helpers.config_validation as cv
 
 
@@ -12,7 +12,13 @@ CONFIG_PATH = 'groups.yaml'
 @asyncio.coroutine
 def async_setup(hass):
     """Set up the Group config API."""
+    @asyncio.coroutine
+    def hook(hass):
+        """post_write_hook for Config View that reloads groups."""
+        yield from hass.services.async_call(DOMAIN, SERVICE_RELOAD)
+
     hass.http.register_view(EditKeyBasedConfigView(
-        'group', 'config', CONFIG_PATH, cv.slug, GROUP_SCHEMA
+        'group', 'config', CONFIG_PATH, cv.slug, GROUP_SCHEMA,
+        post_write_hook=hook
     ))
     return True

--- a/tests/components/config/test_group.py
+++ b/tests/components/config/test_group.py
@@ -1,7 +1,7 @@
-"""Test Z-Wave config panel."""
+"""Test Group config panel."""
 import asyncio
 import json
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
@@ -66,8 +66,11 @@ def test_update_device_config(hass, test_client):
         """Mock writing data."""
         written.append(data)
 
+    mock_call = MagicMock()
+
     with patch('homeassistant.components.config._read', mock_read), \
-            patch('homeassistant.components.config._write', mock_write):
+            patch('homeassistant.components.config._write', mock_write), \
+            patch.object(hass.services, 'async_call', mock_call):
         resp = yield from client.post(
             '/api/config/group/config/hello_beer', data=json.dumps({
                 'name': 'Beer',
@@ -82,6 +85,7 @@ def test_update_device_config(hass, test_client):
     orig_data['hello_beer']['entities'] = ['light.top', 'light.bottom']
 
     assert written[0] == orig_data
+    mock_call.assert_called_once_with('group', 'reload')
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

Reload groups after saving a change via config API

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
