### PR TITLE
Change 'on' to 'heat' as fallback thermostat mode

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -147,7 +147,7 @@ def query_device(entity: Entity, units: UnitSystem) -> dict:
     if entity.domain == climate.DOMAIN:
         mode = entity.attributes.get(climate.ATTR_OPERATION_MODE).lower()
         if mode not in CLIMATE_SUPPORTED_MODES:
-            mode = 'on'
+            mode = 'heat'
         response = {
             'thermostatMode': mode,
             'thermostatTemperatureSetpoint':

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -238,7 +238,7 @@ def test_query_climate_request(hass_fixture, assistant_client):
         'climate.ecobee': {
             'thermostatTemperatureSetpointHigh': 24,
             'thermostatTemperatureAmbient': 23,
-            'thermostatMode': 'on',
+            'thermostatMode': 'heat',
             'thermostatTemperatureSetpointLow': 21
         },
         'climate.hvac': {
@@ -286,7 +286,7 @@ def test_query_climate_request_f(hass_fixture, assistant_client):
         'climate.ecobee': {
             'thermostatTemperatureSetpointHigh': -4.4,
             'thermostatTemperatureAmbient': -5,
-            'thermostatMode': 'on',
+            'thermostatMode': 'heat',
             'thermostatTemperatureSetpointLow': -6.1,
         },
         'climate.hvac': {


### PR DESCRIPTION
'on' isn't recognised as a mode by Google Assistant, rather is used as a method to return a thermostat to a previous mode. In the case where a thermostat doesn't support the standard google modes (e.g. A homematic radiator thermostat) this means the set_temperature doesn't get returned to the user on a request.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
