### PR TITLE
Upgrade aiohttp_cors to 0.6.0

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -36,7 +36,7 @@ from .static import (
     CachingFileResponse, CachingStaticResource, staticresource_middleware)
 from .util import get_real_ip
 
-REQUIREMENTS = ['aiohttp_cors==0.5.3']
+REQUIREMENTS = ['aiohttp_cors==0.6.0']
 
 ALLOWED_CORS_HEADERS = [
     ORIGIN, ACCEPT, HTTP_HEADER_X_REQUESTED_WITH, CONTENT_TYPE,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -66,7 +66,7 @@ aiodns==1.1.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
-aiohttp_cors==0.5.3
+aiohttp_cors==0.6.0
 
 # homeassistant.components.sensor.imap
 aioimaplib==0.7.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -31,7 +31,7 @@ aioautomatic==0.6.4
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
-aiohttp_cors==0.5.3
+aiohttp_cors==0.6.0
 
 # homeassistant.components.notify.apns
 apns2==0.3.0


### PR DESCRIPTION
## Description:
* Support aiohttp views by CorsViewMixin

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
