### PR TITLE
iOS 10 should be served javascript_version:es5

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -584,7 +584,8 @@ def _is_latest(js_option, request):
 
     # on iOS every browser is a Safari which we support from version 11.
     if useragent.os.family == 'iOS':
-        return useragent.os.version[0] >= 11
+        # Was >= 10, temp setting it to 12 to work around issue #11387
+        return useragent.os.version[0] >= 12
 
     family_min_version = {
         'Chrome': 50,   # Probably can reduce this

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -582,9 +582,9 @@ def _is_latest(js_option, request):
     from user_agents import parse
     useragent = parse(request.headers.get('User-Agent'))
 
-    # on iOS every browser is a Safari which we support from version 10.
+    # on iOS every browser is a Safari which we support from version 11.
     if useragent.os.family == 'iOS':
-        return useragent.os.version[0] >= 10
+        return useragent.os.version[0] >= 11
 
     family_min_version = {
         'Chrome': 50,   # Probably can reduce this


### PR DESCRIPTION
## Description:
iOS 10 can't handle `javascript_version: latest` and it's detected as being able to support it. See #11234 and other reports on the forums.

**Related issue (if applicable):** fixes #11234

## Example entry for `configuration.yaml` (if applicable):
```yaml
frontend:
  javascript_version: auto
```