### PR TITLE
Fix errors in zigbee push state

### DIFF
--- a/homeassistant/components/zigbee.py
+++ b/homeassistant/components/zigbee.py
@@ -293,6 +293,8 @@ class ZigBeeDigitalIn(Entity):
             if pin_name not in sample:
                 # Doesn't contain information about our pin
                 return
+            # Set state to the value of sample, respecting any inversion
+            # logic from the on_state config variable.
             self._state = self._config.state2bool[
                 self._config.bool2state[sample[pin_name]]]
             self.schedule_update_ha_state()

--- a/homeassistant/components/zigbee.py
+++ b/homeassistant/components/zigbee.py
@@ -293,7 +293,8 @@ class ZigBeeDigitalIn(Entity):
             if pin_name not in sample:
                 # Doesn't contain information about our pin
                 return
-            self._state = self._config.state2bool[self._config.bool2state[sample[pin_name]]]
+            self._state = self._config.state2bool[
+                self._config.bool2state[sample[pin_name]]]
             self.schedule_update_ha_state()
 
         async_dispatcher_connect(

--- a/homeassistant/components/zigbee.py
+++ b/homeassistant/components/zigbee.py
@@ -288,12 +288,12 @@ class ZigBeeDigitalIn(Entity):
             """
             if not frame_is_relevant(self, frame):
                 return
-            sample = frame['samples'].pop()
+            sample = next(iter(frame['samples']))
             pin_name = DIGITAL_PINS[self._config.pin]
             if pin_name not in sample:
                 # Doesn't contain information about our pin
                 return
-            self._state = self._config.state2bool[sample[pin_name]]
+            self._state = self._config.state2bool[self._config.bool2state[sample[pin_name]]]
             self.schedule_update_ha_state()
 
         async_dispatcher_connect(


### PR DESCRIPTION
## Description:

This PR fixes two separate issues when using the **zigbee** component.

**Issue 1**

When the XBee is configured to broadcast samples (i.e. Sampling Rate > 0), you get the following errors in the HA log on a routine basis:

```
Dec 30 14:22:14 hal hass[7184]: Traceback (most recent call last):
Dec 30 14:22:14 hal hass[7184]:   File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
Dec 30 14:22:14 hal hass[7184]:     result = self.fn(*self.args, **self.kwargs)
Dec 30 14:22:14 hal hass[7184]:   File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/zigbee.py", line 296, in handle_frame
Dec 30 14:22:14 hal hass[7184]:     self._state = self._config.state2bool[sample[pin_name]]
Dec 30 14:22:14 hal hass[7184]: KeyError: False
```

The issue is `sample[pin_name]]` is a Boolean (indicating the state of the pin), but `self._config.state2bool` is a dict keyed by a pin state obj. The solution is to convert the Boolean to its matching state obj before lookup.

(If you are wondering why not simply do `self._state = sample[pin_name]`, its because of the inversion logic that the [on_state](https://home-assistant.io/components/switch.zigbee/) param provides).

**Issue 2**

When using more than one pin on a single XBee, and that XBee is configured to broadcast samples (i.e. Sampling Rate > 0), you get the following errors in the HA log on a routine basis:

```
Dec 30 14:22:14 hal hass[7184]: Traceback (most recent call last):
Dec 30 14:22:14 hal hass[7184]:   File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
Dec 30 14:22:14 hal hass[7184]:     result = self.fn(*self.args, **self.kwargs)
Dec 30 14:22:14 hal hass[7184]:   File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/zigbee.py", line 291, in handle_frame
Dec 30 14:22:14 hal hass[7184]:     sample = frame['samples'].pop()
```

The issue is the list pop() done on zigbee:py:291 _removes_ the samples from the frame. When the dispatcher runs that code block for the next pin, samples is empty, causing the error. The solution is to not pop().

## Example entry for `configuration.yaml`:
```yaml
zigbee:
  device: /dev/ttyUSB0
  baud: 9600

switch:
  - name: Example 1
    platform: zigbee
    pin: 1
    address: 0013A2004150F5AC
    on_state: high
  - name: Example 2
    platform: zigbee
    pin: 2
    address: 0013A2004150F5AC
    on_state: high
```

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
