### PR TITLE
alexa: Add handling for covers

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -243,7 +243,11 @@ def async_api_turn_on(hass, config, request, entity):
     if entity.domain == group.DOMAIN:
         domain = ha.DOMAIN
 
-    yield from hass.services.async_call(domain, SERVICE_TURN_ON, {
+    service = SERVICE_TURN_ON
+    if entity.domain == cover.DOMAIN:
+        service = cover.SERVICE_OPEN_COVER
+
+    yield from hass.services.async_call(domain, service, {
         ATTR_ENTITY_ID: entity.entity_id
     }, blocking=True)
 
@@ -259,7 +263,11 @@ def async_api_turn_off(hass, config, request, entity):
     if entity.domain == group.DOMAIN:
         domain = ha.DOMAIN
 
-    yield from hass.services.async_call(domain, SERVICE_TURN_OFF, {
+    service = SERVICE_TURN_OFF
+    if entity.domain == cover.DOMAIN:
+        service = cover.SERVICE_CLOSE_COVER
+
+    yield from hass.services.async_call(domain, service, {
         ATTR_ENTITY_ID: entity.entity_id
     }, blocking=True)
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -419,7 +419,7 @@ def test_api_function_not_implemented(hass):
 
 
 @asyncio.coroutine
-@pytest.mark.parametrize("domain", ['alert', 'automation', 'group',
+@pytest.mark.parametrize("domain", ['alert', 'automation', 'cover', 'group',
                                     'input_boolean', 'light', 'script',
                                     'switch'])
 def test_api_turn_on(hass, domain):
@@ -438,7 +438,10 @@ def test_api_turn_on(hass, domain):
     if domain == 'group':
         call_domain = 'homeassistant'
 
-    call = async_mock_service(hass, call_domain, 'turn_on')
+    if domain == 'cover':
+        call = async_mock_service(hass, call_domain, 'open_cover')
+    else:
+        call = async_mock_service(hass, call_domain, 'turn_on')
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
@@ -452,7 +455,7 @@ def test_api_turn_on(hass, domain):
 
 
 @asyncio.coroutine
-@pytest.mark.parametrize("domain", ['alert', 'automation', 'group',
+@pytest.mark.parametrize("domain", ['alert', 'automation', 'cover', 'group',
                                     'input_boolean', 'light', 'script',
                                     'switch'])
 def test_api_turn_off(hass, domain):
@@ -471,7 +474,10 @@ def test_api_turn_off(hass, domain):
     if domain == 'group':
         call_domain = 'homeassistant'
 
-    call = async_mock_service(hass, call_domain, 'turn_off')
+    if domain == 'cover':
+        call = async_mock_service(hass, call_domain, 'close_cover')
+    else:
+        call = async_mock_service(hass, call_domain, 'turn_off')
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)


### PR DESCRIPTION
Covers don't support either cover.turn_on or homeassistant.turn_on so
use cover.[open|close]\_cover. Alternately maybe the homeassistant.turn_[on|off] services should support covers? I'd be fine digging around there if that's preferred.

I also picked on == open kind of arbitrarily because honestly neither makes sense but that's similar to how emulated_hue worked.

## Description:

**Related issue (if applicable):** fixes #11211

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
