### PR TITLE
Enable compression when sending json to client

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -362,9 +362,11 @@ class HomeAssistantView(object):
         """Return a JSON response."""
         msg = json.dumps(
             result, sort_keys=True, cls=rem.JSONEncoder).encode('UTF-8')
-        return web.Response(
+        j = web.Response(
             body=msg, content_type=CONTENT_TYPE_JSON, status=status_code,
             headers=headers)
+        j.enable_compression()
+        return j
 
     def json_message(self, message, status_code=200, message_code=None,
                      headers=None):

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -362,11 +362,11 @@ class HomeAssistantView(object):
         """Return a JSON response."""
         msg = json.dumps(
             result, sort_keys=True, cls=rem.JSONEncoder).encode('UTF-8')
-        request = web.Response(
+        response = web.Response(
             body=msg, content_type=CONTENT_TYPE_JSON, status=status_code,
             headers=headers)
-        request.enable_compression()
-        return request
+        response.enable_compression()
+        return response
 
     def json_message(self, message, status_code=200, message_code=None,
                      headers=None):

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -362,11 +362,11 @@ class HomeAssistantView(object):
         """Return a JSON response."""
         msg = json.dumps(
             result, sort_keys=True, cls=rem.JSONEncoder).encode('UTF-8')
-        j = web.Response(
+        request = web.Response(
             body=msg, content_type=CONTENT_TYPE_JSON, status=status_code,
             headers=headers)
-        j.enable_compression()
-        return j
+        request.enable_compression()
+        return request
 
     def json_message(self, message, status_code=200, message_code=None,
                      headers=None):


### PR DESCRIPTION
Make server compress json content when transmitting to client. Json is quite verbose and compresses well.

A real world example is history_graph requested data for in my case 4 temperature sensors updating every half a second for a graph over 10 days lead to 6MB json which compressed to 200KB using deflate compression.