### PR TITLE
Fix handling zero values for state_on/state_off

### DIFF
--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -141,10 +141,17 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
         self._verify_register = (
             verify_register if verify_register else self._register)
         self._register_type = register_type
-        self._state_on = (
-            state_on if state_on else self._command_on)
-        self._state_off = (
-            state_off if state_off else self._command_off)
+
+        if state_on is not None:
+            self._state_on = state_on
+        else:
+            self._state_on = self._command_on
+
+        if state_off is not None:
+            self._state_off = state_off
+        else:
+            self._state_off = self._command_off
+
         self._is_on = None
 
     def turn_on(self, **kwargs):


### PR DESCRIPTION
## Description:
Before this patch if `state_on` or `state_off` was set to zero they are considered as not set. 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
