### PR TITLE
Fix allday events in custom_calendars

### DIFF
--- a/homeassistant/components/calendar/caldav.py
+++ b/homeassistant/components/calendar/caldav.py
@@ -25,7 +25,6 @@ CONF_DEVICE_ID = 'device_id'
 CONF_CALENDARS = 'calendars'
 CONF_CUSTOM_CALENDARS = 'custom_calendars'
 CONF_CALENDAR = 'calendar'
-CONF_ALL_DAY = 'all_day'
 CONF_SEARCH = 'search'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -88,7 +87,7 @@ def setup_platform(hass, config, add_devices, disc_info=None):
                 WebDavCalendarEventDevice(hass,
                                           device_data,
                                           calendar,
-                                          cust_calendar.get(CONF_ALL_DAY),
+                                          True,
                                           cust_calendar.get(CONF_SEARCH))
                 )
 

--- a/tests/components/calendar/test_caldav.py
+++ b/tests/components/calendar/test_caldav.py
@@ -121,8 +121,10 @@ class TestComponentsWebDavCalendar(unittest.TestCase):
             assert len(devices) == 2
             assert devices[0].name == "First"
             assert devices[0].dev_id == "First"
+            self.assertFalse(devices[0].data.include_all_day)
             assert devices[1].name == "Second"
             assert devices[1].dev_id == "Second"
+            self.assertFalse(devices[1].data.include_all_day)
 
         caldav.setup_platform(self.hass,
                               {
@@ -167,6 +169,7 @@ class TestComponentsWebDavCalendar(unittest.TestCase):
             assert len(devices) == 1
             assert devices[0].name == "HomeOffice"
             assert devices[0].dev_id == "Second HomeOffice"
+            self.assertTrue(devices[0].data.include_all_day)
 
         caldav.setup_platform(self.hass,
                               {


### PR DESCRIPTION
## Description:
Fixes another issue with the webdav calendar that events that last the whole day are ignored in custom calendars. They should only be ignored on the main calendar.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in https://github.com/home-assistant/home-assistant.github.io/pull/4265

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
