### PR TITLE
Add wind_speed and visibility units to weather components

### DIFF
--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -73,6 +73,11 @@ class WeatherEntity(Entity):
         return None
 
     @property
+    def wind_speed_unit(self):
+        """Return the unit of measurement."""
+        return None
+
+    @property
     def wind_bearing(self):
         """Return the wind bearing."""
         return None
@@ -90,6 +95,11 @@ class WeatherEntity(Entity):
     @property
     def visibility(self):
         """Return the visibility."""
+        return None
+
+    @property
+    def visibility_unit(self):
+        """Return the unit of measurement."""
         return None
 
     @property
@@ -127,11 +137,15 @@ class WeatherEntity(Entity):
 
         wind_speed = self.wind_speed
         if wind_speed is not None:
-            data[ATTR_WEATHER_WIND_SPEED] = wind_speed
+            data[ATTR_WEATHER_WIND_SPEED] = (
+                self.hass.config.units.speed(wind_speed, self.wind_speed_unit)
+                if self.wind_speed_unit else wind_speed)
 
         visibility = self.visibility
         if visibility is not None:
-            data[ATTR_WEATHER_VISIBILITY] = visibility
+            data[ATTR_WEATHER_VISIBILITY] = (
+                self.hass.config.units.length(visibility, self.visibility_unit)
+                if self.visibility_unit else visibility)
 
         attribution = self.attribution
         if attribution is not None:

--- a/homeassistant/components/weather/bom.py
+++ b/homeassistant/components/weather/bom.py
@@ -9,8 +9,9 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.weather import WeatherEntity, PLATFORM_SCHEMA
-from homeassistant.const import \
-    CONF_NAME, TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.const import (
+    CONF_NAME, TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE,
+    SPEED_KILOMETERS_PER_HOUR)
 from homeassistant.helpers import config_validation as cv
 # Reuse data and API logic from the sensor implementation
 from homeassistant.components.sensor.bom import \
@@ -90,6 +91,11 @@ class BOMWeather(WeatherEntity):
     def wind_speed(self):
         """Return the wind speed."""
         return self.bom_data.data.get('wind_spd_kmh')
+
+    @property
+    def wind_speed_unit(self):
+        """Return the wind speed units."""
+        return SPEED_KILOMETERS_PER_HOUR
 
     @property
     def wind_bearing(self):

--- a/homeassistant/components/weather/buienradar.py
+++ b/homeassistant/components/weather/buienradar.py
@@ -8,8 +8,9 @@ import logging
 import asyncio
 from homeassistant.components.weather import (
     WeatherEntity, PLATFORM_SCHEMA, ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME)
-from homeassistant.const import \
-    CONF_NAME, TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.const import (
+    CONF_NAME, TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE,
+    LENGTH_KILOMETERS, SPEED_KILOMETERS_PER_HOUR)
 from homeassistant.helpers import config_validation as cv
 # Reuse data and API logic from the sensor implementation
 from homeassistant.components.sensor.buienradar import (
@@ -148,10 +149,19 @@ class BrWeather(WeatherEntity):
         """Return the current visibility."""
         return self._data.visibility
 
+    def visibility_unit(self):
+        """Return the visibility units."""
+        return LENGTH_KILOMETERS
+
     @property
     def wind_speed(self):
         """Return the current windspeed."""
         return self._data.wind_speed
+
+    @property
+    def wind_speed_unit(self):
+        """Return the wind speed units."""
+        return SPEED_KILOMETERS_PER_HOUR
 
     @property
     def wind_bearing(self):

--- a/homeassistant/components/weather/demo.py
+++ b/homeassistant/components/weather/demo.py
@@ -8,7 +8,10 @@ from datetime import datetime, timedelta
 
 from homeassistant.components.weather import (
     WeatherEntity, ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME)
-from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT)
+from homeassistant.const import (
+    TEMP_CELSIUS, TEMP_FAHRENHEIT, SPEED_MILES_PER_HOUR,
+    SPEED_KILOMETERS_PER_HOUR,
+    )
 
 CONDITION_CLASSES = {
     'cloudy': [],
@@ -32,8 +35,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Demo weather."""
     add_devices([
         DemoWeather('South', 'Sunshine', 21.6414, 92, 1099, 0.5, TEMP_CELSIUS,
+                    SPEED_KILOMETERS_PER_HOUR,
                     [22, 19, 15, 12, 14, 18, 21]),
         DemoWeather('North', 'Shower rain', -12, 54, 987, 4.8, TEMP_FAHRENHEIT,
+                    SPEED_MILES_PER_HOUR,
                     [-10, -13, -18, -23, -19, -14, -9])
     ])
 
@@ -42,7 +47,7 @@ class DemoWeather(WeatherEntity):
     """Representation of a weather condition."""
 
     def __init__(self, name, condition, temperature, humidity, pressure,
-                 wind_speed, temperature_unit, forecast):
+                 wind_speed, temperature_unit, wind_speed_unit, forecast):
         """Initialize the Demo weather."""
         self._name = name
         self._condition = condition
@@ -51,6 +56,7 @@ class DemoWeather(WeatherEntity):
         self._humidity = humidity
         self._pressure = pressure
         self._wind_speed = wind_speed
+        self._wind_speed_unit = wind_speed_unit
         self._forecast = forecast
 
     @property
@@ -82,6 +88,11 @@ class DemoWeather(WeatherEntity):
     def wind_speed(self):
         """Return the wind speed."""
         return self._wind_speed
+
+    @property
+    def wind_speed_unit(self):
+        """Return the wind speed units."""
+        return self._wind_speed_unit
 
     @property
     def pressure(self):

--- a/homeassistant/components/weather/ecobee.py
+++ b/homeassistant/components/weather/ecobee.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/weather.ecobee/
 from homeassistant.components import ecobee
 from homeassistant.components.weather import (
     WeatherEntity, ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME)
-from homeassistant.const import (TEMP_FAHRENHEIT)
+from homeassistant.const import (TEMP_FAHRENHEIT, SPEED_MILES_PER_HOUR,
+                                 LENGTH_MILES)
 
 
 DEPENDENCIES = ['ecobee']
@@ -100,17 +101,27 @@ class EcobeeWeather(WeatherEntity):
     def visibility(self):
         """Return the visibility."""
         try:
-            return int(self.get_forecast(0, 'visibility'))
+            return float(self.get_forecast(0, 'visibility')) / 1000
         except ValueError:
             return None
+
+    @property
+    def visibility_unit(self):
+        """Return the visibility units."""
+        return LENGTH_MILES
 
     @property
     def wind_speed(self):
         """Return the wind speed."""
         try:
-            return int(self.get_forecast(0, 'windSpeed'))
+            return float(self.get_forecast(0, 'windSpeed')) / 1000
         except ValueError:
             return None
+
+    @property
+    def wind_speed_unit(self):
+        """Return the wind speed units."""
+        return SPEED_MILES_PER_HOUR
 
     @property
     def wind_bearing(self):

--- a/homeassistant/components/weather/metoffice.py
+++ b/homeassistant/components/weather/metoffice.py
@@ -10,7 +10,8 @@ import voluptuous as vol
 
 from homeassistant.components.weather import WeatherEntity, PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME, TEMP_CELSIUS, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE)
+    CONF_NAME, TEMP_CELSIUS, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE,
+    SPEED_KILOMETERS_PER_HOUR)
 from homeassistant.helpers import config_validation as cv
 # Reuse data and API logic from the sensor implementation
 from homeassistant.components.sensor.metoffice import \
@@ -110,6 +111,11 @@ class MetOfficeWeather(WeatherEntity):
     def wind_speed(self):
         """Return the wind speed."""
         return self.data.data.wind_speed.value
+
+    @property
+    def wind_speed_unit(self):
+        """Return the wind speed units."""
+        return SPEED_KILOMETERS_PER_HOUR
 
     @property
     def wind_bearing(self):

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -13,7 +13,7 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME, PLATFORM_SCHEMA, WeatherEntity)
 from homeassistant.const import (
     CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, STATE_UNKNOWN,
-    TEMP_CELSIUS)
+    TEMP_CELSIUS, SPEED_KILOMETERS_PER_HOUR)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
@@ -123,6 +123,11 @@ class OpenWeatherMapWeather(WeatherEntity):
     def wind_speed(self):
         """Return the wind speed."""
         return self.data.get_wind().get('speed')
+
+    @property
+    def wind_speed_unit(self):
+        """Return the wind speed units."""
+        return SPEED_KILOMETERS_PER_HOUR
 
     @property
     def wind_bearing(self):

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -138,9 +138,19 @@ class YahooWeatherWeather(WeatherEntity):
         return self._data.yahoo.Atmosphere['visibility']
 
     @property
+    def visibility_unit(self):
+        """Return the visibility units."""
+        return self._data.yahoo.Units.get('distance')
+
+    @property
     def wind_speed(self):
         """Return the wind speed."""
         return self._data.yahoo.Wind['speed']
+
+    @property
+    def wind_speed_unit(self):
+        """Return the wind speed units."""
+        return self._data.yahoo.Units.get('speed')
 
     @property
     def wind_bearing(self):

--- a/homeassistant/components/weather/zamg.py
+++ b/homeassistant/components/weather/zamg.py
@@ -13,7 +13,8 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_TEMPERATURE, ATTR_WEATHER_WIND_BEARING,
     ATTR_WEATHER_WIND_SPEED, PLATFORM_SCHEMA)
 from homeassistant.const import (
-    CONF_NAME, TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE)
+    CONF_NAME, TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE,
+    SPEED_KILOMETERS_PER_HOUR)
 from homeassistant.helpers import config_validation as cv
 # Reuse data and API logic from the sensor implementation
 from homeassistant.components.sensor.zamg import (
@@ -102,6 +103,11 @@ class ZamgWeather(WeatherEntity):
     def wind_speed(self):
         """Return the wind speed."""
         return self.zamg_data.get_data(ATTR_WEATHER_WIND_SPEED)
+
+    @property
+    def wind_speed_unit(self):
+        """Return the wind speed units."""
+        return SPEED_KILOMETERS_PER_HOUR
 
     @property
     def wind_bearing(self):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -321,6 +321,11 @@ MASS_KILOGRAMS = 'kg'  # type: str
 MASS_OUNCES = 'oz'  # type: str
 MASS_POUNDS = 'lb'  # type: str
 
+# Speed units
+SPEED_MILES_PER_HOUR = "mph"
+SPEED_KILOMETERS_PER_HOUR = "km/h"
+SPEED_METERS_PER_SECOND = "m/s"
+
 # UV Index units
 UNIT_UV_INDEX = 'UV index'  # type: str
 
@@ -419,6 +424,7 @@ LENGTH = 'length'  # type: str
 MASS = 'mass'  # type: str
 VOLUME = 'volume'  # type: str
 TEMPERATURE = 'temperature'  # type: str
+SPEED = 'speed'  # type: str
 SPEED_MS = 'speed_ms'  # type: str
 ILLUMINANCE = 'illuminance'  # type: str
 

--- a/homeassistant/util/speed.py
+++ b/homeassistant/util/speed.py
@@ -38,35 +38,35 @@ def convert(value: float, unit_1: str, unit_2: str) -> float:
     kph = value
 
     if unit_1 == SPEED_MILES_PER_HOUR:
-        kph = __miles_per_hour_to_kilometers_per_hour(value)
+        kph = __mph_to_km_per_hour(value)
     elif unit_1 == SPEED_METERS_PER_SECOND:
-        kph = __meters_per_second_to_kilometers_per_hour(value)
+        kph = __m_per_sec_to_km_per_hour(value)
 
     result = kph
 
     if unit_2 == SPEED_MILES_PER_HOUR:
-        result = __kilometers_per_hour_to_miles_per_hour(kph)
+        result = __km_per_hour_to_mph(kph)
     elif unit_2 == SPEED_METERS_PER_SECOND:
-        result = __kilometers_per_hour_to_meters_per_second(kph)
+        result = __km_per_hour_to_m_per_sec(kph)
 
     return result
 
 
-def __miles_per_hour_to_kilometers_per_hour(mph: float) -> float:
+def __mph_to_km_per_hour(mph: float) -> float:
     """Convert miles-per-hour to kilometers-per-hour."""
     return mph * 1.60934
 
 
-def __meters_per_second_to_kilometers_per_hour(mps: float) -> float:
+def __m_per_sec_to_km_per_hour(mps: float) -> float:
     """Convert meters-per-second to kilometers-per-hour."""
     return mps * 3.6
 
 
-def __kilometers_per_hour_to_miles_per_hour(kph: float) -> float:
+def __km_per_hour_to_mph(kph: float) -> float:
     """Convert kilometers-per-hour to miles-per-hour."""
     return kph * 0.621371
 
 
-def __kilometers_per_hour_to_meters_per_second(kph: float) -> float:
+def __km_per_hour_to_m_per_sec(kph: float) -> float:
     """Convert kilometers-per-hour to meters-per-second."""
     return kph * 0.277778

--- a/homeassistant/util/speed.py
+++ b/homeassistant/util/speed.py
@@ -1,0 +1,72 @@
+"""Distance util functions."""
+
+import logging
+from numbers import Number
+
+from homeassistant.const import (
+    SPEED_KILOMETERS_PER_HOUR,
+    SPEED_MILES_PER_HOUR,
+    SPEED_METERS_PER_SECOND,
+    UNIT_NOT_RECOGNIZED_TEMPLATE,
+    SPEED,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+VALID_UNITS = [
+    SPEED_KILOMETERS_PER_HOUR,
+    SPEED_MILES_PER_HOUR,
+    SPEED_METERS_PER_SECOND,
+]
+
+
+def convert(value: float, unit_1: str, unit_2: str) -> float:
+    """Convert one unit of measurement to another."""
+    if unit_1 not in VALID_UNITS:
+        raise ValueError(
+            UNIT_NOT_RECOGNIZED_TEMPLATE.format(unit_1, SPEED))
+    if unit_2 not in VALID_UNITS:
+        raise ValueError(
+            UNIT_NOT_RECOGNIZED_TEMPLATE.format(unit_2, SPEED))
+
+    if not isinstance(value, Number):
+        raise TypeError('{} is not of numeric type'.format(value))
+
+    if unit_1 == unit_2 or unit_1 not in VALID_UNITS:
+        return value
+
+    kph = value
+
+    if unit_1 == SPEED_MILES_PER_HOUR:
+        kph = __miles_per_hour_to_kilometers_per_hour(value)
+    elif unit_1 == SPEED_METERS_PER_SECOND:
+        kph = __meters_per_second_to_kilometers_per_hour(value)
+
+    result = kph
+
+    if unit_2 == SPEED_MILES_PER_HOUR:
+        result = __kilometers_per_hour_to_miles_per_hour(kph)
+    elif unit_2 == SPEED_METERS_PER_SECOND:
+        result = __kilometers_per_hour_to_meters_per_second(kph)
+
+    return result
+
+
+def __miles_per_hour_to_kilometers_per_hour(mph: float) -> float:
+    """Convert miles-per-hour to kilometers-per-hour."""
+    return mph * 1.60934
+
+
+def __meters_per_second_to_kilometers_per_hour(mps: float) -> float:
+    """Convert meters-per-second to kilometers-per-hour."""
+    return mps * 3.6
+
+
+def __kilometers_per_hour_to_miles_per_hour(kph: float) -> float:
+    """Convert kilometers-per-hour to miles-per-hour."""
+    return kph * 0.621371
+
+
+def __kilometers_per_hour_to_meters_per_second(kph: float) -> float:
+    """Convert kilometers-per-hour to meters-per-second."""
+    return kph * 0.277778

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -8,10 +8,12 @@ from homeassistant.const import (
     LENGTH_KILOMETERS, LENGTH_INCHES, LENGTH_FEET, LENGTH_YARD, LENGTH_MILES,
     VOLUME_LITERS, VOLUME_MILLILITERS, VOLUME_GALLONS, VOLUME_FLUID_OUNCE,
     MASS_GRAMS, MASS_KILOGRAMS, MASS_OUNCES, MASS_POUNDS,
+    SPEED_MILES_PER_HOUR, SPEED_KILOMETERS_PER_HOUR, SPEED_METERS_PER_SECOND,
     CONF_UNIT_SYSTEM_METRIC, CONF_UNIT_SYSTEM_IMPERIAL, LENGTH, MASS, VOLUME,
-    TEMPERATURE, UNIT_NOT_RECOGNIZED_TEMPLATE)
+    TEMPERATURE, SPEED, UNIT_NOT_RECOGNIZED_TEMPLATE)
 from homeassistant.util import temperature as temperature_util
 from homeassistant.util import distance as distance_util
+from homeassistant.util import speed as speed_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,6 +46,12 @@ TEMPERATURE_UNITS = [
     TEMP_CELSIUS,
 ]
 
+SPEED_UNITS = [
+    SPEED_MILES_PER_HOUR,
+    SPEED_KILOMETERS_PER_HOUR,
+    SPEED_METERS_PER_SECOND,
+]
+
 
 def is_valid_unit(unit: str, unit_type: str) -> bool:
     """Check if the unit is valid for it's type."""
@@ -55,6 +63,8 @@ def is_valid_unit(unit: str, unit_type: str) -> bool:
         units = MASS_UNITS
     elif unit_type == VOLUME:
         units = VOLUME_UNITS
+    elif unit_type == SPEED:
+        units = SPEED_UNITS
     else:
         return False
 
@@ -65,7 +75,7 @@ class UnitSystem(object):
     """A container for units of measure."""
 
     def __init__(self: object, name: str, temperature: str, length: str,
-                 volume: str, mass: str) -> None:
+                 volume: str, mass: str, speed: str) -> None:
         """Initialize the unit system object."""
         errors = \
             ', '.join(UNIT_NOT_RECOGNIZED_TEMPLATE.format(unit, unit_type)
@@ -73,7 +83,8 @@ class UnitSystem(object):
                           (temperature, TEMPERATURE),
                           (length, LENGTH),
                           (volume, VOLUME),
-                          (mass, MASS), ]
+                          (mass, MASS),
+                          (speed, SPEED), ]
                       if not is_valid_unit(unit, unit_type))  # type: str
 
         if errors:
@@ -84,6 +95,7 @@ class UnitSystem(object):
         self.length_unit = length
         self.mass_unit = mass
         self.volume_unit = volume
+        self.speed_unit = speed
 
     @property
     def is_metric(self: object) -> bool:
@@ -107,18 +119,29 @@ class UnitSystem(object):
         return distance_util.convert(length, from_unit,
                                      self.length_unit)  # type: float
 
+    def speed(self: object, speed: float, from_unit: str) -> float:
+        """Convert the given speed to this unit system."""
+        if not isinstance(speed, Number):
+            raise TypeError('{} is not a numeric value.'.format(str(speed)))
+
+        return speed_util.convert(speed, from_unit,
+                                  self.speed_unit)  # type: float
+
     def as_dict(self) -> dict:
         """Convert the unit system to a dictionary."""
         return {
             LENGTH: self.length_unit,
             MASS: self.mass_unit,
             TEMPERATURE: self.temperature_unit,
-            VOLUME: self.volume_unit
+            VOLUME: self.volume_unit,
+            SPEED: self.speed_unit
         }
 
 
 METRIC_SYSTEM = UnitSystem(CONF_UNIT_SYSTEM_METRIC, TEMP_CELSIUS,
-                           LENGTH_KILOMETERS, VOLUME_LITERS, MASS_GRAMS)
+                           LENGTH_KILOMETERS, VOLUME_LITERS, MASS_GRAMS,
+                           SPEED_KILOMETERS_PER_HOUR)
 
 IMPERIAL_SYSTEM = UnitSystem(CONF_UNIT_SYSTEM_IMPERIAL, TEMP_FAHRENHEIT,
-                             LENGTH_MILES, VOLUME_GALLONS, MASS_POUNDS)
+                             LENGTH_MILES, VOLUME_GALLONS, MASS_POUNDS,
+                             SPEED_MILES_PER_HOUR)

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     MASS_GRAMS,
     VOLUME_LITERS,
+    SPEED_KILOMETERS_PER_HOUR,
     MATCH_ALL,
 )
 import homeassistant.util.dt as dt_util
@@ -31,7 +32,8 @@ class TestHelpersTemplate(unittest.TestCase):
         self.hass = get_test_home_assistant()
         self.hass.config.units = UnitSystem('custom', TEMP_CELSIUS,
                                             LENGTH_METERS, VOLUME_LITERS,
-                                            MASS_GRAMS)
+                                            MASS_GRAMS,
+                                            SPEED_KILOMETERS_PER_HOUR)
 
     # pylint: disable=invalid-name
     def tearDown(self):

--- a/tests/util/test_speed.py
+++ b/tests/util/test_speed.py
@@ -1,0 +1,78 @@
+"""Test homeasssitant distance utility functions."""
+
+import unittest
+import homeassistant.util.speed as speed_util
+from homeassistant.const import (SPEED_KILOMETERS_PER_HOUR,
+                                 SPEED_MILES_PER_HOUR,
+                                 SPEED_METERS_PER_SECOND)
+
+INVALID_SYMBOL = 'bob'
+VALID_SYMBOL = SPEED_KILOMETERS_PER_HOUR
+
+
+class TestSpeedUtil(unittest.TestCase):
+    """Test the speed utility functions."""
+
+    def test_convert_same_unit(self):
+        """Test conversion from any unit to same unit."""
+        self.assertEqual(5,
+                         speed_util.convert(5, SPEED_KILOMETERS_PER_HOUR,
+                                            SPEED_KILOMETERS_PER_HOUR))
+        self.assertEqual(2,
+                         speed_util.convert(2, SPEED_MILES_PER_HOUR,
+                                            SPEED_MILES_PER_HOUR))
+        self.assertEqual(10,
+                         speed_util.convert(10, SPEED_METERS_PER_SECOND,
+                                            SPEED_METERS_PER_SECOND))
+
+    def test_convert_invalid_unit(self):
+        """Test exception is thrown for invalid units."""
+        with self.assertRaises(ValueError):
+            speed_util.convert(5, INVALID_SYMBOL,
+                               VALID_SYMBOL)
+
+        with self.assertRaises(ValueError):
+            speed_util.convert(5, VALID_SYMBOL,
+                               INVALID_SYMBOL)
+
+    def test_convert_nonnumeric_value(self):
+        """Test exception is thrown for nonnumeric type."""
+        with self.assertRaises(TypeError):
+            speed_util.convert('a', SPEED_KILOMETERS_PER_HOUR,
+                               SPEED_MILES_PER_HOUR)
+
+    def test_convert_from_mph(self):
+        """Test conversion from mph to other units."""
+        mph = 5
+        self.assertEqual(
+            speed_util.convert(mph, SPEED_MILES_PER_HOUR,
+                               SPEED_KILOMETERS_PER_HOUR),
+            8.0467)
+        self.assertEqual(
+            speed_util.convert(mph, SPEED_MILES_PER_HOUR,
+                               SPEED_METERS_PER_SECOND),
+            2.2351962326)
+
+    def test_convert_from_mps(self):
+        """Test conversion from m/s to other units."""
+        mps = 10
+        self.assertEqual(
+            speed_util.convert(mps, SPEED_METERS_PER_SECOND,
+                               SPEED_KILOMETERS_PER_HOUR),
+            36)
+        self.assertEqual(
+            speed_util.convert(mps, SPEED_METERS_PER_SECOND,
+                               SPEED_MILES_PER_HOUR),
+            22.369356)
+
+    def test_convert_from_kph(self):
+        """Test conversion from kph to other units."""
+        kph = 5
+        self.assertEqual(
+            speed_util.convert(kph, SPEED_KILOMETERS_PER_HOUR,
+                               SPEED_MILES_PER_HOUR),
+            3.106855)
+        self.assertEqual(
+            speed_util.convert(kph, SPEED_KILOMETERS_PER_HOUR,
+                               SPEED_METERS_PER_SECOND),
+            1.3888900000000002)

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -12,10 +12,12 @@ from homeassistant.const import (
     MASS_GRAMS,
     VOLUME_LITERS,
     TEMP_CELSIUS,
+    SPEED_KILOMETERS_PER_HOUR,
     LENGTH,
     MASS,
     TEMPERATURE,
-    VOLUME
+    VOLUME,
+    SPEED
 )
 
 SYSTEM_NAME = 'TEST'
@@ -29,19 +31,23 @@ class TestUnitSystem(unittest.TestCase):
         """Test errors are raised when invalid units are passed in."""
         with self.assertRaises(ValueError):
             UnitSystem(SYSTEM_NAME, INVALID_UNIT, LENGTH_METERS, VOLUME_LITERS,
-                       MASS_GRAMS)
+                       MASS_GRAMS, SPEED_KILOMETERS_PER_HOUR)
 
         with self.assertRaises(ValueError):
             UnitSystem(SYSTEM_NAME, TEMP_CELSIUS, INVALID_UNIT, VOLUME_LITERS,
-                       MASS_GRAMS)
+                       MASS_GRAMS, SPEED_KILOMETERS_PER_HOUR)
 
         with self.assertRaises(ValueError):
             UnitSystem(SYSTEM_NAME, TEMP_CELSIUS, LENGTH_METERS, INVALID_UNIT,
-                       MASS_GRAMS)
+                       MASS_GRAMS, SPEED_KILOMETERS_PER_HOUR)
 
         with self.assertRaises(ValueError):
             UnitSystem(SYSTEM_NAME, TEMP_CELSIUS, LENGTH_METERS, VOLUME_LITERS,
-                       INVALID_UNIT)
+                       INVALID_UNIT, SPEED_KILOMETERS_PER_HOUR)
+
+        with self.assertRaises(ValueError):
+            UnitSystem(SYSTEM_NAME, TEMP_CELSIUS, LENGTH_METERS, VOLUME_LITERS,
+                       MASS_GRAMS, INVALID_UNIT)
 
     def test_invalid_value(self):
         """Test no conversion happens if value is non-numeric."""
@@ -49,6 +55,8 @@ class TestUnitSystem(unittest.TestCase):
             METRIC_SYSTEM.length('25a', LENGTH_KILOMETERS)
         with self.assertRaises(TypeError):
             METRIC_SYSTEM.temperature('50K', TEMP_CELSIUS)
+        with self.assertRaises(TypeError):
+            METRIC_SYSTEM.temperature('50mph', SPEED_KILOMETERS_PER_HOUR)
 
     def test_as_dict(self):
         """Test that the as_dict() method returns the expected dictionary."""
@@ -56,7 +64,8 @@ class TestUnitSystem(unittest.TestCase):
             LENGTH: LENGTH_KILOMETERS,
             TEMPERATURE: TEMP_CELSIUS,
             VOLUME: VOLUME_LITERS,
-            MASS: MASS_GRAMS
+            MASS: MASS_GRAMS,
+            SPEED: SPEED_KILOMETERS_PER_HOUR
         }
 
         self.assertEqual(expected, METRIC_SYSTEM.as_dict())
@@ -120,12 +129,41 @@ class TestUnitSystem(unittest.TestCase):
             IMPERIAL_SYSTEM.length(5, METRIC_SYSTEM.length_unit)
         )
 
+    def test_speed_unknown_unit(self):
+        """Test speed conversion with unknown from unit."""
+        with self.assertRaises(ValueError):
+            METRIC_SYSTEM.speed(5, 'fr')
+
+    def test_speed_to_metric(self):
+        """Test length conversion to metric system."""
+        self.assertEqual(
+            100,
+            METRIC_SYSTEM.speed(100, METRIC_SYSTEM.speed_unit)
+        )
+        self.assertEqual(
+            8.0467,
+            METRIC_SYSTEM.speed(5, IMPERIAL_SYSTEM.speed_unit)
+        )
+
+    def test_speed_to_imperial(self):
+        """Test speed conversion to imperial system."""
+        self.assertEqual(
+            100,
+            IMPERIAL_SYSTEM.speed(100,
+                                  IMPERIAL_SYSTEM.speed_unit)
+        )
+        self.assertEqual(
+            3.106855,
+            IMPERIAL_SYSTEM.speed(5, METRIC_SYSTEM.speed_unit)
+        )
+
     def test_properties(self):
         """Test the unit properties are returned as expected."""
         self.assertEqual(LENGTH_KILOMETERS, METRIC_SYSTEM.length_unit)
         self.assertEqual(TEMP_CELSIUS, METRIC_SYSTEM.temperature_unit)
         self.assertEqual(MASS_GRAMS, METRIC_SYSTEM.mass_unit)
         self.assertEqual(VOLUME_LITERS, METRIC_SYSTEM.volume_unit)
+        self.assertEqual(SPEED_KILOMETERS_PER_HOUR, METRIC_SYSTEM.speed_unit)
 
     def test_is_metric(self):
         """Test the is metric flag."""


### PR DESCRIPTION
## Description:
Adds units for wind_speed and visibility to weather components.  Adds new 'speed' unit to valid units.  Add conversions from metric to imperial units for speed
This change was requested in: https://github.com/home-assistant/home-assistant/pull/11136
## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
