### PR TITLE
Fixed typo in automation.py

### DIFF
--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -1,4 +1,4 @@
-"""Provide configuration end points for Z-Wave."""
+"""Provide configuration end points for Automations."""
 import asyncio
 
 from homeassistant.components.config import EditIdBasedConfigView


### PR DESCRIPTION
This is a fix for a docstring in automation.py