### PR TITLE
ZoneMinder event sensor updates

### DIFF
--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import CONF_MONITORED_CONDITIONS
 from homeassistant.helpers.entity import Entity
 import homeassistant.components.zoneminder as zoneminder
 import homeassistant.helpers.config_validation as cv
@@ -22,9 +23,19 @@ CONF_INCLUDE_ARCHIVED = "include_archived"
 
 DEFAULT_INCLUDE_ARCHIVED = False
 
+SENSOR_TYPES = {
+    'all': ['Events'],
+    'hour': ['Events Last Hour'],
+    'day': ['Events Last Day'],
+    'week': ['Events Last Week'],
+    'month': ['Events Last Month'],
+}
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_INCLUDE_ARCHIVED, default=DEFAULT_INCLUDE_ARCHIVED):
         cv.boolean,
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=['all']):
+        vol.All(cv.ensure_list, [vol.In(list(SENSOR_TYPES))]),
 })
 
 
@@ -39,10 +50,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         sensors.append(
             ZMSensorMonitors(int(i['Monitor']['Id']), i['Monitor']['Name'])
         )
-        sensors.append(
-            ZMSensorEvents(int(i['Monitor']['Id']), i['Monitor']['Name'],
-                           include_archived)
-        )
+
+        for sensor in config[CONF_MONITORED_CONDITIONS]:
+            if sensor not in SENSOR_TYPES:
+                _LOGGER.error("Sensor type: %s does not exist", sensor)
+            else:
+                sensors.append(
+                    ZMSensorEvents(int(i['Monitor']['Id']),
+                                   i['Monitor']['Name'],
+                                   include_archived, sensor)
+                )
 
     add_devices(sensors)
 
@@ -80,17 +97,20 @@ class ZMSensorMonitors(Entity):
 class ZMSensorEvents(Entity):
     """Get the number of events for each monitor."""
 
-    def __init__(self, monitor_id, monitor_name, include_archived):
+    def __init__(self, monitor_id, monitor_name, include_archived,
+                 sensor_type):
         """Initialize event sensor."""
         self._monitor_id = monitor_id
         self._monitor_name = monitor_name
         self._include_archived = include_archived
+        self._type = sensor_type
+        self._name = SENSOR_TYPES[sensor_type][0]
         self._state = None
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return '{} Events'.format(self._monitor_name)
+        return '{} {}'.format(self._monitor_name, self._name)
 
     @property
     def unit_of_measurement(self):
@@ -104,13 +124,22 @@ class ZMSensorEvents(Entity):
 
     def update(self):
         """Update the sensor."""
-        archived_filter = '/Archived:0'
+        date_filter = '1%%20%s' % self._type
+        if self._type == 'all':
+            # The consoleEvents API uses DATE_SUB, so give it
+            # something large
+            date_filter = '100%20year'
+
+        archived_filter = '/Archived=:0'
         if self._include_archived:
             archived_filter = ''
 
         event = zoneminder.get_state(
-            'api/events/index/MonitorId:%i%s.json' % (self._monitor_id,
-                                                      archived_filter)
+            'api/events/consoleEvents/%s%s.json' % (date_filter,
+                                                    archived_filter)
         )
 
-        self._state = event['pagination']['count']
+        try:
+            self._state = event['results'][str(self._monitor_id)]
+        except (TypeError, KeyError):
+            self._state = '0'

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -52,14 +52,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         )
 
         for sensor in config[CONF_MONITORED_CONDITIONS]:
-            if sensor not in SENSOR_TYPES:
-                _LOGGER.error("Sensor type: %s does not exist", sensor)
-            else:
-                sensors.append(
-                    ZMSensorEvents(int(i['Monitor']['Id']),
-                                   i['Monitor']['Name'],
-                                   include_archived, sensor)
-                )
+            sensors.append(
+                ZMSensorEvents(int(i['Monitor']['Id']),
+                               i['Monitor']['Name'],
+                               include_archived, sensor)
+            )
 
     add_devices(sensors)
 
@@ -86,7 +83,7 @@ class ZMSensorMonitors(Entity):
     def update(self):
         """Update the sensor."""
         monitor = zoneminder.get_state(
-            'api/monitors/%i.json' % self._monitor_id
+            'api/monitors/{}.json'.format(self._monitor_id)
         )
         if monitor['monitor']['Monitor']['Function'] is None:
             self._state = STATE_UNKNOWN
@@ -124,7 +121,7 @@ class ZMSensorEvents(Entity):
 
     def update(self):
         """Update the sensor."""
-        date_filter = '1%%20%s' % self._type
+        date_filter = '1%20{}'.format(self._type)
         if self._type == 'all':
             # The consoleEvents API uses DATE_SUB, so give it
             # something large
@@ -135,7 +132,7 @@ class ZMSensorEvents(Entity):
             archived_filter = ''
 
         event = zoneminder.get_state(
-            'api/events/consoleEvents/%s%s.json' % (date_filter,
+            'api/events/consoleEvents/{}{}.json'.format(date_filter,
                                                     archived_filter)
         )
 

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -133,7 +133,7 @@ class ZMSensorEvents(Entity):
 
         event = zoneminder.get_state(
             'api/events/consoleEvents/{}{}.json'.format(date_filter,
-                                                    archived_filter)
+                                                        archived_filter)
         )
 
         try:


### PR DESCRIPTION
## Description:

Switch the ZoneMinder event sensor over to use the consoleEvents API, and add monitored_conditions for 'hour', 'day', 'week', 'month' and 'all'. 'all' is enabled by default to provide backward compatibility with the old behaviour.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4303

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
