### PR TITLE
Allow disabling the LEDs on TP-Link smart plugs

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -22,9 +22,12 @@ ATTR_TOTAL_CONSUMPTION = 'total_consumption'
 ATTR_DAILY_CONSUMPTION = 'daily_consumption'
 ATTR_CURRENT = 'current'
 
+CONF_LEDS = 'enable_leds'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_LEDS, default=True): cv.boolean,
 })
 
 
@@ -34,17 +37,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     from pyHS100 import SmartPlug
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
+    leds_on = config.get(CONF_LEDS)
 
-    add_devices([SmartPlugSwitch(SmartPlug(host), name)], True)
+    add_devices([SmartPlugSwitch(SmartPlug(host), name, leds_on)], True)
 
 
 class SmartPlugSwitch(SwitchDevice):
     """Representation of a TPLink Smart Plug switch."""
 
-    def __init__(self, smartplug, name):
+    def __init__(self, smartplug, name, leds_on):
         """Initialize the switch."""
         self.smartplug = smartplug
         self._name = name
+        self._leds_on = leds_on
         self._state = None
         self._available = True
         # Set up emeter cache
@@ -88,6 +93,8 @@ class SmartPlugSwitch(SwitchDevice):
 
             if self._name is None:
                 self._name = self.smartplug.alias
+
+            self.smartplug.led = self._leds_on
 
             if self.smartplug.has_emeter:
                 emeter_readings = self.smartplug.get_emeter_realtime()


### PR DESCRIPTION
## Description:

Allows the LEDs on TP-Link smart plugs to be disabled by the component configuration.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4143

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: tplink
    host: IP_ADDRESS
    enable_leds: False
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
