### PR TITLE
Home-Assistant NAD Telnet component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -439,6 +439,7 @@ omit =
     homeassistant/components/media_player/mpd.py
     homeassistant/components/media_player/nad.py
     homeassistant/components/media_player/nadtcp.py
+    homeassistant/components/media_player/nadtelnet.py
     homeassistant/components/media_player/onkyo.py
     homeassistant/components/media_player/openhome.py
     homeassistant/components/media_player/panasonic_viera.py

--- a/homeassistant/components/media_player/nad.py
+++ b/homeassistant/components/media_player/nad.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['nad_receiver==0.0.9']
+REQUIREMENTS = ['nad_receiver==0.0.11']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/nadtcp.py
+++ b/homeassistant/components/media_player/nadtcp.py
@@ -15,7 +15,7 @@ from homeassistant.components.media_player import (
 from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['nad_receiver==0.0.9']
+REQUIREMENTS = ['nad_receiver==0.0.11']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/nadtelnet.py
+++ b/homeassistant/components/media_player/nadtelnet.py
@@ -102,8 +102,9 @@ class NADTelnet(MediaPlayerDevice):
             self._source = self._source_dict.get(
                 self._receiver.main_source('?'))
         except:
+            # Could be that the NAD got turned off
+            self._state = STATE_OFF
             _LOGGER.debug("Communications with NAD failed")
-            pass
 
     @property
     def volume_level(self):
@@ -126,7 +127,6 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_power('=', 'Off')
         except:
             _LOGGER.debug("Communications with NAD failed")
-            pass
 
     def turn_on(self):
         """Turn the media player on."""
@@ -134,7 +134,6 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_power('=', 'On')
         except:
             _LOGGER.debug("Communications with NAD failed")
-            pass
 
     def volume_up(self):
         """Volume up the media player."""
@@ -142,7 +141,6 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_volume('+')
         except:
             _LOGGER.debug("Communications with NAD failed")
-            pass
 
     def volume_down(self):
         """Volume down the media player."""
@@ -150,7 +148,6 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_volume('-')
         except:
             _LOGGER.debug("Communications with NAD failed")
-            pass
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
@@ -158,7 +155,6 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_volume('=', volume)
         except:
             _LOGGER.debug("Communications with NAD failed")
-            pass
 
     def select_source(self, source):
         """Select input source."""
@@ -166,7 +162,6 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_source('=', self._reverse_mapping.get(source))
         except:
             _LOGGER.debug("Communications with NAD failed")
-            pass
 
     @property
     def source(self):
@@ -187,4 +182,3 @@ class NADTelnet(MediaPlayerDevice):
                 self._receiver.main_mute('=', 'Off')
         except:
             _LOGGER.debug("Communications with NAD failed")
-            pass

--- a/homeassistant/components/media_player/nadtelnet.py
+++ b/homeassistant/components/media_player/nadtelnet.py
@@ -127,6 +127,7 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_power('=', 'Off')
         except:
             _LOGGER.debug("Communications with NAD failed")
+            pass
 
     def turn_on(self):
         """Turn the media player on."""
@@ -134,6 +135,7 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_power('=', 'On')
         except:
             _LOGGER.debug("Communications with NAD failed")
+            pass
 
     def volume_up(self):
         """Volume up the media player."""
@@ -141,6 +143,7 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_volume('+')
         except:
             _LOGGER.debug("Communications with NAD failed")
+            pass
 
     def volume_down(self):
         """Volume down the media player."""
@@ -148,6 +151,7 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_volume('-')
         except:
             _LOGGER.debug("Communications with NAD failed")
+            pass
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
@@ -155,6 +159,7 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_volume('=', volume)
         except:
             _LOGGER.debug("Communications with NAD failed")
+            pass
 
     def select_source(self, source):
         """Select input source."""
@@ -162,6 +167,7 @@ class NADTelnet(MediaPlayerDevice):
             self._receiver.main_source('=', self._reverse_mapping.get(source))
         except:
             _LOGGER.debug("Communications with NAD failed")
+            pass
 
     @property
     def source(self):
@@ -182,3 +188,4 @@ class NADTelnet(MediaPlayerDevice):
                 self._receiver.main_mute('=', 'Off')
         except:
             _LOGGER.debug("Communications with NAD failed")
+            pass

--- a/homeassistant/components/media_player/nadtelnet.py
+++ b/homeassistant/components/media_player/nadtelnet.py
@@ -66,7 +66,7 @@ class NADTelnet(MediaPlayerDevice):
                  source_dict):
         """Initialize the NAD Receiver device."""
         self._name = name
-        self._nad_receiver = nad_receiver
+        self._receiver = nad_receiver
         self._min_volume = min_volume
         self._max_volume = max_volume
         self._source_dict = source_dict
@@ -88,19 +88,19 @@ class NADTelnet(MediaPlayerDevice):
     def update(self):
         """Retrieve latest state."""
         try:
-            if self._nad_receiver.main_power('?') == 'Off':
+            if self._receiver.main_power('?') == 'Off':
                 self._state = STATE_OFF
             else:
                 self._state = STATE_ON
 
-            if self._nad_receiver.main_mute('?') == 'Off':
+            if self._receiver.main_mute('?') == 'Off':
                 self._mute = False
             else:
                 self._mute = True
 
-            self._volume = self._nad_receiver.main_volume('?')
+            self._volume = self._receiver.main_volume('?')
             self._source = self._source_dict.get(
-                self._nad_receiver.main_source('?'))
+                self._receiver.main_source('?'))
         except:
             _LOGGER.debug("Communications with NAD failed")
             pass
@@ -123,7 +123,7 @@ class NADTelnet(MediaPlayerDevice):
     def turn_off(self):
         """Turn the media player off."""
         try:
-            self._nad_receiver.main_power('=', 'Off')
+            self._receiver.main_power('=', 'Off')
         except:
             _LOGGER.debug("Communications with NAD failed")
             pass
@@ -131,7 +131,7 @@ class NADTelnet(MediaPlayerDevice):
     def turn_on(self):
         """Turn the media player on."""
         try:
-            self._nad_receiver.main_power('=', 'On')
+            self._receiver.main_power('=', 'On')
         except:
             _LOGGER.debug("Communications with NAD failed")
             pass
@@ -139,7 +139,7 @@ class NADTelnet(MediaPlayerDevice):
     def volume_up(self):
         """Volume up the media player."""
         try:
-            self._nad_receiver.main_volume('+')
+            self._receiver.main_volume('+')
         except:
             _LOGGER.debug("Communications with NAD failed")
             pass
@@ -147,7 +147,7 @@ class NADTelnet(MediaPlayerDevice):
     def volume_down(self):
         """Volume down the media player."""
         try:
-            self._nad_receiver.main_volume('-')
+            self._receiver.main_volume('-')
         except:
             _LOGGER.debug("Communications with NAD failed")
             pass
@@ -155,7 +155,7 @@ class NADTelnet(MediaPlayerDevice):
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         try:
-            self._nad_receiver.main_volume('=', volume)
+            self._receiver.main_volume('=', volume)
         except:
             _LOGGER.debug("Communications with NAD failed")
             pass
@@ -163,7 +163,7 @@ class NADTelnet(MediaPlayerDevice):
     def select_source(self, source):
         """Select input source."""
         try:
-            self._nad_receiver.main_source('=', self._reverse_mapping.get(source))
+            self._receiver.main_source('=', self._reverse_mapping.get(source))
         except:
             _LOGGER.debug("Communications with NAD failed")
             pass
@@ -182,9 +182,9 @@ class NADTelnet(MediaPlayerDevice):
         """Mute (true) or unmute (false) media player."""
         try:
             if mute:
-                self._nad_receiver.main_mute('=', 'On')
+                self._receiver.main_mute('=', 'On')
             else:
-                self._nad_receiver.main_mute('=', 'Off')
+                self._receiver.main_mute('=', 'Off')
         except:
             _LOGGER.debug("Communications with NAD failed")
             pass

--- a/homeassistant/components/media_player/nadtelnet.py
+++ b/homeassistant/components/media_player/nadtelnet.py
@@ -1,0 +1,158 @@
+"""
+Support for interfacing with NAD receivers through telnet.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.nadtelnet/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.media_player import (
+    SUPPORT_VOLUME_SET,
+    SUPPORT_VOLUME_MUTE, SUPPORT_TURN_ON, SUPPORT_TURN_OFF,
+    SUPPORT_VOLUME_STEP, SUPPORT_SELECT_SOURCE, MediaPlayerDevice,
+    PLATFORM_SCHEMA)
+from homeassistant.const import (
+    CONF_NAME, STATE_OFF, STATE_ON)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['nad_receiver==0.0.9']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'NAD Receiver'
+DEFAULT_MIN_VOLUME = -92
+DEFAULT_MAX_VOLUME = -20
+
+SUPPORT_NAD = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
+    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_VOLUME_STEP | \
+    SUPPORT_SELECT_SOURCE
+
+CONF_NAD_HOST = 'host'
+CONF_MIN_VOLUME = 'min_volume'
+CONF_MAX_VOLUME = 'max_volume'
+CONF_SOURCE_DICT = 'sources'
+
+SOURCE_DICT_SCHEMA = vol.Schema({
+    vol.Range(min=1, max=10): cv.string
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_NAD_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_MIN_VOLUME, default=DEFAULT_MIN_VOLUME): int,
+    vol.Optional(CONF_MAX_VOLUME, default=DEFAULT_MAX_VOLUME): int,
+    vol.Optional(CONF_SOURCE_DICT, default={}): SOURCE_DICT_SCHEMA,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the NAD platform."""
+    from nad_receiver import NADReceiverTelnet
+    add_devices([NADTelnet(
+        config.get(CONF_NAME),
+        NADReceiverTelnet(config.get(CONF_NAD_HOST)),
+        config.get(CONF_MIN_VOLUME),
+        config.get(CONF_MAX_VOLUME),
+        config.get(CONF_SOURCE_DICT)
+    )], True)
+
+
+class NADTelnet(MediaPlayerDevice):
+    """Representation of a NAD Receiver."""
+
+    def __init__(self, name, nad_receiver, min_volume, max_volume,
+                 source_dict):
+        """Initialize the NAD Receiver device."""
+        self._name = name
+        self._nad_receiver = nad_receiver
+        self._min_volume = min_volume
+        self._max_volume = max_volume
+        self._source_dict = source_dict
+        self._reverse_mapping = {value: key for key, value in
+                                 self._source_dict.items()}
+
+        self._volume = self._state = self._mute = self._source = None
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    def update(self):
+        """Retrieve latest state."""
+        if self._nad_receiver.main_power('?') == 'Off':
+            self._state = STATE_OFF
+        else:
+            self._state = STATE_ON
+
+        if self._nad_receiver.main_mute('?') == 'Off':
+            self._mute = False
+        else:
+            self._mute = True
+
+        self._volume = self._nad_receiver.main_volume('?')
+        self._source = self._source_dict.get(
+            self._nad_receiver.main_source('?'))
+
+    @property
+    def volume_level(self):
+        """Volume level of the media player (0..1)."""
+        return self._volume
+
+    @property
+    def is_volume_muted(self):
+        """Boolean if volume is currently muted."""
+        return self._mute
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_NAD
+
+    def turn_off(self):
+        """Turn the media player off."""
+        self._nad_receiver.main_power('=', 'Off')
+
+    def turn_on(self):
+        """Turn the media player on."""
+        self._nad_receiver.main_power('=', 'On')
+
+    def volume_up(self):
+        """Volume up the media player."""
+        self._nad_receiver.main_volume('+')
+
+    def volume_down(self):
+        """Volume down the media player."""
+        self._nad_receiver.main_volume('-')
+
+    def set_volume_level(self, volume):
+        """Set volume level, range 0..1."""
+        self._nad_receiver.main_volume('=', volume)
+
+    def select_source(self, source):
+        """Select input source."""
+        self._nad_receiver.main_source('=', self._reverse_mapping.get(source))
+
+    @property
+    def source(self):
+        """Name of the current input source."""
+        return self._source
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+        return sorted(list(self._reverse_mapping.keys()))
+
+    def mute_volume(self, mute):
+        """Mute (true) or unmute (false) media player."""
+        if mute:
+            self._nad_receiver.main_mute('=', 'On')
+        else:
+            self._nad_receiver.main_mute('=', 'Off')

--- a/homeassistant/components/media_player/nadtelnet.py
+++ b/homeassistant/components/media_player/nadtelnet.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['nad_receiver==0.0.9']
+REQUIREMENTS = ['nad_receiver==0.0.11']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,19 +87,23 @@ class NADTelnet(MediaPlayerDevice):
 
     def update(self):
         """Retrieve latest state."""
-        if self._nad_receiver.main_power('?') == 'Off':
-            self._state = STATE_OFF
-        else:
-            self._state = STATE_ON
+        try:
+            if self._nad_receiver.main_power('?') == 'Off':
+                self._state = STATE_OFF
+            else:
+                self._state = STATE_ON
 
-        if self._nad_receiver.main_mute('?') == 'Off':
-            self._mute = False
-        else:
-            self._mute = True
+            if self._nad_receiver.main_mute('?') == 'Off':
+                self._mute = False
+            else:
+                self._mute = True
 
-        self._volume = self._nad_receiver.main_volume('?')
-        self._source = self._source_dict.get(
-            self._nad_receiver.main_source('?'))
+            self._volume = self._nad_receiver.main_volume('?')
+            self._source = self._source_dict.get(
+                self._nad_receiver.main_source('?'))
+        except:
+            _LOGGER.debug("Communications with NAD failed")
+            pass
 
     @property
     def volume_level(self):
@@ -118,27 +122,51 @@ class NADTelnet(MediaPlayerDevice):
 
     def turn_off(self):
         """Turn the media player off."""
-        self._nad_receiver.main_power('=', 'Off')
+        try:
+            self._nad_receiver.main_power('=', 'Off')
+        except:
+            _LOGGER.debug("Communications with NAD failed")
+            pass
 
     def turn_on(self):
         """Turn the media player on."""
-        self._nad_receiver.main_power('=', 'On')
+        try:
+            self._nad_receiver.main_power('=', 'On')
+        except:
+            _LOGGER.debug("Communications with NAD failed")
+            pass
 
     def volume_up(self):
         """Volume up the media player."""
-        self._nad_receiver.main_volume('+')
+        try:
+            self._nad_receiver.main_volume('+')
+        except:
+            _LOGGER.debug("Communications with NAD failed")
+            pass
 
     def volume_down(self):
         """Volume down the media player."""
-        self._nad_receiver.main_volume('-')
+        try:
+            self._nad_receiver.main_volume('-')
+        except:
+            _LOGGER.debug("Communications with NAD failed")
+            pass
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
-        self._nad_receiver.main_volume('=', volume)
+        try:
+            self._nad_receiver.main_volume('=', volume)
+        except:
+            _LOGGER.debug("Communications with NAD failed")
+            pass
 
     def select_source(self, source):
         """Select input source."""
-        self._nad_receiver.main_source('=', self._reverse_mapping.get(source))
+        try:
+            self._nad_receiver.main_source('=', self._reverse_mapping.get(source))
+        except:
+            _LOGGER.debug("Communications with NAD failed")
+            pass
 
     @property
     def source(self):
@@ -152,7 +180,11 @@ class NADTelnet(MediaPlayerDevice):
 
     def mute_volume(self, mute):
         """Mute (true) or unmute (false) media player."""
-        if mute:
-            self._nad_receiver.main_mute('=', 'On')
-        else:
-            self._nad_receiver.main_mute('=', 'Off')
+        try:
+            if mute:
+                self._nad_receiver.main_mute('=', 'On')
+            else:
+                self._nad_receiver.main_mute('=', 'Off')
+        except:
+            _LOGGER.debug("Communications with NAD failed")
+            pass

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -507,6 +507,7 @@ myusps==1.2.2
 
 # homeassistant.components.media_player.nad
 # homeassistant.components.media_player.nadtcp
+# homeassistant.components.media_player.nadtelnet
 nad_receiver==0.0.9
 
 # homeassistant.components.discovery

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -508,7 +508,7 @@ myusps==1.2.2
 # homeassistant.components.media_player.nad
 # homeassistant.components.media_player.nadtcp
 # homeassistant.components.media_player.nadtelnet
-nad_receiver==0.0.9
+nad_receiver==0.0.11
 
 # homeassistant.components.discovery
 netdisco==1.2.4


### PR DESCRIPTION
Initial code based on media_player.nad
Tested with NAD T787
Requires nad_receiver 0.0.9
Upgraded requirments in nad.py and nadtcp.py

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```
media_player:
  - platform: nadtelnet
    host: my.nad.local
    name: NAD Receiver
    min_volume: -60
    max_volume: -20
    sources:
      1: 'Xbox'
      2: 'TV'
      3: 'Music'
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
