### PR TITLE
Query Samsung TV status via REST end point

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -131,16 +131,16 @@ class SamsungTVDevice(MediaPlayerDevice):
         """Retrieve the latest data."""
         if self._config['method'] == 'websocket' and self._status_via_rest:
             # Check if the TV Rest Server is active
-            self._update_status_via_rest_endpoint()
+            self._update_status_via_rest()
         else:
             # Send an empty key to see if we are still connected
             self.send_key('KEY')
 
-    def _update_status_via_rest_endpoint(self, **kwargs):
+    def _update_status_via_rest(self):
         url = "http://{}:{}/api/v2/"
         url = url.format(self._config['host'], self._config['port'])
         try:
-            res = requests.get(url, timeout=5, **kwargs)
+            res = requests.get(url, timeout=5)
         except (requests.exceptions.Timeout,
                 requests.exceptions.ConnectionError,
                 requests.exceptions.HTTPError,


### PR DESCRIPTION
## Description:
Optionally get the status of a Samsung TV using Samsung's REST end point.
This avoid sending a dummy command that wake up some of the newest model.

**Detail**: When checking for update, the TV wakes up and connect to wifi. If during this time, the status was queried (by sending a dummy command), the TV would be turned ON.
This commit fixed that by checking if the REST endpoint is available instead of sending a key command.

The status of the TV will still appear as ON for a few second several time per day which could be problematic for automation, but at least the TV won't be turned ON and the status will be set back to OFF after a few seconds.

**Related issue (if applicable):** fixes #10905

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4226

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: samsungtv
    host: 192.168.0.123
    port: 8001
    mac: AA:BB:CC:DD:EE:FF
    get_status_via_rest: True
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [-] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [-] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [-] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [-] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
