### PR TITLE
MiFlora - use bluepy on linux systems

### DIFF
--- a/homeassistant/components/light/decora.py
+++ b/homeassistant/components/light/decora.py
@@ -16,7 +16,7 @@ from homeassistant.components.light import (
     PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['decora==0.6', 'bluepy==1.1.1']
+REQUIREMENTS = ['decora==0.6', 'bluepy==1.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -66,7 +66,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the MiFlora sensor."""
     from miflora import miflora_poller
     try:
-        import bluepy.btle  # noqa: F401
+        import bluepy.btle  # noqa: F401 # pylint: disable=unused-variable
         from miflora.backends.bluepy import BluepyBackend
         backend = BluepyBackend
     except ImportError:

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -8,7 +8,6 @@ Unfortunately there is no universal bluetooth library available. So depending
 on the platform different backends are used. On most linux systems bluepy
 should cause the least problems.
 """
-
 import logging
 import sys
 from enum import Enum
@@ -80,16 +79,19 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the MiFlora sensor."""
     from miflora import miflora_poller
+    backend = None
     if _BACKEND == _BACKENDS.BLUEPY:
-        # TODO
-        pass
+        from miflora.backends.bluepy import BluepyBackend
+        backend = BluepyBackend
     else:
         from miflora.backends.gatttool import GatttoolBackend
+        backend = GatttoolBackend
+    _LOGGER.debug('Miflora is using %s backend.', backend.__name__)
 
     cache = config.get(CONF_CACHE)
     poller = miflora_poller.MiFloraPoller(
         config.get(CONF_MAC), cache_timeout=cache,
-        adapter=config.get(CONF_ADAPTER), backend=GatttoolBackend)
+        adapter=config.get(CONF_ADAPTER), backend=backend)
     force_update = config.get(CONF_FORCE_UPDATE)
     median = config.get(CONF_MEDIAN)
     poller.ble_timeout = config.get(CONF_TIMEOUT)

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -3,10 +3,6 @@ Support for Xiaomi Mi Flora BLE plant sensor.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.miflora/
-
-Unfortunately there is no universal bluetooth library available. So depending
-on the platform different backends are used. On most linux systems bluepy
-should cause the least problems.
 """
 import logging
 

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -24,8 +24,10 @@ from homeassistant.const import (
 
 class _BACKENDS(Enum):
     """Symbolic constants for the different bluetooth backends."""
+
     GATTTOOL = 0
     BLUEPY = 1
+
 
 REQUIREMENTS = ['miflora==0.2.0']
 # normally use gatttool as this is what people are used to

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -9,8 +9,6 @@ on the platform different backends are used. On most linux systems bluepy
 should cause the least problems.
 """
 import logging
-import sys
-from enum import Enum
 
 import voluptuous as vol
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -141,7 +141,6 @@ blinkstick==1.1.8
 blockchain==1.4.0
 
 # homeassistant.components.light.decora
-# homeassistant.components.sensor.miflora
 # bluepy==1.1.4
 
 # homeassistant.components.notify.aws_lambda

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -141,7 +141,8 @@ blinkstick==1.1.8
 blockchain==1.4.0
 
 # homeassistant.components.light.decora
-# bluepy==1.1.1
+# homeassistant.components.sensor.miflora
+# bluepy==1.1.4
 
 # homeassistant.components.notify.aws_lambda
 # homeassistant.components.notify.aws_sns


### PR DESCRIPTION
## Description:
There are currently some issues with gatttool not beeing found. On solution would be to **not** use the gatttool binary, but use the bluepy library instead: https://github.com/IanHarvey/bluepy

I also upgraded to the latest version (1.1.4) of bluepy as they fixes some dependecy-issues with their binaries over the last months. This should avoid some problems when installing bluepy.

*Advantage:*
* No dependency to existence on gatttool command line tool. 
* gatttool is deprecated in many OS, so we need to replace it anyway

*Disadvantage:*
* bluepy binaries might not be available on all linux platforms and some platforms might not have build-essential available to build them on the go.
* Does not work on Windows (same as gatttool)
* Not sure if it works on MacOS, I do not have a Mac available... 

The solution with modifying the ```REQUIREMENTS``` is not the most elegant one. I'm happy to hear better ideas on setting the requirements depending on the current platform. It would also be nice to give the user the chance to select the bluetooth back-end that works best for him, but I have no idea how to do that in hass...

*Concerning MacOS/Windows support*:
We're happy to get contributions to support these platforms in the miflora library:
https://github.com/open-homeautomation/miflora/issues

**Related issue (if applicable):** fixes #3458

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** 
https://github.com/home-assistant/home-assistant.github.io/pull/4279

## Example entry for `configuration.yaml` (if applicable):
No changes here

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
