### PR TITLE
Feature/fritzdect errorhandling

### DIFF
--- a/homeassistant/components/switch/fritzdect.py
+++ b/homeassistant/components/switch/fritzdect.py
@@ -14,7 +14,7 @@ from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import TEMP_CELSIUS, ATTR_TEMPERATURE, STATE_UNKNOWN
+from homeassistant.const import TEMP_CELSIUS, ATTR_TEMPERATURE
 
 REQUIREMENTS = ['fritzhome==1.0.4']
 
@@ -170,7 +170,7 @@ class FritzDectSwitchData(object):
         """Initialize the data object."""
         self.fritz = fritz
         self.ain = ain
-        self.state = STATE_UNKNOWN
+        self.state = None
         self.temperature = None
         self.current_consumption = None
         self.total_consumption = None
@@ -189,7 +189,7 @@ class FritzDectSwitchData(object):
             actor = self.fritz.get_actor_by_ain(self.ain)
         except (RequestException, HTTPError):
             _LOGGER.error("Request to actor registry failed")
-            self.state = STATE_UNKNOWN
+            self.state = None
             self.temperature = None
             self.current_consumption = None
             self.total_consumption = None
@@ -197,7 +197,7 @@ class FritzDectSwitchData(object):
 
         if actor is None:
             _LOGGER.error("Actor could not be found")
-            self.state = STATE_UNKNOWN
+            self.state = None
             self.temperature = None
             self.current_consumption = None
             self.total_consumption = None
@@ -209,7 +209,7 @@ class FritzDectSwitchData(object):
             self.total_consumption = (actor.get_energy() or 0.0) / 100000
         except (RequestException, HTTPError):
             _LOGGER.error("Request to actor failed")
-            self.state = STATE_UNKNOWN
+            self.state = None
             self.temperature = None
             self.current_consumption = None
             self.total_consumption = None

--- a/homeassistant/components/switch/fritzdect.py
+++ b/homeassistant/components/switch/fritzdect.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import TEMP_CELSIUS, ATTR_TEMPERATURE, STATE_UNKNOWN
 
-REQUIREMENTS = ['fritzhome==1.0.3']
+REQUIREMENTS = ['fritzhome==1.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/fritzdect.py
+++ b/homeassistant/components/switch/fritzdect.py
@@ -6,6 +6,8 @@ https://home-assistant.io/components/switch.fritzdect/
 """
 import logging
 
+from requests.exceptions import RequestException, HTTPError
+
 import voluptuous as vol
 
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
@@ -46,15 +48,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    # Hack: fritzhome only throws Exception. To prevent pylint from
-    # complaining, we disable the warning here:
-    # pylint: disable=W0703
-
     # Log into Fritz Box
     fritz = FritzBox(host, username, password)
     try:
         fritz.login()
-    except Exception:
+    except Exception:  # pylint: disable=W0703
         _LOGGER.error("Login to Fritz!Box failed")
         return
 
@@ -63,6 +61,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         # Only add devices that support switching
         if actor.has_switch:
             data = FritzDectSwitchData(fritz, actor.actor_id)
+            data.is_online = True
             add_devices([FritzDectSwitch(hass, data, actor.name)], True)
 
 
@@ -86,8 +85,8 @@ class FritzDectSwitch(SwitchDevice):
         attrs = {}
 
         if self.data.has_powermeter and \
-           self.data.current_consumption != STATE_UNKNOWN and \
-           self.data.total_consumption != STATE_UNKNOWN:
+           self.data.current_consumption is not None and \
+           self.data.total_consumption is not None:
             attrs[ATTR_CURRENT_CONSUMPTION] = "{:.1f}".format(
                 self.data.current_consumption)
             attrs[ATTR_CURRENT_CONSUMPTION_UNIT] = "{}".format(
@@ -98,7 +97,7 @@ class FritzDectSwitch(SwitchDevice):
                 ATTR_TOTAL_CONSUMPTION_UNIT_VALUE)
 
         if self.data.has_temperature and \
-           self.data.temperature != STATE_UNKNOWN:
+           self.data.temperature is not None:
             attrs[ATTR_TEMPERATURE] = "{}".format(
                 self.units.temperature(self.data.temperature, TEMP_CELSIUS))
             attrs[ATTR_TEMPERATURE_UNIT] = "{}".format(
@@ -120,17 +119,48 @@ class FritzDectSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""
-        actor = self.data.fritz.get_actor_by_ain(self.data.ain)
-        actor.switch_on()
+        if not self.data.is_online:
+            _LOGGER.error("turn_on: Not online skipping request")
+            return
+
+        try:
+            actor = self.data.fritz.get_actor_by_ain(self.data.ain)
+            actor.switch_on()
+        except (RequestException, HTTPError):
+            _LOGGER.error("Fritz!Box query failed, triggering relogin")
+            self.data.is_online = False
 
     def turn_off(self):
         """Turn the switch off."""
-        actor = self.data.fritz.get_actor_by_ain(self.data.ain)
-        actor.switch_off()
+        if not self.data.is_online:
+            _LOGGER.error("turn_off: Not online skipping request")
+            return
+
+        try:
+            actor = self.data.fritz.get_actor_by_ain(self.data.ain)
+            actor.switch_off()
+        except (RequestException, HTTPError):
+            _LOGGER.error("Fritz!Box query failed, triggering relogin")
+            self.data.is_online = False
 
     def update(self):
         """Get the latest data from the fritz box and updates the states."""
-        self.data.update()
+        if not self.data.is_online:
+            _LOGGER.error("update: Not online, logging back in")
+
+            try:
+                self.data.fritz.login()
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.error("Login to Fritz!Box failed")
+                return
+
+            self.data.is_online = True
+
+        try:
+            self.data.update()
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.error("Fritz!Box query failed, triggering relogin")
+            self.data.is_online = False
 
 
 class FritzDectSwitchData(object):
@@ -141,31 +171,51 @@ class FritzDectSwitchData(object):
         self.fritz = fritz
         self.ain = ain
         self.state = STATE_UNKNOWN
-        self.temperature = STATE_UNKNOWN
-        self.current_consumption = STATE_UNKNOWN
-        self.total_consumption = STATE_UNKNOWN
-        self.has_switch = STATE_UNKNOWN
-        self.has_temperature = STATE_UNKNOWN
-        self.has_powermeter = STATE_UNKNOWN
+        self.temperature = None
+        self.current_consumption = None
+        self.total_consumption = None
+        self.has_switch = False
+        self.has_temperature = False
+        self.has_powermeter = False
+        self.is_online = False
 
     def update(self):
         """Get the latest data from the fritz box."""
-        from requests.exceptions import RequestException
+        if not self.is_online:
+            _LOGGER.error("Not online skipping request")
+            return
 
         try:
             actor = self.fritz.get_actor_by_ain(self.ain)
+        except (RequestException, HTTPError):
+            _LOGGER.error("Request to actor registry failed")
+            self.state = STATE_UNKNOWN
+            self.temperature = None
+            self.current_consumption = None
+            self.total_consumption = None
+            raise Exception('Request to actor registry failed')
+
+        if actor is None:
+            _LOGGER.error("Actor could not be found")
+            self.state = STATE_UNKNOWN
+            self.temperature = None
+            self.current_consumption = None
+            self.total_consumption = None
+            raise Exception('Actor could not be found')
+
+        try:
             self.state = actor.get_state()
-        except RequestException:
+            self.current_consumption = (actor.get_power() or 0.0) / 1000
+            self.total_consumption = (actor.get_energy() or 0.0) / 100000
+        except (RequestException, HTTPError):
             _LOGGER.error("Request to actor failed")
             self.state = STATE_UNKNOWN
-            self.temperature = STATE_UNKNOWN
-            self.current_consumption = STATE_UNKNOWN
-            self.total_consumption = STATE_UNKNOWN
-            return
+            self.temperature = None
+            self.current_consumption = None
+            self.total_consumption = None
+            raise Exception('Request to actor failed')
 
         self.temperature = actor.temperature
-        self.current_consumption = (actor.get_power() or 0.0) / 1000
-        self.total_consumption = (actor.get_energy() or 0.0) / 100000
         self.has_switch = actor.has_switch
         self.has_temperature = actor.has_temperature
         self.has_powermeter = actor.has_powermeter

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -280,7 +280,7 @@ freesms==0.1.2
 # fritzconnection==0.6.5
 
 # homeassistant.components.switch.fritzdect
-fritzhome==1.0.3
+fritzhome==1.0.4
 
 # homeassistant.components.media_player.frontier_silicon
 fsapi==0.0.7


### PR DESCRIPTION
## Description: Adds error handling and auto reconnect to the Fritz!Dect Switches

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54