### PR TITLE
Remove Option to disable VERIFY_SSL 

### DIFF
--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -14,7 +14,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.components.sensor.rest import RestData
 from homeassistant.const import (
     CONF_PAYLOAD, CONF_NAME, CONF_VALUE_TEMPLATE, CONF_METHOD, CONF_RESOURCE,
-    CONF_VERIFY_SSL, CONF_USERNAME, CONF_PASSWORD,
+    CONF_USERNAME, CONF_PASSWORD,
     CONF_HEADERS, CONF_AUTHENTICATION, HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION, CONF_DEVICE_CLASS)
 import homeassistant.helpers.config_validation as cv
@@ -23,7 +23,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_METHOD = 'GET'
 DEFAULT_NAME = 'REST Binary Sensor'
-DEFAULT_VERIFY_SSL = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
@@ -37,7 +36,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
 
 
@@ -47,7 +45,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     resource = config.get(CONF_RESOURCE)
     method = config.get(CONF_METHOD)
     payload = config.get(CONF_PAYLOAD)
-    verify_ssl = config.get(CONF_VERIFY_SSL)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     headers = config.get(CONF_HEADERS)
@@ -64,7 +61,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     else:
         auth = None
 
-    rest = RestData(method, resource, auth, headers, payload, verify_ssl)
+    rest = RestData(method, resource, auth, headers, payload, True)
     rest.update()
 
     if rest.data is None:

--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -61,7 +61,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     else:
         auth = None
 
-    rest = RestData(method, resource, auth, headers, payload, True)
+    rest = RestData(method, resource, auth, headers, payload)
     rest.update()
 
     if rest.data is None:

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
-    CONF_URL, CONF_WHITELIST, CONF_VERIFY_SSL, CONF_TIMEOUT)
+    CONF_URL, CONF_WHITELIST, CONF_TIMEOUT)
 from homeassistant.components.camera import (
     Camera, PLATFORM_SCHEMA)
 from homeassistant.helpers.aiohttp_client import (
@@ -34,14 +34,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_URL): cv.string,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     vol.Optional(CONF_WHITELIST, default=[]): cv.ensure_list,
-    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
 })
 
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up a Synology IP Camera."""
-    verify_ssl = config.get(CONF_VERIFY_SSL)
+    verify_ssl = True
     timeout = config.get(CONF_TIMEOUT)
 
     try:

--- a/homeassistant/components/device_tracker/linksys_ap.py
+++ b/homeassistant/components/device_tracker/linksys_ap.py
@@ -14,7 +14,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
-    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL)
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME)
 
 INTERFACES = 2
 DEFAULT_TIMEOUT = 10
@@ -27,7 +27,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
-    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
 })
 
 
@@ -47,7 +46,6 @@ class LinksysAPDeviceScanner(DeviceScanner):
         self.host = config[CONF_HOST]
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
-        self.verify_ssl = config[CONF_VERIFY_SSL]
         self.last_results = []
 
         # Check if the access point is accessible
@@ -95,5 +93,5 @@ class LinksysAPDeviceScanner(DeviceScanner):
         url = 'https://{}/StatusClients.htm&&unit={}&vap=0'.format(
             self.host, unit)
         return requests.get(
-            url, timeout=DEFAULT_TIMEOUT, verify=self.verify_ssl,
+            url, timeout=DEFAULT_TIMEOUT, verify=True,
             cookies={'LoginName': login, 'LoginPWD': pwd})

--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -12,7 +12,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
-from homeassistant.const import CONF_VERIFY_SSL
 import homeassistant.util.dt as dt_util
 
 REQUIREMENTS = ['pyunifi==2.13']
@@ -36,8 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): vol.Any(
-        cv.boolean, cv.isfile),
     vol.Optional(CONF_DETECTION_TIME, default=DEFAULT_DETECTION_TIME): vol.All(
         cv.time_period, cv.positive_timedelta)
 })
@@ -52,12 +49,11 @@ def get_scanner(hass, config):
     password = config[DOMAIN].get(CONF_PASSWORD)
     site_id = config[DOMAIN].get(CONF_SITE_ID)
     port = config[DOMAIN].get(CONF_PORT)
-    verify_ssl = config[DOMAIN].get(CONF_VERIFY_SSL)
     detection_time = config[DOMAIN].get(CONF_DETECTION_TIME)
 
     try:
         ctrl = Controller(host, username, password, port, version='v4',
-                          site_id=site_id, ssl_verify=verify_ssl)
+                          site_id=site_id, ssl_verify=True)
     except APIError as ex:
         _LOGGER.error("Failed to connect to Unifi: %s", ex)
         hass.components.persistent_notification.create(

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     EVENT_STATE_CHANGED, STATE_UNAVAILABLE, STATE_UNKNOWN, CONF_HOST,
-    CONF_PORT, CONF_SSL, CONF_VERIFY_SSL, CONF_USERNAME, CONF_PASSWORD,
+    CONF_PORT, CONF_SSL, CONF_USERNAME, CONF_PASSWORD,
     CONF_EXCLUDE, CONF_INCLUDE, CONF_DOMAINS, CONF_ENTITIES)
 from homeassistant.helpers import state as state_helper
 from homeassistant.helpers.entity_values import EntityValues
@@ -37,7 +37,6 @@ CONF_RETRY_COUNT = 'max_retries'
 CONF_RETRY_QUEUE = 'retry_queue_limit'
 
 DEFAULT_DATABASE = 'home_assistant'
-DEFAULT_VERIFY_SSL = True
 DOMAIN = 'influxdb'
 TIMEOUT = 5
 
@@ -71,7 +70,6 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Schema({cv.string: cv.string}),
         vol.Optional(CONF_TAGS_ATTRIBUTES, default=[]):
             vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
         vol.Optional(CONF_COMPONENT_CONFIG, default={}):
             vol.Schema({cv.entity_id: COMPONENT_CONFIG_SCHEMA_ENTRY}),
         vol.Optional(CONF_COMPONENT_CONFIG_GLOB, default={}):
@@ -93,7 +91,7 @@ def setup(hass, config):
 
     kwargs = {
         'database': conf[CONF_DB_NAME],
-        'verify_ssl': conf[CONF_VERIFY_SSL],
+        'verify_ssl': True,
         'timeout': TIMEOUT
     }
 

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -61,10 +61,6 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             has_ssl = host_config['ssl']
         except KeyError:
             has_ssl = False
-        try:
-            verify_ssl = host_config['verify']
-        except KeyError:
-            verify_ssl = True
 
     # Via discovery
     elif discovery_info is not None:
@@ -78,28 +74,20 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
             return
         token = None
         has_ssl = False
-        verify_ssl = True
     else:
         return
 
-    setup_plexserver(
-        host, token, has_ssl, verify_ssl,
-        hass, config, add_devices_callback
-    )
+    setup_plexserver(host, token, has_ssl, hass, config, add_devices_callback)
 
 
 def setup_plexserver(
-        host, token, has_ssl, verify_ssl, hass, config, add_devices_callback):
+        host, token, has_ssl, hass, config, add_devices_callback):
     """Set up a plexserver based on host parameter."""
     import plexapi.server
     import plexapi.exceptions
 
     cert_session = None
     http_prefix = 'https' if has_ssl else 'http'
-    if has_ssl and (verify_ssl is False):
-        _LOGGER.info("Ignoring SSL verification")
-        cert_session = requests.Session()
-        cert_session.verify = False
     try:
         plexserver = plexapi.server.PlexServer(
             '%s://%s' % (http_prefix, host),
@@ -125,7 +113,6 @@ def setup_plexserver(
         hass.config.path(PLEX_CONFIG_FILE), {host: {
             'token': token,
             'ssl': has_ssl,
-            'verify': verify_ssl,
         }})
 
     _LOGGER.info('Connected to: %s://%s', http_prefix, host)
@@ -220,7 +207,6 @@ def request_configuration(host, hass, config, add_devices_callback):
         setup_plexserver(
             host, data.get('token'),
             cv.boolean(data.get('has_ssl')),
-            cv.boolean(data.get('do_not_verify')),
             hass, config, add_devices_callback
         )
 
@@ -237,10 +223,6 @@ def request_configuration(host, hass, config, add_devices_callback):
         }, {
             'id': 'has_ssl',
             'name': 'Use SSL',
-            'type': ''
-        }, {
-            'id': 'do_not_verify_ssl',
-            'name': 'Do not verify SSL',
             'type': ''
         }])
 

--- a/homeassistant/components/notify/matrix.py
+++ b/homeassistant/components/notify/matrix.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (ATTR_TARGET, PLATFORM_SCHEMA,
                                              BaseNotificationService)
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.util.json import load_json, save_json
 
 REQUIREMENTS = ['matrix-client==0.0.6']
@@ -27,7 +27,6 @@ CONF_DEFAULT_ROOM = 'default_room'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOMESERVER): cv.url,
-    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_DEFAULT_ROOM): cv.string,
@@ -43,7 +42,6 @@ def get_service(hass, config, discovery_info=None):
             os.path.join(hass.config.path(), SESSION_FILE),
             config.get(CONF_HOMESERVER),
             config.get(CONF_DEFAULT_ROOM),
-            config.get(CONF_VERIFY_SSL),
             config.get(CONF_USERNAME),
             config.get(CONF_PASSWORD))
 
@@ -54,7 +52,7 @@ def get_service(hass, config, discovery_info=None):
 class MatrixNotificationService(BaseNotificationService):
     """Send Notifications to a Matrix Room."""
 
-    def __init__(self, config_file, homeserver, default_room, verify_ssl,
+    def __init__(self, config_file, homeserver, default_room,
                  username, password):
         """Set up the client."""
         self.session_filepath = config_file
@@ -62,7 +60,7 @@ class MatrixNotificationService(BaseNotificationService):
 
         self.homeserver = homeserver
         self.default_room = default_room
-        self.verify_tls = verify_ssl
+        self.verify_tls = True
         self.username = username
         self.password = password
 

--- a/homeassistant/components/sensor/dwd_weather_warnings.py
+++ b/homeassistant/components/sensor/dwd_weather_warnings.py
@@ -176,7 +176,7 @@ class DwdWeatherWarningsAPI(object):
             'jsonp=loadWarnings'
         )
 
-        self._rest = RestData('GET', resource, None, None, None, True)
+        self._rest = RestData('GET', resource, None, None, None)
         self.region_name = region_name
         self.region_id = None
         self.region_state = None

--- a/homeassistant/components/sensor/influxdb.py
+++ b/homeassistant/components/sensor/influxdb.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_USERNAME,
-                                 CONF_PASSWORD, CONF_SSL, CONF_VERIFY_SSL,
+                                 CONF_PASSWORD, CONF_SSL,
                                  CONF_NAME, CONF_UNIT_OF_MEASUREMENT,
                                  CONF_VALUE_TEMPLATE)
 from homeassistant.const import STATE_UNKNOWN
@@ -28,7 +28,6 @@ DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 8086
 DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_SSL = False
-DEFAULT_VERIFY_SSL = False
 DEFAULT_GROUP_FUNCTION = 'mean'
 DEFAULT_FIELD = 'value'
 
@@ -59,7 +58,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Inclusive(CONF_USERNAME, 'authentication'): cv.string,
     vol.Inclusive(CONF_PASSWORD, 'authentication'): cv.string,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean
 })
 
 # Return cached results if last scan was less then this time ago
@@ -74,7 +72,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         'port': config.get(CONF_PORT),
         'ssl': config.get(CONF_SSL),
         'username': config.get(CONF_USERNAME),
-        'verify_ssl': config.get(CONF_VERIFY_SSL),
     }
 
     dev = []
@@ -112,7 +109,7 @@ class InfluxSensor(Entity):
             host=influx_conf['host'], port=influx_conf['port'],
             username=influx_conf['username'], password=influx_conf['password'],
             database=database, ssl=influx_conf['ssl'],
-            verify_ssl=influx_conf['verify_ssl'])
+            verify_ssl=True)
         try:
             influx.query("select * from /.*/ LIMIT 1;")
             self.connected = True

--- a/homeassistant/components/sensor/luftdaten.py
+++ b/homeassistant/components/sensor/luftdaten.py
@@ -5,21 +5,27 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.luftdaten/
 """
 import asyncio
-import json
-import logging
 from datetime import timedelta
+import logging
 
-import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME, CONF_RESOURCE, CONF_MONITORED_CONDITIONS,
-    TEMP_CELSIUS)
-from homeassistant.helpers.entity import Entity
+    ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS, CONF_NAME, TEMP_CELSIUS)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+REQUIREMENTS = ['luftdaten==0.1.1']
 
 _LOGGER = logging.getLogger(__name__)
+
+ATTR_SENSOR_ID = 'sensor_id'
+
+CONF_ATTRIBUTION = "Data provided by luftdaten.info"
+
 
 VOLUME_MICROGRAMS_PER_CUBIC_METER = 'µg/m3'
 
@@ -27,61 +33,66 @@ SENSOR_TEMPERATURE = 'temperature'
 SENSOR_HUMIDITY = 'humidity'
 SENSOR_PM10 = 'P1'
 SENSOR_PM2_5 = 'P2'
+SENSOR_PRESSURE = 'pressure'
 
 SENSOR_TYPES = {
     SENSOR_TEMPERATURE: ['Temperature', TEMP_CELSIUS],
     SENSOR_HUMIDITY: ['Humidity', '%'],
+    SENSOR_PRESSURE: ['Pressure', 'Pa'],
     SENSOR_PM10: ['PM10', VOLUME_MICROGRAMS_PER_CUBIC_METER],
     SENSOR_PM2_5: ['PM2.5', VOLUME_MICROGRAMS_PER_CUBIC_METER]
 }
 
-DEFAULT_NAME = 'Luftdaten Sensor'
-DEFAULT_RESOURCE = 'https://api.luftdaten.info/v1/sensor/'
+DEFAULT_NAME = 'Luftdaten'
 
 CONF_SENSORID = 'sensorid'
 
-SCAN_INTERVAL = timedelta(minutes=3)
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SENSORID): cv.positive_int,
     vol.Required(CONF_MONITORED_CONDITIONS):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_RESOURCE, default=DEFAULT_RESOURCE): cv.string,
 })
 
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Luftdaten sensor."""
+    from luftdaten import Luftdaten
+
     name = config.get(CONF_NAME)
-    sensorid = config.get(CONF_SENSORID)
+    sensor_id = config.get(CONF_SENSORID)
 
+    session = async_get_clientsession(hass)
+    luftdaten = LuftdatenData(Luftdaten(sensor_id, hass.loop, session))
 
-    resource = '{}{}/'.format(config.get(CONF_RESOURCE), sensorid)
+    yield from luftdaten.async_update()
 
-    rest_client = LuftdatenData(resource)
-    rest_client.update()
-
-    if rest_client.data is None:
-        _LOGGER.error("Unable to fetch Luftdaten data")
-        return False
+    if luftdaten.data is None:
+        _LOGGER.error("Sensor is not available: %s", sensor_id)
+        return
 
     devices = []
     for variable in config[CONF_MONITORED_CONDITIONS]:
-        devices.append(LuftdatenSensor(rest_client, name, variable))
+        if luftdaten.data.values[variable] is None:
+            _LOGGER.warning("It might be that sensor %s is not providing "
+                            "measurements for %s", sensor_id, variable)
+        devices.append(LuftdatenSensor(luftdaten, name, variable, sensor_id))
 
-    async_add_devices(devices, True)
+    async_add_devices(devices)
 
 
 class LuftdatenSensor(Entity):
-    """Implementation of a LuftdatenSensor sensor."""
+    """Implementation of a Luftdaten sensor."""
 
-    def __init__(self, rest_client, name, sensor_type):
-        """Initialize the LuftdatenSensor sensor."""
-        self.rest_client = rest_client
+    def __init__(self, luftdaten, name, sensor_type, sensor_id):
+        """Initialize the Luftdaten sensor."""
+        self.luftdaten = luftdaten
         self._name = name
         self._state = None
+        self._sensor_id = sensor_id
         self.sensor_type = sensor_type
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
 
@@ -93,47 +104,50 @@ class LuftdatenSensor(Entity):
     @property
     def state(self):
         """Return the state of the device."""
-        return self._state
+        return self.luftdaten.data.values[self.sensor_type]
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
 
-    def update(self):
-        """Get the latest data from REST API and update the state."""
-        self.rest_client.update()
-        value = self.rest_client.data
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self.luftdaten.data.meta is None:
+            return
 
-        if value is None:
-            self._state = None
-        else:
-            parsed_json = json.loads(value)
+        attr = {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+            ATTR_SENSOR_ID: self._sensor_id,
+            'lat': self.luftdaten.data.meta['latitude'],
+            'long': self.luftdaten.data.meta['longitude'],
+        }
+        return attr
 
-            log_entries_count = len(parsed_json) - 1
-            latest_log_entry = parsed_json[log_entries_count]
-            sensordata_values = latest_log_entry['sensordatavalues']
-            for sensordata_value in sensordata_values:
-                if sensordata_value['value_type'] == self.sensor_type:
-                    self._state = sensordata_value['value']
+    @asyncio.coroutine
+    def async_update(self):
+        """Get the latest data from luftdaten.info and update the state."""
+        try:
+            yield from self.luftdaten.async_update()
+        except TypeError:
+            pass
 
 
 class LuftdatenData(object):
     """Class for handling the data retrieval."""
 
-    def __init__(self, resource):
+    def __init__(self, data):
         """Initialize the data object."""
-        self._request = requests.Request('GET', resource).prepare()
-        self.data = None
+        self.data = data
 
-    def update(self):
-        """Get the latest data from Luftdaten service."""
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    @asyncio.coroutine
+    def async_update(self):
+        """Get the latest data from luftdaten.info."""
+        from luftdaten.exceptions import LuftdatenError
+
         try:
-            with requests.Session() as sess:
-                response = sess.send(
-                    self._request, timeout=10, verify=True)
-
-            self.data = response.text
-        except requests.exceptions.RequestException:
-            _LOGGER.error("Error fetching data: %s", self._request)
-            self.data = None
+            yield from self.data.async_get_data()
+        except LuftdatenError:
+            _LOGGER.error("Unable to retrieve data from luftdaten.info")

--- a/homeassistant/components/sensor/pi_hole.py
+++ b/homeassistant/components/sensor/pi_hole.py
@@ -144,7 +144,7 @@ class PiHoleAPI(object):
         uri_scheme = 'https://' if use_ssl else 'http://'
         resource = "{}{}{}".format(uri_scheme, host, _ENDPOINT)
 
-        self._rest = RestData('GET', resource, None, None, None, True)
+        self._rest = RestData('GET', resource, None, None, None)
         self.data = None
         self.available = True
         self.update()

--- a/homeassistant/components/sensor/pi_hole.py
+++ b/homeassistant/components/sensor/pi_hole.py
@@ -14,7 +14,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME, CONF_HOST, CONF_SSL, CONF_VERIFY_SSL, CONF_MONITORED_CONDITIONS)
+    CONF_NAME, CONF_HOST, CONF_SSL, CONF_MONITORED_CONDITIONS)
 
 _LOGGER = logging.getLogger(__name__)
 _ENDPOINT = '/api.php'
@@ -30,7 +30,6 @@ DEFAULT_LOCATION = 'admin'
 DEFAULT_METHOD = 'GET'
 DEFAULT_NAME = 'Pi-Hole'
 DEFAULT_SSL = False
-DEFAULT_VERIFY_SSL = True
 
 SCAN_INTERVAL = timedelta(minutes=5)
 
@@ -58,7 +57,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
     vol.Optional(CONF_LOCATION, default=DEFAULT_LOCATION): cv.string,
-    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=MONITORED_CONDITIONS):
         vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
 })
@@ -70,9 +68,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     host = config.get(CONF_HOST)
     use_ssl = config.get(CONF_SSL)
     location = config.get(CONF_LOCATION)
-    verify_ssl = config.get(CONF_VERIFY_SSL)
 
-    api = PiHoleAPI('{}/{}'.format(host, location), use_ssl, verify_ssl)
+    api = PiHoleAPI('{}/{}'.format(host, location), use_ssl)
 
     sensors = [PiHoleSensor(hass, api, name, condition)
                for condition in config[CONF_MONITORED_CONDITIONS]]
@@ -140,14 +137,14 @@ class PiHoleSensor(Entity):
 class PiHoleAPI(object):
     """Get the latest data and update the states."""
 
-    def __init__(self, host, use_ssl, verify_ssl):
+    def __init__(self, host, use_ssl):
         """Initialize the data object."""
         from homeassistant.components.sensor.rest import RestData
 
         uri_scheme = 'https://' if use_ssl else 'http://'
         resource = "{}{}{}".format(uri_scheme, host, _ENDPOINT)
 
-        self._rest = RestData('GET', resource, None, None, None, verify_ssl)
+        self._rest = RestData('GET', resource, None, None, None, True)
         self.data = None
         self.available = True
         self.update()

--- a/homeassistant/components/sensor/pvoutput.py
+++ b/homeassistant/components/sensor/pvoutput.py
@@ -30,7 +30,6 @@ ATTR_EFFICIENCY = 'efficiency'
 CONF_SYSTEM_ID = 'system_id'
 
 DEFAULT_NAME = 'PVOutput'
-DEFAULT_VERIFY_SSL = True
 
 SCAN_INTERVAL = timedelta(minutes=2)
 
@@ -48,13 +47,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     system_id = config.get(CONF_SYSTEM_ID)
     method = 'GET'
     payload = auth = None
-    verify_ssl = DEFAULT_VERIFY_SSL
     headers = {
         'X-Pvoutput-Apikey': api_key,
         'X-Pvoutput-SystemId': system_id,
     }
 
-    rest = RestData(method, _ENDPOINT, auth, headers, payload, verify_ssl)
+    rest = RestData(method, _ENDPOINT, auth, headers, payload)
     rest.update()
 
     if rest.data is None:

--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
     CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT, CONF_SSL,
-    CONF_VERIFY_SSL, CONF_TIMEOUT, CONF_MONITORED_CONDITIONS, TEMP_CELSIUS)
+    CONF_TIMEOUT, CONF_MONITORED_CONDITIONS, TEMP_CELSIUS)
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
@@ -90,7 +90,6 @@ _MONITORED_CONDITIONS = list(_SYSTEM_MON_COND.keys()) + \
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_SSL, default=False): cv.boolean,
-    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     vol.Required(CONF_USERNAME): cv.string,
@@ -191,7 +190,7 @@ class QNAPStatsAPI(object):
             config.get(CONF_PORT),
             config.get(CONF_USERNAME),
             config.get(CONF_PASSWORD),
-            verify_ssl=config.get(CONF_VERIFY_SSL),
+            verify_ssl=True,
             timeout=config.get(CONF_TIMEOUT),
         )
 

--- a/homeassistant/components/sensor/scrape.py
+++ b/homeassistant/components/sensor/scrape.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.components.sensor.rest import RestData
 from homeassistant.const import (
     CONF_NAME, CONF_RESOURCE, CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN,
-    CONF_VALUE_TEMPLATE, CONF_VERIFY_SSL, CONF_USERNAME,
+    CONF_VALUE_TEMPLATE, CONF_USERNAME,
     CONF_PASSWORD, CONF_AUTHENTICATION, HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION)
 from homeassistant.helpers.entity import Entity
@@ -27,7 +27,6 @@ CONF_SELECT = 'select'
 CONF_ATTR = 'attribute'
 
 DEFAULT_NAME = 'Web scrape'
-DEFAULT_VERIFY_SSL = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.string,
@@ -40,7 +39,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
 
 
@@ -50,7 +48,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     resource = config.get(CONF_RESOURCE)
     method = 'GET'
     payload = headers = None
-    verify_ssl = config.get(CONF_VERIFY_SSL)
     select = config.get(CONF_SELECT)
     attr = config.get(CONF_ATTR)
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
@@ -67,7 +64,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             auth = HTTPBasicAuth(username, password)
     else:
         auth = None
-    rest = RestData(method, resource, auth, headers, payload, verify_ssl)
+    rest = RestData(method, resource, auth, headers, payload)
     rest.update()
 
     if rest.data is None:


### PR DESCRIPTION
Based on discussion here:
https://github.com/home-assistant/home-assistant/pull/11072

This is a 1st pass at removing the ability to disable SSL_VERIFY this will increase security by ensuring certificates are trusted and have been configured correctly.