### PR TITLE
Allow Sensibo to depend on external entity for state.

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -819,7 +819,7 @@ pyqwikswitch==0.4
 pyrainbird==0.1.3
 
 # homeassistant.components.climate.sensibo
-pysensibo==1.0.1
+pysensibo==1.0.2
 
 # homeassistant.components.sensor.serial
 pyserial-asyncio==0.4


### PR DESCRIPTION
## Description:

Allow Sensibo to depend on external entity for state.

Sensibo is a physical device that is operated via a cloud and controls an A/C via IR commands.

For some A/Cs it can't know the real state of the A/C if A/C was operated by other means (remote).
However a user might be able to know the A/C state via intercepting IR commands or measuring A/C power consumption.

This PR allows to propagate this state to Sensibo so it is up to date and is able to issue correct commands to control the A/C.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: sensibo
    api_key: mykey
    id:
      - deadbeaf1: input_select.ac_state
      - deadbeaf2
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
