### PR TITLE
Wemo - Use returned device name instead of model_name

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -99,7 +99,8 @@ def setup(hass, config):
             device = pywemo.discovery.device_from_description(url, None)
 
         discovery_info = {
-            'model_name': re.search('(?:\S+\s+){1}(\S+)', repr(device)).group(1),
+            'model_name': re.search('(?:\S+\s+){1}(\S+)', repr(device))
+                            .group(1),
             'serial': device.serialnumber,
             'mac_address': device.mac,
             'ssdp_description': url,

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -99,8 +99,7 @@ def setup(hass, config):
             device = pywemo.discovery.device_from_description(url, None)
 
         discovery_info = {
-            'model_name': re.search(r"(?:\S+\s+){1}(\S+)", repr(device))
-                          .group(1),
+            'model_name': re.search(r"(?:\S+\s+)(\S+)", repr(device)).group(1),
             'serial': device.serialnumber,
             'mac_address': device.mac,
             'ssdp_description': url,

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -8,6 +8,8 @@ import logging
 
 import voluptuous as vol
 
+import re
+
 from homeassistant.components.discovery import SERVICE_WEMO
 from homeassistant.helpers import discovery
 from homeassistant.helpers import config_validation as cv
@@ -23,8 +25,8 @@ WEMO_MODEL_DISPATCH = {
     'Bridge':  'light',
     'Insight': 'switch',
     'Maker':   'switch',
-    'Sensor':  'binary_sensor',
-    'Socket':  'switch',
+    'Motion':  'binary_sensor',
+    'Switch':  'switch',
     'LightSwitch': 'switch',
     'CoffeeMaker': 'switch'
 }
@@ -97,7 +99,7 @@ def setup(hass, config):
             device = pywemo.discovery.device_from_description(url, None)
 
         discovery_info = {
-            'model_name': device.model_name,
+            'model_name': re.search('(?:\S+\s+){1}(\S+)', repr(device)).group(1),
             'serial': device.serialnumber,
             'mac_address': device.mac,
             'ssdp_description': url,

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -6,9 +6,9 @@ https://home-assistant.io/components/wemo/
 """
 import logging
 
-import voluptuous as vol
-
 import re
+
+import voluptuous as vol
 
 from homeassistant.components.discovery import SERVICE_WEMO
 from homeassistant.helpers import discovery
@@ -99,8 +99,8 @@ def setup(hass, config):
             device = pywemo.discovery.device_from_description(url, None)
 
         discovery_info = {
-            'model_name': re.search('(?:\S+\s+){1}(\S+)', repr(device))
-                            .group(1),
+            'model_name': re.search(r"(?:\S+\s+){1}(\S+)", repr(device))
+                          .group(1),
             'serial': device.serialnumber,
             'mac_address': device.mac,
             'ssdp_description': url,


### PR DESCRIPTION
model_name in the discovery info is based off the description which is not always correct. Change this to use the output of repr()