### PR TITLE
Add Deconz support for Zigbee green power devices like Hue Tap

### DIFF
--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['pydeconz==23']
+REQUIREMENTS = ['pydeconz==24']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -25,13 +25,13 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    from pydeconz.sensor import DECONZ_SENSOR, SWITCH
+    from pydeconz.sensor import DECONZ_SENSOR, SWITCH as DECONZ_REMOTE
     sensors = hass.data[DECONZ_DATA].sensors
     entities = []
 
     for sensor in sensors.values():
         if sensor.type in DECONZ_SENSOR:
-            if sensor.type in SWITCH:
+            if sensor.type in DECONZ_REMOTE:
                 DeconzEvent(hass, sensor)
                 if sensor.battery:
                     entities.append(DeconzBattery(sensor))

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -17,7 +17,6 @@ from homeassistant.util import slugify
 DEPENDENCIES = ['deconz']
 
 ATTR_EVENT_ID = 'event_id'
-ATTR_ZHASWITCH = 'ZHASwitch'
 
 
 @asyncio.coroutine
@@ -26,13 +25,13 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    from pydeconz.sensor import DECONZ_SENSOR
+    from pydeconz.sensor import DECONZ_SENSOR, SWITCH
     sensors = hass.data[DECONZ_DATA].sensors
     entities = []
 
     for sensor in sensors.values():
         if sensor.type in DECONZ_SENSOR:
-            if sensor.type == ATTR_ZHASWITCH:
+            if sensor.type in SWITCH:
                 DeconzEvent(hass, sensor)
                 if sensor.battery:
                     entities.append(DeconzBattery(sensor))

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -669,7 +669,7 @@ pycsspeechtts==1.0.2
 pydaikin==0.4
 
 # homeassistant.components.deconz
-pydeconz==23
+pydeconz==24
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Description:
Add support for Zigbee green power devices such as the Hue Tap.


## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
