### PR TITLE
Autoremove discovered MQTT switch entities on empty config message

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -84,6 +84,7 @@ ATTR_PAYLOAD = 'payload'
 ATTR_PAYLOAD_TEMPLATE = 'payload_template'
 ATTR_QOS = CONF_QOS
 ATTR_RETAIN = CONF_RETAIN
+ATTR_DISCOVERY_HASH = 'discovery_hash'
 
 MAX_RECONNECT_WAIT = 300  # seconds
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -12,7 +12,7 @@ import re
 import homeassistant.components.mqtt as mqtt
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.const import CONF_PLATFORM
-from homeassistant.components.mqtt import CONF_STATE_TOPIC
+from homeassistant.components.mqtt import CONF_STATE_TOPIC, ATTR_DISCOVERY_HASH
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,47 +49,64 @@ def async_start(hass, discovery_topic, hass_config):
 
         prefix_topic, component, node_id, object_id = match.groups()
 
-        try:
-            payload = json.loads(payload)
-        except ValueError:
-            _LOGGER.warning("Unable to parse JSON %s: %s", object_id, payload)
-            return
-
         if component not in SUPPORTED_COMPONENTS:
             _LOGGER.warning("Component %s is not supported", component)
             return
 
-        payload = dict(payload)
-        platform = payload.get(CONF_PLATFORM, 'mqtt')
-        if platform not in ALLOWED_PLATFORMS.get(component, []):
-            _LOGGER.warning("Platform %s (component %s) is not allowed",
-                            platform, component)
-            return
-
-        payload[CONF_PLATFORM] = platform
-        if CONF_STATE_TOPIC not in payload:
-            payload[CONF_STATE_TOPIC] = '{}/{}/{}{}/state'.format(
-                discovery_topic, component, '%s/' % node_id if node_id else '',
-                object_id)
-
-        if ALREADY_DISCOVERED not in hass.data:
-            hass.data[ALREADY_DISCOVERED] = set()
-
         # If present, the node_id will be included in the discovered object id
         discovery_id = '_'.join((node_id, object_id)) if node_id else object_id
 
+        if ALREADY_DISCOVERED not in hass.data:
+            hass.data[ALREADY_DISCOVERED] = {}
+
         discovery_hash = (component, discovery_id)
-        if discovery_hash in hass.data[ALREADY_DISCOVERED]:
-            _LOGGER.info("Component has already been discovered: %s %s",
-                         component, discovery_id)
-            return
 
-        hass.data[ALREADY_DISCOVERED].add(discovery_hash)
+        if payload:
+            # Add component
+            try:
+                payload = json.loads(payload)
+            except ValueError:
+                _LOGGER.warning("Unable to parse JSON %s: %s",
+                                object_id, payload)
+                return
 
-        _LOGGER.info("Found new component: %s %s", component, discovery_id)
+            payload = dict(payload)
+            platform = payload.get(CONF_PLATFORM, 'mqtt')
+            if platform not in ALLOWED_PLATFORMS.get(component, []):
+                _LOGGER.warning("Platform %s (component %s) is not allowed",
+                                platform, component)
+                return
 
-        yield from async_load_platform(
-            hass, component, platform, payload, hass_config)
+            payload[CONF_PLATFORM] = platform
+            if CONF_STATE_TOPIC not in payload:
+                payload[CONF_STATE_TOPIC] = '{}/{}/{}{}/state'.format(
+                    discovery_topic, component,
+                    '%s/' % node_id if node_id else '', object_id)
+
+            if discovery_hash in hass.data[ALREADY_DISCOVERED]:
+                _LOGGER.info("Component has already been discovered: %s %s",
+                             component, discovery_id)
+                return
+
+            hass.data[ALREADY_DISCOVERED][discovery_hash] = None
+            payload[ATTR_DISCOVERY_HASH] = discovery_hash
+
+            _LOGGER.info("Found new component: %s %s", component, discovery_id)
+
+            yield from async_load_platform(
+                hass, component, platform, payload, hass_config)
+
+        else:
+            # Remove component
+            if discovery_hash in hass.data[ALREADY_DISCOVERED]:
+                _LOGGER.info("Removing component: %s %s",
+                             component, discovery_id)
+
+                if hass.data[ALREADY_DISCOVERED][discovery_hash] is not None:
+                    entity = hass.data[ALREADY_DISCOVERED][discovery_hash]
+                    hass.states.async_remove(entity.entity_id)
+
+                del hass.data[ALREADY_DISCOVERED][discovery_hash]
 
     yield from mqtt.async_subscribe(
         hass, discovery_topic + '/#', async_device_message_received, 0)

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -11,9 +11,11 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.components.mqtt import (
-    CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_AVAILABILITY_TOPIC,
-    CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS, CONF_RETAIN,
-    MqttAvailability)
+    ATTR_DISCOVERY_HASH, CONF_STATE_TOPIC, CONF_COMMAND_TOPIC,
+    CONF_AVAILABILITY_TOPIC, CONF_PAYLOAD_AVAILABLE,
+    CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS, CONF_RETAIN, MqttAvailability)
+from homeassistant.components.mqtt.discovery import (
+    ALREADY_DISCOVERED)
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_OFF,
@@ -48,7 +50,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if value_template is not None:
         value_template.hass = hass
 
-    async_add_devices([MqttSwitch(
+    newswitch = MqttSwitch(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_COMMAND_TOPIC),
@@ -61,7 +63,13 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_PAYLOAD_AVAILABLE),
         config.get(CONF_PAYLOAD_NOT_AVAILABLE),
         value_template,
-    )])
+    )
+
+    async_add_devices([newswitch])
+
+    if discovery_info is not None and ATTR_DISCOVERY_HASH in discovery_info:
+        discovery_hash = discovery_info[ATTR_DISCOVERY_HASH]
+        hass.data[ALREADY_DISCOVERED][discovery_hash] = newswitch
 
 
 class MqttSwitch(MqttAvailability, SwitchDevice):


### PR DESCRIPTION
Autoremove discovered MQTT switch entities on empty config message
* Keep track of discovered switch entities
* Remove entity when an empty config message is posted