### PR TITLE
Adde BLE_ Prefix before mac adress in known_devices.yaml

### DIFF
--- a/homeassistant/components/device_tracker/meraki.py
+++ b/homeassistant/components/device_tracker/meraki.py
@@ -94,7 +94,10 @@ class MerakiView(HomeAssistantView):
     def _handle(self, hass, data):
         for i in data["data"]["observations"]:
             data["data"]["secret"] = "hidden"
-            mac = i["clientMac"]
+            if data['type'] == 'BluetoothDevicesSeen':
+                mac = 'BLE_' + i["clientMac"]
+            else:
+                mac = i["clientMac"]
             _LOGGER.debug("clientMac: %s", mac)
             attrs = {}
             if i.get('os', False):


### PR DESCRIPTION
## Description:
Add a prefix before mac adress in known_devices.yaml. Just like the othe BLE trackers.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**