### PR TITLE
Fido component use now asyncio

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -518,7 +518,6 @@ omit =
     homeassistant/components/sensor/etherscan.py
     homeassistant/components/sensor/fastdotcom.py
     homeassistant/components/sensor/fedex.py
-    homeassistant/components/sensor/fido.py
     homeassistant/components/sensor/fitbit.py
     homeassistant/components/sensor/fixer.py
     homeassistant/components/sensor/fritzbox_callmonitor.py

--- a/homeassistant/components/sensor/fido.py
+++ b/homeassistant/components/sensor/fido.py
@@ -79,7 +79,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     fido_data = FidoData(username, password)
     ret = yield from fido_data.async_update()
     if ret is False:
-        return False
+        return
 
     name = config.get(CONF_NAME)
 

--- a/homeassistant/components/sensor/fido.py
+++ b/homeassistant/components/sensor/fido.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyfido==2.0.1']
+REQUIREMENTS = ['pyfido==2.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,7 +76,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    fido_data = FidoData(username, password)
+    httpsession = hass.helpers.aiohttp_client.async_get_clientsession()
+    fido_data = FidoData(username, password, httpsession)
     ret = yield from fido_data.async_update()
     if ret is False:
         return
@@ -149,10 +150,11 @@ class FidoSensor(Entity):
 class FidoData(object):
     """Get data from Fido."""
 
-    def __init__(self, username, password):
+    def __init__(self, username, password, httpsession):
         """Initialize the data object."""
         from pyfido import FidoClient
-        self.client = FidoClient(username, password, REQUESTS_TIMEOUT)
+        self.client = FidoClient(username, password,
+                                 REQUESTS_TIMEOUT, httpsession)
         self.data = {}
 
     @asyncio.coroutine

--- a/homeassistant/components/sensor/fido.py
+++ b/homeassistant/components/sensor/fido.py
@@ -7,10 +7,10 @@ https://www.fido.ca/pages/#/my-account/wireless
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.fido/
 """
+import asyncio
 import logging
 from datetime import timedelta
 
-import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyfido==1.0.1']
+REQUIREMENTS = ['pyfido==2.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,17 +70,14 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Fido sensor."""
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    try:
-        fido_data = FidoData(username, password)
-        fido_data.update()
-    except requests.exceptions.HTTPError as error:
-        _LOGGER.error("Failt login: %s", error)
-        return False
+    fido_data = FidoData(username, password)
+    yield from fido_data.update()
 
     name = config.get(CONF_NAME)
 
@@ -89,7 +86,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         for variable in config[CONF_MONITORED_VARIABLES]:
             sensors.append(FidoSensor(fido_data, variable, name, number))
 
-    add_devices(sensors, True)
+    async_add_devices(sensors, True)
 
 
 class FidoSensor(Entity):
@@ -133,9 +130,10 @@ class FidoSensor(Entity):
             'number': self._number,
         }
 
-    def update(self):
+    @asyncio.coroutine
+    def async_update(self):
         """Get the latest data from Fido and update the state."""
-        self.fido_data.update()
+        yield from self.fido_data.update()
         if self.type == 'balance':
             if self.fido_data.data.get(self.type) is not None:
                 self._state = round(self.fido_data.data[self.type], 2)
@@ -155,14 +153,14 @@ class FidoData(object):
         self.client = FidoClient(username, password, REQUESTS_TIMEOUT)
         self.data = {}
 
+    @asyncio.coroutine
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from Fido."""
-        from pyfido.client import PyFidoError
         try:
-            self.client.fetch_data()
-        except PyFidoError as err:
-            _LOGGER.error("Error on receive last Fido data: %s", err)
+            yield from self.client.fetch_data()
+        except BaseException as exp:
+            _LOGGER.error("Error on receive last Fido data: %s", exp)
             return
         # Update data
         self.data = self.client.get_data()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -680,7 +680,7 @@ pyenvisalink==2.2
 pyephember==0.1.1
 
 # homeassistant.components.sensor.fido
-pyfido==2.0.1
+pyfido==2.1.0
 
 # homeassistant.components.climate.flexit
 pyflexit==0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -680,7 +680,7 @@ pyenvisalink==2.2
 pyephember==0.1.1
 
 # homeassistant.components.sensor.fido
-pyfido==1.0.1
+pyfido==2.0.1
 
 # homeassistant.components.climate.flexit
 pyflexit==0.3

--- a/tests/components/sensor/test_fido.py
+++ b/tests/components/sensor/test_fido.py
@@ -1,0 +1,92 @@
+"""The test for the fido sensor platform."""
+import asyncio
+import logging
+import sys
+from unittest.mock import MagicMock
+
+from homeassistant.bootstrap import async_setup_component
+from homeassistant.components.sensor import fido
+from tests.common import assert_setup_component
+
+
+CONTRACT = "123456789"
+
+
+class FidoClientMock():
+    """Fake Fido client."""
+
+    def __init__(self, username, password, contract=None):
+        """Fake Fido client init."""
+        pass
+
+    def get_phone_numbers(self):
+        """Return Phone numbers."""
+        return ["1112223344"]
+
+    def get_data(self):
+        """Return fake fido data."""
+        return {"balance": 160.12,
+                "1112223344": {"data_remaining": 100.33}}
+
+    @asyncio.coroutine
+    def fetch_data(self):
+        """Return fake fetching data."""
+        pass
+
+
+class FidoClientMockError(FidoClientMock):
+    """Fake Fido client error."""
+
+    @asyncio.coroutine
+    def fetch_data(self):
+        """Return fake fetching data."""
+        raise fido.PyFidoError("Fake Error")
+
+
+class PyFidoErrorMock(BaseException):
+    """Fake PyFido Error."""
+
+
+@asyncio.coroutine
+def test_fido_sensor(loop, hass):
+    """Test the Fido number sensor."""
+    sys.modules['pyfido'] = MagicMock()
+    sys.modules['pyfido.client'] = MagicMock()
+    sys.modules['pyfido.client.PyFidoError'] = \
+        PyFidoErrorMock
+    import pyfido.client
+    pyfido.FidoClient = FidoClientMock
+    pyfido.client.PyFidoError = PyFidoErrorMock
+    config = {
+        'sensor': {
+            'platform': 'fido',
+            'name': 'fido',
+            'username': 'myusername',
+            'password': 'password',
+            'monitored_variables': [
+                'balance',
+                'data_remaining',
+            ],
+        }
+    }
+    with assert_setup_component(1):
+        yield from async_setup_component(hass, 'sensor', config)
+    state = hass.states.get('sensor.fido_1112223344_balance')
+    assert state.state == "160.12"
+    assert state.attributes.get('number') == "1112223344"
+    state = hass.states.get('sensor.fido_1112223344_data_remaining')
+    assert state.state == "100.33"
+
+
+@asyncio.coroutine
+def test_error(hass, caplog):
+    """Test the Fido sensor errors."""
+    caplog.set_level(logging.ERROR)
+    sys.modules['pyfido'] = MagicMock()
+    sys.modules['pyfido.client'] = MagicMock()
+    import pyfido.client
+    pyfido.FidoClient = FidoClientMockError
+    pyfido.client.PyFidoError = BaseException
+    fido_data = fido.FidoData('username', 'password')
+    yield from fido_data.update()
+    assert "Error on receive last Fido data: " in caplog.text

--- a/tests/components/sensor/test_fido.py
+++ b/tests/components/sensor/test_fido.py
@@ -43,7 +43,7 @@ class FidoClientMockError(FidoClientMock):
         raise PyFidoErrorMock("Fake Error")
 
 
-class PyFidoErrorMock(BaseException):
+class PyFidoErrorMock(Exception):
     """Fake PyFido Error."""
 
 
@@ -105,8 +105,4 @@ def test_error(hass, caplog):
     config = {}
     ret = yield from fido.async_setup_platform(hass, config,
                                                fake_async_add_devices)
-    assert ret is False
-
-    fido_data = fido.FidoData('username', 'password')
-    ret = yield from fido_data.async_update()
-    assert ret is False
+    assert ret is None

--- a/tests/components/sensor/test_fido.py
+++ b/tests/components/sensor/test_fido.py
@@ -103,6 +103,7 @@ def test_error(hass, caplog):
     sys.modules['pyfido.client'] = PyFidoClientFakeModule()
 
     config = {}
-    ret = yield from fido.async_setup_platform(hass, config,
-                                               fake_async_add_devices)
-    assert ret is None
+    fake_async_add_devices = MagicMock()
+    yield from fido.async_setup_platform(hass, config,
+                                         fake_async_add_devices)
+    assert fake_async_add_devices.called is False

--- a/tests/components/sensor/test_fido.py
+++ b/tests/components/sensor/test_fido.py
@@ -15,7 +15,7 @@ CONTRACT = "123456789"
 class FidoClientMock():
     """Fake Fido client."""
 
-    def __init__(self, username, password, contract=None):
+    def __init__(self, username, password, timeout=None, httpsession=None):
         """Fake Fido client init."""
         pass
 


### PR DESCRIPTION
## Description:

The fido component is now using asyncio

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
