### PR TITLE
Upgrade distro to 1.2.0

### DIFF
--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['distro==1.1.0']
+REQUIREMENTS = ['distro==1.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -215,7 +215,7 @@ discogs_client==2.2.1
 discord.py==0.16.12
 
 # homeassistant.components.updater
-distro==1.1.0
+distro==1.2.0
 
 # homeassistant.components.switch.digitalloggers
 dlipower==0.7.165


### PR DESCRIPTION
## Description:
* Lazily load parsers to speed up import time.
* Don't raise import error on non-linux os.
* Decode stdout of shell sys.getfilesystemencoding().
* Explicitly set Python versions for flake8 tests.

## Example entry for `configuration.yaml` (if applicable):
```yaml
updater:
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
