### PR TITLE
Report availability for TP-Link smart bulbs

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -72,6 +72,7 @@ class TPLinkSmartBulb(Light):
         if name is not None:
             self._name = name
         self._state = None
+        self._available = True
         self._color_temp = None
         self._brightness = None
         self._rgb = None
@@ -82,6 +83,11 @@ class TPLinkSmartBulb(Light):
     def name(self):
         """Return the name of the Smart Bulb, if any."""
         return self._name
+
+    @property
+    def available(self) -> bool:
+        """Return if bulb is available."""
+        return self._available
 
     @property
     def device_state_attributes(self):
@@ -132,6 +138,7 @@ class TPLinkSmartBulb(Light):
         """Update the TP-Link Bulb's state."""
         from pyHS100 import SmartDeviceException
         try:
+            self._available = True
             if self._supported_features == 0:
                 self.get_features()
             self._state = (
@@ -163,8 +170,10 @@ class TPLinkSmartBulb(Light):
                 except KeyError:
                     # device returned no daily/monthly history
                     pass
+
         except (SmartDeviceException, OSError) as ex:
-            _LOGGER.warning('Could not read state for %s: %s', self._name, ex)
+            _LOGGER.warning("Could not read state for %s: %s", self._name, ex)
+            self._available = False
 
     @property
     def supported_features(self):


### PR DESCRIPTION
## Description:

Set the availability of TP-Link smart bulbs based on communication errors when updating state.

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: tplink
    host: IP_ADDRESS
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
