### PR TITLE
Move IMAP Email Content body to an attribute

### DIFF
--- a/homeassistant/components/sensor/imap_email_content.py
+++ b/homeassistant/components/sensor/imap_email_content.py
@@ -219,12 +219,12 @@ class EmailContentSensor(Entity):
             return
 
         if self.sender_allowed(email_message):
-            message_body = EmailContentSensor.get_msg_subject(email_message)
+            message = EmailContentSensor.get_msg_subject(email_message)
 
             if self._value_template is not None:
-                message_body = self.render_template(email_message)
+                message = self.render_template(email_message)
 
-            self._message = message_body
+            self._message = message
             self._state_attributes = {
                 ATTR_FROM:
                     EmailContentSensor.get_msg_sender(email_message),

--- a/homeassistant/components/sensor/imap_email_content.py
+++ b/homeassistant/components/sensor/imap_email_content.py
@@ -219,7 +219,7 @@ class EmailContentSensor(Entity):
             return
 
         if self.sender_allowed(email_message):
-            message_body = EmailContentSensor.get_msg_text(email_message)
+            message_body = EmailContentSensor.get_msg_subject(email_message)
 
             if self._value_template is not None:
                 message_body = self.render_template(email_message)
@@ -231,5 +231,7 @@ class EmailContentSensor(Entity):
                 ATTR_SUBJECT:
                     EmailContentSensor.get_msg_subject(email_message),
                 ATTR_DATE:
-                    email_message['Date']
+                    email_message['Date'],
+                ATTR_BODY:
+                    EmailContentSensor.get_msg_text(email_message)
             }

--- a/tests/components/sensor/test_imap_email_content.py
+++ b/tests/components/sensor/test_imap_email_content.py
@@ -60,7 +60,9 @@ class EmailContentSensor(unittest.TestCase):
         sensor.entity_id = 'sensor.emailtest'
         sensor.schedule_update_ha_state(True)
         self.hass.block_till_done()
-        self.assertEqual("Test Message", sensor.state)
+        self.assertEqual('Test', sensor.state)
+        self.assertEqual("Test Message",
+                         sensor.device_state_attributes['body'])
         self.assertEqual('sender@test.com',
                          sensor.device_state_attributes['from'])
         self.assertEqual('Test', sensor.device_state_attributes['subject'])
@@ -89,13 +91,15 @@ class EmailContentSensor(unittest.TestCase):
         sensor.entity_id = "sensor.emailtest"
         sensor.schedule_update_ha_state(True)
         self.hass.block_till_done()
-        self.assertEqual("Test Message", sensor.state)
+        self.assertEqual('Link', sensor.state)
+        self.assertEqual("Test Message",
+                         sensor.device_state_attributes['body'])
 
     def test_multi_part_only_html(self):
         """Test multi part emails with only HTML."""
         msg = MIMEMultipart('alternative')
-        msg['Subject'] = "Link"
-        msg['From'] = "sender@test.com"
+        msg['Subject'] = 'Link'
+        msg['From'] = 'sender@test.com'
 
         html = "<html><head></head><body>Test Message</body></html>"
 
@@ -113,9 +117,10 @@ class EmailContentSensor(unittest.TestCase):
         sensor.entity_id = 'sensor.emailtest'
         sensor.schedule_update_ha_state(True)
         self.hass.block_till_done()
+        self.assertEqual('Link', sensor.state)
         self.assertEqual(
             "<html><head></head><body>Test Message</body></html>",
-            sensor.state)
+            sensor.device_state_attributes['body'])
 
     def test_multi_part_only_other_text(self):
         """Test multi part emails with only other text."""
@@ -136,7 +141,9 @@ class EmailContentSensor(unittest.TestCase):
         sensor.entity_id = 'sensor.emailtest'
         sensor.schedule_update_ha_state(True)
         self.hass.block_till_done()
-        self.assertEqual("Test Message", sensor.state)
+        self.assertEqual('Link', sensor.state)
+        self.assertEqual("Test Message",
+                         sensor.device_state_attributes['body'])
 
     def test_multiple_emails(self):
         """Test multiple emails."""
@@ -172,10 +179,11 @@ class EmailContentSensor(unittest.TestCase):
         sensor.schedule_update_ha_state(True)
         self.hass.block_till_done()
 
-        self.assertEqual("Test Message", states[0].state)
-        self.assertEqual("Test Message 2", states[1].state)
+        self.assertEqual("Test", states[0].state)
+        self.assertEqual("Test 2", states[1].state)
 
-        self.assertEqual("Test Message 2", sensor.state)
+        self.assertEqual("Test Message 2",
+                         sensor.device_state_attributes['body'])
 
     def test_sender_not_allowed(self):
         """Test not whitelisted emails."""


### PR DESCRIPTION
## Description:
This change to IMAP Email Content sensor makes the state the email subject and moves the body to an attribute.  This is to work around the new 255 character limit for states.

**Related issue (if applicable):** fixes #10512

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4199

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: imap_email_content
  server: imap.gmail.com
  port: 993
  username: !secret imap_username
  password: !secret imap_password
  senders:
    - !secret imap_email1
    - !secret imap_email2
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] ~~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  - [ ] ~~New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  - [ ] ~~New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
  - [ ] ~~New files were added to `.coveragerc`.~~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
