### PR TITLE
Add basic mychevy component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -563,6 +563,7 @@ omit =
     homeassistant/components/sensor/mopar.py
     homeassistant/components/sensor/mqtt_room.py
     homeassistant/components/sensor/mvglive.py
+    homeassistant/components/sensor/mychevy.py
     homeassistant/components/sensor/nederlandse_spoorwegen.py
     homeassistant/components/sensor/netdata.py
     homeassistant/components/sensor/neurio_energy.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -145,6 +145,9 @@ omit =
     homeassistant/components/modbus.py
     homeassistant/components/*/modbus.py
 
+    homeassistant/components/mychevy.py
+    homeassistant/components/*/mychevy.py
+
     homeassistant/components/mysensors.py
     homeassistant/components/*/mysensors.py
 
@@ -563,7 +566,6 @@ omit =
     homeassistant/components/sensor/mopar.py
     homeassistant/components/sensor/mqtt_room.py
     homeassistant/components/sensor/mvglive.py
-    homeassistant/components/sensor/mychevy.py
     homeassistant/components/sensor/nederlandse_spoorwegen.py
     homeassistant/components/sensor/netdata.py
     homeassistant/components/sensor/neurio_energy.py

--- a/homeassistant/components/binary_sensor/mychevy.py
+++ b/homeassistant/components/binary_sensor/mychevy.py
@@ -1,0 +1,79 @@
+"""Support for MyChevy sensors."""
+
+from logging import getLogger
+from datetime import datetime as dt
+from datetime import timedelta
+import time
+import threading
+
+from homeassistant.components.mychevy import (
+    EVBinarySensorConfig, DOMAIN, MYCHEVY_ERROR, MYCHEVY_SUCCESS,
+    NOTIFICATION_ID, NOTIFICATION_TITLE
+)
+from homeassistant.components.binary_sensor import (
+    ENTITY_ID_FORMAT, BinarySensorDevice)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import (Throttle, slugify)
+
+_LOGGER = getLogger(__name__)
+
+SENSORS = [
+    EVBinarySensorConfig("Plugged In", "plugged_in", "plug")
+]
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the MyChevy sensors."""
+    if discovery_info is None:
+        return
+
+    sensors = []
+    hub = hass.data[DOMAIN]
+    for sconfig in SENSORS:
+        sensors.append(EVBinarySensor(hub, sconfig))
+
+    add_devices(sensors)
+
+
+
+class EVBinarySensor(BinarySensorDevice):
+    """Base EVSensor class.
+
+    The only real difference between sensors is which units and what
+    attribute from the car object they are returning. All logic can be
+    built with just setting subclass attributes.
+
+    """
+    def __init__(self, connection, config):
+        """Initialize sensor with car connection."""
+        self._conn = connection
+        connection.sensors.append(self)
+        self.car = connection.car
+        self._name = config.name
+        self._attr = config.attr
+        self._type = config.device_class
+
+        self.entity_id = ENTITY_ID_FORMAT.format(
+            '{}_{}'.format(DOMAIN, slugify(self._name)))
+
+    @property
+    def name(self):
+        """Return the name."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return if on."""
+        if self.car is not None:
+            return getattr(self.car, self._attr, None)
+
+    @property
+    def hidden(self):
+        if self.car == None:
+            return True
+        return False
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False

--- a/homeassistant/components/binary_sensor/mychevy.py
+++ b/homeassistant/components/binary_sensor/mychevy.py
@@ -1,4 +1,8 @@
-"""Support for MyChevy sensors."""
+"""Support for MyChevy sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/mychevy/
+"""
 
 import asyncio
 from logging import getLogger
@@ -8,6 +12,7 @@ from homeassistant.components.mychevy import (
 )
 from homeassistant.components.binary_sensor import (
     ENTITY_ID_FORMAT, BinarySensorDevice)
+from homeassistant.core import callback
 from homeassistant.util import (slugify)
 
 _LOGGER = getLogger(__name__)
@@ -17,7 +22,8 @@ SENSORS = [
 ]
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the MyChevy sensors."""
     if discovery_info is None:
         return
@@ -27,7 +33,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for sconfig in SENSORS:
         sensors.append(EVBinarySensor(hub, sconfig))
 
-    add_devices(sensors)
+    async_add_devices(sensors)
 
 
 class EVBinarySensor(BinarySensorDevice):
@@ -66,7 +72,7 @@ class EVBinarySensor(BinarySensorDevice):
         self.hass.helpers.dispatcher.async_dispatcher_connect(
             UPDATE_TOPIC, self.async_update_callback)
 
-    @asyncio.coroutine
+    @callback
     def async_update_callback(self):
         """Update state."""
         if self._conn.car is not None:

--- a/homeassistant/components/binary_sensor/mychevy.py
+++ b/homeassistant/components/binary_sensor/mychevy.py
@@ -1,21 +1,21 @@
 """Support for MyChevy sensors.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/mychevy/
+https://home-assistant.io/components/binary_sensor.mychevy/
 """
 
 import asyncio
-from logging import getLogger
+import logging
 
 from homeassistant.components.mychevy import (
-    EVBinarySensorConfig, DOMAIN, UPDATE_TOPIC
+    EVBinarySensorConfig, DOMAIN as MYCHEVY_DOMAIN, UPDATE_TOPIC
 )
 from homeassistant.components.binary_sensor import (
     ENTITY_ID_FORMAT, BinarySensorDevice)
 from homeassistant.core import callback
-from homeassistant.util import (slugify)
+from homeassistant.util import slugify
 
-_LOGGER = getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 SENSORS = [
     EVBinarySensorConfig("Plugged In", "plugged_in", "plug")
@@ -29,7 +29,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         return
 
     sensors = []
-    hub = hass.data[DOMAIN]
+    hub = hass.data[MYCHEVY_DOMAIN]
     for sconfig in SENSORS:
         sensors.append(EVBinarySensor(hub, sconfig))
 
@@ -54,7 +54,7 @@ class EVBinarySensor(BinarySensorDevice):
         self._is_on = None
 
         self.entity_id = ENTITY_ID_FORMAT.format(
-            '{}_{}'.format(DOMAIN, slugify(self._name)))
+            '{}_{}'.format(MYCHEVY_DOMAIN, slugify(self._name)))
 
     @property
     def name(self):

--- a/homeassistant/components/binary_sensor/mychevy.py
+++ b/homeassistant/components/binary_sensor/mychevy.py
@@ -4,7 +4,7 @@ import asyncio
 from logging import getLogger
 
 from homeassistant.components.mychevy import (
-    EVBinarySensorConfig, DOMAIN
+    EVBinarySensorConfig, DOMAIN, UPDATE_TOPIC
 )
 from homeassistant.components.binary_sensor import (
     ENTITY_ID_FORMAT, BinarySensorDevice)
@@ -64,7 +64,7 @@ class EVBinarySensor(BinarySensorDevice):
     def async_added_to_hass(self):
         """Register callbacks."""
         self.hass.helpers.dispatcher.async_dispatcher_connect(
-            DOMAIN, self.async_update_callback)
+            UPDATE_TOPIC, self.async_update_callback)
 
     @asyncio.coroutine
     def async_update_callback(self):

--- a/homeassistant/components/binary_sensor/mychevy.py
+++ b/homeassistant/components/binary_sensor/mychevy.py
@@ -71,7 +71,7 @@ class EVBinarySensor(BinarySensorDevice):
         """Update state."""
         if self._conn.car is not None:
             self._is_on = getattr(self._conn.car, self._attr, None)
-            yield from self.async_update_ha_state()
+            self.async_schedule_update_ha_state()
 
     @property
     def should_poll(self):

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -26,7 +26,6 @@ DOMAIN = 'mychevy'
 
 MYCHEVY_SUCCESS = "Success"
 MYCHEVY_ERROR = "Error"
-MYCHEVY_UNKNOWN = "Unknown"
 
 NOTIFICATION_ID = 'mychevy_website_notification'
 NOTIFICATION_TITLE = 'MyChevy website status'
@@ -42,6 +41,16 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_PASSWORD): cv.string
     }),
 }, extra=vol.ALLOW_EXTRA)
+
+
+class EVSensorConfig(object):
+    def __init__(self, name, attr, unit_of_measurement=None, icon=None):
+        self.name = name
+        self.attr = attr
+        self.unit_of_measurement = unit_of_measurement
+        self.icon = icon
+
+SENSORS = []
 
 
 def setup(hass, base_config):
@@ -298,7 +307,7 @@ class MyChevyStatus(Entity):
 
     def __init__(self, connection):
         """Initialize sensor with car connection."""
-        self._state = MYCHEVY_UNKNOWN
+        self._state = None
         self._last_update = dt.now()
         self._conn = connection
 

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -97,9 +97,9 @@ class MyChevyHub(threading.Thread):
     starts.
     """
 
-    def __init__(self, client, hass, **kwags):
+    def __init__(self, client, hass):
         """Initialize MyChevy Hub."""
-        super(MyChevyHub, self).__init__()
+        super().__init__()
         self._client = client
         self.hass = hass
         self.car = None

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -21,6 +21,8 @@ from homeassistant.util import Throttle
 REQUIREMENTS = ["mychevy==0.1.1"]
 
 DOMAIN = 'mychevy'
+UPDATE_TOPIC = DOMAIN
+ERROR_TOPIC = DOMAIN + "_error"
 
 MYCHEVY_SUCCESS = "Success"
 MYCHEVY_ERROR = "Error"
@@ -122,11 +124,11 @@ class MyChevyHub(threading.Thread):
             try:
                 _LOGGER.info("Starting mychevy loop")
                 self.update()
-                self.hass.helpers.dispatcher.dispatcher_send(DOMAIN)
+                self.hass.helpers.dispatcher.dispatcher_send(UPDATE_TOPIC)
                 time.sleep(MIN_TIME_BETWEEN_UPDATES.seconds)
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception(
                     "Error updating mychevy data. "
                     "This probably means the OnStar link is down again")
-                self.hass.helpers.dispatcher.dispatcher_send(DOMAIN + "_error")
+                self.hass.helpers.dispatcher.dispatcher_send(ERROR_TOPIC)
                 time.sleep(ERROR_SLEEP_TIME.seconds)

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -71,6 +71,7 @@ def setup(hass, base_config):
         hass.data[DOMAIN].start()
 
     discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
+    discovery.load_platform(hass, 'binary_sensor', DOMAIN, {}, config)
 
     return True
 

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -69,7 +69,6 @@ def setup(hass, base_config):
     import mychevy.mychevy as mc
 
     config = base_config.get(DOMAIN)
-    _LOGGER.debug('Received configuration: %s', config)
 
     email = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -33,7 +33,7 @@ NOTIFICATION_TITLE = 'MyChevy website status'
 
 _LOGGER = getLogger(__name__)
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=2)
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 ERROR_SLEEP_TIME = 5*60
 
 CONFIG_SCHEMA = vol.Schema({
@@ -295,7 +295,6 @@ class MyChevyStatus(Entity):
         self._state = MYCHEVY_UNKNOWN
         self._last_update = dt.now()
         self._conn = connection
-        self.hass = connection.hass
 
     @property
     def device_state_attributes(self):
@@ -307,7 +306,6 @@ class MyChevyStatus(Entity):
         if self._state != MYCHEVY_SUCCESS:
             _LOGGER.info("Successfully connected to mychevy website")
             self._state = MYCHEVY_SUCCESS
-        self._last_update = dt.now()
         self.schedule_update_ha_state()
 
     def error(self):
@@ -319,7 +317,6 @@ class MyChevyStatus(Entity):
                 title=NOTIFICATION_TITLE,
                 notification_id=NOTIFICATION_ID)
             self._state = MYCHEVY_ERROR
-        self._last_update = dt.now()
         self.schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -5,8 +5,8 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/mychevy/
 """
 
-from logging import getLogger
 from datetime import timedelta
+import logging
 import time
 import threading
 
@@ -24,13 +24,13 @@ DOMAIN = 'mychevy'
 UPDATE_TOPIC = DOMAIN
 ERROR_TOPIC = DOMAIN + "_error"
 
-MYCHEVY_SUCCESS = "Success"
-MYCHEVY_ERROR = "Error"
+MYCHEVY_SUCCESS = "success"
+MYCHEVY_ERROR = "error"
 
 NOTIFICATION_ID = 'mychevy_website_notification'
 NOTIFICATION_TITLE = 'MyChevy website status'
 
-_LOGGER = getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 ERROR_SLEEP_TIME = timedelta(minutes=30)
@@ -73,9 +73,8 @@ def setup(hass, base_config):
 
     email = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
-    if hass.data.get(DOMAIN) is None:
-        hass.data[DOMAIN] = MyChevyHub(mc.MyChevy(email, password), hass)
-        hass.data[DOMAIN].start()
+    hass.data[DOMAIN] = MyChevyHub(mc.MyChevy(email, password), hass)
+    hass.data[DOMAIN].start()
 
     discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
     discovery.load_platform(hass, 'binary_sensor', DOMAIN, {}, config)

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ["mychevy==0.1"]
+REQUIREMENTS = ["mychevy==0.1.1"]
 
 DOMAIN = 'mychevy'
 

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -1,0 +1,343 @@
+"""
+Support for Chevy Bolt EV sensors.
+
+For more details about this platform, please refer to the documentation at
+"""
+
+from logging import getLogger
+from datetime import datetime as dt
+from datetime import timedelta
+import time
+import threading
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import ENTITY_ID_FORMAT
+from homeassistant.const import (
+    CONF_USERNAME, CONF_PASSWORD)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import discovery
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+REQUIREMENTS = ["mychevy==0.1"]
+
+DOMAIN = 'mychevy'
+
+MYCHEVY_SUCCESS = "Success"
+MYCHEVY_ERROR = "Error"
+MYCHEVY_UNKNOWN = "Unknown"
+
+NOTIFICATION_ID = 'mychevy_website_notification'
+NOTIFICATION_TITLE = 'MyChevy website status'
+
+_LOGGER = getLogger(__name__)
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=2)
+ERROR_SLEEP_TIME = 5*60
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, base_config):
+    """Setup mychevy platform."""
+    import mychevy.mychevy as mc
+
+    config = base_config.get(DOMAIN)
+    _LOGGER.debug('Received configuration: %s', config)
+
+    email = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    if hass.data.get(DOMAIN) is None:
+        hass.data[DOMAIN] = MyChevyHub(mc.MyChevy(email, password), hass)
+        hass.data[DOMAIN].start()
+
+    discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
+
+    return True
+
+
+class MyChevyHub(threading.Thread):
+    """MyChevy Hub.
+
+    Connecting to the mychevy website is done through a selenium
+    webscraping process. That can only run synchronously. In order to
+    prevent blocking of other parts of Home Assistant the architecture
+    launches a polling loop in a thread.
+
+    When new data is received, sensors are updated, and hass is
+    signaled that there are updates. Sensors are not created until the
+    first update, which will be 60 - 120 seconds after the platform
+    starts.
+    """
+
+    def __init__(self, client, hass, **kwags):
+        """Initialize MyChevy Hub."""
+        super(MyChevyHub, self).__init__()
+        self._client = client
+        self.hass = hass
+        self._car = None
+        self.add_devices = None
+        self.sensors = []
+        # This is a status sensor for the connection itself
+        self.status = MyChevyStatus(self)
+
+    @property
+    def car(self):
+        """An instance of mychevy.mychevy.EVCar."""
+        return self._car
+
+    @car.setter
+    def car(self, data):
+        """Update the EVCar.
+
+        Also update all linked sensors in hass and signal the platform
+        there are updates.
+
+        """
+        self._car = data
+        for sensor in self.sensors:
+            sensor.car = data
+            sensor.schedule_update_ha_state()
+
+    def register_add_devices(self, add_devices):
+        """Register add_devices method.
+
+        This creates the initial status sensor, and makes it possible
+        for the hub to spin up devices as it has appropriate
+        information for them.
+
+        """
+        self.add_devices = add_devices
+        add_devices([self.status], True)
+
+    def _create_sensors(self):
+        """Create the sensors for the car.
+
+        This is not done during initialization because the sensors
+        have no value at initialization time.
+
+        """
+        self.sensors = [
+            EVRange(self),
+            EVMileage(self),
+            EVCharge(self),
+            EVPlugged(self),
+            EVCharging(self),
+            EVChargeMode(self)
+        ]
+        add = self.add_devices
+        add(self.sensors, True)
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Update sensors from mychevy website.
+
+        This is a synchronous polling call.
+        """
+        self.car = self._client.data()
+        self.status.success()
+        if self.add_devices and not self.sensors:
+            self._create_sensors()
+
+    def run(self):
+        """Thread run loop."""
+        # We add the status device first outside of the loop
+
+        # And then busy wait on threads
+        while True:
+            try:
+                _LOGGER.info("Starting mychevy loop")
+                self.update()
+                time.sleep(MIN_TIME_BETWEEN_UPDATES.seconds)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception(
+                    "Error updating mychevy data. "
+                    "This probably means the OnStar link is down again")
+                self.status.error()
+                time.sleep(ERROR_SLEEP_TIME)
+
+
+class EVSensor(Entity):
+    """Base EVSensor class.
+
+    The only real difference between sensors is which units and what
+    attribute from the car object they are returning. All logic can be
+    built with just setting subclass attributes.
+
+    """
+
+    _icon = None
+    _unit = "miles"
+    _name = "EV Sensor"
+    _attr = None
+
+    def __init__(self, connection):
+        """Initialize sensor with car connection."""
+        self._conn = connection
+        self.hass = connection.hass
+        self.car = connection.car
+        self.entity_id = ENTITY_ID_FORMAT.format(
+            '{}_{}'.format(DOMAIN, self.__class__.__name__))
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {"units": self._unit}
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._icon
+
+    @property
+    def name(self):
+        """Return the name."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state."""
+        if self.car is not None:
+            return getattr(self.car, self._attr, None)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement the state is expressed in."""
+        return self._unit
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+
+class EVCharge(EVSensor):
+    """EVCharge Sensor.
+
+    The charge percentage of the EV battery. It is an integer from 0 -
+    100.
+
+    """
+
+    _name = "EV Charge"
+    _unit = "percent"
+    _attr = "percent"
+
+
+class EVMileage(EVSensor):
+    """EVMileage Sensor.
+
+    The total odometer mileage on the car.
+    """
+
+    _name = "EV Mileage"
+    _unit = "miles"
+    _attr = "mileage"
+
+
+class EVRange(EVSensor):
+    """EV Range.
+
+    The estimated average range of the car. This is going to depend on
+    both charge percentage as well as recent driving conditions (for
+    instance very cold temperatures drive down the range quite a bit).
+
+    """
+
+    _name = "EST Range"
+    _unit = "miles"
+    _attr = "range"
+
+
+class EVPlugged(EVSensor):
+    """EV Plugged in.
+
+    Is the EV Plugged in. Returns True or False. This does not
+    indicate whether or not it's currently charging.
+
+    """
+
+    _name = "EV Plugged In"
+    _unit = None
+    _attr = "plugged_in"
+
+
+class EVCharging(EVSensor):
+    """A string representing the charging state."""
+
+    _name = "EV Charging"
+    _unit = None
+    _attr = "charging"
+
+
+class EVChargeMode(EVSensor):
+    """A string representing the charging mode."""
+
+    _name = "EV Charge Mode"
+    _unit = None
+    _attr = "charge_mode"
+
+
+class MyChevyStatus(Entity):
+    """A string representing the charge mode."""
+
+    _name = "MyChevy Status"
+    _icon = None
+
+    def __init__(self, connection):
+        """Initialize sensor with car connection."""
+        self._state = MYCHEVY_UNKNOWN
+        self._last_update = dt.now()
+        self._conn = connection
+        self.hass = connection.hass
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {"last_update": self._last_update}
+
+    def success(self):
+        """Update state, trigger updates."""
+        if self._state != MYCHEVY_SUCCESS:
+            _LOGGER.info("Successfully connected to mychevy website")
+            self._state = MYCHEVY_SUCCESS
+        self._last_update = dt.now()
+        self.schedule_update_ha_state()
+
+    def error(self):
+        """Update state, trigger updates."""
+        if self._state != MYCHEVY_ERROR:
+            self.hass.components.persistent_notification.create(
+                "Error:<br/>Connection to mychevy website failed. "
+                "This probably means the mychevy to OnStar link is down.",
+                title=NOTIFICATION_TITLE,
+                notification_id=NOTIFICATION_ID)
+            self._state = MYCHEVY_ERROR
+        self._last_update = dt.now()
+        self.schedule_update_ha_state()
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._icon
+
+    @property
+    def name(self):
+        """Return the name."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state."""
+        return self._state
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -180,15 +180,9 @@ class EVSensor(Entity):
     def __init__(self, connection):
         """Initialize sensor with car connection."""
         self._conn = connection
-        self.hass = connection.hass
         self.car = connection.car
         self.entity_id = ENTITY_ID_FORMAT.format(
             '{}_{}'.format(DOMAIN, self.__class__.__name__))
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return {"units": self._unit}
 
     @property
     def icon(self):
@@ -226,8 +220,18 @@ class EVCharge(EVSensor):
     """
 
     _name = "EV Charge"
-    _unit = "percent"
+    _unit = "%"
     _attr = "percent"
+
+    @property
+    def icon(self):
+        state = int(self.state / 10)
+        if state == 10:
+            return "mdi:battery"
+        if state >= 1 and state < 10:
+            return "mdi:battery-%d0" % state
+        if state < 1:
+            return "mdi:battery-alert"
 
 
 class EVMileage(EVSensor):
@@ -239,6 +243,7 @@ class EVMileage(EVSensor):
     _name = "EV Mileage"
     _unit = "miles"
     _attr = "mileage"
+    _icon = "mdi:speedometer"
 
 
 class EVRange(EVSensor):
@@ -253,6 +258,7 @@ class EVRange(EVSensor):
     _name = "EST Range"
     _unit = "miles"
     _attr = "range"
+    _icon = "mdi:speedometer"
 
 
 class EVPlugged(EVSensor):
@@ -288,18 +294,13 @@ class MyChevyStatus(Entity):
     """A string representing the charge mode."""
 
     _name = "MyChevy Status"
-    _icon = None
+    _icon = "mdi:car-connected"
 
     def __init__(self, connection):
         """Initialize sensor with car connection."""
         self._state = MYCHEVY_UNKNOWN
         self._last_update = dt.now()
         self._conn = connection
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return {"last_update": self._last_update}
 
     def success(self):
         """Update state, trigger updates."""

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -34,7 +34,7 @@ NOTIFICATION_TITLE = 'MyChevy website status'
 _LOGGER = getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
-ERROR_SLEEP_TIME = 5*60
+ERROR_SLEEP_TIME = timedelta(minutes=30)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -160,7 +160,7 @@ class MyChevyHub(threading.Thread):
                     "Error updating mychevy data. "
                     "This probably means the OnStar link is down again")
                 self.status.error()
-                time.sleep(ERROR_SLEEP_TIME)
+                time.sleep(ERROR_SLEEP_TIME.seconds)
 
 
 class EVSensor(Entity):

--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -4,6 +4,7 @@
 from homeassistant.components import mychevy
 
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the MyChevy sensors."""
     if discovery_info is None:

--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -10,6 +10,7 @@ from homeassistant.components.mychevy import (
 )
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.icon import icon_for_battery_level
 from homeassistant.util import (slugify)
 
 
@@ -127,6 +128,8 @@ class EVSensor(Entity):
     @property
     def icon(self):
         """Return the icon."""
+        if self._icon == "mdi:battery":
+            return icon_for_battery_level(self.state)
         return self._icon
 
     @property

--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -1,0 +1,15 @@
+"""Support for MyChevy sensors."""
+
+
+from homeassistant.components import mychevy
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the MyChevy sensors."""
+    if discovery_info is None:
+        return
+
+    hub = hass.data[mychevy.DOMAIN]
+    hub.register_add_devices(add_devices)
+
+    return True

--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -48,7 +48,6 @@ class MyChevyStatus(Entity):
         self._state = None
         self._last_update = dt.now()
         self._conn = connection
-        connection.status = self
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -140,7 +139,7 @@ class EVSensor(Entity):
         """Update state."""
         if self._conn.car is not None:
             self._state = getattr(self._conn.car, self._attr, None)
-            yield from self.async_update_ha_state()
+            self.async_schedule_update_ha_state()
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -6,7 +6,7 @@ from datetime import datetime as dt
 
 from homeassistant.components.mychevy import (
     EVSensorConfig, DOMAIN, MYCHEVY_ERROR, MYCHEVY_SUCCESS,
-    NOTIFICATION_ID, NOTIFICATION_TITLE
+    NOTIFICATION_ID, NOTIFICATION_TITLE, UPDATE_TOPIC, ERROR_TOPIC
 )
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from homeassistant.helpers.entity import Entity
@@ -54,10 +54,10 @@ class MyChevyStatus(Entity):
     def async_added_to_hass(self):
         """Register callbacks."""
         self.hass.helpers.dispatcher.async_dispatcher_connect(
-            DOMAIN, self.success)
+            UPDATE_TOPIC, self.success)
 
         self.hass.helpers.dispatcher.async_dispatcher_connect(
-            DOMAIN + "_error", self.error)
+            ERROR_TOPIC, self.error)
 
     def success(self):
         """Update state, trigger updates."""
@@ -123,7 +123,7 @@ class EVSensor(Entity):
     def async_added_to_hass(self):
         """Register callbacks."""
         self.hass.helpers.dispatcher.async_dispatcher_connect(
-            DOMAIN, self.async_update_ha_state)
+            UPDATE_TOPIC, self.async_update_callback)
 
     @property
     def icon(self):
@@ -141,11 +141,6 @@ class EVSensor(Entity):
         if self._conn.car is not None:
             self._state = getattr(self._conn.car, self._attr, None)
             yield from self.async_update_ha_state()
-
-    def update(self):
-        """Update state."""
-        if self._conn.car is not None:
-            self._state = getattr(self._conn.car, self._attr, None)
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -1,8 +1,27 @@
 """Support for MyChevy sensors."""
 
+from logging import getLogger
+from datetime import datetime as dt
+from datetime import timedelta
+import time
+import threading
 
-from homeassistant.components import mychevy
+from homeassistant.components.mychevy import (
+    EVSensorConfig, DOMAIN, MYCHEVY_ERROR, MYCHEVY_SUCCESS,
+    NOTIFICATION_ID, NOTIFICATION_TITLE
+)
+from homeassistant.components.sensor import ENTITY_ID_FORMAT
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import (Throttle, slugify)
 
+
+SENSORS = [
+    EVSensorConfig("Mileage", "mileage", "miles", "mdi:speedometer"),
+    EVSensorConfig("Range", "range", "miles", "mdi:speedometer"),
+    EVSensorConfig("Charging", "charging"),
+    EVSensorConfig("Charge Mode", "charge_mode"),
+    EVSensorConfig("EVCharge", "percent", "%", "mdi:battery")
+]
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -10,7 +29,115 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    hub = hass.data[mychevy.DOMAIN]
-    hub.register_add_devices(add_devices)
+    hub = hass.data[DOMAIN]
+    sensors = [MyChevyStatus(hub)]
+    for sconfig in SENSORS:
+        sensors.append(EVSensor(hub, sconfig))
 
-    return True
+    add_devices(sensors)
+
+
+class MyChevyStatus(Entity):
+    """A string representing the charge mode."""
+
+    _name = "MyChevy Status"
+    _icon = "mdi:car-connected"
+
+    def __init__(self, connection):
+        """Initialize sensor with car connection."""
+        self._state = None
+        self._last_update = dt.now()
+        self._conn = connection
+        connection.status = self
+
+    def success(self):
+        """Update state, trigger updates."""
+        if self._state != MYCHEVY_SUCCESS:
+            _LOGGER.info("Successfully connected to mychevy website")
+            self._state = MYCHEVY_SUCCESS
+        self.schedule_update_ha_state()
+
+    def error(self):
+        """Update state, trigger updates."""
+        if self._state != MYCHEVY_ERROR:
+            self.hass.components.persistent_notification.create(
+                "Error:<br/>Connection to mychevy website failed. "
+                "This probably means the mychevy to OnStar link is down.",
+                title=NOTIFICATION_TITLE,
+                notification_id=NOTIFICATION_ID)
+            self._state = MYCHEVY_ERROR
+        self.schedule_update_ha_state()
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._icon
+
+    @property
+    def name(self):
+        """Return the name."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state."""
+        return self._state
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+
+class EVSensor(Entity):
+    """Base EVSensor class.
+
+    The only real difference between sensors is which units and what
+    attribute from the car object they are returning. All logic can be
+    built with just setting subclass attributes.
+
+    """
+    def __init__(self, connection, config):
+        """Initialize sensor with car connection."""
+        self._conn = connection
+        connection.sensors.append(self)
+        self.car = connection.car
+        self._name = config.name
+        self._attr = config.attr
+        self._unit_of_measurement = config.unit_of_measurement
+        self._icon = config.icon
+
+        self.entity_id = ENTITY_ID_FORMAT.format(
+            '{}_{}'.format(DOMAIN, slugify(self._name)))
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._icon
+
+    @property
+    def name(self):
+        """Return the name."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state."""
+        if self.car is not None:
+            return getattr(self.car, self._attr, None)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement the state is expressed in."""
+        return self._unit_of_measurement
+
+    @property
+    def hidden(self):
+        if self.state == None:
+            return True
+        return False
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False

--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -23,6 +23,7 @@ SENSORS = [
     EVSensorConfig("EVCharge", "percent", "%", "mdi:battery")
 ]
 
+_LOGGER = getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the MyChevy sensors."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -491,7 +491,7 @@ motorparts==1.0.2
 mutagen==1.39
 
 # homeassistant.components.mychevy
-mychevy==0.1
+mychevy==0.1.1
 
 # homeassistant.components.mycroft
 mycroftapi==2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -490,6 +490,9 @@ motorparts==1.0.2
 # homeassistant.components.tts
 mutagen==1.39
 
+# homeassistant.components.mychevy
+mychevy==0.1
+
 # homeassistant.components.mycroft
 mycroftapi==2.0
 


### PR DESCRIPTION
This implements a component using the mychevy library (which utilizes
selenium to webscrape the mychevy website for onstar for your
car). The architecture works by having a background thread doing
periodic polling of the website, and updating the sensors when new
data is found.

This requires rather more setup than most platforms, as you need
working selenium. Instructions will be provided on the component
list. All the sensors are spawned and coordinated from a single "hub"
as they are really just attributes of the same web scraping session.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4410

## Example entry for `configuration.yaml` (if applicable):
```yaml
mychevy:
  username: email
  password: password
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
