### PR TITLE
Fix async IO in Sesame lock component.

### DIFF
--- a/homeassistant/components/lock/sesame.py
+++ b/homeassistant/components/lock/sesame.py
@@ -42,18 +42,16 @@ def setup_platform(
 class SesameDevice(LockDevice):
     """Representation of a Sesame device."""
 
-    _sesame = None
-
-    # Cached sesame properties
-    _device_id = None
-    _nickname = None
-    _is_unlocked = False
-    _api_enabled = False
-    _battery = -1
-
     def __init__(self, sesame: object) -> None:
         """Initialize the Sesame device."""
         self._sesame = sesame
+
+        # Cached properties from pysesame object.
+        self._device_id = None
+        self._nickname = None
+        self._is_unlocked = False
+        self._api_enabled = False
+        self._battery = -1
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/lock/sesame.py
+++ b/homeassistant/components/lock/sesame.py
@@ -25,16 +25,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config: ConfigType,
-                   add_devices: Callable[[list], None], discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(
+        hass, config: ConfigType,
+        async_add_devices: Callable[[list], None], discovery_info=None):
     """Set up the Sesame platform."""
     import pysesame
 
     email = config.get(CONF_EMAIL)
     password = config.get(CONF_PASSWORD)
 
-    async_add_devices([SesameDevice(sesame) for sesame
-        in pysesame.get_sesames(email, password)], update_before_add=true)
+    async_add_devices(
+        [SesameDevice(sesame) for sesame in 
+            pysesame.get_sesames(email, password)], 
+        update_before_add=True)
 
 
 class SesameDevice(LockDevice):

--- a/homeassistant/components/lock/sesame.py
+++ b/homeassistant/components/lock/sesame.py
@@ -33,9 +33,8 @@ def setup_platform(hass, config: ConfigType,
     email = config.get(CONF_EMAIL)
     password = config.get(CONF_PASSWORD)
 
-    async_add_devices(
-        [SesameDevice(sesame) for sesame in pysesame.get_sesames(email, password)],
-        update_before_add=true)
+    async_add_devices([SesameDevice(sesame) for sesame
+        in pysesame.get_sesames(email, password)], update_before_add=true)
 
 
 class SesameDevice(LockDevice):

--- a/homeassistant/components/lock/sesame.py
+++ b/homeassistant/components/lock/sesame.py
@@ -4,6 +4,7 @@ Support for Sesame, by CANDY HOUSE.
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/lock.sesame/
 """
+import asyncio
 from typing import Callable  # noqa
 import voluptuous as vol
 
@@ -36,8 +37,8 @@ def async_setup_platform(
     password = config.get(CONF_PASSWORD)
 
     async_add_devices(
-        [SesameDevice(sesame) for sesame in 
-            pysesame.get_sesames(email, password)], 
+        [SesameDevice(sesame) for sesame in
+            pysesame.get_sesames(email, password)],
         update_before_add=True)
 
 

--- a/homeassistant/components/lock/sesame.py
+++ b/homeassistant/components/lock/sesame.py
@@ -33,8 +33,8 @@ def setup_platform(hass, config: ConfigType,
     email = config.get(CONF_EMAIL)
     password = config.get(CONF_PASSWORD)
 
-    add_devices([SesameDevice(sesame) for
-                 sesame in pysesame.get_sesames(email, password)])
+    add_devices([SesameDevice(sesame) for 
+                 sesame in pysesame.get_sesames(email, password)], true)
 
 
 class SesameDevice(LockDevice):

--- a/homeassistant/components/lock/sesame.py
+++ b/homeassistant/components/lock/sesame.py
@@ -33,8 +33,9 @@ def setup_platform(hass, config: ConfigType,
     email = config.get(CONF_EMAIL)
     password = config.get(CONF_PASSWORD)
 
-    add_devices([SesameDevice(sesame) for 
-                 sesame in pysesame.get_sesames(email, password)], true)
+    async_add_devices(
+        [SesameDevice(sesame) for sesame in pysesame.get_sesames(email, password)],
+        update_before_add=true)
 
 
 class SesameDevice(LockDevice):


### PR DESCRIPTION
## Description:
Switch Sesame lock component to use async_add_devices and force the object to cache all it's properties.  Unless someone manually overrides the value of use_cached_state on the internal sesame instance there will be no async IO in the component properties.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.