### PR TITLE
Don't ignore voltage data if sensor data changed

### DIFF
--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -219,7 +219,9 @@ class XiaomiDevice(Entity):
     def push_data(self, data):
         """Push from Hub."""
         _LOGGER.debug("PUSH >> %s: %s", self, data)
-        if self.parse_data(data) or self.parse_voltage(data):
+        is_data = self.parse_data(data)
+        is_voltage = self.parse_voltage(data)
+        if is_data or is_voltage:
             self.schedule_update_ha_state()
 
     def parse_voltage(self, data):


### PR DESCRIPTION
When the heartbeat message received with `voltage` data, it can be ignored and not updated if main data (status, rgb...) will change. So voltage change data will be lost.