### PR TITLE
Input Boolean - Deleted 'DEFAULT_INITIAL'

### DIFF
--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -27,7 +27,6 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 _LOGGER = logging.getLogger(__name__)
 
 CONF_INITIAL = 'initial'
-DEFAULT_INITIAL = False
 
 SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,


### PR DESCRIPTION
## Description:
The constant `DEFAULT_INITIAL` is without use. In case no initial value is given HA tries to restore the value from the database. If that dosn't work, the default value is set to `False` during the execution of `async_added_to_hass`.

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**