### PR TITLE
Implemented event_data_template (new)

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -457,6 +457,7 @@ EVENT_SCHEMA = vol.Schema({
     vol.Optional(CONF_ALIAS): string,
     vol.Required('event'): string,
     vol.Optional('event_data'): dict,
+    vol.Optional('event_data_template'): {match_all: template_complex}
 })
 
 SERVICE_SCHEMA = vol.All(vol.Schema({

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -193,7 +193,7 @@ class Script():
                     """Recursive template creator helper function."""
                     if isinstance(value, list):
                         return [_data_template_creator(item)
-                                    for item in value]
+                                for item in value]
                     elif isinstance(value, dict):
                         return {key: _data_template_creator(item)
                                 for key, item in value.items()}

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -192,7 +192,6 @@ class Script():
             try:
                 event_data.update(template.render_complex(
                     action[CONF_EVENT_DATA_TEMPLATE], variables))
-                _LOGGER.error('event data: %s' % event_data)
             except TemplateError as ex:
                 _LOGGER.error('Error rendering event data template: %s', ex)
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -10,7 +10,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.const import CONF_CONDITION, CONF_TIMEOUT
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import (
-    service, condition, template, config_validation as cv)
+    service, condition, template as template,
+    config_validation as cv)
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time, async_track_template)
 from homeassistant.helpers.typing import ConfigType
@@ -189,18 +190,8 @@ class Script():
         event_data = dict(action.get(CONF_EVENT_DATA, {}))
         if CONF_EVENT_DATA_TEMPLATE in action:
             try:
-                def _data_template_creator(value):
-                    """Recursive template creator helper function."""
-                    if isinstance(value, list):
-                        return [_data_template_creator(item)
-                                for item in value]
-                    elif isinstance(value, dict):
-                        return {key: _data_template_creator(item)
-                                for key, item in value.items()}
-                    value.hass = self.hass
-                    return value.async_render(variables)
-                event_data.update(_data_template_creator(
-                    action[CONF_EVENT_DATA_TEMPLATE]))
+                event_data.update(template.render_complex(
+                    action[CONF_EVENT_DATA_TEMPLATE], variables))
             except TemplateError as ex:
                 _LOGGER.error('Error rendering event data template: %s', ex)
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.const import CONF_CONDITION, CONF_TIMEOUT
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import (
     service, condition, template, config_validation as cv)
 from homeassistant.helpers.event import (
@@ -25,6 +26,7 @@ CONF_SERVICE_DATA = 'data'
 CONF_SEQUENCE = 'sequence'
 CONF_EVENT = 'event'
 CONF_EVENT_DATA = 'event_data'
+CONF_EVENT_DATA_TEMPLATE = 'event_data_template'
 CONF_DELAY = 'delay'
 CONF_WAIT_TEMPLATE = 'wait_template'
 
@@ -145,7 +147,7 @@ class Script():
                     break
 
             elif CONF_EVENT in action:
-                self._async_fire_event(action)
+                self._async_fire_event(action, variables)
 
             else:
                 yield from self._async_call_service(action, variables)
@@ -180,12 +182,30 @@ class Script():
         yield from service.async_call_from_config(
             self.hass, action, True, variables, validate_config=False)
 
-    def _async_fire_event(self, action):
+    def _async_fire_event(self, action, variables):
         """Fire an event."""
         self.last_action = action.get(CONF_ALIAS, action[CONF_EVENT])
         self._log("Executing step %s" % self.last_action)
+        event_data = dict(action.get(CONF_EVENT_DATA, {}))
+        if CONF_EVENT_DATA_TEMPLATE in action:
+            try:
+                def _data_template_creator(value):
+                    """Recursive template creator helper function."""
+                    if isinstance(value, list):
+                        return [_data_template_creator(item)
+                                    for item in value]
+                    elif isinstance(value, dict):
+                        return {key: _data_template_creator(item)
+                                for key, item in value.items()}
+                    value.hass = self.hass
+                    return value.async_render(variables)
+                event_data.update(_data_template_creator(
+                    action[CONF_EVENT_DATA_TEMPLATE]))
+            except TemplateError as ex:
+                _LOGGER.error('Error rendering event data template: %s', ex)
+
         self.hass.bus.async_fire(action[CONF_EVENT],
-                                 action.get(CONF_EVENT_DATA))
+                                 event_data)
 
     def _async_check_condition(self, action, variables):
         """Test if condition is matching."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -192,6 +192,7 @@ class Script():
             try:
                 event_data.update(template.render_complex(
                     action[CONF_EVENT_DATA_TEMPLATE], variables))
+                _LOGGER.error('event data: %s' % event_data)
             except TemplateError as ex:
                 _LOGGER.error('Error rendering event data template: %s', ex)
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -63,17 +63,20 @@ def async_call_from_config(hass, config, blocking=False, variables=None,
     service_data = dict(config.get(CONF_SERVICE_DATA, {}))
 
     if CONF_SERVICE_DATA_TEMPLATE in config:
-        def _data_template_creator(value):
-            """Recursive template creator helper function."""
-            if isinstance(value, list):
-                return [_data_template_creator(item) for item in value]
-            elif isinstance(value, dict):
-                return {key: _data_template_creator(item)
-                        for key, item in value.items()}
-            value.hass = hass
-            return value.async_render(variables)
-        service_data.update(_data_template_creator(
-            config[CONF_SERVICE_DATA_TEMPLATE]))
+        try:
+            def _data_template_creator(value):
+                """Recursive template creator helper function."""
+                if isinstance(value, list):
+                    return [_data_template_creator(item) for item in value]
+                elif isinstance(value, dict):
+                    return {key: _data_template_creator(item)
+                            for key, item in value.items()}
+                value.hass = hass
+                return value.async_render(variables)
+            service_data.update(_data_template_creator(
+                config[CONF_SERVICE_DATA_TEMPLATE]))
+        except TemplateError as ex:
+            _LOGGER.error('Error rendering data template: %s', ex)
 
     if CONF_SERVICE_ENTITY_ID in config:
         service_data[ATTR_ENTITY_ID] = config[CONF_SERVICE_ENTITY_ID]

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant  # NOQA
 from homeassistant.exceptions import TemplateError
+from homeassistant.helpers import template
 from homeassistant.loader import get_component, bind_hass
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.async import run_coroutine_threadsafe
@@ -64,17 +65,9 @@ def async_call_from_config(hass, config, blocking=False, variables=None,
 
     if CONF_SERVICE_DATA_TEMPLATE in config:
         try:
-            def _data_template_creator(value):
-                """Recursive template creator helper function."""
-                if isinstance(value, list):
-                    return [_data_template_creator(item) for item in value]
-                elif isinstance(value, dict):
-                    return {key: _data_template_creator(item)
-                            for key, item in value.items()}
-                value.hass = hass
-                return value.async_render(variables)
-            service_data.update(_data_template_creator(
-                config[CONF_SERVICE_DATA_TEMPLATE]))
+            template.attach(hass, config[CONF_SERVICE_DATA_TEMPLATE])
+            service_data.update(template.render_complex(
+                config[CONF_SERVICE_DATA_TEMPLATE], variables))
         except TemplateError as ex:
             _LOGGER.error('Error rendering data template: %s', ex)
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -43,6 +43,7 @@ def attach(hass, obj):
     elif isinstance(obj, Template):
         obj.hass = hass
 
+
 def render_complex(value, variables=None):
     """Recursive template creator helper function."""
     if isinstance(value, list):
@@ -52,7 +53,6 @@ def render_complex(value, variables=None):
         return {key: render_complex(item, variables)
                 for key, item in value.items()}
     return value.async_render(variables)
-
 
 def extract_entities(template, variables=None):
     """Extract all entities for state_changed listener from template string."""

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -55,6 +55,7 @@ def render_complex(value, variables=None):
                 for key, item in value.items()}
     return value.async_render(variables)
 
+
 def extract_entities(template, variables=None):
     """Extract all entities for state_changed listener from template string."""
     if template is None or _RE_NONE_ENTITIES.search(template):
@@ -77,6 +78,7 @@ def extract_entities(template, variables=None):
     if extraction_final:
         return list(set(extraction_final))
     return MATCH_ALL
+
 
 class Template(object):
     """Class to hold a template and manage caching and rendering."""

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -43,15 +43,13 @@ def attach(hass, obj):
     elif isinstance(obj, Template):
         obj.hass = hass
 
-
-@bind_hass
 def render_complex(value, variables=None):
     """Recursive template creator helper function."""
     if isinstance(value, list):
-        return [render_complex(item)
+        return [render_complex(item, variables)
                 for item in value]
     elif isinstance(value, dict):
-        return {key: render_complex(item)
+        return {key: render_complex(item, variables)
                 for key, item in value.items()}
     return value.async_render(variables)
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -44,6 +44,17 @@ def attach(hass, obj):
         obj.hass = hass
 
 
+@bind_hass
+def render_complex(value, variables=None):
+    """Recursive template creator helper function."""
+    if isinstance(value, list):
+        return [render_complex(item)
+                for item in value]
+    elif isinstance(value, dict):
+        return {key: render_complex(item)
+                for key, item in value.items()}
+    return value.async_render(variables)
+
 def extract_entities(template, variables=None):
     """Extract all entities for state_changed listener from template string."""
     if template is None or _RE_NONE_ENTITIES.search(template):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -54,6 +54,7 @@ def render_complex(value, variables=None):
                 for key, item in value.items()}
     return value.async_render(variables)
 
+
 def extract_entities(template, variables=None):
     """Extract all entities for state_changed listener from template string."""
     if template is None or _RE_NONE_ENTITIES.search(template):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -78,7 +78,6 @@ def extract_entities(template, variables=None):
         return list(set(extraction_final))
     return MATCH_ALL
 
-
 class Template(object):
     """Class to hold a template and manage caching and rendering."""
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -72,7 +72,7 @@ class TestScriptHelper(unittest.TestCase):
             'event': event,
             'event_data_template': {
                 'hello': """
-                    {% if True %}
+                    {% if is_world == 'yes' %}
                         world
                     {% else %}
                         Not world
@@ -81,7 +81,7 @@ class TestScriptHelper(unittest.TestCase):
             }
         }))
 
-        script_obj.run()
+        script_obj.run({'is_world': 'yes'})
 
         self.hass.block_till_done()
 
@@ -132,14 +132,14 @@ class TestScriptHelper(unittest.TestCase):
                 {% endif %}""",
             'data_template': {
                 'hello': """
-                    {% if True %}
+                    {% if is_world == 'yes' %}
                         world
                     {% else %}
                         Not world
                     {% endif %}
                 """
             }
-        })
+        }, {'is_world': 'yes'})
 
         self.hass.block_till_done()
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -56,6 +56,39 @@ class TestScriptHelper(unittest.TestCase):
         assert calls[0].data.get('hello') == 'world'
         assert not script_obj.can_cancel
 
+    def test_firing_event_template(self):
+        """Test the firing of events."""
+        event = 'test_event'
+        calls = []
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            calls.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA({
+            'event': event,
+            'event_data_template': {
+                'hello': """
+                    {% if True %}
+                        world
+                    {% else %}
+                        Not world
+                    {% endif %}
+                """
+            }
+        }))
+
+        script_obj.run()
+
+        self.hass.block_till_done()
+
+        assert len(calls) == 1
+        assert calls[0].data.get('hello') == 'world'
+        assert not script_obj.can_cancel
+
     def test_calling_service(self):
         """Test the calling of a service."""
         calls = []

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -75,7 +75,7 @@ class TestScriptHelper(unittest.TestCase):
                     {% if is_world == 'yes' %}
                         world
                     {% else %}
-                        Not world
+                        not world
                     {% endif %}
                 """
             }
@@ -135,7 +135,7 @@ class TestScriptHelper(unittest.TestCase):
                     {% if is_world == 'yes' %}
                         world
                     {% else %}
-                        Not world
+                        not world
                     {% endif %}
                 """
             }
@@ -180,7 +180,7 @@ class TestScriptHelper(unittest.TestCase):
 
     def test_delay_template(self):
         """Test the delay as a template."""
-        event = 'test_evnt'
+        event = 'test_event'
         events = []
 
         @callback

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -279,6 +279,36 @@ class TestHelpersTemplate(unittest.TestCase):
             '127',
             template.Template('{{ hello }}', self.hass).render({'hello': 127}))
 
+    def test_passing_vars_as_list(self):
+        """Test passing variables as list."""
+        self.assertEqual(
+            "['foo', 'bar']",
+            template.render_complex(template.Template('{{ hello }}',
+                                    self.hass), {'hello': ['foo', 'bar']}))
+
+    def test_passing_vars_as_list_element(self):
+        """Test passing variables as list."""
+        self.assertEqual(
+            'bar',
+            template.render_complex(template.Template('{{ hello[1] }}',
+                                    self.hass),
+                                    {'hello': ['foo', 'bar']}))
+
+    def test_passing_vars_as_dict_element(self):
+        """Test passing variables as list."""
+        self.assertEqual(
+            'bar',
+            template.render_complex(template.Template('{{ hello.foo }}',
+                                    self.hass),
+                                    {'hello': {'foo': 'bar'}}))
+
+    def test_passing_vars_as_dict(self):
+        """Test passing variables as list."""
+        self.assertEqual(
+            "{'foo': 'bar'}",
+            template.render_complex(template.Template('{{ hello }}',
+                                    self.hass), {'hello': {'foo': 'bar'}}))
+
     def test_render_with_possible_json_value_with_valid_json(self):
         """Render with possible JSON value with valid JSON."""
         tpl = template.Template('{{ value_json.hello }}', self.hass)


### PR DESCRIPTION
## Description:

Implemented event_data_template within scripts. This can be used to create custom triggers or
pass data to other scripts. A good use case (mine) would be to pass custom data to an appdaemon app.

**Related issue (if applicable):** fixes #N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4180

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  set_timer:
    sequence:
      - event: APP_SET_TIMER
        event_data_template:
          name: '{{ name }}'
          hours: '{{ hours }}'
          minutes: '{{ minutes }}'
          seconds: '{{ seconds }}'
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
