### PR TITLE
Fix unpredictable entity names in concord232 binary_sensor

### DIFF
--- a/homeassistant/components/binary_sensor/concord232.py
+++ b/homeassistant/components/binary_sensor/concord232.py
@@ -62,6 +62,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("Unable to connect to Concord232: %s", str(ex))
         return False
 
+    # The order of zones returned by client.list_zones() can vary.
+    # When the zones are not named, this can result in the same entity
+    # name mapping to different sensors in an unpredictable way.  Sort
+    # the zones by zone number to prevent this.
+
+    client.zones.sort(key=lambda zone: zone['number'])
+
     for zone in client.zones:
         _LOGGER.info("Loading Zone found: %s", zone['name'])
         if zone['number'] not in exclude:


### PR DESCRIPTION
## Description:

Bug:  When using the concord232 platform, binary_sensor entity names, e.g., binary_sensor.unnamed_device_2, can map to different sensors in the concord alarm system in an unpredictable way.

Fix: Sort the sensors by zone number right after they are queried.  This gives both a predictable order and a simple mapping from zone numbers to entity numbering when the zones do not have names.

**Related issue (if applicable):** fixes #11289

I don't think new documentation is needed, but this should go in the release notes to explain the possibly changed behavior.

## Checklist:


If the code communicates with devices, web services, or third-party tools:
  - [X ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
