### PR TITLE
Ping device tracker now respects interval_seconds

### DIFF
--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -72,7 +72,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
     hosts = [Host(ip, dev_id, hass, config) for (dev_id, ip) in
              config[const.CONF_HOSTS].items()]
     interval = config.get(CONF_SCAN_INTERVAL, timedelta(seconds=len(hosts) *
-                          config[CONF_PING_COUNT]) + DEFAULT_SCAN_INTERVAL)
+                                                        config[CONF_PING_COUNT])
+                          + DEFAULT_SCAN_INTERVAL)
     _LOGGER.info("Started ping tracker with interval=%s on hosts: %s",
                  interval, ",".join([host.ip_address for host in hosts]))
 

--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -83,6 +83,5 @@ def setup_scanner(hass, config, see, discovery_info=None):
         for host in hosts:
             host.update(see)
         track_point_in_utc_time(hass, update, util.dt.utcnow() + interval)
-        return True
 
-    return update(util.dt.utcnow())
+    return update(None)

--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -78,10 +78,14 @@ def setup_scanner(hass, config, see, discovery_info=None):
     _LOGGER.info("Started ping tracker with interval=%s on hosts: %s",
                  interval, ",".join([host.ip_address for host in hosts]))
 
-    def update(now):
+    def update_interval(now):
         """Update all the hosts on every interval time."""
         for host in hosts:
             host.update(see)
         track_point_in_utc_time(hass, update, util.dt.utcnow() + interval)
 
-    return update(None)
+    if not hosts:
+        return False
+    
+    update_interval(None)
+    return True

--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -13,7 +13,8 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
-    PLATFORM_SCHEMA, DEFAULT_SCAN_INTERVAL, SOURCE_TYPE_ROUTER)
+    PLATFORM_SCHEMA, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
+    SOURCE_TYPE_ROUTER)
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant import util
 from homeassistant import const
@@ -70,8 +71,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
     """Set up the Host objects and return the update function."""
     hosts = [Host(ip, dev_id, hass, config) for (dev_id, ip) in
              config[const.CONF_HOSTS].items()]
-    interval = timedelta(seconds=len(hosts) * config[CONF_PING_COUNT]) + \
-        DEFAULT_SCAN_INTERVAL
+    interval = config.get(CONF_SCAN_INTERVAL, timedelta(seconds=len(hosts) * \
+                config[CONF_PING_COUNT]) + DEFAULT_SCAN_INTERVAL)
     _LOGGER.info("Started ping tracker with interval=%s on hosts: %s",
                  interval, ",".join([host.ip_address for host in hosts]))
 

--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -71,8 +71,10 @@ def setup_scanner(hass, config, see, discovery_info=None):
     """Set up the Host objects and return the update function."""
     hosts = [Host(ip, dev_id, hass, config) for (dev_id, ip) in
              config[const.CONF_HOSTS].items()]
-    interval = config.get(CONF_SCAN_INTERVAL, timedelta(seconds=len(hosts) *
-                          config[CONF_PING_COUNT]) + DEFAULT_SCAN_INTERVAL)
+    interval = config.get(CONF_SCAN_INTERVAL,
+                          timedelta(seconds=len(hosts) *
+                                    config[CONF_PING_COUNT])
+                          + DEFAULT_SCAN_INTERVAL)
     _LOGGER.info("Started ping tracker with interval=%s on hosts: %s",
                  interval, ",".join([host.ip_address for host in hosts]))
 

--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -71,7 +71,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
     """Set up the Host objects and return the update function."""
     hosts = [Host(ip, dev_id, hass, config) for (dev_id, ip) in
              config[const.CONF_HOSTS].items()]
-    interval = config.get(CONF_SCAN_INTERVAL, timedelta(seconds=len(hosts) * \
+    interval = config.get(CONF_SCAN_INTERVAL, timedelta(seconds=len(hosts) *
                 config[CONF_PING_COUNT]) + DEFAULT_SCAN_INTERVAL)
     _LOGGER.info("Started ping tracker with interval=%s on hosts: %s",
                  interval, ",".join([host.ip_address for host in hosts]))

--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -72,7 +72,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
     hosts = [Host(ip, dev_id, hass, config) for (dev_id, ip) in
              config[const.CONF_HOSTS].items()]
     interval = config.get(CONF_SCAN_INTERVAL, timedelta(seconds=len(hosts) *
-                            config[CONF_PING_COUNT]) + DEFAULT_SCAN_INTERVAL)
+                          config[CONF_PING_COUNT]) + DEFAULT_SCAN_INTERVAL)
     _LOGGER.info("Started ping tracker with interval=%s on hosts: %s",
                  interval, ",".join([host.ip_address for host in hosts]))
 

--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -75,7 +75,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
                           timedelta(seconds=len(hosts) *
                                     config[CONF_PING_COUNT])
                           + DEFAULT_SCAN_INTERVAL)
-    _LOGGER.info("Started ping tracker with interval=%s on hosts: %s",
+    _LOGGER.debug("Started ping tracker with interval=%s on hosts: %s",
                  interval, ",".join([host.ip_address for host in hosts]))
 
     def update_interval(now):
@@ -84,8 +84,5 @@ def setup_scanner(hass, config, see, discovery_info=None):
             host.update(see)
         track_point_in_utc_time(hass, update, util.dt.utcnow() + interval)
 
-    if not hosts:
-        return False
-    
     update_interval(None)
     return True

--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -72,7 +72,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
     hosts = [Host(ip, dev_id, hass, config) for (dev_id, ip) in
              config[const.CONF_HOSTS].items()]
     interval = config.get(CONF_SCAN_INTERVAL, timedelta(seconds=len(hosts) *
-                config[CONF_PING_COUNT]) + DEFAULT_SCAN_INTERVAL)
+                            config[CONF_PING_COUNT]) + DEFAULT_SCAN_INTERVAL)
     _LOGGER.info("Started ping tracker with interval=%s on hosts: %s",
                  interval, ",".join([host.ip_address for host in hosts]))
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #11148


## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: ping
  interval_seconds: 300
  hosts:
    device1: 192.168.1.100
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
