### PR TITLE
Alexa to not use customize for entity config

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -86,7 +86,7 @@ def async_setup(hass, config):
         should_expose=alexa_conf[CONF_FILTER],
         entity_config=alexa_conf.get(CONF_ENTITY_CONFIG),
     )
-    kwargs['gass_should_expose'] = gactions_conf[CONF_FILTER]
+    kwargs['gactions_should_expose'] = gactions_conf[CONF_FILTER]
     cloud = hass.data[DOMAIN] = Cloud(hass, **kwargs)
 
     success = yield from cloud.initialize()
@@ -101,15 +101,15 @@ def async_setup(hass, config):
 class Cloud:
     """Store the configuration of the cloud connection."""
 
-    def __init__(self, hass, mode, alexa, gass_should_expose,
+    def __init__(self, hass, mode, alexa, gactions_should_expose,
                  cognito_client_id=None, user_pool_id=None, region=None,
                  relayer=None):
         """Create an instance of Cloud."""
         self.hass = hass
         self.mode = mode
         self.alexa_config = alexa
-        self._gass_should_expose = gass_should_expose
-        self._gass_config = None
+        self._gactions_should_expose = gactions_should_expose
+        self._gactions_config = None
         self.jwt_keyset = None
         self.id_token = None
         self.access_token = None
@@ -158,15 +158,15 @@ class Cloud:
         return self.path('{}_auth.json'.format(self.mode))
 
     @property
-    def gass_config(self):
+    def gactions_config(self):
         """Return the Google Assistant config."""
-        if self._gass_config is None:
-            self._gass_config = ga_sh.Config(
-                should_expose=lambda e: self._gass_should_expose(e.entity_id),
+        if self._gactions_config is None:
+            self._gactions_config = ga_sh.Config(
+                should_expose=lambda e: self._gactions_should_expose(e.entity_id),
                 agent_user_id=self.claims['cognito:username']
             )
 
-        return self._gass_config
+        return self._gactions_config
 
     @asyncio.coroutine
     def initialize(self):
@@ -196,7 +196,7 @@ class Cloud:
         self.id_token = None
         self.access_token = None
         self.refresh_token = None
-        self._gass_config = None
+        self._gactions_config = None
 
         yield from self.hass.async_add_job(
             lambda: os.remove(self.user_info_path))

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, CONF_REGION, CONF_MODE)
 from homeassistant.helpers import entityfilter
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import dt as dt_util
 from homeassistant.components.alexa import smart_home as alexa_sh
@@ -25,7 +26,7 @@ REQUIREMENTS = ['warrant==0.6.1']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ALEXA = 'alexa'
-CONF_GOOGLE_ASSISTANT = 'google_assistant'
+CONF_GOOGLE_ACTIONS = 'google_actions'
 CONF_FILTER = 'filter'
 CONF_COGNITO_CLIENT_ID = 'cognito_client_id'
 CONF_RELAYER = 'relayer'
@@ -35,11 +36,23 @@ MODE_DEV = 'development'
 DEFAULT_MODE = 'production'
 DEPENDENCIES = ['http']
 
+CONF_ENTITY_CONFIG = 'entity_config'
+
+ALEXA_ENTITY_SCHEMA = vol.Schema({
+    vol.Optional(alexa_sh.CONF_DESCRIPTION): cv.string,
+    vol.Optional(alexa_sh.CONF_DISPLAY_CATEGORIES): cv.string,
+    vol.Optional(alexa_sh.CONF_NAME): cv.string,
+})
+
 ASSISTANT_SCHEMA = vol.Schema({
     vol.Optional(
         CONF_FILTER,
         default=lambda: entityfilter.generate_filter([], [], [], [])
     ): entityfilter.FILTER_SCHEMA,
+})
+
+ALEXA_SCHEMA = ASSISTANT_SCHEMA.extend({
+    vol.Optional(CONF_ENTITY_CONFIG): {cv.entity_id: ALEXA_ENTITY_SCHEMA}
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -52,7 +65,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_REGION): str,
         vol.Optional(CONF_RELAYER): str,
         vol.Optional(CONF_ALEXA): ASSISTANT_SCHEMA,
-        vol.Optional(CONF_GOOGLE_ASSISTANT): ASSISTANT_SCHEMA,
+        vol.Optional(CONF_GOOGLE_ACTIONS): ASSISTANT_SCHEMA,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -61,18 +74,19 @@ CONFIG_SCHEMA = vol.Schema({
 def async_setup(hass, config):
     """Initialize the Home Assistant cloud."""
     if DOMAIN in config:
-        kwargs = config[DOMAIN]
+        kwargs = dict(config[DOMAIN])
     else:
         kwargs = {CONF_MODE: DEFAULT_MODE}
 
-    if CONF_ALEXA not in kwargs:
-        kwargs[CONF_ALEXA] = ASSISTANT_SCHEMA({})
+    alexa_conf = kwargs.pop(CONF_ALEXA, None) or ALEXA_SCHEMA({})
+    gactions_conf = (kwargs.pop(CONF_GOOGLE_ACTIONS, None) or
+                     ASSISTANT_SCHEMA({}))
 
-    if CONF_GOOGLE_ASSISTANT not in kwargs:
-        kwargs[CONF_GOOGLE_ASSISTANT] = ASSISTANT_SCHEMA({})
-
-    kwargs[CONF_ALEXA] = alexa_sh.Config(**kwargs[CONF_ALEXA])
-    kwargs['gass_should_expose'] = kwargs.pop(CONF_GOOGLE_ASSISTANT)['filter']
+    kwargs[CONF_ALEXA] = alexa_sh.Config(
+        should_expose=alexa_conf[CONF_FILTER],
+        entity_config=alexa_conf.get(CONF_ENTITY_CONFIG),
+    )
+    kwargs['gass_should_expose'] = gactions_conf[CONF_FILTER]
     cloud = hass.data[DOMAIN] = Cloud(hass, **kwargs)
 
     success = yield from cloud.initialize()

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -161,8 +161,12 @@ class Cloud:
     def gactions_config(self):
         """Return the Google Assistant config."""
         if self._gactions_config is None:
+            def should_expose(entity):
+                """If an entity should be exposed."""
+                return self._gactions_should_expose(entity.entity_id)
+
             self._gactions_config = ga_sh.Config(
-                should_expose=lambda e: self._gactions_should_expose(e.entity_id),
+                should_expose=should_expose,
                 agent_user_id=self.claims['cognito:username']
             )
 

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -64,7 +64,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_USER_POOL_ID): str,
         vol.Optional(CONF_REGION): str,
         vol.Optional(CONF_RELAYER): str,
-        vol.Optional(CONF_ALEXA): ASSISTANT_SCHEMA,
+        vol.Optional(CONF_ALEXA): ALEXA_SCHEMA,
         vol.Optional(CONF_GOOGLE_ACTIONS): ASSISTANT_SCHEMA,
     }),
 }, extra=vol.ALLOW_EXTRA)

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -162,7 +162,7 @@ class Cloud:
         """Return the Google Assistant config."""
         if self._gass_config is None:
             self._gass_config = ga_sh.Config(
-                should_expose=self._gass_should_expose,
+                should_expose=lambda e: self._gass_should_expose(e.entity_id),
                 agent_user_id=self.claims['cognito:username']
             )
 

--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -214,7 +214,7 @@ def async_handle_alexa(hass, cloud, payload):
 @asyncio.coroutine
 def async_handle_google_actions(hass, cloud, payload):
     """Handle an incoming IoT message for Google Actions."""
-    result = yield from ga.async_handle_message(hass, cloud.gass_config,
+    result = yield from ga.async_handle_message(hass, cloud.gactions_config,
                                                 payload)
     return result
 

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -319,7 +319,7 @@ def async_devices_sync(hass, config, payload):
     """Handle action.devices.SYNC request."""
     devices = []
     for entity in hass.states.async_all():
-        if not config.should_expose(entity):
+        if not config.should_expose(entity.entity_id):
             continue
 
         device = entity_to_device(entity, hass.config.units)

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -319,7 +319,7 @@ def async_devices_sync(hass, config, payload):
     """Handle action.devices.SYNC request."""
     devices = []
     for entity in hass.states.async_all():
-        if not config.should_expose(entity.entity_id):
+        if not config.should_expose(entity):
             continue
 
         device = entity_to_device(entity, hass.config.units)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import entityfilter
 
 from tests.common import async_mock_service
 
-DEFAULT_CONFIG = smart_home.Config(filter=lambda entity_id: True)
+DEFAULT_CONFIG = smart_home.Config(should_expose=lambda entity_id: True)
 
 
 def get_new_request(namespace, name, endpoint=None):
@@ -338,7 +338,7 @@ def test_exclude_filters(hass):
     hass.states.async_set(
         'cover.deny', 'off', {'friendly_name': "Blocked cover"})
 
-    config = smart_home.Config(filter=entityfilter.generate_filter(
+    config = smart_home.Config(should_expose=entityfilter.generate_filter(
         include_domains=[],
         include_entities=[],
         exclude_domains=['script'],
@@ -371,7 +371,7 @@ def test_include_filters(hass):
     hass.states.async_set(
         'group.allow', 'off', {'friendly_name': "Allowed group"})
 
-    config = smart_home.Config(filter=entityfilter.generate_filter(
+    config = smart_home.Config(should_expose=entityfilter.generate_filter(
         include_domains=['automation', 'group'],
         include_entities=['script.deny'],
         exclude_domains=[],


### PR DESCRIPTION
## Description:
Components should never rely on config stored inside customize. This fixes this for the Alexa integration.

**Related issue (if applicable):** #10732 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Breaking change

Customizations for how entities are exposed to Alexa are no longer set via `customize`. Instead they are set via the configuration of the cloud component:

```yaml
cloud:
  alexa:
    entity_config:
      switch.kitchen:
        name: 'Name for Alexa'
        description: 'Description for Alexa'
        display_categories: 'LIGHT'
```

## Example entry for `configuration.yaml` (if applicable):
```yaml
cloud:
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

  