### PR TITLE
Add some tests to the cloud component

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -72,7 +72,7 @@ def async_setup(hass, config):
         kwargs[CONF_GOOGLE_ASSISTANT] = ASSISTANT_SCHEMA({})
 
     kwargs[CONF_ALEXA] = alexa_sh.Config(**kwargs[CONF_ALEXA])
-    kwargs['gass_should_expose'] = kwargs.pop(CONF_GOOGLE_ASSISTANT)
+    kwargs['gass_should_expose'] = kwargs.pop(CONF_GOOGLE_ASSISTANT)['filter']
     cloud = hass.data[DOMAIN] = Cloud(hass, **kwargs)
 
     success = yield from cloud.initialize()

--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -212,8 +212,8 @@ def async_handle_alexa(hass, cloud, payload):
 
 @HANDLERS.register('google_actions')
 @asyncio.coroutine
-def async_handle_google_assistant(hass, cloud, payload):
-    """Handle an incoming IoT message for Google Assistant."""
+def async_handle_google_actions(hass, cloud, payload):
+    """Handle an incoming IoT message for Google Actions."""
     result = yield from ga.async_handle_message(hass, cloud.gass_config,
                                                 payload)
     return result


### PR DESCRIPTION
## Description:
Add some tests to the cloud component

## Example entry for `configuration.yaml` (if applicable):
```yaml
cloud:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
