### PR TITLE
Make config available to auto discovered components

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -80,8 +80,10 @@ class EntityComponent(object):
         @callback
         def component_platform_discovered(platform, info):
             """Handle the loading of a platform."""
+            d_config = dict(config_per_platform(config, self.domain))
+            p_config = d_config[platform] if d_config is not None else {}
             self.hass.async_add_job(
-                self._async_setup_platform(platform, {}, info))
+                self._async_setup_platform(platform, p_config, info))
 
         discovery.async_listen_platform(
             self.hass, self.domain, component_platform_discovered)

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -81,7 +81,7 @@ class EntityComponent(object):
         def component_platform_discovered(platform, info):
             """Handle the loading of a platform."""
             d_config = dict(config_per_platform(config, self.domain))
-            p_config = d_config[platform] if d_config is not None else {}
+            p_config = d_config.get(platform, {})
             self.hass.async_add_job(
                 self._async_setup_platform(platform, p_config, info))
 


### PR DESCRIPTION
## Description:

This tries to fix an edge case where the config may be entirely unavailable to auto discovered components, making it impossible to specify config parameters that are implicitly supported by all entities, e.g. `entity_namespace`.

For example, the Philips Hue component represents only the bridge (and supports auto discovery itself); once the bridge is discovered it will call `discovery.load_platform` to set up all individual lights connected to that bridge. Existing code passes no configuration, which means `homeassistant/helpers/entity_component.py` cannot load implicit parameters.

With this fix the full config will be available; if a user wishes to customize e.g. `entity_namespace` for their Hue lights, they can do as expected:

```yaml
light:
  - platform: hue
    entity_namespace: foo
```

This works whether the bridge was auto discovered or statically configured.

**Related issue (if applicable):** fixes #11278

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: hue
    entity_namespace: foo

# also works when the bridge is hardcoded
hue:
  bridges:
    - host: 192.168.0.40

light:
  - platform: hue
    scan_interval: 5
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
