### PR TITLE
Silence redundant warnings about slow setup

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -181,9 +181,15 @@ def _async_setup_component(hass: core.HomeAssistant,
 
     start = timer()
     _LOGGER.info("Setting up %s", domain)
-    warn_task = hass.loop.call_later(
-        SLOW_SETUP_WARNING, _LOGGER.warning,
-        "Setup of %s is taking over %s seconds.", domain, SLOW_SETUP_WARNING)
+
+    if hasattr(component, 'PLATFORM_SCHEMA'):
+        # Entity components have their own warning
+        warn_task = None
+    else:
+        warn_task = hass.loop.call_later(
+            SLOW_SETUP_WARNING, _LOGGER.warning,
+            "Setup of %s is taking over %s seconds.",
+            domain, SLOW_SETUP_WARNING)
 
     try:
         if async_comp:
@@ -197,7 +203,8 @@ def _async_setup_component(hass: core.HomeAssistant,
         return False
     finally:
         end = timer()
-        warn_task.cancel()
+        if warn_task:
+            warn_task.cancel()
     _LOGGER.info("Setup of domain %s took %.1f seconds.", domain, end - start)
 
     if result is False:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -182,7 +182,7 @@ def _async_setup_component(hass: core.HomeAssistant,
     start = timer()
     _LOGGER.info("Setting up %s", domain)
     warn_task = hass.loop.call_later(
-        SLOW_SETUP_WARNING, _LOGGER.info,
+        SLOW_SETUP_WARNING, _LOGGER.warning,
         "Setup of %s is taking over %s seconds.", domain, SLOW_SETUP_WARNING)
 
     try:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -182,7 +182,7 @@ def _async_setup_component(hass: core.HomeAssistant,
     start = timer()
     _LOGGER.info("Setting up %s", domain)
     warn_task = hass.loop.call_later(
-        SLOW_SETUP_WARNING, _LOGGER.warning,
+        SLOW_SETUP_WARNING, _LOGGER.info,
         "Setup of %s is taking over %s seconds.", domain, SLOW_SETUP_WARNING)
 
     try:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -461,6 +461,6 @@ def test_component_warn_slow_setup(hass):
         timeout, logger_method = mock_call.mock_calls[0][1][:2]
 
         assert timeout == setup.SLOW_SETUP_WARNING
-        assert logger_method == setup._LOGGER.warning
+        assert logger_method == setup._LOGGER.info
 
         assert mock_call().cancel.called

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -465,6 +465,7 @@ def test_component_warn_slow_setup(hass):
 
         assert mock_call().cancel.called
 
+
 @asyncio.coroutine
 def test_platform_no_warn_slow(hass):
     """Do not warn for long entity setup time."""

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -456,7 +456,7 @@ def test_component_warn_slow_setup(hass):
             hass, 'test_component1', {})
         assert result
         assert mock_call.called
-        assert len(mock_call.mock_calls) == 2
+        assert len(mock_call.mock_calls) == 3
 
         timeout, logger_method = mock_call.mock_calls[0][1][:2]
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -461,6 +461,6 @@ def test_component_warn_slow_setup(hass):
         timeout, logger_method = mock_call.mock_calls[0][1][:2]
 
         assert timeout == setup.SLOW_SETUP_WARNING
-        assert logger_method == setup._LOGGER.info
+        assert logger_method == setup._LOGGER.warning
 
         assert mock_call().cancel.called

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -464,3 +464,16 @@ def test_component_warn_slow_setup(hass):
         assert logger_method == setup._LOGGER.warning
 
         assert mock_call().cancel.called
+
+@asyncio.coroutine
+def test_platform_no_warn_slow(hass):
+    """Do not warn for long entity setup time."""
+    loader.set_component(
+        'test_component1',
+        MockModule('test_component1', platform_schema=PLATFORM_SCHEMA))
+    with mock.patch.object(hass.loop, 'call_later', mock.MagicMock()) \
+            as mock_call:
+        result = yield from setup.async_setup_component(
+            hass, 'test_component1', {})
+        assert result
+        assert not mock_call.called


### PR DESCRIPTION
## Description:

This warning can easily trigger on slow servers (like the Raspberry Pi) because it simply takes more than 10 seconds to get through all the setup.

As users can do nothing to avoid the issue, I propose to downgrade the severity.

**Related issue (if applicable):** [Forum post](https://community.home-assistant.io/t/hassio-io-10-second-warnings/23714)

## Checklist:

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [X] Tests have been added to verify that the new code works.
