### PR TITLE
Home-Assistant NAD Telnet component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -423,6 +423,7 @@ omit =
     homeassistant/components/media_player/mpd.py
     homeassistant/components/media_player/nad.py
     homeassistant/components/media_player/nadtcp.py
+    homeassistant/components/media_player/nadtelnet.py
     homeassistant/components/media_player/onkyo.py
     homeassistant/components/media_player/openhome.py
     homeassistant/components/media_player/panasonic_viera.py

--- a/homeassistant/components/media_player/nadtelnet.py
+++ b/homeassistant/components/media_player/nadtelnet.py
@@ -1,0 +1,158 @@
+"""
+Support for interfacing with NAD receivers through telnet.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.nadtelnet/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.media_player import (
+    SUPPORT_VOLUME_SET,
+    SUPPORT_VOLUME_MUTE, SUPPORT_TURN_ON, SUPPORT_TURN_OFF,
+    SUPPORT_VOLUME_STEP, SUPPORT_SELECT_SOURCE, MediaPlayerDevice,
+    PLATFORM_SCHEMA)
+from homeassistant.const import (
+    CONF_NAME, STATE_OFF, STATE_ON)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['nad_receiver==0.0.9']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'NAD Receiver'
+DEFAULT_MIN_VOLUME = -92
+DEFAULT_MAX_VOLUME = -20
+
+SUPPORT_NAD = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
+    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_VOLUME_STEP | \
+    SUPPORT_SELECT_SOURCE
+
+CONF_NAD_HOST = 'host'
+CONF_MIN_VOLUME = 'min_volume'
+CONF_MAX_VOLUME = 'max_volume'
+CONF_SOURCE_DICT = 'sources'
+
+SOURCE_DICT_SCHEMA = vol.Schema({
+    vol.Range(min=1, max=10): cv.string
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_NAD_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_MIN_VOLUME, default=DEFAULT_MIN_VOLUME): int,
+    vol.Optional(CONF_MAX_VOLUME, default=DEFAULT_MAX_VOLUME): int,
+    vol.Optional(CONF_SOURCE_DICT, default={}): SOURCE_DICT_SCHEMA,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the NAD platform."""
+    from nad_receiver import NADReceiverTelnet
+    add_devices([NADTelnet(
+        config.get(CONF_NAME),
+        NADReceiverTelnet(config.get(CONF_NAD_HOST)),
+        config.get(CONF_MIN_VOLUME),
+        config.get(CONF_MAX_VOLUME),
+        config.get(CONF_SOURCE_DICT)
+    )], True)
+
+
+class NADTelnet(MediaPlayerDevice):
+    """Representation of a NAD Receiver."""
+
+    def __init__(self, name, nad_receiver, min_volume, max_volume,
+                 source_dict):
+        """Initialize the NAD Receiver device."""
+        self._name = name
+        self._nad_receiver = nad_receiver
+        self._min_volume = min_volume
+        self._max_volume = max_volume
+        self._source_dict = source_dict
+        self._reverse_mapping = {value: key for key, value in
+                                 self._source_dict.items()}
+
+        self._volume = self._state = self._mute = self._source = None
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    def update(self):
+        """Retrieve latest state."""
+        if self._nad_receiver.main_power('?') == 'Off':
+            self._state = STATE_OFF
+        else:
+            self._state = STATE_ON
+
+        if self._nad_receiver.main_mute('?') == 'Off':
+            self._mute = False
+        else:
+            self._mute = True
+
+        self._volume = self._nad_receiver.main_volume('?')
+        self._source = self._source_dict.get(
+            self._nad_receiver.main_source('?'))
+
+    @property
+    def volume_level(self):
+        """Volume level of the media player (0..1)."""
+        return self._volume
+
+    @property
+    def is_volume_muted(self):
+        """Boolean if volume is currently muted."""
+        return self._mute
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_NAD
+
+    def turn_off(self):
+        """Turn the media player off."""
+        self._nad_receiver.main_power('=', 'Off')
+
+    def turn_on(self):
+        """Turn the media player on."""
+        self._nad_receiver.main_power('=', 'On')
+
+    def volume_up(self):
+        """Volume up the media player."""
+        self._nad_receiver.main_volume('+')
+
+    def volume_down(self):
+        """Volume down the media player."""
+        self._nad_receiver.main_volume('-')
+
+    def set_volume_level(self, volume):
+        """Set volume level, range 0..1."""
+        self._nad_receiver.main_volume('=', volume)
+
+    def select_source(self, source):
+        """Select input source."""
+        self._nad_receiver.main_source('=', self._reverse_mapping.get(source))
+
+    @property
+    def source(self):
+        """Name of the current input source."""
+        return self._source
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+        return sorted(list(self._reverse_mapping.keys()))
+
+    def mute_volume(self, mute):
+        """Mute (true) or unmute (false) media player."""
+        if mute:
+            self._nad_receiver.main_mute('=', 'On')
+        else:
+            self._nad_receiver.main_mute('=', 'Off')

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -494,6 +494,9 @@ myusps==1.2.2
 # homeassistant.components.media_player.nadtcp
 nad_receiver==0.0.6
 
+# homeassistant.components.media_player.nadtelnet
+nad_receiver==0.0.9
+
 # homeassistant.components.discovery
 netdisco==1.2.3
 


### PR DESCRIPTION
Initial code based on media_player.nad
Tested with NAD T787
Requires nad_receiver 0.0.9

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```
media_player:
  - platform: nadtelnet
    host: my.nad.local
    name: NAD Receiver
    min_volume: -60
    max_volume: -20
    sources:
      1: 'Xbox'
      2: 'TV'
      3: 'Music'
```

## Checklist:
  - [ X ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ X ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ X ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
