### PR TITLE
Bugfix - conf_friendly_name

### DIFF
--- a/homeassistant/components/cover/template.py
+++ b/homeassistant/components/cover/template.py
@@ -63,7 +63,7 @@ COVER_SCHEMA = vol.Schema({
     vol.Optional(CONF_TILT_OPTIMISTIC): cv.boolean,
     vol.Optional(POSITION_ACTION): cv.SCRIPT_SCHEMA,
     vol.Optional(TILT_ACTION): cv.SCRIPT_SCHEMA,
-    vol.Optional(CONF_FRIENDLY_NAME, default=None): cv.string,
+    vol.Optional(CONF_FRIENDLY_NAME): cv.string,
     vol.Optional(CONF_ENTITY_ID): cv.entity_ids
 })
 

--- a/homeassistant/components/light/template.py
+++ b/homeassistant/components/light/template.py
@@ -40,7 +40,7 @@ LIGHT_SCHEMA = vol.Schema({
     vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE, default=None): cv.template,
     vol.Optional(CONF_LEVEL_ACTION, default=None): cv.SCRIPT_SCHEMA,
     vol.Optional(CONF_LEVEL_TEMPLATE, default=None): cv.template,
-    vol.Optional(CONF_FRIENDLY_NAME, default=None): cv.string,
+    vol.Optional(CONF_FRIENDLY_NAME): cv.string,
     vol.Optional(CONF_ENTITY_ID): cv.entity_ids
 })
 


### PR DESCRIPTION
## Description:
`friendly_name = device_config.get(CONF_FRIENDLY_NAME, device)` dosn't work for `default=None`.

## Checklist:

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**