### PR TITLE
Allow tradfri to read the available state of the device

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -160,6 +160,7 @@ class TradfriLight(Light):
         self._rgb_color = None
         self._features = SUPPORTED_FEATURES
         self._temp_supported = False
+        self._available = True
 
         self._refresh(light)
 
@@ -184,7 +185,10 @@ class TradfriLight(Light):
         """Return the devices' state attributes."""
         info = self._light.device_info
 
-        attrs = {}
+        attrs = {
+            'manufacturer': info.manufacturer,
+            'power_source': info.power_source_str,
+        }
 
         if info.battery_level is not None:
             attrs[ATTR_BATTERY_LEVEL] = info.battery_level
@@ -195,6 +199,11 @@ class TradfriLight(Light):
     def async_added_to_hass(self):
         """Start thread when added to hass."""
         self._async_start_observe()
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
 
     @property
     def should_poll(self):
@@ -299,6 +308,7 @@ class TradfriLight(Light):
         self._light = light
 
         # Caching of LightControl and light object
+        self._available = light.reachable
         self._light_control = light.light_control
         self._light_data = light.light_control.lights[0]
         self._name = light.name

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -185,10 +185,7 @@ class TradfriLight(Light):
         """Return the devices' state attributes."""
         info = self._light.device_info
 
-        attrs = {
-            'manufacturer': info.manufacturer,
-            'power_source': info.power_source_str,
-        }
+        attrs = {}
 
         if info.battery_level is not None:
             attrs[ATTR_BATTERY_LEVEL] = info.battery_level


### PR DESCRIPTION
## Description:

Read the available state of the device.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
