### PR TITLE
MQTT json attributes

### DIFF
--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -86,7 +86,7 @@ class MqttSensor(MqttAvailability, Entity):
         self._template = value_template
         self._expire_after = expire_after
         self._expiration_trigger = None
-        self._json_attributes = json_attributes
+        self._json_attributes = set(json_attributes)
         self._attributes = None
 
     @asyncio.coroutine
@@ -111,8 +111,8 @@ class MqttSensor(MqttAvailability, Entity):
                 self._expiration_trigger = async_track_point_in_utc_time(
                     self.hass, self.value_is_expired, expiration_at)
 
-            if len(self._json_attributes) > 0:
-                self._attributes = set({})
+            if self._json_attributes:
+                self._attributes = {}
                 try:
                     json_dict = json.loads(payload)
                     if isinstance(json_dict, dict):

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -72,7 +72,8 @@ class MqttSensor(MqttAvailability, Entity):
 
     def __init__(self, name, state_topic, qos, unit_of_measurement,
                  force_update, expire_after, value_template,
-                 json_attributes, availability_topic, payload_available, payload_not_available):
+                 json_attributes, availability_topic, payload_available,
+                 payload_not_available):
         """Initialize the sensor."""
         super().__init__(availability_topic, qos, payload_available,
                          payload_not_available)

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -116,10 +116,8 @@ class MqttSensor(MqttAvailability, Entity):
                 try:
                     json_dict = json.loads(payload)
                     if isinstance(json_dict, dict):
-                        attrs = {k : json_dict[k] for k in self._json_attributes & json_dict.keys()}
-#                        attrs = {k: json_dict[k] for k in self._json_attributes
-#                                 if k in json_dict}
-                        self._attributes = attrs
+                        attrs = {k: json_dict[k] for k in
+                                 self._json_attributes & json_dict.keys()}
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")
                 except ValueError:

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/sensor.mqtt/
 """
 import asyncio
 import logging
+import json
 from datetime import timedelta
 
 import voluptuous as vol
@@ -26,6 +27,7 @@ from homeassistant.util import dt as dt_util
 _LOGGER = logging.getLogger(__name__)
 
 CONF_EXPIRE_AFTER = 'expire_after'
+CONF_JSON_ATTRS = 'json_attributes'
 
 DEFAULT_NAME = 'MQTT Sensor'
 DEFAULT_FORCE_UPDATE = False
@@ -34,6 +36,7 @@ DEPENDENCIES = ['mqtt']
 PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+    vol.Optional(CONF_JSON_ATTRS, default=[]): cv.ensure_list_csv,
     vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
     vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
@@ -57,6 +60,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_FORCE_UPDATE),
         config.get(CONF_EXPIRE_AFTER),
         value_template,
+        config.get(CONF_JSON_ATTRS),
         config.get(CONF_AVAILABILITY_TOPIC),
         config.get(CONF_PAYLOAD_AVAILABLE),
         config.get(CONF_PAYLOAD_NOT_AVAILABLE),
@@ -68,7 +72,7 @@ class MqttSensor(MqttAvailability, Entity):
 
     def __init__(self, name, state_topic, qos, unit_of_measurement,
                  force_update, expire_after, value_template,
-                 availability_topic, payload_available, payload_not_available):
+                 json_attributes, availability_topic, payload_available, payload_not_available):
         """Initialize the sensor."""
         super().__init__(availability_topic, qos, payload_available,
                          payload_not_available)
@@ -81,6 +85,8 @@ class MqttSensor(MqttAvailability, Entity):
         self._template = value_template
         self._expire_after = expire_after
         self._expiration_trigger = None
+        self._json_attributes = json_attributes
+        self._attributes = None
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -103,6 +109,20 @@ class MqttSensor(MqttAvailability, Entity):
 
                 self._expiration_trigger = async_track_point_in_utc_time(
                     self.hass, self.value_is_expired, expiration_at)
+
+            if self._json_attributes:
+                self._attributes = {}
+                try:
+                    json_dict = json.loads(payload)
+                    if isinstance(json_dict, dict):
+                        attrs = {k: json_dict[k] for k in self._json_attributes
+                                 if k in json_dict}
+                        self._attributes = attrs
+                    else:
+                        _LOGGER.warning("JSON result was not a dictionary")
+                except ValueError:
+                    _LOGGER.warning("MQTT payload could not be parsed as JSON")
+                    _LOGGER.debug("Erroneous JSON: %s", payload)
 
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(
@@ -144,3 +164,8 @@ class MqttSensor(MqttAvailability, Entity):
     def state(self):
         """Return the state of the entity."""
         return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -111,13 +111,14 @@ class MqttSensor(MqttAvailability, Entity):
                 self._expiration_trigger = async_track_point_in_utc_time(
                     self.hass, self.value_is_expired, expiration_at)
 
-            if self._json_attributes:
-                self._attributes = {}
+            if len(self._json_attributes) > 0:
+                self._attributes = set({})
                 try:
                     json_dict = json.loads(payload)
                     if isinstance(json_dict, dict):
-                        attrs = {k: json_dict[k] for k in self._json_attributes
-                                 if k in json_dict}
+                        attrs = {k : json_dict[k] for k in self._json_attributes & json_dict.keys()}
+#                        attrs = {k: json_dict[k] for k in self._json_attributes
+#                                 if k in json_dict}
                         self._attributes = attrs
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -118,6 +118,7 @@ class MqttSensor(MqttAvailability, Entity):
                     if isinstance(json_dict, dict):
                         attrs = {k: json_dict[k] for k in
                                  self._json_attributes & json_dict.keys()}
+                        self._attributes = attrs
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")
                 except ValueError:

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -253,10 +253,13 @@ class TestSensorMQTT(unittest.TestCase):
 
         fire_mqtt_message(self.hass, 'test-topic', '[ "list", "of", "things"]')
         self.hass.block_till_done()
+        state = self.hass.states.get('sensor.test')
 
-        self.assertEqual({}, self.sensor.device_state_attributes)
+        self.assertEqual(None,
+                         state.attributes.get('val'))
         self.assertTrue(mock_logger.warning.called)
 
+    @patch('homeassistant.components.sensor.mqtt._LOGGER')
     def test_update_with_json_attrs_bad_JSON(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
         mock_component(self.hass, 'mqtt')
@@ -273,7 +276,9 @@ class TestSensorMQTT(unittest.TestCase):
         fire_mqtt_message(self.hass, 'test-topic', 'This is not JSON')
         self.hass.block_till_done()
 
-        self.assertEqual({}, self.sensor.device_state_attributes)
+        state = self.hass.states.get('sensor.test')
+        self.assertEqual(None,
+                         state.attributes.get('val'))
         self.assertTrue(mock_logger.warning.called)
         self.assertTrue(mock_logger.debug.called)
 

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -217,7 +217,7 @@ class TestSensorMQTT(unittest.TestCase):
         """Send a time changed event."""
         self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {ha.ATTR_NOW: now})
 
-    def test_setting_sensor_value_via_mqtt_json_message(self):
+    def test_setting_sensor_attribute_via_mqtt_json_message(self):
         """Test the setting of attribute via MQTT with JSON playload."""
         mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, sensor.DOMAIN, {

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -216,3 +216,23 @@ class TestSensorMQTT(unittest.TestCase):
     def _send_time_changed(self, now):
         """Send a time changed event."""
         self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {ha.ATTR_NOW: now})
+
+    def test_setting_sensor_value_via_mqtt_json_message(self):
+        """Test the setting of attribute via MQTT with JSON playload."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, sensor.DOMAIN, {
+            sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'unit_of_measurement': 'fav unit',
+                'json_attributes': 'val'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
+        self.hass.block_till_done()
+        state = self.hass.states.get('sensor.test')
+
+        self.assertEqual('100',
+                         state.attributes.get('val'))

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -237,7 +237,6 @@ class TestSensorMQTT(unittest.TestCase):
         self.assertEqual('100',
                          state.attributes.get('val'))
 
-
     @patch('homeassistant.components.sensor.mqtt._LOGGER')
     def test_update_with_json_attrs_not_dict(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
@@ -280,20 +279,6 @@ class TestSensorMQTT(unittest.TestCase):
 
     def test_update_with_json_attrs_and_template(self):
         """Test attributes get extracted from a JSON result."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(
-                                    '{ "key": "json_state_updated_value" }'))
-        self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
-                                      self.unit_of_measurement,
-                                      self.value_template, ['key'],
-                                      self.force_update)
-        self.sensor.update()
-        self.assertEqual('json_state_updated_value', self.sensor.state)
-        self.assertEqual('json_state_updated_value',
-                         self.sensor.device_state_attributes['key'],
-                         self.force_update)
-
-
         mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, sensor.DOMAIN, {
             sensor.DOMAIN: {
@@ -301,7 +286,7 @@ class TestSensorMQTT(unittest.TestCase):
                 'name': 'test',
                 'state_topic': 'test-topic',
                 'unit_of_measurement': 'fav unit',
-                'value_template': '{{ value_json.val }}'
+                'value_template': '{{ value_json.val }}',
                 'json_attributes': 'val'
             }
         })


### PR DESCRIPTION
## Description:
Based on #10753.  Allow MQTT sensor to process json values as attributes.

**Related issue (if applicable):** fixes

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4334

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

  
  