### PR TITLE
Additional device classes for binary sensors

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -23,6 +23,8 @@ DEVICE_CLASSES = [
     'battery',       # On means low, Off means normal
     'cold',          # On means cold (or too cold)
     'connectivity',  # On means connection present, Off = no connection
+    'door',          # On means open, Off means closed
+    'garage_door',   # On means open, Off means closed
     'gas',           # CO, CO2, etc.
     'heat',          # On means hot (or too hot)
     'light',         # Lightness threshold
@@ -30,7 +32,7 @@ DEVICE_CLASSES = [
     'motion',        # Motion sensor
     'moving',        # On means moving, Off means stopped
     'occupancy',     # On means occupied, Off means not occupied
-    'opening',       # Door, window, etc.
+    'opening',       # Generic contact sensor, On means open, Off means closed
     'plug',          # On means plugged in, Off means unplugged
     'power',         # Power, over-current, etc
     'presence',      # On means home, Off means away
@@ -39,6 +41,7 @@ DEVICE_CLASSES = [
     'smoke',         # Smoke detector
     'sound',         # On means sound detected, Off means no sound
     'vibration',     # On means vibration detected, Off means no vibration
+    'window',        # On means open, Off means closed
 ]
 
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))

--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -28,12 +28,12 @@ DEVICE_CLASSES = [
     'gas',           # On means gas detected, Off means no gas (clear)
     'heat',          # On means hot, Off means normal
     'light',         # On means light detected, Off means no light
-    'moisture',      # On means moisture detected (wet), Off means no moisture (dry)
+    'moisture',      # On means wet, Off means dry
     'motion',        # On means motion detected, Off means no motion (clear)
     'moving',        # On means moving, Off means not moving (stopped)
     'occupancy',     # On means occupied, Off means not occupied (clear)
     'opening',       # On means open, Off means closed
-    'plug',          # On means device is plugged in, Off means device is unplugged
+    'plug',          # On means plugged in, Off means unplugged
     'power',         # On means power detected, Off means no power
     'presence',      # On means home, Off means away
     'problem',       # On means problem detected, Off means no problem (OK)

--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -21,25 +21,25 @@ SCAN_INTERVAL = timedelta(seconds=30)
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 DEVICE_CLASSES = [
     'battery',       # On means low, Off means normal
-    'cold',          # On means cold (or too cold)
-    'connectivity',  # On means connection present, Off = no connection
+    'cold',          # On means cold, Off means normal
+    'connectivity',  # On means connected, Off means disconnected
     'door',          # On means open, Off means closed
     'garage_door',   # On means open, Off means closed
-    'gas',           # CO, CO2, etc.
-    'heat',          # On means hot (or too hot)
-    'light',         # Lightness threshold
-    'moisture',      # Specifically a wetness sensor
-    'motion',        # Motion sensor
-    'moving',        # On means moving, Off means stopped
-    'occupancy',     # On means occupied, Off means not occupied
-    'opening',       # Generic contact sensor, On means open, Off means closed
-    'plug',          # On means plugged in, Off means unplugged
-    'power',         # Power, over-current, etc
+    'gas',           # On means gas detected, Off means no gas (clear)
+    'heat',          # On means hot, Off means normal
+    'light',         # On means light detected, Off means no light
+    'moisture',      # On means moisture detected (wet), Off means no moisture (dry)
+    'motion',        # On means motion detected, Off means no motion (clear)
+    'moving',        # On means moving, Off means not moving (stopped)
+    'occupancy',     # On means occupied, Off means not occupied (clear)
+    'opening',       # On means open, Off means closed
+    'plug',          # On means device is plugged in, Off means device is unplugged
+    'power',         # On means power detected, Off means no power
     'presence',      # On means home, Off means away
-    'problem',       # On means there is a problem, Off means the status is OK
-    'safety',        # Generic on=unsafe, off=safe
-    'smoke',         # Smoke detector
-    'sound',         # On means sound detected, Off means no sound
+    'problem',       # On means problem detected, Off means no problem (OK)
+    'safety',        # On means unsafe, Off means safe
+    'smoke',         # On means smoke detected, Off means no smoke (clear)
+    'sound',         # On means sound detected, Off means no sound (clear)
     'vibration',     # On means vibration detected, Off means no vibration
     'window',        # On means open, Off means closed
 ]


### PR DESCRIPTION
## Description:

- Add new `door`, `garage_door`, and `window` device classes for binary sensors to allow for more accurate icon usage.
- Reverts `opening` device class icons back to previous generic style.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4267

**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) with documentation (if applicable):** home-assistant/home-assistant-polymer#749

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)