### PR TITLE
Volvo on call: Optional use of Scandinavian miles.

### DIFF
--- a/homeassistant/components/sensor/volvooncall.py
+++ b/homeassistant/components/sensor/volvooncall.py
@@ -6,8 +6,10 @@ https://home-assistant.io/components/sensor.volvooncall/
 
 """
 import logging
+from math import floor
 
-from homeassistant.components.volvooncall import VolvoEntity, RESOURCES
+from homeassistant.components.volvooncall import (
+    VolvoEntity, RESOURCES, CONF_SCANDINAVIAN_MILES)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,14 +28,37 @@ class VolvoSensor(VolvoEntity):
     def state(self):
         """Return the state of the sensor."""
         val = getattr(self.vehicle, self._attribute)
+
+        if val is None:
+            return val
+
         if self._attribute == 'odometer':
-            return round(val / 1000)  # km
-        return val
+            val /= 1000  # m -> km
+
+        if 'mil' in self.unit_of_measurement:
+            val /= 10  # km -> mil
+
+        if self._attribute == 'average_fuel_consumption':
+            val /= 10  # L/1000km -> L/100km
+            if 'mil' in self.unit_of_measurement:
+                return round(val, 2)
+            else:
+                return round(val, 1)
+        elif self._attribute == 'distance_to_empty':
+            return int(floor(val))
+        else:
+            return int(round(val))
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return RESOURCES[self._attribute][3]
+        unit = RESOURCES[self._attribute][3]
+        if self._state.config[CONF_SCANDINAVIAN_MILES] and 'km' in unit:
+            if self._attribute == 'average_fuel_consumption':
+                return 'L/mil'
+            else:
+                return unit.replace('km', 'mil')
+        return unit
 
     @property
     def icon(self):

--- a/homeassistant/components/volvooncall.py
+++ b/homeassistant/components/volvooncall.py
@@ -26,11 +26,13 @@ REQUIREMENTS = ['volvooncall==0.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_UPDATE_INTERVAL = 'update_interval'
 MIN_UPDATE_INTERVAL = timedelta(minutes=1)
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=1)
+
+CONF_UPDATE_INTERVAL = 'update_interval'
 CONF_REGION = 'region'
 CONF_SERVICE_URL = 'service_url'
+CONF_SCANDINAVIAN_MILES = 'scandinavian_miles'
 
 SIGNAL_VEHICLE_SEEN = '{}.vehicle_seen'.format(DOMAIN)
 
@@ -41,6 +43,8 @@ RESOURCES = {'position': ('device_tracker',),
              'fuel_amount': ('sensor', 'Fuel amount', 'mdi:gas-station', 'L'),
              'fuel_amount_level': (
                  'sensor', 'Fuel level', 'mdi:water-percent', '%'),
+             'average_fuel_consumption': (
+                 'sensor', 'Fuel consumption', 'mdi:gas-station', 'L/100 km'),
              'distance_to_empty': ('sensor', 'Range', 'mdi:ruler', 'km'),
              'washer_fluid_level': ('binary_sensor', 'Washer fluid'),
              'brake_fluid': ('binary_sensor', 'Brake Fluid'),
@@ -61,6 +65,7 @@ CONFIG_SCHEMA = vol.Schema({
             cv.ensure_list, [vol.In(RESOURCES)]),
         vol.Optional(CONF_REGION): cv.string,
         vol.Optional(CONF_SERVICE_URL): cv.string,
+        vol.Optional(CONF_SCANDINAVIAN_MILES, default=False): cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -123,7 +128,8 @@ class VolvoData:
         """Initialize the component state."""
         self.entities = {}
         self.vehicles = {}
-        self.names = config[DOMAIN].get(CONF_NAME)
+        self.config = config[DOMAIN]
+        self.names = self.config.get(CONF_NAME)
 
     def vehicle_name(self, vehicle):
         """Provide a friendly name for a vehicle."""


### PR DESCRIPTION
## Description:
- Optional use of [Scandinavian miles ](https://en.wikipedia.org/wiki/Scandinavian_mile), normally used in Sweden in the context of distance and fuel consumption.
- Also add average fuel consumption property

Example
```
volvooncall:
  username: <username>
  password: <password>
  scandinavian_miles: yes  #  defaults to no (use km)

```