### PR TITLE
Added numerical range binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/range.py
+++ b/homeassistant/components/binary_sensor/range.py
@@ -1,0 +1,153 @@
+"""
+Monitors if a numerical sensor value is within a defined range.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.range/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA, DEVICE_CLASSES_SCHEMA)
+from homeassistant.const import (
+    CONF_NAME, CONF_ENTITY_ID, STATE_UNKNOWN, ATTR_ENTITY_ID,
+    CONF_DEVICE_CLASS)
+from homeassistant.core import callback
+from homeassistant.helpers.event import async_track_state_change
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_SENSOR_VALUE = "sensor_value"
+ATTR_POSITION = "position"
+ATTR_VALUE_LOWER = "value_lower"
+ATTR_VALUE_UPPER = "value_upper"
+ATTR_HYSTERESIS = "hysteresis"
+
+CONF_VALUE_LOWER = "value_lower"
+CONF_VALUE_UPPER = "value_upper"
+CONF_HYSTERESIS = "hysteresis"
+
+STR_IN_RANGE = "in range"
+STR_ABOVE = "above"
+STR_BELOW = "below"
+
+DEFAULT_NAME = "Range"
+DEFAULT_HYSTERESIS = 0.0
+
+POSITION_SENSOR_UNKNOWN = "sensor value unknown"
+POSITION_BELOW = "below"
+POSITION_IN_RANGE = "in range"
+POSITION_ABOVE = "above"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ENTITY_ID): cv.entity_id,
+    vol.Required(CONF_VALUE_LOWER): vol.Coerce(float),
+    vol.Required(CONF_VALUE_UPPER): vol.Coerce(float),
+    vol.Optional(
+        CONF_HYSTERESIS, default=DEFAULT_HYSTERESIS): vol.Coerce(float),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Threshold sensor."""
+    entity_id = config.get(CONF_ENTITY_ID)
+    name = config.get(CONF_NAME)
+    lower = config.get(CONF_VALUE_LOWER)
+    upper = config.get(CONF_VALUE_UPPER)
+    hysteresis = config.get(CONF_HYSTERESIS)
+    device_class = config.get(CONF_DEVICE_CLASS)
+
+    async_add_devices([RangeSensor(
+        hass, entity_id, name, lower, upper, hysteresis, device_class)
+                      ], True)
+
+    return True
+
+
+class RangeSensor(BinarySensorDevice):
+    """Representation of a Range sensor."""
+
+    def __init__(self, hass, entity_id, name, threshold_lower, threshold_upper,
+                 hysteresis, device_class):
+        """Initialize the Range sensor."""
+        self._hass = hass
+        self._entity_id = entity_id
+        self._name = name
+
+        self._threshold_lower = threshold_lower
+        self._threshold_upper = threshold_upper
+        self._hysteresis = hysteresis
+
+        self._device_class = device_class
+
+        self._state = None
+        self.sensor_value = None
+
+        @callback
+        # pylint: disable=invalid-name
+        def async_threshold_sensor_state_listener(
+                entity, old_state, new_state):
+            """Handle sensor state changes."""
+            try:
+                self.sensor_value = None if new_state.state == STATE_UNKNOWN \
+                    else float(new_state.state)
+            except (ValueError, TypeError):
+                self.sensor_value = None
+                _LOGGER.warning("State is not numerical")
+
+            hass.async_add_job(self.async_update_ha_state, True)
+
+        async_track_state_change(
+            hass, entity_id, async_threshold_sensor_state_listener)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._state == POSITION_IN_RANGE
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def device_class(self):
+        """Return the sensor class of the sensor."""
+        return self._device_class
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return {
+            ATTR_ENTITY_ID: self._entity_id,
+            ATTR_SENSOR_VALUE: self.sensor_value,
+            ATTR_POSITION: self._state,
+            ATTR_VALUE_LOWER: self._threshold_lower,
+            ATTR_VALUE_UPPER: self._threshold_upper,
+            ATTR_HYSTERESIS: self._hysteresis
+        }
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Get the latest data and updates the states."""
+        if self.sensor_value is None:
+            self._state = POSITION_SENSOR_UNKNOWN
+        elif self.sensor_value < (self._threshold_lower - self._hysteresis):
+            self._state = POSITION_BELOW
+        elif self.sensor_value > (self._threshold_upper + self._hysteresis):
+            self._state = POSITION_ABOVE
+        elif self.sensor_value > (self._threshold_lower + self._hysteresis) \
+                and self.sensor_value < \
+                (self._threshold_upper - self._hysteresis):
+            self._state = POSITION_IN_RANGE

--- a/tests/components/binary_sensor/test_range.py
+++ b/tests/components/binary_sensor/test_range.py
@@ -1,0 +1,204 @@
+"""The test for the Range sensor platform."""
+import unittest
+
+from homeassistant.setup import setup_component
+from homeassistant.const import (
+        ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN, TEMP_CELSIUS)
+
+from tests.common import get_test_home_assistant
+
+
+class TestRangeSensor(unittest.TestCase):
+    """Test the Range sensor."""
+
+    def setup_method(self, method):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_sensor_in_range_no_hysteresis(self):
+        """Test if source is within the range."""
+        config = {
+            'binary_sensor': {
+                'platform': 'range',
+                'value_lower': '10',
+                'value_upper': '20',
+                'entity_id': 'sensor.test_monitored',
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.states.set('sensor.test_monitored', 16,
+                             {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('sensor.test_monitored',
+                         state.attributes.get('entity_id'))
+        self.assertEqual(16, state.attributes.get('sensor_value'))
+        self.assertEqual('in range', state.attributes.get('position'))
+        self.assertEqual(float(config['binary_sensor']['value_lower']),
+                         state.attributes.get('value_lower'))
+        self.assertEqual(float(config['binary_sensor']['value_upper']),
+                         state.attributes.get('value_upper'))
+        self.assertEqual(0.0, state.attributes.get('hysteresis'))
+
+        assert state.state == 'on'
+
+        self.hass.states.set('sensor.test_monitored', 9)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('below', state.attributes.get('position'))
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', 21)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('above', state.attributes.get('position'))
+        assert state.state == 'off'
+
+    def test_sensor_in_range_with_hysteresis(self):
+        """Test if source is within the range."""
+        config = {
+            'binary_sensor': {
+                'platform': 'range',
+                'value_lower': '10',
+                'value_upper': '20',
+                'hysteresis': '2',
+                'entity_id': 'sensor.test_monitored',
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.states.set('sensor.test_monitored', 16,
+                             {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('sensor.test_monitored',
+                         state.attributes.get('entity_id'))
+        self.assertEqual(16, state.attributes.get('sensor_value'))
+        self.assertEqual('in range', state.attributes.get('position'))
+        self.assertEqual(float(config['binary_sensor']['value_lower']),
+                         state.attributes.get('value_lower'))
+        self.assertEqual(float(config['binary_sensor']['value_upper']),
+                         state.attributes.get('value_upper'))
+        self.assertEqual(float(config['binary_sensor']['hysteresis']),
+                         state.attributes.get('hysteresis'))
+
+        assert state.state == 'on'
+
+        self.hass.states.set('sensor.test_monitored', 8)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('in range', state.attributes.get('position'))
+        assert state.state == 'on'
+
+        self.hass.states.set('sensor.test_monitored', 7)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('below', state.attributes.get('position'))
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', 12)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('below', state.attributes.get('position'))
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', 13)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('in range', state.attributes.get('position'))
+        assert state.state == 'on'
+
+        self.hass.states.set('sensor.test_monitored', 22)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('in range', state.attributes.get('position'))
+        assert state.state == 'on'
+
+        self.hass.states.set('sensor.test_monitored', 23)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('above', state.attributes.get('position'))
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', 18)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('above', state.attributes.get('position'))
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', 17)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('in range', state.attributes.get('position'))
+        assert state.state == 'on'
+
+    def test_sensor_in_range_unknown_state(self):
+        """Test if source is within the range."""
+        config = {
+            'binary_sensor': {
+                'platform': 'range',
+                'value_lower': '10',
+                'value_upper': '20',
+                'entity_id': 'sensor.test_monitored',
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.states.set('sensor.test_monitored', 16,
+                             {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('sensor.test_monitored',
+                         state.attributes.get('entity_id'))
+        self.assertEqual(16, state.attributes.get('sensor_value'))
+        self.assertEqual('in range', state.attributes.get('position'))
+        self.assertEqual(float(config['binary_sensor']['value_lower']),
+                         state.attributes.get('value_lower'))
+        self.assertEqual(float(config['binary_sensor']['value_upper']),
+                         state.attributes.get('value_upper'))
+        self.assertEqual(0.0, state.attributes.get('hysteresis'))
+
+        assert state.state == 'on'
+
+        self.hass.states.set('sensor.test_monitored', STATE_UNKNOWN)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.range')
+
+        self.assertEqual('sensor value unknown',
+                         state.attributes.get('position'))
+        assert state.state == 'off'


### PR DESCRIPTION
## Description:

Similar to the existing Threshold binary sensor. Used to determine in a numerical sensor falls within a given range.

If the sensor is unavailable or non-numerically valued then this sensor always reports "Off". A state attribute (`position`, suggestions for a better name welcome) reports if the sensor value is above, below, in range or unavailable.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: range
  name: garage_temperature_is_ok
  entity_id: sensor.garage_temperature
  value_lower: 2
  value_upper: 15
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
