### PR TITLE
set default utc offset to 0

### DIFF
--- a/homeassistant/components/sensor/efergy.py
+++ b/homeassistant/components/sensor/efergy.py
@@ -31,6 +31,7 @@ CONF_COST = 'cost'
 CONF_CURRENT_VALUES = 'current_values'
 
 DEFAULT_PERIOD = 'year'
+DEFAULT_UTC_OFFSET = '0'
 
 SENSOR_TYPES = {
     CONF_INSTANT: ['Energy Usage', 'W'],
@@ -50,7 +51,7 @@ SENSORS_SCHEMA = vol.Schema({
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_APPTOKEN): cv.string,
-    vol.Optional(CONF_UTC_OFFSET): cv.string,
+    vol.Optional(CONF_UTC_OFFSET, default=DEFAULT_UTC_OFFSET): cv.string,
     vol.Required(CONF_MONITORED_VARIABLES): [SENSORS_SCHEMA]
 })
 


### PR DESCRIPTION
## Description:

When offset isn't set, efergy api returns  
```
{
  error: {
    id: 400,
    desc: "Bad Request",
    more: "Bad formatting for : offset (not an int)"
  }
}
```
rather than a successful response.

This changes the default utc offset to be `0`