### PR TITLE
Make notify.html5 depend on config

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -29,7 +29,7 @@ from homeassistant.util import ensure_unique_string
 
 REQUIREMENTS = ['pywebpush==1.3.0', 'PyJWT==1.5.3']
 
-DEPENDENCIES = ['frontend']
+DEPENDENCIES = ['frontend', 'config']
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description:
We moved the HTML5 config to the config panel. Add a dependency on the config panel for HTML5 platform.

**Related issue (if applicable):** fixes #11041

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  platform: html5
```

