### PR TITLE
Better error handling

### DIFF
--- a/homeassistant/components/sensor/transmission.py
+++ b/homeassistant/components/sensor/transmission.py
@@ -55,12 +55,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     password = config.get(CONF_PASSWORD)
     port = config.get(CONF_PORT)
 
-    transmission_api = transmissionrpc.Client(
-        host, port=port, user=username, password=password)
     try:
+        transmission_api = transmissionrpc.Client(
+            host, port=port, user=username, password=password)
         transmission_api.session_stats()
-    except TransmissionError:
-        _LOGGER.exception("Connection to Transmission API failed")
+    except TransmissionError as error:
+        _LOGGER.error("Connection to Transmission API failed on %s:%s with message %s", host, port, error.original)
         return False
 
     # pylint: disable=global-statement

--- a/homeassistant/components/sensor/transmission.py
+++ b/homeassistant/components/sensor/transmission.py
@@ -60,7 +60,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             host, port=port, user=username, password=password)
         transmission_api.session_stats()
     except TransmissionError as error:
-        _LOGGER.error("Connection to Transmission API failed on %s:%s with message %s", host, port, error.original)
+        _LOGGER.error(
+            "Connection to Transmission API failed on %s:%s with message %s",
+            host, port, error.original
+        )
         return False
 
     # pylint: disable=global-statement

--- a/homeassistant/components/switch/transmission.py
+++ b/homeassistant/components/switch/transmission.py
@@ -48,7 +48,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             host, port=port, user=username, password=password)
         transmission_api.session_stats()
     except TransmissionError as error:
-        _LOGGING.error("Connection to Transmission API failed on %s:%s with message %s", host, port, error.original)
+        _LOGGING.error(
+            "Connection to Transmission API failed on %s:%s with message %s",
+            host, port, error.original
+        )
         return False
 
     add_devices([TransmissionSwitch(transmission_api, name)])

--- a/homeassistant/components/switch/transmission.py
+++ b/homeassistant/components/switch/transmission.py
@@ -43,12 +43,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     password = config.get(CONF_PASSWORD)
     port = config.get(CONF_PORT)
 
-    transmission_api = transmissionrpc.Client(
-        host, port=port, user=username, password=password)
     try:
+        transmission_api = transmissionrpc.Client(
+            host, port=port, user=username, password=password)
         transmission_api.session_stats()
-    except TransmissionError:
-        _LOGGING.error("Connection to Transmission API failed")
+    except TransmissionError as error:
+        _LOGGING.error("Connection to Transmission API failed on %s:%s with message %s", host, port, error.original)
         return False
 
     add_devices([TransmissionSwitch(transmission_api, name)])


### PR DESCRIPTION
## Description:
Currently I start transmission app only if I need it and when HA starts if it doesn't find it only if fails very ugly with the following message:

```
Error while setting up platform transmission
Traceback (most recent call last):
  File "/usr/lib/python3.5/urllib/request.py", line 1254, in do_open
    h.request(req.get_method(), req.selector, req.data, headers)
  File "/usr/lib/python3.5/http/client.py", line 1106, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python3.5/http/client.py", line 1151, in _send_request
    self.endheaders(body)
  File "/usr/lib/python3.5/http/client.py", line 1102, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python3.5/http/client.py", line 934, in _send_output
    self.send(msg)
  File "/usr/lib/python3.5/http/client.py", line 877, in send
    self.connect()
  File "/usr/lib/python3.5/http/client.py", line 849, in connect
    (self.host,self.port), self.timeout, self.source_address)
  File "/usr/lib/python3.5/socket.py", line 711, in create_connection
    raise err
  File "/usr/lib/python3.5/socket.py", line 702, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vagrant/.homeassistant/deps/lib/python3.5/site-packages/transmissionrpc/httphandler.py", line 65, in request
    response = self.http_opener.open(request, timeout=timeout)
  File "/usr/lib/python3.5/urllib/request.py", line 466, in open
    response = self._open(req, data)
  File "/usr/lib/python3.5/urllib/request.py", line 484, in _open
    '_open', req)
  File "/usr/lib/python3.5/urllib/request.py", line 444, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.5/urllib/request.py", line 1282, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/lib/python3.5/urllib/request.py", line 1256, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [Errno 111] Connection refused>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vagrant/.homeassistant/deps/lib/python3.5/site-packages/transmissionrpc/client.py", line 205, in _http_query
    result = self.http_handler.request(self.url, query, headers, timeout)
  File "/home/vagrant/.homeassistant/deps/lib/python3.5/site-packages/transmissionrpc/httphandler.py", line 77, in request
    raise HTTPHandlerError(httpcode=error.reason.args[0], httpmsg=error.reason.args[1])
transmissionrpc.error.HTTPHandlerError: HTTPHandlerError 111: Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/homeassistant/helpers/entity_component.py", line 171, in _async_setup_platform
    SLOW_SETUP_MAX_WAIT, loop=self.hass.loop)
  File "/usr/lib/python3.5/asyncio/tasks.py", line 392, in wait_for
    return fut.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.5/dist-packages/homeassistant/components/sensor/transmission.py", line 59, in setup_platform
    host, port=port, user=username, password=password)
  File "/home/vagrant/.homeassistant/deps/lib/python3.5/site-packages/transmissionrpc/client.py", line 169, in __init__
    self.get_session()
  File "/home/vagrant/.homeassistant/deps/lib/python3.5/site-packages/transmissionrpc/client.py", line 828, in get_session
    self._request('session-get', timeout=timeout)
  File "/home/vagrant/.homeassistant/deps/lib/python3.5/site-packages/transmissionrpc/client.py", line 247, in _request
    http_data = self._http_query(query, timeout)
  File "/home/vagrant/.homeassistant/deps/lib/python3.5/site-packages/transmissionrpc/client.py", line 223, in _http_query
    raise TransmissionError('Request failed.', error)
transmissionrpc.error.TransmissionError: Request failed. Original exception: HTTPHandlerError, "HTTPHandlerError 111: Connection refused"
```

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: transmission
    host: IP_ADDRESS
    monitored_variables:
      - 'current_status'
      - 'download_speed'
      - 'upload_speed'
      - 'active_torrents'
```

After this change we get the following smaller and more useful error message in the logs without the trace since it's not required as the error message should provide enough information:

`[homeassistant.components.sensor.transmission] Connection to Transmission API failed on [HOST]:[PORT] with message HTTPHandlerError 111: Connection refused` for both sensor and switch transmission components.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
