### PR TITLE
Fix for track_new_devices BC

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -88,7 +88,7 @@ NEW_DEVICE_DEFAULTS_SCHEMA = vol.Any(None, vol.Schema({
 }))
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
-    vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
+    vol.Optional(CONF_TRACK_NEW): cv.boolean,
     vol.Optional(CONF_CONSIDER_HOME,
                  default=DEFAULT_CONSIDER_HOME): vol.All(
                      cv.time_period, cv.positive_timedelta),
@@ -131,8 +131,10 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
     conf = config.get(DOMAIN, [])
     conf = conf[0] if conf else {}
     consider_home = conf.get(CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME)
-    track_new = conf.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
+
     defaults = conf.get(CONF_NEW_DEVICE_DEFAULTS, {})
+    track_new = conf.get(CONF_TRACK_NEW) if conf.get(CONF_TRACK_NEW) \
+        is not None else defaults.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
 
     devices = yield from async_load_config(yaml_path, hass, consider_home)
     tracker = DeviceTracker(
@@ -227,7 +229,8 @@ class DeviceTracker(object):
         self.devices = {dev.dev_id: dev for dev in devices}
         self.mac_to_dev = {dev.mac: dev for dev in devices if dev.mac}
         self.consider_home = consider_home
-        self.track_new = defaults.get(CONF_TRACK_NEW, track_new)
+        self.track_new = track_new if track_new is not None \
+            else defaults.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
         self.defaults = defaults
         self.group = None
         self._is_updating = asyncio.Lock(loop=hass.loop)

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -133,8 +133,9 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
     consider_home = conf.get(CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME)
 
     defaults = conf.get(CONF_NEW_DEVICE_DEFAULTS, {})
-    track_new = conf.get(CONF_TRACK_NEW) if conf.get(CONF_TRACK_NEW) \
-        is not None else defaults.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
+    track_new = conf.get(CONF_TRACK_NEW)
+    if track_new is None:
+        track_new = defaults.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
 
     devices = yield from async_load_config(yaml_path, hass, consider_home)
     tracker = DeviceTracker(

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -675,6 +675,18 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         assert len(config) == 1
         self.assertTrue(config[0].hidden)
 
+    def test_backward_compatibility_for_track_new(self):
+        """Test that default track_new is used."""
+        tracker = device_tracker.DeviceTracker(
+            self.hass, timedelta(seconds=60), False,
+            {device_tracker.CONF_TRACK_NEW: True}, [])
+        tracker.see(dev_id=13)
+        self.hass.block_till_done()
+        config = device_tracker.load_config(self.yaml_devices, self.hass,
+                                            timedelta(seconds=0))
+        assert len(config) == 1
+        self.assertFalse(config[0].track)
+
 
 @asyncio.coroutine
 def test_async_added_to_hass(hass):

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -676,11 +676,23 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         self.assertTrue(config[0].hidden)
 
     def test_backward_compatibility_for_track_new(self):
-        """Test that default track_new is used."""
+        """Test backward compatibility for track new."""
         tracker = device_tracker.DeviceTracker(
             self.hass, timedelta(seconds=60), False,
             {device_tracker.CONF_TRACK_NEW: True}, [])
         tracker.see(dev_id=13)
+        self.hass.block_till_done()
+        config = device_tracker.load_config(self.yaml_devices, self.hass,
+                                            timedelta(seconds=0))
+        assert len(config) == 1
+        self.assertFalse(config[0].track)
+
+    def test_old_style_track_new_is_skipped(self):
+        """Test old style config is skipped."""
+        tracker = device_tracker.DeviceTracker(
+            self.hass, timedelta(seconds=60), None,
+            {device_tracker.CONF_TRACK_NEW: False}, [])
+        tracker.see(dev_id=14)
         self.hass.block_till_done()
         config = device_tracker.load_config(self.yaml_devices, self.hass,
                                             timedelta(seconds=0))


### PR DESCRIPTION
## Description:
Backward compatibility fix for `track_new_devices`

**Related issue (if applicable):** fixes #11184


## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
