### PR TITLE
More tolerant KNX component if gateway cant be connected

### DIFF
--- a/homeassistant/components/binary_sensor/knx.py
+++ b/homeassistant/components/binary_sensor/knx.py
@@ -130,6 +130,11 @@ class KNXBinarySensor(BinarySensorDevice):
         return self.device.name
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.hass.data[DATA_KNX].connected
+
+    @property
     def should_poll(self):
         """No polling needed within KNX."""
         return False

--- a/homeassistant/components/climate/knx.py
+++ b/homeassistant/components/climate/knx.py
@@ -160,6 +160,11 @@ class KNXClimate(ClimateDevice):
         return self.device.name
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.hass.data[DATA_KNX].connected
+
+    @property
     def should_poll(self):
         """No polling needed within KNX."""
         return False

--- a/homeassistant/components/cover/knx.py
+++ b/homeassistant/components/cover/knx.py
@@ -125,6 +125,11 @@ class KNXCover(CoverDevice):
         return self.device.name
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.hass.data[DATA_KNX].connected
+
+    @property
     def should_poll(self):
         """No polling needed within KNX."""
         return False

--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -80,8 +80,11 @@ def async_setup(hass, config):
         yield from hass.data[DATA_KNX].start()
 
     except XKNXException as ex:
-        _LOGGER.exception("Can't connect to KNX interface: %s", ex)
-        return False
+        _LOGGER.warning("Can't connect to KNX interface: %s", ex)
+        hass.components.persistent_notification.async_create(
+            "Can't connect to KNX interface: <br>"
+            "<b>{0}</b>".format(ex),
+            title="KNX")
 
     for component, discovery_type in (
             ('switch', 'Switch'),
@@ -120,9 +123,9 @@ class KNXModule(object):
         """Initialization of KNXModule."""
         self.hass = hass
         self.config = config
-        self.initialized = False
         self.init_xknx()
         self.register_callbacks()
+        self.initialized = True
 
     def init_xknx(self):
         """Initialization of KNX object."""
@@ -139,7 +142,6 @@ class KNXModule(object):
             state_updater=self.config[DOMAIN][CONF_KNX_STATE_UPDATER],
             connection_config=connection_config)
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.stop)
-        self.initialized = True
 
     @asyncio.coroutine
     def stop(self, event):

--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -123,9 +123,10 @@ class KNXModule(object):
         """Initialization of KNXModule."""
         self.hass = hass
         self.config = config
+        self.connected = False
+        self.initialized = True
         self.init_xknx()
         self.register_callbacks()
-        self.initialized = True
 
     def init_xknx(self):
         """Initialization of KNX object."""
@@ -142,6 +143,7 @@ class KNXModule(object):
             state_updater=self.config[DOMAIN][CONF_KNX_STATE_UPDATER],
             connection_config=connection_config)
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.stop)
+        self.connected = True
 
     @asyncio.coroutine
     def stop(self, event):

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -98,6 +98,11 @@ class KNXLight(Light):
         return self.device.name
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.hass.data[DATA_KNX].connected
+
+    @property
     def should_poll(self):
         """No polling needed within KNX."""
         return False

--- a/homeassistant/components/sensor/knx.py
+++ b/homeassistant/components/sensor/knx.py
@@ -91,6 +91,11 @@ class KNXSensor(Entity):
         return self.device.name
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.hass.data[DATA_KNX].connected
+
+    @property
     def should_poll(self):
         """No polling needed within KNX."""
         return False

--- a/homeassistant/components/switch/knx.py
+++ b/homeassistant/components/switch/knx.py
@@ -90,6 +90,11 @@ class KNXSwitch(SwitchDevice):
         return self.device.name
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.hass.data[DATA_KNX].connected
+
+    @property
     def should_poll(self):
         """No polling needed within KNX."""
         return False


### PR DESCRIPTION
## Description:

**Related issue:** fixes #11432

Current behavior: If the KNX tunelling cant be reached, an exception is thrown and no KNX device (lights, covers, etc) are initialized. This caused the side effect that homebridge loses some attributes  which then have to be reconfigured manually.

Expected behaviour: All manually devices still show up - but are marked as not available.

This fix will not stop configuring the component if the gateway can't be reached. Instead it will show an error and mark all devices as not available.

