### PR TITLE
Remove need for separate EgardiaServer setup

### DIFF
--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -84,7 +84,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         raise exc.PlatformNotReady()
     except egardiadevice.UnauthorizedError:
         _LOGGER.error("Unable to authorize. Wrong password or username")
-        return False
+        return
 
     eg_dev = EgardiaAlarm(
         name, egardiasystem, rs_enabled, rs_codes)
@@ -102,7 +102,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 hass.data[D_EGARDIASRV] = server
                 server.start()
         except IOError:
-            return False
+            return
         hass.data[D_EGARDIASRV].register_callback(eg_dev.handle_status_event)
 
     def handle_stop_event(event):

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -95,16 +95,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         try:
             if D_EGARDIASRV not in hass.data:
                 server = egardiaserver.EgardiaServer('', rs_port)
-                hass.data[D_EGARDIASRV] = server
                 bound = server.bind()
-
                 if not bound:
                     raise IOError("Binding error occurred while " +
                                   "starting EgardiaServer")
-                server.register_callback(eg_dev.handle_status_event)
+                hass.data[D_EGARDIASRV] = server
                 server.start()
         except IOError:
             return False
+        hass.data[D_EGARDIASRV].register_callback(eg_dev.handle_status_event)
 
     def handle_stop_event(event):
         """Callback function for HA stop event."""

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -34,7 +34,7 @@ DEFAULT_REPORT_SERVER_ENABLED = False
 DEFAULT_REPORT_SERVER_PORT = 52010
 DEFAULT_VERSION = 'GATE-01'
 DOMAIN = 'egardia'
-DATA_EGARDIASERVER = 'egardiaserver'
+D_EGARDIASRV = 'egardiaserver'
 NOTIFICATION_ID = 'egardia_notification'
 NOTIFICATION_TITLE = 'Egardia'
 
@@ -86,20 +86,20 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("Unable to authorize. Wrong password or username")
         return False
 
-    
     if rs_enabled:
         # Set up the egardia server
         _LOGGER.info("Setting up EgardiaServer")
         try:
-            if DATA_EGARDIASERVER not in hass.data:
-                hass.data[DATA_EGARDIASERVER] = egardiaserver.EgardiaServer('', rs_port)
-                bound = hass.data[DATA_EGARDIASERVER].bind()
+            if D_EGARDIASRV not in hass.data:
+                hass.data[D_EGARDIASRV] = egardiaserver.EgardiaServer('',
+                                                                      rs_port)
+                bound = hass.data[D_EGARDIASRV].bind()
                 if not bound:
                     raise IOError("Binding error occurred while " +
-                                 "starting EgardiaServer")
-        except IOError as ioe:
+                                  "starting EgardiaServer")
+        except IOError:
             return False
-    
+
     add_devices([EgardiaAlarm(
         name, egardiasystem, hass, rs_codes)], True)
 
@@ -113,7 +113,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         self._name = name
         self._egardiasystem = egardiasystem
         self._status = None
-        self._egardiaserver = hass.data[DATA_EGARDIASERVER]
+        self._egardiaserver = hass.data[D_EGARDIASRV]
         self._hass = hass
 
         if rs_codes is not None:
@@ -124,7 +124,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         if self._egardiaserver is not None:
             _LOGGER.debug("Starting EgardiaServer and registering callback")
             # Register callback for alarm status changes through EgardiaServer
-            self._egardiaserver.register_callback(self.handle_system_status_event)
+            self._egardiaserver.register_callback(self.handle_status_event)
             self._egardiaserver.start()
 
     @property
@@ -144,7 +144,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
             return True
         return False
 
-    def handle_system_status_event(self, event):
+    def handle_status_event(self, event):
         """Handle egardia_system_status_event."""
         statuscode = event.get('status')
         if statuscode is not None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -925,7 +925,7 @@ python_opendata_transport==0.0.3
 python_openzwave==0.4.0.35
 
 # homeassistant.components.alarm_control_panel.egardia
-pythonegardia==1.0.22
+pythonegardia==1.0.25
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3


### PR DESCRIPTION
## Description:
We removed the need for the user to run a separate Egardiaserver component. This is a breaking change, but makes the usage of the component much easier (and it can now also run on HASS.io).
This is a replacement for https://github.com/home-assistant/home-assistant/pull/11322

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4282

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: egardia
    host: XX.XX.XX.XX
    username: XX
    password: XX
    report_server_enabled: True
    report_server_port: 52010
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
