### PR TITLE
Allow separate command and state OIDs and payloads in SNMP switch

### DIFF
--- a/homeassistant/components/switch/snmp.py
+++ b/homeassistant/components/switch/snmp.py
@@ -100,7 +100,6 @@ class SnmpSwitch(SwitchDevice):
         else:
             self._commandoid = baseoid
 
-        """Same for the payloads"""
         if command_payload_on:
             self._command_payload_on = command_payload_on
         else:

--- a/homeassistant/components/switch/snmp.py
+++ b/homeassistant/components/switch/snmp.py
@@ -39,15 +39,18 @@ SNMP_VERSIONS = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_BASEOID): cv.string,
-    vol.Optional(CONF_COMMAND_OID, default=None): vol.Any(
-                                                          cv.string,
-                                                          None),
-    vol.Optional(CONF_COMMAND_PAYLOAD_ON, default=None): vol.Any(
-                                                          cv.string,
-                                                          None),
-    vol.Optional(CONF_COMMAND_PAYLOAD_OFF, default=None): vol.Any(
-                                                          cv.string,
-                                                          None),
+    vol.Optional(CONF_COMMAND_OID, default=None):
+        vol.Any(
+            cv.string,
+            None),
+    vol.Optional(CONF_COMMAND_PAYLOAD_ON, default=None):
+        vol.Any(
+            cv.string,
+            None),
+    vol.Optional(CONF_COMMAND_PAYLOAD_OFF, default=None):
+        vol.Any(
+            cv.string,
+            None),
     vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -92,18 +95,18 @@ class SnmpSwitch(SwitchDevice):
         self._baseoid = baseoid
 
         """Set the command OID to the base OID if command OID is unset"""
-        if(commandoid):
+        if commandoid:
             self._commandoid = commandoid
         else:
             self._commandoid = baseoid
 
         """Same for the payloads"""
-        if(command_payload_on):
+        if command_payload_on:
             self._command_payload_on = command_payload_on
         else:
             self._command_payload_on = payload_on
 
-        if(command_payload_off):
+        if command_payload_off:
             self._command_payload_off = command_payload_off
         else:
             self._command_payload_off = payload_off

--- a/homeassistant/components/switch/snmp.py
+++ b/homeassistant/components/switch/snmp.py
@@ -18,6 +18,9 @@ REQUIREMENTS = ['pysnmp==4.4.4']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_BASEOID = 'baseoid'
+CONF_COMMAND_OID = 'command_oid'
+CONF_COMMAND_PAYLOAD_ON = 'command_payload_on'
+CONF_COMMAND_PAYLOAD_OFF = 'command_payload_off'
 CONF_COMMUNITY = 'community'
 CONF_VERSION = 'version'
 
@@ -36,6 +39,15 @@ SNMP_VERSIONS = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_BASEOID): cv.string,
+    vol.Optional(CONF_COMMAND_OID, default=None): vol.Any(
+                                                          cv.string,
+                                                          None),
+    vol.Optional(CONF_COMMAND_PAYLOAD_ON, default=None): vol.Any(
+                                                          cv.string,
+                                                          None),
+    vol.Optional(CONF_COMMAND_PAYLOAD_OFF, default=None): vol.Any(
+                                                          cv.string,
+                                                          None),
     vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -53,26 +65,49 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     port = config.get(CONF_PORT)
     community = config.get(CONF_COMMUNITY)
     baseoid = config.get(CONF_BASEOID)
+    command_oid = config.get(CONF_COMMAND_OID)
+    command_payload_on = config.get(CONF_COMMAND_PAYLOAD_ON)
+    command_payload_off = config.get(CONF_COMMAND_PAYLOAD_OFF)
     version = config.get(CONF_VERSION)
     payload_on = config.get(CONF_PAYLOAD_ON)
     payload_off = config.get(CONF_PAYLOAD_OFF)
 
     add_devices(
-        [SnmpSwitch(name, host, port, community, baseoid, version, payload_on,
-                    payload_off)], True)
+        [SnmpSwitch(name, host, port, community, baseoid, command_oid, version,
+                    payload_on, payload_off,
+                    command_payload_on, command_payload_off)], True)
 
 
 class SnmpSwitch(SwitchDevice):
     """Represents a SNMP switch."""
 
     def __init__(self, name, host, port, community,
-                 baseoid, version, payload_on, payload_off):
+                 baseoid, commandoid, version, payload_on, payload_off,
+                 command_payload_on, command_payload_off):
         """Initialize the switch."""
         self._name = name
         self._host = host
         self._port = port
         self._community = community
         self._baseoid = baseoid
+
+        """Set the command OID to the base OID if command OID is unset"""
+        if(commandoid):
+            self._commandoid = commandoid
+        else:
+            self._commandoid = baseoid
+
+        """Same for the payloads"""
+        if(command_payload_on):
+            self._command_payload_on = command_payload_on
+        else:
+            self._command_payload_on = payload_on
+
+        if(command_payload_off):
+            self._command_payload_off = command_payload_off
+        else:
+            self._command_payload_off = payload_off
+
         self._version = SNMP_VERSIONS[version]
         self._state = None
         self._payload_on = payload_on
@@ -82,13 +117,13 @@ class SnmpSwitch(SwitchDevice):
         """Turn on the switch."""
         from pyasn1.type.univ import (Integer)
 
-        self._set(Integer(self._payload_on))
+        self._set(Integer(self._command_payload_on))
 
     def turn_off(self):
         """Turn off the switch."""
         from pyasn1.type.univ import (Integer)
 
-        self._set(Integer(self._payload_off))
+        self._set(Integer(self._command_payload_off))
 
     def update(self):
         """Update the state."""
@@ -142,7 +177,7 @@ class SnmpSwitch(SwitchDevice):
             CommunityData(self._community, mpModel=self._version),
             UdpTransportTarget((self._host, self._port)),
             ContextData(),
-            ObjectType(ObjectIdentity(self._baseoid), value)
+            ObjectType(ObjectIdentity(self._commandoid), value)
         )
 
         next(request)

--- a/homeassistant/components/switch/snmp.py
+++ b/homeassistant/components/switch/snmp.py
@@ -39,18 +39,9 @@ SNMP_VERSIONS = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_BASEOID): cv.string,
-    vol.Optional(CONF_COMMAND_OID, default=None):
-        vol.Any(
-            cv.string,
-            None),
-    vol.Optional(CONF_COMMAND_PAYLOAD_ON, default=None):
-        vol.Any(
-            cv.string,
-            None),
-    vol.Optional(CONF_COMMAND_PAYLOAD_OFF, default=None):
-        vol.Any(
-            cv.string,
-            None),
+    vol.Optional(CONF_COMMAND_OID): cv.string,
+    vol.Optional(CONF_COMMAND_PAYLOAD_ON): cv.string,
+    vol.Optional(CONF_COMMAND_PAYLOAD_OFF): cv.string,
     vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -95,20 +86,9 @@ class SnmpSwitch(SwitchDevice):
         self._baseoid = baseoid
 
         """Set the command OID to the base OID if command OID is unset"""
-        if commandoid:
-            self._commandoid = commandoid
-        else:
-            self._commandoid = baseoid
-
-        if command_payload_on:
-            self._command_payload_on = command_payload_on
-        else:
-            self._command_payload_on = payload_on
-
-        if command_payload_off:
-            self._command_payload_off = command_payload_off
-        else:
-            self._command_payload_off = payload_off
+        self._commandoid = commandoid or baseoid
+        self._command_payload_on = command_payload_on or payload_on
+        self._command_payload_off = command_payload_off or payload_off
 
         self._version = SNMP_VERSIONS[version]
         self._state = None


### PR DESCRIPTION
## Description:
It is evident that some switch devices, such as the PDU/CDU units made by Server Technology, use different OIDs and payloads for reading vs. writing the on/off state of power outlets. Therefore, I have expanded the SNMP switch component **in a fully backwards-compatible manner** to allow for these devices which use separate command and state OIDs and variable mappings to be used with HA.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4190

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: snmp
    name: Server Technology PDU Outlet 16
    host: 192.168.1.1
    community: private
    version: 2c
    baseoid: .1.3.6.1.4.1.1718.3.2.3.1.10.1.1.16
    command_oid: .1.3.6.1.4.1.1718.3.2.3.1.11.1.1.16
    payload_on: 5
    payload_off: 4
    command_payload_on: 1
    command_payload_off: 2
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)



