### PR TITLE
fix: hmip-etrv-2 now working with homeassistant

### DIFF
--- a/homeassistant/components/climate/homematic.py
+++ b/homeassistant/components/climate/homematic.py
@@ -39,6 +39,7 @@ HM_HUMI_MAP = [
 ]
 
 HM_CONTROL_MODE = 'CONTROL_MODE'
+HM_IP_CONTROL_MODE = 'SET_POINT_MODE'
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
 
@@ -76,9 +77,10 @@ class HMThermostat(HMDevice, ClimateDevice):
             return None
 
         # read state and search
+        hm_code = getattr(self._hmdevice, "MODE", 0)
         for mode, state in HM_STATE_MAP.items():
             code = getattr(self._hmdevice, mode, 0)
-            if self._data.get('CONTROL_MODE') == code:
+            if hm_code == code:
                 return state
 
     @property
@@ -141,7 +143,8 @@ class HMThermostat(HMDevice, ClimateDevice):
         self._state = next(iter(self._hmdevice.WRITENODE.keys()))
         self._data[self._state] = STATE_UNKNOWN
 
-        if HM_CONTROL_MODE in self._hmdevice.ATTRIBUTENODE:
+        if HM_CONTROL_MODE in self._hmdevice.ATTRIBUTENODE \
+          or HM_IP_CONTROL_MODE in self._hmdevice.ATTRIBUTENODE:
             self._data[HM_CONTROL_MODE] = STATE_UNKNOWN
 
         for node in self._hmdevice.SENSORNODE.keys():

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -90,6 +90,7 @@ HM_IGNORE_DISCOVERY_NODE = [
 
 HM_ATTRIBUTE_SUPPORT = {
     'LOWBAT': ['battery', {0: 'High', 1: 'Low'}],
+    'LOW_BAT': ['battery', {0: 'High', 1: 'Low'}],
     'ERROR': ['sabotage', {0: 'No', 1: 'Yes'}],
     'RSSI_DEVICE': ['rssi', {}],
     'VALVE_STATE': ['valve', {}],
@@ -105,6 +106,7 @@ HM_ATTRIBUTE_SUPPORT = {
     'POWER': ['power', {}],
     'CURRENT': ['current', {}],
     'VOLTAGE': ['voltage', {}],
+    'OPERATING_VOLTAGE': ['voltage', {}],
     'WORKING': ['working', {0: 'No', 1: 'Yes'}],
 }
 


### PR DESCRIPTION
 (see also pull request at pyhomematic (https://github.com/danielperna84/pyhomematic/pull/99))

## Description:
I updated the way the current_operation mode is calculated for the homematic climate component. 
This is because the Homematic IP Radiator Thermostat (hmip-etrv-2) does not allow reading the 'CONTROL_MODE' variable anymore. However in the pyhomematic thermostats class we already have the "MODE" as property available. 

I also added that the LOW_BAT and OPERATING_VOLTAGE is properly shown in HASS.

This PR needs that the PR at pyhomematic is merged as well, as it updates the thermostats.py to enable the complete feature set for the HM-etrv-2.
