### PR TITLE
Support pushing all sensors and fix wrong metrics (prometheus).

### DIFF
--- a/homeassistant/components/prometheus.py
+++ b/homeassistant/components/prometheus.py
@@ -13,14 +13,14 @@ from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components import recorder
 from homeassistant.const import (
-    CONF_DOMAINS, CONF_ENTITIES, CONF_EXCLUDE, CONF_INCLUDE, TEMP_CELSIUS,
+    CONF_DOMAINS, CONF_ENTITIES, CONF_EXCLUDE, CONF_INCLUDE,
     EVENT_STATE_CHANGED, TEMP_FAHRENHEIT, CONTENT_TYPE_TEXT_PLAIN,
     ATTR_TEMPERATURE, ATTR_UNIT_OF_MEASUREMENT)
 from homeassistant import core as hacore
 from homeassistant.helpers import state as state_helper
 from homeassistant.util.temperature import fahrenheit_to_celsius
 
-REQUIREMENTS = ['prometheus_client==0.0.21']
+REQUIREMENTS = ['prometheus_client==0.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -181,57 +181,26 @@ class Metrics(object):
             pass
 
     def _handle_sensor(self, state):
-        _sensor_types = {
-            TEMP_CELSIUS: (
-                'temperature_c', self.prometheus_client.Gauge,
-                'Temperature in degrees Celsius',
-            ),
-            TEMP_FAHRENHEIT: (
-                'temperature_c', self.prometheus_client.Gauge,
-                'Temperature in degrees Celsius',
-            ),
-            '%': (
-                'relative_humidity', self.prometheus_client.Gauge,
-                'Relative humidity (0..100)',
-            ),
-            'lux': (
-                'light_lux', self.prometheus_client.Gauge,
-                'Light level in lux',
-            ),
-            'kWh': (
-                'electricity_used_kwh', self.prometheus_client.Gauge,
-                'Electricity used by this device in KWh',
-            ),
-            'V': (
-                'voltage', self.prometheus_client.Gauge,
-                'Currently reported voltage in Volts',
-            ),
-            'W': (
-                'electricity_usage_w', self.prometheus_client.Gauge,
-                'Currently reported electricity draw in Watts',
-            ),
-            'min': (
-                'sensor_min', self.prometheus_client.Gauge,
-                'Time in minutes reported by a sensor'
-            ),
-            'Events': (
-                'sensor_event_count', self.prometheus_client.Gauge,
-                'Number of events for a sensor'
-            ),
-        }
 
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        metric = _sensor_types.get(unit)
+        metric = state.entity_id.split(".")[1]
 
-        if metric is not None:
-            metric = self._metric(*metric)
-            try:
-                value = state_helper.state_as_number(state)
-                if unit == TEMP_FAHRENHEIT:
-                    value = fahrenheit_to_celsius(value)
-                metric.labels(**self._labels(state)).set(value)
-            except ValueError:
-                pass
+        try:
+            int(metric.split("_")[-1])
+            metric = "_".join(metric.split("_")[:-1])
+        except ValueError:
+            pass
+
+        _metric = self._metric(metric, self.prometheus_client.Gauge,
+                               state.entity_id)
+
+        try:
+            value = state_helper.state_as_number(state)
+            if unit == TEMP_FAHRENHEIT:
+                value = fahrenheit_to_celsius(value)
+            _metric.labels(**self._labels(state)).set(value)
+        except ValueError:
+            pass
 
         self._battery(state)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -569,7 +569,7 @@ pocketcasts==0.1
 proliphix==0.4.1
 
 # homeassistant.components.prometheus
-prometheus_client==0.0.21
+prometheus_client==0.1.0
 
 # homeassistant.components.sensor.systemmonitor
 psutil==5.4.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -116,7 +116,7 @@ pilight==0.1.1
 pmsensor==0.4
 
 # homeassistant.components.prometheus
-prometheus_client==0.0.21
+prometheus_client==0.1.0
 
 # homeassistant.components.canary
 py-canary==0.2.3


### PR DESCRIPTION
## Description:

For example all metrics with unit % match humidity.
This generate correct metrics like this
```
# HELP nut_ups_battery_charge sensor.nut_ups_battery_charge
# TYPE nut_ups_battery_charge gauge
nut_ups_battery_charge{entity="sensor.nut_ups_battery_charge",friendly_name="NUT UPS Battery Charge"} 98.0
nut_ups_battery_charge{entity="sensor.nut_ups_battery_charge_2",friendly_name="NUT UPS Battery Charge"} 97.0

Contains breaking changes => changed some metric labels

```
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

fixes #10084, fixes #9346

- https://community.home-assistant.io/t/prometheus-missing-data/23888

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
