### PR TITLE
Proper Steam game names and small fixes

### DIFF
--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -21,6 +21,7 @@ CONF_ACCOUNTS = 'accounts'
 
 ICON = 'mdi:steam'
 
+STATE_OFFLINE = 'Offline'
 STATE_ONLINE = 'Online'
 STATE_BUSY = 'Busy'
 STATE_AWAY = 'Away'
@@ -86,7 +87,7 @@ class SteamSensor(Entity):
                 4: STATE_SNOOZE,
                 5: STATE_TRADE,
                 6: STATE_PLAY,
-            }.get(self._profile.status, 'Offline')
+            }.get(self._profile.status, STATE_OFFLINE)
             self._name = self._profile.persona
             self._avatar = self._profile.avatar_medium
         except self._steamod.api.HTTPTimeoutError as error:

--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -29,8 +29,6 @@ STATE_SNOOZE = 'snooze'
 STATE_LOOKING_TO_TRADE = 'looking_to_trade'
 STATE_LOOKING_TO_PLAY = 'looking_to_play'
 
-NO_GAME = 'None'
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_ACCOUNTS, default=[]):
@@ -108,7 +106,7 @@ class SteamSensor(Entity):
                 # with the game id and the game name
                 return app_list[game_id][1]
 
-        return NO_GAME
+        return None
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -26,8 +26,8 @@ STATE_ONLINE = 'Online'
 STATE_BUSY = 'Busy'
 STATE_AWAY = 'Away'
 STATE_SNOOZE = 'Snooze'
-STATE_TRADE = 'Trade'
-STATE_PLAY = 'Play'
+STATE_LOOKING_TO_TRADE = 'Looking to trade'
+STATE_LOOKING_TO_PLAY = 'Looking to play'
 
 NO_GAME = 'None'
 
@@ -87,8 +87,8 @@ class SteamSensor(Entity):
                 2: STATE_BUSY,
                 3: STATE_AWAY,
                 4: STATE_SNOOZE,
-                5: STATE_TRADE,
-                6: STATE_PLAY,
+                5: STATE_LOOKING_TO_TRADE,
+                6: STATE_LOOKING_TO_PLAY,
             }.get(self._profile.status, STATE_OFFLINE)
             self._name = self._profile.persona
             self._avatar = self._profile.avatar_medium

--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -21,13 +21,13 @@ CONF_ACCOUNTS = 'accounts'
 
 ICON = 'mdi:steam'
 
-STATE_OFFLINE = 'Offline'
-STATE_ONLINE = 'Online'
-STATE_BUSY = 'Busy'
-STATE_AWAY = 'Away'
-STATE_SNOOZE = 'Snooze'
-STATE_LOOKING_TO_TRADE = 'Looking to trade'
-STATE_LOOKING_TO_PLAY = 'Looking to play'
+STATE_OFFLINE = 'offline'
+STATE_ONLINE = 'online'
+STATE_BUSY = 'busy'
+STATE_AWAY = 'away'
+STATE_SNOOZE = 'snooze'
+STATE_LOOKING_TO_TRADE = 'looking_to_trade'
+STATE_LOOKING_TO_PLAY = 'looking_to_play'
 
 NO_GAME = 'None'
 

--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -29,6 +29,8 @@ STATE_SNOOZE = 'Snooze'
 STATE_TRADE = 'Trade'
 STATE_PLAY = 'Play'
 
+NO_GAME = 'None'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_ACCOUNTS, default=[]):
@@ -77,7 +79,7 @@ class SteamSensor(Entity):
         try:
             self._profile = self._steamod.user.profile(self._account)
             if self._profile.current_game[2] is None:
-                self._game = 'None'
+                self._game = NO_GAME
             else:
                 self._game = self._profile.current_game[2]
             self._state = {

--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -79,7 +79,15 @@ class SteamSensor(Entity):
         try:
             self._profile = self._steamod.user.profile(self._account)
             if self._profile.current_game[2] is None:
-                self._game = NO_GAME
+                game_id = self._profile.current_game[0]
+
+                # Initialize app list before usage to benefit from internal caching
+                app_list = self._steamod.apps.app_list()
+                if game_id and game_id in app_list:
+                    # The app list always returns a tuble with the game id and the game name
+                    self._game = app_list[game_id][1]
+                else:
+                    self._game = NO_GAME
             else:
                 self._game = self._profile.current_game[2]
             self._state = {

--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -114,7 +114,7 @@ class SteamSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {'game': self._game}
+        return {'game': self._game} if self._game else None
 
     @property
     def entity_picture(self):


### PR DESCRIPTION
## Description:
The Steam integration was not showing games properly as it was using the "extra information" field which in the majority of cases does not contain any data. This change will actually fetch the proper game name.

There was also a small refactor to consistently use constants and use proper constant names and values and the ones that was there was misleading.

**Related issue (if applicable):** fixes #11240

PS. This is my first PR to the project, if there is anything that I'm doing that goes against the general guide lines please do tell. I read the documentation regarding doing PRs to the project and could not see anything alarming myself regarding this update.

## Breaking changes:
- `game` attribute no longer set in `device_state_attributes` if no game is currently being played
- Connected to the one above:  The string "None" is no longer passed if no current game is being played, instead the `game` attribute is not present.
- States now use lower snake case
- The "Play" and "Trade" states has been renamed to "looking_to_play" and "looking_to_trade" 

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
