### PR TITLE
Add Asterisk Call Data Record to mailboxes component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -37,6 +37,7 @@ omit =
 
     homeassistant/components/asterisk_mbox.py
     homeassistant/components/*/asterisk_mbox.py
+    homeassistant/components/*/asterisk_cdr.py
 
     homeassistant/components/axis.py
     homeassistant/components/*/axis.py

--- a/homeassistant/components/asterisk_mbox.py
+++ b/homeassistant/components/asterisk_mbox.py
@@ -12,8 +12,8 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect, async_dispatcher_send)
+from homeassistant.helpers.dispatcher import (dispatcher_connect,
+                                              async_dispatcher_send)
 
 REQUIREMENTS = ['asterisk_mbox==0.5.0']
 
@@ -62,11 +62,11 @@ class AsteriskData(object):
         self.messages = None
         self.cdr = None
 
-        async_dispatcher_connect(
+        dispatcher_connect(
             self.hass, SIGNAL_MESSAGE_REQUEST, self._request_messages)
-        async_dispatcher_connect(
+        dispatcher_connect(
             self.hass, SIGNAL_CDR_REQUEST, self._request_cdr)
-        async_dispatcher_connect(
+        dispatcher_connect(
             self.hass, SIGNAL_DISCOVER_PLATFORM, self._discover_platform)
 
     @callback

--- a/homeassistant/components/asterisk_mbox.py
+++ b/homeassistant/components/asterisk_mbox.py
@@ -83,13 +83,13 @@ class AsteriskData(object):
 
         if command == CMD_MESSAGE_LIST:
             _LOGGER.debug("AsteriskVM sent updated message list")
-            if not isinstance(self.messages, list):
-                self.messages = []
-                dispatcher_send(self.hass, SIGNAL_DISCOVER_PLATFORM,
-                                DOMAIN)
-
+            old_messages = self.messages
             self.messages = sorted(
                 msg, key=lambda item: item['info']['origtime'], reverse=True)
+
+            if not isinstance(old_messages, list):
+                dispatcher_send(self.hass, SIGNAL_DISCOVER_PLATFORM,
+                                DOMAIN)
             dispatcher_send(self.hass, SIGNAL_MESSAGE_UPDATE, self.messages)
         elif command == CMD_MESSAGE_CDR:
             _LOGGER.info("AsteriskVM sent updated CDR list")

--- a/homeassistant/components/asterisk_mbox.py
+++ b/homeassistant/components/asterisk_mbox.py
@@ -15,14 +15,16 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, async_dispatcher_send)
 
-REQUIREMENTS = ['asterisk_mbox==0.4.0']
+REQUIREMENTS = ['asterisk_mbox==0.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = 'asterisk_mbox'
-
-SIGNAL_MESSAGE_REQUEST = 'asterisk_mbox.message_request'
 SIGNAL_MESSAGE_UPDATE = 'asterisk_mbox.message_updated'
+SIGNAL_MESSAGE_REQUEST = 'asterisk_mbox.message_request'
+SIGNAL_CDR_UPDATE = 'asterisk_mbox.message_updated'
+SIGNAL_CDR_REQUEST = 'asterisk_mbox.message_request'
+
+DOMAIN = 'asterisk_mbox'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -43,7 +45,8 @@ def setup(hass, config):
 
     hass.data[DOMAIN] = AsteriskData(hass, host, port, password)
 
-    discovery.load_platform(hass, 'mailbox', DOMAIN, {}, config)
+    discovery.load_platform(hass, "mailbox", DOMAIN, {}, config)
+    discovery.load_platform(hass, "mailbox", "asterisk_cdr", {}, config)
 
     return True
 
@@ -58,24 +61,42 @@ class AsteriskData(object):
         self.hass = hass
         self.client = asteriskClient(host, port, password, self.handle_data)
         self.messages = []
+        self.cdr = []
 
         async_dispatcher_connect(
             self.hass, SIGNAL_MESSAGE_REQUEST, self._request_messages)
+        async_dispatcher_connect(
+            self.hass, SIGNAL_CDR_REQUEST, self._request_cdr)
 
     @callback
     def handle_data(self, command, msg):
         """Handle changes to the mailbox."""
-        from asterisk_mbox.commands import CMD_MESSAGE_LIST
+        from asterisk_mbox.commands import (CMD_MESSAGE_LIST,
+                                            CMD_MESSAGE_CDR_AVAILABLE,
+                                            CMD_MESSAGE_CDR)
 
         if command == CMD_MESSAGE_LIST:
             _LOGGER.debug("AsteriskVM sent updated message list")
             self.messages = sorted(
                 msg, key=lambda item: item['info']['origtime'], reverse=True)
-            async_dispatcher_send(
-                self.hass, SIGNAL_MESSAGE_UPDATE, self.messages)
+            async_dispatcher_send(self.hass, SIGNAL_MESSAGE_UPDATE,
+                                  self.messages)
+        elif command == CMD_MESSAGE_CDR:
+            _LOGGER.info("AsteriskVM sent updated CDR list")
+            self.cdr = msg['entries']
+            async_dispatcher_send(self.hass, SIGNAL_CDR_UPDATE,
+                                  self.cdr)
+        elif command == CMD_MESSAGE_CDR_AVAILABLE:
+            async_dispatcher_send(self.hass, SIGNAL_CDR_REQUEST)
 
     @callback
     def _request_messages(self):
         """Handle changes to the mailbox."""
         _LOGGER.debug("Requesting message list")
         self.client.messages()
+
+    @callback
+    def _request_cdr(self):
+        """Handle changes to the CDR."""
+        _LOGGER.info("Requesting CDR list")
+        self.client.get_cdr()

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -118,7 +118,6 @@ class MailboxEntity(Entity):
             self.async_schedule_update_ha_state(True)
 
         self.hass.bus.async_listen(EVENT, _mailbox_updated)
-        self.async_schedule_update_ha_state(True)
 
     @property
     def state(self):

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -81,7 +81,7 @@ def async_setup(hass, config):
             return
 
         mailboxes.append(mailbox)
-        mailbox_entity = MailboxEntity(hass, mailbox)
+        mailbox_entity = MailboxEntity(mailbox)
         component = EntityComponent(
             logging.getLogger(__name__), DOMAIN, hass, SCAN_INTERVAL)
         yield from component.async_add_entities([mailbox_entity])
@@ -105,17 +105,20 @@ def async_setup(hass, config):
 class MailboxEntity(Entity):
     """Entity for each mailbox platform to provide a badge display."""
 
-    def __init__(self, hass, mailbox):
+    def __init__(self, mailbox):
         """Initialize mailbox entity."""
         self.mailbox = mailbox
-        self.hass = hass
         self.message_count = 0
 
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Complete entity initialization."""
         @callback
         def _mailbox_updated(event):
             self.async_schedule_update_ha_state(True)
 
-        hass.bus.async_listen(EVENT, _mailbox_updated)
+        self.hass.bus.async_listen(EVENT, _mailbox_updated)
+        self.async_schedule_update_ha_state(True)
 
     @property
     def state(self):

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -27,6 +27,8 @@ DEPENDENCIES = ['http']
 DOMAIN = 'mailbox'
 EVENT = 'mailbox_updated'
 CONTENT_TYPE_MPEG = 'audio/mpeg'
+CONTENT_TYPE_NONE = 'none'
+
 SCAN_INTERVAL = timedelta(seconds=30)
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,7 +103,7 @@ def async_setup(hass, config):
 
 
 class MailboxEntity(Entity):
-    """Entity for each mailbox platform."""
+    """Entity for each mailbox platform to provide a badge display."""
 
     def __init__(self, hass, mailbox):
         """Initialize mailbox entity."""
@@ -148,6 +150,16 @@ class Mailbox(object):
     def media_type(self):
         """Return the supported media type."""
         raise NotImplementedError()
+
+    @property
+    def can_delete(self):
+        """Return if messages can be deleted."""
+        return False
+
+    @property
+    def has_media(self):
+        """Return if messages have attached media files."""
+        return False
 
     @asyncio.coroutine
     def async_get_media(self, msgid):
@@ -196,7 +208,12 @@ class MailboxPlatformsView(MailboxView):
         """Retrieve list of platforms."""
         platforms = []
         for mailbox in self.mailboxes:
-            platforms.append(mailbox.name)
+            platforms.append(
+                {
+                    'name': mailbox.name,
+                    'has_media': mailbox.has_media,
+                    'can_delete': mailbox.can_delete
+                })
         return self.json(platforms)
 
 

--- a/homeassistant/components/mailbox/asterisk_cdr.py
+++ b/homeassistant/components/mailbox/asterisk_cdr.py
@@ -1,0 +1,61 @@
+"""
+Asterisk CDR interface.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/mailbox.asteriskvm/
+"""
+import asyncio
+import logging
+import hashlib
+import datetime
+
+from homeassistant.core import callback
+from homeassistant.components.asterisk_mbox import SIGNAL_CDR_UPDATE
+from homeassistant.components.asterisk_mbox import DOMAIN as MBOX_DOMAIN
+from homeassistant.components.mailbox import Mailbox
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+DEPENDENCIES = ['asterisk_mbox']
+_LOGGER = logging.getLogger(__name__)
+DOMAIN = "asterisk_cdr"
+
+
+@asyncio.coroutine
+def async_get_handler(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Asterix CDR platform."""
+    return AsteriskCDR(hass, DOMAIN)
+
+
+class AsteriskCDR(Mailbox):
+    """Asterisk VM Call Data Record mailbox."""
+
+    def __init__(self, hass, name):
+        """Initialie Asterisk CDR."""
+        super().__init__(hass, name)
+        self.cdr = []
+        async_dispatcher_connect(
+            self.hass, SIGNAL_CDR_UPDATE, self._update_callback)
+
+    @callback
+    def _update_callback(self, msg):
+        """Update the message count in HA, if needed."""
+        cdr = []
+        for entry in self.hass.data[MBOX_DOMAIN].cdr:
+            timestamp = datetime.datetime.strptime(
+                entry['time'], "%Y-%m-%d %H:%M:%S").timestamp()
+            info = {
+                'origtime': timestamp,
+                'callerid': entry['callerid'],
+                'duration': entry['duration'],
+            }
+            sha = hashlib.sha256(str(entry).encode('utf-8')).hexdigest()
+            msg = "Destination: {}\nApplication: {}\n Context: {}".format(
+                entry['dest'], entry['application'], entry['context'])
+            cdr.append({'info': info, 'sha': sha, 'text': msg})
+        self.cdr = cdr
+        self.async_update()
+
+    @asyncio.coroutine
+    def async_get_messages(self):
+        """Return a list of the current messages."""
+        return self.cdr

--- a/homeassistant/components/mailbox/asterisk_mbox.py
+++ b/homeassistant/components/mailbox/asterisk_mbox.py
@@ -45,6 +45,16 @@ class AsteriskMailbox(Mailbox):
         """Return the supported media type."""
         return CONTENT_TYPE_MPEG
 
+    @property
+    def can_delete(self):
+        """Return if messages can be deleted."""
+        return True
+
+    @property
+    def has_media(self):
+        """Return if messages have attached media files."""
+        return True
+
     @asyncio.coroutine
     def async_get_media(self, msgid):
         """Return the media blob for the msgid."""

--- a/homeassistant/components/mailbox/demo.py
+++ b/homeassistant/components/mailbox/demo.py
@@ -50,6 +50,16 @@ class DemoMailbox(Mailbox):
         """Return the supported media type."""
         return CONTENT_TYPE_MPEG
 
+    @property
+    def can_delete(self):
+        """Return if messages can be deleted."""
+        return True
+
+    @property
+    def has_media(self):
+        """Return if messages have attached media files."""
+        return True
+
     @asyncio.coroutine
     def async_get_media(self, msgid):
         """Return the media blob for the msgid."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -99,7 +99,7 @@ apcaccess==0.0.13
 apns2==0.3.0
 
 # homeassistant.components.asterisk_mbox
-asterisk_mbox==0.4.0
+asterisk_mbox==0.5.0
 
 # homeassistant.components.light.avion
 # avion==0.7

--- a/tests/components/mailbox/test_init.py
+++ b/tests/components/mailbox/test_init.py
@@ -29,7 +29,7 @@ def test_get_platforms_from_mailbox(mock_http_client):
     req = yield from mock_http_client.get(url)
     assert req.status == 200
     result = yield from req.json()
-    assert len(result) == 1 and "DemoMailbox" in result
+    assert len(result) == 1 and "DemoMailbox" == result[0].get('name', None)
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:
This adds the ability to see the call-history from Asterisk as a mailbox component.  There is an associated frontend change as well to allow viewing each mailbox component on its own tab.

The frontend pull request is here: https://github.com/home-assistant/home-assistant-polymer/pull/719

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4173

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

