### PR TITLE
Report availability of TP-Link smart sockets

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.tplink/
 """
 import logging
-
 import time
 
 import voluptuous as vol
@@ -107,9 +106,9 @@ class SmartPlugSwitch(SwitchDevice):
                     self._emeter_params[ATTR_DAILY_CONSUMPTION] \
                         = "%.2f kW" % emeter_statics[int(time.strftime("%e"))]
                 except KeyError:
-                    # device returned no daily history
+                    # Device returned no daily history
                     pass
 
         except (SmartDeviceException, OSError) as ex:
-            _LOGGER.warning('Could not read state for %s: %s', self.name, ex)
+            _LOGGER.warning("Could not read state for %s: %s", self.name, ex)
             self._available = False

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -47,6 +47,7 @@ class SmartPlugSwitch(SwitchDevice):
         self.smartplug = smartplug
         self._name = name
         self._state = None
+        self._available = True
         # Set up emeter cache
         self._emeter_params = {}
 
@@ -54,6 +55,11 @@ class SmartPlugSwitch(SwitchDevice):
     def name(self):
         """Return the name of the Smart Plug, if any."""
         return self._name
+
+    @property
+    def available(self) -> bool:
+        """Return if switch is available."""
+        return self._available
 
     @property
     def is_on(self):
@@ -77,6 +83,7 @@ class SmartPlugSwitch(SwitchDevice):
         """Update the TP-Link switch's state."""
         from pyHS100 import SmartDeviceException
         try:
+            self._available = True
             self._state = self.smartplug.state == \
                 self.smartplug.SWITCH_STATE_ON
 
@@ -105,3 +112,4 @@ class SmartPlugSwitch(SwitchDevice):
 
         except (SmartDeviceException, OSError) as ex:
             _LOGGER.warning('Could not read state for %s: %s', self.name, ex)
+            self._available = False


### PR DESCRIPTION
## Description:

Set the availability of TP-Link smart sockets based on communication errors when updating state.

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: tplink
    host: IP_ADDRESS
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
