### PR TITLE
Correct units used in TP-Link energy monioring

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -23,9 +23,9 @@ REQUIREMENTS = ['pyHS100==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_CURRENT_CONSUMPTION = 'current_consumption'
-ATTR_DAILY_CONSUMPTION = 'daily_consumption'
-ATTR_MONTHLY_CONSUMPTION = 'monthly_consumption'
+ATTR_CURRENT_POWER_W = 'current_power_w'
+ATTR_DAILY_ENERGY_KWH = 'daily_energy_kwh'
+ATTR_MONTHLY_ENERGY_KWH = 'monthly_energy_kwh'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -149,17 +149,17 @@ class TPLinkSmartBulb(Light):
             if self._supported_features & SUPPORT_RGB_COLOR:
                 self._rgb = hsv_to_rgb(self.smartbulb.hsv)
             if self.smartbulb.has_emeter:
-                self._emeter_params[ATTR_CURRENT_CONSUMPTION] \
-                    = "%.1f W" % (self.smartbulb.current_consumption() / 1e3)
+                self._emeter_params[ATTR_CURRENT_POWER_W] = '{:.1f}'.format(
+                    self.smartbulb.current_consumption() / 1e3)
                 daily_statistics = self.smartbulb.get_emeter_daily()
                 monthly_statistics = self.smartbulb.get_emeter_monthly()
                 try:
-                    self._emeter_params[ATTR_DAILY_CONSUMPTION] \
-                        = "%.2f Wh" % daily_statistics[int(
-                            time.strftime("%d"))]
-                    self._emeter_params[ATTR_MONTHLY_CONSUMPTION] \
-                        = "%.2f Wh" % monthly_statistics[int(
-                            time.strftime("%m"))]
+                    self._emeter_params[ATTR_DAILY_ENERGY_KWH] \
+                        = "{:.3f}".format(
+                            daily_statistics[int(time.strftime("%d"))] / 1e3)
+                    self._emeter_params[ATTR_MONTHLY_ENERGY_KWH] \
+                        = "{:.3f}".format(
+                            monthly_statistics[int(time.strftime("%m"))] / 1e3)
                 except KeyError:
                     # device returned no daily/monthly history
                     pass

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -150,15 +150,15 @@ class TPLinkSmartBulb(Light):
                 self._rgb = hsv_to_rgb(self.smartbulb.hsv)
             if self.smartbulb.has_emeter:
                 self._emeter_params[ATTR_CURRENT_CONSUMPTION] \
-                    = "%.1f W" % self.smartbulb.current_consumption()
+                    = "%.1f W" % (self.smartbulb.current_consumption() / 1e3)
                 daily_statistics = self.smartbulb.get_emeter_daily()
                 monthly_statistics = self.smartbulb.get_emeter_monthly()
                 try:
                     self._emeter_params[ATTR_DAILY_CONSUMPTION] \
-                        = "%.2f kW" % daily_statistics[int(
+                        = "%.2f Wh" % daily_statistics[int(
                             time.strftime("%d"))]
                     self._emeter_params[ATTR_MONTHLY_CONSUMPTION] \
-                        = "%.2f kW" % monthly_statistics[int(
+                        = "%.2f Wh" % monthly_statistics[int(
                             time.strftime("%m"))]
                 except KeyError:
                     # device returned no daily/monthly history

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -9,7 +9,8 @@ import time
 
 import voluptuous as vol
 
-from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.components.switch import (
+    SwitchDevice, PLATFORM_SCHEMA, ATTR_CURRENT_POWER_W, ATTR_TODAY_ENERGY_KWH)
 from homeassistant.const import (CONF_HOST, CONF_NAME, ATTR_VOLTAGE)
 import homeassistant.helpers.config_validation as cv
 
@@ -17,10 +18,8 @@ REQUIREMENTS = ['pyHS100==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_CURRENT_CONSUMPTION = 'current_consumption'
-ATTR_TOTAL_CONSUMPTION = 'total_consumption'
-ATTR_DAILY_CONSUMPTION = 'daily_consumption'
-ATTR_CURRENT = 'current'
+ATTR_TOTAL_ENERGY_KWH = 'total_energy_kwh'
+ATTR_CURRENT_A = 'current_a'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -92,19 +91,20 @@ class SmartPlugSwitch(SwitchDevice):
             if self.smartplug.has_emeter:
                 emeter_readings = self.smartplug.get_emeter_realtime()
 
-                self._emeter_params[ATTR_CURRENT_CONSUMPTION] \
-                    = "%.1f W" % emeter_readings["power"]
-                self._emeter_params[ATTR_TOTAL_CONSUMPTION] \
-                    = "%.2f kWh" % emeter_readings["total"]
+                self._emeter_params[ATTR_CURRENT_POWER_W] \
+                    = "{:.2f}".format(emeter_readings["power"])
+                self._emeter_params[ATTR_TOTAL_ENERGY_KWH] \
+                    = "{:.3f}".format(emeter_readings["total"])
                 self._emeter_params[ATTR_VOLTAGE] \
-                    = "%.2f V" % emeter_readings["voltage"]
-                self._emeter_params[ATTR_CURRENT] \
-                    = "%.1f A" % emeter_readings["current"]
+                    = "{:.1f}".format(emeter_readings["voltage"])
+                self._emeter_params[ATTR_CURRENT_A] \
+                    = "{:.2f}".format(emeter_readings["current"])
 
                 emeter_statics = self.smartplug.get_emeter_daily()
                 try:
-                    self._emeter_params[ATTR_DAILY_CONSUMPTION] \
-                        = "%.2f kWh" % emeter_statics[int(time.strftime("%e"))]
+                    self._emeter_params[ATTR_TODAY_ENERGY_KWH] \
+                        = "{:.3f}".format(
+                            emeter_statics[int(time.strftime("%e"))])
                 except KeyError:
                     # Device returned no daily history
                     pass

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -95,7 +95,7 @@ class SmartPlugSwitch(SwitchDevice):
                 self._emeter_params[ATTR_CURRENT_CONSUMPTION] \
                     = "%.1f W" % emeter_readings["power"]
                 self._emeter_params[ATTR_TOTAL_CONSUMPTION] \
-                    = "%.2f kW" % emeter_readings["total"]
+                    = "%.2f kWh" % emeter_readings["total"]
                 self._emeter_params[ATTR_VOLTAGE] \
                     = "%.2f V" % emeter_readings["voltage"]
                 self._emeter_params[ATTR_CURRENT] \
@@ -104,7 +104,7 @@ class SmartPlugSwitch(SwitchDevice):
                 emeter_statics = self.smartplug.get_emeter_daily()
                 try:
                     self._emeter_params[ATTR_DAILY_CONSUMPTION] \
-                        = "%.2f kW" % emeter_statics[int(time.strftime("%e"))]
+                        = "%.2f kWh" % emeter_statics[int(time.strftime("%e"))]
                 except KeyError:
                     # Device returned no daily history
                     pass


### PR DESCRIPTION
## Description:

- Report correct units (in attribute names)
- Correct unit conversions for:
  - Power is reported in mW for bulbs (converted to W)
  - Energy is reported in Wh for bulbs (converted to kWh)

Units are now included in the attribute names.

### Breaking changes:

The following attributes have been renamed:
- Light
  - `current_consumption` -> `current_power_w`
  - `daily_consumption` -> `daily_energy_kwh`
  - `monthly_consumption` -> `monthly_energy_kwh`
- Switch
  - `current` -> `current_a`
  - `current_consumption` -> `current_power_w`
  - `total_consumption` -> `total_energy_kwh`
  - `daily_consumption` -> `today_energy_kwh`

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: tplink
    host: IP_ADDRESS

switch:
  - platform: tplink
    host: IP_ADDRESS
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
