### PR TITLE
Update ecobee version to fix stack-trace issue

### DIFF
--- a/homeassistant/components/ecobee.py
+++ b/homeassistant/components/ecobee.py
@@ -16,7 +16,7 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.util import Throttle
 from homeassistant.util.json import save_json
 
-REQUIREMENTS = ['python-ecobee-api==0.0.12']
+REQUIREMENTS = ['python-ecobee-api==0.0.14']
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -809,7 +809,7 @@ python-clementine-remote==1.0.1
 python-digitalocean==1.12
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.0.12
+python-ecobee-api==0.0.14
 
 # homeassistant.components.climate.eq3btsmart
 # python-eq3bt==0.1.6


### PR DESCRIPTION
## Description:
Use new upstream python-ecobee-api version which will catch a stack-trace on failed connection to the Ecobee server.


**Related issue (if applicable):** fixes #10892

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

