### PR TITLE
Disable html5 notify dependency

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -29,7 +29,7 @@ from homeassistant.util import ensure_unique_string
 
 REQUIREMENTS = ['pywebpush==1.3.0', 'PyJWT==1.5.3']
 
-DEPENDENCIES = ['frontend', 'config']
+DEPENDENCIES = ['frontend']
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
I've added `config` as a dependency to the notify.html5 platform. Forgot about the explicit blacklist that you are not allowed to depend on `config` (as it exposes an interface to update the Home Assistant configuration)