### PR TITLE
Fix leak sensors always showing Unknown until Wet

### DIFF
--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -55,10 +55,9 @@ def setup_platform(hass, config: ConfigType,
                           node.nid, node.parent_nid)
         else:
             device_type = _detect_device_type(node)
-            if device_type in ['moisture', 'opening']:
-                subnode_id = int(node.nid[-1])
-                # Leak and door/window sensors work the same way with negative
-                # nodes and heartbeat nodes
+            subnode_id = int(node.nid[-1])
+            if device_type == 'opening':
+                # Door/window sensors use an optional "negative" node
                 if subnode_id == 4:
                     # Subnode 4 is the heartbeat node, which we will represent
                     # as a separate binary_sensor
@@ -67,6 +66,14 @@ def setup_platform(hass, config: ConfigType,
                     devices.append(device)
                 elif subnode_id == 2:
                     parent_device.add_negative_node(node)
+            elif device_type == 'moisture':
+                # Moisure nodes have a subnode 2, but we ignore it because it's
+                # just the inverse of the primary node.
+                if subnode_id == 4:
+                    # Heartbeat node
+                    device = ISYBinarySensorHeartbeat(node, parent_device)
+                    parent_device.add_heartbeat_device(device)
+                    devices.append(device)
             else:
                 # We don't yet have any special logic for other sensor types,
                 # so add the nodes as individual devices


### PR DESCRIPTION
## Description:
Bugfix for my changes in 0.60.

Insteon Leak sensors were using the "wet" node as a negative node, which prevented them from ever getting a Dry status unless the user pressed the button on the hardware after every Hass reboot.

This change ignores the Wet node, as it is just always the exact inverse of the Dry node. We don't need to watch both.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
