### PR TITLE
Don't repeat getting receiver name on each update

### DIFF
--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_ON, CONF_ZONE, CONF_TIMEOUT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['denonavr==0.5.4']
+REQUIREMENTS = ['denonavr==0.5.5']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,12 +102,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if config.get(CONF_HOST) is None and discovery_info is None:
         d_receivers = denonavr.discover()
         # More than one receiver could be discovered by that method
-        if d_receivers is not None:
-            for d_receiver in d_receivers:
-                host = d_receiver["host"]
-                name = d_receiver["friendlyName"]
-                new_hosts.append(
-                    NewHost(host=host, name=name))
+        for d_receiver in d_receivers:
+            host = d_receiver["host"]
+            name = d_receiver["friendlyName"]
+            new_hosts.append(
+                NewHost(host=host, name=name))
 
     for entry in new_hosts:
         # Check if host not in cache, append it and save for later

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -197,7 +197,7 @@ defusedxml==0.5.0
 deluge-client==1.0.5
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.5.4
+denonavr==0.5.5
 
 # homeassistant.components.media_player.directv
 directpy==0.2


### PR DESCRIPTION
## Description:
- Don't repeat getting receiver name on each update
- Pushed to denonavr 0.5.5

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
