### PR TITLE
Snips (new) added speech response, parse snips/duration

### DIFF
--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -59,7 +59,10 @@ def async_setup(hass, config):
             _LOGGER.error('Intent has invalid schema: %s. %s', err, request)
             return
 
-        intent_type = request['intent']['intentName'].split('__')[-1]
+        if request['intent']['intentName'].startswith('user'):
+            intent_type = request['intent']['intentName'].split('__')[-1]
+        else:
+            intent_type = request['intent']['intentName'].split(':')[-1]
         slots = {}
         for slot in request.get('slots', []):
             if 'value' in slot['value']:

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -7,8 +7,9 @@ https://home-assistant.io/components/snips/
 import asyncio
 import json
 import logging
+from datetime import timedelta
 import voluptuous as vol
-from homeassistant.helpers import intent, template, config_validation as cv
+from homeassistant.helpers import intent, config_validation as cv
 import homeassistant.components.mqtt as mqtt
 
 DOMAIN = 'snips'
@@ -60,7 +61,7 @@ def async_setup(hass, config):
             _LOGGER.error('Intent has invalid schema: %s. %s', err, request)
             return
 
-        snips_response = SnipsResponse(hass, request.get('siteId', 'default'))
+        snips_response = None
 
         if request['intent']['intentName'].startswith('user'):
             intent_type = request['intent']['intentName'].split('__')[-1]
@@ -68,62 +69,46 @@ def async_setup(hass, config):
             intent_type = request['intent']['intentName'].split(':')[-1]
         slots = {}
         for slot in request.get('slots', []):
-            if 'value' in slot['value']:
-                slots[slot['slotName']] = {'value': slot['value']['value']}
-            else:
-                slots[slot['slotName']] = {'value': slot['rawValue']}
+            slots[slot['slotName']] = {'value': resolve_slot_values(slot)}
 
         try:
             intent_response = yield from intent.async_handle(
                 hass, DOMAIN, intent_type, slots, request['input'])
+            if 'plain' in intent_response.speech:
+                snips_response = intent_response.speech['plain']['speech']
         except intent.UnknownIntent as err:
             _LOGGER.warning("Received unknown intent %s",
                             request['intent']['intentName'])
-            snips_response.add_speech(
-                "This intent is not yet configured within Home Assistant.")
+            snips_response = "Unknown Intent"
         except intent.IntentError:
             _LOGGER.exception("Error while handling intent: %s.", intent_type)
+            snips_response = "Error while handling intent"
 
-        if 'plain' in intent_response.speech:
-            snips_response.add_speech(
-                intent_response.speech['plain']['speech'])
+        notification = {'sessionId': request.get('sessionId', 'default'),
+                        'text': snips_response}
 
-        if intent_response.speech:
-            snips_response.send_response()
+        _LOGGER.debug("send_response %s", json.dumps(notification))
+        mqtt.async_publish(hass, 'hermes/dialogueManager/endSession',
+                           json.dumps(notification))
 
     yield from hass.components.mqtt.async_subscribe(
         INTENT_TOPIC, message_received)
 
     return True
 
+def resolve_slot_values(slot):
+    """Convert snips builtin types to useable values."""
+    if 'value' in slot['value']:
+        value = slot['value']['value']
+    else:
+        value = slot['rawValue']
 
-class SnipsResponse(object):
-    """Help generating the response for Snips."""
+    if slot.get('entity') == "snips/duration":
+        delta = timedelta(weeks=slot['value']['weeks'],
+                          days=slot['value']['days'],
+                          hours=slot['value']['hours'],
+                          minutes=slot['value']['minutes'],
+                          seconds=slot['value']['seconds'])
+        value = delta.seconds
 
-    def __init__(self, hass, siteid):
-        """Initialize the Snips response."""
-        self.hass = hass
-        self.text = None
-        self.siteid = siteid
-
-    def add_speech(self, text):
-        """Add speech to the response."""
-        assert self.text is None
-
-        if isinstance(text, template.Template):
-            text = text.async_render()
-
-        self.text = text
-
-    def as_dict(self):
-        """Return response in a Snips valid dictionary."""
-        return {
-            'siteId': self.siteid,
-            'init': {'type': 'notification', 'text': self.text}
-        }
-
-    def send_response(self):
-        """ Send response as TTS. """
-        _LOGGER.debug("send_response %s", json.dumps(self.as_dict()))
-        mqtt.async_publish(self.hass, 'hermes/dialogueManager/startSession',
-                           json.dumps(self.as_dict()))
+    return value

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -8,7 +8,8 @@ import asyncio
 import json
 import logging
 import voluptuous as vol
-from homeassistant.helpers import intent, config_validation as cv
+from homeassistant.helpers import intent, template, config_validation as cv
+import homeassistant.components.mqtt as mqtt
 
 DOMAIN = 'snips'
 DEPENDENCIES = ['mqtt']
@@ -59,6 +60,8 @@ def async_setup(hass, config):
             _LOGGER.error('Intent has invalid schema: %s. %s', err, request)
             return
 
+        snips_response = SnipsResponse(hass, request.get('siteId', 'default'))
+
         if request['intent']['intentName'].startswith('user'):
             intent_type = request['intent']['intentName'].split('__')[-1]
         else:
@@ -71,12 +74,55 @@ def async_setup(hass, config):
                 slots[slot['slotName']] = {'value': slot['rawValue']}
 
         try:
-            yield from intent.async_handle(
+            intent_response = yield from intent.async_handle(
                 hass, DOMAIN, intent_type, slots, request['input'])
+        except intent.UnknownIntent as err:
+            _LOGGER.warning("Received unknown intent %s",
+                            request['intent']['intentName'])
+            snips_response.add_speech(
+                "This intent is not yet configured within Home Assistant.")
         except intent.IntentError:
             _LOGGER.exception("Error while handling intent: %s.", intent_type)
+
+        if 'plain' in intent_response.speech:
+            snips_response.add_speech(
+                intent_response.speech['plain']['speech'])
+
+        if intent_response.speech:
+            snips_response.send_response()
 
     yield from hass.components.mqtt.async_subscribe(
         INTENT_TOPIC, message_received)
 
     return True
+
+class SnipsResponse(object):
+    """Help generating the response for Snips."""
+
+    def __init__(self, hass, siteid):
+        """Initialize the Snips response."""
+        self.hass = hass
+        self.text = None
+        self.siteid = siteid
+
+    def add_speech(self, text):
+        """Add speech to the response."""
+        assert self.text is None
+
+        if isinstance(text, template.Template):
+            text = text.async_render()
+
+        self.text = text
+
+    def as_dict(self):
+        """Return response in a Snips valid dictionary."""
+        return {
+            'siteId': self.siteid,
+            'init': {'type': 'notification', 'text': self.text}
+        }
+
+    def send_response(self):
+        """ Send response as TTS. """
+        _LOGGER.debug("send_response %s", json.dumps(self.as_dict()))
+        mqtt.async_publish(self.hass, 'hermes/dialogueManager/startSession',
+                           json.dumps(self.as_dict()))

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -63,10 +63,7 @@ def async_setup(hass, config):
 
         snips_response = None
 
-        if request['intent']['intentName'].startswith('user'):
-            intent_type = request['intent']['intentName'].split('__')[-1]
-        else:
-            intent_type = request['intent']['intentName'].split(':')[-1]
+        intent_type = request['intent']['intentName'].split('__')[-1]
         slots = {}
         for slot in request.get('slots', []):
             slots[slot['slotName']] = {'value': resolve_slot_values(slot)}

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -96,6 +96,7 @@ def async_setup(hass, config):
 
     return True
 
+
 def resolve_slot_values(slot):
     """Convert snips builtin types to useable values."""
     if 'value' in slot['value']:

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -96,6 +96,7 @@ def async_setup(hass, config):
 
     return True
 
+
 class SnipsResponse(object):
     """Help generating the response for Snips."""
 

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -10,6 +10,7 @@ from tests.common import (get_test_home_assistant, fire_mqtt_message,
 
 class TestSnips(unittest.TestCase):
     """Test Snips."""
+
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
@@ -162,7 +163,6 @@ class TestSnips(unittest.TestCase):
             fire_mqtt_message(self.hass,
                               'hermes/intent/CallServiceIntent', payload)
             self.hass.block_till_done()
-            #print("test_handle:", test_handle.output[1])
             self.assertIn("payload={\"sessionId\": \"abcdef1234567890\","
                           " \"text\": \"Service called\"}",
                           test_handle.output[1])

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -1,227 +1,120 @@
-"""The tests for the Dialogflow component."""
-import unittest
+"""Test the Snips component."""
+import asyncio
 
 from homeassistant.core import callback
-from homeassistant.components import snips
-from homeassistant.setup import async_setup_component, setup_component
-from tests.common import (get_test_home_assistant, fire_mqtt_message,
-                          mock_mqtt_component, mock_component, mock_service)
+from homeassistant.bootstrap import async_setup_component
+from tests.common import async_fire_mqtt_message, async_mock_intent
 
 
-class TestSnips(unittest.TestCase):
-    """Test Snips."""
+@asyncio.coroutine
+def test_snips_call_action(hass, mqtt_mock):
+    """Test calling action via Snips."""
+    result = yield from async_setup_component(hass, "snips", {
+        "snips": {},
+    })
+    assert result
+    payload = """
+    {
+        "input": "turn the lights green",
+        "intent": {
+            "intentName": "Lights",
+            "probability": 1
+        },
+        "slots": [
+            {
+                "slotName": "light_color",
+                "value": {
+                    "kind": "Custom",
+                    "value": "green"
+                }
+            }
+        ]
+    }
+    """
 
-    def setUp(self):
-        """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.calls = []
+    intents = async_mock_intent(hass, 'Lights')
 
-        mock_mqtt_component(self.hass)
-        assert async_setup_component(self.hass, snips.DOMAIN, {
-            "snips": {},
-        })
-        self.hass.start()
+    async_fire_mqtt_message(hass, 'hermes/intent/Lights',
+                            payload)
+    yield from hass.async_block_till_done()
+    assert len(intents) == 1
+    intent = intents[0]
+    assert intent.platform == 'snips'
+    assert intent.intent_type == 'Lights'
+    assert intent.slots == {'light_color': {'value': 'green'}}
+    assert intent.text_input == 'turn the lights green'
 
-    def tearDown(self):  # pylint: disable=invalid-name
-        """Stop everything that was started."""
-        self.hass.stop()
+
+@asyncio.coroutine
+def test_snips_unknown_intent(hass, mqtt_mock):
+    """Test calling action via Snips."""
+    result = yield from async_setup_component(hass, "snips", {
+        "snips": {},
+    })
+    assert result
+    payload = """
+    {
+        "input": "what to do",
+        "intent": {
+            "intentName": "unknownIntent"
+        },
+        "slots": []
+    }
+    """
+    intents = async_mock_intent(hass, 'knownIntent')
+
+    async_fire_mqtt_message(hass, 'hermes/intent/unknownIntent',
+                            payload)
+    yield from hass.async_block_till_done()
+    assert len(intents) == 1
+    intent = intents[0]
+    assert intent.platform == 'snips'
+    assert intent.intent_type == 'unknownIntent'
+    assert intent.text_input == 'what to do'
+
+
+@asyncio.coroutine
+def test_intent_response(hass, mqtt_mock):
+    """Test intent response."""
+    event = 'call_service'
+    events = []
 
     @callback
-    def record_calls(self, *args):
-        """Helper for recording calls."""
-        self.calls.append(args)
+    def record_event(event):
+        """Add recorded event to set."""
+        events.append(event)
 
-    def test_intent_call_service(self):
-        """Test intent calling a service."""
-        mock_component(self.hass, 'mqtt')
-        setup_component(self.hass, snips.DOMAIN, {
-            snips.DOMAIN: {},
-        })
-        setup_component(self.hass, "intent_script", {
-            "intent_script": {
-                "CallServiceIntent": {
-                    "speech": {
-                        "type": "plain",
-                        "text": "Service called",
-                    },
-                    "action": {
-                        "service": "test.snips",
-                        "data_template": {
-                            "zodiac_sign": "{{ ZodiacSign }}"
-                        },
-                        "entity_id": "switch.test",
-                    }
+    result = yield from async_setup_component(hass, "snips", {
+        "snips": {},
+    })
+    assert result
+    result = yield from async_setup_component(hass, "intent_script", {
+        "intent_script": {
+            "spokenIntent": {
+                "speech": {
+                    "type": "plain",
+                    "text": "Hello",
                 }
             }
-        })
-
-        service_calls = mock_service(self.hass, 'test', 'snips')
-        payload = """
-        {
-            "input": "zodiac forecast for virgo",
-            "sessionId": "abcdef1234567890",
-            "intent": {
-                "intentName": "CallServiceIntent"
-            },
-            "slots": [
-                {
-                    "slotName": "ZodiacSign",
-                    "rawValue": "virgo",
-                    "value": {
-                        "kind": "custom",
-                        "value": "virgo"
-                    }
-                }
-            ]
         }
-        """
-        fire_mqtt_message(self.hass, 'hermes/intent/CallServiceIntent',
-                          payload)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(service_calls))
-        self.assertEqual('virgo', service_calls[0].data['zodiac_sign'])
-        self.assertEqual('switch.test', service_calls[0].data['entity_id'][0])
-
-    def test_intent_with_snips_duration(self):
-        """Test intent with snips duration."""
-        mock_component(self.hass, 'mqtt')
-        setup_component(self.hass, snips.DOMAIN, {
-            snips.DOMAIN: {},
-        })
-        setup_component(self.hass, "intent_script", {
-            "intent_script": {
-                "SetTimer": {
-                    "speech": {
-                        "type": "plain",
-                        "text": "Timer set {{ timer_duration }}",
-                    },
-                }
-            }
-        })
-        payload = """
-        {
-            "input": "set a timer of five minutes",
-            "intent": {
-                "intentName": "SetTimer"
-            },
-            "slots": [
-                {
-                    "rawValue": "five minutes",
-                    "value": {
-                        "kind": "Duration",
-                        "years": 0,
-                        "quarters": 0,
-                        "months": 0,
-                        "weeks": 0,
-                        "days": 0,
-                        "hours": 0,
-                        "minutes": 5,
-                        "seconds": 0,
-                        "precision": "Exact"
-                    },
-                    "entity": "snips/duration",
-                    "slotName": "timer_duration"
-                }
-            ]
-        }
-        """
-        with self.assertLogs(level='INFO') as test_handle:
-            fire_mqtt_message(self.hass,
-                              'hermes/intent/SetTimer', payload)
-            self.hass.block_till_done()
-            self.assertIn("\"sessionId\": \"default\"",
-                          test_handle.output[1])
-            self.assertIn("\"text\": \"Timer set 300\"}",
-                          test_handle.output[1])
-
-    def test_intent_response(self):
-        """Test intent response."""
-        mock_component(self.hass, 'mqtt')
-        setup_component(self.hass, snips.DOMAIN, {
-            snips.DOMAIN: {},
-        })
-        setup_component(self.hass, "intent_script", {
-            "intent_script": {
-                "spokenIntent": {
-                    "speech": {
-                        "type": "plain",
-                        "text": "Service called",
-                    }
-                }
-            }
-        })
-        payload = """
-        {
-            "input": "speak to me",
-            "sessionId": "abcdef1234567890",
-            "intent": {
-                "intentName": "spokenIntent"
-            },
-            "slots": []
-        }
-        """
-        with self.assertLogs(level='INFO') as test_handle:
-            fire_mqtt_message(self.hass,
-                              'hermes/intent/CallServiceIntent', payload)
-            self.hass.block_till_done()
-            self.assertIn("\"sessionId\": \"abcdef1234567890\"",
-                          test_handle.output[1])
-            self.assertIn("\"text\": \"Service called\"}",
-                          test_handle.output[1])
-
-    def test_unknown_intent(self):
-        """Test unknown intent."""
-        mock_mqtt_component(self.hass)
-        setup_component(self.hass, snips.DOMAIN, {
-            snips.DOMAIN: {},
-        })
-        payload = """
-        {
-            "input": "I don't know what I am supposed to do",
-            "sessionId": "abcdef1234567890",
-            "intent": {
-                "intentName": "unknownIntent"
-            },
-            "slots": []
-        }
-        """
-        with self.assertLogs(level='WARNING') as test_handle:
-            fire_mqtt_message(self.hass,
-                              'hermes/intent/unknownIntent', payload)
-            self.hass.block_till_done()
-            self.assertIn("WARNING:homeassistant.components.snips:"
-                          "Received unknown intent unknownIntent",
-                          test_handle.output[0])
-
-    def test_intent_invalid_confg(self):
-        """Test when intent has invalid config."""
-        setup_component(self.hass, snips.DOMAIN, {
-            "snips": {},
-        })
-        payload = """
-        {
-            "input": "turn the lights green",
-            "sessionId": "abcdef1234567890",
-            "intent": {
-                "intentName": "activateLights",
-                "probability": 1
-            },
-            "slots": [
-                {
-                    "rawValue": "green",
-                    "value": {
-                        "value": "green"
-                    },
-                    "entity": "light_color",
-                    "slotName": "light_color"
-                }
-            ]
-        }
-        """
-        with self.assertLogs(level='ERROR') as test_handle:
-            fire_mqtt_message(self.hass,
-                              'hermes/intent/activateLights', payload)
-            self.hass.block_till_done()
-            self.assertIn("ERROR:homeassistant.components.snips:"
-                          "Intent has invalid schema",
-                          test_handle.output[0])
+    })
+    assert result
+    payload = """
+    {
+        "input": "speak to me",
+        "intent": {
+            "intentName": "spokenIntent"
+        },
+        "slots": []
+    }
+    """
+    async_fire_mqtt_message(hass, 'hermes/intent/spokenIntent',
+                            payload)
+    yield from hass.async_block_till_done()
+    hass.bus.listen(event, record_event)
+    # assert len(intents) == 1
+    # intent = intents[0]
+    # assert intent.platform == 'snips'
+    # assert intent.intent_type == 'spokenIntent'
+    # assert intent.text_input == 'speak to me'
+    # assert len(events) == 0

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -189,13 +189,6 @@ class TestSnips(unittest.TestCase):
             "slots": []
         }
         """
-        #unsub = mqtt.subscribe(self.hass,
-        #                       'hermes/dialogueManager/endSession',
-        #                       self.record_calls)
-        #print("self.calls:", self.calls)
-        #self.assertEqual('hermes/dialogueManager/endSession',
-        #                 self.calls[0][1])
-
         with self.assertLogs(level='WARNING') as test_handle:
             fire_mqtt_message(self.hass,
                               'hermes/intent/unknownIntent', payload)
@@ -203,14 +196,12 @@ class TestSnips(unittest.TestCase):
             self.assertIn("WARNING:homeassistant.components.snips:"
                           "Received unknown intent unknownIntent",
                           test_handle.output[0])
-        # unsub()
 
     def test_intent_invalid_confg(self):
         """Test when intent has invalid config."""
         setup_component(self.hass, snips.DOMAIN, {
             "snips": {},
         })
-        # intent should contain a slot.value.kind key
         payload = """
         {
             "input": "turn the lights green",

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -1,5 +1,6 @@
 """Test the Snips component."""
 import asyncio
+import json
 
 from homeassistant.core import callback
 from homeassistant.bootstrap import async_setup_component
@@ -7,8 +8,8 @@ from tests.common import async_fire_mqtt_message, async_mock_intent
 
 
 @asyncio.coroutine
-def test_snips_call_action(hass, mqtt_mock):
-    """Test calling action via Snips."""
+def test_snips_intent(hass, mqtt_mock):
+    """Test intent via Snips."""
     result = yield from async_setup_component(hass, "snips", {
         "snips": {},
     })
@@ -46,36 +47,58 @@ def test_snips_call_action(hass, mqtt_mock):
 
 
 @asyncio.coroutine
-def test_snips_unknown_intent(hass, mqtt_mock):
-    """Test calling action via Snips."""
+def test_snips_intent_with_snips_duration(hass, mqtt_mock):
+    """Test intent with Snips duration."""
     result = yield from async_setup_component(hass, "snips", {
         "snips": {},
     })
     assert result
     payload = """
     {
-        "input": "what to do",
-        "intent": {
-            "intentName": "unknownIntent"
-        },
-        "slots": []
+      "input": "set a timer of five minutes",
+      "intent": {
+        "intentName": "SetTimer"
+      },
+      "slots": [
+        {
+          "rawValue": "five minutes",
+          "value": {
+            "kind": "Duration",
+            "years": 0,
+            "quarters": 0,
+            "months": 0,
+            "weeks": 0,
+            "days": 0,
+            "hours": 0,
+            "minutes": 5,
+            "seconds": 0,
+            "precision": "Exact"
+          },
+          "range": {
+            "start": 15,
+            "end": 27
+          },
+          "entity": "snips/duration",
+          "slotName": "timer_duration"
+        }
+      ]
     }
     """
-    intents = async_mock_intent(hass, 'knownIntent')
+    intents = async_mock_intent(hass, 'SetTimer')
 
-    async_fire_mqtt_message(hass, 'hermes/intent/unknownIntent',
+    async_fire_mqtt_message(hass, 'hermes/intent/SetTimer',
                             payload)
     yield from hass.async_block_till_done()
     assert len(intents) == 1
     intent = intents[0]
     assert intent.platform == 'snips'
-    assert intent.intent_type == 'unknownIntent'
-    assert intent.text_input == 'what to do'
+    assert intent.intent_type == 'SetTimer'
+    assert intent.slots == {'timer_duration': {'value': 300}}
 
 
 @asyncio.coroutine
-def test_intent_response(hass, mqtt_mock):
-    """Test intent response."""
+def test_intent_speech_response(hass, mqtt_mock):
+    """Test intent speech response via Snips."""
     event = 'call_service'
     events = []
 
@@ -93,7 +116,7 @@ def test_intent_response(hass, mqtt_mock):
             "spokenIntent": {
                 "speech": {
                     "type": "plain",
-                    "text": "Hello",
+                    "text": "I am speaking to you"
                 }
             }
         }
@@ -102,19 +125,60 @@ def test_intent_response(hass, mqtt_mock):
     payload = """
     {
         "input": "speak to me",
+        "sessionId": "abcdef0123456789",
         "intent": {
             "intentName": "spokenIntent"
         },
         "slots": []
     }
     """
+    hass.bus.async_listen(event, record_event)
     async_fire_mqtt_message(hass, 'hermes/intent/spokenIntent',
                             payload)
     yield from hass.async_block_till_done()
-    hass.bus.listen(event, record_event)
-    # assert len(intents) == 1
-    # intent = intents[0]
-    # assert intent.platform == 'snips'
-    # assert intent.intent_type == 'spokenIntent'
-    # assert intent.text_input == 'speak to me'
-    # assert len(events) == 0
+
+    assert len(events) == 1
+    assert events[0].data['domain'] == 'mqtt'
+    assert events[0].data['service'] == 'publish'
+    payload = json.loads(events[0].data['service_data']['payload'])
+    topic = events[0].data['service_data']['topic']
+    assert payload['sessionId'] == 'abcdef0123456789'
+    assert payload['text'] == 'I am speaking to you'
+    assert topic == 'hermes/dialogueManager/endSession'
+
+@asyncio.coroutine
+def test_snips_unknown_intent(hass, mqtt_mock):
+    """Test calling unknown Intent via Snips."""
+    event = 'call_service'
+    events = []
+
+    @callback
+    def record_event(event):
+        """Add recorded event to set."""
+        events.append(event)
+    result = yield from async_setup_component(hass, "snips", {
+        "snips": {},
+    })
+    assert result
+    payload = """
+    {
+        "input": "what to do",
+        "intent": {
+            "intentName": "unknownIntent"
+        },
+        "slots": []
+    }
+    """
+    intents = async_mock_intent(hass, 'knownIntent')
+    hass.bus.async_listen(event, record_event)
+    async_fire_mqtt_message(hass, 'hermes/intent/unknownIntent',
+                            payload)
+    yield from hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data['domain'] == 'mqtt'
+    assert events[0].data['service'] == 'publish'
+    payload = json.loads(events[0].data['service_data']['payload'])
+    topic = events[0].data['service_data']['topic']
+    assert payload['text'] == 'Unknown Intent'
+    assert topic == 'hermes/dialogueManager/endSession'

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -146,6 +146,7 @@ def test_intent_speech_response(hass, mqtt_mock):
     assert payload['text'] == 'I am speaking to you'
     assert topic == 'hermes/dialogueManager/endSession'
 
+
 @asyncio.coroutine
 def test_snips_unknown_intent(hass, mqtt_mock):
     """Test calling unknown Intent via Snips."""
@@ -175,6 +176,7 @@ def test_snips_unknown_intent(hass, mqtt_mock):
                             payload)
     yield from hass.async_block_till_done()
 
+    assert len(intents) == 0
     assert len(events) == 1
     assert events[0].data['domain'] == 'mqtt'
     assert events[0].data['service'] == 'publish'

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -2,7 +2,6 @@
 import unittest
 
 from homeassistant.core import callback
-#from homeassistant import setup
 from homeassistant.components import snips
 from homeassistant.setup import async_setup_component, setup_component
 from tests.common import (get_test_home_assistant, fire_mqtt_message,

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -1,6 +1,5 @@
 """The tests for the Dialogflow component."""
 import unittest
-#from unittest import mock
 
 from homeassistant.core import callback
 #from homeassistant import setup
@@ -8,10 +7,6 @@ from homeassistant.components import snips
 from homeassistant.setup import async_setup_component, setup_component
 from tests.common import (get_test_home_assistant, fire_mqtt_message,
                           mock_mqtt_component, mock_component, mock_service)
-
-# An unknown action takes 8 s to return. Request timeout should be bigger to
-# allow the test to finish
-REQUEST_TIMEOUT = 15
 
 
 class TestSnips(unittest.TestCase):

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -1,45 +1,240 @@
-"""Test the Snips component."""
-import asyncio
+"""The tests for the Dialogflow component."""
+import unittest
+#from unittest import mock
 
-from homeassistant.bootstrap import async_setup_component
-from tests.common import async_fire_mqtt_message, async_mock_intent
+from homeassistant.core import callback
+#from homeassistant import setup
+from homeassistant.components import snips
+from homeassistant.setup import async_setup_component, setup_component
+from tests.common import (get_test_home_assistant, fire_mqtt_message,
+                          mock_mqtt_component, mock_component, mock_service)
 
-EXAMPLE_MSG = """
-{
-    "input": "turn the lights green",
-    "intent": {
-        "intentName": "Lights",
-        "probability": 1
-    },
-    "slots": [
-        {
-            "slotName": "light_color",
-            "value": {
-                "kind": "Custom",
-                "value": "green"
+# An unknown action takes 8 s to return. Request timeout should be bigger to
+# allow the test to finish
+REQUEST_TIMEOUT = 15
+
+
+class TestSnips(unittest.TestCase):
+    """Test Snips."""
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.calls = []
+
+        mock_mqtt_component(self.hass)
+        assert async_setup_component(self.hass, snips.DOMAIN, {
+            "snips": {},
+        })
+        self.hass.start()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @callback
+    def record_calls(self, *args):
+        """Helper for recording calls."""
+        self.calls.append(args)
+
+    def test_intent_call_service(self):
+        """Test intent calling a service."""
+        mock_component(self.hass, 'mqtt')
+        setup_component(self.hass, snips.DOMAIN, {
+            snips.DOMAIN: {},
+        })
+        setup_component(self.hass, "intent_script", {
+            "intent_script": {
+                "CallServiceIntent": {
+                    "speech": {
+                        "type": "plain",
+                        "text": "Service called",
+                    },
+                    "action": {
+                        "service": "test.snips",
+                        "data_template": {
+                            "zodiac_sign": "{{ ZodiacSign }}"
+                        },
+                        "entity_id": "switch.test",
+                    }
+                }
             }
+        })
+
+        service_calls = mock_service(self.hass, 'test', 'snips')
+        payload = """
+        {
+            "input": "zodiac forecast for virgo",
+            "sessionId": "abcdef1234567890",
+            "intent": {
+                "intentName": "CallServiceIntent"
+            },
+            "slots": [
+                {
+                    "slotName": "ZodiacSign",
+                    "rawValue": "virgo",
+                    "value": {
+                        "kind": "custom",
+                        "value": "virgo"
+                    }
+                }
+            ]
         }
-    ]
-}
-"""
+        """
+        fire_mqtt_message(self.hass, 'hermes/intent/CallServiceIntent',
+                          payload)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(service_calls))
+        self.assertEqual('virgo', service_calls[0].data['zodiac_sign'])
+        self.assertEqual('switch.test', service_calls[0].data['entity_id'][0])
 
+    def test_intent_with_snips_duration(self):
+        """Test intent with snips duration."""
+        mock_component(self.hass, 'mqtt')
+        setup_component(self.hass, snips.DOMAIN, {
+            snips.DOMAIN: {},
+        })
+        setup_component(self.hass, "intent_script", {
+            "intent_script": {
+                "SetTimer": {
+                    "speech": {
+                        "type": "plain",
+                        "text": "Timer set {{ timer_duration }}",
+                    },
+                }
+            }
+        })
+        payload = """
+        {
+            "input": "set a timer of five minutes",
+            "intent": {
+                "intentName": "SetTimer"
+            },
+            "slots": [
+                {
+                    "rawValue": "five minutes",
+                    "value": {
+                        "kind": "Duration",
+                        "years": 0,
+                        "quarters": 0,
+                        "months": 0,
+                        "weeks": 0,
+                        "days": 0,
+                        "hours": 0,
+                        "minutes": 5,
+                        "seconds": 0,
+                        "precision": "Exact"
+                    },
+                    "entity": "snips/duration",
+                    "slotName": "timer_duration"
+                }
+            ]
+        }
+        """
+        with self.assertLogs(level='INFO') as test_handle:
+            fire_mqtt_message(self.hass,
+                              'hermes/intent/SetTimer', payload)
+            self.hass.block_till_done()
+            self.assertIn("payload={\"sessionId\": \"default\","
+                          " \"text\": \"Timer set 300\"}",
+                          test_handle.output[1])
 
-@asyncio.coroutine
-def test_snips_call_action(hass, mqtt_mock):
-    """Test calling action via Snips."""
-    result = yield from async_setup_component(hass, "snips", {
-        "snips": {},
-    })
-    assert result
+    def test_intent_response(self):
+        """Test intent response."""
+        mock_component(self.hass, 'mqtt')
+        setup_component(self.hass, snips.DOMAIN, {
+            snips.DOMAIN: {},
+        })
+        setup_component(self.hass, "intent_script", {
+            "intent_script": {
+                "spokenIntent": {
+                    "speech": {
+                        "type": "plain",
+                        "text": "Service called",
+                    }
+                }
+            }
+        })
+        payload = """
+        {
+            "input": "speak to me",
+            "sessionId": "abcdef1234567890",
+            "intent": {
+                "intentName": "spokenIntent"
+            },
+            "slots": []
+        }
+        """
+        with self.assertLogs(level='INFO') as test_handle:
+            fire_mqtt_message(self.hass,
+                              'hermes/intent/CallServiceIntent', payload)
+            self.hass.block_till_done()
+            #print("test_handle:", test_handle.output[1])
+            self.assertIn("payload={\"sessionId\": \"abcdef1234567890\","
+                          " \"text\": \"Service called\"}",
+                          test_handle.output[1])
 
-    intents = async_mock_intent(hass, 'Lights')
+    def test_unknown_intent(self):
+        """Test unknown intent."""
+        mock_mqtt_component(self.hass)
+        setup_component(self.hass, snips.DOMAIN, {
+            snips.DOMAIN: {},
+        })
+        payload = """
+        {
+            "input": "I don't know what I am supposed to do",
+            "sessionId": "abcdef1234567890",
+            "intent": {
+                "intentName": "unknownIntent"
+            },
+            "slots": []
+        }
+        """
+        #unsub = mqtt.subscribe(self.hass,
+        #                       'hermes/dialogueManager/endSession',
+        #                       self.record_calls)
+        #print("self.calls:", self.calls)
+        #self.assertEqual('hermes/dialogueManager/endSession',
+        #                 self.calls[0][1])
 
-    async_fire_mqtt_message(hass, 'hermes/intent/activateLights',
-                            EXAMPLE_MSG)
-    yield from hass.async_block_till_done()
-    assert len(intents) == 1
-    intent = intents[0]
-    assert intent.platform == 'snips'
-    assert intent.intent_type == 'Lights'
-    assert intent.slots == {'light_color': {'value': 'green'}}
-    assert intent.text_input == 'turn the lights green'
+        with self.assertLogs(level='WARNING') as test_handle:
+            fire_mqtt_message(self.hass,
+                              'hermes/intent/unknownIntent', payload)
+            self.hass.block_till_done()
+            self.assertIn("WARNING:homeassistant.components.snips:"
+                          "Received unknown intent unknownIntent",
+                          test_handle.output[0])
+        # unsub()
+
+    def test_intent_invalid_confg(self):
+        """Test when intent has invalid config."""
+        setup_component(self.hass, snips.DOMAIN, {
+            "snips": {},
+        })
+        # intent should contain a slot.value.kind key
+        payload = """
+        {
+            "input": "turn the lights green",
+            "sessionId": "abcdef1234567890",
+            "intent": {
+                "intentName": "activateLights",
+                "probability": 1
+            },
+            "slots": [
+                {
+                    "rawValue": "green",
+                    "value": {
+                        "value": "green"
+                    },
+                    "entity": "light_color",
+                    "slotName": "light_color"
+                }
+            ]
+        }
+        """
+        with self.assertLogs(level='ERROR') as test_handle:
+            fire_mqtt_message(self.hass,
+                              'hermes/intent/activateLights', payload)
+            self.hass.block_till_done()
+            self.assertIn("ERROR:homeassistant.components.snips:"
+                          "Intent has invalid schema",
+                          test_handle.output[0])

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -129,7 +129,7 @@ class TestSnips(unittest.TestCase):
             fire_mqtt_message(self.hass,
                               'hermes/intent/SetTimer', payload)
             self.hass.block_till_done()
-            self.assertIn("\"sessionId\": \"abcdef1234567890\"",
+            self.assertIn("\"sessionId\": \"default\"",
                           test_handle.output[1])
             self.assertIn("\"text\": \"Timer set 300\"}",
                           test_handle.output[1])

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -129,7 +129,7 @@ class TestSnips(unittest.TestCase):
             fire_mqtt_message(self.hass,
                               'hermes/intent/SetTimer', payload)
             self.hass.block_till_done()
-            self.assertIn("\"sessionId\": \"abcdef1234567890\",
+            self.assertIn("\"sessionId\": \"abcdef1234567890\"",
                           test_handle.output[1])
             self.assertIn("\"text\": \"Timer set 300\"}",
                           test_handle.output[1])
@@ -164,7 +164,7 @@ class TestSnips(unittest.TestCase):
             fire_mqtt_message(self.hass,
                               'hermes/intent/CallServiceIntent', payload)
             self.hass.block_till_done()
-            self.assertIn("\"sessionId\": \"abcdef1234567890\",
+            self.assertIn("\"sessionId\": \"abcdef1234567890\"",
                           test_handle.output[1])
             self.assertIn("\"text\": \"Service called\"}",
                           test_handle.output[1])

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -129,8 +129,9 @@ class TestSnips(unittest.TestCase):
             fire_mqtt_message(self.hass,
                               'hermes/intent/SetTimer', payload)
             self.hass.block_till_done()
-            self.assertIn("payload={\"sessionId\": \"default\","
-                          " \"text\": \"Timer set 300\"}",
+            self.assertIn("\"sessionId\": \"abcdef1234567890\",
+                          test_handle.output[1])
+            self.assertIn("\"text\": \"Timer set 300\"}",
                           test_handle.output[1])
 
     def test_intent_response(self):
@@ -163,8 +164,9 @@ class TestSnips(unittest.TestCase):
             fire_mqtt_message(self.hass,
                               'hermes/intent/CallServiceIntent', payload)
             self.hass.block_till_done()
-            self.assertIn("payload={\"sessionId\": \"abcdef1234567890\","
-                          " \"text\": \"Service called\"}",
+            self.assertIn("\"sessionId\": \"abcdef1234567890\",
+                          test_handle.output[1])
+            self.assertIn("\"text\": \"Service called\"}",
                           test_handle.output[1])
 
     def test_unknown_intent(self):


### PR DESCRIPTION
## Description:

Split this from the other snips pr which fixes a new custom intentName format from snips console

- Added a response object that posts a tts notification to the snips device if speech is specified in the intent_script and properly ends the snips dialogue
- Added parsing of the snips builtin duration type
- Added tests for unknown intent, snips duration and speech response.

**Related issue (if applicable):** fixes #8582 
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
