### PR TITLE
Added password for GPS logger endpoint

### DIFF
--- a/homeassistant/components/device_tracker/gpslogger.py
+++ b/homeassistant/components/device_tracker/gpslogger.py
@@ -4,11 +4,11 @@ Support for the GPSLogger platform.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.gpslogger/
 """
-from aiohttp.web import Request, HTTPUnauthorized  # NOQA
 import asyncio
 from functools import partial
 import logging
 
+from aiohttp.web import Request, HTTPUnauthorized  # NOQA
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -62,7 +62,6 @@ class GPSLoggerView(HomeAssistantView):
     @asyncio.coroutine
     def _handle(self, hass, request: Request):
         """Handle GPSLogger requests."""
-
         data = request.query
 
         if self._password is not None:

--- a/homeassistant/components/device_tracker/gpslogger.py
+++ b/homeassistant/components/device_tracker/gpslogger.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.gpslogger/
 """
 import asyncio
-from functools import partial
 import logging
 
 from aiohttp.web import Request, HTTPUnauthorized  # NOQA

--- a/homeassistant/components/device_tracker/gpslogger.py
+++ b/homeassistant/components/device_tracker/gpslogger.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/device_tracker.gpslogger/
 """
 import asyncio
 import logging
+from hmac import compare_digest
 
 from aiohttp.web import Request, HTTPUnauthorized  # NOQA
 import voluptuous as vol
@@ -60,7 +61,6 @@ class GPSLoggerView(HomeAssistantView):
         data = request.query
 
         if self._password is not None:
-            from hmac import compare_digest
             authenticated = CONF_API_PASSWORD in data and compare_digest(
                 self._password,
                 data[CONF_API_PASSWORD]


### PR DESCRIPTION
## Description:
Adds separate authentication possible for GPS logger entry point. The goal here is to minimize the impact if GPS logger password is disclosed.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4253

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: gpslogger
    password: !secret gpslogger_password
```

