### PR TITLE
Upgrade pychromecast to 1.0.3

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -20,9 +20,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-# Do not upgrade to 1.0.2, it breaks a bunch of stuff
-# https://github.com/home-assistant/home-assistant/issues/10926
-REQUIREMENTS = ['pychromecast==0.8.2']
+REQUIREMENTS = ['pychromecast==1.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -650,7 +650,7 @@ pybbox==0.0.5-alpha
 # pybluez==0.22
 
 # homeassistant.components.media_player.cast
-pychromecast==0.8.2
+pychromecast==1.0.3
 
 # homeassistant.components.media_player.cmus
 pycmus==0.1.0


### PR DESCRIPTION
## Description:
This is basically redoing the #10728 PR, which bumped pychromecast to 1.0.2. In a nutshell, the upgrade of pychromecast to 1.0.2 was supposed to fix an issue causing cast devices with never firmwares not being added to Home Assistant. But that fix introduces a new, probably even worse bug, that caused all cast devices to basically stop working - that bug, however, seems to have been fixed with 1.0.3.

In order to prevent a second google cast platform outage for Home Assistant, this time I asked for some feedback in #9965 before creating a new PR - and as far as I've heard, 1.0.3 seems to work fine.

**Related issue (if applicable):** fixes #11192, #11117, #9965

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
