### PR TITLE
Make rpi_rf.py threadsafe

### DIFF
--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -53,7 +53,7 @@ class RFDeviceWrapper:
         self._tx_queue = queue.Queue()
         def txsender():
             while True:
-                code_list, protocol, pulselength, repetitions = queue.get()
+                code_list, protocol, pulselength, repetitions = self._tx_queue.get()
                 self._rfdevice._tx_repeat = repetitions
                 for code in code_list:
                     self._rfdevice.tx_code(code, protocol, pulselength)

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -60,14 +60,14 @@ class RFDeviceWrapper:
         self._tx_sender = threading.Thread(target=txsender, daemon=True)
         self._tx_sender.start()
         
-    def send_code(code_list, protocol, pulselength, repetitions):
+    def send_code(self, code_list, protocol, pulselength, repetitions):
         for i in range(0, repetitions):
             self._tx_queue.put((code_list, protocol, pulselength))
             
-    def enable_tx():
+    def enable_tx(self):
         self._rfdevice.enable_tx()
         
-    def cleanup():
+    def cleanup(self):
         self._rfdevice.cleanup()
 
 # pylint: disable=unused-argument, import-error

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -61,8 +61,7 @@ class RFDeviceWrapper:
         self._tx_sender.start()
         
     def send_code(self, code_list, protocol, pulselength, repetitions):
-        for i in range(0, repetitions):
-            self._tx_queue.put((code_list, protocol, pulselength))
+        self._tx_queue.put((code_list, protocol, pulselength, repetitions))
             
     def enable_tx(self):
         self._rfdevice.enable_tx()
@@ -135,7 +134,7 @@ class RPiRFSwitch(SwitchDevice):
     def _send_code(self, code_list, protocol, pulselength):
         """Send the code(s) with a specified pulselength."""
         _LOGGER.info("Sending code(s): %s", code_list)
-        self._rfdevice.send_code(code_list, protocol, pulselength)
+        self._rfdevice.send_code(code_list, protocol, pulselength, self._repetitions)
         return True
 
     def turn_on(self):

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -46,6 +46,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 class RFDeviceWrapper:
     def __init__(self, gpio):
         import rpi_rf
+        import queue
+        import threading
+        
         self._rfdevice = rpi_rf.RFDevice(gpio)
         self._tx_queue = queue.Queue()
         def txsender():

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -45,6 +45,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 class RFDeviceWrapper:
     def __init__(self, gpio):
+        import rpi_rf
         self._rfdevice = rpi_rf.RFDevice(gpio)
         self._tx_queue = queue.Queue()
         def txsender():
@@ -69,7 +70,6 @@ class RFDeviceWrapper:
 # pylint: disable=unused-argument, import-error
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return switches controlled by a generic RF device via GPIO."""
-    import rpi_rf
 
     gpio = config.get(CONF_GPIO)
     rfdevice = RFDeviceWrapper(gpio)


### PR DESCRIPTION
## Description:
The rpi_rf suffered from a race condition where, when two switches were triggered simultaneously (e.g. by the emulated_hue component through an Alexa command) would interfere with each other. This implementation uses a worker thread and a tx code submission queue to remove the race.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

