### PR TITLE
Upgrade pywebpush to 1.5.0

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import ensure_unique_string
 
-REQUIREMENTS = ['pywebpush==1.3.0', 'PyJWT==1.5.3']
+REQUIREMENTS = ['pywebpush==1.5.0', 'PyJWT==1.5.3']
 
 DEPENDENCIES = ['frontend']
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -974,7 +974,7 @@ pyvizio==0.0.2
 pyvlx==0.1.3
 
 # homeassistant.components.notify.html5
-pywebpush==1.3.0
+pywebpush==1.5.0
 
 # homeassistant.components.wemo
 pywemo==0.4.25

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -143,7 +143,7 @@ pythonwhois==2.4.3
 pyunifi==2.13
 
 # homeassistant.components.notify.html5
-pywebpush==1.3.0
+pywebpush==1.5.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0b2


### PR DESCRIPTION
## Description:
This version includes a fix for the serialization errors that occurred
when updating push subscriptions.

Changes since version 1.3.0:
https://github.com/web-push-libs/pywebpush/compare/1.3.0...28d2b55f

**Related issue (if applicable):**  
fixes #10751
fixes #11024

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: NOTIFIER_NAME
    platform: html5
    gcm_api_key: 'gcm-server-key'
    gcm_sender_id: 'gcm-sender-id'
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

  