### PR TITLE
Upgrade luftdaten to 0.1.3

### DIFF
--- a/homeassistant/components/sensor/luftdaten.py
+++ b/homeassistant/components/sensor/luftdaten.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['luftdaten==0.1.1']
+REQUIREMENTS = ['luftdaten==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,16 +114,16 @@ class LuftdatenSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        if self.luftdaten.data.meta is None:
+        try:
+            attr = {
+                ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+                ATTR_SENSOR_ID: self._sensor_id,
+                'lat': self.luftdaten.data.meta['latitude'],
+                'long': self.luftdaten.data.meta['longitude'],
+            }
+            return attr
+        except KeyError:
             return
-
-        attr = {
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-            ATTR_SENSOR_ID: self._sensor_id,
-            'lat': self.luftdaten.data.meta['latitude'],
-            'long': self.luftdaten.data.meta['longitude'],
-        }
-        return attr
 
     @asyncio.coroutine
     def async_update(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -451,7 +451,7 @@ liveboxplaytv==2.0.2
 lmnotify==0.0.4
 
 # homeassistant.components.sensor.luftdaten
-luftdaten==0.1.1
+luftdaten==0.1.3
 
 # homeassistant.components.sensor.lyft
 lyft_rides==0.2


### PR DESCRIPTION
## Description:
Add ordering fix by @ReneNulschDE

**Related issue (if applicable):** fixes #11283

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: luftdaten
    sensorid: 3123
    monitored_conditions:
      - P1
      - P2
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

