### PR TITLE
Ping server to verify connection still exists.

### DIFF
--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -78,7 +78,7 @@ class CloudIoT:
             yield from hass.async_add_job(auth_api.check_token, self.cloud)
 
             self.client = client = yield from session.ws_connect(
-                self.cloud.relayer, headers={
+                self.cloud.relayer, heartbeat=55, headers={
                     hdrs.AUTHORIZATION:
                         'Bearer {}'.format(self.cloud.id_token)
                 })

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -263,7 +263,7 @@ class ActiveConnection:
     def handle(self):
         """Handle the websocket connection."""
         request = self.request
-        wsock = self.wsock = web.WebSocketResponse()
+        wsock = self.wsock = web.WebSocketResponse(heartbeat=55)
         yield from wsock.prepare(request)
         self.debug("Connected")
 


### PR DESCRIPTION
## Description:
Send a ping to the Cloud server when no messages have been received for 60 seconds.

## Example entry for `configuration.yaml` (if applicable):
```yaml
cloud:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
