### PR TITLE
Fix Egardia alarm status shown as unknown after restart

### DIFF
--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -116,12 +116,20 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         """Return the state of the device."""
         return self._status
 
+    @property
+    def should_poll(self):
+        """Poll if no report server is enabled."""
+        if not self._rs_enabled:
+            return True
+        return False
+
     def handle_system_status_event(self, event):
         """Handle egardia_system_status_event."""
         if event.data.get('status') is not None:
             statuscode = event.data.get('status')
             status = self.lookupstatusfromcode(statuscode)
             self.parsestatus(status)
+            self.schedule_update_ha_state()
 
     def listen_to_system_status(self):
         """Subscribe to egardia_system_status event."""
@@ -161,9 +169,8 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
 
     def update(self):
         """Update the alarm status."""
-        if not self._rs_enabled:
-            status = self._egardiasystem.getstate()
-            self.parsestatus(status)
+        status = self._egardiasystem.getstate()
+        self.parsestatus(status)
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""


### PR DESCRIPTION
## Description:
In some situations, after a restart of HASS the Egardia alarm system was reported with status 'unknown'. This PR fixes this issue by doing an extra status update regardless of exact config of the pythonegardia component.
This is a replacement of [PR 10940](https://github.com/home-assistant/home-assistant/pull/10940).
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
