### PR TITLE
Sensor component for Fronius inverters, storages, and smart meters

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -522,6 +522,7 @@ omit =
     homeassistant/components/sensor/fixer.py
     homeassistant/components/sensor/fritzbox_callmonitor.py
     homeassistant/components/sensor/fritzbox_netmonitor.py
+    homeassistant/components/sensor/fronius.py
     homeassistant/components/sensor/gearbest.py
     homeassistant/components/sensor/geizhals.py
     homeassistant/components/sensor/gitter.py

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -128,7 +128,6 @@ class FroniusSensor(Entity):
         if values:
             self._state = values['status']['Code']
             self._attributes = self._get_attributes(values)
-            self.async_update_ha_state()
 
     @asyncio.coroutine
     def _update(self):

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -119,9 +119,9 @@ class FroniusSensor(Entity):
         try:
             values = yield from self._update()
         except ServerDisconnectedError:
-            _LOGGER.error("ServerDisconnectedError")
+            _LOGGER.error("Sensor data cannot be updated because of connection error.")
         except TimeoutError:
-            _LOGGER.error("TimeoutError")
+            _LOGGER.error("Sensor data cannot be updated because of timeout.")
 
         _LOGGER.debug(values)
 

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -5,19 +5,18 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/sensor.fronius/
 """
 import asyncio
-import logging
-from datetime import timedelta
-from aiohttp.client_exceptions import ServerDisconnectedError
 from concurrent.futures._base import TimeoutError
+from datetime import timedelta
+import logging
 
-import voluptuous as vol
-
-import homeassistant.helpers.config_validation as cv
+from aiohttp.client_exceptions import ServerDisconnectedError
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_HOST, CONF_SCAN_INTERVAL)
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.const import CONF_HOST, CONF_SCAN_INTERVAL
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_time_interval
+import voluptuous as vol
 
 REQUIREMENTS = ['pyfronius==0.2']
 

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -5,18 +5,18 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/sensor.fronius/
 """
 import asyncio
-from concurrent.futures._base import TimeoutError
+from asyncio import TimeoutError
 from datetime import timedelta
 import logging
-
+import voluptuous as vol
 from aiohttp.client_exceptions import ServerDisconnectedError
+
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_HOST, CONF_SCAN_INTERVAL
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
-import voluptuous as vol
 
 REQUIREMENTS = ['pyfronius==0.2']
 

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -119,9 +119,9 @@ class FroniusSensor(Entity):
         try:
             values = yield from self._update()
         except ServerDisconnectedError:
-            _LOGGER.error("Sensor data cannot be updated because of connection error.")
+            _LOGGER.error("Sensor data cannot be updated: connection error.")
         except TimeoutError:
-            _LOGGER.error("Sensor data cannot be updated because of timeout.")
+            _LOGGER.error("Sensor data cannot be updated: timeout.")
 
         _LOGGER.debug(values)
 
@@ -148,7 +148,7 @@ class FroniusSensor(Entity):
             return self.data.current_power_flow()
 
     def _get_attributes(self, values):
-        """Map the attributes and ensure proper values."""  
+        """Map the attributes and ensure proper values."""
         attributes = {}
         for key in values:
             if 'value' in values[key] and values[key]['value']:

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -51,7 +51,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up of Fronius platform."""
-    _LOGGER.debug("Running setup")
     _LOGGER.debug(config)
     import pyfronius
 

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -1,9 +1,9 @@
-'''
+"""
 Support for Fronius devices.
 
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/sensor.fronius/
-'''
+"""
 import asyncio
 import logging
 from datetime import timedelta

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -23,7 +23,7 @@ REQUIREMENTS = ['pyfronius==0.2']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_TYPE = 'type'
-CONF_DEVICE = 'device'
+CONF_DEVICEID = 'device'
 CONF_SCOPE = 'scope'
 
 TYPE_INVERTER = 'inverter'
@@ -44,7 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_TYPE): vol.In(SENSOR_TYPES),
     vol.Optional(CONF_SCOPE, default=DEFAULT_SCOPE):
         vol.All(cv.ensure_list, [vol.In(SCOPE_TYPES)]),
-    vol.Optional(CONF_DEVICE): cv.positive_int,
+    vol.Optional(CONF_DEVICEID): cv.positive_int,
 })
 
 
@@ -59,8 +59,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     fronius = pyfronius.Fronius(session, config[CONF_HOST])
 
     name = "fronius_{}_{}".format(config[CONF_TYPE], config[CONF_HOST])
-    if CONF_DEVICE in config.keys():
-        device = config[CONF_DEVICE]
+    if CONF_DEVICEID in config.keys():
+        device = config[CONF_DEVICEID]
         name = name + "_{}".format(device)
     else:
         device = DEFAULT_DEVICE

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -102,7 +102,7 @@ class FroniusSensor(Entity):
 
     @property
     def state(self):
-        """Return the ???."""
+        """Return the current state."""
         return self._state
 
     @property

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -83,6 +83,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
 
 class FroniusSensor(Entity):
+    """The Fronius sensor implementation"""
+
     def __init__(self, data, name, device_type, scope, device):
         """Initialize the sensor."""
         self.data = data

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -112,7 +112,7 @@ class FroniusSensor(Entity):
 
     @asyncio.coroutine
     def async_update(self):
-        """Retrieve latest state."""
+        """Retrieve and update latest state."""
         _LOGGER.debug("Update {}".format(self.name))
 
         values = {}
@@ -133,6 +133,7 @@ class FroniusSensor(Entity):
 
     @asyncio.coroutine
     def _update(self):
+        """Get the values for the current state."""
         if self._type == TYPE_INVERTER:
             if self._scope == SCOPE_SYSTEM:
                 return self.data.current_system_inverter_data()
@@ -148,6 +149,7 @@ class FroniusSensor(Entity):
             return self.data.current_power_flow()
 
     def _get_attributes(self, values):
+        """Map the attributes and ensure proper values."""  
         attributes = {}
         for key in values:
             if 'value' in values[key] and values[key]['value']:

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -74,7 +74,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         """Update all the fronius sensors."""
         try:
             yield from sensor.async_update()
-        except:
+        except Exception:
             _LOGGER.error("Update of sensor data failed.")
 
     interval = config.get(CONF_SCAN_INTERVAL) or timedelta(seconds=10)

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -75,7 +75,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         try:
             yield from sensor.async_update()
         except:
-            _LOGGER.error("yield failed")
+            _LOGGER.error("Update of sensor data failed.")
 
     interval = config.get(CONF_SCAN_INTERVAL) or timedelta(seconds=10)
     async_track_time_interval(hass, async_fronius, interval)

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -82,7 +82,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
 
 class FroniusSensor(Entity):
-    """The Fronius sensor implementation"""
+    """The Fronius sensor implementation."""
 
     def __init__(self, data, name, device_type, scope, device):
         """Initialize the sensor."""

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -51,7 +51,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up of Fronius platform."""
-    _LOGGER.debug(config)
     import pyfronius
 
     session = async_get_clientsession(hass)

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -1,0 +1,132 @@
+'''
+Support for Fronius devices.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/sensor.fronius/
+'''
+import asyncio
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_HOST, CONF_SCAN_INTERVAL)
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = [ 'pyfronius==0.2' ]
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_TYPE = 'type'
+CONF_DEVICE = 'device'
+CONF_SCOPE = 'scope'
+
+DEFAULT_SCOPE = 'device'
+DEFAULT_DEVICE = None
+
+TYPE_INVERTER = 'inverter'
+TYPE_STORAGE = 'storage'
+TYPE_METER = 'meter'
+TYPE_POWER_FLOW = 'power_flow'
+
+SENSOR_TYPES = [ TYPE_INVERTER, TYPE_STORAGE, TYPE_METER, TYPE_POWER_FLOW ]
+SCOPE_TYPES = [ 'device', 'system' ]
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_TYPE): vol.In(SENSOR_TYPES),
+    vol.Optional(CONF_SCOPE, default=DEFAULT_SCOPE): vol.All(cv.ensure_list, [vol.In(SCOPE_TYPES)]),
+    vol.Optional(CONF_DEVICE): cv.positive_int,
+})
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up of Fronius platform."""
+    _LOGGER.debug("Running setup")
+    _LOGGER.debug(config)
+    import pyfronius
+    
+    session = async_get_clientsession(hass)
+    fronius = pyfronius.Fronius(session, config[CONF_HOST])
+
+    name = "fronius_{}_{}".format(config[CONF_TYPE], config[CONF_HOST])
+    if CONF_DEVICE in config.keys():
+        device = config[CONF_DEVICE]
+        name = name + "_{}".format(device)
+    else:
+        device = DEFAULT_DEVICE
+    
+    sensor = FroniusSensor(fronius, name, config[CONF_TYPE], config[CONF_SCOPE], device)
+    
+    async_add_devices([sensor])
+
+    @asyncio.coroutine
+    def async_fronius(event):
+        """Update all the fronius sensors."""
+        yield from sensor.async_update()
+
+    interval = config.get(CONF_SCAN_INTERVAL) or timedelta(seconds=5)
+    async_track_time_interval(hass, async_fronius, interval)
+
+
+class FroniusSensor(Entity):
+    def __init__(self, data, name, device_type, scope, device):
+        """Initialize the sensor."""
+        self.data = data
+        self._name = name
+        self._type = device_type
+        self._device = device
+        self._scope = scope
+        self._state = None
+        self._attributes = {}
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the ???."""
+        return self._state
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Retrieve latest state."""
+        _LOGGER.debug("Update {}".format(self.name))
+        
+        values = yield from self.update()
+
+        _LOGGER.debug(values)
+
+        if values: 
+            self._state = values['status']['Code']
+            self._attributes = self._get_attributes(values)
+            self.async_update_ha_state()
+
+    @asyncio.coroutine
+    def update(self):
+        if self._type == TYPE_INVERTER:
+            return self.data.current_inverter_data()
+        elif self._type == TYPE_STORAGE:
+            return self.data.current_storage_data()
+        elif self._type == TYPE_METER:
+            return self.data.current_meter_data()
+        elif self._type == TYPE_POWER_FLOW:
+            return self.data.current_power_flow()
+
+    def _get_attributes(self, values):
+        attributes = {}
+        for key in values:
+            if 'value' in values[key]:
+                attributes[key] = values[key]['value'] if values[key]['value'] else 0
+        return attributes

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = [ 'pyfronius==0.2' ]
+REQUIREMENTS = ['pyfronius==0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,15 +37,17 @@ SCOPE_SYSTEM = 'system'
 DEFAULT_SCOPE = SCOPE_DEVICE
 DEFAULT_DEVICE = None
 
-SENSOR_TYPES = [ TYPE_INVERTER, TYPE_STORAGE, TYPE_METER, TYPE_POWER_FLOW ]
-SCOPE_TYPES = [ SCOPE_DEVICE, SCOPE_SYSTEM ]
+SENSOR_TYPES = [TYPE_INVERTER, TYPE_STORAGE, TYPE_METER, TYPE_POWER_FLOW]
+SCOPE_TYPES = [SCOPE_DEVICE, SCOPE_SYSTEM]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_TYPE): vol.In(SENSOR_TYPES),
-    vol.Optional(CONF_SCOPE, default=DEFAULT_SCOPE): vol.All(cv.ensure_list, [vol.In(SCOPE_TYPES)]),
+    vol.Optional(CONF_SCOPE, default=DEFAULT_SCOPE):
+        vol.All(cv.ensure_list, [vol.In(SCOPE_TYPES)]),
     vol.Optional(CONF_DEVICE): cv.positive_int,
 })
+
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
@@ -53,7 +55,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     _LOGGER.debug("Running setup")
     _LOGGER.debug(config)
     import pyfronius
-    
+
     session = async_get_clientsession(hass)
     fronius = pyfronius.Fronius(session, config[CONF_HOST])
 
@@ -63,9 +65,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         name = name + "_{}".format(device)
     else:
         device = DEFAULT_DEVICE
-    
-    sensor = FroniusSensor(fronius, name, config[CONF_TYPE], config[CONF_SCOPE], device)
-    
+
+    sensor = FroniusSensor(
+        fronius, name, config[CONF_TYPE], config[CONF_SCOPE], device)
+
     async_add_devices([sensor])
 
     @asyncio.coroutine
@@ -110,9 +113,9 @@ class FroniusSensor(Entity):
     def async_update(self):
         """Retrieve latest state."""
         _LOGGER.debug("Update {}".format(self.name))
-        
+
         values = {}
-        
+
         try:
             values = yield from self._update()
         except ServerDisconnectedError:
@@ -146,6 +149,9 @@ class FroniusSensor(Entity):
     def _get_attributes(self, values):
         attributes = {}
         for key in values:
-            if 'value' in values[key]:
-                attributes[key] = values[key]['value'] if values[key]['value'] else 0
+            if 'value' in values[key] and values[key]['value']:
+                attributes[key] = values[key]['value']
+            else:
+                attributes[key] = 0
+
         return attributes

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -25,15 +25,15 @@ CONF_TYPE = 'type'
 CONF_DEVICE = 'device'
 CONF_SCOPE = 'scope'
 
-DEFAULT_SCOPE = 'device'
-DEFAULT_DEVICE = None
-
 TYPE_INVERTER = 'inverter'
 TYPE_STORAGE = 'storage'
 TYPE_METER = 'meter'
 TYPE_POWER_FLOW = 'power_flow'
 SCOPE_DEVICE = 'device'
 SCOPE_SYSTEM = 'system'
+
+DEFAULT_SCOPE = SCOPE_DEVICE
+DEFAULT_DEVICE = None
 
 SENSOR_TYPES = [ TYPE_INVERTER, TYPE_STORAGE, TYPE_METER, TYPE_POWER_FLOW ]
 SCOPE_TYPES = [ SCOPE_DEVICE, SCOPE_SYSTEM ]
@@ -122,7 +122,7 @@ class FroniusSensor(Entity):
                 return self.data.current_system_inverter_data()
             elif self._scope == SCOPE_DEVICE and self._device:
                 return self.data.current_inverter_data(self._device)
-            elif self._scope == SCOPE_DEVICE and self._device:
+            elif self._scope == SCOPE_DEVICE:
                 return self.data.current_inverter_data()
         elif self._type == TYPE_STORAGE:
             return self.data.current_storage_data()

--- a/homeassistant/components/sensor/fronius.py
+++ b/homeassistant/components/sensor/fronius.py
@@ -125,7 +125,7 @@ class FroniusSensor(Entity):
 
         _LOGGER.debug(values)
 
-        if values: 
+        if values:
             self._state = values['status']['Code']
             self._attributes = self._get_attributes(values)
             self.async_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -348,9 +348,6 @@ http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b89974819
 # homeassistant.components.remember_the_milk
 httplib2==0.10.3
 
-# homeassistant.components.xiaomi
-https://github.com/Danielhiversen/PyXiaomiGateway/archive/aa9325fe6fdd62a8ef8c9ca1dce31d3292f484bb.zip#PyXiaomiGateway==0.2.0
-
 # homeassistant.components.sensor.dht
 # https://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.2
 
@@ -871,9 +868,6 @@ python-juicenet==0.0.5
 # homeassistant.components.switch.xiaomi_miio
 # homeassistant.components.vacuum.xiaomi_miio
 python-miio==0.3.2
-
-# homeassistant.components.switch.xiaomi_vacuum
-python-mirobo==0.1.2
 
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -348,6 +348,9 @@ http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b89974819
 # homeassistant.components.remember_the_milk
 httplib2==0.10.3
 
+# homeassistant.components.xiaomi
+https://github.com/Danielhiversen/PyXiaomiGateway/archive/aa9325fe6fdd62a8ef8c9ca1dce31d3292f484bb.zip#PyXiaomiGateway==0.2.0
+
 # homeassistant.components.sensor.dht
 # https://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.2
 
@@ -682,6 +685,9 @@ pyfido==1.0.1
 # homeassistant.components.climate.flexit
 pyflexit==0.3
 
+# homeassistant.components.sensor.fronius
+pyfronius==0.2
+
 # homeassistant.components.ifttt
 pyfttt==0.3
 
@@ -865,6 +871,9 @@ python-juicenet==0.0.5
 # homeassistant.components.switch.xiaomi_miio
 # homeassistant.components.vacuum.xiaomi_miio
 python-miio==0.3.2
+
+# homeassistant.components.switch.xiaomi_vacuum
+python-mirobo==0.1.2
 
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4339

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: fronius
  host: 172.31.106.10
  device: 1
  type: inverter

- platform: fronius
  host: 172.31.106.11
  type: power_flow

## optional: create shortcut to attributes of the device
- platform: template
  sensors:
    electricity_inverter1_power_netto:
      unit_of_measurement: 'W'
      value_template: >-
        {% if states.sensor.fronius_inverter_1723110610_1.attributes.power_ac is defined %}
          {{ states.sensor.fronius_inverter_1723110610_1.attributes.power_ac | float | round(2) }}
        {% else %}
          0
        {% endif %}
    electricity_autonomy:  
      unit_of_measurement: '%'
      value_template: >-
        {% if states.sensor.fronius_power_flow_1723110611.attributes.relative_autonomy is defined %}
          {{ states.sensor.fronius_power_flow_1723110611.attributes.relative_autonomy | float | round(2) }}
        {% else %}
          0
        {% endif %}
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [WiP] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [-] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [-] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

  