### PR TITLE
Fix time functions would throw errors in python scripts

### DIFF
--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -202,4 +202,10 @@ class TimeWrapper:
 
     def __getattr__(self, attr):
         """Fetch an attribute from Time module."""
-        return getattr(time, attr)
+        a = getattr(time, attr)
+        if callable(a):
+            def wrapper(*args, **kw):
+                return a(*args, **kw)
+            return wrapper
+        else:
+            return a

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -202,10 +202,10 @@ class TimeWrapper:
 
     def __getattr__(self, attr):
         """Fetch an attribute from Time module."""
-        a = getattr(time, attr)
-        if callable(a):
+        attribute = getattr(time, attr)
+        if callable(attribute):
             def wrapper(*args, **kw):
-                return a(*args, **kw)
+                return attribute(*args, **kw)
             return wrapper
         else:
-            return a
+            return attribute

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -205,7 +205,7 @@ class TimeWrapper:
         attribute = getattr(time, attr)
         if callable(attribute):
             def wrapper(*args, **kw):
-                """Wrapper to return callable method if attribute is callable."""
+                """Wrapper to return callable method if callable."""
                 return attribute(*args, **kw)
             return wrapper
         else:

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -205,6 +205,7 @@ class TimeWrapper:
         attribute = getattr(time, attr)
         if callable(attribute):
             def wrapper(*args, **kw):
+                """Wrapper to return callable method if attribute is callable."""
                 return attribute(*args, **kw)
             return wrapper
         else:

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -236,6 +236,8 @@ def test_exposed_modules(hass, caplog):
     caplog.set_level(logging.ERROR)
     source = """
 hass.states.set('module.time', time.strftime('%Y', time.gmtime(521276400)))
+hass.states.set('module.time_strptime',
+                time.strftime('%H:%M', time.strptime('12:34', '%H:%M')))
 hass.states.set('module.datetime',
                 datetime.timedelta(minutes=1).total_seconds())
 """
@@ -244,6 +246,7 @@ hass.states.set('module.datetime',
     yield from hass.async_block_till_done()
 
     assert hass.states.is_state('module.time', '1986')
+    assert hass.states.is_state('module.time_strptime', '12:34')
     assert hass.states.is_state('module.datetime', '60.0')
 
     # No errors logged = good


### PR DESCRIPTION
## Description:

Python scripts would fail when using time functions. For example a python script containing:
t = time.strptime('08:00', '%H:%M')

Will throw:
Error executing script: '__import__'

**Related issue (if applicable):** fixes #N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
