### PR TITLE
Add `alarm_toggle_chime` method in the Alarm Decoder component

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -121,6 +121,7 @@ def alarm_arm_custom_bypass(hass, code=None, entity_id=None):
 
     hass.services.call(DOMAIN, SERVICE_ALARM_ARM_CUSTOM_BYPASS, data)
 
+
 @bind_hass
 def alarm_toggle_chime(hass, code=None, entity_id=None):
     """Send the alarm the command to toggle the chime."""

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -14,7 +14,8 @@ import voluptuous as vol
 from homeassistant.const import (
     ATTR_CODE, ATTR_CODE_FORMAT, ATTR_ENTITY_ID, SERVICE_ALARM_TRIGGER,
     SERVICE_ALARM_DISARM, SERVICE_ALARM_ARM_HOME, SERVICE_ALARM_ARM_AWAY,
-    SERVICE_ALARM_ARM_NIGHT, SERVICE_ALARM_ARM_CUSTOM_BYPASS)
+    SERVICE_ALARM_ARM_NIGHT, SERVICE_ALARM_ARM_CUSTOM_BYPASS,
+    SERVICE_ALARM_TOGGLE_CHIME)
 from homeassistant.config import load_yaml_config_file
 from homeassistant.loader import bind_hass
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
@@ -34,7 +35,8 @@ SERVICE_TO_METHOD = {
     SERVICE_ALARM_ARM_AWAY: 'alarm_arm_away',
     SERVICE_ALARM_ARM_NIGHT: 'alarm_arm_night',
     SERVICE_ALARM_ARM_CUSTOM_BYPASS: 'alarm_arm_custom_bypass',
-    SERVICE_ALARM_TRIGGER: 'alarm_trigger'
+    SERVICE_ALARM_TRIGGER: 'alarm_trigger',
+    SERVICE_ALARM_TOGGLE_CHIME: 'alarm_toggle_chime'
 }
 
 ATTR_TO_PROPERTY = [
@@ -118,6 +120,17 @@ def alarm_arm_custom_bypass(hass, code=None, entity_id=None):
         data[ATTR_ENTITY_ID] = entity_id
 
     hass.services.call(DOMAIN, SERVICE_ALARM_ARM_CUSTOM_BYPASS, data)
+
+@bind_hass
+def alarm_toggle_chime(hass, code=None, entity_id=None):
+    """Send the alarm the command to toggle the chime."""
+    data = {}
+    if code:
+        data[ATTR_CODE] = code
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    hass.services.call(DOMAIN, SERVICE_ALARM_TOGGLE_CHIME, data)
 
 
 @asyncio.coroutine
@@ -239,6 +252,17 @@ class AlarmControlPanel(Entity):
         This method must be run in the event loop and returns a coroutine.
         """
         return self.hass.async_add_job(self.alarm_arm_custom_bypass, code)
+
+    def alarm_toggle_chime(self, code=None):
+        """Send toggle chime command."""
+        raise NotImplementedError()
+
+    def async_alarm_toggle_chime(self, code=None):
+        """Send toggle chime command.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.async_add_job(self.alarm_toggle_chime, code)
 
     @property
     def state_attributes(self):

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -97,8 +97,8 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
             _LOGGER.debug("alarm_arm_home: sending %s3", str(code))
             self.hass.data[DATA_AD].send("{!s}3".format(code))
 
-    def alarm_arm_custom_bypass(self, code=None):
-        """Send custom bypass command."""
+    def alarm_toggle_chime(self, code=None):
+        """Send toggle chime command."""
         if code:
-            _LOGGER.debug("alarm_arm_custom_bypass: sending %s", str(code))
-            self.hass.data[DATA_AD].send("{!s}".format(code))
+            _LOGGER.debug("alarm_toggle_chime: sending %s9", str(code))
+            self.hass.data[DATA_AD].send("{!s}9".format(code))

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -12,7 +12,7 @@ from homeassistant.components.alarmdecoder import (
     DATA_AD, SIGNAL_PANEL_MESSAGE)
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
-    STATE_ALARM_ARMED_CUSTOM_BYPASS, STATE_ALARM_TRIGGERED)
+    STATE_ALARM_TRIGGERED)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -12,7 +12,7 @@ from homeassistant.components.alarmdecoder import (
     DATA_AD, SIGNAL_PANEL_MESSAGE)
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
-    STATE_ALARM_TRIGGERED)
+    STATE_ALARM_ARMED_CUSTOM_BYPASS, STATE_ALARM_TRIGGERED)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,3 +96,9 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
         if code:
             _LOGGER.debug("alarm_arm_home: sending %s3", str(code))
             self.hass.data[DATA_AD].send("{!s}3".format(code))
+
+    def alarm_arm_custom_bypass(self, code=None):
+        """Send custom bypass command."""
+        if code:
+            _LOGGER.debug("alarm_arm_custom_bypass: sending %s", str(code))
+            self.hass.data[DATA_AD].send("{!s}".format(code))

--- a/homeassistant/components/alarm_control_panel/services.yaml
+++ b/homeassistant/components/alarm_control_panel/services.yaml
@@ -50,6 +50,16 @@ alarm_trigger:
       description: An optional code to trigger the alarm control panel with.
       example: 1234
 
+alarm_toggle_chime:
+  description: Send the alarm the command to toggle the chime.
+  fields:
+    entity_id:
+      description: Name of alarm control panel to trigger.
+      example: 'alarm_control_panel.downstairs'
+    code:
+      description: An optional code to toggle the alarm control panel chime with.
+      example: 1234
+
 envisalink_alarm_keypress:
   description: Send custom keypresses to the alarm.
   fields:

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -352,7 +352,7 @@ SERVICE_ALARM_ARM_AWAY = 'alarm_arm_away'
 SERVICE_ALARM_ARM_NIGHT = 'alarm_arm_night'
 SERVICE_ALARM_ARM_CUSTOM_BYPASS = 'alarm_arm_custom_bypass'
 SERVICE_ALARM_TRIGGER = 'alarm_trigger'
-
+SERVICE_ALARM_TOGGLE_CHIME = 'alarm_toggle_chime'
 
 SERVICE_LOCK = 'lock'
 SERVICE_UNLOCK = 'unlock'


### PR DESCRIPTION
## Description:
Add the method `alarm_toggle_chime` in the Alarm Decoder component. Doing so allows this service method to be called in the Home Assistant UI Services tab, the REST API, or the Websocket API with an alarm code that sends the command to toggle the alarm's chime function on or off.

Note: Getting the actual status of the chime will come in https://github.com/home-assistant/home-assistant/pull/11155.

```release-note
Added a new `alarm_toggle_chime` method in the Alarm Decoder component.
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
