### PR TITLE
Add a 'last' mode and attribute to min_max sensor

### DIFF
--- a/homeassistant/components/sensor/min_max.py
+++ b/homeassistant/components/sensor/min_max.py
@@ -23,12 +23,14 @@ ATTR_MIN_VALUE = 'min_value'
 ATTR_MAX_VALUE = 'max_value'
 ATTR_COUNT_SENSORS = 'count_sensors'
 ATTR_MEAN = 'mean'
+ATTR_LAST = 'last'
 
 ATTR_TO_PROPERTY = [
     ATTR_COUNT_SENSORS,
     ATTR_MAX_VALUE,
     ATTR_MEAN,
     ATTR_MIN_VALUE,
+    ATTR_LAST,
 ]
 
 CONF_ENTITY_IDS = 'entity_ids'
@@ -40,6 +42,7 @@ SENSOR_TYPES = {
     ATTR_MIN_VALUE: 'min',
     ATTR_MAX_VALUE: 'max',
     ATTR_MEAN: 'mean',
+    ATTR_LAST: 'last',
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -116,7 +119,7 @@ class MinMaxSensor(Entity):
                      if self._sensor_type == v)).capitalize()
         self._unit_of_measurement = None
         self._unit_of_measurement_mismatch = False
-        self.min_value = self.max_value = self.mean = STATE_UNKNOWN
+        self.min_value = self.max_value = self.mean = self.last = STATE_UNKNOWN
         self.count_sensors = len(self._entity_ids)
         self.states = {}
 
@@ -142,6 +145,7 @@ class MinMaxSensor(Entity):
 
             try:
                 self.states[entity] = float(new_state.state)
+                self.last = float(new_state.state)
             except ValueError:
                 _LOGGER.warning("Unable to store state. "
                                 "Only numerical states are supported")

--- a/tests/components/sensor/test_min_max.py
+++ b/tests/components/sensor/test_min_max.py
@@ -20,6 +20,7 @@ class TestMinMaxSensor(unittest.TestCase):
         self.mean = round(sum(self.values) / self.count, 2)
         self.mean_1_digit = round(sum(self.values) / self.count, 1)
         self.mean_4_digits = round(sum(self.values) / self.count, 4)
+        self.last = self.values[-1]
 
     def teardown_method(self, method):
         """Stop everything that was started."""
@@ -53,6 +54,7 @@ class TestMinMaxSensor(unittest.TestCase):
         self.assertEqual(str(float(self.min)), state.state)
         self.assertEqual(self.max, state.attributes.get('max_value'))
         self.assertEqual(self.mean, state.attributes.get('mean'))
+        self.assertEqual(self.last, state.attributes.get('last'))
 
     def test_max_sensor(self):
         """Test the max sensor."""
@@ -82,6 +84,7 @@ class TestMinMaxSensor(unittest.TestCase):
         self.assertEqual(str(float(self.max)), state.state)
         self.assertEqual(self.min, state.attributes.get('min_value'))
         self.assertEqual(self.mean, state.attributes.get('mean'))
+        self.assertEqual(self.last, state.attributes.get('last'))
 
     def test_mean_sensor(self):
         """Test the mean sensor."""
@@ -111,6 +114,7 @@ class TestMinMaxSensor(unittest.TestCase):
         self.assertEqual(str(float(self.mean)), state.state)
         self.assertEqual(self.min, state.attributes.get('min_value'))
         self.assertEqual(self.max, state.attributes.get('max_value'))
+        self.assertEqual(self.last, state.attributes.get('last'))
 
     def test_mean_1_digit_sensor(self):
         """Test the mean with 1-digit precision sensor."""
@@ -141,6 +145,7 @@ class TestMinMaxSensor(unittest.TestCase):
         self.assertEqual(str(float(self.mean_1_digit)), state.state)
         self.assertEqual(self.min, state.attributes.get('min_value'))
         self.assertEqual(self.max, state.attributes.get('max_value'))
+        self.assertEqual(self.last, state.attributes.get('last'))
 
     def test_mean_4_digit_sensor(self):
         """Test the mean with 1-digit precision sensor."""
@@ -171,6 +176,7 @@ class TestMinMaxSensor(unittest.TestCase):
         self.assertEqual(str(float(self.mean_4_digits)), state.state)
         self.assertEqual(self.min, state.attributes.get('min_value'))
         self.assertEqual(self.max, state.attributes.get('max_value'))
+        self.assertEqual(self.last, state.attributes.get('last'))
 
     def test_not_enough_sensor_value(self):
         """Test that there is nothing done if not enough values available."""
@@ -260,3 +266,33 @@ class TestMinMaxSensor(unittest.TestCase):
 
         self.assertEqual(STATE_UNKNOWN, state.state)
         self.assertEqual('ERR', state.attributes.get('unit_of_measurement'))
+
+    def test_last_sensor(self):
+        """Test the last sensor."""
+        config = {
+            'sensor': {
+                'platform': 'min_max',
+                'name': 'test_last',
+                'type': 'last',
+                'entity_ids': [
+                    'sensor.test_1',
+                    'sensor.test_2',
+                    'sensor.test_3',
+                ]
+            }
+        }
+
+        assert setup_component(self.hass, 'sensor', config)
+
+        entity_ids = config['sensor']['entity_ids']
+
+        for entity_id, value in dict(zip(entity_ids, self.values)).items():
+            self.hass.states.set(entity_id, value)
+            self.hass.block_till_done()
+
+        state = self.hass.states.get('sensor.test_last')
+
+        self.assertEqual(str(float(self.last)), state.state)
+        self.assertEqual(self.min, state.attributes.get('min_value'))
+        self.assertEqual(self.max, state.attributes.get('max_value'))
+        self.assertEqual(self.mean, state.attributes.get('mean'))

--- a/tests/components/sensor/test_min_max.py
+++ b/tests/components/sensor/test_min_max.py
@@ -20,7 +20,6 @@ class TestMinMaxSensor(unittest.TestCase):
         self.mean = round(sum(self.values) / self.count, 2)
         self.mean_1_digit = round(sum(self.values) / self.count, 1)
         self.mean_4_digits = round(sum(self.values) / self.count, 4)
-        self.last = self.values[-1]
 
     def teardown_method(self, method):
         """Stop everything that was started."""
@@ -54,7 +53,6 @@ class TestMinMaxSensor(unittest.TestCase):
         self.assertEqual(str(float(self.min)), state.state)
         self.assertEqual(self.max, state.attributes.get('max_value'))
         self.assertEqual(self.mean, state.attributes.get('mean'))
-        self.assertEqual(self.last, state.attributes.get('last'))
 
     def test_max_sensor(self):
         """Test the max sensor."""
@@ -84,7 +82,6 @@ class TestMinMaxSensor(unittest.TestCase):
         self.assertEqual(str(float(self.max)), state.state)
         self.assertEqual(self.min, state.attributes.get('min_value'))
         self.assertEqual(self.mean, state.attributes.get('mean'))
-        self.assertEqual(self.last, state.attributes.get('last'))
 
     def test_mean_sensor(self):
         """Test the mean sensor."""
@@ -114,7 +111,6 @@ class TestMinMaxSensor(unittest.TestCase):
         self.assertEqual(str(float(self.mean)), state.state)
         self.assertEqual(self.min, state.attributes.get('min_value'))
         self.assertEqual(self.max, state.attributes.get('max_value'))
-        self.assertEqual(self.last, state.attributes.get('last'))
 
     def test_mean_1_digit_sensor(self):
         """Test the mean with 1-digit precision sensor."""
@@ -145,7 +141,6 @@ class TestMinMaxSensor(unittest.TestCase):
         self.assertEqual(str(float(self.mean_1_digit)), state.state)
         self.assertEqual(self.min, state.attributes.get('min_value'))
         self.assertEqual(self.max, state.attributes.get('max_value'))
-        self.assertEqual(self.last, state.attributes.get('last'))
 
     def test_mean_4_digit_sensor(self):
         """Test the mean with 1-digit precision sensor."""
@@ -176,7 +171,6 @@ class TestMinMaxSensor(unittest.TestCase):
         self.assertEqual(str(float(self.mean_4_digits)), state.state)
         self.assertEqual(self.min, state.attributes.get('min_value'))
         self.assertEqual(self.max, state.attributes.get('max_value'))
-        self.assertEqual(self.last, state.attributes.get('last'))
 
     def test_not_enough_sensor_value(self):
         """Test that there is nothing done if not enough values available."""
@@ -285,14 +279,14 @@ class TestMinMaxSensor(unittest.TestCase):
         assert setup_component(self.hass, 'sensor', config)
 
         entity_ids = config['sensor']['entity_ids']
+        state = self.hass.states.get('sensor.test_last')
 
         for entity_id, value in dict(zip(entity_ids, self.values)).items():
             self.hass.states.set(entity_id, value)
             self.hass.block_till_done()
+            state = self.hass.states.get('sensor.test_last')
+            self.assertEqual(str(float(value)), state.state)
 
-        state = self.hass.states.get('sensor.test_last')
-
-        self.assertEqual(str(float(self.last)), state.state)
         self.assertEqual(self.min, state.attributes.get('min_value'))
         self.assertEqual(self.max, state.attributes.get('max_value'))
         self.assertEqual(self.mean, state.attributes.get('mean'))


### PR DESCRIPTION
## Add a 'last' mode and attribute to min_max sensor

Inspired by this question ["Combining multiple sensor values into one with most recent wins strategy"](https://community.home-assistant.io/t/combining-multiple-sensor-values-into-one-with-most-recent-wins-strategy/20724/6), provide a mode of min_max sensor to report only the most recent value received from a list of sensors. (Follows the nomenclature of Grafana for 'last' value of a sensor).

This solves the issue of multiple sensors providing intermittent and unsolicited readings of the same metric - multiple battery-powered temperature sensors within a room for example.

It does not identify which of the monitored sensors provided the most recent update.

The current workaround is a template sensor or virtual device (input_number or similar) with an automation to update the value when any of the monitored sensors triggers.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#4167

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
sensor:
  - platform: min_max
    type: last
    entity_ids:
      - sensor.kitchen_east_temperature
      - sensor.kitchen_west_temperature

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
