### PR TITLE
Fix vultr tests

### DIFF
--- a/tests/components/binary_sensor/test_vultr.py
+++ b/tests/components/binary_sensor/test_vultr.py
@@ -1,5 +1,8 @@
 """Test the Vultr binary sensor platform."""
+import json
 import unittest
+from unittest.mock import patch
+
 import requests_mock
 import pytest
 import voluptuous as vol
@@ -50,10 +53,6 @@ class TestVultrBinarySensorSetup(unittest.TestCase):
         """Stop our started services."""
         self.hass.stop()
 
-    def test_failed_hub(self):
-        """Test a hub setup failure."""
-        base_vultr.setup(self.hass, VALID_CONFIG)
-
     @requests_mock.Mocker()
     def test_binary_sensor(self, mock):
         """Test successful instance."""
@@ -61,12 +60,12 @@ class TestVultrBinarySensorSetup(unittest.TestCase):
             'https://api.vultr.com/v1/account/info?api_key=ABCDEFG1234567',
             text=load_fixture('vultr_account_info.json'))
 
-        mock.get(
-            'https://api.vultr.com/v1/server/list?api_key=ABCDEFG1234567',
-            text=load_fixture('vultr_server_list.json'))
-
-        # Setup hub
-        base_vultr.setup(self.hass, VALID_CONFIG)
+        with patch(
+            'vultr.Vultr.server_list',
+            return_value=json.loads(
+                load_fixture('vultr_server_list.json'))):
+            # Setup hub
+            base_vultr.setup(self.hass, VALID_CONFIG)
 
         # Setup each of our test configs
         for config in self.configs:
@@ -137,11 +136,12 @@ class TestVultrBinarySensorSetup(unittest.TestCase):
             'https://api.vultr.com/v1/account/info?api_key=ABCDEFG1234567',
             text=load_fixture('vultr_account_info.json'))
 
-        mock.get(
-            'https://api.vultr.com/v1/server/list?api_key=ABCDEFG1234567',
-            text=load_fixture('vultr_server_list.json'))
-
-        base_vultr.setup(self.hass, VALID_CONFIG)
+        with patch(
+            'vultr.Vultr.server_list',
+            return_value=json.loads(
+                load_fixture('vultr_server_list.json'))):
+            # Setup hub
+            base_vultr.setup(self.hass, VALID_CONFIG)
 
         bad_conf = {}  # No subscription
 

--- a/tests/components/sensor/test_vultr.py
+++ b/tests/components/sensor/test_vultr.py
@@ -1,6 +1,9 @@
 """The tests for the Vultr sensor platform."""
-import pytest
+import json
 import unittest
+from unittest.mock import patch
+
+import pytest
 import requests_mock
 import voluptuous as vol
 
@@ -59,11 +62,12 @@ class TestVultrSensorSetup(unittest.TestCase):
             'https://api.vultr.com/v1/account/info?api_key=ABCDEFG1234567',
             text=load_fixture('vultr_account_info.json'))
 
-        mock.get(
-            'https://api.vultr.com/v1/server/list?api_key=ABCDEFG1234567',
-            text=load_fixture('vultr_server_list.json'))
-
-        base_vultr.setup(self.hass, VALID_CONFIG)
+        with patch(
+            'vultr.Vultr.server_list',
+            return_value=json.loads(
+                load_fixture('vultr_server_list.json'))):
+            # Setup hub
+            base_vultr.setup(self.hass, VALID_CONFIG)
 
         for config in self.configs:
             setup = vultr.setup_platform(self.hass,
@@ -146,11 +150,12 @@ class TestVultrSensorSetup(unittest.TestCase):
             'https://api.vultr.com/v1/account/info?api_key=ABCDEFG1234567',
             text=load_fixture('vultr_account_info.json'))
 
-        mock.get(
-            'https://api.vultr.com/v1/server/list?api_key=ABCDEFG1234567',
-            text=load_fixture('vultr_server_list.json'))
-
-        base_vultr.setup(self.hass, VALID_CONFIG)
+        with patch(
+            'vultr.Vultr.server_list',
+            return_value=json.loads(
+                load_fixture('vultr_server_list.json'))):
+            # Setup hub
+            base_vultr.setup(self.hass, VALID_CONFIG)
 
         bad_conf = {
             CONF_MONITORED_CONDITIONS: vultr.MONITORED_CONDITIONS,

--- a/tests/components/switch/test_vultr.py
+++ b/tests/components/switch/test_vultr.py
@@ -1,5 +1,8 @@
 """Test the Vultr switch platform."""
+import json
 import unittest
+from unittest.mock import patch
+
 import requests_mock
 import pytest
 import voluptuous as vol
@@ -57,12 +60,12 @@ class TestVultrSwitchSetup(unittest.TestCase):
             'https://api.vultr.com/v1/account/info?api_key=ABCDEFG1234567',
             text=load_fixture('vultr_account_info.json'))
 
-        mock.get(
-            'https://api.vultr.com/v1/server/list?api_key=ABCDEFG1234567',
-            text=load_fixture('vultr_server_list.json'))
-
-        # Setup hub
-        base_vultr.setup(self.hass, VALID_CONFIG)
+        with patch(
+            'vultr.Vultr.server_list',
+            return_value=json.loads(
+                load_fixture('vultr_server_list.json'))):
+            # Setup hub
+            base_vultr.setup(self.hass, VALID_CONFIG)
 
         # Setup each of our test configs
         for config in self.configs:
@@ -128,36 +131,30 @@ class TestVultrSwitchSetup(unittest.TestCase):
     @requests_mock.Mocker()
     def test_turn_on(self, mock):
         """Test turning a subscription on."""
-        mock.get(
-            'https://api.vultr.com/v1/server/list?api_key=ABCDEFG1234567',
-            text=load_fixture('vultr_server_list.json'))
+        with patch(
+            'vultr.Vultr.server_list',
+            return_value=json.loads(load_fixture('vultr_server_list.json'))), \
+                patch('vultr.Vultr.server_start') as mock_start:
+            for device in self.DEVICES:
+                if device.name == 'Failed Server':
+                    device.turn_on()
 
-        mock.post(
-            'https://api.vultr.com/v1/server/start?api_key=ABCDEFG1234567')
-
-        for device in self.DEVICES:
-            if device.name == 'Failed Server':
-                device.turn_on()
-
-        # Turn on, force date update
-        self.assertEqual(2, mock.call_count)
+        # Turn on
+        self.assertEqual(1, mock_start.call_count)
 
     @requests_mock.Mocker()
     def test_turn_off(self, mock):
         """Test turning a subscription off."""
-        mock.get(
-            'https://api.vultr.com/v1/server/list?api_key=ABCDEFG1234567',
-            text=load_fixture('vultr_server_list.json'))
+        with patch(
+            'vultr.Vultr.server_list',
+            return_value=json.loads(load_fixture('vultr_server_list.json'))), \
+                patch('vultr.Vultr.server_halt') as mock_halt:
+            for device in self.DEVICES:
+                if device.name == 'A Server':
+                    device.turn_off()
 
-        mock.post(
-            'https://api.vultr.com/v1/server/halt?api_key=ABCDEFG1234567')
-
-        for device in self.DEVICES:
-            if device.name == 'A Server':
-                device.turn_off()
-
-        # Turn off, force update
-        self.assertEqual(2, mock.call_count)
+        # Turn off
+        self.assertEqual(1, mock_halt.call_count)
 
     def test_invalid_switch_config(self):
         """Test config type failures."""
@@ -173,11 +170,12 @@ class TestVultrSwitchSetup(unittest.TestCase):
             'https://api.vultr.com/v1/account/info?api_key=ABCDEFG1234567',
             text=load_fixture('vultr_account_info.json'))
 
-        mock.get(
-            'https://api.vultr.com/v1/server/list?api_key=ABCDEFG1234567',
-            text=load_fixture('vultr_server_list.json'))
-
-        base_vultr.setup(self.hass, VALID_CONFIG)
+        with patch(
+            'vultr.Vultr.server_list',
+            return_value=json.loads(
+                load_fixture('vultr_server_list.json'))):
+            # Setup hub
+            base_vultr.setup(self.hass, VALID_CONFIG)
 
         bad_conf = {}  # No subscription
 

--- a/tests/components/test_vultr.py
+++ b/tests/components/test_vultr.py
@@ -1,8 +1,11 @@
 """The tests for the Vultr component."""
+from copy import deepcopy
+import json
 import unittest
+from unittest.mock import patch
+
 import requests_mock
 
-from copy import deepcopy
 from homeassistant import setup
 import homeassistant.components.vultr as vultr
 
@@ -31,14 +34,11 @@ class TestVultr(unittest.TestCase):
     @requests_mock.Mocker()
     def test_setup(self, mock):
         """Test successful setup."""
-        mock.get(
-            'https://api.vultr.com/v1/account/info?api_key=ABCDEFG1234567',
-            text=load_fixture('vultr_account_info.json'))
-        mock.get(
-            'https://api.vultr.com/v1/server/list?api_key=ABCDEFG1234567',
-            text=load_fixture('vultr_server_list.json'))
-
-        response = vultr.setup(self.hass, self.config)
+        with patch(
+            'vultr.Vultr.server_list',
+            return_value=json.loads(
+                load_fixture('vultr_server_list.json'))):
+            response = vultr.setup(self.hass, self.config)
         self.assertTrue(response)
 
     def test_setup_no_api_key(self):


### PR DESCRIPTION
## Description:
One Vultr tests was making a web requests that would occasionally fail when their API would crap out. There is also something funky going on inside the Vultr package as mocking the requests GET still takes a second. Patching out the method makes the tests instant. Fixed both.

Also removed 1 test that did not test anything (no asserts)

Before:
```
Results (11.87s):
      14 passed
```

After:
```
Results (0.34s):
      13 passed
```

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
