### PR TITLE
Support LIFX Mini products

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -33,7 +33,7 @@ import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['aiolifx==0.6.0', 'aiolifx_effects==0.1.2']
+REQUIREMENTS = ['aiolifx==0.6.1', 'aiolifx_effects==0.1.2']
 
 UDP_BROADCAST_PORT = 56700
 
@@ -156,22 +156,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     return True
 
-
-def lifxwhite(device):
-    """Return whether this is a white-only bulb."""
-    features = aiolifx().products.features_map.get(device.product, None)
-    if features:
-        return not features["color"]
-    return False
-
-
-def lifxmultizone(device):
-    """Return whether this is a multizone bulb/strip."""
-    features = aiolifx().products.features_map.get(device.product, None)
-    if features:
-        return features["multizone"]
-    return False
-
+def lifx_features(device):
+    """Return a feature map for this device, or a default map if unknown."""
+    return aiolifx().products.features_map.get(device.product) or \
+           aiolifx().products.features_map.get(1)
 
 def find_hsbk(**kwargs):
     """Find the desired color from a number of possible inputs."""
@@ -342,12 +330,12 @@ class LIFXManager(object):
                 device.retry_count = MESSAGE_RETRIES
                 device.unregister_timeout = UNAVAILABLE_GRACE
 
-                if lifxwhite(device):
-                    entity = LIFXWhite(device, self.effects_conductor)
-                elif lifxmultizone(device):
+                if lifx_features(device)["multizone"]:
                     entity = LIFXStrip(device, self.effects_conductor)
-                else:
+                elif lifx_features(device)["color"]:
                     entity = LIFXColor(device, self.effects_conductor)
+                else:
+                    entity = LIFXWhite(device, self.effects_conductor)
 
                 _LOGGER.debug("%s register READY", entity.who)
                 self.entities[device.mac_addr] = entity
@@ -426,6 +414,29 @@ class LIFXLight(Light):
     def who(self):
         """Return a string identifying the device."""
         return "%s (%s)" % (self.device.ip_addr, self.name)
+
+    @property
+    def min_mireds(self):
+        """Return the coldest color_temp that this light supports."""
+        kelvin = lifx_features(self.device)['max_kelvin']
+        return math.floor(color_util.color_temperature_kelvin_to_mired(kelvin))
+
+    @property
+    def max_mireds(self):
+        """Return the warmest color_temp that this light supports."""
+        kelvin = lifx_features(self.device)['min_kelvin']
+        return math.ceil(color_util.color_temperature_kelvin_to_mired(kelvin))
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        support = SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION | SUPPORT_EFFECT
+
+        device_features = lifx_features(self.device)
+        if device_features['min_kelvin'] != device_features['max_kelvin']:
+            support |= SUPPORT_COLOR_TEMP
+
+        return support
 
     @property
     def brightness(self):
@@ -572,22 +583,6 @@ class LIFXWhite(LIFXLight):
     """Representation of a white-only LIFX light."""
 
     @property
-    def min_mireds(self):
-        """Return the coldest color_temp that this light supports."""
-        return math.floor(color_util.color_temperature_kelvin_to_mired(6500))
-
-    @property
-    def max_mireds(self):
-        """Return the warmest color_temp that this light supports."""
-        return math.ceil(color_util.color_temperature_kelvin_to_mired(2700))
-
-    @property
-    def supported_features(self):
-        """Flag supported features."""
-        return (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_TRANSITION |
-                SUPPORT_EFFECT)
-
-    @property
     def effect_list(self):
         """Return the list of supported effects for this light."""
         return [
@@ -600,20 +595,11 @@ class LIFXColor(LIFXLight):
     """Representation of a color LIFX light."""
 
     @property
-    def min_mireds(self):
-        """Return the coldest color_temp that this light supports."""
-        return math.floor(color_util.color_temperature_kelvin_to_mired(9000))
-
-    @property
-    def max_mireds(self):
-        """Return the warmest color_temp that this light supports."""
-        return math.ceil(color_util.color_temperature_kelvin_to_mired(2500))
-
-    @property
     def supported_features(self):
         """Flag supported features."""
-        return (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_TRANSITION |
-                SUPPORT_EFFECT | SUPPORT_RGB_COLOR | SUPPORT_XY_COLOR)
+        support = super().supported_features
+        support |= SUPPORT_RGB_COLOR | SUPPORT_XY_COLOR
+        return support
 
     @property
     def effect_list(self):

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -156,10 +156,12 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     return True
 
+
 def lifx_features(device):
     """Return a feature map for this device, or a default map if unknown."""
     return aiolifx().products.features_map.get(device.product) or \
-           aiolifx().products.features_map.get(1)
+        aiolifx().products.features_map.get(1)
+
 
 def find_hsbk(**kwargs):
     """Find the desired color from a number of possible inputs."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -72,7 +72,7 @@ aiohttp_cors==0.5.3
 aioimaplib==0.7.13
 
 # homeassistant.components.light.lifx
-aiolifx==0.6.0
+aiolifx==0.6.1
 
 # homeassistant.components.light.lifx
 aiolifx_effects==0.1.2


### PR DESCRIPTION
## Description:

This adds support for the LIFX Mini products that have Kelvin ranges different from any existing product. To make things simpler, the Kelvin information has been moved to the feature map in the third party library.

I do not own a LIFX Mini so this implementation is based only on the available documentation.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
