### PR TITLE
apple_tv: Rate limit play status updates

### DIFF
--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     STATE_OFF, CONF_NAME, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.util.dt as dt_util
 
+from ratelimit import rate_limited
 
 DEPENDENCIES = ['apple_tv']
 
@@ -110,6 +111,7 @@ class AppleTvDevice(MediaPlayerDevice):
             return STATE_STANDBY  # Bad or unknown state?
 
     @callback
+    @rate_limited(1)  # only update status once per second
     def playstatus_update(self, updater, playing):
         """Print what is currently playing when it changes."""
         self._playing = playing

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -641,6 +641,7 @@ pyasn1==0.3.7
 
 # homeassistant.components.apple_tv
 pyatv==0.3.9
+ratelimit==1.4.1
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox


### PR DESCRIPTION
## Description:
Currently the apple_tv spams the log with around 5-6 updates per second (while playing) which seems excessive. Maximum of 1 per second seems reasonable since that's the speed media plays at.

I could make it configurable but that seemed like overkill, let me know if that's desired.

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
