### PR TITLE
Add ability to specify a sender in the clicksend notification

### DIFF
--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -14,7 +14,8 @@ import voluptuous as vol
 from homeassistant.components.notify import (
     PLATFORM_SCHEMA, BaseNotificationService)
 from homeassistant.const import (
-    CONF_API_KEY, CONF_USERNAME, CONF_RECIPIENT, CONF_SENDER, CONTENT_TYPE_JSON)
+    CONF_API_KEY, CONF_USERNAME, CONF_RECIPIENT, CONF_SENDER,
+    CONTENT_TYPE_JSON)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,7 +52,6 @@ class ClicksendNotificationService(BaseNotificationService):
         self.sender = config.get(CONF_SENDER)
         if (self.sender == ""):
             self.sender = self.recipient
-
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant.components.notify import (
     PLATFORM_SCHEMA, BaseNotificationService)
 from homeassistant.const import (
-    CONF_API_KEY, CONF_USERNAME, CONF_RECIPIENT, CONTENT_TYPE_JSON)
+    CONF_API_KEY, CONF_USERNAME, CONF_RECIPIENT, CONF_SENDER, CONTENT_TYPE_JSON)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,6 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_RECIPIENT): cv.string,
+    vol.Optional(CONF_SENDER, default=""): cv.string,
 })
 
 
@@ -47,10 +48,14 @@ class ClicksendNotificationService(BaseNotificationService):
         self.username = config.get(CONF_USERNAME)
         self.api_key = config.get(CONF_API_KEY)
         self.recipient = config.get(CONF_RECIPIENT)
+        self.sender = config.get(CONF_SENDER)
+        if (self.sender == ""):
+            self.sender = self.recipient
+
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        data = ({'messages': [{'source': 'hass.notify', 'from': self.recipient,
+        data = ({'messages': [{'source': 'hass.notify', 'from': self.sender,
                                'to': self.recipient, 'body': message}]})
 
         api_url = "{}/sms/send".format(BASE_API_URL)

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant.components.notify import (
     PLATFORM_SCHEMA, BaseNotificationService)
 from homeassistant.const import (
-    CONF_API_KEY, CONF_USERNAME, CONF_RECIPIENT, CONF_SENDER,
+    CONF_API_KEY, CONF_RECIPIENT, CONF_SENDER, CONF_USERNAME,
     CONTENT_TYPE_JSON)
 import homeassistant.helpers.config_validation as cv
 
@@ -24,16 +24,27 @@ BASE_API_URL = 'https://rest.clicksend.com/v3'
 
 HEADERS = {CONTENT_TYPE: CONTENT_TYPE_JSON}
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_API_KEY): cv.string,
-    vol.Required(CONF_RECIPIENT): cv.string,
-    vol.Optional(CONF_SENDER): cv.string,
-})
+
+def validate_sender(config):
+    """Set the optional sender name if sender name is not provided."""
+    if CONF_SENDER in config:
+        return config
+    config[CONF_SENDER] = config[CONF_RECIPIENT]
+    return config
+
+
+PLATFORM_SCHEMA = vol.Schema(
+    vol.All(PLATFORM_SCHEMA.extend({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_API_KEY): cv.string,
+        vol.Required(CONF_RECIPIENT): cv.string,
+        vol.Optional(CONF_SENDER): cv.string,
+    }), validate_sender))
 
 
 def get_service(hass, config, discovery_info=None):
     """Get the ClickSend notification service."""
+    print("#### ", config)
     if _authenticate(config) is False:
         _LOGGER.exception("You are not authorized to access ClickSend")
         return None
@@ -53,13 +64,22 @@ class ClicksendNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        data = ({'messages': [{'source': 'hass.notify', 'from': self.sender,
-                               'to': self.recipient, 'body': message}]})
+        data = ({
+            'messages': [
+                {
+                    'source': 'hass.notify',
+                    'from': self.sender,
+                    'to': self.recipient,
+                    'body': message,
+                }
+            ]
+        })
 
         api_url = "{}/sms/send".format(BASE_API_URL)
 
-        resp = requests.post(api_url, data=json.dumps(data), headers=HEADERS,
-                             auth=(self.username, self.api_key), timeout=5)
+        resp = requests.post(
+            api_url, data=json.dumps(data), headers=HEADERS,
+            auth=(self.username, self.api_key), timeout=5)
 
         obj = json.loads(resp.text)
         response_msg = obj['response_msg']
@@ -73,9 +93,9 @@ class ClicksendNotificationService(BaseNotificationService):
 def _authenticate(config):
     """Authenticate with ClickSend."""
     api_url = '{}/account'.format(BASE_API_URL)
-    resp = requests.get(api_url, headers=HEADERS,
-                        auth=(config.get(CONF_USERNAME),
-                              config.get(CONF_API_KEY)), timeout=5)
+    resp = requests.get(
+        api_url, headers=HEADERS, auth=(config.get(CONF_USERNAME),
+                                        config.get(CONF_API_KEY)), timeout=5)
 
     if resp.status_code != 200:
         return False

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -28,7 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_RECIPIENT): cv.string,
-    vol.Optional(CONF_SENDER, default=""): cv.string,
+    vol.Optional(CONF_SENDER): cv.string,
 })
 
 
@@ -49,9 +49,7 @@ class ClicksendNotificationService(BaseNotificationService):
         self.username = config.get(CONF_USERNAME)
         self.api_key = config.get(CONF_API_KEY)
         self.recipient = config.get(CONF_RECIPIENT)
-        self.sender = config.get(CONF_SENDER)
-        if (self.sender == ""):
-            self.sender = self.recipient
+        self.sender = config.get(CONF_SENDER, CONF_RECIPIENT)
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""


### PR DESCRIPTION
## Description:

Add the ability to specify a sender string to the notify.clicksend component (previous version used the recipient as the sender).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4422

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: clicksend
    name: ClickSend
    username: CLICKSEND_USERNAME
    api_key: CLICKSEND_API_KEY
    recipient: PHONE_NO
    sender: HomeAssistant
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

