### PR TITLE
Account for User-Agent being non-existent, causing a TypeError

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -580,23 +580,22 @@ def _is_latest(js_option, request):
         return js_option == 'latest'
 
     useragent = request.headers.get('User-Agent')
-    if useragent:
-        from user_agents import parse
-        useragent = parse(useragent)
+    if not useragent:
+        return False
+    
+    from user_agents import parse
+    useragent = parse(useragent)
 
-        # on iOS every browser is a Safari which we support from version 10.
-        if useragent.os.family == 'iOS':
-            return useragent.os.version[0] >= 10
+    # on iOS every browser is a Safari which we support from version 10.
+    if useragent.os.family == 'iOS':
+        return useragent.os.version[0] >= 10
 
-        family_min_version = {
-            'Chrome': 50,   # Probably can reduce this
-            'Firefox': 43,  # Array.protopype.includes added in 43
-            'Opera': 40,    # Probably can reduce this
-            'Edge': 14,     # Array.protopype.includes added in 14
-            'Safari': 10,   # many features not supported by 9
-        }
-        version = family_min_version.get(useragent.browser.family)
-        return version and useragent.browser.version[0] >= version
-
-    # last resort
-    return False
+    family_min_version = {
+        'Chrome': 50,   # Probably can reduce this
+        'Firefox': 43,  # Array.protopype.includes added in 43
+        'Opera': 40,    # Probably can reduce this
+        'Edge': 14,     # Array.protopype.includes added in 14
+        'Safari': 10,   # many features not supported by 9
+    }
+    version = family_min_version.get(useragent.browser.family)
+    return version and useragent.browser.version[0] >= version

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -582,7 +582,7 @@ def _is_latest(js_option, request):
     useragent = request.headers.get('User-Agent')
     if not useragent:
         return False
-    
+
     from user_agents import parse
     useragent = parse(useragent)
 

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -579,8 +579,10 @@ def _is_latest(js_option, request):
     if js_option != 'auto':
         return js_option == 'latest'
 
-    from user_agents import parse
-    useragent = parse(request.headers.get('User-Agent'))
+    useragent = request.headers.get('User-Agent')
+    if useragent:
+        from user_agents import parse
+        useragent = parse(useragent)
 
     # on iOS every browser is a Safari which we support from version 10.
     if useragent.os.family == 'iOS':

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -599,4 +599,4 @@ def _is_latest(js_option, request):
         return version and useragent.browser.version[0] >= version
 
     # last resort
-    return True
+    return False

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -584,16 +584,19 @@ def _is_latest(js_option, request):
         from user_agents import parse
         useragent = parse(useragent)
 
-    # on iOS every browser is a Safari which we support from version 10.
-    if useragent.os.family == 'iOS':
-        return useragent.os.version[0] >= 10
+        # on iOS every browser is a Safari which we support from version 10.
+        if useragent.os.family == 'iOS':
+            return useragent.os.version[0] >= 10
 
-    family_min_version = {
-        'Chrome': 50,   # Probably can reduce this
-        'Firefox': 43,  # Array.protopype.includes added in 43
-        'Opera': 40,    # Probably can reduce this
-        'Edge': 14,     # Array.protopype.includes added in 14
-        'Safari': 10,   # many features not supported by 9
-    }
-    version = family_min_version.get(useragent.browser.family)
-    return version and useragent.browser.version[0] >= version
+        family_min_version = {
+            'Chrome': 50,   # Probably can reduce this
+            'Firefox': 43,  # Array.protopype.includes added in 43
+            'Opera': 40,    # Probably can reduce this
+            'Edge': 14,     # Array.protopype.includes added in 14
+            'Safari': 10,   # many features not supported by 9
+        }
+        version = family_min_version.get(useragent.browser.family)
+        return version and useragent.browser.version[0] >= version
+
+    # last resort
+    return True


### PR DESCRIPTION
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

```yaml

```


If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54