### PR TITLE
xiaomi_aqara: Fix covers never being closed

### DIFF
--- a/homeassistant/components/cover/xiaomi_aqara.py
+++ b/homeassistant/components/cover/xiaomi_aqara.py
@@ -41,7 +41,7 @@ class XiaomiGenericCover(XiaomiDevice, CoverDevice):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        return self.current_cover_position < 0
+        return self.current_cover_position <= 0
 
     def close_cover(self, **kwargs):
         """Close the cover."""


### PR DESCRIPTION
Bug in equality testing

## Description:
covers added by xiaomi_aquara are never closed in hass as the minimum value of position is 0.
Fixed the equality testing

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
