### PR TITLE
Skip HASS emulated Hue bridges from detection.

### DIFF
--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -107,6 +107,9 @@ def setup(hass, config):
 
 def bridge_discovered(hass, service, discovery_info):
     """Dispatcher for Hue discovery events."""
+    if "HASS Bridge" in discovery_info.get('name', ''):
+        return
+
     host = discovery_info.get('host')
     serial = discovery_info.get('serial')
 


### PR DESCRIPTION
When refactoring the Hue support we lost a check for HASS bridges; restore that.

## Description:


**Related issue (if applicable):** fixes #11127

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
