### PR TITLE
Allow exposing sensors as temperature or humidity 'climate' devices to Google Assistant

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -154,8 +154,8 @@ def entity_to_device(entity: Entity, config: Config, units: UnitSystem):
 def query_device(entity: Entity, units: UnitSystem) -> dict:
     """Take an entity and return a properly formatted device object."""
     def celsius(
-            deg: Optional[float],
-            unit_of_measurement: Optional[str]
+        deg: Optional[float],
+        unit_of_measurement: Optional[str]
     ) -> Optional[float]:
         """Convert a float to Celsius and rounds to one decimal place."""
         if deg is None:

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -135,9 +135,6 @@ def entity_to_device(entity: Entity, config: Config, units: UnitSystem):
                                 entity.attributes.get(light.ATTR_MIN_MIREDS))))
 
     if entity.domain == climate.DOMAIN:
-        unit_of_measurement = entity.attributes.get(
-            ATTR_UNIT_OF_MEASUREMENT
-        )
         modes = ','.join(
             m.lower() for m in entity.attributes.get(
                 climate.ATTR_OPERATION_LIST, [])
@@ -145,7 +142,7 @@ def entity_to_device(entity: Entity, config: Config, units: UnitSystem):
         device['attributes'] = {
             'availableThermostatModes': modes,
             'thermostatTemperatureUnit':
-            'F' if unit_of_measurement == TEMP_FAHRENHEIT else 'C',
+            'F' if units.temperature_unit == TEMP_FAHRENHEIT else 'C',
         }
         _LOGGER.debug('Thermostat attributes %s', device['attributes'])
     return device

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -167,7 +167,6 @@ def query_device(entity: Entity, units: UnitSystem) -> dict:
             'thermostatHumidityAmbient':
             entity.attributes.get(climate.ATTR_CURRENT_HUMIDITY),
         }
-
         return {k: v for k, v in response.items() if v is not None}
 
     final_state = entity.state != STATE_OFF

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -167,6 +167,7 @@ def query_device(entity: Entity, units: UnitSystem) -> dict:
             'thermostatHumidityAmbient':
             entity.attributes.get(climate.ATTR_CURRENT_HUMIDITY),
         }
+
         return {k: v for k, v in response.items() if v is not None}
 
     final_state = entity.state != STATE_OFF

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -75,14 +75,15 @@ ERROR_NOT_SUPPORTED = "notSupported"
 class SmartHomeError(Exception):
     """Google Assistant Smart Home errors."""
 
-    def __init__(self, error_code, error_msg):
+    def __init__(self, code, msg):
         """Log error code."""
-        super(SmartHomeError, self).__init__(error_msg)
+        super(SmartHomeError, self).__init__(msg)
         _LOGGER.error(
-            "An error has ocurred in Google SmartHome: {}."
-            "Error code: {}".format(error_msg, error_code)
+            "An error has ocurred in Google SmartHome: %s."
+            "Error code: %s", msg, code
         )
-        self.error_code = error_code
+        self.code = code
+
 
 class Config:
     """Hold the configuration for Google Assistant."""
@@ -433,8 +434,8 @@ def async_devices_query(hass, config, payload):
 
         try:
             devices[devid] = query_device(state, config, hass.config.units)
-        except SmartHomeError as e:
-            devices[devid] = {'errorCode': e.error_code}
+        except SmartHomeError as error:
+            devices[devid] = {'errorCode': error.code}
 
     return {'devices': devices}
 

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -20,7 +20,8 @@ from homeassistant.const import (
     CONF_NAME, CONF_TYPE
 )
 from homeassistant.components import (
-    switch, light, cover, media_player, group, fan, scene, script, climate
+    switch, light, cover, media_player, group, fan, scene, script, climate,
+    sensor
 )
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
@@ -148,6 +149,7 @@ def query_device(entity: Entity, units: UnitSystem) -> dict:
         if deg is None:
             return None
         return round(METRIC_SYSTEM.temperature(deg, units.temperature_unit), 1)
+
     if entity.domain == climate.DOMAIN:
         mode = entity.attributes.get(climate.ATTR_OPERATION_MODE).lower()
         if mode not in CLIMATE_SUPPORTED_MODES:

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -153,10 +153,9 @@ def entity_to_device(entity: Entity, config: Config, units: UnitSystem):
 
 def query_device(entity: Entity, units: UnitSystem) -> dict:
     """Take an entity and return a properly formatted device object."""
-    def celsius(
-        deg: Optional[float],
-        unit_of_measurement: Optional[str]
-    ) -> Optional[float]:
+    unit_of_measurement = entity.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+
+    def celsius(deg: Optional[float]) -> Optional[float]:
         """Convert a float to Celsius and rounds to one decimal place."""
         if deg is None:
             return None

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -395,7 +395,7 @@ def async_handle_message(hass, config, message):
 
 @HANDLERS.register('action.devices.SYNC')
 @asyncio.coroutine
-def async_devices_sync(hass, config, payload):
+def async_devices_sync(hass, config: Config, payload):
     """Handle action.devices.SYNC request."""
     devices = []
     for entity in hass.states.async_all():

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -14,8 +14,14 @@ from homeassistant.util.unit_system import UnitSystem  # NOQA
 from homeassistant.util.decorator import Registry
 
 from homeassistant.const import (
+<<<<<<< 4bec91531b2fc2da94ce889455c5cf916109488e
     ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID,
     STATE_OFF, SERVICE_TURN_OFF, SERVICE_TURN_ON,
+=======
+    ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID, ATTR_UNIT_OF_MEASUREMENT,
+    CONF_FRIENDLY_NAME, STATE_OFF,
+    SERVICE_TURN_OFF, SERVICE_TURN_ON,
+>>>>>>> Handled correctly unit of measurement to fix humidity
     TEMP_FAHRENHEIT, TEMP_CELSIUS,
     CONF_NAME, CONF_TYPE
 )

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -198,7 +198,7 @@ def query_device(entity: Entity, config: Config, units: UnitSystem) -> dict:
                 raise SmartHomeError(
                     ERROR_NOT_SUPPORTED,
                     "Invalid value {} for the climate sensor"
-                        .format(entity.state)
+                    .format(entity.state)
                 )
 
             # detect if we report temperature or humidity
@@ -215,7 +215,7 @@ def query_device(entity: Entity, config: Config, units: UnitSystem) -> dict:
                 raise SmartHomeError(
                     ERROR_NOT_SUPPORTED,
                     "Unit {} is not supported by the climate sensor"
-                        .format(unit_of_measurement)
+                    .format(unit_of_measurement)
                 )
 
             return {attr: value}

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -135,6 +135,9 @@ def entity_to_device(entity: Entity, config: Config, units: UnitSystem):
                                 entity.attributes.get(light.ATTR_MIN_MIREDS))))
 
     if entity.domain == climate.DOMAIN:
+        unit_of_measurement = entity.attributes.get(
+            ATTR_UNIT_OF_MEASUREMENT
+        )
         modes = ','.join(
             m.lower() for m in entity.attributes.get(
                 climate.ATTR_OPERATION_LIST, [])
@@ -142,7 +145,7 @@ def entity_to_device(entity: Entity, config: Config, units: UnitSystem):
         device['attributes'] = {
             'availableThermostatModes': modes,
             'thermostatTemperatureUnit':
-            'F' if units.temperature_unit == TEMP_FAHRENHEIT else 'C',
+            'F' if unit_of_measurement == TEMP_FAHRENHEIT else 'C',
         }
         _LOGGER.debug('Thermostat attributes %s', device['attributes'])
     return device

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -150,13 +150,11 @@ def entity_to_device(entity: Entity, config: Config, units: UnitSystem):
 
 def query_device(entity: Entity, units: UnitSystem) -> dict:
     """Take an entity and return a properly formatted device object."""
-    unit_of_measurement = entity.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-
     def celsius(deg: Optional[float]) -> Optional[float]:
         """Convert a float to Celsius and rounds to one decimal place."""
         if deg is None:
             return None
-        return round(METRIC_SYSTEM.temperature(deg, unit_of_measurement), 1)
+        return round(METRIC_SYSTEM.temperature(deg, units.temperature_unit), 1)
 
     if entity.domain == climate.DOMAIN:
         mode = entity.attributes.get(climate.ATTR_OPERATION_MODE).lower()

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -153,11 +153,14 @@ def entity_to_device(entity: Entity, config: Config, units: UnitSystem):
 
 def query_device(entity: Entity, units: UnitSystem) -> dict:
     """Take an entity and return a properly formatted device object."""
-    def celsius(deg: Optional[float]) -> Optional[float]:
+    def celsius(
+            deg: Optional[float],
+            unit_of_measurement: Optional[str]
+    ) -> Optional[float]:
         """Convert a float to Celsius and rounds to one decimal place."""
         if deg is None:
             return None
-        return round(METRIC_SYSTEM.temperature(deg, units.temperature_unit), 1)
+        return round(METRIC_SYSTEM.temperature(deg, unit_of_measurement), 1)
 
     if entity.domain == climate.DOMAIN:
         mode = entity.attributes.get(climate.ATTR_OPERATION_MODE).lower()

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -230,4 +230,20 @@ DEMO_DEVICES = [{
     'traits': ['action.devices.traits.TemperatureSetting'],
     'type': 'action.devices.types.THERMOSTAT',
     'willReportState': False
+}, {
+    'id': 'sensor.outside_temperature',
+    'name': {
+        'name': 'Outside Temperature'
+    },
+    'traits': ['action.devices.traits.TemperatureSetting'],
+    'type': 'action.devices.types.THERMOSTAT',
+    'willReportState': False
+}, {
+    'id': 'sensor.outside_humidity',
+    'name': {
+        'name': 'Outside Humidity'
+    },
+    'traits': ['action.devices.traits.TemperatureSetting'],
+    'type': 'action.devices.types.THERMOSTAT',
+    'willReportState': False
 }]

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -194,6 +194,7 @@ def test_query_request(hass_fixture, assistant_client):
     assert devices['light.kitchen_lights']['color']['spectrumRGB'] == 16727919
     assert devices['light.kitchen_lights']['color']['temperature'] == 4166
 
+
 @asyncio.coroutine
 def test_query_climate_request(hass_fixture, assistant_client):
     """Test a query request."""

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -8,7 +8,7 @@ import pytest
 
 from homeassistant import core, const, setup
 from homeassistant.components import (
-    fan, cover, light, switch, climate, async_setup, media_player)
+    fan, cover, light, switch, climate, async_setup, media_player, sensor)
 from homeassistant.components import google_assistant as ga
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
@@ -43,6 +43,14 @@ def assistant_client(loop, hass, test_client):
                     },
                     'switch.decorative_lights': {
                         'type': 'light'
+                    },
+                    'sensor.outside_humidity': {
+                        'type': 'climate',
+                        'expose': True
+                    },
+                    'sensor.outside_temperature': {
+                        'type': 'climate',
+                        'expose': True
                     }
                 }
             }
@@ -53,7 +61,7 @@ def assistant_client(loop, hass, test_client):
 
 @pytest.fixture
 def hass_fixture(loop, hass):
-    """Set up a HOme Assistant instance for these tests."""
+    """Set up a Home Assistant instance for these tests."""
     # We need to do this to get access to homeassistant/turn_(on,off)
     loop.run_until_complete(async_setup(hass, {core.DOMAIN: {}}))
 
@@ -93,6 +101,13 @@ def hass_fixture(loop, hass):
     loop.run_until_complete(
         setup.async_setup_component(hass, climate.DOMAIN, {
             'climate': [{
+                'platform': 'demo'
+            }]
+        }))
+
+    loop.run_until_complete(
+        setup.async_setup_component(hass, sensor.DOMAIN, {
+            'sensor': [{
                 'platform': 'demo'
             }]
         }))
@@ -179,7 +194,6 @@ def test_query_request(hass_fixture, assistant_client):
     assert devices['light.kitchen_lights']['color']['spectrumRGB'] == 16727919
     assert devices['light.kitchen_lights']['color']['temperature'] == 4166
 
-
 @asyncio.coroutine
 def test_query_climate_request(hass_fixture, assistant_client):
     """Test a query request."""
@@ -194,6 +208,8 @@ def test_query_climate_request(hass_fixture, assistant_client):
                     {'id': 'climate.hvac'},
                     {'id': 'climate.heatpump'},
                     {'id': 'climate.ecobee'},
+                    {'id': 'sensor.outside_temperature'},
+                    {'id': 'sensor.outside_humidity'}
                 ]
             }
         }]
@@ -223,6 +239,12 @@ def test_query_climate_request(hass_fixture, assistant_client):
             'thermostatTemperatureAmbient': 22,
             'thermostatMode': 'cool',
             'thermostatHumidityAmbient': 54,
+        },
+        'sensor.outside_temperature': {
+            'thermostatTemperatureAmbient': 15.6
+        },
+        'sensor.outside_humidity': {
+            'thermostatHumidityAmbient': 54.0
         }
     }
 
@@ -242,6 +264,7 @@ def test_query_climate_request_f(hass_fixture, assistant_client):
                     {'id': 'climate.hvac'},
                     {'id': 'climate.heatpump'},
                     {'id': 'climate.ecobee'},
+                    {'id': 'sensor.outside_temperature'}
                 ]
             }
         }]
@@ -271,6 +294,9 @@ def test_query_climate_request_f(hass_fixture, assistant_client):
             'thermostatTemperatureAmbient': -5.6,
             'thermostatMode': 'cool',
             'thermostatHumidityAmbient': 54,
+        },
+        'sensor.outside_temperature': {
+            'thermostatTemperatureAmbient': -9.1
         }
     }
 


### PR DESCRIPTION
## Description:
I currently own a couple of qubino zwave switches which also have the possibility to attach a temperature sensor to them so they can be exposed by zwave as separate sensors with badges.

The problem is that they can't be exposed to Google Assistant to report back the temperature and ask for questions like "What's the temperatur in the bedroom ?" because sensors are currently not handled at all.

This implementation can be used also with ZWave fibaro devices which also have the possibility to connect a temperature sensor to them as well as with any other sensor (not even related to zwave) which reports a number along with the unit of measurement which can be one of the classic constants (°C, °F or %) and Google Assistant can be queried for the temperature or humidity in the room where the device is reported to be installed.

Since they are sensors and can only report a value they can only be queried that's why I've quoted "climate" since you can't turn them on or off or perform any other settings like temperature, humidity, etc like a complete climate device would be able to.

## Example entry for `configuration.yaml` (if applicable):
```yaml
    sensor.qubino_zmnhbdx_flush_2_relays_temperature:
      google_assistant: true
      google_assistant_type: climate
      google_assistant_name: bedroom
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
