### PR TITLE
Add 2 media_player services and 1 custom service to Squeezebox platform

### DIFF
--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -288,6 +288,9 @@ squeezebox_call_method:
     entity_id:
       description: Name(s) of the Squeexebox entities where to run the API method.
       example: 'media_player.squeezebox_radio'
-    method:
-      description: Squeezebox JSON/RPC method call, in the form of an array of positional parameters. See 'Command Line Interface' official help page from Logitech for details.
-      example: '["playlist", "loadtracks", "track.titlesearch=highway to hell"]'
+    command:
+      description: Name of the Squeezebox command.
+      example: 'playlist'
+    parameters:
+      description: Optional array of parameters to be appended to the command. See 'Command Line Interface' official help page from Logitech for details.
+      example: '["loadtracks", "track.titlesearch=highway to hell"]'

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -281,3 +281,13 @@ kodi_call_method:
     method:
       description: Name of the Kodi JSONRPC API method to be called.
       example: 'VideoLibrary.GetRecentlyAddedEpisodes'
+
+squeezebox_call_method:
+  description: 'Call a Squeezebox JSON/RPC API method.'
+  fields:
+    entity_id:
+      description: Name(s) of the Squeexebox entities where to run the API method.
+      example: 'media_player.squeezebox_radio'
+    method:
+      description: Squeezebox JSON/RPC method call, in the form of an array of positional parameters. See 'Command Line Interface' official help page from Logitech for details.
+      example: '["playlist", "loadtracks", "track.titlesearch=you''re welcome"]'

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -290,4 +290,4 @@ squeezebox_call_method:
       example: 'media_player.squeezebox_radio'
     method:
       description: Squeezebox JSON/RPC method call, in the form of an array of positional parameters. See 'Command Line Interface' official help page from Logitech for details.
-      example: '["playlist", "loadtracks", "track.titlesearch=you''re welcome"]'
+      example: '["playlist", "loadtracks", "track.titlesearch=highway to hell"]'

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -490,7 +490,7 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         """Send the media player the command for clear playlist."""
         return self.async_query('playlist', 'clear')
 
-    def async_call_method(self, command, parameters=[]):
+    def async_call_method(self, command, parameters=None):
         """
         Call Squeezebox JSON/RPC method.
 
@@ -498,6 +498,7 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         of positional parameters (p0, p1...,  pN) passed to JSON/RPC server.
         """
         all_params = [command]
-        for parameter in parameters:
-            all_params.append(urllib.parse.quote(parameter, safe=':='))
+        if parameters:
+            for parameter in parameters:
+                all_params.append(urllib.parse.quote(parameter, safe=':='))
         return self.async_query(*all_params)

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -8,9 +8,9 @@ import logging
 import asyncio
 import urllib.parse
 import json
+import os
 import aiohttp
 import async_timeout
-import os
 
 import voluptuous as vol
 

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -10,14 +10,17 @@ import urllib.parse
 import json
 import aiohttp
 import async_timeout
+import os
 
 import voluptuous as vol
 
+from homeassistant.config import load_yaml_config_file
 from homeassistant.components.media_player import (
     ATTR_MEDIA_ENQUEUE, SUPPORT_PLAY_MEDIA,
     MEDIA_TYPE_MUSIC, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, PLATFORM_SCHEMA,
     SUPPORT_PREVIOUS_TRACK, SUPPORT_SEEK, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_PLAY, MediaPlayerDevice)
+    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_PLAY, MediaPlayerDevice,
+    MEDIA_PLAYER_SCHEMA, DOMAIN, SUPPORT_SHUFFLE_SET, SUPPORT_CLEAR_PLAYLIST)
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, STATE_IDLE, STATE_OFF,
     STATE_PAUSED, STATE_PLAYING, STATE_UNKNOWN, CONF_PORT)
@@ -33,7 +36,7 @@ TIMEOUT = 10
 SUPPORT_SQUEEZEBOX = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | \
     SUPPORT_VOLUME_MUTE | SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | \
     SUPPORT_SEEK | SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PLAY_MEDIA | \
-    SUPPORT_PLAY
+    SUPPORT_PLAY | SUPPORT_SHUFFLE_SET | SUPPORT_CLEAR_PLAYLIST
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -42,11 +45,31 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_USERNAME): cv.string,
 })
 
+SERVICE_CALL_METHOD = 'squeezebox_call_method'
+
+DATA_SQUEEZEBOX = 'squeexebox'
+
+ATTR_METHOD = 'method'
+
+SQUEEZEBOX_CALL_METHOD_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
+    vol.Required(ATTR_METHOD):
+        vol.All(cv.ensure_list, vol.Length(min=1), [cv.string]),
+})
+
+SERVICE_TO_METHOD = {
+    SERVICE_CALL_METHOD: {
+        'method': 'async_call_method',
+        'schema': SQUEEZEBOX_CALL_METHOD_SCHEMA},
+}
+
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the squeezebox platform."""
     import socket
+
+    if DATA_SQUEEZEBOX not in hass.data:
+        hass.data[DATA_SQUEEZEBOX] = []
 
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
@@ -74,7 +97,43 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     lms = LogitechMediaServer(hass, host, port, username, password)
 
     players = yield from lms.create_players()
+
+    hass.data[DATA_SQUEEZEBOX].extend(players)
     async_add_devices(players)
+
+    @asyncio.coroutine
+    def async_service_handler(service):
+        """Map services to methods on MediaPlayerDevice."""
+        method = SERVICE_TO_METHOD.get(service.service)
+        if not method:
+            return
+
+        params = {key: value for key, value in service.data.items()
+                  if key != 'entity_id'}
+        entity_ids = service.data.get('entity_id')
+        if entity_ids:
+            target_players = [player for player in hass.data[DATA_SQUEEZEBOX]
+                              if player.entity_id in entity_ids]
+        else:
+            target_players = hass.data[DATA_SQUEEZEBOX]
+
+        update_tasks = []
+        for player in target_players:
+            yield from getattr(player, method['method'])(**params)
+            update_tasks.append(player.async_update_ha_state(True))
+
+        if update_tasks:
+            yield from asyncio.wait(update_tasks, loop=hass.loop)
+
+    descriptions = yield from hass.async_add_job(
+        load_yaml_config_file, os.path.join(
+            os.path.dirname(__file__), 'services.yaml'))
+
+    for service in SERVICE_TO_METHOD:
+        schema = SERVICE_TO_METHOD[service]['schema']
+        hass.services.async_register(
+            DOMAIN, service, async_service_handler,
+            description=descriptions.get(service), schema=schema)
 
     return True
 
@@ -306,6 +365,12 @@ class SqueezeBoxDevice(MediaPlayerDevice):
             return self._status['album']
 
     @property
+    def shuffle(self):
+        """Boolean if shuffle is enabled."""
+        if 'playlist_shuffle' in self._status:
+            return self._status['playlist_shuffle'] == 1
+
+    @property
     def supported_features(self):
         """Flag media player features that are supported."""
         return SUPPORT_SQUEEZEBOX
@@ -415,3 +480,21 @@ class SqueezeBoxDevice(MediaPlayerDevice):
     def _add_uri_to_playlist(self, media_id):
         """Add a items to the existing playlist."""
         return self.async_query('playlist', 'add', media_id)
+
+    def async_set_shuffle(self, shuffle):
+        """Enable/disable shuffle mode."""
+        return self.async_query('playlist', 'shuffle', int(shuffle))
+
+    def async_clear_playlist(self):
+        """Send the media player the command for clear playlist."""
+        return self.async_query('playlist', 'clear')
+
+    def async_call_method(self, method):
+        """
+        Call Squeezebox JSON/RPC method.
+
+        Parameter 'method' should be the list of positional parameters (p0, p1,
+        pN) to be passed to JSON/RPC server.
+        """
+        return self.async_query(
+            *[urllib.parse.quote(element, safe=':=') for element in method])


### PR DESCRIPTION
## Description:

1. Add support for 2 media_player services to Squeezebox platform: `shuffle_set` and `clear_playlist`
This part is quite straightforward.

2. Add 1 custom service to Squeezebox platform: squeezebox_call_method
Such hass service can be used to invoke any JSON/RPC service provided by Squeezebox server.
It makes it much simpler to integrate any Squeezebox action to an automation.
Also it can be used to target a Squeezebox from IFTT (or DialogFlow, Alexa...).
For example, to play an album from your collection:
Create an IFTT Google assistant/Webhook with sentence  
`"I want to listen to album $"`  
and the JSON body would be:  
`{ "entity_id": "media_player.squeezebox_radio", "method": ["playlist", "loadtracks", "album.titlesearch={{TextField}}"] }`  
Works with title search and basically any thing. The same wouldn't have worked to call directly Squeezebox server as IFTT cannot escape the text field.
Implementation is done very similarly as custom services in sonos and kodi platforms,.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4142

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
