### PR TITLE
Fix bluetooth tracker source

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -81,6 +81,8 @@ ATTR_VENDOR = 'vendor'
 
 SOURCE_TYPE_GPS = 'gps'
 SOURCE_TYPE_ROUTER = 'router'
+SOURCE_TYPE_BLUETOOTH = 'bluetooth'
+SOURCE_TYPE_BLUETOOTH_LE = 'bluetooth_le'
 
 NEW_DEVICE_DEFAULTS_SCHEMA = vol.Any(None, vol.Schema({
     vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,

--- a/homeassistant/components/device_tracker/bluetooth_le_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_le_tracker.py
@@ -54,7 +54,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 new_devices[address] = 1
                 return
 
-        see(mac=BLE_PREFIX + address, host_name=name.strip("\x00"), 
+        see(mac=BLE_PREFIX + address, host_name=name.strip("\x00"),
             source_type=SOURCE_TYPE_BLUETOOTH_LE)
 
     def discover_ble_devices():

--- a/homeassistant/components/device_tracker/bluetooth_le_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_le_tracker.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant.components.device_tracker import (
     YAML_DEVICES, CONF_TRACK_NEW, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
-    PLATFORM_SCHEMA, load_config
+    PLATFORM_SCHEMA, load_config, SOURCE_TYPE_BLUETOOTH_LE
 )
 import homeassistant.util.dt as dt_util
 import homeassistant.helpers.config_validation as cv
@@ -54,7 +54,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 new_devices[address] = 1
                 return
 
-        see(mac=BLE_PREFIX + address, host_name=name.strip("\x00"))
+        see(mac=BLE_PREFIX + address, host_name=name.strip("\x00"), 
+            source_type=SOURCE_TYPE_BLUETOOTH_LE)
 
     def discover_ble_devices():
         """Discover Bluetooth LE devices."""

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant.components.device_tracker import (
     YAML_DEVICES, CONF_TRACK_NEW, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
-    load_config, PLATFORM_SCHEMA, DEFAULT_TRACK_NEW)
+    load_config, PLATFORM_SCHEMA, DEFAULT_TRACK_NEW, SOURCE_TYPE_BLUETOOTH)
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     def see_device(device):
         """Mark a device as seen."""
-        see(mac=BT_PREFIX + device[0], host_name=device[1])
+        see(mac=BT_PREFIX + device[0], host_name=device[1], source_type=SOURCE_TYPE_BLUETOOTH)
 
     def discover_devices():
         """Discover Bluetooth devices."""

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -33,7 +33,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     def see_device(device):
         """Mark a device as seen."""
-        see(mac=BT_PREFIX + device[0], host_name=device[1], source_type=SOURCE_TYPE_BLUETOOTH)
+        see(mac=BT_PREFIX + device[0], host_name=device[1],
+            source_type=SOURCE_TYPE_BLUETOOTH)
 
     def discover_devices():
         """Discover Bluetooth devices."""


### PR DESCRIPTION
## Description:
Add new sources for bluetooth and bluetooth_le trackers (rather than just using the generic 'gps' catch-all).

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  