### PR TITLE
Log exceptions that happen during service call

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1024,19 +1024,23 @@ class ServiceRegistry(object):
 
         service_call = ServiceCall(domain, service, service_data, call_id)
 
-        if service_handler.is_callback:
-            service_handler.func(service_call)
-            fire_service_executed()
-        elif service_handler.is_coroutinefunction:
-            yield from service_handler.func(service_call)
-            fire_service_executed()
-        else:
-            def execute_service():
-                """Execute a service and fires a SERVICE_EXECUTED event."""
+        try:
+            if service_handler.is_callback:
                 service_handler.func(service_call)
                 fire_service_executed()
+            elif service_handler.is_coroutinefunction:
+                yield from service_handler.func(service_call)
+                fire_service_executed()
+            else:
+                def execute_service():
+                    """Execute a service and fires a SERVICE_EXECUTED event."""
+                    service_handler.func(service_call)
+                    fire_service_executed()
 
-            self._hass.async_add_job(execute_service)
+                yield from self._hass.async_add_job(execute_service)
+        except Exception:
+            _LOGGER.exception('Error executing service %s/%s: %s',
+                              domain, service, service_data)
 
 
 class Config(object):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1038,9 +1038,8 @@ class ServiceRegistry(object):
                     fire_service_executed()
 
                 yield from self._hass.async_add_job(execute_service)
-        except Exception:
-            _LOGGER.exception('Error executing service %s/%s: %s',
-                              domain, service, service_data)
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception('Error executing service %s', service_call)
 
 
 class Config(object):


### PR DESCRIPTION
## Description:
Log the error when a service method blows up. Used this to track down some bugs in tests. This should allow users to give better feedback to us.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
