### PR TITLE
Add workaround for running tox on Windows platforms

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,7 @@ setenv =
 ; utf8 one, tox's env is reset. And the install of these 2 packages
 ; fail.
 whitelist_externals = /usr/bin/env
-install_command = pip install {opts} {packages}
-#install_command = /usr/bin/env LANG=C.UTF-8 pip install {opts} {packages}
+install_command = /usr/bin/env LANG=C.UTF-8 pip install {opts} {packages}
 commands =
      py.test --timeout=15 --duration=10 --cov --cov-report= {posargs}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@ setenv =
 ; utf8 one, tox's env is reset. And the install of these 2 packages
 ; fail.
 whitelist_externals = /usr/bin/env
-install_command = /usr/bin/env LANG=C.UTF-8 pip install {opts} {packages}
+install_command = pip install {opts} {packages}
+#install_command = /usr/bin/env LANG=C.UTF-8 pip install {opts} {packages}
 commands =
      py.test --timeout=15 --duration=10 --cov --cov-report= {posargs}
 deps =
@@ -18,7 +19,7 @@ deps =
      -c{toxinidir}/homeassistant/package_constraints.txt
 
 [testenv:pylint]
-basepython = python3
+basepython = {env:PYTHON3_PATH:python3}
 ignore_errors = True
 deps =
      -r{toxinidir}/requirements_all.txt
@@ -28,7 +29,7 @@ commands =
      pylint homeassistant
 
 [testenv:lint]
-basepython = python3
+basepython = {env:PYTHON3_PATH:python3}
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
@@ -37,7 +38,7 @@ commands =
          pydocstyle homeassistant tests
 
 [testenv:typing]
-basepython = python3
+basepython = {env:PYTHON3_PATH:python3}
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =


### PR DESCRIPTION
## Description:
Running `tox` on Windows fails because the tox configuration uses `basepython=python3` which doesn't exist on standard Python installations for Windows.  This environment variable allows Windows users to easily specify and override for their system.

```cmd
set PYTHON3_PATH=python 
```

or

```powershell
$env:PYTHON3_PATH="python"
```