### PR TITLE
Fix bytearray to utf-8 in response from netdisco

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -97,6 +97,10 @@ def async_setup(hass, config):
     @asyncio.coroutine
     def new_service_found(service, info):
         """Handle a new service if one is found."""
+        # Fix bytearray to utf-8.
+        if isinstance(info, dict):
+            info = {a: str(b, 'utf-8') if isinstance(b,
+                    (bytes, bytearray)) else b for a, b in info.items()}
         if service in ignored_platforms:
             logger.info("Ignoring service: %s %s", service, info)
             return


### PR DESCRIPTION
## Description:

Fixes an utf-8 issue with some data from netdisco.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
