### PR TITLE
Notify webos timeout error fix

### DIFF
--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -12,7 +12,8 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
     ATTR_DATA, BaseNotificationService, PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_FILENAME, CONF_HOST, CONF_ICON)
+from homeassistant.const import (CONF_FILENAME, CONF_HOST, CONF_ICON,
+                                 CONF_TIMEOUT)
 
 REQUIREMENTS = ['pylgtv==0.1.7']
 
@@ -26,7 +27,8 @@ HOME_ASSISTANT_ICON_PATH = os.path.join(os.path.dirname(__file__), '..',
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string,
-    vol.Optional(CONF_ICON, default=HOME_ASSISTANT_ICON_PATH): cv.string
+    vol.Optional(CONF_ICON, default=HOME_ASSISTANT_ICON_PATH): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=8): cv.positive_int
 })
 
 
@@ -36,7 +38,8 @@ def get_service(hass, config, discovery_info=None):
     from pylgtv import PyLGTVPairException
 
     path = hass.config.path(config.get(CONF_FILENAME))
-    client = WebOsClient(config.get(CONF_HOST), key_file_path=path)
+    client = WebOsClient(config.get(CONF_HOST), key_file_path=path,
+                         timeout_connect=config.get(CONF_TIMEOUT))
 
     if not client.is_registered():
         try:

--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 WEBOSTV_CONFIG_FILE = 'webostv.conf'
 HOME_ASSISTANT_ICON_PATH = os.path.join(os.path.dirname(__file__), '..',
                                         'frontend', 'www_static', 'icons',
-                                        'favicon-1024x1024.png')
+                                        'favicon-192x192.png')
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,

--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -5,30 +5,23 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.webostv/
 """
 import logging
-import os
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
     ATTR_DATA, BaseNotificationService, PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_FILENAME, CONF_HOST, CONF_ICON,
-                                 CONF_TIMEOUT)
+from homeassistant.const import (CONF_FILENAME, CONF_HOST, CONF_ICON)
 
 REQUIREMENTS = ['pylgtv==0.1.7']
 
 _LOGGER = logging.getLogger(__name__)
 
 WEBOSTV_CONFIG_FILE = 'webostv.conf'
-HOME_ASSISTANT_ICON_PATH = os.path.join(os.path.dirname(__file__), '..',
-                                        'frontend', 'www_static', 'icons',
-                                        'favicon-192x192.png')
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string,
-    vol.Optional(CONF_ICON, default=HOME_ASSISTANT_ICON_PATH): cv.string,
-    vol.Optional(CONF_TIMEOUT, default=8): cv.positive_int
+    vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string
 })
 
 
@@ -39,7 +32,7 @@ def get_service(hass, config, discovery_info=None):
 
     path = hass.config.path(config.get(CONF_FILENAME))
     client = WebOsClient(config.get(CONF_HOST), key_file_path=path,
-                         timeout_connect=config.get(CONF_TIMEOUT))
+                         timeout_connect=8)
 
     if not client.is_registered():
         try:
@@ -67,9 +60,7 @@ class LgWebOSNotificationService(BaseNotificationService):
         from pylgtv import PyLGTVPairException
 
         try:
-            data = kwargs.get(ATTR_DATA)
-            icon_path = data.get(CONF_ICON, self._icon_path) if data else \
-                self._icon_path
+            icon_path = kwargs.get(ATTR_DATA, {}).get(CONF_ICON)
             self._client.send_message(message, icon_path=icon_path)
         except PyLGTVPairException:
             _LOGGER.error("Pairing with TV failed")

--- a/homeassistant/components/notify/webostv.py
+++ b/homeassistant/components/notify/webostv.py
@@ -21,7 +21,8 @@ WEBOSTV_CONFIG_FILE = 'webostv.conf'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string
+    vol.Optional(CONF_FILENAME, default=WEBOSTV_CONFIG_FILE): cv.string,
+    vol.Optional(CONF_ICON): cv.string
 })
 
 
@@ -60,7 +61,9 @@ class LgWebOSNotificationService(BaseNotificationService):
         from pylgtv import PyLGTVPairException
 
         try:
-            icon_path = kwargs.get(ATTR_DATA, {}).get(CONF_ICON)
+            data = kwargs.get(ATTR_DATA)
+            icon_path = data.get(CONF_ICON, self._icon_path) if data else \
+                self._icon_path
             self._client.send_message(message, icon_path=icon_path)
         except PyLGTVPairException:
             _LOGGER.error("Pairing with TV failed")


### PR DESCRIPTION
## Description:
Fix for timeout error caused by big image icon for notification
Default image changed to smaller size.
Added timeout option for connection.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4196

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: webostv
    host: 192.168.0.112
    name: livingroom_tv
    filename: webostv.conf
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
