### PR TITLE
Autoremove entity when removing retained MQTT discovery message

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -49,47 +49,58 @@ def async_start(hass, discovery_topic, hass_config):
 
         prefix_topic, component, node_id, object_id = match.groups()
 
-        try:
-            payload = json.loads(payload)
-        except ValueError:
-            _LOGGER.warning("Unable to parse JSON %s: %s", object_id, payload)
-            return
-
         if component not in SUPPORTED_COMPONENTS:
             _LOGGER.warning("Component %s is not supported", component)
             return
 
-        payload = dict(payload)
-        platform = payload.get(CONF_PLATFORM, 'mqtt')
-        if platform not in ALLOWED_PLATFORMS.get(component, []):
-            _LOGGER.warning("Platform %s (component %s) is not allowed",
-                            platform, component)
-            return
-
-        payload[CONF_PLATFORM] = platform
-        if CONF_STATE_TOPIC not in payload:
-            payload[CONF_STATE_TOPIC] = '{}/{}/{}{}/state'.format(
-                discovery_topic, component, '%s/' % node_id if node_id else '',
-                object_id)
-
-        if ALREADY_DISCOVERED not in hass.data:
-            hass.data[ALREADY_DISCOVERED] = set()
-
         # If present, the node_id will be included in the discovered object id
         discovery_id = '_'.join((node_id, object_id)) if node_id else object_id
 
+        if ALREADY_DISCOVERED not in hass.data:
+                hass.data[ALREADY_DISCOVERED] = set()
+
         discovery_hash = (component, discovery_id)
-        if discovery_hash in hass.data[ALREADY_DISCOVERED]:
-            _LOGGER.info("Component has already been discovered: %s %s",
-                         component, discovery_id)
-            return
 
-        hass.data[ALREADY_DISCOVERED].add(discovery_hash)
+        if payload:
+                # Add component
+                try:
+                    payload = json.loads(payload)
+                except ValueError:
+                    _LOGGER.warning("Unable to parse JSON %s: %s", object_id, payload)
+                    return
 
-        _LOGGER.info("Found new component: %s %s", component, discovery_id)
+                payload = dict(payload)
+                platform = payload.get(CONF_PLATFORM, 'mqtt')
+                if platform not in ALLOWED_PLATFORMS.get(component, []):
+                    _LOGGER.warning("Platform %s (component %s) is not allowed",
+                                    platform, component)
+                    return
 
-        yield from async_load_platform(
-            hass, component, platform, payload, hass_config)
+                payload[CONF_PLATFORM] = platform
+                if CONF_STATE_TOPIC not in payload:
+                    payload[CONF_STATE_TOPIC] = '{}/{}/{}{}/state'.format(
+                        discovery_topic, component, '%s/' % node_id if node_id else '',
+                        object_id)
+
+                if discovery_hash in hass.data[ALREADY_DISCOVERED]:
+                    _LOGGER.info("Component has already been discovered: %s %s",
+                                 component, discovery_id)
+                    return
+
+                hass.data[ALREADY_DISCOVERED].add(discovery_hash)
+
+                _LOGGER.info("Found new component: %s %s", component, discovery_id)
+
+                yield from async_load_platform(
+                    hass, component, platform, payload, hass_config)
+
+        else:
+                # Remove component
+                if discovery_hash in hass.data[ALREADY_DISCOVERED]:
+                        _LOGGER.info("Removing component: %s %s" % (component, discovery_id))
+
+                        hass.data[ALREADY_DISCOVERED].remove(discovery_hash)
+                        hass.states.async_remove("%s.%s" % (component, discovery_id))
 
     yield from mqtt.async_subscribe(
         hass, discovery_topic + '/#', async_device_message_received, 0)


### PR DESCRIPTION
This code adds functionality to removes a previously discovered MQTT device when an empty message is published on the discovery topic in order to remove a retained discovery message.
