### PR TITLE
MQTT thermostat: unquote payloads

### DIFF
--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -135,6 +135,12 @@ class TestMQTTClimate(unittest.TestCase):
         self.assertEqual("cool", state.attributes.get('operation_mode'))
         self.assertEqual("cool", state.state)
 
+        fire_mqtt_message(self.hass, 'mode-state', '"heat"')
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("heat", state.attributes.get('operation_mode'))
+        self.assertEqual("heat", state.state)
+
     def test_set_fan_mode_bad_attr(self):
         """Test setting fan mode without required attribute."""
         assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
@@ -169,6 +175,11 @@ class TestMQTTClimate(unittest.TestCase):
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual('high', state.attributes.get('fan_mode'))
+
+        fire_mqtt_message(self.hass, 'fan-state', '"low"')
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual('low', state.attributes.get('fan_mode'))
 
     def test_set_fan_mode(self):
         """Test setting of new fan mode."""
@@ -217,6 +228,11 @@ class TestMQTTClimate(unittest.TestCase):
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual("on", state.attributes.get('swing_mode'))
+
+        fire_mqtt_message(self.hass, 'swing-state', '"off"')
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual("off", state.attributes.get('swing_mode'))
 
     def test_set_swing(self):
         """Test setting of new swing mode."""
@@ -306,7 +322,7 @@ class TestMQTTClimate(unittest.TestCase):
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual('on', state.attributes.get('away_mode'))
 
-        fire_mqtt_message(self.hass, 'away-state', 'OFF')
+        fire_mqtt_message(self.hass, 'away-state', '"OFF"')
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual('off', state.attributes.get('away_mode'))
@@ -364,6 +380,11 @@ class TestMQTTClimate(unittest.TestCase):
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual('off', state.attributes.get('hold_mode'))
 
+        fire_mqtt_message(self.hass, 'hold-state', '"quoted"')
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        self.assertEqual('quoted', state.attributes.get('hold_mode'))
+
     def test_set_hold(self):
         """Test setting the hold mode."""
         assert setup_component(self.hass, climate.DOMAIN, DEFAULT_CONFIG)
@@ -403,7 +424,7 @@ class TestMQTTClimate(unittest.TestCase):
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual('on', state.attributes.get('aux_heat'))
 
-        fire_mqtt_message(self.hass, 'aux-state', 'OFF')
+        fire_mqtt_message(self.hass, 'aux-state', '"OFF"')
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual('off', state.attributes.get('aux_heat'))


### PR DESCRIPTION
## Description:

For payloads incoming via the `*_STATE` MQTT channels, we should unquote them if they are quoted.

This targets a (probably pretty common) use case of using the MQTT thermostat with another HA instance on the other side, and using `mqtt_statestream` for the `*_STATE` channels. Since #9872 , the values set from the "master" HA instance will be echoed in a quoted form on the state channels by the "slave" HA instance, causing errors. There is currently no easy way of circumventing this.

I thought about making unquoting optional, but I don't think we do any harm just always trying this. We always try setting both quoted and unquoted form, so nothing that works now should break. There are two scenarios where I could imagine trouble:
* If someone has `FOO` as well as `"FOO"` in their `operations_list` (or any other list), this will break. But this seems like an insane configuration.
* If some device wants `"FOO"` as their `hold_mode`, unquoting would turn this into `FOO`, since we don't have a list of values for the `hold_mode`, and thus always apply unquoting here.

**Related issue (if applicable):** fixes parts of #10209

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.