### PR TITLE
Upgrade yarl to 0.16.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,7 +6,7 @@ jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.3.5
-yarl==0.15.0
+yarl==0.16.0
 async_timeout==2.0.0
 chardet==3.0.4
 astral==1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -7,7 +7,7 @@ jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
 aiohttp==2.3.5
-yarl==0.15.0
+yarl==0.16.0
 async_timeout==2.0.0
 chardet==3.0.4
 astral==1.4

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ REQUIRES = [
     'voluptuous==0.10.5',
     'typing>=3,<4',
     'aiohttp==2.3.5',   # If updated, check if yarl also needs an update!
-    'yarl==0.15.0',
+    'yarl==0.16.0',
     'async_timeout==2.0.0',
     'chardet==3.0.4',
     'astral==1.4',


### PR DESCRIPTION
## Description:
* Fix raising `TypeError` by `url.query_string()` after `url.with_query({})` (empty mapping)

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
