### PR TITLE
Update linksys_ap.py to fix DeviceScanner class inheritance

### DIFF
--- a/homeassistant/components/device_tracker/linksys_ap.py
+++ b/homeassistant/components/device_tracker/linksys_ap.py
@@ -11,7 +11,8 @@ import requests
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.device_tracker import DOMAIN, PLATFORM_SCHEMA
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL)
 
@@ -38,7 +39,7 @@ def get_scanner(hass, config):
         return None
 
 
-class LinksysAPDeviceScanner(object):
+class LinksysAPDeviceScanner(DeviceScanner):
     """This class queries a Linksys Access Point."""
 
     def __init__(self, config):


### PR DESCRIPTION
## Description:
As per issue #8638, the class wasn't inheriting from DeviceScanner, this patches it up.

**Related issue (if applicable):** fixes #8638

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**



