### PR TITLE
Update snips to listen on new mqtt topic and utilize rawValue

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -376,7 +376,6 @@ def async_setup(hass, config):
         load_yaml_config_file, os.path.join(
             os.path.dirname(__file__), 'services.yaml'))
 
-
     @asyncio.coroutine
     def async_service_handler(service):
         """Map services to methods on MediaPlayerDevice."""

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -376,6 +376,7 @@ def async_setup(hass, config):
         load_yaml_config_file, os.path.join(
             os.path.dirname(__file__), 'services.yaml'))
 
+
     @asyncio.coroutine
     def async_service_handler(service):
         """Map services to methods on MediaPlayerDevice."""

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -32,7 +32,7 @@ INTENT_SCHEMA = vol.Schema({
         vol.Required('slotName'): str,
         vol.Required('value'): {
             vol.Required('kind'): str,
-            vol.Optional('value'): cv.match_all
+            vol.Optional('value'): cv.match_all,
             vol.Optional('rawValue'): cv.match_all
         }
     }]

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -15,7 +15,7 @@ DEPENDENCIES = ['mqtt']
 CONF_INTENTS = 'intents'
 CONF_ACTION = 'action'
 
-INTENT_TOPIC = 'hermes/nlu/intentParsed'
+INTENT_TOPIC = 'hermes/intent/#'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +32,8 @@ INTENT_SCHEMA = vol.Schema({
         vol.Required('slotName'): str,
         vol.Required('value'): {
             vol.Required('kind'): str,
-            vol.Required('value'): cv.match_all
+            vol.Optional('value'): cv.match_all
+            vol.Optional('rawValue'): cv.match_all
         }
     }]
 }, extra=vol.ALLOW_EXTRA)
@@ -59,8 +60,11 @@ def async_setup(hass, config):
             return
 
         intent_type = request['intent']['intentName'].split('__')[-1]
-        slots = {slot['slotName']: {'value': slot['value']['value']}
-                 for slot in request.get('slots', [])}
+        for slot in request.get('slots', []):
+            if 'value' in slot['value']:
+                slots[slot['slotName']] = {'value': slot['value']['value']}
+            else:
+                slots[slot['slotName']] = {'value': slot['rawValue']}
 
         try:
             yield from intent.async_handle(

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -60,6 +60,7 @@ def async_setup(hass, config):
             return
 
         intent_type = request['intent']['intentName'].split('__')[-1]
+        slots = {}
         for slot in request.get('slots', []):
             if 'value' in slot['value']:
                 slots[slot['slotName']] = {'value': slot['value']['value']}

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -34,7 +34,7 @@ def test_snips_call_action(hass, mqtt_mock):
 
     intents = async_mock_intent(hass, 'Lights')
 
-    async_fire_mqtt_message(hass, 'hermes/nlu/intentParsed',
+    async_fire_mqtt_message(hass, 'hermes/intent/activateLights',
                             EXAMPLE_MSG)
     yield from hass.async_block_till_done()
     assert len(intents) == 1


### PR DESCRIPTION
## Description:
Snips has changed their intent structure and now intents should be read from hermes/intent instead of hermes/nlu/intentParsed. IntentParsed is incomplete in the case of dialogues (ex. "Set a timer", "For how long?", "two minutes')

Snips also doesn't always send a slot.value.value key and we should utilize rawValue in that case. I would prefer to extend the slot structure in hass to support all the attributes under value, but that involves much more extensive changes to templating and such.

This will break functionality for people that have only the specific hermes/nlu/intentParsed bridged between snips and hass. Since this is a fairly simple fix for them and greatly improves the functionality of snips, I feel this is acceptable, but would love discussion.

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
