### PR TITLE
Tado ignore invalid devices

### DIFF
--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -80,7 +80,6 @@ def create_climate_device(tado, hass, zone, name, zone_id):
         temperatures = capabilities['HEAT']['temperatures']
     elif 'temperatures' in capabilities:
         temperatures = capabilities['temperatures']
-        temperatures = capabilities['temperatures']
     else:
         _LOGGER.debug("Recieved zone %s has no temperature; not adding", name)
         return

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -58,12 +58,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return
 
     climate_devices = []
-     for zone in zones:
-        climate_devices.append(create_climate_device(
+    for zone in zones:
         device = create_climate_device(
             tado, hass, zone, zone['name'], zone['id'])
         if device is False:
-          continue
+            continue
         climate_devices.append(device)
 
     if climate_devices:
@@ -80,11 +79,11 @@ def create_climate_device(tado, hass, zone, name, zone_id):
     if ac_mode:
         temperatures = capabilities['HEAT']['temperatures']
     elif 'temperatures' in capabilities:
-         temperatures = capabilities['temperatures']
-         temperatures = capabilities['temperatures']
+        temperatures = capabilities['temperatures']
+        temperatures = capabilities['temperatures']
     else:
         _LOGGER.debug("Recieved zone %s has no temperature; not adding", name)
-        return False;
+        return False
 
     min_temp = float(temperatures['celsius']['min'])
     max_temp = float(temperatures['celsius']['max'])

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -58,9 +58,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return
 
     climate_devices = []
-    for zone in zones:
+     for zone in zones:
         climate_devices.append(create_climate_device(
+        device = create_climate_device(
             tado, hass, zone, zone['name'], zone['id']))
+            tado, hass, zone, zone['name'], zone['id'])
+        if device is False:
+          continue
+        climate_devices.append(device)
 
     if climate_devices:
         add_devices(climate_devices, True)
@@ -75,8 +80,12 @@ def create_climate_device(tado, hass, zone, name, zone_id):
 
     if ac_mode:
         temperatures = capabilities['HEAT']['temperatures']
+    elif 'temperatures' in capabilities:
+         temperatures = capabilities['temperatures']
+         temperatures = capabilities['temperatures']
     else:
-        temperatures = capabilities['temperatures']
+        _LOGGER.debug("Recieved zone %s has no temperature; not adding", name)
+        return False;
 
     min_temp = float(temperatures['celsius']['min'])
     max_temp = float(temperatures['celsius']['max'])

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -81,7 +81,7 @@ def create_climate_device(tado, hass, zone, name, zone_id):
     elif 'temperatures' in capabilities:
         temperatures = capabilities['temperatures']
     else:
-        _LOGGER.debug("Recieved zone %s has no temperature; not adding", name)
+        _LOGGER.debug("Received zone %s has no temperature; not adding", name)
         return
 
     min_temp = float(temperatures['celsius']['min'])

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -61,7 +61,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
      for zone in zones:
         climate_devices.append(create_climate_device(
         device = create_climate_device(
-            tado, hass, zone, zone['name'], zone['id']))
             tado, hass, zone, zone['name'], zone['id'])
         if device is False:
           continue

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -61,7 +61,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for zone in zones:
         device = create_climate_device(
             tado, hass, zone, zone['name'], zone['id'])
-        if device is False:
+        if not device:
             continue
         climate_devices.append(device)
 
@@ -83,7 +83,7 @@ def create_climate_device(tado, hass, zone, name, zone_id):
         temperatures = capabilities['temperatures']
     else:
         _LOGGER.debug("Recieved zone %s has no temperature; not adding", name)
-        return False
+        return
 
     min_temp = float(temperatures['celsius']['min'])
     max_temp = float(temperatures['celsius']['max'])


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #9530 

Ignores devices that do not have temperatures.