### PR TITLE
Reset Wunderground alerts on API update

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -656,7 +656,7 @@ class WUndergroundSensor(Entity):
         self.rest = rest
         self._condition = condition
         self._state = None
-        self._attributes = self._init_attrs()
+        self._attributes = self._init_attrs
         self._icon = None
         self._entity_picture = None
         self._unit_of_measurement = self._cfg_expand("unit_of_measurement")
@@ -678,7 +678,8 @@ class WUndergroundSensor(Entity):
 
         return val
 
-    def _init_attrs(self):
+    @staticmethod
+    def _init_attrs():
         return {
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
         }
@@ -687,7 +688,7 @@ class WUndergroundSensor(Entity):
         """Parse and update device state attributes."""
         attrs = self._cfg_expand("device_state_attributes", {})
 
-        self._attributes = self._init_attrs()
+        self._attributes = self._init_attrs
         self._attributes[ATTR_FRIENDLY_NAME] = self._cfg_expand(
             "friendly_name")
 

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -656,7 +656,7 @@ class WUndergroundSensor(Entity):
         self.rest = rest
         self._condition = condition
         self._state = None
-        self._attributes = self._init_attrs
+        self._attributes = self._init_attrs()
         self._icon = None
         self._entity_picture = None
         self._unit_of_measurement = self._cfg_expand("unit_of_measurement")
@@ -688,7 +688,7 @@ class WUndergroundSensor(Entity):
         """Parse and update device state attributes."""
         attrs = self._cfg_expand("device_state_attributes", {})
 
-        self._attributes = self._init_attrs
+        self._attributes = self._init_attrs()
         self._attributes[ATTR_FRIENDLY_NAME] = self._cfg_expand(
             "friendly_name")
 

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -656,9 +656,7 @@ class WUndergroundSensor(Entity):
         self.rest = rest
         self._condition = condition
         self._state = None
-        self._attributes = {
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-        }
+        self._attributes = self._init_attrs()
         self._icon = None
         self._entity_picture = None
         self._unit_of_measurement = self._cfg_expand("unit_of_measurement")
@@ -680,10 +678,16 @@ class WUndergroundSensor(Entity):
 
         return val
 
+    def _init_attrs(self):
+        return {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+        }
+
     def _update_attrs(self):
         """Parse and update device state attributes."""
         attrs = self._cfg_expand("device_state_attributes", {})
 
+        self._attributes = self._init_attrs()
         self._attributes[ATTR_FRIENDLY_NAME] = self._cfg_expand(
             "friendly_name")
 

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -212,6 +212,7 @@ def mocked_requests_get_invalid(*args, **kwargs):
 
 MOCKED_ALERTS_CALLED = 0
 
+
 def mocked_requests_get_alerts(*args, **kwargs):
     """Mock requests.get invocations."""
     class MockResponse:
@@ -374,6 +375,11 @@ class TestWundergroundSetup(unittest.TestCase):
             device.update()
             device.update()
             self.assertEqual(1, device.state)
-            self.assertEqual(ALERT_MESSAGE, device.device_state_attributes['Message'])
-            self.assertIsNone(device.device_state_attributes.get("Message_FLO"))
-            self.assertIsNone(device.device_state_attributes.get("Message_WND"))
+            self.assertEqual(ALERT_MESSAGE,
+                             device.device_state_attributes['Message'])
+            self.assertIsNone(device
+                              .device_state_attributes
+                              .get("Message_FLO"))
+            self.assertIsNone(device
+                              .device_state_attributes
+                              .get("Message_WND"))

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -370,9 +370,9 @@ class TestWundergroundSetup(unittest.TestCase):
     @unittest.mock.patch('requests.get',
                          side_effect=mocked_requests_get_alerts)
     @unittest.mock.patch('wunderground.WUndergroundData.update',
-                         side_effect=
-                         partial(wundergroundWUndergroundData.update,
-                                 no_throttle=True))
+                         side_effect=partial(
+                             wunderground.WUndergroundData.update,
+                             no_throttle=True))
     def test_alert_data(self, req_mock):
         """Test the WUnderground invalid data."""
         wunderground.setup_platform(self.hass, VALID_CONFIG_ALERT,

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -374,7 +374,7 @@ class TestWundergroundSetup(unittest.TestCase):
         side_effect=partial(
             wunderground.WUndergroundData.update,
             no_throttle=True))
-    def test_alert_data(self, req_mock):
+    def test_alert_data(self, req_mock, upd_mock):
         """Test the WUnderground invalid data."""
         wunderground.setup_platform(self.hass, VALID_CONFIG_ALERT,
                                     self.add_devices, None)

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -9,6 +9,8 @@ from requests.exceptions import ConnectionError
 
 from tests.common import get_test_home_assistant
 
+from functools import partial
+
 VALID_CONFIG_PWS = {
     'platform': 'wunderground',
     'api_key': 'foo',
@@ -367,6 +369,10 @@ class TestWundergroundSetup(unittest.TestCase):
 
     @unittest.mock.patch('requests.get',
                          side_effect=mocked_requests_get_alerts)
+    @unittest.mock.patch('wunderground.WUndergroundData.update',
+                         side_effect=
+                         partial(wundergroundWUndergroundData.update,
+                                 no_throttle=True))
     def test_alert_data(self, req_mock):
         """Test the WUnderground invalid data."""
         wunderground.setup_platform(self.hass, VALID_CONFIG_ALERT,

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -372,8 +372,8 @@ class TestWundergroundSetup(unittest.TestCase):
         wunderground.setup_platform(self.hass, VALID_CONFIG_ALERT,
                                     self.add_devices, None)
         for device in self.DEVICES:
-            device.update()
-            device.update()
+            device.update(no_throttle=True)
+            device.update(no_throttle=True)
             self.assertEqual(1, device.state)
             self.assertEqual(ALERT_MESSAGE,
                              device.device_state_attributes['Message'])

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -369,10 +369,11 @@ class TestWundergroundSetup(unittest.TestCase):
 
     @unittest.mock.patch('requests.get',
                          side_effect=mocked_requests_get_alerts)
-    @unittest.mock.patch('wunderground.WUndergroundData.update',
-                         side_effect=partial(
-                             wunderground.WUndergroundData.update,
-                             no_throttle=True))
+    @unittest.mock.patch(
+        'homeassistant.components.sensor.wunderground.WUndergroundData.update',
+        side_effect=partial(
+            wunderground.WUndergroundData.update,
+            no_throttle=True))
     def test_alert_data(self, req_mock):
         """Test the WUnderground invalid data."""
         wunderground.setup_platform(self.hass, VALID_CONFIG_ALERT,

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -372,8 +372,8 @@ class TestWundergroundSetup(unittest.TestCase):
         wunderground.setup_platform(self.hass, VALID_CONFIG_ALERT,
                                     self.add_devices, None)
         for device in self.DEVICES:
-            device.update(no_throttle=True)
-            device.update(no_throttle=True)
+            device.update()
+            device.update()
             self.assertEqual(1, device.state)
             self.assertEqual(ALERT_MESSAGE,
                              device.device_state_attributes['Message'])


### PR DESCRIPTION
## Description:
The wunderground web service may return multiple alerts if they are applicable. In that case, each of the sensor attributes is suffixed with the warning type. But since the attribute list is never re-initialized, values that disappear never get removed from the list.

This PR fixes the issue by re-initializing the sensor attribute dictionary for every API call. This is no problem because we never get differential updates. Instead, weather data is always returned completely.

*Notes*:
1. I added a test for this new feature. However, I don't know how to disable the `Throttle` in https://github.com/keneanung/home-assistant/blob/abebfbe554f7f236b63ae6ebcf9379a575b7d626/homeassistant/components/sensor/wunderground.py#L780 for the tests. It worked locally because I removed the line completely when developing the test. Can you advice what to do?
2. ~~I will take care of the code style issues soon. I wanted to get the PR in to get a comment on the first point above.~~ Done

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
  