### PR TITLE
Upgrade aiohttp to 2.3.7

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ pip>=8.0.3
 jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.3.6
+aiohttp==2.3.7
 yarl==0.16.0
 async_timeout==2.0.0
 chardet==3.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ pip>=8.0.3
 jinja2>=2.9.6
 voluptuous==0.10.5
 typing>=3,<4
-aiohttp==2.3.6
+aiohttp==2.3.7
 yarl==0.16.0
 async_timeout==2.0.0
 chardet==3.0.4

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ REQUIRES = [
     'jinja2>=2.9.6',
     'voluptuous==0.10.5',
     'typing>=3,<4',
-    'aiohttp==2.3.6',   # If updated, check if yarl also needs an update!
+    'aiohttp==2.3.7',   # If updated, check if yarl also needs an update!
     'yarl==0.16.0',
     'async_timeout==2.0.0',
     'chardet==3.0.4',


### PR DESCRIPTION
## Description:
- Fixed race-condition for iterating addresses from the DNSCache.
- Fix docstring for request.host
- Fix docstring for request.remote

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
