### PR TITLE
fix construct==2.8.17 Cause the plug-in failure

### DIFF
--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -31,7 +31,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-miio==0.3.2', 'construct==2.8.16']
+REQUIREMENTS = ['python-miio==0.3.2','construct==2.8.16']
 
 ATTR_TEMPERATURE = 'temperature'
 ATTR_HUMIDITY = 'humidity'

--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -31,7 +31,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-miio==0.3.2','construct==2.8.16']
+REQUIREMENTS = ['python-miio==0.3.2', 'construct==2.8.16']
 
 ATTR_TEMPERATURE = 'temperature'
 ATTR_HUMIDITY = 'humidity'

--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -31,7 +31,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-miio==0.3.2']
+REQUIREMENTS = ['python-miio==0.3.2', 'construct==2.8.16']
 
 ATTR_TEMPERATURE = 'temperature'
 ATTR_HUMIDITY = 'humidity'

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -28,7 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-miio==0.3.2']
+REQUIREMENTS = ['python-miio==0.3.2', 'construct==2.8.16']
 
 # The light does not accept cct values < 1
 CCT_MIN = 1

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -25,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-miio==0.3.2']
+REQUIREMENTS = ['python-miio==0.3.2', 'construct==2.8.16']
 
 ATTR_POWER = 'power'
 ATTR_TEMPERATURE = 'temperature'

--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_TOKEN, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-miio==0.3.2']
+REQUIREMENTS = ['python-miio==0.3.2', 'construct==2.8.16']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_TOKEN, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-miio==0.3.2', 'construct==2.8.16']
+REQUIREMENTS = ['python-miio==0.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -859,6 +859,7 @@ python-juicenet==0.0.5
 # homeassistant.components.switch.xiaomi_miio
 # homeassistant.components.vacuum.xiaomi_miio
 python-miio==0.3.2
+construct==2.8.16
 
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5


### PR DESCRIPTION
fix construct==2.8.17 Cause the plug-in failure

## Description:

**Related issue :** fixes <https://github.com/home-assistant/home-assistant/issues/11048#issuecomment-350797761>

At the same time update in python-miio
<https://github.com/rytilahti/python-miio/pull/140>

See which side to submit first
See which side first submitted to solve the problem