### PR TITLE
pass stops_at to get_station_by_name

### DIFF
--- a/homeassistant/components/sensor/irish_rail_transport.py
+++ b/homeassistant/components/sensor/irish_rail_transport.py
@@ -148,7 +148,8 @@ class IrishRailTransportData(object):
         """Get the latest data from irishrail."""
         trains = self._ir_api.get_station_by_name(self.station,
                                                   direction=self.direction,
-                                                  destination=self.destination)
+                                                  destination=self.destination,
+                                                  stops_at=self.stops_at)
         stops_at = self.stops_at if self.stops_at else ''
         self.info = []
         for train in trains:


### PR DESCRIPTION
## Description:
Fixes an issue where the stops_at filter for the Irish Rail Transport component wasn't being correctly passed to the underlying library

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
