### PR TITLE
 Fix RGB template ordering in MQTT Light

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -424,7 +424,7 @@ class MqttLight(Light):
 
             tpl = self._templates[CONF_RGB_COMMAND_TEMPLATE]
             if tpl:
-                colors = {'red', 'green', 'blue'}
+                colors = ('red', 'green', 'blue')
                 variables = {key: val for key, val in
                              zip(colors, kwargs[ATTR_RGB_COLOR])}
                 rgb_color_str = tpl.async_render(variables)

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -546,17 +546,17 @@ class TestLightMQTT(unittest.TestCase):
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_OFF, state.state)
 
-        light.turn_on(self.hass, 'light.test', rgb_color=[255, 255, 255])
+        light.turn_on(self.hass, 'light.test', rgb_color=[255, 128, 64])
         self.hass.block_till_done()
 
         self.mock_publish().async_publish.assert_has_calls([
             mock.call('test_light_rgb/set', 'on', 0, False),
-            mock.call('test_light_rgb/rgb/set', '#ffffff', 0, False),
+            mock.call('test_light_rgb/rgb/set', '#ff8040', 0, False),
         ], any_order=True)
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_ON, state.state)
-        self.assertEqual((255, 255, 255), state.attributes['rgb_color'])
+        self.assertEqual((255, 128, 64), state.attributes['rgb_color'])
 
     def test_show_brightness_if_only_command_topic(self):
         """Test the brightness if only a command topic is present."""

--- a/tests/components/light/test_mqtt_template.py
+++ b/tests/components/light/test_mqtt_template.py
@@ -145,12 +145,12 @@ class TestLightMQTTTemplate(unittest.TestCase):
 
         # turn on the light, full white
         fire_mqtt_message(self.hass, 'test_light_rgb',
-                          'on,255,145,123,255-255-255,')
+                          'on,255,145,123,255-128-64,')
         self.hass.block_till_done()
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_ON, state.state)
-        self.assertEqual([255, 255, 255], state.attributes.get('rgb_color'))
+        self.assertEqual([255, 128, 64], state.attributes.get('rgb_color'))
         self.assertEqual(255, state.attributes.get('brightness'))
         self.assertEqual(145, state.attributes.get('color_temp'))
         self.assertEqual(123, state.attributes.get('white_value'))


### PR DESCRIPTION
## Description:

Ensures that RGB channels are sent in the correct order when using a colour template with MQTT Light.

The first commit modifies the existing tests that use RGB values in a template to have differing values, making this issue apparent when running the tests.

**Related issue (if applicable):** fixes #11145

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: mqtt
    name: "FakeBulb2"
    command_topic: "cmnd/fake-bulb-2/POWER"
    rgb_command_topic: "cmnd/fake-bulb-2/COLOR"
    rgb_command_template: "{{ '%02x%02x%02x0000'| format(red, green, blue) }}"
    brightness_command_topic: "cmnd/fake-bulb-2/DIMMER"
    brightness_value_template: "{{ value_json.Dimmer }}"
    brightness_scale: 100
    qos: 1
    payload_on: "ON"
    payload_off: "OFF"
    optimistic: false
    retain: true
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
