### PR TITLE
Performance optimization of TP-Link switch

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -24,12 +24,11 @@ ATTR_CURRENT_A = 'current_a'
 CONF_LEDS = 'enable_leds'
 
 DEFAULT_NAME = 'TP-Link Switch'
-DEFAULT_LEDS = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_LEDS, default=DEFAULT_LEDS): cv.boolean,
+    vol.Optional(CONF_LEDS): cv.boolean,
 })
 
 
@@ -51,7 +50,8 @@ class SmartPlugSwitch(SwitchDevice):
         """Initialize the switch."""
         self.smartplug = smartplug
         self._name = name
-        self._leds_on = leds_on
+        if leds_on is not None:
+            self.smartplug.led = leds_on
         self._state = None
         self._available = True
         # Set up emeter cache
@@ -95,8 +95,6 @@ class SmartPlugSwitch(SwitchDevice):
 
             if self._name is None:
                 self._name = self.smartplug.alias
-
-            self.smartplug.led = self._leds_on
 
             if self.smartplug.has_emeter:
                 emeter_readings = self.smartplug.get_emeter_realtime()


### PR DESCRIPTION
## Description:

Setting the LED state (introduced with #10980) on my HS110 takes around a second. With many switches around the house, this adds up to a noticeable delay during each `update`.

This PR moves the setting from `update` to `setup_platform` time so it only happens once.

The PR also changes the default so the LED is left alone if no option is specified. I think that is more reasonable and it completely avoids the slow setting operation for the common case of people not caring about the LED state. I will update the docs if we can agree on this change.

CC: @DanNixon

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4327

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).</s>
  - [ ] <s>New dependencies are only imported inside functions that use them ([example][ex-import]).</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54