### PR TITLE
Fixing Egardia alarm status shown as unknown after restart

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,9 @@ omit =
     homeassistant/components/abode.py
     homeassistant/components/*/abode.py
 
+    homeassistant/components/ads/__init__.py
+    homeassistant/components/*/ads.py
+
     homeassistant/components/alarmdecoder.py
     homeassistant/components/*/alarmdecoder.py
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -517,6 +517,7 @@ omit =
     homeassistant/components/sensor/fixer.py
     homeassistant/components/sensor/fritzbox_callmonitor.py
     homeassistant/components/sensor/fritzbox_netmonitor.py
+    homeassistant/components/sensor/gearbest.py
     homeassistant/components/sensor/geizhals.py
     homeassistant/components/sensor/gitter.py
     homeassistant/components/sensor/glances.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -430,6 +430,7 @@ omit =
     homeassistant/components/media_player/volumio.py
     homeassistant/components/media_player/yamaha.py
     homeassistant/components/media_player/yamaha_musiccast.py
+    homeassistant/components/media_player/ziggo_mediabox_xl.py
     homeassistant/components/mycroft.py
     homeassistant/components/notify/aws_lambda.py
     homeassistant/components/notify/aws_sns.py

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure Docker script files uses LF to support Docker for Windows.
+setup_docker_prereqs    eol=lf
+/virtualization/Docker/scripts/*    eol=lf

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -54,6 +54,7 @@ homeassistant/components/media_player/kodi.py @armills
 homeassistant/components/media_player/monoprice.py @etsinko
 homeassistant/components/media_player/yamaha_musiccast.py @jalmeroth
 homeassistant/components/sensor/airvisual.py @bachya
+homeassistant/components/sensor/gearbest.py @HerrHofrat
 homeassistant/components/sensor/irish_rail_transport.py @ttroy50
 homeassistant/components/sensor/miflora.py @danielhiversen
 homeassistant/components/sensor/sytadin.py @gautric

--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -1,0 +1,217 @@
+"""
+ADS Component.
+
+For more details about this component, please refer to the documentation.
+https://home-assistant.io/components/ads/
+
+"""
+import os
+import threading
+import struct
+import logging
+import ctypes
+from collections import namedtuple
+import voluptuous as vol
+from homeassistant.const import CONF_DEVICE, CONF_PORT, CONF_IP_ADDRESS, \
+    EVENT_HOMEASSISTANT_STOP
+from homeassistant.config import load_yaml_config_file
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pyads==2.2.6']
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_ADS = 'data_ads'
+
+# Supported Types
+ADSTYPE_INT = 'int'
+ADSTYPE_UINT = 'uint'
+ADSTYPE_BYTE = 'byte'
+ADSTYPE_BOOL = 'bool'
+
+DOMAIN = 'ads'
+
+# config variable names
+CONF_ADS_VAR = 'adsvar'
+CONF_ADS_VAR_BRIGHTNESS = 'adsvar_brightness'
+CONF_ADS_TYPE = 'adstype'
+CONF_ADS_FACTOR = 'factor'
+CONF_ADS_VALUE = 'value'
+
+SERVICE_WRITE_DATA_BY_NAME = 'write_data_by_name'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_DEVICE): cv.string,
+        vol.Required(CONF_PORT): cv.port,
+        vol.Optional(CONF_IP_ADDRESS): cv.string,
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+SCHEMA_SERVICE_WRITE_DATA_BY_NAME = vol.Schema({
+    vol.Required(CONF_ADS_VAR): cv.string,
+    vol.Required(CONF_ADS_TYPE): vol.In([ADSTYPE_INT, ADSTYPE_UINT,
+                                         ADSTYPE_BYTE]),
+    vol.Required(CONF_ADS_VALUE): cv.match_all
+})
+
+
+def setup(hass, config):
+    """Set up the ADS component."""
+    import pyads
+    conf = config[DOMAIN]
+
+    # get ads connection parameters from config
+    net_id = conf.get(CONF_DEVICE)
+    ip_address = conf.get(CONF_IP_ADDRESS)
+    port = conf.get(CONF_PORT)
+
+    # create a new ads connection
+    client = pyads.Connection(net_id, port, ip_address)
+
+    # add some constants to AdsHub
+    AdsHub.ADS_TYPEMAP = {
+        ADSTYPE_BOOL: pyads.PLCTYPE_BOOL,
+        ADSTYPE_BYTE: pyads.PLCTYPE_BYTE,
+        ADSTYPE_INT: pyads.PLCTYPE_INT,
+        ADSTYPE_UINT: pyads.PLCTYPE_UINT,
+    }
+
+    AdsHub.PLCTYPE_BOOL = pyads.PLCTYPE_BOOL
+    AdsHub.PLCTYPE_BYTE = pyads.PLCTYPE_BYTE
+    AdsHub.PLCTYPE_INT = pyads.PLCTYPE_INT
+    AdsHub.PLCTYPE_UINT = pyads.PLCTYPE_UINT
+    AdsHub.ADSError = pyads.ADSError
+
+    # connect to ads client and try to connect
+    try:
+        ads = AdsHub(client)
+    except pyads.pyads.ADSError:
+        _LOGGER.error(
+            'Could not connect to ADS host (netid=%s, port=%s)', net_id, port
+        )
+        return False
+
+    # add ads hub to hass data collection, listen to shutdown
+    hass.data[DATA_ADS] = ads
+    hass.bus.listen(EVENT_HOMEASSISTANT_STOP, ads.shutdown)
+
+    def handle_write_data_by_name(call):
+        """Write a value to the connected ADS device."""
+        ads_var = call.data.get(CONF_ADS_VAR)
+        ads_type = call.data.get(CONF_ADS_TYPE)
+        value = call.data.get(CONF_ADS_VALUE)
+
+        try:
+            ads.write_by_name(ads_var, value, ads.ADS_TYPEMAP[ads_type])
+        except pyads.ADSError as err:
+            _LOGGER.error(err)
+
+    # load descriptions from services.yaml
+    descriptions = load_yaml_config_file(
+        os.path.join(os.path.dirname(__file__), 'services.yaml'))
+
+    hass.services.register(
+        DOMAIN, SERVICE_WRITE_DATA_BY_NAME, handle_write_data_by_name,
+        descriptions[SERVICE_WRITE_DATA_BY_NAME],
+        schema=SCHEMA_SERVICE_WRITE_DATA_BY_NAME
+    )
+
+    return True
+
+
+# tuple to hold data needed for notification
+NotificationItem = namedtuple(
+    'NotificationItem', 'hnotify huser name plc_datatype callback'
+)
+
+
+class AdsHub:
+    """Representation of a PyADS connection."""
+
+    def __init__(self, ads_client):
+        """Initialize the ADS Hub."""
+        self._client = ads_client
+        self._client.open()
+
+        # all ADS devices are registered here
+        self._devices = []
+        self._notification_items = {}
+        self._lock = threading.Lock()
+
+    def shutdown(self, *args, **kwargs):
+        """Shutdown ADS connection."""
+        _LOGGER.debug('Shutting down ADS')
+        for notification_item in self._notification_items.values():
+            self._client.del_device_notification(
+                notification_item.hnotify,
+                notification_item.huser
+            )
+            _LOGGER.debug(
+                'Deleting device notification %d, %d',
+                notification_item.hnotify, notification_item.huser
+            )
+        self._client.close()
+
+    def register_device(self, device):
+        """Register a new device."""
+        self._devices.append(device)
+
+    def write_by_name(self, name, value, plc_datatype):
+        """Write a value to the device."""
+        with self._lock:
+            return self._client.write_by_name(name, value, plc_datatype)
+
+    def read_by_name(self, name, plc_datatype):
+        """Read a value from the device."""
+        with self._lock:
+            return self._client.read_by_name(name, plc_datatype)
+
+    def add_device_notification(self, name, plc_datatype, callback):
+        """Add a notification to the ADS devices."""
+        from pyads import NotificationAttrib
+        attr = NotificationAttrib(ctypes.sizeof(plc_datatype))
+
+        with self._lock:
+            hnotify, huser = self._client.add_device_notification(
+                name, attr, self._device_notification_callback
+            )
+            hnotify = int(hnotify)
+
+        _LOGGER.debug(
+            'Added Device Notification %d for variable %s', hnotify, name
+        )
+
+        self._notification_items[hnotify] = NotificationItem(
+            hnotify, huser, name, plc_datatype, callback
+        )
+
+    def _device_notification_callback(self, addr, notification, huser):
+        """Handle device notifications."""
+        contents = notification.contents
+
+        hnotify = int(contents.hNotification)
+        _LOGGER.debug('Received Notification %d', hnotify)
+        data = contents.data
+
+        try:
+            notification_item = self._notification_items[hnotify]
+        except KeyError:
+            _LOGGER.debug('Unknown Device Notification handle: %d', hnotify)
+            return
+
+        # parse data to desired datatype
+        if notification_item.plc_datatype == self.PLCTYPE_BOOL:
+            value = bool(struct.unpack('<?', bytearray(data)[:1])[0])
+        elif notification_item.plc_datatype == self.PLCTYPE_INT:
+            value = struct.unpack('<h', bytearray(data)[:2])[0]
+        elif notification_item.plc_datatype == self.PLCTYPE_BYTE:
+            value = struct.unpack('<B', bytearray(data)[:1])[0]
+        elif notification_item.plc_datatype == self.PLCTYPE_UINT:
+            value = struct.unpack('<H', bytearray(data)[:2])[0]
+        else:
+            value = bytearray(data)
+            _LOGGER.warning('No callback available for this datatype.')
+
+        # execute callback
+        notification_item.callback(notification_item.name, value)

--- a/homeassistant/components/ads/services.yaml
+++ b/homeassistant/components/ads/services.yaml
@@ -1,0 +1,15 @@
+# Describes the format for available ADS services
+
+write_data_by_name:
+  description: Write a value to the connected ADS device.
+
+  fields:
+    adsvar:
+      description: The name of the variable to write to.
+      example: '.global_var'
+    adstype:
+      description: The data type of the variable to write to.
+      example: 'int'
+    value:
+      description: The value to write to the variable.
+      example: 1

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -103,8 +103,6 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         else:
             self._rs_codes = rs_codes
 
-        self.getstatusfromsystem()
-
         if self._rs_enabled:
             self.listen_to_system_status()
 
@@ -118,12 +116,20 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         """Return the state of the device."""
         return self._status
 
+    @property
+    def should_poll(self):
+        """Poll if no report server is enabled."""
+        if not self._rs_enabled:
+            return True
+        return False
+
     def handle_system_status_event(self, event):
         """Handle egardia_system_status_event."""
         if event.data.get('status') is not None:
             statuscode = event.data.get('status')
             status = self.lookupstatusfromcode(statuscode)
             self.parsestatus(status)
+            self.schedule_update_ha_state()
 
     def listen_to_system_status(self):
         """Subscribe to egardia_system_status event."""
@@ -163,11 +169,6 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
 
     def update(self):
         """Update the alarm status."""
-        if not self._rs_enabled:
-            self.getstatusfromsystem()
-
-    def getstatusfromsystem(self):
-        """Get status from EgardiaSystem."""
         status = self._egardiasystem.getstate()
         self.parsestatus(status)
 

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -103,6 +103,8 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         else:
             self._rs_codes = rs_codes
 
+        self.getstatusfromsystem()
+
         if self._rs_enabled:
             self.listen_to_system_status()
 
@@ -162,8 +164,12 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
     def update(self):
         """Update the alarm status."""
         if not self._rs_enabled:
-            status = self._egardiasystem.getstate()
-            self.parsestatus(status)
+            self.getstatusfromsystem()
+
+    def getstatusfromsystem(self):
+        """Get status from EgardiaSystem."""
+        status = self._egardiasystem.getstate()
+        self.parsestatus(status)
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""

--- a/homeassistant/components/binary_sensor/ads.py
+++ b/homeassistant/components/binary_sensor/ads.py
@@ -1,0 +1,87 @@
+"""
+Support for ADS binary sensors.
+
+For more details about this platform, please refer to the documentation.
+https://home-assistant.io/components/binary_sensor.ads/
+
+"""
+import asyncio
+import logging
+import voluptuous as vol
+from homeassistant.components.binary_sensor import BinarySensorDevice, \
+    PLATFORM_SCHEMA, DEVICE_CLASSES_SCHEMA
+from homeassistant.components.ads import DATA_ADS, CONF_ADS_VAR
+from homeassistant.const import CONF_NAME, CONF_DEVICE_CLASS
+import homeassistant.helpers.config_validation as cv
+
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['ads']
+DEFAULT_NAME = 'ADS binary sensor'
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ADS_VAR): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Binary Sensor platform for ADS."""
+    ads_hub = hass.data.get(DATA_ADS)
+
+    ads_var = config.get(CONF_ADS_VAR)
+    name = config.get(CONF_NAME)
+    device_class = config.get(CONF_DEVICE_CLASS)
+
+    ads_sensor = AdsBinarySensor(ads_hub, name, ads_var, device_class)
+    add_devices([ads_sensor])
+
+
+class AdsBinarySensor(BinarySensorDevice):
+    """Representation of ADS binary sensors."""
+
+    def __init__(self, ads_hub, name, ads_var, device_class):
+        """Initialize AdsBinarySensor entity."""
+        self._name = name
+        self._state = False
+        self._device_class = device_class or 'moving'
+        self._ads_hub = ads_hub
+        self.ads_var = ads_var
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register device notification."""
+        def update(name, value):
+            """Handle device notifications."""
+            _LOGGER.debug('Variable %s changed its value to %d',
+                          name, value)
+            self._state = value
+            self.schedule_update_ha_state()
+
+        self.hass.async_add_job(
+            self._ads_hub.add_device_notification,
+            self.ads_var, self._ads_hub.PLCTYPE_BOOL, update
+        )
+
+    @property
+    def name(self):
+        """Return the default name of the binary sensor."""
+        return self._name
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return self._device_class
+
+    @property
+    def is_on(self):
+        """Return if the binary sensor is on."""
+        return self._state
+
+    @property
+    def should_poll(self):
+        """Return False because entity pushes its state to HA."""
+        return False

--- a/homeassistant/components/binary_sensor/vera.py
+++ b/homeassistant/components/binary_sensor/vera.py
@@ -19,8 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Perform the setup for Vera controller devices."""
     add_devices(
-        VeraBinarySensor(device, VERA_CONTROLLER)
-        for device in VERA_DEVICES['binary_sensor'])
+        VeraBinarySensor(device, hass.data[VERA_CONTROLLER])
+        for device in hass.data[VERA_DEVICES]['binary_sensor'])
 
 
 class VeraBinarySensor(VeraDevice, BinarySensorDevice):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -13,7 +13,8 @@ from homeassistant.core import callback
 from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.components.climate import (
     STATE_HEAT, STATE_COOL, STATE_IDLE, ClimateDevice, PLATFORM_SCHEMA,
-    STATE_AUTO, SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE)
+    STATE_AUTO, ATTR_OPERATION_MODE, SUPPORT_OPERATION_MODE,
+    SUPPORT_TARGET_TEMPERATURE)
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, STATE_ON, STATE_OFF, ATTR_TEMPERATURE,
     CONF_NAME, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF)
@@ -40,7 +41,7 @@ CONF_MIN_DUR = 'min_cycle_duration'
 CONF_COLD_TOLERANCE = 'cold_tolerance'
 CONF_HOT_TOLERANCE = 'hot_tolerance'
 CONF_KEEP_ALIVE = 'keep_alive'
-
+CONF_INITIAL_OPERATION_MODE = 'initial_operation_mode'
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -58,6 +59,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TARGET_TEMP): vol.Coerce(float),
     vol.Optional(CONF_KEEP_ALIVE): vol.All(
         cv.time_period, cv.positive_timedelta),
+    vol.Optional(CONF_INITIAL_OPERATION_MODE):
+        vol.In([STATE_AUTO, STATE_OFF])
 })
 
 
@@ -75,11 +78,12 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     cold_tolerance = config.get(CONF_COLD_TOLERANCE)
     hot_tolerance = config.get(CONF_HOT_TOLERANCE)
     keep_alive = config.get(CONF_KEEP_ALIVE)
+    initial_operation_mode = config.get(CONF_INITIAL_OPERATION_MODE)
 
     async_add_devices([GenericThermostat(
         hass, name, heater_entity_id, sensor_entity_id, min_temp, max_temp,
         target_temp, ac_mode, min_cycle_duration, cold_tolerance,
-        hot_tolerance, keep_alive)])
+        hot_tolerance, keep_alive, initial_operation_mode)])
 
 
 class GenericThermostat(ClimateDevice):
@@ -87,7 +91,8 @@ class GenericThermostat(ClimateDevice):
 
     def __init__(self, hass, name, heater_entity_id, sensor_entity_id,
                  min_temp, max_temp, target_temp, ac_mode, min_cycle_duration,
-                 cold_tolerance, hot_tolerance, keep_alive):
+                 cold_tolerance, hot_tolerance, keep_alive,
+                 initial_operation_mode):
         """Initialize the thermostat."""
         self.hass = hass
         self._name = name
@@ -97,7 +102,11 @@ class GenericThermostat(ClimateDevice):
         self._cold_tolerance = cold_tolerance
         self._hot_tolerance = hot_tolerance
         self._keep_alive = keep_alive
-        self._enabled = True
+        self._initial_operation_mode = initial_operation_mode
+        if initial_operation_mode == STATE_OFF:
+            self._enabled = False
+        else:
+            self._enabled = True
 
         self._active = False
         self._cur_temp = None
@@ -122,13 +131,19 @@ class GenericThermostat(ClimateDevice):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Run when entity about to be added."""
-        # If we have an old state and no target temp, restore
-        if self._target_temp is None:
-            old_state = yield from async_get_last_state(self.hass,
-                                                        self.entity_id)
-            if old_state is not None:
+        # Check If we have an old state
+        old_state = yield from async_get_last_state(self.hass,
+                                                    self.entity_id)
+        if old_state is not None:
+            # If we have no initial temperature, restore
+            if self._target_temp is None:
                 self._target_temp = float(
                     old_state.attributes[ATTR_TEMPERATURE])
+
+            # If we have no initial operation mode, restore
+            if self._initial_operation_mode is None:
+                if old_state.attributes[ATTR_OPERATION_MODE] == STATE_OFF:
+                    self._enabled = False
 
     @property
     def should_poll(self):

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -59,8 +59,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     climate_devices = []
     for zone in zones:
-        climate_devices.append(create_climate_device(
-            tado, hass, zone, zone['name'], zone['id']))
+        device = create_climate_device(
+            tado, hass, zone, zone['name'], zone['id'])
+        if not device:
+            continue
+        climate_devices.append(device)
 
     if climate_devices:
         add_devices(climate_devices, True)
@@ -75,8 +78,11 @@ def create_climate_device(tado, hass, zone, name, zone_id):
 
     if ac_mode:
         temperatures = capabilities['HEAT']['temperatures']
-    else:
+    elif 'temperatures' in capabilities:
         temperatures = capabilities['temperatures']
+    else:
+        _LOGGER.debug("Received zone %s has no temperature; not adding", name)
+        return
 
     min_temp = float(temperatures['celsius']['min'])
     max_temp = float(temperatures['celsius']['max'])

--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -32,8 +32,8 @@ SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE |
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up of Vera thermostats."""
     add_devices_callback(
-        VeraThermostat(device, VERA_CONTROLLER) for
-        device in VERA_DEVICES['climate'])
+        VeraThermostat(device, hass.data[VERA_CONTROLLER]) for
+        device in hass.data[VERA_DEVICES]['climate'])
 
 
 class VeraThermostat(VeraDevice, ClimateDevice):

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -18,8 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera covers."""
     add_devices(
-        VeraCover(device, VERA_CONTROLLER) for
-        device in VERA_DEVICES['cover'])
+        VeraCover(device, hass.data[VERA_CONTROLLER]) for
+        device in hass.data[VERA_DEVICES]['cover'])
 
 
 class VeraCover(VeraDevice, CoverDevice):

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -53,6 +53,7 @@ YAML_DEVICES = 'known_devices.yaml'
 
 CONF_TRACK_NEW = 'track_new_devices'
 DEFAULT_TRACK_NEW = True
+CONF_NEW_DEVICE_DEFAULTS = 'new_device_defaults'
 
 CONF_CONSIDER_HOME = 'consider_home'
 DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
@@ -81,12 +82,18 @@ ATTR_VENDOR = 'vendor'
 SOURCE_TYPE_GPS = 'gps'
 SOURCE_TYPE_ROUTER = 'router'
 
+NEW_DEVICE_DEFAULTS_SCHEMA = vol.Any(None, vol.Schema({
+    vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
+    vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
+}))
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
     vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
     vol.Optional(CONF_CONSIDER_HOME,
                  default=DEFAULT_CONSIDER_HOME): vol.All(
-                     cv.time_period, cv.positive_timedelta)
+                     cv.time_period, cv.positive_timedelta),
+    vol.Optional(CONF_NEW_DEVICE_DEFAULTS,
+                 default={}): NEW_DEVICE_DEFAULTS_SCHEMA
 })
 
 
@@ -125,9 +132,11 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
     conf = conf[0] if conf else {}
     consider_home = conf.get(CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME)
     track_new = conf.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
+    defaults = conf.get(CONF_NEW_DEVICE_DEFAULTS, {})
 
     devices = yield from async_load_config(yaml_path, hass, consider_home)
-    tracker = DeviceTracker(hass, consider_home, track_new, devices)
+    tracker = DeviceTracker(
+        hass, consider_home, track_new, defaults, devices)
 
     @asyncio.coroutine
     def async_setup_platform(p_type, p_config, disc_info=None):
@@ -211,13 +220,15 @@ class DeviceTracker(object):
     """Representation of a device tracker."""
 
     def __init__(self, hass: HomeAssistantType, consider_home: timedelta,
-                 track_new: bool, devices: Sequence) -> None:
+                 track_new: bool, defaults: dict,
+                 devices: Sequence) -> None:
         """Initialize a device tracker."""
         self.hass = hass
         self.devices = {dev.dev_id: dev for dev in devices}
         self.mac_to_dev = {dev.mac: dev for dev in devices if dev.mac}
         self.consider_home = consider_home
-        self.track_new = track_new
+        self.track_new = defaults.get(CONF_TRACK_NEW, track_new)
+        self.defaults = defaults
         self.group = None
         self._is_updating = asyncio.Lock(loop=hass.loop)
 
@@ -274,7 +285,8 @@ class DeviceTracker(object):
         device = Device(
             self.hass, self.consider_home, self.track_new,
             dev_id, mac, (host_name or dev_id).replace('_', ' '),
-            picture=picture, icon=icon)
+            picture=picture, icon=icon,
+            hide_if_away=self.defaults.get(CONF_AWAY_HIDE, DEFAULT_AWAY_HIDE))
         self.devices[dev_id] = device
         if mac is not None:
             self.mac_to_dev[mac] = device

--- a/homeassistant/components/device_tracker/linksys_ap.py
+++ b/homeassistant/components/device_tracker/linksys_ap.py
@@ -11,7 +11,8 @@ import requests
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.device_tracker import DOMAIN, PLATFORM_SCHEMA
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL)
 
@@ -38,7 +39,7 @@ def get_scanner(hass, config):
         return None
 
 
-class LinksysAPDeviceScanner(object):
+class LinksysAPDeviceScanner(DeviceScanner):
     """This class queries a Linksys Access Point."""
 
     def __init__(self, config):

--- a/homeassistant/components/device_tracker/meraki.py
+++ b/homeassistant/components/device_tracker/meraki.py
@@ -1,0 +1,116 @@
+"""
+Support for the Meraki CMX location service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.meraki/
+
+"""
+import asyncio
+import logging
+import json
+
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (HTTP_BAD_REQUEST, HTTP_UNPROCESSABLE_ENTITY)
+from homeassistant.core import callback
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.device_tracker import (
+    PLATFORM_SCHEMA, SOURCE_TYPE_ROUTER)
+
+CONF_VALIDATOR = 'validator'
+CONF_SECRET = 'secret'
+DEPENDENCIES = ['http']
+URL = '/api/meraki'
+VERSION = '2.0'
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_VALIDATOR): cv.string,
+    vol.Required(CONF_SECRET): cv.string
+})
+
+
+@asyncio.coroutine
+def async_setup_scanner(hass, config, async_see, discovery_info=None):
+    """Set up an endpoint for the Meraki tracker."""
+    hass.http.register_view(
+        MerakiView(config, async_see))
+
+    return True
+
+
+class MerakiView(HomeAssistantView):
+    """View to handle Meraki requests."""
+
+    url = URL
+    name = 'api:meraki'
+
+    def __init__(self, config, async_see):
+        """Initialize Meraki URL endpoints."""
+        self.async_see = async_see
+        self.validator = config[CONF_VALIDATOR]
+        self.secret = config[CONF_SECRET]
+
+    @asyncio.coroutine
+    def get(self, request):
+        """Meraki message received as GET."""
+        return self.validator
+
+    @asyncio.coroutine
+    def post(self, request):
+        """Meraki CMX message received."""
+        try:
+            data = yield from request.json()
+        except ValueError:
+            return self.json_message('Invalid JSON', HTTP_BAD_REQUEST)
+        _LOGGER.debug("Meraki Data from Post: %s", json.dumps(data))
+        if not data.get('secret', False):
+            _LOGGER.error("secret invalid")
+            return self.json_message('No secret', HTTP_UNPROCESSABLE_ENTITY)
+        if data['secret'] != self.secret:
+            _LOGGER.error("Invalid Secret received from Meraki")
+            return self.json_message('Invalid secret',
+                                     HTTP_UNPROCESSABLE_ENTITY)
+        elif data['version'] != VERSION:
+            _LOGGER.error("Invalid API version: %s", data['version'])
+            return self.json_message('Invalid version',
+                                     HTTP_UNPROCESSABLE_ENTITY)
+        else:
+            _LOGGER.debug('Valid Secret')
+            if data['type'] not in ('DevicesSeen', 'BluetoothDevicesSeen'):
+                _LOGGER.error("Unknown Device %s", data['type'])
+                return self.json_message('Invalid device type',
+                                         HTTP_UNPROCESSABLE_ENTITY)
+            _LOGGER.debug("Processing %s", data['type'])
+        if len(data["data"]["observations"]) == 0:
+            _LOGGER.debug("No observations found")
+            return
+        self._handle(request.app['hass'], data)
+
+    @callback
+    def _handle(self, hass, data):
+        for i in data["data"]["observations"]:
+            data["data"]["secret"] = "hidden"
+            mac = i["clientMac"]
+            _LOGGER.debug("clientMac: %s", mac)
+            attrs = {}
+            if i.get('os', False):
+                attrs['os'] = i['os']
+            if i.get('manufacturer', False):
+                attrs['manufacturer'] = i['manufacturer']
+            if i.get('ipv4', False):
+                attrs['ipv4'] = i['ipv4']
+            if i.get('ipv6', False):
+                attrs['ipv6'] = i['ipv6']
+            if i.get('seenTime', False):
+                attrs['seenTime'] = i['seenTime']
+            if i.get('ssid', False):
+                attrs['ssid'] = i['ssid']
+            hass.async_add_job(self.async_see(
+                mac=mac,
+                source_type=SOURCE_TYPE_ROUTER,
+                attributes=attrs
+            ))

--- a/homeassistant/components/dominos.py
+++ b/homeassistant/components/dominos.py
@@ -136,6 +136,7 @@ class Dominos():
 
     def get_menu(self):
         """Return the products from the closest stores menu."""
+        self.update_closest_store()
         if self.closest_store is None:
             _LOGGER.warning('Cannot get menu. Store may be closed')
             return []

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.const import CONF_NAME, EVENT_THEMES_UPDATED
 from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['home-assistant-frontend==20171204.0', 'user-agents==1.1.0']
+REQUIREMENTS = ['home-assistant-frontend==20171206.0', 'user-agents==1.1.0']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log']

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -583,9 +583,9 @@ def _is_latest(js_option, request):
 
     family_min_version = {
         'Chrome': 50,   # Probably can reduce this
-        'Firefox': 41,  # Destructuring added in 41
+        'Firefox': 43,  # Array.protopype.includes added in 43
         'Opera': 40,    # Probably can reduce this
-        'Edge': 14,     # Maybe can reduce this
+        'Edge': 14,     # Array.protopype.includes added in 14
         'Safari': 10,   # many features not supported by 9
     }
     version = family_min_version.get(useragent.browser.family)

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -303,7 +303,7 @@ def async_setup(hass, config):
             "/home-assistant-polymer", repo_path, False)
         hass.http.register_static_path(
             "/static/translations",
-            os.path.join(repo_path, "build-translations"), False)
+            os.path.join(repo_path, "build-translations/output"), False)
         sw_path_es5 = os.path.join(repo_path, "build-es5/service_worker.js")
         sw_path_latest = os.path.join(repo_path, "build/service_worker.js")
         static_path = os.path.join(repo_path, 'hass_frontend')

--- a/homeassistant/components/light/ads.py
+++ b/homeassistant/components/light/ads.py
@@ -1,0 +1,117 @@
+"""
+Support for ADS light sources.
+
+For more details about this platform, please refer to the documentation.
+https://home-assistant.io/components/light.ads/
+
+"""
+import asyncio
+import logging
+import voluptuous as vol
+from homeassistant.components.light import Light, ATTR_BRIGHTNESS, \
+    SUPPORT_BRIGHTNESS, PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
+from homeassistant.components.ads import DATA_ADS, CONF_ADS_VAR, \
+    CONF_ADS_VAR_BRIGHTNESS
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+DEPENDENCIES = ['ads']
+DEFAULT_NAME = 'ADS Light'
+CONF_ADSVAR_BRIGHTNESS = 'adsvar_brightness'
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ADS_VAR): cv.string,
+    vol.Optional(CONF_ADS_VAR_BRIGHTNESS): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the light platform for ADS."""
+    ads_hub = hass.data.get(DATA_ADS)
+
+    ads_var_enable = config.get(CONF_ADS_VAR)
+    ads_var_brightness = config.get(CONF_ADS_VAR_BRIGHTNESS)
+    name = config.get(CONF_NAME)
+
+    add_devices([AdsLight(ads_hub, ads_var_enable, ads_var_brightness,
+                          name)], True)
+
+
+class AdsLight(Light):
+    """Representation of ADS light."""
+
+    def __init__(self, ads_hub, ads_var_enable, ads_var_brightness, name):
+        """Initialize AdsLight entity."""
+        self._ads_hub = ads_hub
+        self._on_state = False
+        self._brightness = None
+        self._name = name
+        self.ads_var_enable = ads_var_enable
+        self.ads_var_brightness = ads_var_brightness
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register device notification."""
+        def update_on_state(name, value):
+            """Handle device notifications for state."""
+            _LOGGER.debug('Variable %s changed its value to %d', name, value)
+            self._on_state = value
+            self.schedule_update_ha_state()
+
+        def update_brightness(name, value):
+            """Handle device notification for brightness."""
+            _LOGGER.debug('Variable %s changed its value to %d', name, value)
+            self._brightness = value
+            self.schedule_update_ha_state()
+
+        self.hass.async_add_job(
+            self._ads_hub.add_device_notification,
+            self.ads_var_enable, self._ads_hub.PLCTYPE_BOOL, update_on_state
+        )
+        self.hass.async_add_job(
+            self._ads_hub.add_device_notification,
+            self.ads_var_brightness, self._ads_hub.PLCTYPE_INT,
+            update_brightness
+        )
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """Return the brightness of the light (0..255)."""
+        return self._brightness
+
+    @property
+    def is_on(self):
+        """Return if light is on."""
+        return self._on_state
+
+    @property
+    def should_poll(self):
+        """Return False because entity pushes its state to HA."""
+        return False
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        if self.ads_var_brightness is not None:
+            return SUPPORT_BRIGHTNESS
+
+    def turn_on(self, **kwargs):
+        """Turn the light on or set a specific dimmer value."""
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+        self._ads_hub.write_by_name(self.ads_var_enable, True,
+                                    self._ads_hub.PLCTYPE_BOOL)
+
+        if self.ads_var_brightness is not None and brightness is not None:
+            self._ads_hub.write_by_name(self.ads_var_brightness, brightness,
+                                        self._ads_hub.PLCTYPE_UINT)
+
+    def turn_off(self, **kwargs):
+        """Turn the light off."""
+        self._ads_hub.write_by_name(self.ads_var_enable, False,
+                                    self._ads_hub.PLCTYPE_BOOL)

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -99,7 +99,7 @@ class TradfriGroup(Light):
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Instruct the group lights to turn off."""
-        self.hass.async_add_job(self._api(self._group.set_state(0)))
+        yield from self._api(self._group.set_state(0))
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
@@ -112,10 +112,10 @@ class TradfriGroup(Light):
             if kwargs[ATTR_BRIGHTNESS] == 255:
                 kwargs[ATTR_BRIGHTNESS] = 254
 
-            self.hass.async_add_job(self._api(
-                self._group.set_dimmer(kwargs[ATTR_BRIGHTNESS], **keys)))
+            yield from self._api(
+                self._group.set_dimmer(kwargs[ATTR_BRIGHTNESS], **keys))
         else:
-            self.hass.async_add_job(self._api(self._group.set_state(1)))
+            yield from self._api(self._group.set_state(1))
 
     @callback
     def _async_start_observe(self, exc=None):
@@ -140,11 +140,11 @@ class TradfriGroup(Light):
         self._group = group
         self._name = group.name
 
+    @callback
     def _observe_update(self, tradfri_device):
         """Receive new state data for this light."""
         self._refresh(tradfri_device)
-
-        self.hass.async_add_job(self.async_update_ha_state())
+        self.async_schedule_update_ha_state()
 
 
 class TradfriLight(Light):
@@ -238,8 +238,7 @@ class TradfriLight(Light):
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Instruct the light to turn off."""
-        self.hass.async_add_job(self._api(
-            self._light_control.set_state(False)))
+        yield from self._api(self._light_control.set_state(False))
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
@@ -250,17 +249,17 @@ class TradfriLight(Light):
         for ATTR_RGB_COLOR, this also supports Philips Hue bulbs.
         """
         if ATTR_RGB_COLOR in kwargs and self._light_data.hex_color is not None:
-            self.hass.async_add_job(self._api(
+            yield from self._api(
                 self._light.light_control.set_rgb_color(
-                    *kwargs[ATTR_RGB_COLOR])))
+                    *kwargs[ATTR_RGB_COLOR]))
 
         elif ATTR_COLOR_TEMP in kwargs and \
                 self._light_data.hex_color is not None and \
                 self._temp_supported:
             kelvin = color_util.color_temperature_mired_to_kelvin(
                 kwargs[ATTR_COLOR_TEMP])
-            self.hass.async_add_job(self._api(
-                self._light_control.set_kelvin_color(kelvin)))
+            yield from self._api(
+                self._light_control.set_kelvin_color(kelvin))
 
         keys = {}
         if ATTR_TRANSITION in kwargs:
@@ -270,12 +269,12 @@ class TradfriLight(Light):
             if kwargs[ATTR_BRIGHTNESS] == 255:
                 kwargs[ATTR_BRIGHTNESS] = 254
 
-            self.hass.async_add_job(self._api(
+            yield from self._api(
                 self._light_control.set_dimmer(kwargs[ATTR_BRIGHTNESS],
-                                               **keys)))
+                                               **keys))
         else:
-            self.hass.async_add_job(self._api(
-                self._light_control.set_state(True)))
+            yield from self._api(
+                self._light_control.set_state(True))
 
     @callback
     def _async_start_observe(self, exc=None):
@@ -318,10 +317,11 @@ class TradfriLight(Light):
         self._temp_supported = self._light.device_info.manufacturer \
             in ALLOWED_TEMPERATURES
 
+    @callback
     def _observe_update(self, tradfri_device):
         """Receive new state data for this light."""
         self._refresh(tradfri_device)
         self._rgb_color = color_util.rgb_hex_to_rgb_list(
             self._light_data.hex_color_inferred
         )
-        self.hass.async_add_job(self.async_update_ha_state())
+        self.async_schedule_update_ha_state()

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -21,7 +21,8 @@ DEPENDENCIES = ['vera']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera lights."""
     add_devices(
-        VeraLight(device, VERA_CONTROLLER) for device in VERA_DEVICES['light'])
+        VeraLight(device, hass.data[VERA_CONTROLLER]) for
+        device in hass.data[VERA_DEVICES]['light'])
 
 
 class VeraLight(VeraDevice, Light):

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -19,8 +19,8 @@ DEPENDENCIES = ['vera']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return Vera locks."""
     add_devices(
-        VeraLock(device, VERA_CONTROLLER) for
-        device in VERA_DEVICES['lock'])
+        VeraLock(device, hass.data[VERA_CONTROLLER]) for
+        device in hass.data[VERA_DEVICES]['lock'])
 
 
 class VeraLock(VeraDevice, LockDevice):

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -20,7 +20,9 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['pychromecast==1.0.2']
+# Do not upgrade to 1.0.2, it breaks a bunch of stuff
+# https://github.com/home-assistant/home-assistant/issues/10926
+REQUIREMENTS = ['pychromecast==0.8.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -322,12 +322,15 @@ class LgWebOSDevice(MediaPlayerDevice):
 
     def select_source(self, source):
         """Select input source."""
-        if self._source_list.get(source).get('title'):
-            self._current_source_id = self._source_list[source]['id']
+        source = self._source_list.get(source)
+        if source is None:
+            _LOGGER.warning("Source %s not found for %s", source, self.name)
+            return
+        self._current_source_id = self._source_list[source]['id']
+        if source.get('title'):
             self._current_source = self._source_list[source]['title']
             self._client.launch_app(self._source_list[source]['id'])
-        elif self._source_list.get(source).get('label'):
-            self._current_source_id = self._source_list[source]['id']
+        elif source.get('label'):
             self._current_source = self._source_list[source]['label']
             self._client.set_input(self._source_list[source]['id'])
 

--- a/homeassistant/components/media_player/ziggo_mediabox_xl.py
+++ b/homeassistant/components/media_player/ziggo_mediabox_xl.py
@@ -1,0 +1,174 @@
+"""
+Support for interface with a Ziggo Mediabox XL.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.ziggo_mediabox_xl/
+"""
+import logging
+import socket
+
+import voluptuous as vol
+
+from homeassistant.components.media_player import (
+    PLATFORM_SCHEMA, MediaPlayerDevice,
+    SUPPORT_TURN_ON, SUPPORT_TURN_OFF,
+    SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE,
+    SUPPORT_PLAY, SUPPORT_PAUSE)
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_PAUSED, STATE_PLAYING)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['ziggo-mediabox-xl==1.0.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_KNOWN_DEVICES = 'ziggo_mediabox_xl_known_devices'
+
+SUPPORT_ZIGGO = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
+    SUPPORT_NEXT_TRACK | SUPPORT_PAUSE | SUPPORT_PREVIOUS_TRACK | \
+    SUPPORT_SELECT_SOURCE | SUPPORT_PLAY
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Ziggo Mediabox XL platform."""
+    from ziggo_mediabox_xl import ZiggoMediaboxXL
+
+    hass.data[DATA_KNOWN_DEVICES] = known_devices = set()
+
+    # Is this a manual configuration?
+    if config.get(CONF_HOST) is not None:
+        host = config.get(CONF_HOST)
+        name = config.get(CONF_NAME)
+    elif discovery_info is not None:
+        host = discovery_info.get('host')
+        name = discovery_info.get('name')
+    else:
+        _LOGGER.error("Cannot determine device")
+        return
+
+    # Only add a device once, so discovered devices do not override manual
+    # config.
+    hosts = []
+    ip_addr = socket.gethostbyname(host)
+    if ip_addr not in known_devices:
+        try:
+            mediabox = ZiggoMediaboxXL(ip_addr)
+            if mediabox.test_connection():
+                hosts.append(ZiggoMediaboxXLDevice(mediabox, host, name))
+                known_devices.add(ip_addr)
+            else:
+                _LOGGER.error("Can't connect to %s", host)
+        except socket.error as error:
+            _LOGGER.error("Can't connect to %s: %s", host, error)
+    else:
+        _LOGGER.info("Ignoring duplicate Ziggo Mediabox XL %s", host)
+    add_devices(hosts, True)
+
+
+class ZiggoMediaboxXLDevice(MediaPlayerDevice):
+    """Representation of a Ziggo Mediabox XL Device."""
+
+    def __init__(self, mediabox, host, name):
+        """Initialize the device."""
+        # Generate a configuration for the Samsung library
+        self._mediabox = mediabox
+        self._host = host
+        self._name = name
+        self._state = None
+
+    def update(self):
+        """Retrieve the state of the device."""
+        try:
+            if self._mediabox.turned_on():
+                if self._state != STATE_PAUSED:
+                    self._state = STATE_PLAYING
+            else:
+                self._state = STATE_OFF
+        except socket.error:
+            _LOGGER.error("Couldn't fetch state from %s", self._host)
+
+    def send_keys(self, keys):
+        """Send keys to the device and handle exceptions."""
+        try:
+            self._mediabox.send_keys(keys)
+        except socket.error:
+            _LOGGER.error("Couldn't send keys to %s", self._host)
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def source_list(self):
+        """List of available sources (channels)."""
+        return [self._mediabox.channels()[c]
+                for c in sorted(self._mediabox.channels().keys())]
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_ZIGGO
+
+    def turn_on(self):
+        """Turn the media player on."""
+        self.send_keys(['POWER'])
+        self._state = STATE_ON
+
+    def turn_off(self):
+        """Turn off media player."""
+        self.send_keys(['POWER'])
+        self._state = STATE_OFF
+
+    def media_play(self):
+        """Send play command."""
+        self.send_keys(['PLAY'])
+        self._state = STATE_PLAYING
+
+    def media_pause(self):
+        """Send pause command."""
+        self.send_keys(['PAUSE'])
+        self._state = STATE_PAUSED
+
+    def media_play_pause(self):
+        """Simulate play pause media player."""
+        self.send_keys(['PAUSE'])
+        if self._state == STATE_PAUSED:
+            self._state = STATE_PLAYING
+        else:
+            self._state = STATE_PAUSED
+
+    def media_next_track(self):
+        """Channel up."""
+        self.send_keys(['CHAN_UP'])
+        self._state = STATE_PLAYING
+
+    def media_previous_track(self):
+        """Channel down."""
+        self.send_keys(['CHAN_DOWN'])
+        self._state = STATE_PLAYING
+
+    def select_source(self, source):
+        """Select the channel."""
+        if str(source).isdigit():
+            digits = str(source)
+        else:
+            digits = next((
+                key for key, value in self._mediabox.channels().items()
+                if value == source), None)
+        if digits is None:
+            return
+
+        self.send_keys(['NUM_{}'.format(digit)
+                        for digit in str(digits)])
+        self._state = STATE_PLAYING

--- a/homeassistant/components/scene/vera.py
+++ b/homeassistant/components/scene/vera.py
@@ -1,0 +1,60 @@
+"""
+Support for Vera scenes.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/scene.vera/
+"""
+import logging
+
+from homeassistant.util import slugify
+from homeassistant.components.scene import Scene
+from homeassistant.components.vera import (
+    VERA_CONTROLLER, VERA_SCENES, VERA_ID_FORMAT)
+
+DEPENDENCIES = ['vera']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Vera scenes."""
+    add_devices(
+        [VeraScene(scene, hass.data[VERA_CONTROLLER])
+         for scene in hass.data[VERA_SCENES]], True)
+
+
+class VeraScene(Scene):
+    """Representation of a Vera scene entity."""
+
+    def __init__(self, vera_scene, controller):
+        """Initialize the scene."""
+        self.vera_scene = vera_scene
+        self.controller = controller
+
+        self._name = self.vera_scene.name
+        # Append device id to prevent name clashes in HA.
+        self.vera_id = VERA_ID_FORMAT.format(
+            slugify(vera_scene.name), vera_scene.scene_id)
+
+    def update(self):
+        """Update the scene status."""
+        self.vera_scene.refresh()
+
+    def activate(self, **kwargs):
+        """Activate the scene."""
+        self.vera_scene.activate()
+
+    @property
+    def name(self):
+        """Return the name of the scene."""
+        return self._name
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the scene."""
+        return {'vera_scene_id': self.vera_scene.vera_scene_id}
+
+    @property
+    def should_poll(self):
+        """Return that polling is not necessary."""
+        return False

--- a/homeassistant/components/sensor/ads.py
+++ b/homeassistant/components/sensor/ads.py
@@ -1,0 +1,103 @@
+"""
+Support for ADS sensors.
+
+For more details about this platform, please refer to the documentation.
+https://home-assistant.io/components/sensor.ads/
+
+"""
+import asyncio
+import logging
+import voluptuous as vol
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME, CONF_UNIT_OF_MEASUREMENT
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components import ads
+from homeassistant.components.ads import CONF_ADS_VAR, CONF_ADS_TYPE, \
+    CONF_ADS_FACTOR
+
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'ADS sensor'
+DEPENDENCIES = ['ads']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ADS_VAR): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT, default=''): cv.string,
+    vol.Optional(CONF_ADS_TYPE, default=ads.ADSTYPE_INT): vol.In(
+        [ads.ADSTYPE_INT, ads.ADSTYPE_UINT, ads.ADSTYPE_BYTE]
+    ),
+    vol.Optional(CONF_ADS_FACTOR): cv.positive_int,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up an ADS sensor device."""
+    ads_hub = hass.data.get(ads.DATA_ADS)
+
+    ads_var = config.get(CONF_ADS_VAR)
+    ads_type = config.get(CONF_ADS_TYPE)
+    name = config.get(CONF_NAME)
+    unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
+    factor = config.get(CONF_ADS_FACTOR)
+
+    entity = AdsSensor(ads_hub, ads_var, ads_type, name,
+                       unit_of_measurement, factor)
+
+    add_devices([entity])
+
+
+class AdsSensor(Entity):
+    """Representation of an ADS sensor entity."""
+
+    def __init__(self, ads_hub, ads_var, ads_type, name, unit_of_measurement,
+                 factor):
+        """Initialize AdsSensor entity."""
+        self._ads_hub = ads_hub
+        self._name = name
+        self._value = None
+        self._unit_of_measurement = unit_of_measurement
+        self.ads_var = ads_var
+        self.ads_type = ads_type
+        self.factor = factor
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register device notification."""
+        def update(name, value):
+            """Handle device notifications."""
+            _LOGGER.debug('Variable %s changed its value to %d', name, value)
+
+            # if factor is set use it otherwise not
+            if self.factor is None:
+                self._value = value
+            else:
+                self._value = value / self.factor
+            self.schedule_update_ha_state()
+
+        self.hass.async_add_job(
+            self._ads_hub.add_device_notification,
+            self.ads_var, self._ads_hub.ADS_TYPEMAP[self.ads_type], update
+        )
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._value
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._unit_of_measurement
+
+    @property
+    def should_poll(self):
+        """Return False because entity pushes its state to HA."""
+        return False

--- a/homeassistant/components/sensor/gearbest.py
+++ b/homeassistant/components/sensor/gearbest.py
@@ -1,0 +1,127 @@
+"""
+Parse prices of a item from gearbest.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.gearbest/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import track_time_interval
+from homeassistant.const import (CONF_NAME, CONF_ID, CONF_URL, CONF_CURRENCY)
+
+REQUIREMENTS = ['gearbest_parser==1.0.5']
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ITEMS = 'items'
+
+ICON = 'mdi:coin'
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=2*60*60)  # 2h
+MIN_TIME_BETWEEN_CURRENCY_UPDATES = timedelta(seconds=12*60*60)  # 12h
+
+
+_ITEM_SCHEMA = vol.All(
+    vol.Schema({
+        vol.Exclusive(CONF_URL, 'XOR'): cv.string,
+        vol.Exclusive(CONF_ID, 'XOR'): cv.string,
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_CURRENCY): cv.string
+    }), cv.has_at_least_one_key(CONF_URL, CONF_ID)
+)
+
+_ITEMS_SCHEMA = vol.Schema([_ITEM_SCHEMA])
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ITEMS): _ITEMS_SCHEMA,
+    vol.Required(CONF_CURRENCY): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Gearbest sensor."""
+    from gearbest_parser import CurrencyConverter
+    currency = config.get(CONF_CURRENCY)
+
+    sensors = []
+    items = config.get(CONF_ITEMS)
+
+    converter = CurrencyConverter()
+    converter.update()
+
+    for item in items:
+        try:
+            sensors.append(GearbestSensor(converter, item, currency))
+        except ValueError as exc:
+            _LOGGER.error(exc)
+
+    def currency_update(event_time):
+        """Update currency list."""
+        converter.update()
+
+    track_time_interval(hass,
+                        currency_update,
+                        MIN_TIME_BETWEEN_CURRENCY_UPDATES)
+
+    add_devices(sensors, True)
+
+
+class GearbestSensor(Entity):
+    """Implementation of the sensor."""
+
+    def __init__(self, converter, item, currency):
+        """Initialize the sensor."""
+        from gearbest_parser import GearbestParser
+
+        self._name = item.get(CONF_NAME)
+        self._parser = GearbestParser()
+        self._parser.set_currency_converter(converter)
+        self._item = self._parser.load(item.get(CONF_ID),
+                                       item.get(CONF_URL),
+                                       item.get(CONF_CURRENCY, currency))
+        if self._item is None:
+            raise ValueError("id and url could not be resolved")
+
+    @property
+    def name(self):
+        """Return the name of the item."""
+        return self._name if self._name is not None else self._item.name
+
+    @property
+    def icon(self):
+        """Return the icon for the frontend."""
+        return ICON
+
+    @property
+    def state(self):
+        """Return the price of the selected product."""
+        return self._item.price
+
+    @property
+    def unit_of_measurement(self):
+        """Return the currency."""
+        return self._item.currency
+
+    @property
+    def entity_picture(self):
+        """Return the image."""
+        return self._item.image
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attrs = {'name': self._item.name,
+                 'description': self._item.description,
+                 'currency': self._item.currency,
+                 'url': self._item.url}
+        return attrs
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest price from gearbest and updates the state."""
+        self._item.update()

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -25,8 +25,8 @@ SCAN_INTERVAL = timedelta(seconds=5)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera controller devices."""
     add_devices(
-        VeraSensor(device, VERA_CONTROLLER)
-        for device in VERA_DEVICES['sensor'])
+        VeraSensor(device, hass.data[VERA_CONTROLLER])
+        for device in hass.data[VERA_DEVICES]['sensor'])
 
 
 class VeraSensor(VeraDevice, Entity):

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -437,7 +437,7 @@ input_text:
   set_value:
     description: Set the value of an input text entity.
     fields:
-      entity_id: 
+      entity_id:
         description: Entity id of the input text to set the new value.
         example: 'input_text.text1'
       value:
@@ -448,7 +448,7 @@ input_number:
   set_value:
     description: Set the value of an input number entity.
     fields:
-      entity_id: 
+      entity_id:
         description: Entity id of the input number to set the new value.
         example: 'input_number.threshold'
       value:
@@ -457,13 +457,13 @@ input_number:
   increment:
     description: Increment the value of an input number entity by its stepping.
     fields:
-      entity_id: 
+      entity_id:
         description: Entity id of the input number the should be incremented.
         example: 'input_number.threshold'
   decrement:
     description: Decrement the value of an input number entity by its stepping.
     fields:
-      entity_id: 
+      entity_id:
         description: Entity id of the input number the should be decremented.
         example: 'input_number.threshold'
 

--- a/homeassistant/components/switch/ads.py
+++ b/homeassistant/components/switch/ads.py
@@ -1,0 +1,85 @@
+"""
+Support for ADS switch platform.
+
+For more details about this platform, please refer to the documentation.
+https://home-assistant.io/components/switch.ads/
+
+"""
+import asyncio
+import logging
+import voluptuous as vol
+from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
+from homeassistant.components.ads import DATA_ADS, CONF_ADS_VAR
+from homeassistant.helpers.entity import ToggleEntity
+import homeassistant.helpers.config_validation as cv
+
+
+_LOGGER = logging.getLogger(__name__)
+DEPENDENCIES = ['ads']
+DEFAULT_NAME = 'ADS Switch'
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ADS_VAR): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up switch platform for ADS."""
+    ads_hub = hass.data.get(DATA_ADS)
+
+    name = config.get(CONF_NAME)
+    ads_var = config.get(CONF_ADS_VAR)
+
+    add_devices([AdsSwitch(ads_hub, name, ads_var)], True)
+
+
+class AdsSwitch(ToggleEntity):
+    """Representation of an Ads switch device."""
+
+    def __init__(self, ads_hub, name, ads_var):
+        """Initialize the AdsSwitch entity."""
+        self._ads_hub = ads_hub
+        self._on_state = False
+        self._name = name
+        self.ads_var = ads_var
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register device notification."""
+        def update(name, value):
+            """Handle device notification."""
+            _LOGGER.debug('Variable %s changed its value to %d',
+                          name, value)
+            self._on_state = value
+            self.schedule_update_ha_state()
+
+        self.hass.async_add_job(
+            self._ads_hub.add_device_notification,
+            self.ads_var, self._ads_hub.PLCTYPE_BOOL, update
+        )
+
+    @property
+    def is_on(self):
+        """Return if the switch is turned on."""
+        return self._on_state
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """Return False because entity pushes its state to HA."""
+        return False
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        self._ads_hub.write_by_name(self.ads_var, True,
+                                    self._ads_hub.PLCTYPE_BOOL)
+
+    def turn_off(self, **kwargs):
+        """Turn the switch off."""
+        self._ads_hub.write_by_name(self.ads_var, False,
+                                    self._ads_hub.PLCTYPE_BOOL)

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -22,9 +22,12 @@ ATTR_TOTAL_CONSUMPTION = 'total_consumption'
 ATTR_DAILY_CONSUMPTION = 'daily_consumption'
 ATTR_CURRENT = 'current'
 
+CONF_LEDS = 'enable_leds'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_LEDS, default=True): cv.boolean,
 })
 
 
@@ -34,17 +37,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     from pyHS100 import SmartPlug
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
+    leds_on = config.get(CONF_LEDS)
 
-    add_devices([SmartPlugSwitch(SmartPlug(host), name)], True)
+    add_devices([SmartPlugSwitch(SmartPlug(host), name, leds_on)], True)
 
 
 class SmartPlugSwitch(SwitchDevice):
     """Representation of a TPLink Smart Plug switch."""
 
-    def __init__(self, smartplug, name):
+    def __init__(self, smartplug, name, leds_on):
         """Initialize the switch."""
         self.smartplug = smartplug
         self._name = name
+        self._leds_on = leds_on
         self._state = None
         self._available = True
         # Set up emeter cache
@@ -88,6 +93,8 @@ class SmartPlugSwitch(SwitchDevice):
 
             if self._name is None:
                 self._name = self.smartplug.alias
+
+            self.smartplug.led = self._leds_on
 
             if self.smartplug.has_emeter:
                 emeter_readings = self.smartplug.get_emeter_realtime()

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -19,8 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera switches."""
     add_devices(
-        VeraSwitch(device, VERA_CONTROLLER) for
-        device in VERA_DEVICES['switch'])
+        VeraSwitch(device, hass.data[VERA_CONTROLLER]) for
+        device in hass.data[VERA_DEVICES]['switch'])
 
 
 class VeraSwitch(VeraDevice, SwitchDevice):

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -24,7 +24,7 @@ APPLICATION_NAME = 'Home Assistant'
 
 DOMAIN = 'tellduslive'
 
-REQUIREMENTS = ['tellduslive==0.10.3']
+REQUIREMENTS = ['tellduslive==0.10.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -19,13 +19,13 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP, CONF_LIGHTS, CONF_EXCLUDE)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.38']
+REQUIREMENTS = ['pyvera==0.2.39']
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'vera'
 
-VERA_CONTROLLER = None
+VERA_CONTROLLER = 'vera_controller'
 
 CONF_CONTROLLER = 'vera_controller_url'
 
@@ -34,7 +34,8 @@ VERA_ID_FORMAT = '{}_{}'
 ATTR_CURRENT_POWER_W = "current_power_w"
 ATTR_CURRENT_ENERGY_KWH = "current_energy_kwh"
 
-VERA_DEVICES = defaultdict(list)
+VERA_DEVICES = 'vera_devices'
+VERA_SCENES = 'vera_scenes'
 
 VERA_ID_LIST_SCHEMA = vol.Schema([int])
 
@@ -47,20 +48,20 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 VERA_COMPONENTS = [
-    'binary_sensor', 'sensor', 'light', 'switch', 'lock', 'climate', 'cover'
+    'binary_sensor', 'sensor', 'light', 'switch',
+    'lock', 'climate', 'cover', 'scene'
 ]
 
 
 # pylint: disable=unused-argument, too-many-function-args
 def setup(hass, base_config):
     """Set up for Vera devices."""
-    global VERA_CONTROLLER
     import pyvera as veraApi
 
     def stop_subscription(event):
         """Shutdown Vera subscriptions and subscription thread on exit."""
         _LOGGER.info("Shutting down subscriptions")
-        VERA_CONTROLLER.stop()
+        hass.data[VERA_CONTROLLER].stop()
 
     config = base_config.get(DOMAIN)
 
@@ -70,11 +71,14 @@ def setup(hass, base_config):
     exclude_ids = config.get(CONF_EXCLUDE)
 
     # Initialize the Vera controller.
-    VERA_CONTROLLER, _ = veraApi.init_controller(base_url)
+    controller, _ = veraApi.init_controller(base_url)
+    hass.data[VERA_CONTROLLER] = controller
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_subscription)
 
     try:
-        all_devices = VERA_CONTROLLER.get_devices()
+        all_devices = controller.get_devices()
+
+        all_scenes = controller.get_scenes()
     except RequestException:
         # There was a network related error connecting to the Vera controller.
         _LOGGER.exception("Error communicating with Vera API")
@@ -84,12 +88,19 @@ def setup(hass, base_config):
     devices = [device for device in all_devices
                if device.device_id not in exclude_ids]
 
+    vera_devices = defaultdict(list)
     for device in devices:
         device_type = map_vera_device(device, light_ids)
         if device_type is None:
             continue
 
-        VERA_DEVICES[device_type].append(device)
+        vera_devices[device_type].append(device)
+    hass.data[VERA_DEVICES] = vera_devices
+
+    vera_scenes = []
+    for scene in all_scenes:
+        vera_scenes.append(scene)
+    hass.data[VERA_SCENES] = vera_scenes
 
     for component in VERA_COMPONENTS:
         discovery.load_platform(hass, component, DOMAIN, {}, base_config)

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -219,7 +219,9 @@ class XiaomiDevice(Entity):
     def push_data(self, data):
         """Push from Hub."""
         _LOGGER.debug("PUSH >> %s: %s", self, data)
-        if self.parse_data(data) or self.parse_voltage(data):
+        is_data = self.parse_data(data)
+        is_voltage = self.parse_voltage(data)
+        if is_data or is_voltage:
             self.schedule_update_ha_state()
 
     def parse_voltage(self, data):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 59
-PATCH_VERSION = '1'
+PATCH_VERSION = '2'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -21,7 +21,8 @@ from homeassistant.components.climate import (
     ATTR_HUMIDITY, ATTR_OPERATION_MODE, ATTR_SWING_MODE,
     SERVICE_SET_AUX_HEAT, SERVICE_SET_AWAY_MODE, SERVICE_SET_HOLD_MODE,
     SERVICE_SET_FAN_MODE, SERVICE_SET_HUMIDITY, SERVICE_SET_OPERATION_MODE,
-    SERVICE_SET_SWING_MODE, SERVICE_SET_TEMPERATURE)
+    SERVICE_SET_SWING_MODE, SERVICE_SET_TEMPERATURE, STATE_HEAT, STATE_COOL,
+    STATE_IDLE)
 from homeassistant.components.climate.ecobee import (
     ATTR_FAN_MIN_ON_TIME, SERVICE_SET_FAN_MIN_ON_TIME,
     ATTR_RESUME_ALL, SERVICE_RESUME_PROGRAM)
@@ -210,10 +211,11 @@ def state_as_number(state):
     Raises ValueError if this is not possible.
     """
     if state.state in (STATE_ON, STATE_LOCKED, STATE_ABOVE_HORIZON,
-                       STATE_OPEN, STATE_HOME):
+                       STATE_OPEN, STATE_HOME, STATE_HEAT, STATE_COOL):
         return 1
     elif state.state in (STATE_OFF, STATE_UNLOCKED, STATE_UNKNOWN,
-                         STATE_BELOW_HORIZON, STATE_CLOSED, STATE_NOT_HOME):
+                         STATE_BELOW_HORIZON, STATE_CLOSED, STATE_NOT_HOME,
+                         STATE_IDLE):
         return 0
 
     return float(state.state)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -925,7 +925,7 @@ pyunifi==2.13
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.2.38
+pyvera==0.2.39
 
 # homeassistant.components.media_player.vizio
 pyvizio==0.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1185,3 +1185,6 @@ zengge==0.2
 
 # homeassistant.components.zeroconf
 zeroconf==0.19.1
+
+# homeassistant.components.media_player.ziggo_mediabox_xl
+ziggo-mediabox-xl==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -623,7 +623,7 @@ pybbox==0.0.5-alpha
 # pybluez==0.22
 
 # homeassistant.components.media_player.cast
-pychromecast==1.0.2
+pychromecast==0.8.2
 
 # homeassistant.components.media_player.cmus
 pycmus==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -883,7 +883,7 @@ python-velbus==2.0.11
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.7.0
+python-wink==1.7.1
 
 # homeassistant.components.sensor.swiss_public_transport
 python_opendata_transport==0.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -600,6 +600,9 @@ pyTibber==0.2.1
 # homeassistant.components.switch.dlink
 pyW215==0.6.0
 
+# homeassistant.components.ads
+pyads==2.2.6
+
 # homeassistant.components.sensor.airvisual
 pyairvisual==1.0.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1063,7 +1063,7 @@ tellcore-net==0.3
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.10.3
+tellduslive==0.10.4
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1069,7 +1069,7 @@ tellcore-net==0.3
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.10.3
+tellduslive==0.10.4
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -632,7 +632,7 @@ pybbox==0.0.5-alpha
 # pybluez==0.22
 
 # homeassistant.components.media_player.cast
-pychromecast==1.0.2
+pychromecast==0.8.2
 
 # homeassistant.components.media_player.cmus
 pycmus==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -337,7 +337,7 @@ hipnotify==1.0.8
 holidays==0.8.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20171204.0
+home-assistant-frontend==20171206.0
 
 # homeassistant.components.camera.onvif
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -895,7 +895,7 @@ python-velbus==2.0.11
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.7.0
+python-wink==1.7.1
 
 # homeassistant.components.sensor.swiss_public_transport
 python_opendata_transport==0.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -291,6 +291,9 @@ gTTS-token==1.1.1
 # homeassistant.components.device_tracker.bluetooth_le_tracker
 # gattlib==0.20150805
 
+# homeassistant.components.sensor.gearbest
+gearbest_parser==1.0.5
+
 # homeassistant.components.sensor.gitter
 gitterpy==0.1.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -74,7 +74,7 @@ hbmqtt==0.9.1
 holidays==0.8.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20171204.0
+home-assistant-frontend==20171206.0
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -9,7 +9,8 @@ import voluptuous as vol
 from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.components.device_tracker import (
-    CONF_CONSIDER_HOME, CONF_TRACK_NEW)
+    CONF_CONSIDER_HOME, CONF_TRACK_NEW, CONF_NEW_DEVICE_DEFAULTS,
+    CONF_AWAY_HIDE)
 from homeassistant.components.device_tracker.asuswrt import (
     CONF_PROTOCOL, CONF_MODE, CONF_PUB_KEY, DOMAIN,
     CONF_PORT, PLATFORM_SCHEMA)
@@ -78,7 +79,11 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
                 CONF_USERNAME: 'fake_user',
                 CONF_PASSWORD: 'fake_pass',
                 CONF_TRACK_NEW: True,
-                CONF_CONSIDER_HOME: timedelta(seconds=180)
+                CONF_CONSIDER_HOME: timedelta(seconds=180),
+                CONF_NEW_DEVICE_DEFAULTS: {
+                    CONF_TRACK_NEW: True,
+                    CONF_AWAY_HIDE: False
+                }
             }
         }
 
@@ -104,7 +109,11 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
                 CONF_USERNAME: 'fake_user',
                 CONF_PUB_KEY: FAKEFILE,
                 CONF_TRACK_NEW: True,
-                CONF_CONSIDER_HOME: timedelta(seconds=180)
+                CONF_CONSIDER_HOME: timedelta(seconds=180),
+                CONF_NEW_DEVICE_DEFAULTS: {
+                    CONF_TRACK_NEW: True,
+                    CONF_AWAY_HIDE: False
+                }
             }
         }
 

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -123,7 +123,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                                   'My device', None, None, False),
             device_tracker.Device(self.hass, True, True, 'your_device',
                                   'AB:01', 'Your device', None, None, False)]
-        device_tracker.DeviceTracker(self.hass, False, True, devices)
+        device_tracker.DeviceTracker(self.hass, False, True, {}, devices)
         _LOGGER.debug(mock_warning.call_args_list)
         assert mock_warning.call_count == 1, \
             "The only warning call should be duplicates (check DEBUG)"
@@ -137,7 +137,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                                   'AB:01', 'My device', None, None, False),
             device_tracker.Device(self.hass, True, True, 'my_device',
                                   None, 'Your device', None, None, False)]
-        device_tracker.DeviceTracker(self.hass, False, True, devices)
+        device_tracker.DeviceTracker(self.hass, False, True, {}, devices)
 
         _LOGGER.debug(mock_warning.call_args_list)
         assert mock_warning.call_count == 1, \
@@ -299,7 +299,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         vendor_string = 'Raspberry Pi Foundation'
 
         tracker = device_tracker.DeviceTracker(
-            self.hass, timedelta(seconds=60), 0, [])
+            self.hass, timedelta(seconds=60), 0, {}, [])
 
         with mock_aiohttp_client() as aioclient_mock:
             aioclient_mock.get('http://api.macvendors.com/b8:27:eb',
@@ -622,7 +622,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     def test_see_failures(self, mock_warning):
         """Test that the device tracker see failures."""
         tracker = device_tracker.DeviceTracker(
-            self.hass, timedelta(seconds=60), 0, [])
+            self.hass, timedelta(seconds=60), 0, {}, [])
 
         # MAC is not a string (but added)
         tracker.see(mac=567, host_name="Number MAC")
@@ -654,7 +654,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     def test_picture_and_icon_on_see_discovery(self):
         """Test that picture and icon are set in initial see."""
         tracker = device_tracker.DeviceTracker(
-            self.hass, timedelta(seconds=60), False, [])
+            self.hass, timedelta(seconds=60), False, {}, [])
         tracker.see(dev_id=11, picture='pic_url', icon='mdi:icon')
         self.hass.block_till_done()
         config = device_tracker.load_config(self.yaml_devices, self.hass,
@@ -662,6 +662,18 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         assert len(config) == 1
         assert config[0].icon == 'mdi:icon'
         assert config[0].entity_picture == 'pic_url'
+
+    def test_default_hide_if_away_is_used(self):
+        """Test that default track_new is used."""
+        tracker = device_tracker.DeviceTracker(
+            self.hass, timedelta(seconds=60), False,
+            {device_tracker.CONF_AWAY_HIDE: True}, [])
+        tracker.see(dev_id=12)
+        self.hass.block_till_done()
+        config = device_tracker.load_config(self.yaml_devices, self.hass,
+                                            timedelta(seconds=0))
+        assert len(config) == 1
+        self.assertTrue(config[0].hidden)
 
 
 @asyncio.coroutine

--- a/tests/components/device_tracker/test_meraki.py
+++ b/tests/components/device_tracker/test_meraki.py
@@ -1,0 +1,139 @@
+"""The tests the for Meraki device tracker."""
+import asyncio
+import json
+from unittest.mock import patch
+import pytest
+from homeassistant.components.device_tracker.meraki import (
+    CONF_VALIDATOR, CONF_SECRET)
+from homeassistant.setup import async_setup_component
+import homeassistant.components.device_tracker as device_tracker
+from homeassistant.const import CONF_PLATFORM
+from homeassistant.components.device_tracker.meraki import URL
+
+
+@pytest.fixture
+def meraki_client(loop, hass, test_client):
+    """Meraki mock client."""
+    assert loop.run_until_complete(async_setup_component(
+        hass, device_tracker.DOMAIN, {
+            device_tracker.DOMAIN: {
+                CONF_PLATFORM: 'meraki',
+                CONF_VALIDATOR: 'validator',
+                CONF_SECRET: 'secret'
+
+            }
+        }))
+
+    with patch('homeassistant.components.device_tracker.update_config'):
+        yield loop.run_until_complete(test_client(hass.http.app))
+
+
+@asyncio.coroutine
+def test_invalid_or_missing_data(meraki_client):
+    """Test validator with invalid or missing data."""
+    req = yield from meraki_client.get(URL)
+    text = yield from req.text()
+    assert req.status == 200
+    assert text == 'validator'
+
+    req = yield from meraki_client.post(URL, data=b"invalid")
+    text = yield from req.json()
+    assert req.status == 400
+    assert text['message'] == 'Invalid JSON'
+
+    req = yield from meraki_client.post(URL, data=b"{}")
+    text = yield from req.json()
+    assert req.status == 422
+    assert text['message'] == 'No secret'
+
+    data = {
+        "version": "1.0",
+        "secret": "secret"
+    }
+    req = yield from meraki_client.post(URL, data=json.dumps(data))
+    text = yield from req.json()
+    assert req.status == 422
+    assert text['message'] == 'Invalid version'
+
+    data = {
+        "version": "2.0",
+        "secret": "invalid"
+    }
+    req = yield from meraki_client.post(URL, data=json.dumps(data))
+    text = yield from req.json()
+    assert req.status == 422
+    assert text['message'] == 'Invalid secret'
+
+    data = {
+        "version": "2.0",
+        "secret": "secret",
+        "type": "InvalidType"
+    }
+    req = yield from meraki_client.post(URL, data=json.dumps(data))
+    text = yield from req.json()
+    assert req.status == 422
+    assert text['message'] == 'Invalid device type'
+
+    data = {
+        "version": "2.0",
+        "secret": "secret",
+        "type": "BluetoothDevicesSeen",
+        "data": {
+            "observations": []
+        }
+    }
+    req = yield from meraki_client.post(URL, data=json.dumps(data))
+    assert req.status == 200
+
+
+@asyncio.coroutine
+def test_data_will_be_saved(hass, meraki_client):
+    """Test with valid data."""
+    data = {
+        "version": "2.0",
+        "secret": "secret",
+        "type": "DevicesSeen",
+        "data": {
+            "observations": [
+                {
+                    "location": {
+                        "lat": "51.5355157",
+                        "lng": "21.0699035",
+                        "unc": "46.3610585",
+                    },
+                    "seenTime": "2016-09-12T16:23:13Z",
+                    "ssid": 'ssid',
+                    "os": 'HA',
+                    "ipv6": '2607:f0d0:1002:51::4/64',
+                    "clientMac": "00:26:ab:b8:a9:a4",
+                    "seenEpoch": "147369739",
+                    "rssi": "20",
+                    "manufacturer": "Seiko Epson"
+                },
+                {
+                    "location": {
+                        "lat": "51.5355357",
+                        "lng": "21.0699635",
+                        "unc": "46.3610585",
+                    },
+                    "seenTime": "2016-09-12T16:21:13Z",
+                    "ssid": 'ssid',
+                    "os": 'HA',
+                    "ipv4": '192.168.0.1',
+                    "clientMac": "00:26:ab:b8:a9:a5",
+                    "seenEpoch": "147369750",
+                    "rssi": "20",
+                    "manufacturer": "Seiko Epson"
+                }
+            ]
+        }
+    }
+    req = yield from meraki_client.post(URL, data=json.dumps(data))
+    assert req.status == 200
+    state_name = hass.states.get('{}.{}'.format('device_tracker',
+                                                '0026abb8a9a4')).state
+    assert 'home' == state_name
+
+    state_name = hass.states.get('{}.{}'.format('device_tracker',
+                                                '0026abb8a9a5')).state
+    assert 'home' == state_name

--- a/tests/components/device_tracker/test_unifi_direct.py
+++ b/tests/components/device_tracker/test_unifi_direct.py
@@ -11,7 +11,8 @@ import voluptuous as vol
 from homeassistant.setup import setup_component
 from homeassistant.components import device_tracker
 from homeassistant.components.device_tracker import (
-    CONF_CONSIDER_HOME, CONF_TRACK_NEW)
+    CONF_CONSIDER_HOME, CONF_TRACK_NEW, CONF_AWAY_HIDE,
+    CONF_NEW_DEVICE_DEFAULTS)
 from homeassistant.components.device_tracker.unifi_direct import (
     DOMAIN, CONF_PORT, PLATFORM_SCHEMA, _response_to_json, get_scanner)
 from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
@@ -54,7 +55,11 @@ class TestComponentsDeviceTrackerUnifiDirect(unittest.TestCase):
                 CONF_USERNAME: 'fake_user',
                 CONF_PASSWORD: 'fake_pass',
                 CONF_TRACK_NEW: True,
-                CONF_CONSIDER_HOME: timedelta(seconds=180)
+                CONF_CONSIDER_HOME: timedelta(seconds=180),
+                CONF_NEW_DEVICE_DEFAULTS: {
+                    CONF_TRACK_NEW: True,
+                    CONF_AWAY_HIDE: False
+                }
             }
         }
 


### PR DESCRIPTION
## Description:
In some situations, after a restart of HASS the Egardia alarm system was reported with status 'unknown'. This PR fixes this issue by doing an extra status update regardless of exact config of the pythonegardia component.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
