### PR TITLE
timer: include the remaining time in the state attributes

### DIFF
--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -29,6 +29,7 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 DEFAULT_DURATION = 0
 ATTR_DURATION = 'duration'
+ATTR_REMAINING = 'remaining'
 CONF_DURATION = 'duration'
 
 STATUS_IDLE = 'idle'
@@ -227,6 +228,7 @@ class Timer(Entity):
         """Return the state attributes."""
         return {
             ATTR_DURATION: str(self._duration),
+            ATTR_REMAINING: str(self._remaining)
         }
 
     @asyncio.coroutine


### PR DESCRIPTION
## Description:
Add the amount of remaining time before a timer is finished in its state attributes, so that it is received when fetching a timer state.

In my particular case, it allows me to correctly implement a UI for a timer when it is paused and when the UI didn't received the pause state change (which happens when the UI is started after the pause). In this case, it is impossible to show the remaining amount of time before the timer ends.
