### PR TITLE
Catch everything when calling to OctoPrint API to fix #10557

### DIFF
--- a/homeassistant/components/octoprint.py
+++ b/homeassistant/components/octoprint.py
@@ -117,9 +117,7 @@ class OctoPrintAPI(object):
                 self.job_error_logged = False
                 self.printer_error_logged = False
             return response.json()
-        except (requests.exceptions.ConnectionError,
-                requests.exceptions.HTTPError,
-                requests.exceptions.ReadTimeout) as conn_exc:
+        except Exception as conn_exc:  # pylint: disable=broad-except
             log_string = "Failed to update OctoPrint status. " + \
                                "  Error: %s" % (conn_exc)
             # Only log the first failure


### PR DESCRIPTION
## Description:
Fixes https://github.com/home-assistant/home-assistant/issues/10557 for some reason, some users are still seeing the HTTPError from requests even though it was being caught?

**Related issue (if applicable):** fixes #10557

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
