### PR TITLE
add custom bypass status to total connect

### DIFF
--- a/homeassistant/components/alarm_control_panel/totalconnect.py
+++ b/homeassistant/components/alarm_control_panel/totalconnect.py
@@ -14,7 +14,9 @@ from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_PASSWORD, CONF_USERNAME, STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_NIGHT, STATE_ALARM_DISARMED,
-    STATE_ALARM_ARMING, STATE_ALARM_DISARMING, STATE_UNKNOWN, CONF_NAME)
+    STATE_ALARM_ARMING, STATE_ALARM_DISARMING, STATE_UNKNOWN, CONF_NAME,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS)
+
 
 REQUIREMENTS = ['total_connect_client==0.16']
 
@@ -76,6 +78,8 @@ class TotalConnect(alarm.AlarmControlPanel):
             state = STATE_ALARM_ARMED_AWAY
         elif status == self._client.ARMED_STAY_NIGHT:
             state = STATE_ALARM_ARMED_NIGHT
+        elif status == self._client.ARMED_CUSTOM_BYPASS:
+            state = STATE_ALARM_ARMED_CUSTOM_BYPASS
         elif status == self._client.ARMING:
             state = STATE_ALARM_ARMING
         elif status == self._client.DISARMING:
@@ -84,6 +88,8 @@ class TotalConnect(alarm.AlarmControlPanel):
             state = STATE_UNKNOWN
 
         self._state = state
+
+        _LOGGER.info("Alarm State: " + state)
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""

--- a/homeassistant/components/alarm_control_panel/totalconnect.py
+++ b/homeassistant/components/alarm_control_panel/totalconnect.py
@@ -89,8 +89,6 @@ class TotalConnect(alarm.AlarmControlPanel):
 
         self._state = state
 
-        _LOGGER.info("Alarm State: " + state)
-
     def alarm_disarm(self, code=None):
         """Send disarm command."""
         self._client.disarm()


### PR DESCRIPTION
## Description:
This PR adds the new custom bypass status to the total connect platform

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: totalconnect
    username: username
    password: password
```

## Checklist:
If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
