### PR TITLE
Allow setting headers in camera.generic

### DIFF
--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -27,7 +27,6 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_CONTENT_TYPE = 'content_type'
 CONF_LIMIT_REFETCH_TO_URL_CHANGE = 'limit_refetch_to_url_change'
-CONF_REFERER = 'referer'
 CONF_STILL_IMAGE_URL = 'still_image_url'
 
 DEFAULT_NAME = 'Generic Camera'

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -15,7 +15,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_AUTHENTICATION,
-    HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION)
+    CONF_HEADERS, HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION)
 from homeassistant.exceptions import TemplateError
 from homeassistant.components.camera import (
     PLATFORM_SCHEMA, DEFAULT_CONTENT_TYPE, Camera)
@@ -41,7 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_CONTENT_TYPE, default=DEFAULT_CONTENT_TYPE): cv.string,
-    vol.Optional(CONF_REFERER): cv.string
+    vol.Optional(CONF_HEADERS): {cv.string: cv.string}
 })
 
 
@@ -77,11 +77,7 @@ class GenericCamera(Camera):
         else:
             self._auth = None
 
-        referer = device_info.get(CONF_REFERER)
-        if referer:
-            self._headers = {'Referer': referer}
-        else:
-            self._headers = None
+        self._headers = device_info.get(CONF_HEADERS)
 
         self._last_url = None
         self._last_image = None


### PR DESCRIPTION
## Description:
I wanted to include the public camera feed from [this public webcam](http://metz.fr/pages/webcams/quartier_amphitheatre.php), but it required the `Referer` header to be set correctly. This PR adds a new config option to set ~~the `Referer` header~~ any header.

## Documentation
https://github.com/home-assistant/home-assistant.github.io/pull/4212

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: generic
    name: pompidou
    still_image_url: "http://metz.fr/pages/webcams/images/amphitheatre.jpg?{{ as_timestamp(now()) * 1000 }}"
    headers:
      referer: "http://metz.fr/pages/webcams/quartier_amphitheatre.php"
```