### PR TITLE
Fix canary flaky test

### DIFF
--- a/tests/components/sensor/test_canary.py
+++ b/tests/components/sensor/test_canary.py
@@ -1,10 +1,9 @@
 """The tests for the Canary sensor platform."""
 import copy
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock
 
 from canary.api import SensorType
-from homeassistant.components import canary as base_canary
 from homeassistant.components.canary import DATA_CANARY
 from homeassistant.components.sensor import canary
 from homeassistant.components.sensor.canary import CanarySensor
@@ -39,16 +38,13 @@ class TestCanarySensorSetup(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    @patch('homeassistant.components.canary.CanaryData')
-    def test_setup_sensors(self, mock_canary):
+    def test_setup_sensors(self):
         """Test the sensor setup."""
-        base_canary.setup(self.hass, self.config)
-
         online_device_at_home = mock_device(20, "Dining Room", True)
         offline_device_at_home = mock_device(21, "Front Yard", False)
         online_device_at_work = mock_device(22, "Office", True)
 
-        self.hass.data[DATA_CANARY] = mock_canary()
+        self.hass.data[DATA_CANARY] = Mock()
         self.hass.data[DATA_CANARY].locations = [
             mock_location("Home", True, devices=[online_device_at_home,
                                                  offline_device_at_home]),


### PR DESCRIPTION
## Description:
The Canary sensor test was flaky ([example](https://travis-ci.org/home-assistant/home-assistant/jobs/326155185#L914)), causing web requests after Home Assistant stopped, resulting in a timeout. After analyzing the test, it looks like the problem occurred because they would initialize the main component which would fire a discovery event for all other platforms.

After looking at the test code, no logic from the main component was needed and so I replaced it with a mock.

Test also became 0.5s faster 👍 

Before:

```
Results (0.82s):
       8 passed
```

After:

```
Results (0.27s):
       8 passed
```

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
