### PR TITLE
Removed status block that didn't respect base class definition

### DIFF
--- a/homeassistant/components/climate/netatmo.py
+++ b/homeassistant/components/climate/netatmo.py
@@ -80,11 +80,6 @@ class NetatmoThermostat(ClimateDevice):
         return self._name
 
     @property
-    def state(self):
-        """Return the state of the device."""
-        return self._target_temperature
-
-    @property
     def temperature_unit(self):
         """Return the unit of measurement."""
         return TEMP_CELSIUS


### PR DESCRIPTION
## Description:
This PR was created to remove an unused block of code that redefines state and it conflicts with the base class definition.
This PR would allow https://github.com/home-assistant/home-assistant-polymer/issues/763 to be fixed without this component getting an invalid state display on the UI. 

The PR https://github.com/home-assistant/home-assistant-polymer/pull/759 changes the UI to use "status" instead of "operation_mode" that reflects better the thermostat state by allowing "idle" and other states to be visible on the interface.

**Related issue (if applicable):** 
https://github.com/home-assistant/home-assistant-polymer/pull/766
https://github.com/home-assistant/home-assistant-polymer/issues/763


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
