### PR TITLE
Tado improvements - hot water zone sensors and climate precision

### DIFF
--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/climate.tado/
 """
 import logging
 
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import (PRECISION_TENTHS, TEMP_CELSIUS)
 from homeassistant.components.climate import (
     ClimateDevice, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE)
 from homeassistant.const import ATTR_TEMPERATURE
@@ -191,6 +191,11 @@ class TadoClimate(ClimateDevice):
     def is_away_mode_on(self):
         """Return true if away mode is on."""
         return self._is_away
+
+    @property
+    def target_temperature_step(self):
+        """Return the supported step of target temperature."""
+        return PRECISION_TENTHS
 
     @property
     def target_temperature(self):

--- a/homeassistant/components/sensor/tado.py
+++ b/homeassistant/components/sensor/tado.py
@@ -18,8 +18,10 @@ ATTR_DEVICE = 'device'
 ATTR_NAME = 'name'
 ATTR_ZONE = 'zone'
 
-SENSOR_TYPES = ['temperature', 'humidity', 'power',
-                'link', 'heating', 'tado mode', 'overlay']
+CLIMATE_SENSOR_TYPES = ['temperature', 'humidity', 'power',
+                        'link', 'heating', 'tado mode', 'overlay']
+
+HOT_WATER_SENSOR_TYPES = ['power', 'link', 'tado mode', 'overlay']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -35,10 +37,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     sensor_items = []
     for zone in zones:
         if zone['type'] == 'HEATING':
-            for variable in SENSOR_TYPES:
+            for variable in CLIMATE_SENSOR_TYPES:
                 sensor_items.append(create_zone_sensor(
                     tado, zone, zone['name'], zone['id'],
                     variable))
+        elif zone['type'] == 'HOT_WATER':
+            for variable in HOT_WATER_SENSOR_TYPES:
+                sensor_items.append(create_zone_sensor(
+                    tado, zone, zone['name'], zone['id'],
+                    variable
+                ))
 
     me_data = tado.get_me()
     sensor_items.append(create_device_sensor(


### PR DESCRIPTION
## Description:

- Add appropriate sensors for any Tado hot water zones
- Set the precision on Tado climate device, to match the 0.1 precision available in the Tado app and website


** Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully.