### PR TITLE
Correction of Samsung Power OFF behaviour

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -183,8 +183,7 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def turn_off(self):
         """Turn off media player."""
-        self._end_of_power_off \
-            = dt_util.utcnow() + timedelta(seconds=15)
+        self._end_of_power_off = dt_util.utcnow() + timedelta(seconds=15)
 
         if self._config['method'] == 'websocket':
             self.send_key('KEY_POWER')

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/media_player.samsungtv/
 """
 import logging
 import socket
+from datetime import timedelta
 
 import voluptuous as vol
 
@@ -17,6 +18,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_PORT,
     CONF_MAC)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util import dt as dt_util
 
 REQUIREMENTS = ['samsungctl==0.6.0', 'wakeonlan==0.2.2']
 
@@ -100,6 +102,9 @@ class SamsungTVDevice(MediaPlayerDevice):
         self._playing = True
         self._state = STATE_UNKNOWN
         self._remote = None
+        # Mark the end of a shutdown command (need to wait 15 seconds before
+        # sending the next command to avoid turning the TV back ON).
+        self._end_of_power_off_command = None
         # Generate a configuration for the Samsung library
         self._config = {
             'name': 'HomeAssistant',
@@ -118,7 +123,7 @@ class SamsungTVDevice(MediaPlayerDevice):
     def update(self):
         """Retrieve the latest data."""
         # Send an empty key to see if we are still connected
-        return self.send_key('KEY')
+        self.send_key('KEY')
 
     def get_remote(self):
         """Create or return a remote control instance."""
@@ -130,6 +135,10 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def send_key(self, key):
         """Send a key to the tv and handles exceptions."""
+        if self._power_off_in_progress() \
+                and not (key == 'KEY_POWER' or key == 'KEY_POWEROFF'):
+            _LOGGER.info("TV is powering off, not sending command: %s", key)
+            return
         try:
             self.get_remote().control(key)
             self._state = STATE_ON
@@ -139,13 +148,16 @@ class SamsungTVDevice(MediaPlayerDevice):
             # BrokenPipe can occur when the commands is sent to fast
             self._state = STATE_ON
             self._remote = None
-            return False
+            return
         except (self._exceptions_class.ConnectionClosed, OSError):
             self._state = STATE_OFF
             self._remote = None
-            return False
+        if self._power_off_in_progress():
+            self._state = STATE_OFF
 
-        return True
+    def _power_off_in_progress(self):
+        return self._end_of_power_off_command is not None and \
+               self._end_of_power_off_command > dt_util.utcnow()
 
     @property
     def name(self):
@@ -171,6 +183,9 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def turn_off(self):
         """Turn off media player."""
+        self._end_of_power_off_command \
+            = dt_util.utcnow() + timedelta(seconds=15)
+
         if self._config['method'] == 'websocket':
             self.send_key('KEY_POWER')
         else:

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -104,7 +104,7 @@ class SamsungTVDevice(MediaPlayerDevice):
         self._remote = None
         # Mark the end of a shutdown command (need to wait 15 seconds before
         # sending the next command to avoid turning the TV back ON).
-        self._end_of_power_off_command = None
+        self._end_of_power_off = None
         # Generate a configuration for the Samsung library
         self._config = {
             'name': 'HomeAssistant',
@@ -156,8 +156,8 @@ class SamsungTVDevice(MediaPlayerDevice):
             self._state = STATE_OFF
 
     def _power_off_in_progress(self):
-        return self._end_of_power_off_command is not None and \
-               self._end_of_power_off_command > dt_util.utcnow()
+        return self._end_of_power_off is not None and \
+               self._end_of_power_off > dt_util.utcnow()
 
     @property
     def name(self):
@@ -183,7 +183,7 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def turn_off(self):
         """Turn off media player."""
-        self._end_of_power_off_command \
+        self._end_of_power_off \
             = dt_util.utcnow() + timedelta(seconds=15)
 
         if self._config['method'] == 'websocket':


### PR DESCRIPTION
Addition of a delay after powering OFF a Samsung TV to avoid status
update to power the TV back ON.

## Description:
The Samsung TV component send a KEY to the TV to check the status of the TV (on/off).
This if made just after powering OFF the TV, turn some of the latest Samsung TV back ON (the TV stays connected to the network for a few seconds).

To fix this issue, I added a 15 seconds timer after the TV has been turned OFF during which no command are send to the TV.

**Related issue (if applicable):** fixes #10905

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4123

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

