### PR TITLE
Handle OSError when forcibly turning off media_player.samsungtv

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -190,7 +190,10 @@ class SamsungTVDevice(MediaPlayerDevice):
         else:
             self.send_key('KEY_POWEROFF')
         # Force closing of remote session to provide instant UI feedback
-        self.get_remote().close()
+        try:
+            self.get_remote().close()
+        except OSError:
+            _LOGGER.debug("Could not establish connection.")
 
     def volume_up(self):
         """Volume up the media player."""


### PR DESCRIPTION
## Description:

Resulted in an OSError which bubbled as an unhandled exception to core.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**