### PR TITLE
Add transition to Lutron Caseta lights

### DIFF
--- a/homeassistant/components/light/lutron_caseta.py
+++ b/homeassistant/components/light/lutron_caseta.py
@@ -65,9 +65,9 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
                                         to_lutron_level(brightness))
 
     @asyncio.coroutine
-    def transition(self, transition, from_, to):
+    def transition(self, transition, from_, target):
         """Transition from one level of brightness to another."""
-        delta = to - from_
+        delta = target - from_
         step = delta / transition / TRANSITION_RATE
         for i in range(int(transition * TRANSITION_RATE)):
             step_brightness = int(max(0, from_ + (i + 1) * step))

--- a/homeassistant/components/light/lutron_caseta.py
+++ b/homeassistant/components/light/lutron_caseta.py
@@ -66,6 +66,7 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
 
     @asyncio.coroutine
     def transition(self, transition, from_, to):
+        """Transition from one level of brightness to another."""
         delta = to - from_
         step = delta / transition / TRANSITION_RATE
         for i in range(int(transition * TRANSITION_RATE)):
@@ -73,7 +74,6 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
             self._smartbridge.set_value(self._device_id,
                                         to_lutron_level(step_brightness))
             yield from asyncio.sleep(1 / TRANSITION_RATE)
-
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):


### PR DESCRIPTION
I manually added support for transitioning Lutron Caseta lights using async.sleep. Submitting it in case it is useful to anyone else. Tested on my home installation and both turning on and off seem to work well.
