### PR TITLE
Reload closest store on api menu request

### DIFF
--- a/homeassistant/components/dominos.py
+++ b/homeassistant/components/dominos.py
@@ -136,6 +136,7 @@ class Dominos():
 
     def get_menu(self):
         """Return the products from the closest stores menu."""
+        self.update_closest_store()
         if self.closest_store is None:
             _LOGGER.warning('Cannot get menu. Store may be closed')
             return []
@@ -169,7 +170,8 @@ class DominosProductListView(http.HomeAssistantView):
     @callback
     def get(self, request):
         """Retrieve if API is running."""
-        return self.json(self.dominos.get_menu())
+        menu = self.dominos.get_menu()
+        return self.json(menu)
 
 
 class DominosOrder(Entity):

--- a/homeassistant/components/dominos.py
+++ b/homeassistant/components/dominos.py
@@ -170,8 +170,7 @@ class DominosProductListView(http.HomeAssistantView):
     @callback
     def get(self, request):
         """Retrieve if API is running."""
-        menu = self.dominos.get_menu()
-        return self.json(menu)
+        return self.json(self.dominos.get_menu())
 
 
 class DominosOrder(Entity):


### PR DESCRIPTION
## Description:
refresh closest store when menu requested


**Related issue (if applicable):** fixes #10929

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
