### PR TITLE
Add support for homematic ip

### DIFF
--- a/homeassistant/components/homematicip.py
+++ b/homeassistant/components/homematicip.py
@@ -1,0 +1,115 @@
+"""
+Support for HomematicIP.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/homematicip/
+"""
+
+import asyncio
+import logging
+
+import voluptuous as vol
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.helpers.entity import Entity, async_generate_entity_id
+from homeassistant.helpers.event import async_track_state_change
+from datetime import datetime
+from homeassistant.const import (ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, 
+	EVENT_HOMEASSISTANT_START)
+
+from datetime import timedelta
+
+REQUIREMENTS = ['homematicip>=0.7.0']
+from homematicip.home import Home
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'homematicip'
+
+EVENT_HOME_CHANGED = 'homematicip_home_changed'
+EVENT_DEVICE_CHANGED = 'homematicip_device_changed'
+EVENT_GROUP_CHANGED = 'homematicip_group_changed'
+EVENT_SECURITY_CHANGED = 'homematicip_security_changed'
+EVENT_JOURNAL_CHANGED = 'homematicip_journal_changed'
+
+CONF_NAME = 'name'
+CONF_HUBID = 'hubid'
+CONF_AUTHTOKEN = 'authtoken'
+CONF_TIMEOUT = 'timeout'
+CONF_RECONNECT = 'reconnect'
+
+CONFIG_SCHEMA = vol.Schema({
+	vol.Optional(DOMAIN): [ vol.Schema({
+		vol.Optional(CONF_NAME, default='None'): cv.string,
+		vol.Required(CONF_HUBID): cv.string,
+		vol.Required(CONF_AUTHTOKEN): cv.string,
+		vol.Optional(CONF_TIMEOUT, default=timedelta(seconds=20)): (
+			vol.All(cv.time_period, cv.positive_timedelta)),
+		vol.Optional(CONF_RECONNECT, default=timedelta(minutes=10)): (
+		vol.All(cv.time_period, cv.positive_timedelta)),
+#		vol.Optional(CONF_DISCOVERY, default=True): cv.boolean,
+	}) ],
+}, extra=vol.ALLOW_EXTRA)
+
+
+class HomematicIP(Home):
+	"""Representation of an HomeMaticIP."""
+	label = None
+
+
+	def __init__(self, hass, name, hubid, authtoken, timeout=20, reconnect=10):
+		"""Set up connection and hook it into HA for reconnect/shutdown."""
+		super().__init__()
+		
+		def events_hmip(events):
+			"""Handle incoming HomeMaticIP events."""
+			for event in events:
+				eventType = event["eventType"]
+				_LOGGER.debug("Fire event: {}, label: {}".format(eventType, event["data"].label))
+				if eventType == 'DEVICE_CHANGED':
+					hass.bus.async_fire(EVENT_DEVICE_CHANGED, event["data"].id)
+				if eventType == 'GROUP_CHANGED':
+					hass.bus.async_fire(EVENT_GROUP_CHANGED, event["data"].id)
+				if eventType == 'HOME_CHANGED':
+					hass.bus.async_fire(EVENT_HOME_CHANGED, event["data"].id)
+				if eventType == 'JOURNAL_CHANGED':
+					hass.bus.async_fire(EVENT_SECURITY_CHANGED, event["data"].id)
+		
+		try:
+			self.init(hubid)
+			self.set_auth_token(authtoken)
+			self.get_current_state()
+			self.onEvent += events_hmip
+			self.enable_events()
+			_LOGGER.info('Connected to HomematicIP server')
+		except timeout as exc:
+			hass.loop.call_later(connect, reconnect, exc)
+			_LOGGER.warning("Connection to server could not be established")
+		
+		self.label = name	
+	
+
+@asyncio.coroutine
+def async_setup(hass, config):
+	"""Set up the HomematicIP component."""
+	hass.data.setdefault(DOMAIN, {})
+	homes = hass.data[DOMAIN]
+
+	hubs = config.get(DOMAIN, [])
+	for device in hubs:
+		name = device.get(CONF_NAME)
+		hubid = device.get(CONF_HUBID)
+		authtoken = device.get(CONF_AUTHTOKEN)
+		timeout = device.get(CONF_TIMEOUT)
+		reconnect = device.get(CONF_RECONNECT)
+		_LOGGER.info('Initiating HomematicIP hub {}, {}'.format(name, hubid))
+		home = HomematicIP(hass, name, hubid, authtoken, timeout, reconnect)
+		homes[home.id] = home
+		_LOGGER.info('HUB name: {}, id: {}'.format(home.label, home.id))
+		for component in 'sensor', 'climate':
+			hass.async_add_job(async_load_platform(hass, component, DOMAIN, {'homeid': home.id}, config))
+
+	return True
+
+

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -72,6 +72,7 @@ class TPLinkSmartBulb(Light):
         if name is not None:
             self._name = name
         self._state = None
+        self._available = True
         self._color_temp = None
         self._brightness = None
         self._rgb = None
@@ -82,6 +83,11 @@ class TPLinkSmartBulb(Light):
     def name(self):
         """Return the name of the Smart Bulb, if any."""
         return self._name
+
+    @property
+    def available(self) -> bool:
+        """Return if bulb is available."""
+        return self._available
 
     @property
     def device_state_attributes(self):
@@ -132,6 +138,7 @@ class TPLinkSmartBulb(Light):
         """Update the TP-Link Bulb's state."""
         from pyHS100 import SmartDeviceException
         try:
+            self._available = True
             if self._supported_features == 0:
                 self.get_features()
             self._state = (
@@ -163,8 +170,10 @@ class TPLinkSmartBulb(Light):
                 except KeyError:
                     # device returned no daily/monthly history
                     pass
+
         except (SmartDeviceException, OSError) as ex:
-            _LOGGER.warning('Could not read state for %s: %s', self._name, ex)
+            _LOGGER.warning("Could not read state for %s: %s", self._name, ex)
+            self._available = False
 
     @property
     def supported_features(self):

--- a/homeassistant/components/sensor/homematicip.py
+++ b/homeassistant/components/sensor/homematicip.py
@@ -1,0 +1,231 @@
+"""
+Support for HomematicIP sensors.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/homematicip/
+"""
+
+import asyncio
+import logging
+
+
+from homeassistant.core import callback
+from homeassistant.const import (
+	ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE,
+	CONF_ICON_TEMPLATE, ATTR_ENTITY_ID,
+	CONF_SENSORS)
+from homeassistant.helpers.entity import Entity, async_generate_entity_id
+from homeassistant.components.homematicip import ( DOMAIN,
+	EVENT_HOME_CHANGED, EVENT_DEVICE_CHANGED)
+#from datetime import timedelta
+
+import homematicip
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_ID = 'device_id'
+ATTR_HOME_ID = 'home_id'
+ATTR_LABEL = 'label'
+ATTR_LASTSTATUS_UPDATE = 'last_status_update'
+ATTR_FIRMWARE = 'status_firmware'
+ATTR_ACTUAL_FIRMWARE = 'actual_firmware'
+ATTR_AVAILABLE_FIRMWARE = 'available_firmware'
+ATTR_LOW_BATTERY = 'low_battery'
+ATTR_UNREACHABLE = 'not_reachable'
+ATTR_SABOTAGE = 'sabotage'
+ATTR_UPTODATE = 'up_to_date'
+ATTR_WINDOW = 'window'
+ATTR_ON = 'on'
+ATTR_VALVE_POSITION = 'valve_position'
+ATTR_TEMPERATURE_OFFSET = 'temperature_offset'
+
+ATTR_CONNECTED = 'connected'
+ATTR_DUTYCYCLE = 'dutycycle'
+ATTR_CURRENT_APVERSION = 'current_apversion'
+ATTR_AVAILABLE_APVERSION = 'available_apversion'
+ATTR_TIMEZONE_ID = 'timezone_id'
+ATTR_PIN_ASSIGNED = 'pin_assigned'
+ATTR_UPDATE_STATE = 'update_state'
+ATTR_APEXCHANGE_CLIENTID = 'apexchange_clientid'
+ATTR_APEXCHANGE_STATE = 'apexchange_state'
+ATTR_HUB_ID = 'hub_id'
+
+
+@asyncio.coroutine
+# pylint: disable=unused-argument
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+	"""Set up the HomematicIP sensors devices."""
+	_LOGGER.info('Setting up HomeMaticIP AccesPoint & Generic')
+	homeid = discovery_info['homeid']
+	home = hass.data[DOMAIN][homeid]
+
+	async_add_devices([HomeMaticIP_AccessPoint(hass, home)])
+	for device in home.devices:
+		async_add_devices([HomeMaticIP_GenericDevice(hass, home, device)])
+	return True
+
+
+class HomeMaticIP_AccessPoint(Entity):
+	"""Representation of an HomeMaticIP access point."""
+
+	def __init__(self, hass, home):
+		"""Initialize the access point sensor."""
+		self.hass = hass
+		self._home = home
+
+		@callback
+		def event_accesspoint(event):
+			"""Handle device state changes."""
+			_LOGGER.debug('Event Access Point: {}'.format(self._home.label))
+			self.async_schedule_update_ha_state(True)
+
+		hass.bus.async_listen(EVENT_HOME_CHANGED, event_accesspoint)
+
+	@property
+	def name(self):
+		"""Return the name of the access point device."""
+		if self._home.label == 'None':
+			return 'Access Point Status'
+		else:
+			return '{} Access Point Status'.format(self._home.label)
+
+	@property
+	def icon(self):
+		return 'mdi:access-point-network'
+
+	@property
+	def state(self):
+		"""Return the state of the access point."""
+		return self._home.dutyCycle
+
+	@property
+	def force_update(self):
+		"""Force update."""
+		return True
+
+	@property
+	def device_state_attributes(self):
+		"""Return the state attributes of the access point."""
+		return {
+			ATTR_CONNECTED: self._home.connected,
+			ATTR_DUTYCYCLE: self._home.dutyCycle,
+			ATTR_CURRENT_APVERSION: self._home.currentAPVersion,
+			ATTR_AVAILABLE_APVERSION: self._home.availableAPVersion,
+			ATTR_TIMEZONE_ID: self._home.timeZoneId,
+			ATTR_PIN_ASSIGNED: self._home.pinAssigned,
+			ATTR_UPDATE_STATE: self._home.updateState,
+			ATTR_APEXCHANGE_CLIENTID: self._home.apExchangeClientId,
+			ATTR_APEXCHANGE_STATE: self._home.apExchangeState,
+			ATTR_ID: self._home.id,
+			ATTR_LABEL: self._home.label,
+			}
+
+
+
+class HomeMaticIP_GenericDevice(Entity):
+	"""Representation of an HomeMaticIP generic device."""
+
+	def __init__(self, hass, home, device, signal=None):
+		"""Initialize the generic device."""
+		self.hass = hass
+		self._home = home
+		self._device = device
+		_LOGGER.debug('Setting up generic sensor device: {}'.format(device.label))
+
+		@callback
+		def event_sensor(event):
+			"""Receive notification that new data exists."""
+			if event.data == self._device.id:
+				_LOGGER.debug('Event GenericDevice: {}'.format(self._device.label))
+				self.async_schedule_update_ha_state(True)
+
+		if signal is None:
+			hass.bus.async_listen(EVENT_DEVICE_CHANGED, event_sensor)
+		else:
+			hass.bus.async_listen(signal, event_sensor)
+
+	@property
+	def name(self):
+		"""Return the name of the generic device."""
+		if self._home.label != 'None':
+			return '{} {}'.format(self._home.label, self._device.label)
+		return self._device.label
+
+	@property
+	def icon(self):
+		"""Return the icon of the generic device."""
+		if self._device.unreach: return 'mdi:wifi-off'
+		if self._device.lowBat: return 'mdi:battery-outline'
+		if self._device.updateState.lower() != ATTR_UPTODATE: return 'mdi:refresh'
+		return 'mdi:check'
+
+	@property
+	def state(self):
+		"""Return the state of the generic device."""
+		if self._device.unreach: return ATTR_UNREACHABLE
+		if self._device.lowBat: return ATTR_LOW_BATTERY
+		if self._device.updateState.lower() != ATTR_UPTODATE: return self._device.updateState.lower()
+		return 'ok'
+
+	@property
+	def force_update(self):
+		"""Force update."""
+		return True
+
+	@property
+	def should_poll(self):
+		"""No polling needed."""
+		return False
+
+	@property
+	def available(self):
+		return not self._device.unreach
+
+	@asyncio.coroutine
+	def async_update(self):
+		return True
+
+	def _generic_state_attributes(self):
+		"""Return the state attributes of the generic device."""
+		attr = {}
+		if hasattr(self._device, 'id'):
+			attr.update({ATTR_ID: self._device.id.lower()})
+		if hasattr(self._device, 'homeId'):
+			attr.update({ATTR_HOME_ID: self._device.homeId})
+		if hasattr(self._device, 'lastStatusUpdate') and  self._device.lastStatusUpdate != None:
+			attr.update({ATTR_LASTSTATUS_UPDATE: self._device.lastStatusUpdate.strftime('%d-%m-%Y %H:%M:%S')})
+		if hasattr(self._device, 'updateState') and self._device.updateState != None:
+			attr.update({ATTR_FIRMWARE: self._device.updateState.lower()})
+		if hasattr(self._device, 'firmwareVersion'):
+			attr.update({ATTR_ACTUAL_FIRMWARE: self._device.firmwareVersion})
+		if hasattr(self._device, 'availableFirmwareVersion'):
+			attr.update({ATTR_AVAILABLE_FIRMWARE: self._device.availableFirmwareVersion})
+		if hasattr(self._device, 'lowBat') and self._device.lowBat != None:
+			attr.update({ATTR_LOW_BATTERY: self._device.lowBat})
+		if hasattr(self._device, 'unreach') and self._device.unreach != None:
+			attr.update({ATTR_UNREACHABLE: self._device.unreach})
+		if hasattr(self._device, 'sabotage') and self._device.sabotage != None:
+			attr.update({ATTR_SABOTAGE: self._device.sabotage})
+
+		if hasattr(self._device, 'windowState') and self._device.windowState != None:
+			attr.update({ATTR_WINDOW: self._device.windowState.lower()})
+		if hasattr(self._device, 'on') and self._device.on != None:
+			attr.update({ATTR_ON: self._device.on})
+
+		if hasattr(self._device, 'valvePosition') and self._device.valvePosition != None:
+			attr.update({ATTR_VALVE_POSITION: self._device.valvePosition})
+		if hasattr(self._device, 'temperatureOffset') and self._device.temperatureOffset != None:
+			attr.update({ATTR_TEMPERATURE_OFFSET: self._device.temperatureOffset})
+
+		if hasattr(self._device, 'currentPowerConsumption') and self._device.currentPowerConsumption != None:
+			attr.update({'currentPowerConsumption': self._device.currentPowerConsumption})
+
+		return attr
+
+	@property
+	def device_state_attributes(self):
+		"""Return the state attributes of the generic device."""
+		return self._generic_state_attributes()
+
+
+


### PR DESCRIPTION
## Description:

Add support for Homematic IP components.

## Example entry for `configuration.yaml` (if applicable):
```yaml
homematicip:
  - name: None
    hubid: !secret homematicip_accesspoint
    authtoken: !secret homematicip_authtoken
```

