### PR TITLE
"Alarm group" platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -308,6 +308,7 @@ omit =
     homeassistant/components/alarm_control_panel/alarmdotcom.py
     homeassistant/components/alarm_control_panel/canary.py
     homeassistant/components/alarm_control_panel/concord232.py
+    homeassistant/components/alarm_control_panel/group.py
     homeassistant/components/alarm_control_panel/ialarm.py
     homeassistant/components/alarm_control_panel/manual_mqtt.py
     homeassistant/components/alarm_control_panel/nx584.py

--- a/homeassistant/components/alarm_control_panel/group.py
+++ b/homeassistant/components/alarm_control_panel/group.py
@@ -1,0 +1,241 @@
+"""
+Group platform for alarm control panel component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_control_panel.group/
+"""
+import asyncio
+from collections import Counter
+from copy import deepcopy
+import logging
+import voluptuous as vol
+
+from homeassistant.core import callback
+import homeassistant.components.alarm_control_panel as alarm
+from homeassistant.components.alarm_control_panel import (
+    DOMAIN, SERVICE_ALARM_DISARM, SERVICE_ALARM_ARM_HOME,
+    SERVICE_ALARM_ARM_AWAY, SERVICE_ALARM_ARM_NIGHT, SERVICE_ALARM_TRIGGER,
+    SERVICE_ALARM_ARM_CUSTOM_BYPASS)
+from homeassistant.const import (
+    ATTR_ENTITY_ID, ATTR_PRE_PENDING_STATE, ATTR_POST_PENDING_STATE,
+    STATE_ALARM_DISARMED, STATE_ALARM_ARMED_CUSTOM_BYPASS, STATE_ALARM_PENDING,
+    STATE_ALARM_TRIGGERED, CONF_PLATFORM, CONF_NAME, EVENT_HOMEASSISTANT_START)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_state_change
+
+ATTR_TRIGGERED_PANELS = 'triggered_panels'
+
+CONF_CODE_FORMAT = 'code_format'
+CONF_PANELS = 'panels'
+CONF_PANEL = 'panel'
+
+DEFAULT_ALARM_NAME = 'Group Alarm'
+
+PLATFORM_SCHEMA = vol.Schema(vol.All({
+    vol.Required(CONF_PLATFORM): 'group',
+    vol.Optional(CONF_NAME, default=DEFAULT_ALARM_NAME): cv.string,
+    vol.Optional(CONF_CODE_FORMAT, default=''): cv.string,
+    vol.Required(CONF_PANELS): vol.All(cv.ensure_list, [{
+        vol.Required(CONF_PANEL): cv.entity_id,
+    }])
+}))
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the manual alarm platform."""
+    add_devices([GroupAlarm(
+        hass,
+        config[CONF_NAME],
+        config[CONF_CODE_FORMAT],
+        config.get(CONF_PANELS)
+        )])
+
+
+class GroupAlarm(alarm.AlarmControlPanel):
+    """Implement the notification service for the group notify platform."""
+
+    def __init__(self, hass, name, code_format, entities):
+        """Initialize the service."""
+        self._hass = hass
+        self._name = name
+        self._code_format = code_format if code_format else None
+        self._entity_ids = [entity.get(CONF_PANEL) for entity in entities]
+        self._triggered_panels = []
+        self._state = STATE_ALARM_DISARMED
+        self._pre_state = self._state
+        self._post_state = self._state
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
+        @callback
+        def group_alarm_state_listener(entity, old_state, new_state):
+            """Handle device state changes."""
+            self.async_schedule_update_ha_state(True)
+
+        @callback
+        def group_alarm_startup(event):
+            """Update template on startup."""
+            async_track_state_change(
+                self.hass, self._entity_ids, group_alarm_state_listener)
+
+            self.async_schedule_update_ha_state(True)
+
+        self.hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_START, group_alarm_startup)
+
+    @asyncio.coroutine
+    def _async_send_message(self, service, **kwargs):
+        """Send message to all entities in the group."""
+        payload = {key: val for key, val in kwargs.items() if val}
+
+        tasks = []
+        for entity_id in self._entity_ids:
+            sending_payload = deepcopy(payload.copy())
+            sending_payload[ATTR_ENTITY_ID] = entity_id
+            tasks.append(self.hass.services.async_call(
+                DOMAIN, service, sending_payload))
+
+        if tasks:
+            yield from asyncio.wait(tasks, loop=self.hass.loop)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def code_format(self):
+        """The code format is customizable."""
+        return self._code_format
+
+    @asyncio.coroutine
+    def async_alarm_disarm(self, code=None):
+        """Send disarm command."""
+        yield from self._async_send_message(SERVICE_ALARM_DISARM,
+                                            code=code)
+
+    @asyncio.coroutine
+    def async_alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        yield from self._async_send_message(SERVICE_ALARM_ARM_HOME,
+                                            code=code)
+
+    @asyncio.coroutine
+    def async_alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        yield from self._async_send_message(SERVICE_ALARM_ARM_AWAY,
+                                            code=code)
+
+    @asyncio.coroutine
+    def async_alarm_arm_night(self, code=None):
+        """Send arm night command."""
+        yield from self._async_send_message(SERVICE_ALARM_ARM_NIGHT,
+                                            code=code)
+
+    @asyncio.coroutine
+    def async_alarm_trigger(self, code=None):
+        """Send alarm trigger command."""
+        yield from self._async_send_message(SERVICE_ALARM_TRIGGER,
+                                            code=code)
+
+    @asyncio.coroutine
+    def async_alarm_arm_custom_bypass(self, code=None):
+        """Send arm custom bypass command."""
+        yield from self._async_send_message(SERVICE_ALARM_ARM_CUSTOM_BYPASS,
+                                            code=code)
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        # _update_state always behaves as if a transition was in progress.
+        # But if the pre- and post-state match, we're not "pending"!
+        self._update_state()
+        if self._pre_state == self._post_state:
+            self._state = self._post_state
+        else:
+            self._state = STATE_ALARM_PENDING
+        return self._state
+
+    def _update_state(self):
+        """Update the current transition state of the device."""
+        def _common_state(states):
+            # This can happen if the sub-panels have not loaded yet.
+            if len(states) == 0:
+                return STATE_ALARM_DISARMED
+
+            # One triggered sub-panel is enough to trigger the whole panel.
+            if states[STATE_ALARM_TRIGGERED]:
+                return STATE_ALARM_TRIGGERED
+
+            # This only happens if a member does not provide pre or
+            # post_pending_state.  In that case, ensure the pending state
+            # percolates up to device_state_attributes, and the attribute
+            # will be left out in the group as well.
+            if states[STATE_ALARM_PENDING]:
+                return STATE_ALARM_PENDING
+
+            # If all entities have the same state, great.  Otherwise,
+            # we can only summarize the state as "custom bypass".
+            if len(states) == 1:
+                return next(iter(states))
+            return STATE_ALARM_ARMED_CUSTOM_BYPASS
+
+        # First collect the pre- and post-states for all devices.
+        self._triggered_panels = []
+        pre_states = Counter()
+        post_states = Counter()
+        for entity_id, state in self._states:
+            if state.state == STATE_ALARM_PENDING and \
+                    (ATTR_PRE_PENDING_STATE in state.attributes):
+                pre_state = state.attributes[ATTR_PRE_PENDING_STATE]
+            else:
+                pre_state = state.state
+
+            if state.state == STATE_ALARM_PENDING and \
+                    (ATTR_POST_PENDING_STATE in state.attributes):
+                post_state = state.attributes[ATTR_POST_PENDING_STATE]
+            else:
+                post_state = state.state
+
+            if pre_state == STATE_ALARM_TRIGGERED:
+                self._triggered_panels.append(entity_id)
+            pre_states[pre_state] += 1
+            post_states[post_state] += 1
+
+        # Now find the pre- and post-state for the entire group.
+        self._pre_state = _common_state(pre_states)
+        self._post_state = _common_state(post_states)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        state_attr = {}
+
+        if self._state == STATE_ALARM_TRIGGERED:
+            state_attr[ATTR_TRIGGERED_PANELS] = self._triggered_panels
+
+        if self._state == STATE_ALARM_PENDING:
+            # If the pre or post state is pending, the sub-entities are
+            # not able to provide accurate pre/post-state information;
+            # leave out the attribute
+            if self._pre_state != STATE_ALARM_PENDING:
+                state_attr[ATTR_PRE_PENDING_STATE] = self._pre_state
+            if self._post_state != STATE_ALARM_PENDING:
+                state_attr[ATTR_POST_PENDING_STATE] = self._post_state
+
+        return state_attr
+
+    @property
+    def _states(self):
+        for entity_id in self._entity_ids:
+            state_obj = self.hass.states.get(entity_id)
+            if state_obj is not None:
+                yield entity_id, state_obj

--- a/homeassistant/components/alarm_control_panel/group.py
+++ b/homeassistant/components/alarm_control_panel/group.py
@@ -64,7 +64,7 @@ class GroupAlarm(alarm.AlarmControlPanel):
         self._code_format = code_format if code_format else None
         self._entity_ids = [entity.get(CONF_PANEL) for entity in entities]
         self._triggered_panels = []
-        self._state = STATE_ALARM_DISARMED
+        self._state = None
         self._pre_state = self._state
         self._post_state = self._state
 
@@ -164,7 +164,7 @@ class GroupAlarm(alarm.AlarmControlPanel):
         def _common_state(states):
             # This can happen if the sub-panels have not loaded yet.
             if len(states) == 0:
-                return STATE_ALARM_DISARMED
+                return None
 
             # One triggered sub-panel is enough to trigger the whole panel.
             if states[STATE_ALARM_TRIGGERED]:

--- a/homeassistant/components/alarm_control_panel/group.py
+++ b/homeassistant/components/alarm_control_panel/group.py
@@ -159,7 +159,7 @@ class GroupAlarm(alarm.AlarmControlPanel):
         """Update the current state and state attributes of the device."""
         def _common_state(states):
             # This can happen if the sub-panels have not loaded yet.
-            if len(states) == 0:
+            if not states:
                 return None
 
             # One triggered sub-panel is enough to trigger the whole panel.

--- a/homeassistant/components/alarm_control_panel/group.py
+++ b/homeassistant/components/alarm_control_panel/group.py
@@ -19,7 +19,7 @@ from homeassistant.components.alarm_control_panel import (
     SERVICE_ALARM_ARM_CUSTOM_BYPASS)
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_PRE_PENDING_STATE, ATTR_POST_PENDING_STATE,
-    CONF_NAME, EVENT_HOMEASSISTANT_START,
+    CONF_ENTITIES, CONF_NAME, EVENT_HOMEASSISTANT_START,
     STATE_ALARM_ARMED_CUSTOM_BYPASS, STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED)
 import homeassistant.helpers.config_validation as cv
@@ -28,17 +28,13 @@ from homeassistant.helpers.event import async_track_state_change
 ATTR_TRIGGERED_PANELS = 'triggered_panels'
 
 CONF_CODE_FORMAT = 'code_format'
-CONF_PANELS = 'panels'
-CONF_PANEL = 'panel'
 
 DEFAULT_ALARM_NAME = 'Group Alarm'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_ALARM_NAME): cv.string,
     vol.Optional(CONF_CODE_FORMAT, default=''): cv.string,
-    vol.Required(CONF_PANELS): vol.All(cv.ensure_list, [{
-        vol.Required(CONF_PANEL): cv.entity_id,
-    }])
+    vol.Required(CONF_ENTITIES): vol.All(cv.ensure_list, [cv.entity_id]),
 })
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,19 +46,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         hass,
         config[CONF_NAME],
         config[CONF_CODE_FORMAT],
-        config[CONF_PANELS]
+        config[CONF_ENTITIES]
         )])
 
 
 class GroupAlarm(alarm.AlarmControlPanel):
-    """Implement services and state computation for the group alarm platform."""
+    """Implement services and compute state for the group alarm platform."""
 
     def __init__(self, hass, name, code_format, entities):
         """Initialize the platform."""
         self._hass = hass
         self._name = name
         self._code_format = code_format if code_format else None
-        self._entity_ids = [entity.get(CONF_PANEL) for entity in entities]
+        self._entity_ids = entities
         self._triggered_panels = []
         self._state = None
         self._pre_state = self._state

--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.const import (
+    ATTR_PRE_PENDING_STATE, ATTR_POST_PENDING_STATE,
     CONF_CODE, CONF_DELAY_TIME, CONF_DISARM_AFTER_TRIGGER, CONF_NAME,
     CONF_PENDING_TIME, CONF_PLATFORM, CONF_TRIGGER_TIME,
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_CUSTOM_BYPASS,
@@ -40,9 +41,6 @@ SUPPORTED_PRETRIGGER_STATES = [state for state in SUPPORTED_STATES
 
 SUPPORTED_PENDING_STATES = [state for state in SUPPORTED_STATES
                             if state != STATE_ALARM_DISARMED]
-
-ATTR_PRE_PENDING_STATE = 'pre_pending_state'
-ATTR_POST_PENDING_STATE = 'post_pending_state'
 
 
 def _state_validator(config):

--- a/homeassistant/components/alarm_control_panel/manual_mqtt.py
+++ b/homeassistant/components/alarm_control_panel/manual_mqtt.py
@@ -17,7 +17,8 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_DISARMED, STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED,
     CONF_PLATFORM, CONF_NAME, CONF_CODE, CONF_DELAY_TIME, CONF_PENDING_TIME,
-    CONF_TRIGGER_TIME, CONF_DISARM_AFTER_TRIGGER)
+    CONF_TRIGGER_TIME, CONF_DISARM_AFTER_TRIGGER, ATTR_PRE_PENDING_STATE,
+    ATTR_POST_PENDING_STATE)
 import homeassistant.components.mqtt as mqtt
 
 from homeassistant.helpers.event import async_track_state_change
@@ -54,9 +55,6 @@ SUPPORTED_PRETRIGGER_STATES = [state for state in SUPPORTED_STATES
 
 SUPPORTED_PENDING_STATES = [state for state in SUPPORTED_STATES
                             if state != STATE_ALARM_DISARMED]
-
-ATTR_PRE_PENDING_STATE = 'pre_pending_state'
-ATTR_POST_PENDING_STATE = 'post_pending_state'
 
 
 def _state_validator(config):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -291,6 +291,10 @@ ATTR_DEVICE_CLASS = 'device_class'
 # Temperature attribute
 ATTR_TEMPERATURE = 'temperature'
 
+# For alarms' STATE_ALARM_PENDING
+ATTR_PRE_PENDING_STATE = 'pre_pending_state'
+ATTR_POST_PENDING_STATE = 'post_pending_state'
+
 # #### UNITS OF MEASUREMENT ####
 # Temperature units
 TEMP_CELSIUS = '°C'

--- a/tests/components/alarm_control_panel/test_group.py
+++ b/tests/components/alarm_control_panel/test_group.py
@@ -1,0 +1,451 @@
+"""The tests for the manual Alarm Control Panel component."""
+from datetime import timedelta
+import unittest
+from unittest.mock import patch
+
+from homeassistant.setup import setup_component
+from homeassistant.const import (
+    ATTR_PRE_PENDING_STATE, ATTR_POST_PENDING_STATE,
+    STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_NIGHT, STATE_ALARM_ARMED_CUSTOM_BYPASS,
+    STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED)
+import homeassistant.components.alarm_control_panel as alarm
+
+import homeassistant.util.dt as dt_util
+
+from tests.common import (
+    assert_setup_component, fire_time_changed, get_test_home_assistant)
+
+CODE = '1234'
+TAMPER_CODE = '123456'
+TAMPER_CODE_TEMPLATE = '{{"1234" if from_state != "triggered" else "123456"}}'
+
+
+class TestAlarmControlPanelGroup(unittest.TestCase):
+    """Test the group alarm module."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        with assert_setup_component(5):
+            setup_component(self.hass, alarm.DOMAIN, {
+                'alarm_control_panel': [{
+                    # The living room doesn't do anything special
+                    'platform': 'manual',
+                    'name': 'livingroom',
+                    'code': CODE,
+                    'delay_time': 0,
+                    'pending_time': 0,
+                    'disarmed': {
+                        'trigger_time': 0
+                    }
+                }, {
+                    # The garage gives you some time to come and go,
+                    # when armed "away"
+                    'platform': 'manual',
+                    'name': 'garage',
+                    'code': CODE,
+                    'delay_time': 30,
+                    'pending_time': 30,
+                    'armed_home': {
+                        'delay_time': 0,
+                        'pending_time': 0
+                    },
+                    'armed_night': {
+                        'delay_time': 0,
+                        'pending_time': 0
+                    },
+                    'triggered': {
+                        'pending_time': 0
+                    },
+                    'disarmed': {
+                        'trigger_time': 0
+                    }
+                }, {
+                    # The bedroom is turned off at night
+                    'platform': 'manual',
+                    'name': 'bedroom',
+                    'code': CODE,
+                    'delay_time': 0,
+                    'pending_time': 0,
+                    'armed_night': {
+                        'trigger_time': 0
+                    },
+                    'disarmed': {
+                        'trigger_time': 0
+                    }
+                }, {
+                    # The tampering switch is turned off by a special code,
+                    # and triggers the siren even if the alarm is not armed
+                    'platform': 'manual',
+                    'name': 'tamper',
+                    'delay_time': 0,
+                    'pending_time': 0,
+                    'code_template': TAMPER_CODE_TEMPLATE,
+                }, {
+                    'platform': 'group',
+                    'name': 'testgroup',
+                    'panels': [
+                        {'panel': 'alarm_control_panel.livingroom'},
+                        {'panel': 'alarm_control_panel.garage'},
+                        {'panel': 'alarm_control_panel.bedroom'},
+                        {'panel': 'alarm_control_panel.tamper'},
+                    ]
+                }]
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def _assert_states(self, **states):
+        for which, state in states.items():
+            entity_id = 'alarm_control_panel.' + which
+            self.assertEqual(state, self.hass.states.get(entity_id).state,
+                             msg=('mismatch on %s state' % which))
+
+    def test_create(self):
+        """Basic test for state method."""
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+
+    def test_group_arm(self):
+        """Test propagation of the children panel's states."""
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+        alarm.alarm_arm_home(self.hass, CODE,
+                             entity_id='alarm_control_panel.testgroup')
+        self.hass.block_till_done()
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        with patch(('homeassistant.components.alarm_control_panel.manual.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+            self._assert_states(garage=STATE_ALARM_ARMED_HOME,
+                                livingroom=STATE_ALARM_ARMED_HOME,
+                                bedroom=STATE_ALARM_ARMED_HOME,
+                                tamper=STATE_ALARM_ARMED_HOME,
+                                testgroup=STATE_ALARM_ARMED_HOME)
+
+    def test_child_trigger_no_action(self):
+        """Test triggering a child with zero trigger time."""
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+        alarm.alarm_trigger(self.hass,
+                            entity_id='alarm_control_panel.livingroom')
+        self.hass.block_till_done()
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+
+    def test_child_trigger_and_disarm(self):
+        """Test triggering a child with non-zero trigger time."""
+        entity_id = 'alarm_control_panel.testgroup'
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+        alarm.alarm_trigger(self.hass, entity_id='alarm_control_panel.tamper')
+        self.hass.block_till_done()
+        self._assert_states(garage=STATE_ALARM_DISARMED,
+                            livingroom=STATE_ALARM_DISARMED,
+                            bedroom=STATE_ALARM_DISARMED,
+                            tamper=STATE_ALARM_TRIGGERED,
+                            testgroup=STATE_ALARM_TRIGGERED)
+
+        alarm.alarm_disarm(self.hass, CODE, entity_id)
+        self.hass.block_till_done()
+        self._assert_states(tamper=STATE_ALARM_TRIGGERED,
+                            testgroup=STATE_ALARM_TRIGGERED)
+
+        alarm.alarm_disarm(self.hass, TAMPER_CODE, entity_id)
+        self.hass.block_till_done()
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+
+    def test_child_arm_separately(self):
+        """Test arming a child of a group."""
+        entity_id = 'alarm_control_panel.testgroup'
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+        alarm.alarm_arm_away(self.hass, CODE,
+                             entity_id='alarm_control_panel.bedroom')
+        self.hass.block_till_done()
+
+        self._assert_states(garage=STATE_ALARM_DISARMED,
+                            livingroom=STATE_ALARM_DISARMED,
+                            bedroom=STATE_ALARM_ARMED_AWAY,
+                            tamper=STATE_ALARM_DISARMED,
+                            testgroup=STATE_ALARM_ARMED_CUSTOM_BYPASS)
+        alarm.alarm_disarm(self.hass, CODE, entity_id=entity_id)
+        self.hass.block_till_done()
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+
+    def test_child_arm_separately_pending(self):
+        """Test arming a child of a group with non-zero pending_time."""
+        entity_id = 'alarm_control_panel.testgroup'
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+        alarm.alarm_arm_away(self.hass, CODE,
+                             entity_id='alarm_control_panel.garage')
+        self.hass.block_till_done()
+
+        self._assert_states(garage=STATE_ALARM_PENDING,
+                            livingroom=STATE_ALARM_DISARMED,
+                            bedroom=STATE_ALARM_DISARMED,
+                            tamper=STATE_ALARM_DISARMED,
+                            testgroup=STATE_ALARM_PENDING)
+
+        state = self.hass.states.get('alarm_control_panel.garage')
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         state.attributes[ATTR_PRE_PENDING_STATE])
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         state.attributes[ATTR_POST_PENDING_STATE])
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         state.attributes[ATTR_PRE_PENDING_STATE])
+        self.assertEqual(STATE_ALARM_ARMED_CUSTOM_BYPASS,
+                         state.attributes[ATTR_POST_PENDING_STATE])
+        alarm.alarm_disarm(self.hass, CODE, entity_id=entity_id)
+        self.hass.block_till_done()
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+
+    def test_arm_invalid_code(self):
+        """Test arming with an invalid code."""
+        entity_id = 'alarm_control_panel.testgroup'
+        self._assert_states(garage=STATE_ALARM_DISARMED,
+                            bedroom=STATE_ALARM_DISARMED,
+                            livingroom=STATE_ALARM_DISARMED,
+                            tamper=STATE_ALARM_DISARMED,
+                            testgroup=STATE_ALARM_DISARMED)
+        alarm.alarm_arm_night(self.hass, 'abc', entity_id=entity_id)
+        self.hass.block_till_done()
+        self._assert_states(garage=STATE_ALARM_DISARMED,
+                            bedroom=STATE_ALARM_DISARMED,
+                            livingroom=STATE_ALARM_DISARMED,
+                            tamper=STATE_ALARM_DISARMED,
+                            testgroup=STATE_ALARM_DISARMED)
+
+    def test_arm_invalid_code_for_template(self):
+        """Test arming with an invalid code for the disarmed state."""
+        entity_id = 'alarm_control_panel.testgroup'
+        self._assert_states(garage=STATE_ALARM_DISARMED,
+                            bedroom=STATE_ALARM_DISARMED,
+                            livingroom=STATE_ALARM_DISARMED,
+                            tamper=STATE_ALARM_DISARMED,
+                            testgroup=STATE_ALARM_DISARMED)
+        alarm.alarm_arm_night(self.hass, TAMPER_CODE, entity_id=entity_id)
+        self.hass.block_till_done()
+        self._assert_states(garage=STATE_ALARM_DISARMED,
+                            bedroom=STATE_ALARM_DISARMED,
+                            livingroom=STATE_ALARM_DISARMED,
+                            tamper=STATE_ALARM_DISARMED,
+                            testgroup=STATE_ALARM_DISARMED)
+
+    def test_arm_and_trigger_ignored_zone(self):
+        """Test armed group with a child that has zero trigger-time."""
+        entity_id = 'alarm_control_panel.testgroup'
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+        alarm.alarm_arm_night(self.hass, CODE, entity_id=entity_id)
+        self.hass.block_till_done()
+        self._assert_states(testgroup=STATE_ALARM_ARMED_NIGHT,
+                            garage=STATE_ALARM_ARMED_NIGHT,
+                            livingroom=STATE_ALARM_ARMED_NIGHT,
+                            bedroom=STATE_ALARM_ARMED_NIGHT,
+                            tamper=STATE_ALARM_ARMED_NIGHT)
+        alarm.alarm_trigger(self.hass, entity_id='alarm_control_panel.bedroom')
+        self.hass.block_till_done()
+        self._assert_states(testgroup=STATE_ALARM_ARMED_NIGHT,
+                            garage=STATE_ALARM_ARMED_NIGHT,
+                            livingroom=STATE_ALARM_ARMED_NIGHT,
+                            bedroom=STATE_ALARM_ARMED_NIGHT,
+                            tamper=STATE_ALARM_ARMED_NIGHT)
+        alarm.alarm_disarm(self.hass, CODE, entity_id=entity_id)
+        self.hass.block_till_done()
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+
+    def test_arm_with_child_pending(self):
+        """Test 'pending' state during pending_time."""
+        entity_id = 'alarm_control_panel.testgroup'
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+        alarm.alarm_arm_away(self.hass, CODE, entity_id=entity_id)
+        self.hass.block_till_done()
+
+        self._assert_states(testgroup=STATE_ALARM_PENDING,
+                            garage=STATE_ALARM_PENDING,
+                            livingroom=STATE_ALARM_ARMED_AWAY,
+                            bedroom=STATE_ALARM_ARMED_AWAY,
+                            tamper=STATE_ALARM_ARMED_AWAY)
+        state = self.hass.states.get('alarm_control_panel.garage')
+        self.assertEqual(STATE_ALARM_DISARMED,
+                         state.attributes[ATTR_PRE_PENDING_STATE])
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         state.attributes[ATTR_POST_PENDING_STATE])
+
+        # pre-state is custom bypass because the garage is still disarmed
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(STATE_ALARM_ARMED_CUSTOM_BYPASS,
+                         state.attributes[ATTR_PRE_PENDING_STATE])
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         state.attributes[ATTR_POST_PENDING_STATE])
+
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        with patch(('homeassistant.components.alarm_control_panel.manual.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+            alarm.alarm_trigger(self.hass,
+                                entity_id='alarm_control_panel.garage')
+            self.hass.block_till_done()
+            state = self.hass.states.get('alarm_control_panel.garage')
+            self.assertEqual(STATE_ALARM_DISARMED,
+                             state.attributes[ATTR_PRE_PENDING_STATE])
+            self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                             state.attributes[ATTR_POST_PENDING_STATE])
+            state = self.hass.states.get(entity_id)
+            self.assertEqual(STATE_ALARM_PENDING, state.state)
+            self.assertEqual(STATE_ALARM_ARMED_CUSTOM_BYPASS,
+                             state.attributes[ATTR_PRE_PENDING_STATE])
+            self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                             state.attributes[ATTR_POST_PENDING_STATE])
+
+            alarm.alarm_trigger(self.hass,
+                                entity_id='alarm_control_panel.livingroom')
+            self.hass.block_till_done()
+            self._assert_states(testgroup=STATE_ALARM_TRIGGERED,
+                                garage=STATE_ALARM_PENDING,
+                                livingroom=STATE_ALARM_TRIGGERED,
+                                bedroom=STATE_ALARM_ARMED_AWAY,
+                                tamper=STATE_ALARM_ARMED_AWAY)
+
+        alarm.alarm_disarm(self.hass, CODE, entity_id=entity_id)
+        self.hass.block_till_done()
+        self._assert_states(testgroup=STATE_ALARM_DISARMED,
+                            garage=STATE_ALARM_DISARMED,
+                            livingroom=STATE_ALARM_DISARMED,
+                            bedroom=STATE_ALARM_DISARMED,
+                            tamper=STATE_ALARM_DISARMED)
+
+    def test_trigger_with_child_delay(self):
+        """Test 'pending' state during delay_time."""
+        entity_id = 'alarm_control_panel.testgroup'
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+        alarm.alarm_arm_away(self.hass, CODE, entity_id=entity_id)
+        self.hass.block_till_done()
+
+        self._assert_states(testgroup=STATE_ALARM_PENDING,
+                            garage=STATE_ALARM_PENDING,
+                            livingroom=STATE_ALARM_ARMED_AWAY,
+                            bedroom=STATE_ALARM_ARMED_AWAY,
+                            tamper=STATE_ALARM_ARMED_AWAY)
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(STATE_ALARM_ARMED_CUSTOM_BYPASS,
+                         state.attributes[ATTR_PRE_PENDING_STATE])
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         state.attributes[ATTR_POST_PENDING_STATE])
+
+        future = dt_util.utcnow() + timedelta(seconds=31)
+        with patch(('homeassistant.components.alarm_control_panel.manual.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+            self._assert_states(testgroup=STATE_ALARM_ARMED_AWAY,
+                                garage=STATE_ALARM_ARMED_AWAY,
+                                livingroom=STATE_ALARM_ARMED_AWAY,
+                                bedroom=STATE_ALARM_ARMED_AWAY,
+                                tamper=STATE_ALARM_ARMED_AWAY)
+
+            alarm.alarm_trigger(self.hass,
+                                entity_id='alarm_control_panel.garage')
+            self.hass.block_till_done()
+            self._assert_states(testgroup=STATE_ALARM_PENDING,
+                                garage=STATE_ALARM_PENDING,
+                                livingroom=STATE_ALARM_ARMED_AWAY,
+                                bedroom=STATE_ALARM_ARMED_AWAY,
+                                tamper=STATE_ALARM_ARMED_AWAY)
+
+            state = self.hass.states.get(entity_id)
+            self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                             state.attributes[ATTR_PRE_PENDING_STATE])
+            self.assertEqual(STATE_ALARM_TRIGGERED,
+                             state.attributes[ATTR_POST_PENDING_STATE])
+
+            state = self.hass.states.get('alarm_control_panel.garage')
+            self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                             state.attributes[ATTR_PRE_PENDING_STATE])
+            self.assertEqual(STATE_ALARM_TRIGGERED,
+                             state.attributes[ATTR_POST_PENDING_STATE])
+
+        future = dt_util.utcnow() + timedelta(seconds=62)
+        with patch(('homeassistant.components.alarm_control_panel.manual.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+            self._assert_states(testgroup=STATE_ALARM_TRIGGERED,
+                                garage=STATE_ALARM_TRIGGERED,
+                                livingroom=STATE_ALARM_ARMED_AWAY,
+                                bedroom=STATE_ALARM_ARMED_AWAY,
+                                tamper=STATE_ALARM_ARMED_AWAY)
+
+        alarm.alarm_disarm(self.hass, CODE, entity_id=entity_id)
+        self.hass.block_till_done()
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+
+    def test_trigger_and_disarm_with_child_delay(self):
+        """Test 'pending' state causing the group to trigger."""
+        entity_id = 'alarm_control_panel.testgroup'
+        self._assert_states(testgroup=STATE_ALARM_DISARMED)
+        alarm.alarm_arm_away(self.hass, CODE, entity_id=entity_id)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(STATE_ALARM_PENDING, state.state)
+        self.assertEqual(STATE_ALARM_ARMED_CUSTOM_BYPASS,
+                         state.attributes[ATTR_PRE_PENDING_STATE])
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         state.attributes[ATTR_POST_PENDING_STATE])
+
+        future = dt_util.utcnow() + timedelta(seconds=31)
+        with patch(('homeassistant.components.alarm_control_panel.manual.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+            self._assert_states(testgroup=STATE_ALARM_ARMED_AWAY,
+                                garage=STATE_ALARM_ARMED_AWAY,
+                                livingroom=STATE_ALARM_ARMED_AWAY,
+                                bedroom=STATE_ALARM_ARMED_AWAY,
+                                tamper=STATE_ALARM_ARMED_AWAY)
+
+            alarm.alarm_trigger(self.hass,
+                                entity_id='alarm_control_panel.garage')
+            self.hass.block_till_done()
+            self._assert_states(testgroup=STATE_ALARM_PENDING,
+                                garage=STATE_ALARM_PENDING,
+                                livingroom=STATE_ALARM_ARMED_AWAY,
+                                bedroom=STATE_ALARM_ARMED_AWAY,
+                                tamper=STATE_ALARM_ARMED_AWAY)
+
+            state = self.hass.states.get(entity_id)
+            self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                             state.attributes[ATTR_PRE_PENDING_STATE])
+            self.assertEqual(STATE_ALARM_TRIGGERED,
+                             state.attributes[ATTR_POST_PENDING_STATE])
+
+            state = self.hass.states.get('alarm_control_panel.garage')
+            self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                             state.attributes[ATTR_PRE_PENDING_STATE])
+            self.assertEqual(STATE_ALARM_TRIGGERED,
+                             state.attributes[ATTR_POST_PENDING_STATE])
+
+        future = dt_util.utcnow() + timedelta(seconds=42)
+        with patch(('homeassistant.components.alarm_control_panel.manual.'
+                    'dt_util.utcnow'), return_value=future):
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+            self._assert_states(testgroup=STATE_ALARM_PENDING,
+                                garage=STATE_ALARM_PENDING,
+                                livingroom=STATE_ALARM_ARMED_AWAY,
+                                bedroom=STATE_ALARM_ARMED_AWAY,
+                                tamper=STATE_ALARM_ARMED_AWAY)
+
+            alarm.alarm_disarm(self.hass, CODE, entity_id=entity_id)
+            self.hass.block_till_done()
+            self._assert_states(testgroup=STATE_ALARM_DISARMED)

--- a/tests/components/alarm_control_panel/test_group.py
+++ b/tests/components/alarm_control_panel/test_group.py
@@ -85,11 +85,11 @@ class TestAlarmControlPanelGroup(unittest.TestCase):
                 }, {
                     'platform': 'group',
                     'name': 'testgroup',
-                    'panels': [
-                        {'panel': 'alarm_control_panel.livingroom'},
-                        {'panel': 'alarm_control_panel.garage'},
-                        {'panel': 'alarm_control_panel.bedroom'},
-                        {'panel': 'alarm_control_panel.tamper'},
+                    'entities': [
+                        'alarm_control_panel.livingroom',
+                        'alarm_control_panel.garage',
+                        'alarm_control_panel.bedroom',
+                        'alarm_control_panel.tamper',
                     ]
                 }]
             })

--- a/tests/components/alarm_control_panel/test_manual.py
+++ b/tests/components/alarm_control_panel/test_manual.py
@@ -7,6 +7,7 @@ from homeassistant.components.alarm_control_panel import demo
 
 from homeassistant.setup import setup_component
 from homeassistant.const import (
+    ATTR_PRE_PENDING_STATE, ATTR_POST_PENDING_STATE,
     STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_NIGHT, STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED)
@@ -83,7 +84,8 @@ class TestAlarmControlPanelManual(unittest.TestCase):
                          self.hass.states.get(entity_id).state)
 
         state = self.hass.states.get(entity_id)
-        assert state.attributes['post_pending_state'] == STATE_ALARM_ARMED_HOME
+        self.assertEqual(STATE_ALARM_ARMED_HOME,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -190,7 +192,8 @@ class TestAlarmControlPanelManual(unittest.TestCase):
                          self.hass.states.get(entity_id).state)
 
         state = self.hass.states.get(entity_id)
-        assert state.attributes['post_pending_state'] == STATE_ALARM_ARMED_AWAY
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -271,8 +274,8 @@ class TestAlarmControlPanelManual(unittest.TestCase):
                          self.hass.states.get(entity_id).state)
 
         state = self.hass.states.get(entity_id)
-        assert state.attributes['post_pending_state'] == \
-            STATE_ALARM_ARMED_NIGHT
+        self.assertEqual(STATE_ALARM_ARMED_NIGHT,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -374,7 +377,7 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(STATE_ALARM_PENDING, state.state)
         self.assertEqual(STATE_ALARM_TRIGGERED,
-                         state.attributes['post_pending_state'])
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -455,7 +458,8 @@ class TestAlarmControlPanelManual(unittest.TestCase):
                          self.hass.states.get(entity_id).state)
 
         state = self.hass.states.get(entity_id)
-        assert state.attributes['post_pending_state'] == STATE_ALARM_TRIGGERED
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=2)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -508,7 +512,7 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(STATE_ALARM_PENDING, state.state)
         self.assertEqual(STATE_ALARM_TRIGGERED,
-                         state.attributes['post_pending_state'])
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=5)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -552,7 +556,7 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(STATE_ALARM_PENDING, state.state)
         self.assertEqual(STATE_ALARM_TRIGGERED,
-                         state.attributes['post_pending_state'])
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -595,7 +599,8 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
         state = self.hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
-        assert state.attributes['post_pending_state'] == STATE_ALARM_TRIGGERED
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -605,7 +610,8 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
         state = self.hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
-        assert state.attributes['post_pending_state'] == STATE_ALARM_TRIGGERED
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future += timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -651,7 +657,8 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
         state = self.hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
-        assert state.attributes['post_pending_state'] == STATE_ALARM_TRIGGERED
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -661,7 +668,8 @@ class TestAlarmControlPanelManual(unittest.TestCase):
 
         state = self.hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
-        assert state.attributes['post_pending_state'] == STATE_ALARM_TRIGGERED
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future += timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -1182,8 +1190,8 @@ class TestAlarmControlPanelManual(unittest.TestCase):
                          self.hass.states.get(entity_id).state)
 
         state = self.hass.states.get(entity_id)
-        assert state.attributes['post_pending_state'] == \
-            STATE_ALARM_ARMED_CUSTOM_BYPASS
+        self.assertEqual(STATE_ALARM_ARMED_CUSTOM_BYPASS,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -1277,9 +1285,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(STATE_ALARM_PENDING, state.state)
         self.assertEqual(STATE_ALARM_DISARMED,
-                         state.attributes['pre_pending_state'])
+                         state.attributes[ATTR_PRE_PENDING_STATE])
         self.assertEqual(STATE_ALARM_ARMED_AWAY,
-                         state.attributes['post_pending_state'])
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         alarm_control_panel.alarm_trigger(self.hass, entity_id=entity_id)
         self.hass.block_till_done()
@@ -1287,9 +1295,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(STATE_ALARM_PENDING, state.state)
         self.assertEqual(STATE_ALARM_DISARMED,
-                         state.attributes['pre_pending_state'])
+                         state.attributes[ATTR_PRE_PENDING_STATE])
         self.assertEqual(STATE_ALARM_ARMED_AWAY,
-                         state.attributes['post_pending_state'])
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'
@@ -1306,9 +1314,9 @@ class TestAlarmControlPanelManual(unittest.TestCase):
             state = self.hass.states.get(entity_id)
             self.assertEqual(STATE_ALARM_PENDING, state.state)
             self.assertEqual(STATE_ALARM_ARMED_AWAY,
-                             state.attributes['pre_pending_state'])
+                             state.attributes[ATTR_PRE_PENDING_STATE])
             self.assertEqual(STATE_ALARM_TRIGGERED,
-                             state.attributes['post_pending_state'])
+                             state.attributes[ATTR_POST_PENDING_STATE])
 
         future += timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual.'

--- a/tests/components/alarm_control_panel/test_manual_mqtt.py
+++ b/tests/components/alarm_control_panel/test_manual_mqtt.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from homeassistant.setup import setup_component
 from homeassistant.const import (
+    ATTR_PRE_PENDING_STATE, ATTR_POST_PENDING_STATE,
     STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_NIGHT, STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED)
 from homeassistant.components import alarm_control_panel
@@ -101,7 +102,8 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                          self.hass.states.get(entity_id).state)
 
         state = self.hass.states.get(entity_id)
-        assert state.attributes['post_pending_state'] == STATE_ALARM_ARMED_HOME
+        self.assertEqual(STATE_ALARM_ARMED_HOME,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -216,7 +218,8 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                          self.hass.states.get(entity_id).state)
 
         state = self.hass.states.get(entity_id)
-        assert state.attributes['post_pending_state'] == STATE_ALARM_ARMED_AWAY
+        self.assertEqual(STATE_ALARM_ARMED_AWAY,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -303,8 +306,8 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                          self.hass.states.get(entity_id).state)
 
         state = self.hass.states.get(entity_id)
-        assert state.attributes['post_pending_state'] == \
-            STATE_ALARM_ARMED_NIGHT
+        self.assertEqual(STATE_ALARM_ARMED_NIGHT,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -412,7 +415,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(STATE_ALARM_PENDING, state.state)
         self.assertEqual(STATE_ALARM_TRIGGERED,
-                         state.attributes['post_pending_state'])
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -499,7 +502,8 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                          self.hass.states.get(entity_id).state)
 
         state = self.hass.states.get(entity_id)
-        assert state.attributes['post_pending_state'] == STATE_ALARM_TRIGGERED
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=2)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -823,7 +827,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(STATE_ALARM_PENDING, state.state)
         self.assertEqual(STATE_ALARM_TRIGGERED,
-                         state.attributes['post_pending_state'])
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=5)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -869,7 +873,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(STATE_ALARM_PENDING, state.state)
         self.assertEqual(STATE_ALARM_TRIGGERED,
-                         state.attributes['post_pending_state'])
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -914,7 +918,8 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
 
         state = self.hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
-        assert state.attributes['post_pending_state'] == STATE_ALARM_TRIGGERED
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -924,7 +929,8 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
 
         state = self.hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
-        assert state.attributes['post_pending_state'] == STATE_ALARM_TRIGGERED
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future += timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -972,7 +978,8 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
 
         state = self.hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
-        assert state.attributes['post_pending_state'] == STATE_ALARM_TRIGGERED
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -982,7 +989,8 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
 
         state = self.hass.states.get(entity_id)
         assert state.state == STATE_ALARM_PENDING
-        assert state.attributes['post_pending_state'] == STATE_ALARM_TRIGGERED
+        self.assertEqual(STATE_ALARM_TRIGGERED,
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future += timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -1164,9 +1172,9 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(STATE_ALARM_PENDING, state.state)
         self.assertEqual(STATE_ALARM_DISARMED,
-                         state.attributes['pre_pending_state'])
+                         state.attributes[ATTR_PRE_PENDING_STATE])
         self.assertEqual(STATE_ALARM_ARMED_AWAY,
-                         state.attributes['post_pending_state'])
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         alarm_control_panel.alarm_trigger(self.hass, entity_id=entity_id)
         self.hass.block_till_done()
@@ -1174,9 +1182,9 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(STATE_ALARM_PENDING, state.state)
         self.assertEqual(STATE_ALARM_DISARMED,
-                         state.attributes['pre_pending_state'])
+                         state.attributes[ATTR_PRE_PENDING_STATE])
         self.assertEqual(STATE_ALARM_ARMED_AWAY,
-                         state.attributes['post_pending_state'])
+                         state.attributes[ATTR_POST_PENDING_STATE])
 
         future = dt_util.utcnow() + timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'
@@ -1193,9 +1201,9 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
             state = self.hass.states.get(entity_id)
             self.assertEqual(STATE_ALARM_PENDING, state.state)
             self.assertEqual(STATE_ALARM_ARMED_AWAY,
-                             state.attributes['pre_pending_state'])
+                             state.attributes[ATTR_PRE_PENDING_STATE])
             self.assertEqual(STATE_ALARM_TRIGGERED,
-                             state.attributes['post_pending_state'])
+                             state.attributes[ATTR_POST_PENDING_STATE])
 
         future += timedelta(seconds=1)
         with patch(('homeassistant.components.alarm_control_panel.manual_mqtt.'


### PR DESCRIPTION
## Description:

This pull request introduces a "group" alarm control panel platform. The platform distributes the commands to multiple sub-panels, and reports a unified state from all the sub-panels. The main use case is to apply different delay times to different rooms, and to disable some rooms in the "armed_home" or "armed_night" states.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4283

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm:
  - name: ALARM_NAME
    platform: group
    code_format: '\d+'
    panels:
    - panel: alarm_control_panel.garage
    - panel: alarm_control_panel.living_room
    - panel: alarm_control_panel.bedroom
    - panel: alarm_control_panel.tampering 
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New files were added to `.coveragerc`.
  - [x] Tests have been added to verify that the new code works.
