### PR TITLE
Adds support for disabled Tiles and automatic session renewal

### DIFF
--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -19,7 +19,7 @@ from homeassistant.util.json import load_json, save_json
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pytile==1.0.0']
+REQUIREMENTS = ['pytile==1.1.0']
 
 CLIENT_UUID_CONFIG_FILE = '.tile.conf'
 DEFAULT_ICON = 'mdi:bluetooth'
@@ -34,9 +34,12 @@ ATTR_LAST_UPDATED = 'last_updated'
 ATTR_RING_STATE = 'ring_state'
 ATTR_VOIP_STATE = 'voip_state'
 
+CONF_SHOW_INACTIVE = 'show_inactive'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_SHOW_INACTIVE, default=False): cv.boolean,
     vol.Optional(CONF_MONITORED_VARIABLES):
         vol.All(cv.ensure_list, [vol.In(DEVICE_TYPES)]),
 })
@@ -79,6 +82,7 @@ class TileDeviceScanner(DeviceScanner):
         _LOGGER.debug('Client UUID: %s', self._client.client_uuid)
         _LOGGER.debug('User UUID: %s', self._client.user_uuid)
 
+        self._show_inactive = config.get(CONF_SHOW_INACTIVE)
         self._types = config.get(CONF_MONITORED_VARIABLES)
 
         self.devices = {}
@@ -91,29 +95,27 @@ class TileDeviceScanner(DeviceScanner):
 
     def _update_info(self, now=None) -> None:
         """Update the device info."""
-        device_data = self._client.get_tiles(type_whitelist=self._types)
+        self.devices = self._client.get_tiles(
+            type_whitelist=self._types, show_inactive=self._show_inactive)
 
-        try:
-            self.devices = device_data['result']
-        except KeyError:
+        if not self.devices:
             _LOGGER.warning('No Tiles found')
-            _LOGGER.debug(device_data)
             return
 
-        for info in self.devices.values():
-            dev_id = 'tile_{0}'.format(slugify(info['name']))
-            lat = info['tileState']['latitude']
-            lon = info['tileState']['longitude']
+        for dev in self.devices:
+            dev_id = 'tile_{0}'.format(slugify(dev['name']))
+            lat = dev['tileState']['latitude']
+            lon = dev['tileState']['longitude']
 
             attrs = {
-                ATTR_ALTITUDE: info['tileState']['altitude'],
-                ATTR_CONNECTION_STATE: info['tileState']['connection_state'],
-                ATTR_IS_DEAD: info['is_dead'],
-                ATTR_IS_LOST: info['tileState']['is_lost'],
-                ATTR_LAST_SEEN: info['tileState']['timestamp'],
-                ATTR_LAST_UPDATED: device_data['timestamp_ms'],
-                ATTR_RING_STATE: info['tileState']['ring_state'],
-                ATTR_VOIP_STATE: info['tileState']['voip_state'],
+                ATTR_ALTITUDE: dev['tileState']['altitude'],
+                ATTR_CONNECTION_STATE: dev['tileState']['connection_state'],
+                ATTR_IS_DEAD: dev['is_dead'],
+                ATTR_IS_LOST: dev['tileState']['is_lost'],
+                ATTR_LAST_SEEN: dev['tileState']['timestamp'],
+                ATTR_LAST_UPDATED: dev['tileState']['last_owner_update'],
+                ATTR_RING_STATE: dev['tileState']['ring_state'],
+                ATTR_VOIP_STATE: dev['tileState']['voip_state'],
             }
 
             self.see(

--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -29,7 +29,6 @@ ATTR_ALTITUDE = 'altitude'
 ATTR_CONNECTION_STATE = 'connection_state'
 ATTR_IS_DEAD = 'is_dead'
 ATTR_IS_LOST = 'is_lost'
-ATTR_LAST_SEEN = 'last_seen'
 ATTR_LAST_UPDATED = 'last_updated'
 ATTR_RING_STATE = 'ring_state'
 ATTR_VOIP_STATE = 'voip_state'
@@ -112,7 +111,6 @@ class TileDeviceScanner(DeviceScanner):
                 ATTR_CONNECTION_STATE: dev['tileState']['connection_state'],
                 ATTR_IS_DEAD: dev['is_dead'],
                 ATTR_IS_LOST: dev['tileState']['is_lost'],
-                ATTR_LAST_SEEN: dev['tileState']['timestamp'],
                 ATTR_LAST_UPDATED: dev['tileState']['last_owner_update'],
                 ATTR_RING_STATE: dev['tileState']['ring_state'],
                 ATTR_VOIP_STATE: dev['tileState']['voip_state'],

--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -29,7 +29,6 @@ ATTR_ALTITUDE = 'altitude'
 ATTR_CONNECTION_STATE = 'connection_state'
 ATTR_IS_DEAD = 'is_dead'
 ATTR_IS_LOST = 'is_lost'
-ATTR_LAST_UPDATED = 'last_updated'
 ATTR_RING_STATE = 'ring_state'
 ATTR_VOIP_STATE = 'voip_state'
 
@@ -111,7 +110,6 @@ class TileDeviceScanner(DeviceScanner):
                 ATTR_CONNECTION_STATE: dev['tileState']['connection_state'],
                 ATTR_IS_DEAD: dev['is_dead'],
                 ATTR_IS_LOST: dev['tileState']['is_lost'],
-                ATTR_LAST_UPDATED: dev['tileState']['last_owner_update'],
                 ATTR_RING_STATE: dev['tileState']['ring_state'],
                 ATTR_VOIP_STATE: dev['tileState']['voip_state'],
             }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -919,7 +919,7 @@ pythonegardia==1.0.22
 pythonwhois==2.4.3
 
 # homeassistant.components.device_tracker.tile
-pytile==1.0.0
+pytile==1.1.0
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5


### PR DESCRIPTION
## Description:
This PR adds two features to the Tile device tracker:

1. Via a new `show_inactive` configuration parameter, users can choose to show or hide disabled/inactive Tiles.
2. If the Tile API session expires, it is automatically renewed without user intervention.

**(1) is a breaking change: by default, `show_inactive` is set to `False` (because expired Tiles serve only a niche use case); if users were previously used to seeing _all_ Tiles – active and inactive – some will disappear by default.**

**Breaking changes for release Notes:**
The platform now shows only active Tiles by default; to show all Tiles, including expired/inactive ones, `show_inactive` must be `True`.
The following state attributes have been removed:
`last_seen`
`last_updated`

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4223

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: tile
    username: user@email.com
    password: my_password_123
    monitored_variables:
      - TILE
    show_inactive: true
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

  
  