### PR TITLE
Google Assistant -> Google Actions

### DIFF
--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -210,7 +210,7 @@ def async_handle_alexa(hass, cloud, payload):
     return result
 
 
-@HANDLERS.register('google_assistant')
+@HANDLERS.register('google_actions')
 @asyncio.coroutine
 def async_handle_google_assistant(hass, cloud, payload):
     """Handle an incoming IoT message for Google Assistant."""


### PR DESCRIPTION
Just a quick 1 line rename of the Google Assistant handler for HASS Cloud. Should be called `google_actions`.