### PR TITLE
New features for Owntracks device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -96,8 +96,7 @@ def async_setup_scanner(hass, config, async_see, discovery_info=None):
 
 
 def _parse_topic(topic, subscribe_topic):
-    """Parse an MQTT topic {subscribe_topic}/user/dev,
-    return (user, dev) tuple.
+    """Parse an MQTT topic {sub_topic}/user/dev, return (user, dev) tuple.
 
     Async friendly.
     """

--- a/homeassistant/components/device_tracker/owntracks_http.py
+++ b/homeassistant/components/device_tracker/owntracks_http.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.owntracks_http/
 """
 import asyncio
+import re
 
 from aiohttp.web_exceptions import HTTPInternalServerError
 
@@ -43,8 +44,11 @@ class OwnTracksView(HomeAssistantView):
         """Handle an OwnTracks message."""
         hass = request.app['hass']
 
+        subscription = self.context.mqtt_topic
+        topic = re.sub('/#$', '', subscription)
+
         message = yield from request.json()
-        message['topic'] = 'owntracks/{}/{}'.format(user, device)
+        message['topic'] = '{}/{}/{}'.format(topic, user, device)
 
         try:
             yield from async_handle_message(hass, self.context, message)

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -627,7 +627,7 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
         self.assert_location_state('inner')
 
     def test_events_only_on(self):
-        """Test events_only config suppresses location updates"""
+        """Test events_only config suppresses location updates."""
         # Sending a location message that is not home
         self.send_message(LOCATION_TOPIC, LOCATION_MESSAGE_NOT_HOME)
         self.assert_location_state(STATE_NOT_HOME)
@@ -636,6 +636,7 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
 
         # Enter and Leave messages
         self.send_message(EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE_OUTER)
+        self.assert_location_state('outer')
         self.send_message(EVENT_TOPIC, REGION_GPS_LEAVE_MESSAGE_OUTER)
         self.assert_location_state(STATE_NOT_HOME)
 
@@ -646,7 +647,7 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
         self.assert_location_state(STATE_NOT_HOME)
 
     def test_events_only_off(self):
-        """Test when events_only is False"""
+        """Test when events_only is False."""
         # Sending a location message that is not home
         self.send_message(LOCATION_TOPIC, LOCATION_MESSAGE_NOT_HOME)
         self.assert_location_state(STATE_NOT_HOME)
@@ -655,6 +656,7 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
 
         # Enter and Leave messages
         self.send_message(EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE_OUTER)
+        self.assert_location_state('outer')
         self.send_message(EVENT_TOPIC, REGION_GPS_LEAVE_MESSAGE_OUTER)
         self.assert_location_state(STATE_NOT_HOME)
 
@@ -1404,7 +1406,7 @@ class TestDeviceTrackerOwnTrackConfigs(BaseMQTT):
         self.assert_location_latitude(LOCATION_MESSAGE['lat'])
 
     def test_customized_mqtt_topic(self):
-        """Test subscribing to a custom mqtt topic"""
+        """Test subscribing to a custom mqtt topic."""
         with assert_setup_component(1, device_tracker.DOMAIN):
             assert setup_component(self.hass, device_tracker.DOMAIN, {
                 device_tracker.DOMAIN: {
@@ -1418,7 +1420,7 @@ class TestDeviceTrackerOwnTrackConfigs(BaseMQTT):
         self.assert_location_latitude(LOCATION_MESSAGE['lat'])
 
     def test_region_mapping(self):
-        """Test region to zone mapping"""
+        """Test region to zone mapping."""
         with assert_setup_component(1, device_tracker.DOMAIN):
             assert setup_component(self.hass, device_tracker.DOMAIN, {
                 device_tracker.DOMAIN: {

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -35,6 +35,7 @@ CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 CONF_WAYPOINT_IMPORT = owntracks.CONF_WAYPOINT_IMPORT
 CONF_WAYPOINT_WHITELIST = owntracks.CONF_WAYPOINT_WHITELIST
 CONF_SECRET = owntracks.CONF_SECRET
+CONF_MQTT_TOPIC = owntracks.CONF_MQTT_TOPIC
 
 TEST_ZONE_LAT = 45.0
 TEST_ZONE_LON = 90.0
@@ -1111,7 +1112,8 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
         test_config = {
             CONF_PLATFORM: 'owntracks',
             CONF_MAX_GPS_ACCURACY: 200,
-            CONF_WAYPOINT_IMPORT: True
+            CONF_WAYPOINT_IMPORT: True,
+            CONF_MQTT_TOPIC: 'owntracks/#',
         }
         run_coroutine_threadsafe(owntracks.async_setup_scanner(
             self.hass, test_config, mock_see), self.hass.loop).result()


### PR DESCRIPTION
- Supporting a mapping of region names in OT to zones in HA, allowing
  separate namespaces in both applications. This is especially helpful
  if using one OT instance to update geofences for multiple homes.
- Creating a setting to ignore all location updates, allowing users to
  rely completely on enter and leave events. I have personally always
  used OT integrations with home automation this way and find it the
  most reliable.
- Allowing the OT topic to be overridden in configuration

## Description:


**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4350

## Example entry for `configuration.yaml` (if applicable):
```
device_tracker:
  platform: owntracks
  mqtt_topic: "owntracks/#"
  events_only: yes
  region_mapping:
    cabin: home
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

  