### PR TITLE
Set tahoma cover scan interval to 60 seconds

### DIFF
--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.tahoma/
 """
 import logging
+from datetime import timedelta
 
 from homeassistant.components.cover import CoverDevice, ENTITY_ID_FORMAT
 from homeassistant.components.tahoma import (

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -14,6 +14,7 @@ DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
+SCAN_INTERVAL = timedelta(seconds=60)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Tahoma covers."""

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -17,6 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=60)
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Tahoma covers."""
     controller = hass.data[TAHOMA_DOMAIN]['controller']


### PR DESCRIPTION
## Description:
Scanning for the state of a cover happens every 15 seconds. This is the default number in the cover component. This gives lot's of issues with tahoma since it floods the API with requests if you have a lot of covers. Updates don't have to happen that frequent.

Note: I have done this the way it is done in: https://github.com/home-assistant/home-assistant/blob/b548116f9bbaa75d61900c6dd1059249195094d4/homeassistant/components/sensor/tahoma.py#L20

If this is not correct I would be happy to change this obviously.

**Related issue (if applicable):** (semi-)fixes #11219 

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

  
  