### PR TITLE
Control ordering of display in history component

### DIFF
--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -316,7 +316,7 @@ class HistoryPeriodView(HomeAssistantView):
                     result.remove(state_list)
         sorted_result.extend(result)
 
-        return self.json(result)
+        return self.json(sorted_result)
 
 
 class Filters(object):

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -310,10 +310,11 @@ class HistoryPeriodView(HomeAssistantView):
 
         sorted_result = []
         for order_entity in self.filters.included_entities:
-            for state_list in result[:]:
+            for state_list in result:
                 if state_list[0].entity_id == order_entity:
                     sorted_result.append(state_list)
                     result.remove(state_list)
+                    break
         sorted_result.extend(result)
 
         return self.json(sorted_result)

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -304,6 +304,18 @@ class HistoryPeriodView(HomeAssistantView):
             elapsed = time.perf_counter() - timer_start
             _LOGGER.debug(
                 'Extracted %d states in %fs', sum(map(len, result)), elapsed)
+
+        # Reorder the result to respect the ordering given by any
+        # entities explicitly included in the configuration.
+
+        sorted_result = []
+        for order_entity in self.filters.included_entities:
+            for state_list in result[:]:
+                if state_list[0].entity_id == order_entity:
+                    sorted_result.append(state_list)
+                    result.remove(state_list)
+        sorted_result.extend(result)
+
         return self.json(result)
 
 


### PR DESCRIPTION
## Description:
The ordering of the items shown in the history component is currently unpredictable and variable.  This patch sorts the items to reflect the ordering given in the list of explicitly included entities (and appends any other entities without modifying their order).

This allows the user to explicitly control the history display ordering, simply by explicitly including the entities in the desired order in the configuration.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4289

I added one sentence to describe the new behavior regarding order.

If user exposed functionality or configuration variables are added/changed: N/A

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
Tests might be useful here, but I am not sure how to add them for this case.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
