### PR TITLE
Fix webdav calendar schema

### DIFF
--- a/homeassistant/components/calendar/caldav.py
+++ b/homeassistant/components/calendar/caldav.py
@@ -29,7 +29,8 @@ CONF_ALL_DAY = 'all_day'
 CONF_SEARCH = 'search'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_URL): vol.Url,
+    # pylint: disable=no-value-for-parameter
+    vol.Required(CONF_URL): vol.Url(),
     vol.Optional(CONF_CALENDARS, default=[]):
         vol.All(cv.ensure_list, vol.Schema([
             cv.string


### PR DESCRIPTION
Hi !
I just updated Home Assistant and found a bug in the final version of my PR to add support for WebDav based calendars (https://github.com/home-assistant/home-assistant/pull/10842). It prevents the component to start. This PR fixes it.
My apologies. 
Max
