### PR TITLE
Upgrade aiohttp to 2.3.5

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ pip>=8.0.3
 jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.3.2
+aiohttp==2.3.5
 yarl==0.14.0
 async_timeout==2.0.0
 chardet==3.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ pip>=8.0.3
 jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.3.2
+aiohttp==2.3.5
 yarl==0.14.0
 async_timeout==2.0.0
 chardet==3.0.4

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ REQUIRES = [
     'jinja2>=2.9.6',
     'voluptuous==0.10.5',
     'typing>=3,<4',
-    'aiohttp==2.3.2',   # If updated, check if yarl also needs an update!
+    'aiohttp==2.3.5',   # If updated, check if yarl also needs an update!
     'yarl==0.14.0',
     'async_timeout==2.0.0',
     'chardet==3.0.4',


### PR DESCRIPTION
## Description:
- Fix compatibility with pytest 3.3+
- Make request.app point to proper application instance when using nested applications (with middlewares).
- Change base class of ClientConnectorSSLError to ClientSSLError from ClientConnectorError.
- Return client connection back to free pool on error in connector.connect().

Changelog: https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
