### PR TITLE
Changed device type of media player and cover to switch

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -56,12 +56,12 @@ MAPPING_COMPONENT = {
         }
     ],
     cover.DOMAIN: [
-        TYPE_LIGHT, TRAIT_ONOFF, {
+        TYPE_SWITCH, TRAIT_ONOFF, {
             cover.SUPPORT_SET_POSITION: TRAIT_BRIGHTNESS
         }
     ],
     media_player.DOMAIN: [
-        TYPE_LIGHT, TRAIT_ONOFF, {
+        TYPE_SWITCH, TRAIT_ONOFF, {
             media_player.SUPPORT_VOLUME_SET: TRAIT_BRIGHTNESS
         }
     ],

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -95,7 +95,7 @@ DEMO_DEVICES = [{
     'traits':
     ['action.devices.traits.OnOff', 'action.devices.traits.Brightness'],
     'type':
-    'action.devices.types.LIGHT',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {
@@ -107,7 +107,7 @@ DEMO_DEVICES = [{
     'traits':
     ['action.devices.traits.OnOff', 'action.devices.traits.Brightness'],
     'type':
-    'action.devices.types.LIGHT',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {
@@ -116,7 +116,7 @@ DEMO_DEVICES = [{
         'name': 'Garage Door'
     },
     'traits': ['action.devices.traits.OnOff'],
-    'type': 'action.devices.types.LIGHT',
+    'type': 'action.devices.types.SWITCH',
     'willReportState': False
 }, {
     'id': 'cover.kitchen_window',
@@ -124,7 +124,7 @@ DEMO_DEVICES = [{
         'name': 'Kitchen Window'
     },
     'traits': ['action.devices.traits.OnOff'],
-    'type': 'action.devices.types.LIGHT',
+    'type': 'action.devices.types.SWITCH',
     'willReportState': False
 }, {
     'id': 'group.all_covers',
@@ -143,7 +143,7 @@ DEMO_DEVICES = [{
     'traits':
     ['action.devices.traits.OnOff', 'action.devices.traits.Brightness'],
     'type':
-    'action.devices.types.LIGHT',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {
@@ -155,7 +155,7 @@ DEMO_DEVICES = [{
     'traits':
     ['action.devices.traits.OnOff', 'action.devices.traits.Brightness'],
     'type':
-    'action.devices.types.LIGHT',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {
@@ -164,7 +164,7 @@ DEMO_DEVICES = [{
         'name': 'Lounge room'
     },
     'traits': ['action.devices.traits.OnOff'],
-    'type': 'action.devices.types.LIGHT',
+    'type': 'action.devices.types.SWITCH',
     'willReportState': False
 }, {
     'id':
@@ -175,7 +175,7 @@ DEMO_DEVICES = [{
     'traits':
     ['action.devices.traits.OnOff', 'action.devices.traits.Brightness'],
     'type':
-    'action.devices.types.LIGHT',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {


### PR DESCRIPTION
## Description:
Covers and media players should not be of device type 'light'. Example: If user requests all lights to switch to off, covers are closed and media players are affected too. Change affects user experience on Google Assistants voice commands only.


## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
