### PR TITLE
Updated snips component to expose all values in a slot

### DIFF
--- a/homeassistant/components/intent_script.py
+++ b/homeassistant/components/intent_script.py
@@ -76,8 +76,12 @@ class ScriptIntentHandler(intent.IntentHandler):
         card = self.config.get(CONF_CARD)
         action = self.config.get(CONF_ACTION)
         is_async_action = self.config.get(CONF_ASYNC_ACTION)
-        slots = {key: value['value'] for key, value
-                 in intent_obj.slots.items()}
+        slots = {}
+        for key, value in intent_obj.slots.items():
+            if value.get('value') is not None:
+                slots[key] = value['value']
+            elif key == 'slots':
+                slots[key] = value
 
         if action is not None:
             if is_async_action:

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -61,11 +61,14 @@ def async_setup(hass, config):
 
         intent_type = request['intent']['intentName'].split('__')[-1]
         slots = {}
+        slots['slots'] = {}
         for slot in request.get('slots', []):
             if 'value' in slot['value']:
                 slots[slot['slotName']] = {'value': slot['value']['value']}
             else:
                 slots[slot['slotName']] = {'value': slot['rawValue']}
+            slots['slots'][slot['slotName']] = slot
+        _LOGGER.debug("slots: %s", slots)
 
         try:
             yield from intent.async_handle(

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -41,8 +41,16 @@ def test_snips_call_action(hass, mqtt_mock):
     intent = intents[0]
     assert intent.platform == 'snips'
     assert intent.intent_type == 'Lights'
-    assert intent.slots == {'slots': {'light_color': {'slotName':
-                            'light_color', 'value': {'kind': 'Custom',
-                                'value': 'green'}}}, 'light_color':
-                                    {'value': 'green'}}
+    assert intent.slots == {
+        'slots': {
+            'light_color': {
+                'slotName': 'light_color',
+                'value': {
+                    'kind': 'Custom',
+                    'value': 'green'
+                }
+            }
+        },
+            'light_color': {'value': 'green'}
+    }
     assert intent.text_input == 'turn the lights green'

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -51,8 +51,8 @@ def test_snips_call_action(hass, mqtt_mock):
                 }
             }
         },
-            'light_color': {
-                'value': 'green'
-            }
+        'light_color': {
+            'value': 'green'
+        }
     }
     assert intent.text_input == 'turn the lights green'

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -41,5 +41,6 @@ def test_snips_call_action(hass, mqtt_mock):
     intent = intents[0]
     assert intent.platform == 'snips'
     assert intent.intent_type == 'Lights'
-    assert intent.slots == {'light_color': {'value': 'green'}}
+    assert intent.slots == {'light_color': {'value': 'green'}, 'slots': {'slotName': 'light_color',
+            'value': { 'kind': 'Custom', 'value': 'green'}}}
     assert intent.text_input == 'turn the lights green'

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -42,6 +42,7 @@ def test_snips_call_action(hass, mqtt_mock):
     assert intent.platform == 'snips'
     assert intent.intent_type == 'Lights'
     assert intent.slots == {'slots': {'light_color': {'slotName':
-                        'light_color', 'value': {'kind': 'Custom', 'value':
-                        'green'}}}, 'light_color': {'value': 'green'}}
+                            'light_color', 'value': {'kind': 'Custom',
+                            'value': 'green'}}}, 'light_color':
+                            {'value': 'green'}}
     assert intent.text_input == 'turn the lights green'

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -41,6 +41,7 @@ def test_snips_call_action(hass, mqtt_mock):
     intent = intents[0]
     assert intent.platform == 'snips'
     assert intent.intent_type == 'Lights'
-    assert intent.slots == {'light_color': {'value': 'green'}, 'slots': {'slotName': 'light_color',
-            'value': { 'kind': 'Custom', 'value': 'green'}}}
+    assert intent.slots == {'slots': {'light_color': {'slotName':
+                'light_color', 'value': {'kind': 'Custom', 'value':
+                'green'}}}, 'light_color': {'value': 'green'}}
     assert intent.text_input == 'turn the lights green'

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -42,6 +42,6 @@ def test_snips_call_action(hass, mqtt_mock):
     assert intent.platform == 'snips'
     assert intent.intent_type == 'Lights'
     assert intent.slots == {'slots': {'light_color': {'slotName':
-                'light_color', 'value': {'kind': 'Custom', 'value':
-                'green'}}}, 'light_color': {'value': 'green'}}
+                        'light_color', 'value': {'kind': 'Custom', 'value':
+                        'green'}}}, 'light_color': {'value': 'green'}}
     assert intent.text_input == 'turn the lights green'

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -51,6 +51,8 @@ def test_snips_call_action(hass, mqtt_mock):
                 }
             }
         },
-            'light_color': {'value': 'green'}
+            'light_color': {
+                'value': 'green'
+            }
     }
     assert intent.text_input == 'turn the lights green'

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -43,6 +43,6 @@ def test_snips_call_action(hass, mqtt_mock):
     assert intent.intent_type == 'Lights'
     assert intent.slots == {'slots': {'light_color': {'slotName':
                             'light_color', 'value': {'kind': 'Custom',
-                            'value': 'green'}}}, 'light_color':
-                            {'value': 'green'}}
+                                'value': 'green'}}}, 'light_color':
+                                    {'value': 'green'}}
     assert intent.text_input == 'turn the lights green'


### PR DESCRIPTION
## Description:

Updated snips component to expose all values in a slot.

Intent_script can now expose all the values in a slot

Given an intent that comes from snips like this:
```
{
  "input": "set a timer of five minutes",
  "intent": {
    "intentName": "user_rZEKlr8M7M3__SetTimer",
    "probability": 0.5397341
  },
  "slots": [
    {
      "rawValue": "five minutes",
      "value": {
        "kind": "Duration",
        "years": 0,
        "quarters": 0,
        "months": 0,
        "weeks": 0,
        "days": 0,
        "hours": 0,
        "minutes": 5,
        "seconds": 0,
        "precision": "Exact"
      },
      "range": {
        "start": 15,
        "end": 27
      },
      "entity": "snips/duration",
      "slotName": "timer_duration"
    }
  ]
}
```
You can now expose values within your intent script with this format:
```
SetTimer:
  speech:
    type: plain
    text: weather
  action:
    service: script.set_timer
    data_template:
      name: "{{ timer_name | default('none') }}"
      duration: "{{ timer_duration }}"
      seconds: "{{ slots.timer_duration.value.seconds }}"
      minutes: "{{ slots.timer_duration.value.minutes }}"
      hours: "{{ slots.timer_duration.value.hours }}"
```

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4172


## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
