### PR TITLE
Add options feature to Baidu TTS.

### DIFF
--- a/homeassistant/components/tts/baidu.py
+++ b/homeassistant/components/tts/baidu.py
@@ -47,7 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 # Keys are options in the config file, and Values are options
 # required by Baidu TTS API.
-_options = {
+_OPTIONS = {
     CONF_SPEED: 'spd',
     CONF_PITCH: 'pit',
     CONF_VOLUME: 'vol',
@@ -83,10 +83,10 @@ class BaiduTTSProvider(Provider):
         }
 
         self._speech_conf_data = {
-            _options[CONF_SPEED]: conf.get(CONF_SPEED),
-            _options[CONF_PITCH]: conf.get(CONF_PITCH),
-            _options[CONF_VOLUME]: conf.get(CONF_VOLUME),
-            _options[CONF_PERSON]: conf.get(CONF_PERSON),
+            _OPTIONS[CONF_SPEED]: conf.get(CONF_SPEED),
+            _OPTIONS[CONF_PITCH]: conf.get(CONF_PITCH),
+            _OPTIONS[CONF_VOLUME]: conf.get(CONF_VOLUME),
+            _OPTIONS[CONF_PERSON]: conf.get(CONF_PERSON),
         }
 
     @property
@@ -103,10 +103,10 @@ class BaiduTTSProvider(Provider):
     def default_options(self):
         """Return a dict include default options."""
         return {
-            CONF_SPEED: self._speech_conf_data[_options[CONF_SPEED]],
-            CONF_PITCH: self._speech_conf_data[_options[CONF_PITCH]],
-            CONF_VOLUME: self._speech_conf_data[_options[CONF_VOLUME]],
-            CONF_PERSON: self._speech_conf_data[_options[CONF_PERSON]],
+            CONF_SPEED: self._speech_conf_data[_OPTIONS[CONF_SPEED]],
+            CONF_PITCH: self._speech_conf_data[_OPTIONS[CONF_PITCH]],
+            CONF_VOLUME: self._speech_conf_data[_OPTIONS[CONF_VOLUME]],
+            CONF_PERSON: self._speech_conf_data[_OPTIONS[CONF_PERSON]],
         }
 
     @property
@@ -129,8 +129,8 @@ class BaiduTTSProvider(Provider):
             )
         else:
             speech_data = self._speech_conf_data.copy()
-            for k, v in options.items():
-                speech_data[_options[k]] = v
+            for key, value in options.items():
+                speech_data[_OPTIONS[key]] = value
 
             result = aip_speech.synthesis(
                 message, language, 1, speech_data
@@ -142,6 +142,6 @@ class BaiduTTSProvider(Provider):
                 result['err_no'],
                 result['err_msg'],
                 result['err_detail'])
-            return (None, None)
+            return None, None
 
-        return (self._codec, result)
+        return self._codec, result

--- a/homeassistant/components/tts/baidu.py
+++ b/homeassistant/components/tts/baidu.py
@@ -128,7 +128,7 @@ class BaiduTTSProvider(Provider):
                 message, language, 1, self._speech_conf_data
             )
         else:
-            speech_data = {**self._speech_conf_data}
+            speech_data = self._speech_conf_data.copy()
             for k, v in options.items():
                 speech_data[_options[k]] = v
 

--- a/homeassistant/components/tts/baidu.py
+++ b/homeassistant/components/tts/baidu.py
@@ -8,8 +8,8 @@ https://home-assistant.io/components/tts.baidu/
 import logging
 import voluptuous as vol
 
+from homeassistant.components.tts import Provider, CONF_LANG, PLATFORM_SCHEMA
 from homeassistant.const import CONF_API_KEY
-from homeassistant.components.tts import Provider, PLATFORM_SCHEMA, CONF_LANG
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ["baidu-aip==1.6.6"]
@@ -96,12 +96,12 @@ class BaiduTTSProvider(Provider):
 
     @property
     def supported_languages(self):
-        """Return list of supported languages."""
+        """Return a list of supported languages."""
         return SUPPORTED_LANGUAGES
 
     @property
     def default_options(self):
-        """Return a dict include default options."""
+        """Return a dict including default options."""
         return {
             CONF_PERSON: self._speech_conf_data[_OPTIONS[CONF_PERSON]],
             CONF_PITCH: self._speech_conf_data[_OPTIONS[CONF_PITCH]],
@@ -141,7 +141,8 @@ class BaiduTTSProvider(Provider):
                 "Baidu TTS error-- err_no:%d; err_msg:%s; err_detail:%s",
                 result['err_no'],
                 result['err_msg'],
-                result['err_detail'])
+                result['err_detail']
+            )
             return None, None
 
         return self._codec, result

--- a/homeassistant/components/tts/baidu.py
+++ b/homeassistant/components/tts/baidu.py
@@ -1,5 +1,5 @@
 """
-Support for the baidu speech service.
+Support for Baidu speech service.
 
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/tts.baidu/
@@ -12,17 +12,12 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.components.tts import Provider, PLATFORM_SCHEMA, CONF_LANG
 import homeassistant.helpers.config_validation as cv
 
-
 REQUIREMENTS = ["baidu-aip==1.6.6"]
 
 _LOGGER = logging.getLogger(__name__)
 
-
-SUPPORT_LANGUAGES = [
-    'zh',
-]
+SUPPORTED_LANGUAGES = ['zh']
 DEFAULT_LANG = 'zh'
-
 
 CONF_APP_ID = 'app_id'
 CONF_SECRET_KEY = 'secret_key'
@@ -32,19 +27,38 @@ CONF_VOLUME = 'volume'
 CONF_PERSON = 'person'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORT_LANGUAGES),
+    vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORTED_LANGUAGES),
     vol.Required(CONF_APP_ID): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_SECRET_KEY): cv.string,
     vol.Optional(CONF_SPEED, default=5): vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=9)),
+        vol.Coerce(int), vol.Range(min=0, max=9)
+    ),
     vol.Optional(CONF_PITCH, default=5): vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=9)),
+        vol.Coerce(int), vol.Range(min=0, max=9)
+    ),
     vol.Optional(CONF_VOLUME, default=5): vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=15)),
+        vol.Coerce(int), vol.Range(min=0, max=15)
+    ),
     vol.Optional(CONF_PERSON, default=0): vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=4)),
+        vol.Coerce(int), vol.Range(min=0, max=4)
+    ),
 })
+
+# Keys are options in the config file, and Values are options
+# required by Baidu TTS API.
+_options = {
+    CONF_SPEED: 'spd',
+    CONF_PITCH: 'pit',
+    CONF_VOLUME: 'vol',
+    CONF_PERSON: 'per',
+}
+SUPPORTED_OPTIONS = [
+    CONF_SPEED,
+    CONF_PITCH,
+    CONF_VOLUME,
+    CONF_PERSON,
+]
 
 
 def get_engine(hass, config):
@@ -66,14 +80,14 @@ class BaiduTTSProvider(Provider):
             'appid': conf.get(CONF_APP_ID),
             'apikey': conf.get(CONF_API_KEY),
             'secretkey': conf.get(CONF_SECRET_KEY),
-            }
+        }
 
         self._speech_conf_data = {
-            'spd': conf.get(CONF_SPEED),
-            'pit': conf.get(CONF_PITCH),
-            'vol': conf.get(CONF_VOLUME),
-            'per': conf.get(CONF_PERSON),
-            }
+            _options[CONF_SPEED]: conf.get(CONF_SPEED),
+            _options[CONF_PITCH]: conf.get(CONF_PITCH),
+            _options[CONF_VOLUME]: conf.get(CONF_VOLUME),
+            _options[CONF_PERSON]: conf.get(CONF_PERSON),
+        }
 
     @property
     def default_language(self):
@@ -83,7 +97,22 @@ class BaiduTTSProvider(Provider):
     @property
     def supported_languages(self):
         """Return list of supported languages."""
-        return SUPPORT_LANGUAGES
+        return SUPPORTED_LANGUAGES
+
+    @property
+    def default_options(self):
+        """Return a dict include default options."""
+        return {
+            CONF_SPEED: self._speech_conf_data[_options[CONF_SPEED]],
+            CONF_PITCH: self._speech_conf_data[_options[CONF_PITCH]],
+            CONF_VOLUME: self._speech_conf_data[_options[CONF_VOLUME]],
+            CONF_PERSON: self._speech_conf_data[_options[CONF_PERSON]],
+        }
+
+    @property
+    def supported_options(self):
+        """Return a list of supported options."""
+        return SUPPORTED_OPTIONS
 
     def get_tts_audio(self, message, language, options=None):
         """Load TTS from BaiduTTS."""
@@ -92,10 +121,20 @@ class BaiduTTSProvider(Provider):
             self._app_data['appid'],
             self._app_data['apikey'],
             self._app_data['secretkey']
-            )
+        )
 
-        result = aip_speech.synthesis(
-            message, language, 1, self._speech_conf_data)
+        if options is None:
+            result = aip_speech.synthesis(
+                message, language, 1, self._speech_conf_data
+            )
+        else:
+            speech_data = {**self._speech_conf_data}
+            for k, v in options.items():
+                speech_data[_options[k]] = v
+
+            result = aip_speech.synthesis(
+                message, language, 1, speech_data
+            )
 
         if isinstance(result, dict):
             _LOGGER.error(

--- a/homeassistant/components/tts/baidu.py
+++ b/homeassistant/components/tts/baidu.py
@@ -48,16 +48,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # Keys are options in the config file, and Values are options
 # required by Baidu TTS API.
 _OPTIONS = {
-    CONF_SPEED: 'spd',
-    CONF_PITCH: 'pit',
-    CONF_VOLUME: 'vol',
     CONF_PERSON: 'per',
+    CONF_PITCH: 'pit',
+    CONF_SPEED: 'spd',
+    CONF_VOLUME: 'vol',
 }
 SUPPORTED_OPTIONS = [
-    CONF_SPEED,
-    CONF_PITCH,
-    CONF_VOLUME,
     CONF_PERSON,
+    CONF_PITCH,
+    CONF_SPEED,
+    CONF_VOLUME,
 ]
 
 
@@ -83,10 +83,10 @@ class BaiduTTSProvider(Provider):
         }
 
         self._speech_conf_data = {
-            _OPTIONS[CONF_SPEED]: conf.get(CONF_SPEED),
-            _OPTIONS[CONF_PITCH]: conf.get(CONF_PITCH),
-            _OPTIONS[CONF_VOLUME]: conf.get(CONF_VOLUME),
             _OPTIONS[CONF_PERSON]: conf.get(CONF_PERSON),
+            _OPTIONS[CONF_PITCH]: conf.get(CONF_PITCH),
+            _OPTIONS[CONF_SPEED]: conf.get(CONF_SPEED),
+            _OPTIONS[CONF_VOLUME]: conf.get(CONF_VOLUME),
         }
 
     @property
@@ -103,10 +103,10 @@ class BaiduTTSProvider(Provider):
     def default_options(self):
         """Return a dict include default options."""
         return {
-            CONF_SPEED: self._speech_conf_data[_OPTIONS[CONF_SPEED]],
-            CONF_PITCH: self._speech_conf_data[_OPTIONS[CONF_PITCH]],
-            CONF_VOLUME: self._speech_conf_data[_OPTIONS[CONF_VOLUME]],
             CONF_PERSON: self._speech_conf_data[_OPTIONS[CONF_PERSON]],
+            CONF_PITCH: self._speech_conf_data[_OPTIONS[CONF_PITCH]],
+            CONF_SPEED: self._speech_conf_data[_OPTIONS[CONF_SPEED]],
+            CONF_VOLUME: self._speech_conf_data[_OPTIONS[CONF_VOLUME]],
         }
 
     @property


### PR DESCRIPTION
## Description:
Add options feature: supported_options() and default_options() added, get_tts_audio updated to accommodate options.

## Example entry for `configuration.yaml`:
```yaml
- platform: baidu
    #app_id，api_key，secret_key can be achieved from https://cloud.baidu.com/product/speech/tts
    app_id: xxxxxxxx 
    api_key: xxxxxxxxxxxxxxxxxxx
    secret_key: xxxxxxxxxxxxxxxxxxxx
    #speed：0-9 (default: 5)
    #pitch：0-9 (default: 5)
    #volume：0-15 (default: 5)
    #person：0: female, 1: male, 3: synthesized by Baidu, 4: synthesized by Baidu (default: 0)
    speed: 5
    pitch: 5
    volume: 15
    person: 3
```

## Checklist:
  - [x] The code change is tested and works locally.

 the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
