### PR TITLE
Add Etekcity smart wifi outlets component

### DIFF
--- a/homeassistant/components/switch/vesync.py
+++ b/homeassistant/components/switch/vesync.py
@@ -12,7 +12,7 @@ from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['Vesync==1.0.1']
+REQUIREMENTS = ['vesync==1.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/vesync.py
+++ b/homeassistant/components/switch/vesync.py
@@ -34,13 +34,13 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     try:
         api = VesyncApi(config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
         _LOGGER.info("Connected to Vesync API")
-    except RuntimeException:
+    except RuntimeError:
         _LOGGER.error("Failed to connect to Vesync API")
 
     try:
         devices = api.get_devices()
         _LOGGER.info("Retrieved devices from Vesync API")
-    except RuntimeException:
+    except RuntimeError:
         _LOGGER.error("Failed to retrieve devices from Vesync API")
 
     for switch in devices:
@@ -83,19 +83,19 @@ class VesyncSwitch(SwitchDevice):
                 if (device["cid"] == self._switch["cid"]):
                     self._switch = device
                     break
-        except RuntimeException:
+        except RuntimeError:
             _LOGGER.exception("Error while fetching Vesync state")
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
         try:
             self._api.turn_on(self._switch["cid"])
-        except RuntimeException:
+        except RuntimeError:
             _LOGGER.exception("Error while turning on Vesync")
 
     def turn_off(self, **kwargs):
         """Turn the device on."""
         try:
             self._api.turn_off(self._switch["cid"])
-        except RuntimeException:
+        except RuntimeError:
             _LOGGER.exception("Error while turning off Vesync")

--- a/homeassistant/components/switch/vesync.py
+++ b/homeassistant/components/switch/vesync.py
@@ -1,0 +1,102 @@
+"""
+Support for Etekcity Wifi Smart Switches.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.Vesync/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_NAME, CONF_SWITCHES, CONF_USERNAME, CONF_PASSWORD
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['Vesync==1.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Etekcity Vesync Switch'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Set up Vesync switches."""
+    from vesync.api import VesyncApi
+
+    switch_data = {}
+    switches = []
+
+    try:
+        api = VesyncApi(config.get(CONF_USERNAME),config.get(CONF_PASSWORD))
+        _LOGGER.info("Connected to Vesync API")
+    except RuntimeException:
+        _LOGGER.error("Failed to connect to Vesync API")
+
+    try:
+        devices = api.get_devices()
+        _LOGGER.info("Retrieved devices from Vesync API")
+    except RuntimeException:
+        _LOGGER.error("Failed to retrieve devices from Vesync API")
+
+    for switch in devices:
+        switches.append(VesyncSwitch(switch,api))
+
+    add_devices_callback(switches)
+
+
+class VesyncSwitch(SwitchDevice):
+    """Representation of an EtekCity Vesync switch."""
+
+    def __init__(self, switch, api):
+        """Initialize the Vesync device."""
+        self._switch = switch
+        self._api = api
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._switch["deviceName"]
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        if (self._switch["deviceStatus"] == "on"):
+            return True
+        else:
+            return False
+
+    def update(self):
+        """Update device state."""
+        try:
+            devices = self._api.get_devices()
+            for device in devices:
+                if (device["cid"] == self._switch["cid"]):
+                    self._switch = device
+                    break
+        except RuntimeException:
+            _LOGGER.exception("Error while fetching Vesync state")
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        try:
+            self._api.turn_on(self._switch["cid"])
+        except RuntimeException:
+            _LOGGER.exception("Error while turning on Vesync")
+
+    def turn_off(self, **kwargs):
+        """Turn the device on."""
+        try:
+            self._api.turn_off(self._switch["cid"])
+        except RuntimeException:
+            _LOGGER.exception("Error while turning off Vesync")

--- a/homeassistant/components/switch/vesync.py
+++ b/homeassistant/components/switch/vesync.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
-from homeassistant.const import CONF_NAME, CONF_SWITCHES, CONF_USERNAME, CONF_PASSWORD
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['Vesync==1.0.1']
@@ -29,11 +29,10 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up Vesync switches."""
     from vesync.api import VesyncApi
 
-    switch_data = {}
     switches = []
 
     try:
-        api = VesyncApi(config.get(CONF_USERNAME),config.get(CONF_PASSWORD))
+        api = VesyncApi(config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
         _LOGGER.info("Connected to Vesync API")
     except RuntimeException:
         _LOGGER.error("Failed to connect to Vesync API")
@@ -45,7 +44,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
         _LOGGER.error("Failed to retrieve devices from Vesync API")
 
     for switch in devices:
-        switches.append(VesyncSwitch(switch,api))
+        switches.append(VesyncSwitch(switch, api))
 
     add_devices_callback(switches)
 


### PR DESCRIPTION
## Description:

This PR adds support for the EtekCity Smart Wifi Outlets. This PR (and my library) only support getting device state and turning it on and off. I would be welcome to PRs on the main library for support for monitoring. 

I am new to python but I have tested this component and it works great.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: vesync
    username: email@example.com
    password: MyAwesomePassword!
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
