### PR TITLE
Added support for TekSavvy bandwidth sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -591,6 +591,7 @@ omit =
     homeassistant/components/sensor/sytadin.py
     homeassistant/components/sensor/tank_utility.py
     homeassistant/components/sensor/ted5000.py
+    homeassistant/components/sensor/teksavvy.py
     homeassistant/components/sensor/temper.py
     homeassistant/components/sensor/tibber.py
     homeassistant/components/sensor/time_date.py

--- a/homeassistant/components/sensor/teksavvy.py
+++ b/homeassistant/components/sensor/teksavvy.py
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = 'TekSavvy'
 CONF_TOTAL_BANDWIDTH = 'total_bandwidth'
 
-GIGABITS = 'Gb'  # type: str
+GIGABYTES = 'GB'  # type: str
 PERCENT = '%'  # type: str
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(hours=1)
@@ -38,15 +38,15 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(hours=1)
 
 SENSOR_TYPES = {
     'usage': ['Usage', PERCENT, 'mdi:percent'],
-    'usage_gb': ['Usage', GIGABITS, 'mdi:download'],
-    'limit': ['Data limit', GIGABITS, 'mdi:download'],
-    'onpeak_download': ['On Peak Download', GIGABITS, 'mdi:download'],
-    'onpeak_upload': ['On Peak Upload ', GIGABITS, 'mdi:upload'],
-    'onpeak_total': ['On Peak Total', GIGABITS, 'mdi:download'],
-    'offpeak_download': ['Off Peak download', GIGABITS, 'mdi:download'],
-    'offpeak_upload': ['Off Peak Upload', GIGABITS, 'mdi:upload'],
-    'offpeak_total': ['Off Peak Total', GIGABITS, 'mdi:download'],
-    'onpeak_remaining': ['Remaining', GIGABITS, 'mdi:download']
+    'usage_gb': ['Usage', GIGABYTES, 'mdi:download'],
+    'limit': ['Data limit', GIGABYTES, 'mdi:download'],
+    'onpeak_download': ['On Peak Download', GIGABYTES, 'mdi:download'],
+    'onpeak_upload': ['On Peak Upload ', GIGABYTES, 'mdi:upload'],
+    'onpeak_total': ['On Peak Total', GIGABYTES, 'mdi:download'],
+    'offpeak_download': ['Off Peak download', GIGABYTES, 'mdi:download'],
+    'offpeak_upload': ['Off Peak Upload', GIGABYTES, 'mdi:upload'],
+    'offpeak_total': ['Off Peak Total', GIGABYTES, 'mdi:download'],
+    'onpeak_remaining': ['Remaining', GIGABYTES, 'mdi:download']
 }
 
 API_HA_MAP = (

--- a/homeassistant/components/sensor/teksavvy.py
+++ b/homeassistant/components/sensor/teksavvy.py
@@ -59,7 +59,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-    """Setup the sensor platform."""
+    """Set up the sensor platform."""
     websession = async_get_clientsession(hass)
     apikey = config.get(CONF_API_KEY)
     bandwidthcap = config.get(CONF_TOTAL_BANDWIDTH)
@@ -67,7 +67,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     ts_data = TekSavvyData(hass.loop, websession, apikey, bandwidthcap)
     ret = yield from ts_data.async_update()
     if ret is False:
-        _LOGGER.error("Invalid Teksavvy API key:%s", apikey)
+        _LOGGER.error("Invalid Teksavvy API key: %s", apikey)
         return
 
     name = config.get(CONF_NAME)
@@ -78,7 +78,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
 
 class TekSavvySensor(Entity):
-    """TekSavvy Bandwidth sensor."""
+    """Representation of TekSavvy Bandwidth sensor."""
 
     def __init__(self, teksavvydata, sensor_type, name):
         """Initialize the sensor."""

--- a/homeassistant/components/sensor/teksavvy.py
+++ b/homeassistant/components/sensor/teksavvy.py
@@ -144,20 +144,20 @@ class TekSavvyData(object):
         req = '/web/Usage/UsageSummaryRecords?$filter=IsCurrent%20eq%20true'
         conn.request('GET', req, '', headers)
         response = conn.getresponse()
-        jsonData = response.read().decode("utf-8")
-        data = json.loads(jsonData)
-        for (Api, Ha) in API_HA_MAP:
-            self.data[Ha] = float(data["value"][0][Api])
-        OnPeakDownload = self.data["onpeak_download"]
-        OnPeakUpload = self.data["onpeak_upload"]
-        OffPeakDownload = self.data["offpeak_download"]
-        OffPeakUpload = self.data["offpeak_upload"]
-        Limit = self.data["limit"]
-        self.data["usage"] = 100*OnPeakDownload/self.bandwidth_cap
-        self.data["usage_gb"] = OnPeakDownload
-        self.data["onpeak_total"] = OnPeakDownload + OnPeakUpload
-        self.data["offpeak_total"] = OffPeakDownload + OffPeakUpload
-        self.data["onpeak_remaining"] = Limit - OnPeakUpload
+        json_data = response.read().decode("utf-8")
+        data = json.loads(json_data)
+        for (api, ha_name) in API_HA_MAP:
+            self.data[ha_name] = float(data["value"][0][api])
+        on_peak_download = self.data["onpeak_download"]
+        on_peak_upload = self.data["onpeak_upload"]
+        off_peak_download = self.data["offpeak_download"]
+        off_peak_upload = self.data["offpeak_upload"]
+        limit = self.data["limit"]
+        self.data["usage"] = 100*on_peak_download/self.bandwidth_cap
+        self.data["usage_gb"] = on_peak_download
+        self.data["onpeak_total"] = on_peak_download + on_peak_upload
+        self.data["offpeak_total"] = off_peak_download + off_peak_upload
+        self.data["onpeak_remaining"] = limit - on_peak_upload
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/sensor/teksavvy.py
+++ b/homeassistant/components/sensor/teksavvy.py
@@ -12,8 +12,6 @@ https://home-assistant.io/components/sensor.teksavvy/
 """
 import logging
 from datetime import timedelta
-import http.client
-import json
 import asyncio
 import async_timeout
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -65,6 +63,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
+
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Setup the sensor platform."""
@@ -77,7 +76,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         ret = yield from ts_data.async_update()
     except ValueError as error:
         _LOGGER.error("Failed conversion %s %s", CONF_TOTAL_BANDWIDTH, error)
-    if ret == False:
+    if ret is False:
         return
 
     name = config.get(CONF_NAME)
@@ -85,6 +84,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     for variable in config[CONF_MONITORED_VARIABLES]:
         sensors.append(TekSavvySensor(ts_data, variable, name))
     async_add_devices(sensors, True)
+
 
 class TekSavvySensor(Entity):
     """TekSavvy Bandwidth sensor."""
@@ -126,6 +126,7 @@ class TekSavvySensor(Entity):
         if self.type in self.teksavvydata.data:
             self._state = round(self.teksavvydata.data[self.type], 2)
 
+
 class TekSavvyData(object):
     """Get data from TekSavvy API."""
 
@@ -147,7 +148,7 @@ class TekSavvyData(object):
         url = "https://api.teksavvy.com/"\
               "web/Usage/UsageSummaryRecords?$filter=IsCurrent%20eq%20true"
         with async_timeout.timeout(REQUEST_TIMEOUT, loop=self.loop):
-            req = yield from self.websession.get(url, headers = headers)
+            req = yield from self.websession.get(url, headers=headers)
         if req.status != 200:
             _LOGGER.error("Request failed with status: %u", req.status)
             return False

--- a/homeassistant/components/sensor/teksavvy.py
+++ b/homeassistant/components/sensor/teksavvy.py
@@ -14,16 +14,15 @@ import logging
 from datetime import timedelta
 import asyncio
 import async_timeout
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-
 import voluptuous as vol
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
 from homeassistant.const import (
     CONF_API_KEY, CONF_NAME, CONF_MONITORED_VARIABLES)
 
-from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/teksavvy.py
+++ b/homeassistant/components/sensor/teksavvy.py
@@ -7,8 +7,8 @@ https://home-assistant.io/components/sensor.teksavvy/
 from datetime import timedelta
 import logging
 
-import async_timeout
 import asyncio
+import async_timeout
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_API_KEY, CONF_MONITORED_VARIABLES, CONF_NAME)

--- a/homeassistant/components/sensor/teksavvy.py
+++ b/homeassistant/components/sensor/teksavvy.py
@@ -1,0 +1,165 @@
+"""
+Support for TekSavvy.
+
+Get bandwidth comsumption data using Teksavvy API
+You can get your API key here:
+https://myaccount.teksavvy.com/ApiKey/ApiKeyManagement
+
+TekSavvy only counts download only as part of the bandwidth
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.teksavvy/
+"""
+import logging
+from datetime import timedelta
+import http.client
+import json
+import requests
+import voluptuous as vol
+from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    CONF_API_KEY, CONF_NAME, CONF_MONITORED_VARIABLES)
+
+from homeassistant.util import Throttle
+
+_LOGGER = logging.getLogger(__name__)
+
+
+DEFAULT_NAME = 'TekSavvy'
+CONF_TOTAL_BANDWIDTH = 'total_bandwidth'
+
+GIGABITS = 'Gb'  # type: str
+PERCENT = '%'  # type: str
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(hours=1)
+
+
+SENSOR_TYPES = {
+    'usage': ['Usage', PERCENT, 'mdi:percent'],
+    'usage_gb': ['Usage', GIGABITS, 'mdi:download'],
+    'limit': ['Data limit', GIGABITS, 'mdi:download'],
+    'onpeak_download': ['On Peak Download', GIGABITS, 'mdi:download'],
+    'onpeak_upload': ['On Peak Upload ', GIGABITS, 'mdi:upload'],
+    'onpeak_total': ['On Peak Total', GIGABITS, 'mdi:download'],
+    'offpeak_download': ['Off Peak download', GIGABITS, 'mdi:download'],
+    'offpeak_upload': ['Off Peak Upload', GIGABITS, 'mdi:upload'],
+    'offpeak_total': ['Off Peak Total', GIGABITS, 'mdi:download'],
+    'onpeak_remaining': ['Remaining', GIGABITS, 'mdi:download']
+}
+
+API_HA_MAP = (
+    ('OnPeakDownload', 'onpeak_download'),
+    ('OnPeakUpload', 'onpeak_upload'),
+    ('OffPeakDownload', 'offpeak_download'),
+    ('OffPeakUpload', 'offpeak_upload'))
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MONITORED_VARIABLES):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_TOTAL_BANDWIDTH): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the sensor platform."""
+    apikey = config.get(CONF_API_KEY)
+    bandwidthcapstr = config.get(CONF_TOTAL_BANDWIDTH)
+
+    try:
+        bandwidthcap = int(bandwidthcapstr)
+        teksavvy_data = TekSavvyData(apikey, bandwidthcap)
+        teksavvy_data.update()
+    except ValueError as error:
+        _LOGGER.error("Failed conversion %s %s", CONF_TOTAL_BANDWIDTH, error)
+    except requests.exceptions.HTTPError as error:
+        _LOGGER.error("Fail to fetch data %s", error)
+        return False
+
+    name = config.get(CONF_NAME)
+
+    sensors = []
+    for variable in config[CONF_MONITORED_VARIABLES]:
+        sensors.append(TekSavvySensor(teksavvy_data, variable, name))
+
+    add_devices(sensors, True)
+
+
+class TekSavvySensor(Entity):
+    """TekSavvy Bandwidth sensor."""
+
+    def __init__(self, teksavvydata, sensor_type, name):
+        """Initialize the sensor."""
+        self.client_name = name
+        self.type = sensor_type
+        self._name = SENSOR_TYPES[sensor_type][0]
+        self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        self._icon = SENSOR_TYPES[sensor_type][2]
+        self.teksavvydata = teksavvydata
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} {}'.format(self.client_name, self._name)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit_of_measurement
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    def update(self):
+        """Get the latest data from TekSavvy and update the state."""
+        self.teksavvydata.update()
+        if self.type in self.teksavvydata.data:
+            self._state = round(self.teksavvydata.data[self.type], 2)
+
+
+class TekSavvyData(object):
+    """Get data from TekSavvy API."""
+
+    def __init__(self, api_key, bandwidth_cap):
+        """Initialize the data object."""
+        self.api_key = api_key
+        self.bandwidth_cap = bandwidth_cap
+        self.data = dict()
+        self.data["limit"] = self.bandwidth_cap
+
+    def _fetch_data(self):
+        headers = {"TekSavvy-APIKey": self.api_key}
+        conn = http.client.HTTPSConnection("api.teksavvy.com")
+        req = '/web/Usage/UsageSummaryRecords?$filter=IsCurrent%20eq%20true'
+        conn.request('GET', req, '', headers)
+        response = conn.getresponse()
+        jsonData = response.read().decode("utf-8")
+        data = json.loads(jsonData)
+        for (Api, Ha) in API_HA_MAP:
+            self.data[Ha] = float(data["value"][0][Api])
+        OnPeakDownload = self.data["onpeak_download"]
+        OnPeakUpload = self.data["onpeak_upload"]
+        OffPeakDownload = self.data["offpeak_download"]
+        OffPeakUpload = self.data["offpeak_upload"]
+        Limit = self.data["limit"]
+        self.data["usage"] = 100*OnPeakDownload/self.bandwidth_cap
+        self.data["usage_gb"] = OnPeakDownload
+        self.data["onpeak_total"] = OnPeakDownload + OnPeakUpload
+        self.data["offpeak_total"] = OffPeakDownload + OffPeakUpload
+        self.data["onpeak_remaining"] = Limit - OnPeakUpload
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Return the latest collected data from TekSavvy."""
+        self._fetch_data()


### PR DESCRIPTION
# Description:
TekSavvy is a an internet provider in Canada. This sensors allows to monitor bandwidth usage.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4227

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: teksavvy
    api_key: API_KEY
    total_bandwidth: 400
    monitored_variables:
     - usage
     - usage_gb
     - limit
     - onpeak_download
     - onpeak_upload
     - onpeak_total
     - offpeak_download
     - offpeak_upload
     - offpeak_total
     - onpeak_remaining
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
