### PR TITLE
Don't connect to cloud if subscription expired

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -27,7 +27,7 @@ CONF_RELAYER = 'relayer'
 CONF_USER_POOL_ID = 'user_pool_id'
 
 MODE_DEV = 'development'
-DEFAULT_MODE = MODE_DEV
+DEFAULT_MODE = 'production'
 DEPENDENCIES = ['http']
 
 ALEXA_SCHEMA = vol.Schema({
@@ -42,10 +42,10 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_MODE, default=DEFAULT_MODE):
             vol.In([MODE_DEV] + list(SERVERS)),
         # Change to optional when we include real servers
-        vol.Required(CONF_COGNITO_CLIENT_ID): str,
-        vol.Required(CONF_USER_POOL_ID): str,
-        vol.Required(CONF_REGION): str,
-        vol.Required(CONF_RELAYER): str,
+        vol.Optional(CONF_COGNITO_CLIENT_ID): str,
+        vol.Optional(CONF_USER_POOL_ID): str,
+        vol.Optional(CONF_REGION): str,
+        vol.Optional(CONF_RELAYER): str,
         vol.Optional(CONF_ALEXA): ALEXA_SCHEMA
     }),
 }, extra=vol.ALLOW_EXTRA)
@@ -117,10 +117,6 @@ class Cloud:
     @property
     def subscription_expired(self):
         """Return a boolen if the subscription has expired."""
-        # For now, don't enforce subscriptions to exist
-        if 'custom:sub-exp' not in self.claims:
-            return False
-
         return dt_util.utcnow() > self.expiration_date
 
     @property

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -4,13 +4,12 @@ CONFIG_DIR = '.cloud'
 REQUEST_TIMEOUT = 10
 
 SERVERS = {
-    # Example entry:
-    # 'production': {
-    #     'cognito_client_id': '',
-    #     'user_pool_id': '',
-    #     'region': '',
-    #     'relayer': ''
-    # }
+    'production': {
+        'cognito_client_id': '60i2uvhvbiref2mftj7rgcrt9u',
+        'user_pool_id': 'us-east-1_87ll5WOP8',
+        'region': 'us-east-1',
+        'relayer': 'wss://cloud.hass.io:8000/websocket'
+    }
 }
 
 MESSAGE_EXPIRATION = """

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -110,6 +110,9 @@ sensor:
 tts:
   - platform: google
 
+# Cloud
+cloud:
+
 group: !include groups.yaml
 automation: !include automations.yaml
 script: !include scripts.yaml

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -133,15 +133,6 @@ def test_write_user_info():
 
 
 @asyncio.coroutine
-def test_subscription_not_expired_without_sub_in_claim():
-    """Test that we do not enforce subscriptions yet."""
-    cl = cloud.Cloud(None, cloud.MODE_DEV)
-    cl.id_token = jwt.encode({}, 'test')
-
-    assert not cl.subscription_expired
-
-
-@asyncio.coroutine
 def test_subscription_expired():
     """Test subscription being expired."""
     cl = cloud.Cloud(None, cloud.MODE_DEV)


### PR DESCRIPTION
This will make sure the cloud component does not try to connect when the subscription has expired (connection would bounce anyway)