### PR TITLE
Load the game name from the steam store api

### DIFF
--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -8,7 +8,8 @@ import logging
 
 import voluptuous as vol
 
-import urllib.request, json
+import urllib.request
+import json
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity

--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -8,6 +8,8 @@ import logging
 
 import voluptuous as vol
 
+import urllib.request, json
+
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import CONF_API_KEY
@@ -75,10 +77,17 @@ class SteamSensor(Entity):
         """Update device state."""
         try:
             self._profile = self._steamod.user.profile(self._account)
-            if self._profile.current_game[2] is None:
+            if self._profile.current_game[0] is None:
                 self._game = 'None'
             else:
-                self._game = self._profile.current_game[2]
+                if self._profile.current_game[2] is None:
+                    game_id = self._profile.current_game[0]
+                    url = 'http://store.steampowered.com/api/appdetails?appids=' + str(game_id)
+                    with urllib.request.urlopen(url) as url:
+                        data = json.loads(url.read().decode())
+                        self._game = data[str(game_id)]['data']['name']
+                else:
+                    self._game = self._profile.current_game[2]
             self._state = {
                 1: STATE_ONLINE,
                 2: STATE_BUSY,


### PR DESCRIPTION
If the game name hasn't been set in what we get back from steamod we load it from the steam api.

## Description:
The game name doesn't get pulled through and always says 'None'. The game ID however does get pulled through. This just uses the steam api to get the games name

fixes #11240

## Checklist:


If user exposed functionality or configuration variables are added/changed:
  - [Not done - no functionality change ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [This hasn't been done yet...] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [None ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [I placed the imports in the same place the others were... maybe they need moving?] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [None ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ None] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
