### PR TITLE
Fix detection of if a negative node is in use

### DIFF
--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -165,7 +165,7 @@ class ISYBinarySensorDevice(isy.ISYDevice, BinarySensorDevice):
         """
         self._negative_node = child
 
-        if not _is_val_unknown(self._negative_node):
+        if not _is_val_unknown(self._negative_node.status._val):
             # If the negative node has a value, it means the negative node is
             # in use for this device. Therefore, we cannot determine the state
             # of the sensor until we receive our first ON event.

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -165,6 +165,7 @@ class ISYBinarySensorDevice(isy.ISYDevice, BinarySensorDevice):
         """
         self._negative_node = child
 
+        # pylint: disable=protected-access
         if not _is_val_unknown(self._negative_node.status._val):
             # If the negative node has a value, it means the negative node is
             # in use for this device. Therefore, we cannot determine the state


### PR DESCRIPTION
## Description:
Fix a problem where every negative node gets detected as in-use. Code was not checking the correct property.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

