### PR TITLE
Allow chime to work for wink siren/chime

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -880,7 +880,7 @@ python-velbus==2.0.11
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.7.0
+python-wink==1.7.1
 
 # homeassistant.components.sensor.swiss_public_transport
 python_opendata_transport==0.0.3


### PR DESCRIPTION
## Description:
This fixes three things.
1. This adds the Wink branded siren/chime to the list of supported Wink siren devices that can also be used as a chime.
2. python-wink update fixes an issue for some users where their hub doesn't have a local control ID causing Wink to fail and not start up.
3. python-wink update which sets Wink lock extended features via the online API not via local control. Local control isn't supported for the extended features (vacation mode, alarm sensitivity, ...) so the request must be sent online.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies have been added to `requirements_all.txt` by running

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
