### PR TITLE
Reconnect before mochad switch send command

### DIFF
--- a/homeassistant/components/switch/mochad.py
+++ b/homeassistant/components/switch/mochad.py
@@ -14,7 +14,6 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (CONF_NAME, CONF_DEVICES,
                                  CONF_PLATFORM, CONF_ADDRESS)
 from homeassistant.helpers import config_validation as cv
-from pymochad.exceptions import MochadException 
 
 DEPENDENCIES = ['mochad']
 _LOGGER = logging.getLogger(__name__)
@@ -65,11 +64,12 @@ class MochadSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""
+        from pymochad.exceptions import MochadException 
+        _LOGGER.debug("Reconnect %s:%s", self._controller.server,
+                      self._controller.port)
         with mochad.REQ_LOCK:
             try:
                 # Recycle socket on new command to recover mochad connection
-                _LOGGER.debug("Reconnect %s:%s", self._controller.server,
-                              self._controller.port)
                 self._controller.reconnect()
                 self.device.send_cmd('on')
                 # No read data on CM19A which is rf only
@@ -81,11 +81,12 @@ class MochadSwitch(SwitchDevice):
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
+        from pymochad.exceptions import MochadException 
+        _LOGGER.debug("Reconnect %s:%s", self._controller.server,
+                      self._controller.port)
         with mochad.REQ_LOCK:
             try:
                 # Recycle socket on new command to recover mochad connection
-                _LOGGER.debug("Reconnect %s:%s", self._controller.server,
-                              self._controller.port)
                 self._controller.reconnect()
                 self.device.send_cmd('off')
                 # No read data on CM19A which is rf only

--- a/homeassistant/components/switch/mochad.py
+++ b/homeassistant/components/switch/mochad.py
@@ -50,7 +50,12 @@ class MochadSwitch(SwitchDevice):
         self._comm_type = dev.get(mochad.CONF_COMM_TYPE, 'pl')
         self.device = device.Device(ctrl, self._address,
                                     comm_type=self._comm_type)
-        self._state = self._get_device_status()
+        # Init with false to avoid locking HA for long on CM19A (goes from rf
+        # to pl via TM751, but not other way around)
+        if (self._comm_type == 'pl'):
+            self._state = self._get_device_status()
+        else:
+            self._state = False
 
     @property
     def name(self):
@@ -59,17 +64,35 @@ class MochadSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""
-        self._state = True
         with mochad.REQ_LOCK:
-            self.device.send_cmd('on')
-            self._controller.read_data()
+            try:
+                self._state = True
+                # Recycle socket on new command to recover mochad connection
+                _LOGGER.debug("Reconnect %s:%s", self._controller.server,
+                                self._controller.port)
+                self._controller.reconnect()
+                self.device.send_cmd('on')
+                # No read data on CM19A which is rf only
+                if (self._comm_type == 'pl'):
+                    self._controller.read_data()
+            except Exception as e:
+                _LOGGER.error("Error with mochad communication: %s", e)
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
-        self._state = False
         with mochad.REQ_LOCK:
-            self.device.send_cmd('off')
-            self._controller.read_data()
+            try:
+                self._state = False
+                # Recycle socket on new command to recover mochad connection
+                _LOGGER.debug("Reconnect %s:%s", self._controller.server,
+                                self._controller.port)
+                self._controller.reconnect()
+                self.device.send_cmd('off')
+                # No read data on CM19A which is rf only
+                if (self._comm_type == 'pl'):
+                    self._controller.read_data()
+            except Exception as e:
+                _LOGGER.error("Error with mochad communication: %s", e)
 
     def _get_device_status(self):
         """Get the status of the switch from mochad."""

--- a/homeassistant/components/switch/mochad.py
+++ b/homeassistant/components/switch/mochad.py
@@ -52,7 +52,7 @@ class MochadSwitch(SwitchDevice):
                                     comm_type=self._comm_type)
         # Init with false to avoid locking HA for long on CM19A (goes from rf
         # to pl via TM751, but not other way around)
-        if (self._comm_type == 'pl'):
+        if self._comm_type == 'pl':
             self._state = self._get_device_status()
         else:
             self._state = False
@@ -73,7 +73,7 @@ class MochadSwitch(SwitchDevice):
                 self._controller.reconnect()
                 self.device.send_cmd('on')
                 # No read data on CM19A which is rf only
-                if (self._comm_type == 'pl'):
+                if self._comm_type == 'pl':
                     self._controller.read_data()
                 self._state = True
             except (MochadException, OSError) as exc:
@@ -90,7 +90,7 @@ class MochadSwitch(SwitchDevice):
                 self._controller.reconnect()
                 self.device.send_cmd('off')
                 # No read data on CM19A which is rf only
-                if (self._comm_type == 'pl'):
+                if self._comm_type == 'pl':
                     self._controller.read_data()
                 self._state = False
             except (MochadException, OSError) as exc:

--- a/homeassistant/components/switch/mochad.py
+++ b/homeassistant/components/switch/mochad.py
@@ -64,7 +64,7 @@ class MochadSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""
-        from pymochad.exceptions import MochadException 
+        from pymochad.exceptions import MochadException
         _LOGGER.debug("Reconnect %s:%s", self._controller.server,
                       self._controller.port)
         with mochad.REQ_LOCK:
@@ -81,7 +81,7 @@ class MochadSwitch(SwitchDevice):
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
-        from pymochad.exceptions import MochadException 
+        from pymochad.exceptions import MochadException
         _LOGGER.debug("Reconnect %s:%s", self._controller.server,
                       self._controller.port)
         with mochad.REQ_LOCK:

--- a/homeassistant/components/switch/mochad.py
+++ b/homeassistant/components/switch/mochad.py
@@ -14,6 +14,7 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (CONF_NAME, CONF_DEVICES,
                                  CONF_PLATFORM, CONF_ADDRESS)
 from homeassistant.helpers import config_validation as cv
+from pymochad.exceptions import MochadException 
 
 DEPENDENCIES = ['mochad']
 _LOGGER = logging.getLogger(__name__)
@@ -66,33 +67,33 @@ class MochadSwitch(SwitchDevice):
         """Turn the switch on."""
         with mochad.REQ_LOCK:
             try:
-                self._state = True
                 # Recycle socket on new command to recover mochad connection
                 _LOGGER.debug("Reconnect %s:%s", self._controller.server,
-                                self._controller.port)
+                              self._controller.port)
                 self._controller.reconnect()
                 self.device.send_cmd('on')
                 # No read data on CM19A which is rf only
                 if (self._comm_type == 'pl'):
                     self._controller.read_data()
-            except Exception as e:
-                _LOGGER.error("Error with mochad communication: %s", e)
+                self._state = True
+            except (MochadException, OSError) as exc:
+                _LOGGER.error("Error with mochad communication: %s", exc)
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
         with mochad.REQ_LOCK:
             try:
-                self._state = False
                 # Recycle socket on new command to recover mochad connection
                 _LOGGER.debug("Reconnect %s:%s", self._controller.server,
-                                self._controller.port)
+                              self._controller.port)
                 self._controller.reconnect()
                 self.device.send_cmd('off')
                 # No read data on CM19A which is rf only
                 if (self._comm_type == 'pl'):
                     self._controller.read_data()
-            except Exception as e:
-                _LOGGER.error("Error with mochad communication: %s", e)
+                self._state = False
+            except (MochadException, OSError) as exc:
+                _LOGGER.error("Error with mochad communication: %s", exc)
 
     def _get_device_status(self):
         """Get the status of the switch from mochad."""

--- a/tests/components/switch/test_mochad.py
+++ b/tests/components/switch/test_mochad.py
@@ -10,6 +10,7 @@ from homeassistant.components.switch import mochad
 
 from tests.common import get_test_home_assistant
 
+
 @pytest.fixture(autouse=True)
 def pymochad_mock():
     """Mock pymochad."""

--- a/tests/components/switch/test_mochad.py
+++ b/tests/components/switch/test_mochad.py
@@ -8,7 +8,9 @@ from homeassistant.setup import setup_component
 from homeassistant.components import switch
 from homeassistant.components.switch import mochad
 
-from tests.common import get_test_home_assistant
+from tests.common import (
+    get_test_home_assistant, MockDependency
+)
 
 
 @pytest.fixture(autouse=True)
@@ -72,11 +74,13 @@ class TestMochadSwitch(unittest.TestCase):
         """Test the name."""
         self.assertEqual('fake_switch', self.switch.name)
 
+    @MockDependency('pymochad')
     def test_turn_on(self):
         """Test turn_on."""
         self.switch.turn_on()
         self.switch.device.send_cmd.assert_called_once_with('on')
 
+    @MockDependency('pymochad')
     def test_turn_off(self):
         """Test turn_off."""
         self.switch.turn_off()

--- a/tests/components/switch/test_mochad.py
+++ b/tests/components/switch/test_mochad.py
@@ -74,13 +74,13 @@ class TestMochadSwitch(unittest.TestCase):
         """Test the name."""
         self.assertEqual('fake_switch', self.switch.name)
 
-    @MockDependency('pymochad')
+    @mock.patch('pymochad.exceptions.MochadException')
     def test_turn_on(self):
         """Test turn_on."""
         self.switch.turn_on()
         self.switch.device.send_cmd.assert_called_once_with('on')
 
-    @MockDependency('pymochad')
+    @mock.patch('pymochad.exceptions.MochadException')
     def test_turn_off(self):
         """Test turn_off."""
         self.switch.turn_off()

--- a/tests/components/switch/test_mochad.py
+++ b/tests/components/switch/test_mochad.py
@@ -18,6 +18,7 @@ def pymochad_mock():
     """Mock pymochad."""
     with mock.patch.dict('sys.modules', {
         'pymochad': mock.MagicMock(),
+        'pymochad.exceptions': mock.MagicMock(),
     }):
         yield
 
@@ -74,13 +75,11 @@ class TestMochadSwitch(unittest.TestCase):
         """Test the name."""
         self.assertEqual('fake_switch', self.switch.name)
 
-    @mock.patch('pymochad.exceptions.MochadException')
     def test_turn_on(self):
         """Test turn_on."""
         self.switch.turn_on()
         self.switch.device.send_cmd.assert_called_once_with('on')
 
-    @mock.patch('pymochad.exceptions.MochadException')
     def test_turn_off(self):
         """Test turn_off."""
         self.switch.turn_off()

--- a/tests/components/switch/test_mochad.py
+++ b/tests/components/switch/test_mochad.py
@@ -8,10 +8,7 @@ from homeassistant.setup import setup_component
 from homeassistant.components import switch
 from homeassistant.components.switch import mochad
 
-from tests.common import (
-    get_test_home_assistant, MockDependency
-)
-
+from tests.common import get_test_home_assistant
 
 @pytest.fixture(autouse=True)
 def pymochad_mock():


### PR DESCRIPTION
## Description:
Connection to mochad occasionally stalls on RPi and CM19A. Re-connect the underlying socket in controller.PyMochad when X10 swtich is set to on/off. 
Current design of mochad in homeassistant is to keep 24/7 connection to mochad server open. There is no watchdog nor automatic reconnect routine.  

There is a known issue for mochad to get locked up occasionally. e.g. as seen often on RPi.
https://sourceforge.net/p/mochad/discussion/1320003/thread/1c193f01/

When this happens, mochad can be recovered by restarting it. However, mochad.py components in home-assistant once connected on HA startup, won't ever reconnect.

This improvement allows to reconnect underlying socket in controller. PyMochad when X10 commands are sent to mochad server. It's tested to work fine on my HA.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://sourceforge.net/p/mochad/discussion/1320003/thread/1c193f01/

