### PR TITLE
0.59.2

### DIFF
--- a/homeassistant/components/device_tracker/linksys_ap.py
+++ b/homeassistant/components/device_tracker/linksys_ap.py
@@ -11,7 +11,8 @@ import requests
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.device_tracker import DOMAIN, PLATFORM_SCHEMA
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL)
 
@@ -38,7 +39,7 @@ def get_scanner(hass, config):
         return None
 
 
-class LinksysAPDeviceScanner(object):
+class LinksysAPDeviceScanner(DeviceScanner):
     """This class queries a Linksys Access Point."""
 
     def __init__(self, config):

--- a/homeassistant/components/dominos.py
+++ b/homeassistant/components/dominos.py
@@ -136,6 +136,7 @@ class Dominos():
 
     def get_menu(self):
         """Return the products from the closest stores menu."""
+        self.update_closest_store()
         if self.closest_store is None:
             _LOGGER.warning('Cannot get menu. Store may be closed')
             return []

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -583,9 +583,9 @@ def _is_latest(js_option, request):
 
     family_min_version = {
         'Chrome': 50,   # Probably can reduce this
-        'Firefox': 41,  # Destructuring added in 41
+        'Firefox': 43,  # Array.protopype.includes added in 43
         'Opera': 40,    # Probably can reduce this
-        'Edge': 14,     # Maybe can reduce this
+        'Edge': 14,     # Array.protopype.includes added in 14
         'Safari': 10,   # many features not supported by 9
     }
     version = family_min_version.get(useragent.browser.family)

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -20,7 +20,9 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['pychromecast==1.0.2']
+# Do not upgrade to 1.0.2, it breaks a bunch of stuff
+# https://github.com/home-assistant/home-assistant/issues/10926
+REQUIREMENTS = ['pychromecast==0.8.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -24,7 +24,7 @@ APPLICATION_NAME = 'Home Assistant'
 
 DOMAIN = 'tellduslive'
 
-REQUIREMENTS = ['tellduslive==0.10.3']
+REQUIREMENTS = ['tellduslive==0.10.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 59
-PATCH_VERSION = '1'
+PATCH_VERSION = '2'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -623,7 +623,7 @@ pybbox==0.0.5-alpha
 # pybluez==0.22
 
 # homeassistant.components.media_player.cast
-pychromecast==1.0.2
+pychromecast==0.8.2
 
 # homeassistant.components.media_player.cmus
 pycmus==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -883,7 +883,7 @@ python-velbus==2.0.11
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.7.0
+python-wink==1.7.1
 
 # homeassistant.components.sensor.swiss_public_transport
 python_opendata_transport==0.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1063,7 +1063,7 @@ tellcore-net==0.3
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.10.3
+tellduslive==0.10.4
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.3


### PR DESCRIPTION
- Require FF43 for latest js ([@andrey-git] - [#10941])
- Fix linksys_ap.py by inheriting DeviceScanner ([@mateuszdrab] - [#10947]) ([device_tracker.linksys_ap docs])
- Upgrade tellduslive library version (closes https://github.com/home-assistant/home-assistant/issues/10922) ([@molobrakos] - [#10950]) ([tellduslive docs])
- Allow chime to work for wink siren/chime ([@w1ll1am23] - [#10961]) ([wink docs])
- Reload closest store on api menu request ([@wardcraigj] - [#10962]) ([dominos docs])
- Revert pychromecast update ([@balloob] - [#10989]) ([media_player.cast docs])

[#10941]: https://github.com/home-assistant/home-assistant/pull/10941
[#10947]: https://github.com/home-assistant/home-assistant/pull/10947
[#10950]: https://github.com/home-assistant/home-assistant/pull/10950
[#10961]: https://github.com/home-assistant/home-assistant/pull/10961
[#10962]: https://github.com/home-assistant/home-assistant/pull/10962
[#10989]: https://github.com/home-assistant/home-assistant/pull/10989
[@andrey-git]: https://github.com/andrey-git
[@balloob]: https://github.com/balloob
[@mateuszdrab]: https://github.com/mateuszdrab
[@molobrakos]: https://github.com/molobrakos
[@w1ll1am23]: https://github.com/w1ll1am23
[@wardcraigj]: https://github.com/wardcraigj
[device_tracker.linksys_ap docs]: https://home-assistant.io/components/device_tracker.linksys_ap/
[dominos docs]: https://home-assistant.io/components/dominos/
[media_player.cast docs]: https://home-assistant.io/components/media_player.cast/
[tellduslive docs]: https://home-assistant.io/components/tellduslive/
[wink docs]: https://home-assistant.io/components/wink/
