### PR TITLE
Add Chime status and control to Alarm Decoder component

### DIFF
--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -34,6 +34,15 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
         self._display = ""
         self._name = "Alarm Panel"
         self._state = None
+        self._ac_power = None
+        self._backlight_on = None
+        self._battery_low = None
+        self._check_zone = None
+        self._chime = None
+        self._entry_delay_off = None
+        self._programming_mode = None
+        self._ready = None
+        self._zone_bypassed = None
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -42,22 +51,63 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
             SIGNAL_PANEL_MESSAGE, self._message_callback)
 
     def _message_callback(self, message):
+        do_update = False
+
         if message.alarm_sounding or message.fire_alarm:
             if self._state != STATE_ALARM_TRIGGERED:
                 self._state = STATE_ALARM_TRIGGERED
-                self.schedule_update_ha_state()
+                do_update = True
         elif message.armed_away:
             if self._state != STATE_ALARM_ARMED_AWAY:
                 self._state = STATE_ALARM_ARMED_AWAY
-                self.schedule_update_ha_state()
+                do_update = True
         elif message.armed_home:
             if self._state != STATE_ALARM_ARMED_HOME:
                 self._state = STATE_ALARM_ARMED_HOME
-                self.schedule_update_ha_state()
+                do_update = True
         else:
             if self._state != STATE_ALARM_DISARMED:
                 self._state = STATE_ALARM_DISARMED
-                self.schedule_update_ha_state()
+                do_update = True
+
+        if self._ac_power != message.ac_power:
+            self._ac_power = message.ac_power
+            do_update = True
+
+        if self._backlight_on != message.backlight_on:
+            self._backlight_on = message.backlight_on
+            do_update = True
+
+        if self._battery_low != message.battery_low:
+            self._battery_low = message.battery_low
+            do_update = True
+
+        if self._check_zone != message.check_zone:
+            self._check_zone = message.check_zone
+            do_update = True
+
+        if self._chime != message.chime_on:
+            self._chime = message.chime_on
+            do_update = True
+
+        if self._entry_delay_off != message.entry_delay_off:
+            self._entry_delay_off = message.entry_delay_off
+            do_update = True
+
+        if self._programming_mode != message.programming_mode:
+            self._programming_mode = message.programming_mode
+            do_update = True
+
+        if self._ready != message.ready:
+            self._ready = message.ready
+            do_update = True
+
+        if self._zone_bypassed != message.zone_bypassed:
+            self._zone_bypassed = message.zone_bypassed
+            do_update = True
+
+        if do_update is True:
+            self.schedule_update_ha_state()
 
     @property
     def name(self):
@@ -78,6 +128,21 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
     def state(self):
         """Return the state of the device."""
         return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            'ac_power': self._ac_power,
+            'backlight_on': self._backlight_on,
+            'battery_low': self._battery_low,
+            'check_zone': self._check_zone,
+            'chime': self._chime,
+            'entry_delay_off': self._entry_delay_off,
+            'programming_mode': self._programming_mode,
+            'ready': self._ready,
+            'zone_bypassed': self._zone_bypassed
+        }
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -27,6 +27,7 @@ ALARM_TOGGLE_CHIME_SCHEMA = vol.Schema({
     vol.Optional(ATTR_CODE): cv.string,
 })
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up for AlarmDecoder alarm panels."""
     device = AlarmDecoderAlarmPanel()

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/alarm_control_panel.alarmdecoder/
 """
 import asyncio
 import logging
-import os
+from os import path
 
 import voluptuous as vol
 
@@ -39,9 +39,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         code = service.data.get(ATTR_CODE)
         device.alarm_toggle_chime(code)
 
-    descriptions = yield from hass.async_add_job(
-        load_yaml_config_file, os.path.join(
-            os.path.dirname(__file__), 'services.yaml'))
+    descriptions = load_yaml_config_file(
+        path.join(path.dirname(__file__), 'services.yaml'))
 
     hass.services.register(
         alarm.DOMAIN, SERVICE_ALARM_TOGGLE_CHIME, alarm_toggle_chime_handler,

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -15,8 +15,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.alarmdecoder import (
     DATA_AD, SIGNAL_PANEL_MESSAGE)
 from homeassistant.const import (
-    ATTR_CODE, STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
-    STATE_ALARM_TRIGGERED)
+    ATTR_CODE, STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -6,10 +6,10 @@ https://home-assistant.io/components/alarm_control_panel.alarmdecoder/
 """
 import asyncio
 import logging
+import os
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 import homeassistant.components.alarm_control_panel as alarm
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config import load_yaml_config_file
@@ -45,7 +45,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     hass.services.register(
         alarm.DOMAIN, SERVICE_ALARM_TOGGLE_CHIME, alarm_toggle_chime_handler,
-        descriptions.get(SERVICE_ALARM_TOGGLE_CHIME), schema=ALARM_TOGGLE_CHIME_SCHEMA)
+        descriptions.get(SERVICE_ALARM_TOGGLE_CHIME),
+        schema=ALARM_TOGGLE_CHIME_SCHEMA)
 
 
 class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):

--- a/homeassistant/components/alarm_control_panel/services.yaml
+++ b/homeassistant/components/alarm_control_panel/services.yaml
@@ -59,3 +59,13 @@ envisalink_alarm_keypress:
     keypress:
       description: 'String to send to the alarm panel (1-6 characters).'
       example: '*71'
+
+alarmdecoder_alarm_toggle_chime:
+  description: Send the alarm the toggle chime command.
+  fields:
+    entity_id:
+      description: Name of the alarm control panel to trigger.
+      example: 'alarm_control_panel.downstairs'
+    code:
+      description: A required code to toggle the alarm control panel chime with.
+      example: 1234


### PR DESCRIPTION
## Description:
Add the method `alarmdecoder_alarm_toggle_chime` in the Alarm Decoder component only. Doing so allows this service method to be called in the Home Assistant UI Services tab, the REST API, or the Websocket API with an alarm code that sends the command to toggle the alarm's chime function on or off.

This PR also includes the changes from https://github.com/home-assistant/home-assistant/pull/11155 done by @hawk259, which exposes additional attributes on the Alarm Decoder alarm panel. The `chime` and `ready` attributes in particular are required to round out this feature.

```release-note
- Added a new `alarmdecoder_alarm_toggle_chime` method in the Alarm Decoder component. (@goyney)
- Added new status attributes to the Alarm Decoder alarm panel: `ac_power`,
  `backlight_on`, `battery_low`, `check_zone`, `chime`, `entry_delay_off`,
  `programming_mode`, `ready`, `zone_bypassed` (@hawk259)
```
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4277

## Example entry for `configuration.yaml` (if applicable):
With these changes, you can easily add a template switch to show status and control your chime.
```yaml
- platform: template
  switches:
    alarm_chime:
      friendly_name: Chime
      value_template: "{{ is_state_attr('alarm_control_panel.alarm_panel', 'chime', true) }}"
      turn_on:
        service: alarm_control_panel.alarmdecoder_alarm_toggle_chime
        data:
          code: !secret alarm_code
      turn_off:
        service: alarm_control_panel.alarmdecoder_alarm_toggle_chime
        data:
          code: !secret alarm_code
      icon_template: >-
          {% if is_state_attr('alarm_control_panel.alarm_panel', 'chime', true) %}
            mdi:bell-ring
          {% else %}
            mdi:bell-off
          {% endif %}
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
