### PR TITLE
Don't block on sevice call for alexa

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -249,7 +249,7 @@ def async_api_turn_on(hass, config, request, entity):
 
     yield from hass.services.async_call(domain, service, {
         ATTR_ENTITY_ID: entity.entity_id
-    }, blocking=True)
+    }, blocking=False)
 
     return api_message(request)
 
@@ -269,7 +269,7 @@ def async_api_turn_off(hass, config, request, entity):
 
     yield from hass.services.async_call(domain, service, {
         ATTR_ENTITY_ID: entity.entity_id
-    }, blocking=True)
+    }, blocking=False)
 
     return api_message(request)
 
@@ -284,7 +284,7 @@ def async_api_set_brightness(hass, config, request, entity):
     yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
         ATTR_ENTITY_ID: entity.entity_id,
         light.ATTR_BRIGHTNESS_PCT: brightness,
-    }, blocking=True)
+    }, blocking=False)
 
     return api_message(request)
 
@@ -308,7 +308,7 @@ def async_api_adjust_brightness(hass, config, request, entity):
     yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
         ATTR_ENTITY_ID: entity.entity_id,
         light.ATTR_BRIGHTNESS_PCT: brightness,
-    }, blocking=True)
+    }, blocking=False)
 
     return api_message(request)
 
@@ -329,14 +329,14 @@ def async_api_set_color(hass, config, request, entity):
         yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
             ATTR_ENTITY_ID: entity.entity_id,
             light.ATTR_RGB_COLOR: rgb,
-        }, blocking=True)
+        }, blocking=False)
     else:
         xyz = color_util.color_RGB_to_xy(*rgb)
         yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
             ATTR_ENTITY_ID: entity.entity_id,
             light.ATTR_XY_COLOR: (xyz[0], xyz[1]),
             light.ATTR_BRIGHTNESS: xyz[2],
-        }, blocking=True)
+        }, blocking=False)
 
     return api_message(request)
 
@@ -351,7 +351,7 @@ def async_api_set_color_temperature(hass, config, request, entity):
     yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
         ATTR_ENTITY_ID: entity.entity_id,
         light.ATTR_KELVIN: kelvin,
-    }, blocking=True)
+    }, blocking=False)
 
     return api_message(request)
 
@@ -369,7 +369,7 @@ def async_api_decrease_color_temp(hass, config, request, entity):
     yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
         ATTR_ENTITY_ID: entity.entity_id,
         light.ATTR_COLOR_TEMP: value,
-    }, blocking=True)
+    }, blocking=False)
 
     return api_message(request)
 
@@ -387,7 +387,7 @@ def async_api_increase_color_temp(hass, config, request, entity):
     yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
         ATTR_ENTITY_ID: entity.entity_id,
         light.ATTR_COLOR_TEMP: value,
-    }, blocking=True)
+    }, blocking=False)
 
     return api_message(request)
 
@@ -399,7 +399,7 @@ def async_api_activate(hass, config, request, entity):
     """Process a activate request."""
     yield from hass.services.async_call(entity.domain, SERVICE_TURN_ON, {
         ATTR_ENTITY_ID: entity.entity_id
-    }, blocking=True)
+    }, blocking=False)
 
     return api_message(request)
 
@@ -429,8 +429,8 @@ def async_api_set_percentage(hass, config, request, entity):
         service = SERVICE_SET_COVER_POSITION
         data[cover.ATTR_POSITION] = percentage
 
-    yield from hass.services.async_call(entity.domain, service,
-                                        data, blocking=True)
+    yield from hass.services.async_call(
+        entity.domain, service, data, blocking=False)
 
     return api_message(request)
 
@@ -477,8 +477,8 @@ def async_api_adjust_percentage(hass, config, request, entity):
 
         data[cover.ATTR_POSITION] = max(0, percentage_delta + current)
 
-    yield from hass.services.async_call(entity.domain, service,
-                                        data, blocking=True)
+    yield from hass.services.async_call(
+        entity.domain, service, data, blocking=False)
 
     return api_message(request)
 
@@ -490,7 +490,7 @@ def async_api_lock(hass, config, request, entity):
     """Process a lock request."""
     yield from hass.services.async_call(entity.domain, SERVICE_LOCK, {
         ATTR_ENTITY_ID: entity.entity_id
-    }, blocking=True)
+    }, blocking=False)
 
     return api_message(request)
 
@@ -503,7 +503,7 @@ def async_api_unlock(hass, config, request, entity):
     """Process a unlock request."""
     yield from hass.services.async_call(entity.domain, SERVICE_UNLOCK, {
         ATTR_ENTITY_ID: entity.entity_id
-    }, blocking=True)
+    }, blocking=False)
 
     return api_message(request)
 
@@ -520,8 +520,9 @@ def async_api_set_volume(hass, config, request, entity):
         media_player.ATTR_MEDIA_VOLUME_LEVEL: volume,
     }
 
-    yield from hass.services.async_call(entity.domain, SERVICE_VOLUME_SET,
-                                        data, blocking=True)
+    yield from hass.services.async_call(
+        entity.domain, SERVICE_VOLUME_SET,
+        data, blocking=False)
 
     return api_message(request)
 
@@ -548,9 +549,9 @@ def async_api_adjust_volume(hass, config, request, entity):
         media_player.ATTR_MEDIA_VOLUME_LEVEL: volume,
     }
 
-    yield from hass.services.async_call(entity.domain,
-                                        media_player.SERVICE_VOLUME_SET,
-                                        data, blocking=True)
+    yield from hass.services.async_call(
+        entity.domain, media_player.SERVICE_VOLUME_SET,
+        data, blocking=False)
 
     return api_message(request)
 
@@ -567,9 +568,9 @@ def async_api_set_mute(hass, config, request, entity):
         media_player.ATTR_MEDIA_VOLUME_MUTED: mute,
     }
 
-    yield from hass.services.async_call(entity.domain,
-                                        media_player.SERVICE_VOLUME_MUTE,
-                                        data, blocking=True)
+    yield from hass.services.async_call(
+        entity.domain, media_player.SERVICE_VOLUME_MUTE,
+        data, blocking=False)
 
     return api_message(request)
 
@@ -583,8 +584,9 @@ def async_api_play(hass, config, request, entity):
         ATTR_ENTITY_ID: entity.entity_id
     }
 
-    yield from hass.services.async_call(entity.domain, SERVICE_MEDIA_PLAY,
-                                        data, blocking=True)
+    yield from hass.services.async_call(
+        entity.domain, SERVICE_MEDIA_PLAY,
+        data, blocking=False)
 
     return api_message(request)
 
@@ -598,8 +600,9 @@ def async_api_pause(hass, config, request, entity):
         ATTR_ENTITY_ID: entity.entity_id
     }
 
-    yield from hass.services.async_call(entity.domain, SERVICE_MEDIA_PAUSE,
-                                        data, blocking=True)
+    yield from hass.services.async_call(
+        entity.domain, SERVICE_MEDIA_PAUSE,
+        data, blocking=False)
 
     return api_message(request)
 
@@ -613,8 +616,9 @@ def async_api_stop(hass, config, request, entity):
         ATTR_ENTITY_ID: entity.entity_id
     }
 
-    yield from hass.services.async_call(entity.domain, SERVICE_MEDIA_STOP,
-                                        data, blocking=True)
+    yield from hass.services.async_call(
+        entity.domain, SERVICE_MEDIA_STOP,
+        data, blocking=False)
 
     return api_message(request)
 
@@ -628,9 +632,9 @@ def async_api_next(hass, config, request, entity):
         ATTR_ENTITY_ID: entity.entity_id
     }
 
-    yield from hass.services.async_call(entity.domain,
-                                        SERVICE_MEDIA_NEXT_TRACK,
-                                        data, blocking=True)
+    yield from hass.services.async_call(
+        entity.domain, SERVICE_MEDIA_NEXT_TRACK,
+        data, blocking=False)
 
     return api_message(request)
 
@@ -644,8 +648,8 @@ def async_api_previous(hass, config, request, entity):
         ATTR_ENTITY_ID: entity.entity_id
     }
 
-    yield from hass.services.async_call(entity.domain,
-                                        SERVICE_MEDIA_PREVIOUS_TRACK,
-                                        data, blocking=True)
+    yield from hass.services.async_call(
+        entity.domain, SERVICE_MEDIA_PREVIOUS_TRACK,
+        data, blocking=False)
 
     return api_message(request)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -346,6 +346,7 @@ def test_exclude_filters(hass):
     ))
 
     msg = yield from smart_home.async_handle_message(hass, config, request)
+    yield from hass.async_block_till_done()
 
     msg = msg['event']
 
@@ -378,6 +379,7 @@ def test_include_filters(hass):
     ))
 
     msg = yield from smart_home.async_handle_message(hass, config, request)
+    yield from hass.async_block_till_done()
 
     msg = msg['event']
 
@@ -393,6 +395,7 @@ def test_api_entity_not_exists(hass):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -445,6 +448,7 @@ def test_api_turn_on(hass, domain):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -481,6 +485,7 @@ def test_api_turn_off(hass, domain):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -507,6 +512,7 @@ def test_api_set_brightness(hass):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -538,6 +544,7 @@ def test_api_adjust_brightness(hass, result, adjust):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -572,6 +579,7 @@ def test_api_set_color_rgb(hass):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -606,6 +614,7 @@ def test_api_set_color_xy(hass):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -635,6 +644,7 @@ def test_api_set_color_temperature(hass):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -664,6 +674,7 @@ def test_api_decrease_color_temp(hass, result, initial):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -693,6 +704,7 @@ def test_api_increase_color_temp(hass, result, initial):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -720,6 +732,7 @@ def test_api_activate(hass, domain):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -746,6 +759,7 @@ def test_api_set_percentage_fan(hass):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -775,6 +789,7 @@ def test_api_set_percentage_cover(hass):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -806,6 +821,7 @@ def test_api_adjust_percentage_fan(hass, result, adjust):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -838,6 +854,7 @@ def test_api_adjust_percentage_cover(hass, result, adjust):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -865,6 +882,7 @@ def test_api_lock(hass, domain):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -891,6 +909,7 @@ def test_api_play(hass, domain):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -917,6 +936,7 @@ def test_api_pause(hass, domain):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -943,6 +963,7 @@ def test_api_stop(hass, domain):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -969,6 +990,7 @@ def test_api_next(hass, domain):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -995,6 +1017,7 @@ def test_api_previous(hass, domain):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -1023,6 +1046,7 @@ def test_api_set_volume(hass):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -1054,6 +1078,7 @@ def test_api_adjust_volume(hass, result, adjust):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']
@@ -1083,6 +1108,7 @@ def test_api_mute(hass, domain):
 
     msg = yield from smart_home.async_handle_message(
         hass, DEFAULT_CONFIG, request)
+    yield from hass.async_block_till_done()
 
     assert 'event' in msg
     msg = msg['event']


### PR DESCRIPTION
## Description:

Some times the service call is to slow for alexa response and end in a error. We don't block the service call now and response immediately back.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
