### PR TITLE
Add iAlarm support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -263,6 +263,7 @@ omit =
     homeassistant/components/alarm_control_panel/alarmdotcom.py
     homeassistant/components/alarm_control_panel/concord232.py
     homeassistant/components/alarm_control_panel/egardia.py
+    homeassistant/components/alarm_control_panel/ialarm.py
     homeassistant/components/alarm_control_panel/manual_mqtt.py
     homeassistant/components/alarm_control_panel/nx584.py
     homeassistant/components/alarm_control_panel/simplisafe.py

--- a/homeassistant/components/alarm_control_panel/ialarm.py
+++ b/homeassistant/components/alarm_control_panel/ialarm.py
@@ -26,15 +26,16 @@ def no_application_protocol(value):
     """Validate that value is without the application protocol"""
     protocol_separator = "://"
     if not value or protocol_separator in value:
-        raise vol.Invalid('invalid host')
+        raise vol.Invalid(
+            'Invalid host, {} is not allowed'.format(protocol_separator))
 
-    return str(value)
+    return value
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_HOST): no_application_protocol,
+    vol.Required(CONF_HOST): vol.All(cv.string, no_application_protocol),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/alarm_control_panel/ialarm.py
+++ b/homeassistant/components/alarm_control_panel/ialarm.py
@@ -21,10 +21,20 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'iAlarm'
 
+
+def no_application_protocol(value):
+    """Validate that value is without the application protocol"""
+    protocol_separator = "://"
+    if not value or protocol_separator in value:
+        raise vol.Invalid('invalid host')
+
+    return str(value)
+
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_HOST): no_application_protocol,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/alarm_control_panel/ialarm.py
+++ b/homeassistant/components/alarm_control_panel/ialarm.py
@@ -23,7 +23,7 @@ DEFAULT_NAME = 'iAlarm'
 
 
 def no_application_protocol(value):
-    """Validate that value is without the application protocol"""
+    """Validate that value is without the application protocol."""
     protocol_separator = "://"
     if not value or protocol_separator in value:
         raise vol.Invalid(

--- a/homeassistant/components/alarm_control_panel/ialarmpanel.py
+++ b/homeassistant/components/alarm_control_panel/ialarmpanel.py
@@ -1,0 +1,97 @@
+"""
+Interfaces with iAlarm control panels.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_control_panel.ialarm/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+import homeassistant.components.alarm_control_panel as alarm
+from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_PASSWORD, CONF_USERNAME, CONF_HOST, STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_UNKNOWN, CONF_NAME)
+
+REQUIREMENTS = ['pyialarm==0.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'iAlarm'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up an iAlarm control panel."""
+    name = config.get(CONF_NAME)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    host = config.get(CONF_HOST)
+
+    url = 'http://{}'.format(host)
+    ialarm = IAlarmPanel(name, username, password, url)
+    add_devices([ialarm], True)
+
+
+class IAlarmPanel(alarm.AlarmControlPanel):
+    """Represent an iAlarm status."""
+
+    def __init__(self, name, username, password, url):
+        """Initialize the iAlarm status."""
+        from pyialarm import IAlarm
+
+        _LOGGER.debug("Setting up iAlarm...")
+        self._name = name
+        self._username = username
+        self._password = password
+        self._url = url
+        self._state = STATE_UNKNOWN
+        self._client = IAlarm(username, password, url)
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    def update(self):
+        """Return the state of the device."""
+        status = self._client.get_status()
+        _LOGGER.debug('iAlarm status: %s', status)
+        if status:
+            status = int(status)
+
+        if status == self._client.DISARMED:
+            state = STATE_ALARM_DISARMED
+        elif status == self._client.ARMED_AWAY:
+            state = STATE_ALARM_ARMED_AWAY
+        elif status == self._client.ARMED_STAY:
+            state = STATE_ALARM_ARMED_HOME
+        else:
+            state = STATE_UNKNOWN
+
+        self._state = state
+
+    def alarm_disarm(self, code=None):
+        """Send disarm command."""
+        self._client.disarm()
+
+    def alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        self._client.arm_away()
+
+    def alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        self._client.arm_stay()

--- a/homeassistant/components/alarm_control_panel/ialarmpanel.py
+++ b/homeassistant/components/alarm_control_panel/ialarmpanel.py
@@ -13,7 +13,7 @@ import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_PASSWORD, CONF_USERNAME, CONF_HOST, STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_UNKNOWN, CONF_NAME)
+    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, CONF_NAME)
 
 REQUIREMENTS = ['pyialarm==0.2']
 
@@ -48,12 +48,11 @@ class IAlarmPanel(alarm.AlarmControlPanel):
         """Initialize the iAlarm status."""
         from pyialarm import IAlarm
 
-        _LOGGER.debug("Setting up iAlarm...")
         self._name = name
         self._username = username
         self._password = password
         self._url = url
-        self._state = STATE_UNKNOWN
+        self._state = None
         self._client = IAlarm(username, password, url)
 
     @property
@@ -80,7 +79,7 @@ class IAlarmPanel(alarm.AlarmControlPanel):
         elif status == self._client.ARMED_STAY:
             state = STATE_ALARM_ARMED_HOME
         else:
-            state = STATE_UNKNOWN
+            state = None
 
         self._state = state
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -682,6 +682,9 @@ pyhomematic==0.1.35
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==1.3.1
 
+# homeassistant.components.alarm_control_panel.ialarmpanel
+pyialarm==0.2
+
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.9.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -682,7 +682,7 @@ pyhomematic==0.1.35
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==1.3.1
 
-# homeassistant.components.alarm_control_panel.ialarmpanel
+# homeassistant.components.alarm_control_panel.ialarm
 pyialarm==0.2
 
 # homeassistant.components.device_tracker.icloud


### PR DESCRIPTION
## Description:

Add support for Antifurto365 iAlarm alarm systems.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4106

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: ialarm
    host: ALARM_SYSTEM_IP
    username: YOUR_USERNAME
    password: YOUR_PASSWORD
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
