### PR TITLE
Adding information about current TV channel to WebOS media player

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -39,8 +39,6 @@ DEFAULT_NAME = 'LG webOS Smart TV'
 
 WEBOSTV_CONFIG_FILE = 'webostv.conf'
 
-ATTR_CHANNEL = 'channel'
-
 SUPPORT_WEBOSTV = SUPPORT_TURN_OFF | \
     SUPPORT_NEXT_TRACK | SUPPORT_PAUSE | SUPPORT_PREVIOUS_TRACK | \
     SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_STEP | \
@@ -199,12 +197,7 @@ class LgWebOSDevice(MediaPlayerDevice):
             if self._state is not STATE_OFF:
                 self._muted = self._client.get_muted()
                 self._volume = self._client.get_volume()
-
-                ch = self._client.get_current_channel()
-                if 'channelName' in ch:
-                   self._channel = ch['channelName']
-                else:
-                   self._channel = None
+                self._channel = self._client.get_current_channel()
 
                 self._source_list = {}
                 self._app_list = {}
@@ -366,13 +359,5 @@ class LgWebOSDevice(MediaPlayerDevice):
         self._client.rewind()
 
     @property 
-    def channel(self):
-        """Return current TV channel"""
-        return self._channel
-
-    @property
-    def device_state_attributes(self):
-        if self._state is not STATE_OFF:
-           return { ATTR_CHANNEL: self.channel }
-        else:
-           return None
+    def media_title(self):
+        return self._channel['channelName'] if (self._channel!=None) and ('channelName' in self._channel) else None

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -267,10 +267,13 @@ class LgWebOSDevice(MediaPlayerDevice):
         """Content type of current playing media."""
         return MEDIA_TYPE_CHANNEL
 
-    @property 
+    @property
     def media_title(self):
         """Title of current playing media."""
-        return self._channel['channelName'] if (self._channel!=None) and ('channelName' in self._channel) else None
+        if (self._channel is not None) and ('channelName' in self._channel):
+            return self._channel['channelName']
+        else:
+            return None
 
     @property
     def media_image_url(self):

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -39,6 +39,8 @@ DEFAULT_NAME = 'LG webOS Smart TV'
 
 WEBOSTV_CONFIG_FILE = 'webostv.conf'
 
+ATTR_CHANNEL = 'channel'
+
 SUPPORT_WEBOSTV = SUPPORT_TURN_OFF | \
     SUPPORT_NEXT_TRACK | SUPPORT_PAUSE | SUPPORT_PREVIOUS_TRACK | \
     SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_STEP | \
@@ -176,6 +178,7 @@ class LgWebOSDevice(MediaPlayerDevice):
         self._state = STATE_UNKNOWN
         self._source_list = {}
         self._app_list = {}
+        self._channel = None
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):
@@ -191,10 +194,17 @@ class LgWebOSDevice(MediaPlayerDevice):
                 self._state = STATE_OFF
                 self._current_source = None
                 self._current_source_id = None
+                self._channel = None
 
             if self._state is not STATE_OFF:
                 self._muted = self._client.get_muted()
                 self._volume = self._client.get_volume()
+
+                ch = self._client.get_current_channel()
+                if 'channelName' in ch:
+                   self._channel = ch['channelName']
+                else:
+                   self._channel = None
 
                 self._source_list = {}
                 self._app_list = {}
@@ -227,6 +237,7 @@ class LgWebOSDevice(MediaPlayerDevice):
             self._state = STATE_OFF
             self._current_source = None
             self._current_source_id = None
+            self._channel = None
 
     @property
     def name(self):
@@ -353,3 +364,15 @@ class LgWebOSDevice(MediaPlayerDevice):
     def media_previous_track(self):
         """Send the previous track command."""
         self._client.rewind()
+
+    @property 
+    def channel(self):
+        """Return current TV channel"""
+        return self._channel
+
+    @property
+    def device_state_attributes(self):
+        if self._state is not STATE_OFF:
+           return { ATTR_CHANNEL: self.channel }
+        else:
+           return None

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -267,6 +267,11 @@ class LgWebOSDevice(MediaPlayerDevice):
         """Content type of current playing media."""
         return MEDIA_TYPE_CHANNEL
 
+    @property 
+    def media_title(self):
+        """Title of current playing media."""
+        return self._channel['channelName'] if (self._channel!=None) and ('channelName' in self._channel) else None
+
     @property
     def media_image_url(self):
         """Image url of current playing media."""
@@ -357,7 +362,3 @@ class LgWebOSDevice(MediaPlayerDevice):
     def media_previous_track(self):
         """Send the previous track command."""
         self._client.rewind()
-
-    @property 
-    def media_title(self):
-        return self._channel['channelName'] if (self._channel!=None) and ('channelName' in self._channel) else None


### PR DESCRIPTION
## Description:
This update added display information about current TV channel for WebOS devices. Information about current channel is stored in media_title attribute.

## Checklist:
  - [x] Local tests with `tox` run successfully.
