### PR TITLE
Greenwave Reality (TCP Connected) Lighting Component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -365,6 +365,7 @@ omit =
     homeassistant/components/light/decora.py
     homeassistant/components/light/decora_wifi.py
     homeassistant/components/light/flux_led.py
+    homeassistant/components/light/greenwave.py
     homeassistant/components/light/hue.py
     homeassistant/components/light/hyperion.py
     homeassistant/components/light/lifx.py

--- a/homeassistant/components/light/greenwave.py
+++ b/homeassistant/components/light/greenwave.py
@@ -84,8 +84,10 @@ class TcpLights(Light):
     def turn_on(self, **kwargs):
         """Instruct the light to turn on."""
         import greenwavereality as greenwave
-        temp_brightness = int((kwargs.get(ATTR_BRIGHTNESS, 255) / 255) * 100)
-        greenwave.set_brightness(self._host, self._did, temp_brightness, self.token)
+        temp_brightness = int((kwargs.get(ATTR_BRIGHTNESS, 255)
+                               / 255) * 100)
+        greenwave.set_brightness(self._host, self._did,
+                                 temp_brightness, self.token)
         greenwave.turn_on(self._host, self._did, self.token)
 
     def turn_off(self, **kwargs):

--- a/homeassistant/components/light/greenwave.py
+++ b/homeassistant/components/light/greenwave.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_HOST
 import homeassistant.helpers.config_validation as cv
 
 SUPPORTED_FEATURES = (SUPPORT_BRIGHTNESS)
-REQUIREMENTS = ['greenwavereality']
+REQUIREMENTS = ['greenwavereality==0.2.9']
 _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,

--- a/homeassistant/components/light/greenwave.py
+++ b/homeassistant/components/light/greenwave.py
@@ -2,7 +2,7 @@
 Support for Greenwave Reality (TCP Connected) lights.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/light.tcpbulbs/
+https://home-assistant.io/components/light.greenwave/
 """
 import logging
 import voluptuous as vol
@@ -21,7 +21,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup TCP Connected Platform."""
+    """Setup Greenwave Reality Platform."""
     import greenwavereality as greenwave
     import os
     host = config.get(CONF_HOST)
@@ -39,14 +39,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     else:
         token = None
     doc = greenwave.grab_xml(host, token)
-    add_devices(TcpLights(device, host, token) for device in doc)
+    add_devices(GreenwaveLight(device, host, token) for device in doc)
 
 
 class GreenwaveLight(Light):
-    """Representation of an TCP Connected Light."""
+    """Representation of an Greenwave Reality Light."""
 
     def __init__(self, light, host, token):
-        """Initialize a TCP Connected Light."""
+        """Initialize a Greenwave Reality Light."""
         import greenwavereality as greenwave
         self._did = light['did']
         self._name = light['name']

--- a/homeassistant/components/light/greenwave.py
+++ b/homeassistant/components/light/greenwave.py
@@ -1,0 +1,106 @@
+"""
+Support for Greenwave Reality (TCP Connected) lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.tcpbulbs/
+"""
+import logging
+import voluptuous as vol
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, Light, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS)
+from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
+
+SUPPORTED_FEATURES = (SUPPORT_BRIGHTNESS)
+REQUIREMENTS = ['greenwavereality']
+_LOGGER = logging.getLogger(__name__)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required("version"): cv.positive_int,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup TCP Connected Platform."""
+    import greenwavereality as greenwave
+    import os
+    host = config.get(CONF_HOST)
+    tokenfile = hass.config.path('greenwave.token')
+    if config.get("version") == 3:
+        if os.path.exists(tokenfile):
+            tokenfile = open(tokenfile)
+            token = tokenfile.read()
+            tokenfile.close()
+        else:
+            token = greenwave.grab_token(host, 'hass', 'homeassistant')
+            tokenfile = open(tokenfile, "w+")
+            tokenfile.write(token)
+            tokenfile.close()
+    else:
+        token = None
+    doc = greenwave.grab_xml(host, token)
+    add_devices(TcpLights(device, host, token) for device in doc)
+
+
+class TcpLights(Light):
+    """Representation of an TCP Connected Light."""
+
+    def __init__(self, light, host, token):
+        """Initialize a TCP Connected Light."""
+        import greenwavereality as greenwave
+        self._did = light['did']
+        self._name = light['name']
+        self._state = int(light['state'])
+        self._brightness = greenwave.hass_brightness(light)
+        self._host = host
+        self._online = greenwave.check_online(light)
+        self.token = token
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORTED_FEATURES
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._online
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """Return the brightness of the light."""
+        return self._brightness
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Instruct the light to turn on."""
+        import greenwavereality as greenwave
+        temp_brightness = int((kwargs.get(ATTR_BRIGHTNESS, 255) / 255) * 100)
+        greenwave.set_brightness(self._host, self._did, temp_brightness, self.token)
+        greenwave.turn_on(self._host, self._did, self.token)
+
+    def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        import greenwavereality as greenwave
+        greenwave.turn_off(self._host, self._did, self.token)
+
+    def update(self):
+        """Fetch new state data for this light."""
+        import greenwavereality as greenwave
+        doc = greenwave.grab_xml(self._host, self.token)
+
+        for device in doc:
+            if device['did'] == self._did:
+                self._state = int(device['state'])
+                self._brightness = greenwave.hass_brightness(device)
+                self._online = greenwave.check_online(device)
+                self._name = device['name']

--- a/homeassistant/components/light/greenwave.py
+++ b/homeassistant/components/light/greenwave.py
@@ -5,15 +5,19 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.greenwave/
 """
 import logging
+
 import voluptuous as vol
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, Light, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS)
 from homeassistant.const import CONF_HOST
 import homeassistant.helpers.config_validation as cv
 
 SUPPORTED_FEATURES = (SUPPORT_BRIGHTNESS)
+
 REQUIREMENTS = ['greenwavereality==0.2.9']
 _LOGGER = logging.getLogger(__name__)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required("version"): cv.positive_int,

--- a/homeassistant/components/light/greenwave.py
+++ b/homeassistant/components/light/greenwave.py
@@ -25,7 +25,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import greenwavereality as greenwave
     import os
     host = config.get(CONF_HOST)
-    tokenfile = hass.config.path('greenwave.token')
+    tokenfile = hass.config.path('.greenwave')
     if config.get("version") == 3:
         if os.path.exists(tokenfile):
             tokenfile = open(tokenfile)
@@ -42,7 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(TcpLights(device, host, token) for device in doc)
 
 
-class TcpLights(Light):
+class GreenwaveLight(Light):
     """Representation of an TCP Connected Light."""
 
     def __init__(self, light, host, token):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -315,6 +315,9 @@ googlemaps==2.5.1
 # homeassistant.components.sensor.gpsd
 gps3==0.33.3
 
+# homeassistant.components.light.greenwave
+greenwavereality==0.2.9
+
 # homeassistant.components.media_player.gstreamer
 gstreamer-player==1.1.0
 
@@ -1173,7 +1176,6 @@ xboxapi==0.1.1
 # homeassistant.components.knx
 xknx==0.7.18
 
-# homeassistant.components.light.greenwave
 # homeassistant.components.media_player.bluesound
 # homeassistant.components.sensor.swiss_hydrological_data
 # homeassistant.components.sensor.ted5000

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1173,6 +1173,7 @@ xboxapi==0.1.1
 # homeassistant.components.knx
 xknx==0.7.18
 
+# homeassistant.components.light.greenwave
 # homeassistant.components.media_player.bluesound
 # homeassistant.components.sensor.swiss_hydrological_data
 # homeassistant.components.sensor.ted5000


### PR DESCRIPTION
Created component to add support for End of Life Greenwave Reality (TCP Connected) gateway and lightbulbs

## Description:


**Related issue (if applicable):** Added support for new platform

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: greenwave
    host: 192.168.1.97
    version: 3
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
   - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
- [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
 - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
 - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
