### PR TITLE
Bump pymusiccast to version 0.1.6

### DIFF
--- a/homeassistant/components/media_player/yamaha_musiccast.py
+++ b/homeassistant/components/media_player/yamaha_musiccast.py
@@ -36,7 +36,7 @@ SUPPORTED_FEATURES = (
 KNOWN_HOSTS_KEY = 'data_yamaha_musiccast'
 INTERVAL_SECONDS = 'interval_seconds'
 
-REQUIREMENTS = ['pymusiccast==0.1.5']
+REQUIREMENTS = ['pymusiccast==0.1.6']
 
 DEFAULT_PORT = 5005
 DEFAULT_INTERVAL = 480

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -753,7 +753,7 @@ pymodbus==1.3.1
 pymonoprice==0.2
 
 # homeassistant.components.media_player.yamaha_musiccast
-pymusiccast==0.1.5
+pymusiccast==0.1.6
 
 # homeassistant.components.cover.myq
 pymyq==0.0.8


### PR DESCRIPTION
## Description:
Bump pymusiccast to version 0.1.6

Changelog:
- pymusiccast uses internal constants now rather importing home-assistant ones (hat tip to @amelchio for his suggestions https://github.com/home-assistant/home-assistant/pull/10256#pullrequestreview-75899334)