### PR TITLE
Added mochad max_xdim_value for older X10 modules

### DIFF
--- a/homeassistant/components/light/mochad.py
+++ b/homeassistant/components/light/mochad.py
@@ -26,6 +26,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Optional(CONF_NAME): cv.string,
         vol.Required(CONF_ADDRESS): cv.x10_address,
         vol.Optional(mochad.CONF_COMM_TYPE): cv.string,
+        vol.Optional(mochad.CONF_MAX_XDIM_VALUE): cv.byte,
     }]
 })
 
@@ -50,6 +51,7 @@ class MochadLight(Light):
         self._name = dev.get(CONF_NAME,
                              'x10_light_dev_{}'.format(self._address))
         self._comm_type = dev.get(mochad.CONF_COMM_TYPE, 'pl')
+        self._max_xdim_value = dev.get(mochad.CONF_MAX_XDIM_VALUE, 255)
         self.device = device.Device(ctrl, self._address,
                                     comm_type=self._comm_type)
         self._brightness = 0
@@ -90,7 +92,8 @@ class MochadLight(Light):
         """Send the command to turn the light on."""
         self._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
         with mochad.REQ_LOCK:
-            self.device.send_cmd("xdim {}".format(self._brightness))
+            xdim_value = int(self._brightness * self._max_xdim_value / 255)
+            self.device.send_cmd("xdim {}".format(xdim_value))
             self._controller.read_data()
         self._state = True
 

--- a/homeassistant/components/mochad.py
+++ b/homeassistant/components/mochad.py
@@ -21,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 CONTROLLER = None
 
 CONF_COMM_TYPE = 'comm_type'
+CONF_MAX_XDIM_VALUE = 'max_xdim_value'
 
 DOMAIN = 'mochad'
 


### PR DESCRIPTION
## Description:
Added mochad max_xdim_value for older X10 modules
the xdim command has less than 8 bits for older modules 
mine has fewer so the max value is 63 instead of 255

**Related issue (if applicable):** fixes # not issued just fixed

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: mochad
    devices:
    - address: c9
      name: Hal Overloop
      max_xdim_value: 63

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ prepared not yet commited] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ done] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ not applicalbe] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ not applicalbe] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ not applicalbe] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ not applicalbe] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ done] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ not applicalbe] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
