### PR TITLE
Fix X10 commands for mochad light turn on

### DIFF
--- a/homeassistant/components/light/mochad.py
+++ b/homeassistant/components/light/mochad.py
@@ -12,8 +12,8 @@ import voluptuous as vol
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light, PLATFORM_SCHEMA)
 from homeassistant.components import mochad
-from homeassistant.const import (CONF_NAME, CONF_PLATFORM, CONF_DEVICES,
-                                 CONF_ADDRESS)
+from homeassistant.const import (
+    CONF_NAME, CONF_PLATFORM, CONF_DEVICES, CONF_ADDRESS)
 from homeassistant.helpers import config_validation as cv
 
 DEPENDENCIES = ['mochad']
@@ -28,7 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Optional(CONF_NAME): cv.string,
         vol.Required(CONF_ADDRESS): cv.x10_address,
         vol.Optional(mochad.CONF_COMM_TYPE): cv.string,
-        vol.Optional(CONF_BRIGHTNESS_LEVELS, default=32): 
+        vol.Optional(CONF_BRIGHTNESS_LEVELS, default=32):
             vol.All(vol.Coerce(int), vol.In([32, 64, 256])),
     }]
 })

--- a/homeassistant/components/light/mochad.py
+++ b/homeassistant/components/light/mochad.py
@@ -19,6 +19,8 @@ from homeassistant.helpers import config_validation as cv
 DEPENDENCIES = ['mochad']
 _LOGGER = logging.getLogger(__name__)
 
+CONF_BRIGHTNESS_LEVELS = 'brightness_levels'
+
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PLATFORM): mochad.DOMAIN,
@@ -26,7 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Optional(CONF_NAME): cv.string,
         vol.Required(CONF_ADDRESS): cv.x10_address,
         vol.Optional(mochad.CONF_COMM_TYPE): cv.string,
-        vol.Optional('brightness_levels', default=32): 
+        vol.Optional(CONF_BRIGHTNESS_LEVELS, default=32): 
             vol.All(vol.Coerce(int), vol.In([32, 64, 256])),
     }]
 })
@@ -56,7 +58,7 @@ class MochadLight(Light):
                                     comm_type=self._comm_type)
         self._brightness = 0
         self._state = self._get_device_status()
-        self._brightness_levels = dev.get('brightness_levels', 32) - 1
+        self._brightness_levels = dev.get(CONF_BRIGHTNESS_LEVELS) - 1
 
     @property
     def brightness(self):

--- a/homeassistant/components/light/mochad.py
+++ b/homeassistant/components/light/mochad.py
@@ -26,9 +26,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Optional(CONF_NAME): cv.string,
         vol.Required(CONF_ADDRESS): cv.x10_address,
         vol.Optional(mochad.CONF_COMM_TYPE): cv.string,
-        vol.Optional('brightness_levels',
-                     default=32): vol.All(vol.Coerce(int),
-                                          vol.In([32, 64, 256])),
+        vol.Optional('brightness_levels', default=32): 
+            vol.All(vol.Coerce(int), vol.In([32, 64, 256])),
     }]
 })
 

--- a/homeassistant/components/light/mochad.py
+++ b/homeassistant/components/light/mochad.py
@@ -26,6 +26,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Optional(CONF_NAME): cv.string,
         vol.Required(CONF_ADDRESS): cv.x10_address,
         vol.Optional(mochad.CONF_COMM_TYPE): cv.string,
+        vol.Optional('brightness_levels',
+                     default=32): vol.All(vol.Coerce(int),
+                                          vol.In([32, 64, 256])),
     }]
 })
 
@@ -54,6 +57,7 @@ class MochadLight(Light):
                                     comm_type=self._comm_type)
         self._brightness = 0
         self._state = self._get_device_status()
+        self._brightness_levels = dev.get('brightness_levels', 32) - 1
 
     @property
     def brightness(self):
@@ -86,12 +90,38 @@ class MochadLight(Light):
         """X10 devices are normally 1-way so we have to assume the state."""
         return True
 
+    def _calculate_brightness_value(self, value):
+        return int(value * (float(self._brightness_levels) / 255.0))
+
+    def _adjust_brightness(self, brightness):
+        if self._brightness > brightness:
+            bdelta = self._brightness - brightness
+            mochad_brightness = self._calculate_brightness_value(bdelta)
+            self.device.send_cmd("dim {}".format(mochad_brightness))
+            self._controller.read_data()
+        elif self._brightness < brightness:
+            bdelta = brightness - self._brightness
+            mochad_brightness = self._calculate_brightness_value(bdelta)
+            self.device.send_cmd("bright {}".format(mochad_brightness))
+            self._controller.read_data()
+
     def turn_on(self, **kwargs):
         """Send the command to turn the light on."""
-        self._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
         with mochad.REQ_LOCK:
-            self.device.send_cmd("xdim {}".format(self._brightness))
-            self._controller.read_data()
+            if self._brightness_levels > 32:
+                out_brightness = self._calculate_brightness_value(brightness)
+                self.device.send_cmd('xdim {}'.format(out_brightness))
+                self._controller.read_data()
+            else:
+                self.device.send_cmd("on")
+                self._controller.read_data()
+                # There is no persistence for X10 modules so a fresh on command
+                # will be full brightness
+                if self._brightness == 0:
+                    self._brightness = 255
+                self._adjust_brightness(brightness)
+        self._brightness = brightness
         self._state = True
 
     def turn_off(self, **kwargs):
@@ -99,4 +129,8 @@ class MochadLight(Light):
         with mochad.REQ_LOCK:
             self.device.send_cmd('off')
             self._controller.read_data()
+            # There is no persistence for X10 modules so we need to prepare
+            # to track a fresh on command will full brightness
+            if self._brightness_levels == 31:
+                self._brightness = 0
         self._state = False

--- a/tests/components/light/test_mochad.py
+++ b/tests/components/light/test_mochad.py
@@ -60,7 +60,8 @@ class TestMochadLight(unittest.TestCase):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         controller_mock = mock.MagicMock()
-        dev_dict = {'address': 'a1', 'name': 'fake_light'}
+        dev_dict = {'address': 'a1', 'name': 'fake_light',
+                    'brightness_levels': 32}
         self.light = mochad.MochadLight(self.hass, controller_mock,
                                         dev_dict)
 

--- a/tests/components/light/test_mochad.py
+++ b/tests/components/light/test_mochad.py
@@ -75,12 +75,77 @@ class TestMochadLight(unittest.TestCase):
     def test_turn_on_with_no_brightness(self):
         """Test turn_on."""
         self.light.turn_on()
+        self.light.device.send_cmd.assert_called_once_with('on')
+
+    def test_turn_on_with_brightness(self):
+        """Test turn_on."""
+        self.light.turn_on(brightness=45)
+        self.light.device.send_cmd.assert_has_calls(
+            [mock.call('on'), mock.call('dim 25')])
+
+    def test_turn_off(self):
+        """Test turn_off."""
+        self.light.turn_off()
+        self.light.device.send_cmd.assert_called_once_with('off')
+
+
+class TestMochadLight256Levels(unittest.TestCase):
+    """Test for mochad light platform."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        controller_mock = mock.MagicMock()
+        dev_dict = {'address': 'a1', 'name': 'fake_light',
+                    'brightness_levels': 256}
+        self.light = mochad.MochadLight(self.hass, controller_mock,
+                                        dev_dict)
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_turn_on_with_no_brightness(self):
+        """Test turn_on."""
+        self.light.turn_on()
         self.light.device.send_cmd.assert_called_once_with('xdim 255')
 
     def test_turn_on_with_brightness(self):
         """Test turn_on."""
         self.light.turn_on(brightness=45)
         self.light.device.send_cmd.assert_called_once_with('xdim 45')
+
+    def test_turn_off(self):
+        """Test turn_off."""
+        self.light.turn_off()
+        self.light.device.send_cmd.assert_called_once_with('off')
+
+
+class TestMochadLight64Levels(unittest.TestCase):
+    """Test for mochad light platform."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        controller_mock = mock.MagicMock()
+        dev_dict = {'address': 'a1', 'name': 'fake_light',
+                    'brightness_levels': 64}
+        self.light = mochad.MochadLight(self.hass, controller_mock,
+                                        dev_dict)
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_turn_on_with_no_brightness(self):
+        """Test turn_on."""
+        self.light.turn_on()
+        self.light.device.send_cmd.assert_called_once_with('xdim 63')
+
+    def test_turn_on_with_brightness(self):
+        """Test turn_on."""
+        self.light.turn_on(brightness=45)
+        self.light.device.send_cmd.assert_called_once_with('xdim 11')
 
     def test_turn_off(self):
         """Test turn_off."""


### PR DESCRIPTION
## Description:

This commit attempts to address issues that a lot of people are having
with the x10 light component. Originally this was written to use the
xdim (extended dim) X10 command. However, not every X10 dimmer device
supports the xdim command. Additionally, it turns out the number of
dim/brighness levels the X10 device supports is device specific and
there is no way to detect this (given the mostly 1 way nature of X10)

To address these issues, this commit removes the usage of xdim and
instead relies on using the 'on' command and the 'dim' command. This
should work on all x10 light devices. In an attempt to address the
different dim/brightness levels supported by different devices this
commit also adds a new optional config value, 'brightness_levels', to
specify if it's either 32, 64, or 256. By default 32 levels are used
as this is the normal case and what is documented by mochad.

**Related issue (if applicable):** 
Fixes #8943

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4214

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  mochad:
    devices:
       - address: a1
         brightness_levels: 64
```

## Checklist:

  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
