### PR TITLE
Tado fixes

### DIFF
--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -289,7 +289,7 @@ class TadoClimate(ClimateDevice):
 
         overlay = False
         overlay_data = None
-        termination = self._current_operation
+        termination = CONST_MODE_SMART_SCHEDULE
         cooling = False
         fan_speed = CONST_MODE_OFF
 

--- a/homeassistant/components/tado.py
+++ b/homeassistant/components/tado.py
@@ -120,9 +120,9 @@ class TadoDataStore:
     def reset_zone_overlay(self, zone_id):
         """Wrap for resetZoneOverlay(..)."""
         self.tado.resetZoneOverlay(zone_id)
-        self.update(no_throttle=True) #pylint: disable=unexpected-keyword-arg
+        self.update(no_throttle=True)  # pylint: disable=unexpected-keyword-arg
 
     def set_zone_overlay(self, zone_id, mode, temperature=None, duration=None):
         """Wrap for setZoneOverlay(..)."""
         self.tado.setZoneOverlay(zone_id, mode, temperature, duration)
-        self.update(no_throttle=True) #pylint: disable=unexpected-keyword-arg
+        self.update(no_throttle=True)  # pylint: disable=unexpected-keyword-arg

--- a/homeassistant/components/tado.py
+++ b/homeassistant/components/tado.py
@@ -119,8 +119,10 @@ class TadoDataStore:
 
     def reset_zone_overlay(self, zone_id):
         """Wrap for resetZoneOverlay(..)."""
-        return self.tado.resetZoneOverlay(zone_id)
+        self.tado.resetZoneOverlay(zone_id)
+        self.update(no_throttle=True) #pylint: disable=unexpected-keyword-arg
 
     def set_zone_overlay(self, zone_id, mode, temperature=None, duration=None):
         """Wrap for setZoneOverlay(..)."""
-        return self.tado.setZoneOverlay(zone_id, mode, temperature, duration)
+        self.tado.setZoneOverlay(zone_id, mode, temperature, duration)
+        self.update(no_throttle=True) #pylint: disable=unexpected-keyword-arg


### PR DESCRIPTION
## Description:

Previously, when tado ended an overlay state itself, say because a timer expired or a scheduled temperature change ocurred, the tado climate
component would not return to Smart Schedule mode. This change fixes that issue

Previosuly, making two changes to tado climate within 10 seconds, for example setting operation mode to Tado mode, then changing the temperature, would leave the entity showing the incorrect state for up to a minute. This change forces an unthrottled update after setting the climate state, which fixes the issue

**Related issue (if applicable):** None reported

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
