### PR TITLE
Snips: (fix) support new intentName format

### DIFF
--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -59,7 +59,10 @@ def async_setup(hass, config):
             _LOGGER.error('Intent has invalid schema: %s. %s', err, request)
             return
 
-        intent_type = request['intent']['intentName'].split('__')[-1]
+        if request['intent']['intentName'].startswith('user'):
+            intent_type = request['intent']['intentName'].split('__')[-1]
+        else:
+            intent_type = request['intent']['intentName'].split(':')[-1]
         slots = {}
         for slot in request.get('slots', []):
             if 'value' in slot['value']:

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -61,7 +61,7 @@ def async_setup(hass, config):
             _LOGGER.error('Intent has invalid schema: %s. %s', err, request)
             return
 
-        if request['intent']['intentName'].startswith('user'):
+        if request['intent']['intentName'].startswith('user_'):
             intent_type = request['intent']['intentName'].split('__')[-1]
         else:
             intent_type = request['intent']['intentName'].split(':')[-1]

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -47,7 +47,7 @@ def test_snips_intent(hass, mqtt_mock):
 
 
 @asyncio.coroutine
-def test_snips_intent_with_snips_duration(hass, mqtt_mock):
+def test_snips_intent_with_duration(hass, mqtt_mock):
     """Test intent with Snips duration."""
     result = yield from async_setup_component(hass, "snips", {
         "snips": {},
@@ -176,7 +176,7 @@ def test_snips_unknown_intent(hass, mqtt_mock):
                             payload)
     yield from hass.async_block_till_done()
 
-    assert len(intents) == 0
+    assert not intents
     assert len(events) == 1
     assert events[0].data['domain'] == 'mqtt'
     assert events[0].data['service'] == 'publish'
@@ -187,7 +187,7 @@ def test_snips_unknown_intent(hass, mqtt_mock):
 
 
 @asyncio.coroutine
-def test_snips_intent_format_user(hass, mqtt_mock):
+def test_snips_intent_user(hass, mqtt_mock):
     """Test intentName format user_XXX__intentName."""
     result = yield from async_setup_component(hass, "snips", {
         "snips": {},
@@ -214,7 +214,7 @@ def test_snips_intent_format_user(hass, mqtt_mock):
 
 
 @asyncio.coroutine
-def test_snips_intent_format_username(hass, mqtt_mock):
+def test_snips_intent_username(hass, mqtt_mock):
     """Test intentName format username:intentName."""
     result = yield from async_setup_component(hass, "snips", {
         "snips": {},

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -184,3 +184,57 @@ def test_snips_unknown_intent(hass, mqtt_mock):
     topic = events[0].data['service_data']['topic']
     assert payload['text'] == 'Unknown Intent'
     assert topic == 'hermes/dialogueManager/endSession'
+
+
+@asyncio.coroutine
+def test_snips_intent_format_user(hass, mqtt_mock):
+    """Test intentName format user_XXX__intentName."""
+    result = yield from async_setup_component(hass, "snips", {
+        "snips": {},
+    })
+    assert result
+    payload = """
+    {
+        "input": "what to do",
+        "intent": {
+            "intentName": "user_ABCDEF123__Lights"
+        },
+        "slots": []
+    }
+    """
+    intents = async_mock_intent(hass, 'Lights')
+    async_fire_mqtt_message(hass, 'hermes/intent/user_ABCDEF123__Lights',
+                            payload)
+    yield from hass.async_block_till_done()
+
+    assert len(intents) == 1
+    intent = intents[0]
+    assert intent.platform == 'snips'
+    assert intent.intent_type == 'Lights'
+
+
+@asyncio.coroutine
+def test_snips_intent_format_username(hass, mqtt_mock):
+    """Test intentName format username:intentName."""
+    result = yield from async_setup_component(hass, "snips", {
+        "snips": {},
+    })
+    assert result
+    payload = """
+    {
+        "input": "what to do",
+        "intent": {
+            "intentName": "username:Lights"
+        },
+        "slots": []
+    }
+    """
+    intents = async_mock_intent(hass, 'Lights')
+    async_fire_mqtt_message(hass, 'hermes/intent/username:Lights',
+                            payload)
+    yield from hass.async_block_till_done()
+
+    assert len(intents) == 1
+    intent = intents[0]
+    assert intent.platform == 'snips'
+    assert intent.intent_type == 'Lights'


### PR DESCRIPTION
## Description:
Description:
snips console now creates custom user intents in the format Username:intentName as opposed to the previous user_SOMEHEXID__intentName. This change supports both

**Related issue (if applicable):** fixes #N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
