### PR TITLE
Enhance ZHA and add groundwork for new sensor types

### DIFF
--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -106,6 +106,7 @@ class TemperatureSensor(Sensor):
         return convert_temperature(
             celsius, TEMP_CELSIUS, self.unit_of_measurement)
 
+
 class CentraliteBatterySensor(Sensor):
     """ZHA battery sensor."""
 
@@ -116,20 +117,20 @@ class CentraliteBatterySensor(Sensor):
     minVolts = 15
     maxVolts = 28
     values = {
-        28:100,
-        27:100,
-        26:100,
-        25:90,
-        24:90,
-        23:70,
-        22:70,
-        21:50,
-        20:50,
-        19:30,
-        18:30,
-        17:15,
-        16:1,
-        15:0
+        28: 100,
+        27: 100,
+        26: 100,
+        25: 90,
+        24: 90,
+        23: 70,
+        22: 70,
+        21: 50,
+        20: 50,
+        19: 30,
+        18: 30,
+        17: 15,
+        16: 1,
+        15: 0
     }
 
     @property
@@ -151,6 +152,7 @@ class CentraliteBatterySensor(Sensor):
 
         return self.values.get(self._state, 'unknown')
 
+
 class MeteringSensor(Sensor):
     """ZHA Metering sensor."""
 
@@ -169,6 +171,7 @@ class MeteringSensor(Sensor):
 
         return self._state
 
+
 class IlluminanceMeasurementSensor(Sensor):
     """ZHA lux sensor."""
 
@@ -184,6 +187,7 @@ class IlluminanceMeasurementSensor(Sensor):
             return 'unknown'
 
         return self._state
+
 
 class RelativeHumiditySensor(Sensor):
     """ZHA humidity sensor."""

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -67,7 +67,7 @@ def make_sensor(discovery_info):
 
 class Sensor(zha.Entity):
     """Base ZHA sensor."""
-    
+
     _domain = DOMAIN
     value_attribute = 0
     min_reportable_change = 1
@@ -89,7 +89,7 @@ class Sensor(zha.Entity):
 
 class TemperatureSensor(Sensor):
     """ZHA temperature sensor."""
-    
+
     min_reportable_change = 50  # 0.5'C
 
     @property
@@ -109,7 +109,7 @@ class TemperatureSensor(Sensor):
 
 class CentraliteBatterySensor(Sensor):
     """ZHA battery sensor."""
-    
+
     # currently restricted to centralite sensors because the value
     # conversion is specific to centralite sensors.
 
@@ -154,7 +154,7 @@ class CentraliteBatterySensor(Sensor):
 
 class MeteringSensor(Sensor):
     """ZHA Metering sensor."""
-    
+
     value_attribute = 1024
 
     @property
@@ -173,7 +173,7 @@ class MeteringSensor(Sensor):
 
 class IlluminanceMeasurementSensor(Sensor):
     """ZHA lux sensor."""
-    
+
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity."""
@@ -190,7 +190,7 @@ class IlluminanceMeasurementSensor(Sensor):
 
 class RelativeHumiditySensor(Sensor):
     """ZHA humidity sensor."""
-    
+
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity."""

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -67,6 +67,7 @@ def make_sensor(discovery_info):
 
 class Sensor(zha.Entity):
     """Base ZHA sensor."""
+    
     _domain = DOMAIN
     value_attribute = 0
     min_reportable_change = 1
@@ -88,6 +89,7 @@ class Sensor(zha.Entity):
 
 class TemperatureSensor(Sensor):
     """ZHA temperature sensor."""
+    
     min_reportable_change = 50  # 0.5'C
 
     @property
@@ -107,6 +109,7 @@ class TemperatureSensor(Sensor):
 
 class CentraliteBatterySensor(Sensor):
     """ZHA battery sensor."""
+    
     # currently restricted to centralite sensors because the value
     # conversion is specific to centralite sensors.
 
@@ -151,6 +154,7 @@ class CentraliteBatterySensor(Sensor):
 
 class MeteringSensor(Sensor):
     """ZHA Metering sensor."""
+    
     value_attribute = 1024
 
     @property
@@ -169,6 +173,7 @@ class MeteringSensor(Sensor):
 
 class IlluminanceMeasurementSensor(Sensor):
     """ZHA lux sensor."""
+    
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity."""
@@ -185,6 +190,7 @@ class IlluminanceMeasurementSensor(Sensor):
 
 class RelativeHumiditySensor(Sensor):
     """ZHA humidity sensor."""
+    
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity."""

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -41,7 +41,8 @@ def make_sensor(discovery_info):
 
     if TemperatureMeasurement.cluster_id in in_clusters:
         sensor = TemperatureSensor(**discovery_info)
-    elif PowerConfiguration.cluster_id in in_clusters and discovery_info['manufacturer'] == 'CentraLite':
+    elif PowerConfiguration.cluster_id in in_clusters \
+            and discovery_info['manufacturer'] == 'CentraLite':
         sensor = CentraliteBatterySensor(**discovery_info)
     elif Metering.cluster_id in in_clusters:
         sensor = MeteringSensor(**discovery_info)
@@ -108,8 +109,8 @@ class TemperatureSensor(Sensor):
 class CentraliteBatterySensor(Sensor):
     """ZHA battery sensor."""
 
-    #currently restricted to centralite sensors because the value conversion
-    #is specific to centralite sensors
+    #currently restricted to centralite sensors because the value
+    #conversion is specific to centralite sensors.
 
     value_attribute = 32
     minVolts = 15

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -67,7 +67,6 @@ def make_sensor(discovery_info):
 
 class Sensor(zha.Entity):
     """Base ZHA sensor."""
-
     _domain = DOMAIN
     value_attribute = 0
     min_reportable_change = 1
@@ -89,7 +88,6 @@ class Sensor(zha.Entity):
 
 class TemperatureSensor(Sensor):
     """ZHA temperature sensor."""
-
     min_reportable_change = 50  # 0.5'C
 
     @property
@@ -109,7 +107,6 @@ class TemperatureSensor(Sensor):
 
 class CentraliteBatterySensor(Sensor):
     """ZHA battery sensor."""
-
     # currently restricted to centralite sensors because the value
     # conversion is specific to centralite sensors.
 
@@ -141,7 +138,6 @@ class CentraliteBatterySensor(Sensor):
     @property
     def state(self):
         """Return the state of the entity."""
-
         if self._state == 'unknown':
             return 'unknown'
 
@@ -155,7 +151,6 @@ class CentraliteBatterySensor(Sensor):
 
 class MeteringSensor(Sensor):
     """ZHA Metering sensor."""
-
     value_attribute = 1024
 
     @property
@@ -174,7 +169,6 @@ class MeteringSensor(Sensor):
 
 class IlluminanceMeasurementSensor(Sensor):
     """ZHA lux sensor."""
-
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity."""
@@ -191,7 +185,6 @@ class IlluminanceMeasurementSensor(Sensor):
 
 class RelativeHumiditySensor(Sensor):
     """ZHA humidity sensor."""
-
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity."""

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -110,8 +110,8 @@ class TemperatureSensor(Sensor):
 class CentraliteBatterySensor(Sensor):
     """ZHA battery sensor."""
 
-    #currently restricted to centralite sensors because the value
-    #conversion is specific to centralite sensors.
+    # currently restricted to centralite sensors because the value
+    # conversion is specific to centralite sensors.
 
     value_attribute = 32
     minVolts = 15

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -166,6 +166,10 @@ class ApplicationListener:
                     profile_clusters = profile.CLUSTERS[endpoint.device_type]
                     profile_info = zha_const.DEVICE_CLASS[endpoint.profile_id]
                     component = profile_info[endpoint.device_type]
+            else:
+                # These may be manufacturer specific profiles and they will need special handling
+                _LOGGER.info("Skipping endpoint with profile_id: %s", endpoint.profile_id)
+                continue
 
             if ha_const.CONF_TYPE in node_config:
                 component = node_config[ha_const.CONF_TYPE]
@@ -235,12 +239,13 @@ class Entity(entity.Entity):
             '%02x' % (o, ) for o in endpoint.device.ieee[-4:]
         ])
         if manufacturer and model is not None:
-            self.entity_id = '%s.%s_%s_%s_%s' % (
+            self.entity_id = '%s.%s_%s_%s_%s_%s' % (
                 self._domain,
                 slugify(manufacturer),
                 slugify(model),
                 ieeetail,
                 endpoint.endpoint_id,
+                slugify(self.__class__.__name__),
             )
             self._device_state_attributes['friendly_name'] = '%s %s' % (
                 manufacturer,
@@ -252,10 +257,14 @@ class Entity(entity.Entity):
                 ieeetail,
                 endpoint.endpoint_id,
             )
+        self._device_state_attributes['endpoint_id'] = endpoint.endpoint_id
+        self._device_state_attributes['ieee'] = "%s" % (endpoint.device.ieee, )
         for cluster in in_clusters.values():
             cluster.add_listener(self)
+            self._device_state_attributes['%s (%s)' % ('in_cluster', cluster.cluster_id,)] = cluster.name
         for cluster in out_clusters.values():
             cluster.add_listener(self)
+            self._device_state_attributes['%s_%s' % ('out_cluster', cluster.cluster_id,)] = cluster.name
         self._endpoint = endpoint
         self._in_clusters = in_clusters
         self._out_clusters = out_clusters

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -170,7 +170,7 @@ class ApplicationListener:
                 # These may be manufacturer specific profiles and they
                 # will need special handling if they are to be supported
                 # correctly.
-                _LOGGER.info("Skipping endpoint with profile_id: %s", 
+                _LOGGER.info("Skipping endpoint with profile_id: %s",
                              endpoint.profile_id)
                 continue
 

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -170,7 +170,8 @@ class ApplicationListener:
                 # These may be manufacturer specific profiles and they
                 # will need special handling if they are to be supported
                 # correctly.
-                _LOGGER.info("Skipping endpoint with profile_id: %s", endpoint.profile_id)
+                _LOGGER.info("Skipping endpoint with profile_id: %s", 
+                             endpoint.profile_id)
                 continue
 
             if ha_const.CONF_TYPE in node_config:

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -167,7 +167,9 @@ class ApplicationListener:
                     profile_info = zha_const.DEVICE_CLASS[endpoint.profile_id]
                     component = profile_info[endpoint.device_type]
             else:
-                # These may be manufacturer specific profiles and they will need special handling
+                # These may be manufacturer specific profiles and they
+                # will need special handling if they are to be supported
+                # correctly.
                 _LOGGER.info("Skipping endpoint with profile_id: %s", endpoint.profile_id)
                 continue
 
@@ -261,10 +263,16 @@ class Entity(entity.Entity):
         self._device_state_attributes['ieee'] = "%s" % (endpoint.device.ieee, )
         for cluster in in_clusters.values():
             cluster.add_listener(self)
-            self._device_state_attributes['%s (%s)' % ('in_cluster', cluster.cluster_id,)] = cluster.name
+            self._device_state_attributes['%s (%s)' % (
+                'in_cluster',
+                cluster.cluster_id,
+            )] = cluster.name
         for cluster in out_clusters.values():
             cluster.add_listener(self)
-            self._device_state_attributes['%s_%s' % ('out_cluster', cluster.cluster_id,)] = cluster.name
+            self._device_state_attributes['%s_%s' % (
+                'out_cluster',
+                cluster.cluster_id,
+            )] = cluster.name
         self._endpoint = endpoint
         self._in_clusters = in_clusters
         self._out_clusters = out_clusters

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -38,6 +38,10 @@ def populate_data():
     SINGLE_CLUSTER_DEVICE_CLASS.update({
         zcl.clusters.general.OnOff: 'switch',
         zcl.clusters.measurement.TemperatureMeasurement: 'sensor',
+        zcl.clusters.measurement.IlluminanceMeasurement: 'sensor',
+        zcl.clusters.measurement.RelativeHumidity: 'sensor',
+        zcl.clusters.general.PowerConfiguration: 'sensor',
+        zcl.clusters.smartenergy.Metering: 'sensor',
         zcl.clusters.security.IasZone: 'binary_sensor',
     })
 


### PR DESCRIPTION
## Description:
Updates ZHA with the following changes:

- Skips attempting to initialize devices defined on manufacturer specific zigbee profile id's. There isn't a good way to handle them at the moment in ZHA so skipping them altogether is a better user experience. 
- Adds clusters, endpoint id, and network address to entity attributes
- Adds the groundwork for several new sensor types to be supported by ZHA:

1. Metering (energy consumption for connected devices)
2. PowerConfiguration (battery sensors - currently limited to Centralite devices)
3. RelativeHumidity
4. IlluminanceMeasurement

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**  N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
