### PR TITLE
Always consume the no_throttle keyword argument.

### DIFF
--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -299,7 +299,7 @@ class Throttle(object):
                 return None
 
             # Check if method is never called or no_throttle is given
-            force = not throttle[1] or kwargs.pop('no_throttle', False)
+            force = kwargs.pop('no_throttle', False) or not throttle[1]
 
             try:
                 if force or utcnow() - throttle[1] > self.min_time:


### PR DESCRIPTION
The current code relies on the assumption that the first invocation will never specify no_throttle=True.
However that puts us in a pickle when writing unit tests: if we had a fictitious:

  def setup_platform():
    update()

  @Throttle(MIN_TIME_BETWEEN_SCANS)
  def update():
    pass

Then given multiple tests, the second and some of subsequent tests would be throttled (depending on timing).
But we also can't change that code to call `update(no_throttle=True)' because that's not currently accepted.

This diff shouldn't change the visibile behavior of any component, but allows this extra flexibility.

## Description:


**Related issue (if applicable):** fixes #11125

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
