### PR TITLE
Switch to gamertag

### DIFF
--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -57,12 +57,12 @@ class XboxSensor(Entity):
         self._api = api
 
         # get profile info
-        profile = self._api.get_user_profile(self._xuid)
+        profile = self._api.get_user_gamercard(self._xuid)
 
         if profile.get('success', True) and profile.get('code', 0) != 28:
             self.success_init = True
-            self._gamertag = profile.get('Gamertag')
-            self._picture = profile.get('GameDisplayPicRaw')
+            self._gamertag = profile.get('gamertag')
+            self._picture = profile.get('gamerpicSmallSslImagePath')
         else:
             self.success_init = False
 


### PR DESCRIPTION
## Description:
Switch to gamertag to receive ssl image URL

**Related issue (if applicable):**
fixes #7292, fixes #9412

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
No changes

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
no changes

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
