### PR TITLE
Ignore Sonos players with unknown hostnames

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -140,7 +140,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             hosts = hosts.split(',') if isinstance(hosts, str) else hosts
             players = []
             for host in hosts:
-                players.append(soco.SoCo(socket.gethostbyname(host)))
+                try:
+                    players.append(soco.SoCo(socket.gethostbyname(host)))
+                except OSError:
+                    _LOGGER.warning("Failed to initialize '%s'", host)
 
         if not players:
             players = soco.discover(


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #10906

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: sonos
    hosts:
      - unknown
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).</s>
  - [ ] <s>New dependencies are only imported inside functions that use them ([example][ex-import]).</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54