### PR TITLE
Add default names and validation for TP-Link devices

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -8,10 +8,13 @@ import logging
 import colorsys
 import time
 
+import voluptuous as vol
+
 from homeassistant.const import (CONF_HOST, CONF_NAME)
 from homeassistant.components.light import (
     Light, ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_KELVIN, ATTR_RGB_COLOR,
-    SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR)
+    SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR, PLATFORM_SCHEMA)
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 from homeassistant.util.color import (
@@ -26,6 +29,13 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_CURRENT_CONSUMPTION = 'current_consumption'
 ATTR_DAILY_CONSUMPTION = 'daily_consumption'
 ATTR_MONTHLY_CONSUMPTION = 'monthly_consumption'
+
+DEFAULT_NAME = 'TP-Link Light'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
+})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -24,10 +24,13 @@ ATTR_CURRENT = 'current'
 
 CONF_LEDS = 'enable_leds'
 
+DEFAULT_NAME = 'TP-Link Switch'
+DEFAULT_LEDS = True
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_LEDS, default=True): cv.boolean,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_LEDS, default=DEFAULT_LEDS): cv.boolean,
 })
 
 


### PR DESCRIPTION
## Description:

Adds missing platform schema for TP-Link smart sockets and adds default names for smart sockets and bulbs.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4294

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: tplink
    host: 192.168.1.100

light:
  - platform: tplink
    host: 192.168.1.101
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
