### PR TITLE
Reconnect to alarmdecoder on disconnect

### DIFF
--- a/homeassistant/components/alarmdecoder.py
+++ b/homeassistant/components/alarmdecoder.py
@@ -14,7 +14,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.util import dt as dt_util
 
-REQUIREMENTS = ['alarmdecoder==0.12.3']
+REQUIREMENTS = ['alarmdecoder==1.13.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -81,7 +81,7 @@ aiolifx_effects==0.1.2
 aiopvapi==1.5.4
 
 # homeassistant.components.alarmdecoder
-alarmdecoder==0.12.3
+alarmdecoder==1.13.2
 
 # homeassistant.components.sensor.alpha_vantage
 alpha_vantage==1.6.0


### PR DESCRIPTION
## Description:
Reconnect to alarm decoder if connection is lost

**Related issue (if applicable):** This was brought up in #11157 but does not necessarily address that issue.

## Checklist:


If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
