### PR TITLE
webostv: Ensure source exists before use

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -322,12 +322,15 @@ class LgWebOSDevice(MediaPlayerDevice):
 
     def select_source(self, source):
         """Select input source."""
-        if self._source_list.get(source).get('title'):
-            self._current_source_id = self._source_list[source]['id']
+        source = self._source_list.get(source)
+        if source is None:
+            _LOGGER.warning("Source %s not found for %s", source, self.name)
+            return
+        self._current_source_id = self._source_list[source]['id']
+        if source.get('title'):
             self._current_source = self._source_list[source]['title']
             self._client.launch_app(self._source_list[source]['id'])
-        elif self._source_list.get(source).get('label'):
-            self._current_source_id = self._source_list[source]['id']
+        elif source.get('label'):
             self._current_source = self._source_list[source]['label']
             self._client.set_input(self._source_list[source]['id'])
 


### PR DESCRIPTION
In a case where either (a) an incorrect source name is used, or (b) the
TV isn't currently queryable (e.g. it's off), we get tracebacks because
we assume the source that we are being asked to select exists in
self._source_list.

This makes the lookup code a little more rugged, and adds in a warning
message (in place of the current exception).