### PR TITLE
AlarmDecoder remove icon function as BinarySensorDevice handles it correctly now

### DIFF
--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -77,17 +77,6 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
         return self._name
 
     @property
-    def icon(self):
-        """Icon for device by its type."""
-        if "window" in self._name.lower():
-            return "mdi:window-open" if self.is_on else "mdi:window-closed"
-
-        if self._type == 'smoke':
-            return "mdi:fire"
-
-        return None
-
-    @property
     def should_poll(self):
         """No polling needed."""
         return False

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -55,7 +55,6 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
         self._zone_type = zone_type
         self._state = None
         self._name = zone_name
-        self._type = zone_type
         self._rfid = zone_rfid
         self._rfstate = None
 


### PR DESCRIPTION
## Description:

BinarySensorDevice has been updated to include lots of device_types, including window and smoke.  The icons correctly update with out this function.

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54