### PR TITLE
convert alarmdecoder interface from async to sync

### DIFF
--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -29,7 +29,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
     """Representation of an AlarmDecoder-based alarm panel."""
 
-    def __init__(self, name, hass):
+    def __init__(self):
         """Initialize the alarm panel."""
         self._display = ""
         self._name = "Alarm Panel"

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/alarm_control_panel.alarmdecoder/
 import asyncio
 import logging
 
-from homeassistant.helpers.dispatcher import dispatcher_connect
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarmdecoder import (
     DATA_AD, SIGNAL_PANEL_MESSAGE)

--- a/homeassistant/components/alarmdecoder.py
+++ b/homeassistant/components/alarmdecoder.py
@@ -68,9 +68,9 @@ ZONE_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_DEVICE): 
-            vol.Any(DEVICE_SOCKET_SCHEMA, DEVICE_SERIAL_SCHEMA, 
-                    DEVICE_USB_SCHEMA),
+        vol.Required(CONF_DEVICE): vol.Any(
+            DEVICE_SOCKET_SCHEMA, DEVICE_SERIAL_SCHEMA,
+            DEVICE_USB_SCHEMA),
         vol.Optional(CONF_PANEL_DISPLAY,
                      default=DEFAULT_PANEL_DISPLAY): cv.boolean,
         vol.Optional(CONF_ZONES): {vol.Coerce(int): ZONE_SCHEMA},

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -48,10 +48,10 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Register callbacks."""
-        hass.helpers.dispatcher.async_dispatcher_connect(
+        self.hass.helpers.dispatcher.async_dispatcher_connect(
             SIGNAL_ZONE_FAULT, self._fault_callback)
 
-        hass.helpers.dispatcher.async_dispatcher_connect(
+        self.hass.helpers.dispatcher.async_dispatcher_connect(
             SIGNAL_ZONE_RESTORE, self._restore_callback)
 
     @property

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -9,8 +9,8 @@ import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.alarmdecoder import (
-  ZONE_SCHEMA, CONF_ZONES, CONF_ZONE_NAME, CONF_ZONE_TYPE, SIGNAL_ZONE_FAULT,
-  SIGNAL_ZONE_RESTORE)
+    ZONE_SCHEMA, CONF_ZONES, CONF_ZONE_NAME, CONF_ZONE_TYPE, 
+    SIGNAL_ZONE_FAULT, SIGNAL_ZONE_RESTORE)
 
 DEPENDENCIES = ['alarmdecoder']
 

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -7,13 +7,10 @@ https://home-assistant.io/components/binary_sensor.alarmdecoder/
 import asyncio
 import logging
 
-from homeassistant.helpers.dispatcher import dispatcher_connect
 from homeassistant.components.binary_sensor import BinarySensorDevice
-
 from homeassistant.components.alarmdecoder import (
   ZONE_SCHEMA, CONF_ZONES, CONF_ZONE_NAME, CONF_ZONE_TYPE, SIGNAL_ZONE_FAULT,
   SIGNAL_ZONE_RESTORE)
-
 
 DEPENDENCIES = ['alarmdecoder']
 
@@ -25,7 +22,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     configured_zones = discovery_info[CONF_ZONES]
 
     devices = []
-
     for zone_num in configured_zones:
         device_config_data = ZONE_SCHEMA(configured_zones[zone_num])
         zone_type = device_config_data[CONF_ZONE_TYPE]

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -37,7 +37,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AlarmDecoderBinarySensor(BinarySensorDevice):
     """Representation of an AlarmDecoder binary sensor."""
 
-    def __init__(self, hass, zone_number, zone_name, zone_type):
+    def __init__(self, zone_number, zone_name, zone_type):
         """Initialize the binary_sensor."""
         self._zone_number = zone_number
         self._zone_type = zone_type

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -9,7 +9,7 @@ import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.alarmdecoder import (
-    ZONE_SCHEMA, CONF_ZONES, CONF_ZONE_NAME, CONF_ZONE_TYPE, 
+    ZONE_SCHEMA, CONF_ZONES, CONF_ZONE_NAME, CONF_ZONE_TYPE,
     SIGNAL_ZONE_FAULT, SIGNAL_ZONE_RESTORE)
 
 DEPENDENCIES = ['alarmdecoder']

--- a/homeassistant/components/sensor/alarmdecoder.py
+++ b/homeassistant/components/sensor/alarmdecoder.py
@@ -4,13 +4,11 @@ Support for AlarmDecoder Sensors (Shows Panel Display).
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.alarmdecoder/
 """
+import asyncio
 import logging
 
-from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.alarmdecoder import (SIGNAL_PANEL_MESSAGE)
-from homeassistant.const import (STATE_UNKNOWN)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,16 +30,16 @@ class AlarmDecoderSensor(Entity):
     def __init__(self, hass):
         """Initialize the alarm panel."""
         self._display = ""
-        self._state = STATE_UNKNOWN
+        self._state = None
         self._icon = 'mdi:alarm-check'
         self._name = 'Alarm Panel Display'
 
-        dispatcher_connect(
-            hass, SIGNAL_PANEL_MESSAGE, self._message_callback)
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
+        self.hass.helpers.dispatcher.async_dispatcher_connect(
+            SIGNAL_PANEL_MESSAGE, self._message_callback)
 
-        _LOGGER.debug("Setting up panel")
-
-    @callback
     def _message_callback(self, message):
         if self._display != message.text:
             self._display = message.text

--- a/homeassistant/components/sensor/alarmdecoder.py
+++ b/homeassistant/components/sensor/alarmdecoder.py
@@ -4,11 +4,10 @@ Support for AlarmDecoder Sensors (Shows Panel Display).
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.alarmdecoder/
 """
-import asyncio
 import logging
 
 from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.dispatcher import dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.alarmdecoder import (SIGNAL_PANEL_MESSAGE)
 from homeassistant.const import (STATE_UNKNOWN)
@@ -18,14 +17,13 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['alarmdecoder']
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up for AlarmDecoder sensor devices."""
-    _LOGGER.debug("AlarmDecoderSensor: async_setup_platform")
+    _LOGGER.debug("AlarmDecoderSensor: setup_platform")
 
     device = AlarmDecoderSensor(hass)
 
-    async_add_devices([device])
+    add_devices([device])
 
 
 class AlarmDecoderSensor(Entity):
@@ -38,19 +36,16 @@ class AlarmDecoderSensor(Entity):
         self._icon = 'mdi:alarm-check'
         self._name = 'Alarm Panel Display'
 
-        _LOGGER.debug("Setting up panel")
+        dispatcher_connect(
+            hass, SIGNAL_PANEL_MESSAGE, self._message_callback)
 
-    @asyncio.coroutine
-    def async_added_to_hass(self):
-        """Register callbacks."""
-        async_dispatcher_connect(
-            self.hass, SIGNAL_PANEL_MESSAGE, self._message_callback)
+        _LOGGER.debug("Setting up panel")
 
     @callback
     def _message_callback(self, message):
         if self._display != message.text:
             self._display = message.text
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
     @property
     def icon(self):


### PR DESCRIPTION
## Description:
The alarmDecoder package uses a thread to monitor the alarm system, but the home-assistant implementation assumes an asyncio interface.  This patch converts the interface to be synchronous.

I left the alarm_control_panel interface as async because I believe sensing data to alarmdecoder asynchronously should not cause any issue.

**Related issue (if applicable):** fixes #11157 (this is not confirmed..I cannot reproduce the issue in that ticket on my own systems)

This issue was also mentioned in #11155

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
