### PR TITLE
Update modbus.py

### DIFF
--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -40,7 +40,7 @@ SERIAL_SCHEMA = {
 ETHERNET_SCHEMA = {
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PORT): cv.positive_int,
-    vol.Required(CONF_TYPE): vol.Any('tcp', 'udp'),
+    vol.Required(CONF_TYPE): vol.Any('tcp', 'udp', 'rtuovertcp'),
     vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
 }
 
@@ -91,6 +91,13 @@ def setup(hass, config):
                               stopbits=config[DOMAIN][CONF_STOPBITS],
                               bytesize=config[DOMAIN][CONF_BYTESIZE],
                               parity=config[DOMAIN][CONF_PARITY],
+                              timeout=config[DOMAIN][CONF_TIMEOUT])
+    elif client_type == 'rtuovertcp':
+        from pymodbus.client.sync import ModbusTcpClient as ModbusClient
+        from pymodbus.transaction import ModbusRtuFramer as ModbusFramer
+        client = ModbusClient(host=config[DOMAIN][CONF_HOST],
+                              port=config[DOMAIN][CONF_PORT],
+                              framer=ModbusFramer,
                               timeout=config[DOMAIN][CONF_TIMEOUT])
     elif client_type == 'tcp':
         from pymodbus.client.sync import ModbusTcpClient as ModbusClient


### PR DESCRIPTION
Support of MODBUS RTU over TCP ethernet mode. See more info here:  https://www.eltima.com/modbus-over-ethernet/

## Description:
Pull request for the documentaiton update: https://github.com/home-assistant/home-assistant.github.io/pull/4261

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
modbus:
  type: rtuovertcp
  host: 192.168.0.11
  port: 10001
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
