### PR TITLE
Deprecate explicit entity_id in template platforms

### DIFF
--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -38,6 +38,11 @@ SENSOR_SCHEMA = vol.Schema({
         vol.All(cv.time_period, cv.positive_timedelta),
 })
 
+SENSOR_SCHEMA = vol.All(
+    cv.deprecated(ATTR_ENTITY_ID),
+    SENSOR_SCHEMA,
+)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SENSORS): vol.Schema({cv.slug: SENSOR_SCHEMA}),
 })
@@ -49,11 +54,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     sensors = []
 
     for device, device_config in config[CONF_SENSORS].items():
-        if device_config.get(ATTR_ENTITY_ID):
-            _LOGGER.warning(
-                "Unneeded 'entity_id' in %s template '%s' is deprecated.",
-                "binary_sensor", device)
-
         value_template = device_config[CONF_VALUE_TEMPLATE]
         entity_ids = (device_config.get(ATTR_ENTITY_ID) or
                       value_template.extract_entities())

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -49,6 +49,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     sensors = []
 
     for device, device_config in config[CONF_SENSORS].items():
+        if device_config.get(ATTR_ENTITY_ID):
+            _LOGGER.warning(
+                "Unneeded 'entity_id' in %s template '%s' is deprecated.",
+                "binary_sensor", device)
+
         value_template = device_config[CONF_VALUE_TEMPLATE]
         entity_ids = (device_config.get(ATTR_ENTITY_ID) or
                       value_template.extract_entities())

--- a/homeassistant/components/cover/template.py
+++ b/homeassistant/components/cover/template.py
@@ -67,9 +67,9 @@ COVER_SCHEMA = vol.Schema({
     vol.Optional(CONF_ENTITY_ID): cv.entity_ids
 })
 
-SENSOR_SCHEMA = vol.All(
+COVER_SCHEMA = vol.All(
     cv.deprecated(CONF_ENTITY_ID),
-    SENSOR_SCHEMA,
+    COVER_SCHEMA,
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/cover/template.py
+++ b/homeassistant/components/cover/template.py
@@ -67,6 +67,11 @@ COVER_SCHEMA = vol.Schema({
     vol.Optional(CONF_ENTITY_ID): cv.entity_ids
 })
 
+SENSOR_SCHEMA = vol.All(
+    cv.deprecated(CONF_ENTITY_ID),
+    SENSOR_SCHEMA,
+)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COVERS): vol.Schema({cv.slug: COVER_SCHEMA}),
 })
@@ -78,11 +83,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     covers = []
 
     for device, device_config in config[CONF_COVERS].items():
-        if device_config.get(CONF_ENTITY_ID):
-            _LOGGER.warning(
-                "Unneeded 'entity_id' in %s template '%s' is deprecated.",
-                "cover", device)
-
         friendly_name = device_config.get(CONF_FRIENDLY_NAME, device)
         state_template = device_config.get(CONF_VALUE_TEMPLATE)
         position_template = device_config.get(CONF_POSITION_TEMPLATE)

--- a/homeassistant/components/cover/template.py
+++ b/homeassistant/components/cover/template.py
@@ -78,6 +78,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     covers = []
 
     for device, device_config in config[CONF_COVERS].items():
+        if device_config.get(CONF_ENTITY_ID):
+            _LOGGER.warning(
+                "Unneeded 'entity_id' in %s template '%s' is deprecated.",
+                "cover", device)
+
         friendly_name = device_config.get(CONF_FRIENDLY_NAME, device)
         state_template = device_config.get(CONF_VALUE_TEMPLATE)
         position_template = device_config.get(CONF_POSITION_TEMPLATE)

--- a/homeassistant/components/light/template.py
+++ b/homeassistant/components/light/template.py
@@ -44,9 +44,9 @@ LIGHT_SCHEMA = vol.Schema({
     vol.Optional(CONF_ENTITY_ID): cv.entity_ids
 })
 
-SENSOR_SCHEMA = vol.All(
+LIGHT_SCHEMA = vol.All(
     cv.deprecated(CONF_ENTITY_ID),
-    SENSOR_SCHEMA,
+    LIGHT_SCHEMA,
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/light/template.py
+++ b/homeassistant/components/light/template.py
@@ -55,6 +55,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     lights = []
 
     for device, device_config in config[CONF_LIGHTS].items():
+        if device_config.get(CONF_ENTITY_ID):
+            _LOGGER.warning(
+                "Unneeded 'entity_id' in %s template '%s' is deprecated.",
+                "light", device)
+
         friendly_name = device_config.get(CONF_FRIENDLY_NAME, device)
         state_template = device_config[CONF_VALUE_TEMPLATE]
         icon_template = device_config.get(CONF_ICON_TEMPLATE)

--- a/homeassistant/components/light/template.py
+++ b/homeassistant/components/light/template.py
@@ -44,6 +44,11 @@ LIGHT_SCHEMA = vol.Schema({
     vol.Optional(CONF_ENTITY_ID): cv.entity_ids
 })
 
+SENSOR_SCHEMA = vol.All(
+    cv.deprecated(CONF_ENTITY_ID),
+    SENSOR_SCHEMA,
+)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_LIGHTS): vol.Schema({cv.slug: LIGHT_SCHEMA}),
 })
@@ -55,11 +60,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     lights = []
 
     for device, device_config in config[CONF_LIGHTS].items():
-        if device_config.get(CONF_ENTITY_ID):
-            _LOGGER.warning(
-                "Unneeded 'entity_id' in %s template '%s' is deprecated.",
-                "light", device)
-
         friendly_name = device_config.get(CONF_FRIENDLY_NAME, device)
         state_template = device_config[CONF_VALUE_TEMPLATE]
         icon_template = device_config.get(CONF_ICON_TEMPLATE)

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -31,6 +31,11 @@ SENSOR_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
 })
 
+SENSOR_SCHEMA = vol.All(
+    cv.deprecated(ATTR_ENTITY_ID),
+    SENSOR_SCHEMA,
+)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SENSORS): vol.Schema({cv.slug: SENSOR_SCHEMA}),
 })
@@ -43,11 +48,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     sensors = []
 
     for device, device_config in config[CONF_SENSORS].items():
-        if device_config.get(ATTR_ENTITY_ID):
-            _LOGGER.warning(
-                "Unneeded 'entity_id' in %s template '%s' is deprecated.",
-                "sensor", device)
-
         state_template = device_config[CONF_VALUE_TEMPLATE]
         icon_template = device_config.get(CONF_ICON_TEMPLATE)
         entity_picture_template = device_config.get(

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -43,6 +43,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     sensors = []
 
     for device, device_config in config[CONF_SENSORS].items():
+        if device_config.get(ATTR_ENTITY_ID):
+            _LOGGER.warning(
+                "Unneeded 'entity_id' in %s template '%s' is deprecated.",
+                "sensor", device)
+
         state_template = device_config[CONF_VALUE_TEMPLATE]
         icon_template = device_config.get(CONF_ICON_TEMPLATE)
         entity_picture_template = device_config.get(

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -38,6 +38,11 @@ SWITCH_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
 })
 
+SENSOR_SCHEMA = vol.All(
+    cv.deprecated(ATTR_ENTITY_ID),
+    SENSOR_SCHEMA,
+)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SWITCHES): vol.Schema({cv.slug: SWITCH_SCHEMA}),
 })
@@ -50,11 +55,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     switches = []
 
     for device, device_config in config[CONF_SWITCHES].items():
-        if device_config.get(ATTR_ENTITY_ID):
-            _LOGGER.warning(
-                "Unneeded 'entity_id' in %s template '%s' is deprecated.",
-                "switch", device)
-
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         state_template = device_config[CONF_VALUE_TEMPLATE]
         icon_template = device_config.get(CONF_ICON_TEMPLATE)

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -50,6 +50,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     switches = []
 
     for device, device_config in config[CONF_SWITCHES].items():
+        if device_config.get(ATTR_ENTITY_ID):
+            _LOGGER.warning(
+                "Unneeded 'entity_id' in %s template '%s' is deprecated.",
+                "switch", device)
+
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         state_template = device_config[CONF_VALUE_TEMPLATE]
         icon_template = device_config.get(CONF_ICON_TEMPLATE)

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -38,9 +38,9 @@ SWITCH_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
 })
 
-SENSOR_SCHEMA = vol.All(
+SWITCH_SCHEMA = vol.All(
     cv.deprecated(ATTR_ENTITY_ID),
-    SENSOR_SCHEMA,
+    SWITCH_SCHEMA,
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -5,6 +5,8 @@ import os
 import re
 from urllib.parse import urlparse
 from socket import _GLOBAL_DEFAULT_TIMEOUT
+import logging
+import inspect
 
 from typing import Any, Union, TypeVar, Callable, Sequence, Dict
 
@@ -428,6 +430,22 @@ def ensure_list_csv(value: Any) -> Sequence:
     if isinstance(value, str):
         return [member.strip() for member in value.split(',')]
     return ensure_list(value)
+
+
+def deprecated(key):
+    """Log key as deprecated."""
+    module_name = inspect.getmodule(inspect.stack()[1][0]).__name__
+
+    def validator(config):
+        """Check if key is in config and log warning."""
+        if key in config:
+            logging.getLogger(module_name).warning(
+                "The '%s' option is deprecated, please remove it from your "
+                "configuration.", key)
+
+        return config
+
+    return validator
 
 
 # Validator helpers

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -440,8 +440,8 @@ def deprecated(key):
         """Check if key is in config and log warning."""
         if key in config:
             logging.getLogger(module_name).warning(
-                "The '%s' option is deprecated, please remove it from your "
-                "configuration.", key)
+                "The '%s' option (with value '%s') is deprecated, please "
+                "remove it from your configuration.", key, config[key])
 
         return config
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -453,9 +453,11 @@ def test_deprecated(caplog):
     )
 
     deprecated_schema({'venus': True})
-    assert "venus" not in caplog.text
+    assert len(caplog.records) == 0
 
     deprecated_schema({'mars': True})
+    assert len(caplog.records) == 1
+    assert caplog.records[0].name == __name__
     assert ("The 'mars' option (with value 'True') is deprecated, "
             "please remove it from your configuration.") in caplog.text
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -441,6 +441,25 @@ def test_datetime():
     schema('2016-11-23T18:59:08')
 
 
+def test_deprecated(caplog):
+    """Test deprecation log."""
+    schema = vol.Schema({
+        'venus': cv.boolean,
+        'mars': cv.boolean
+    })
+    deprecated_schema = vol.All(
+        cv.deprecated('mars'),
+        schema
+    )
+
+    deprecated_schema({'venus': True})
+    assert "venus" not in caplog.text
+
+    deprecated_schema({'mars': True})
+    assert ("The 'mars' option (with value 'True') is deprecated, "
+            "please remove it from your configuration.") in caplog.text
+
+
 def test_key_dependency():
     """Test key_dependency validator."""
     schema = vol.Schema(cv.key_dependency('beer', 'soda'))


### PR DESCRIPTION
## Description:

The optional `entity_id` configuration introduced for template platforms in #2144 was obsoleted by the automatic entity id extraction in #3521.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4209

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [X] Tests have been added to verify that the new code works.
