### PR TITLE
Make the rpi_rf component thread-safe using an RLock

### DIFF
--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -48,9 +48,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return switches controlled by a generic RF device via GPIO."""
     import rpi_rf
+    from threading import RLock
 
     gpio = config.get(CONF_GPIO)
     rfdevice = rpi_rf.RFDevice(gpio)
+    rfdevice_lock = RLock()
     switches = config.get(CONF_SWITCHES)
 
     devices = []
@@ -60,6 +62,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 hass,
                 properties.get(CONF_NAME, dev_name),
                 rfdevice,
+                rfdevice_lock,
                 properties.get(CONF_PROTOCOL),
                 properties.get(CONF_PULSELENGTH),
                 properties.get(CONF_SIGNAL_REPETITIONS),
@@ -79,13 +82,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiRFSwitch(SwitchDevice):
     """Representation of a GPIO RF switch."""
 
-    def __init__(self, hass, name, rfdevice, protocol, pulselength,
+    def __init__(self, hass, name, rfdevice, lock, protocol, pulselength,
                  signal_repetitions, code_on, code_off):
         """Initialize the switch."""
         self._hass = hass
         self._name = name
         self._state = False
         self._rfdevice = rfdevice
+        self._lock = lock
         self._protocol = protocol
         self._pulselength = pulselength
         self._code_on = code_on
@@ -109,9 +113,10 @@ class RPiRFSwitch(SwitchDevice):
 
     def _send_code(self, code_list, protocol, pulselength):
         """Send the code(s) with a specified pulselength."""
-        _LOGGER.info("Sending code(s): %s", code_list)
-        for code in code_list:
-            self._rfdevice.tx_code(code, protocol, pulselength)
+        with self._lock:
+            _LOGGER.info("Sending code(s): %s", code_list)
+            for code in code_list:
+                self._rfdevice.tx_code(code, protocol, pulselength)
         return True
 
     def turn_on(self):

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -59,7 +59,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for dev_name, properties in switches.items():
         devices.append(
             RPiRFSwitch(
-                hass,
                 properties.get(CONF_NAME, dev_name),
                 rfdevice,
                 rfdevice_lock,

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -82,10 +82,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RPiRFSwitch(SwitchDevice):
     """Representation of a GPIO RF switch."""
 
-    def __init__(self, hass, name, rfdevice, lock, protocol, pulselength,
+    def __init__(self, name, rfdevice, lock, protocol, pulselength,
                  signal_repetitions, code_on, code_off):
         """Initialize the switch."""
-        self._hass = hass
         self._name = name
         self._state = False
         self._rfdevice = rfdevice


### PR DESCRIPTION
## Description:
The implementation in rpi_rf.py suffers from race conditions when two rpi_rf switches are triggered at exactly the same time. This implementation uses an RLock to give one thread at a time exclusive access to the rfdevice object.
(this is a new version of #11285 using an RLock instead of a worker thread, as per @pvizeli 's suggestion)

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
