### PR TITLE
Binary Sensor Template: Add icon_template and entity_picture_template support

### DIFF
--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -75,7 +75,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         sensors.append(
             BinarySensorTemplate(
                 hass, device, friendly_name, device_class, value_template,
-                icon_template, entity_picture_template, entity_ids, delay_on, delay_off)
+                icon_template, entity_picture_template, entity_ids,
+                delay_on, delay_off)
             )
     if not sensors:
         _LOGGER.error("No sensors added")
@@ -89,7 +90,8 @@ class BinarySensorTemplate(BinarySensorDevice):
     """A virtual binary sensor that triggers from another sensor."""
 
     def __init__(self, hass, device, friendly_name, device_class,
-                 value_template, icon_template, entity_picture_template, entity_ids, delay_on, delay_off):
+                 value_template, icon_template, entity_picture_template, entity_ids,
+                 delay_on, delay_off):
         """Initialize the Template binary sensor."""
         self.hass = hass
         self.entity_id = async_generate_entity_id(
@@ -197,7 +199,6 @@ class BinarySensorTemplate(BinarySensorDevice):
                     return
         return state
 
-            
     @callback
     def async_check_state(self):
         """Update the state from the template."""

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -15,6 +15,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA)
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_ENTITY_ID, CONF_VALUE_TEMPLATE,
+    CONF_ICON_TEMPLATE, CONF_ENTITY_PICTURE_TEMPLATE,
     CONF_SENSORS, CONF_DEVICE_CLASS, EVENT_HOMEASSISTANT_START)
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
@@ -29,6 +30,8 @@ CONF_DELAY_OFF = 'delay_off'
 
 SENSOR_SCHEMA = vol.Schema({
     vol.Required(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_ICON_TEMPLATE): cv.template,
+    vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
     vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
@@ -50,6 +53,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     for device, device_config in config[CONF_SENSORS].items():
         value_template = device_config[CONF_VALUE_TEMPLATE]
+        icon_template = device_config.get(CONF_ICON_TEMPLATE)
+        entity_picture_template = device_config.get(
+            CONF_ENTITY_PICTURE_TEMPLATE)
         entity_ids = (device_config.get(ATTR_ENTITY_ID) or
                       value_template.extract_entities())
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
@@ -60,10 +66,16 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         if value_template is not None:
             value_template.hass = hass
 
+        if icon_template is not None:
+            icon_template.hass = hass
+
+        if entity_picture_template is not None:
+            entity_picture_template.hass = hass
+
         sensors.append(
             BinarySensorTemplate(
                 hass, device, friendly_name, device_class, value_template,
-                entity_ids, delay_on, delay_off)
+                icon_template, entity_picture_template, entity_ids, delay_on, delay_off)
             )
     if not sensors:
         _LOGGER.error("No sensors added")
@@ -77,7 +89,7 @@ class BinarySensorTemplate(BinarySensorDevice):
     """A virtual binary sensor that triggers from another sensor."""
 
     def __init__(self, hass, device, friendly_name, device_class,
-                 value_template, entity_ids, delay_on, delay_off):
+                 value_template, icon_template, entity_picture_template, entity_ids, delay_on, delay_off):
         """Initialize the Template binary sensor."""
         self.hass = hass
         self.entity_id = async_generate_entity_id(
@@ -86,6 +98,10 @@ class BinarySensorTemplate(BinarySensorDevice):
         self._device_class = device_class
         self._template = value_template
         self._state = None
+        self._icon_template = icon_template
+        self._entity_picture_template = entity_picture_template
+        self._icon = None
+        self._entity_picture = None
         self._entities = entity_ids
         self._delay_on = delay_on
         self._delay_off = delay_off
@@ -115,6 +131,16 @@ class BinarySensorTemplate(BinarySensorDevice):
         return self._name
 
     @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def entity_picture(self):
+        """Return the entity_picture to use in the frontend, if any."""
+        return self._entity_picture
+
+    @property
     def is_on(self):
         """Return true if sensor is on."""
         return self._state
@@ -132,8 +158,9 @@ class BinarySensorTemplate(BinarySensorDevice):
     @callback
     def _async_render(self):
         """Get the state of template."""
+        state = None
         try:
-            return self._template.async_render().lower() == 'true'
+            state = (self._template.async_render().lower() == 'true')
         except TemplateError as ex:
             if ex.args and ex.args[0].startswith(
                     "UndefinedError: 'None' has no attribute"):
@@ -143,6 +170,34 @@ class BinarySensorTemplate(BinarySensorDevice):
                 return
             _LOGGER.error("Could not render template %s: %s", self._name, ex)
 
+        for property_name, template in (
+                ('_icon', self._icon_template),
+                ('_entity_picture', self._entity_picture_template)):
+            if template is None:
+                continue
+
+            try:
+                setattr(self, property_name, template.async_render())
+            except TemplateError as ex:
+                friendly_property_name = property_name[1:].replace('_', ' ')
+                if ex.args and ex.args[0].startswith(
+                        "UndefinedError: 'None' has no attribute"):
+                    # Common during HA startup - so just a warning
+                    _LOGGER.warning('Could not render %s template %s,'
+                                    ' the state is unknown.',
+                                    friendly_property_name, self._name)
+                    return
+
+                try:
+                    setattr(self, property_name,
+                            getattr(super(), property_name))
+                except AttributeError:
+                    _LOGGER.error('Could not render %s template %s: %s',
+                                  friendly_property_name, self._name, ex)
+                    return
+        return state
+
+            
     @callback
     def async_check_state(self):
         """Update the state from the template."""

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -107,7 +107,7 @@ class BinarySensorTemplate(BinarySensorDevice):
         self._entities = entity_ids
         self._delay_on = delay_on
         self._delay_off = delay_off
-        
+
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Register callbacks."""

--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -90,8 +90,8 @@ class BinarySensorTemplate(BinarySensorDevice):
     """A virtual binary sensor that triggers from another sensor."""
 
     def __init__(self, hass, device, friendly_name, device_class,
-                 value_template, icon_template, entity_picture_template, entity_ids,
-                 delay_on, delay_off):
+                 value_template, icon_template, entity_picture_template,
+                 entity_ids, delay_on, delay_off):
         """Initialize the Template binary sensor."""
         self.hass = hass
         self.entity_id = async_generate_entity_id(
@@ -107,7 +107,7 @@ class BinarySensorTemplate(BinarySensorDevice):
         self._entities = entity_ids
         self._delay_on = delay_on
         self._delay_off = delay_off
-
+        
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Register callbacks."""

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -108,10 +108,10 @@ class TestBinarySensorTemplate(unittest.TestCase):
                         'test_template_sensor': {
                             'value_template': "State",
                             'icon_template':
-                                "{% if states.binary_sensor.test_state.state == "
-                                "'Works' %}"
-                                "mdi:check"
-                                "{% endif %}"
+                              "{% if states.binary_sensor.test_state.state == "
+                              "'Works' %}"
+                              "mdi:check"
+                              "{% endif %}"
                         }
                     }
                 }
@@ -138,10 +138,10 @@ class TestBinarySensorTemplate(unittest.TestCase):
                         'test_template_sensor': {
                             'value_template': "State",
                             'entity_picture_template':
-                                "{% if states.binary_sensor.test_state.state == "
-                                "'Works' %}"
-                                "/local/sensor.png"
-                                "{% endif %}"
+                              "{% if states.binary_sensor.test_state.state == "
+                              "'Works' %}"
+                              "/local/sensor.png"
+                              "{% endif %}"
                         }
                     }
                 }

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -108,10 +108,11 @@ class TestBinarySensorTemplate(unittest.TestCase):
                         'test_template_sensor': {
                             'value_template': "State",
                             'icon_template':
-                              "{% if states.binary_sensor.test_state.state == "
-                              "'Works' %}"
-                              "mdi:check"
-                              "{% endif %}"
+                                "{% if "
+                                "states.binary_sensor.test_state.state == "
+                                "'Works' %}"
+                                "mdi:check"
+                                "{% endif %}"
                         }
                     }
                 }
@@ -138,10 +139,11 @@ class TestBinarySensorTemplate(unittest.TestCase):
                         'test_template_sensor': {
                             'value_template': "State",
                             'entity_picture_template':
-                              "{% if states.binary_sensor.test_state.state == "
-                              "'Works' %}"
-                              "/local/sensor.png"
-                              "{% endif %}"
+                                "{% if "
+                                "states.binary_sensor.test_state.state == "
+                                "'Works' %}"
+                                "/local/sensor.png"
+                                "{% endif %}"
                         }
                     }
                 }

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -98,13 +98,73 @@ class TestBinarySensorTemplate(unittest.TestCase):
                 }
             })
 
+    def test_icon_template(self):
+        """Test icon template."""
+        with assert_setup_component(1):
+            assert setup.setup_component(self.hass, 'binary_sensor', {
+                'binary_sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test_template_sensor': {
+                            'value_template': "State",
+                            'icon_template':
+                                "{% if states.binary_sensor.test_state.state == "
+                                "'Works' %}"
+                                "mdi:check"
+                                "{% endif %}"
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_template_sensor')
+        assert state.attributes.get('icon') == ''
+
+        self.hass.states.set('binary_sensor.test_state', 'Works')
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.test_template_sensor')
+        assert state.attributes['icon'] == 'mdi:check'
+
+    def test_entity_picture_template(self):
+        """Test entity_picture template."""
+        with assert_setup_component(1):
+            assert setup.setup_component(self.hass, 'binary_sensor', {
+                'binary_sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test_template_sensor': {
+                            'value_template': "State",
+                            'entity_picture_template':
+                                "{% if states.binary_sensor.test_state.state == "
+                                "'Works' %}"
+                                "/local/sensor.png"
+                                "{% endif %}"
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_template_sensor')
+        assert state.attributes.get('entity_picture') == ''
+
+        self.hass.states.set('binary_sensor.test_state', 'Works')
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.test_template_sensor')
+        assert state.attributes['entity_picture'] == '/local/sensor.png'
+
     def test_attributes(self):
         """"Test the attributes."""
         vs = run_callback_threadsafe(
             self.hass.loop, template.BinarySensorTemplate,
             self.hass, 'parent', 'Parent', 'motion',
-            template_hlpr.Template('{{ 1 > 1 }}', self.hass), MATCH_ALL,
-            None, None
+            template_hlpr.Template('{{ 1 > 1 }}', self.hass),
+            None, None, MATCH_ALL, None, None
         ).result()
         self.assertFalse(vs.should_poll)
         self.assertEqual('motion', vs.device_class)
@@ -156,8 +216,8 @@ class TestBinarySensorTemplate(unittest.TestCase):
         vs = run_callback_threadsafe(
             self.hass.loop, template.BinarySensorTemplate,
             self.hass, 'parent', 'Parent', 'motion',
-            template_hlpr.Template('{{ 1 > 1 }}', self.hass), MATCH_ALL,
-            None, None
+            template_hlpr.Template('{{ 1 > 1 }}', self.hass),
+            None, None, MATCH_ALL, None, None
         ).result()
         mock_render.side_effect = TemplateError('foo')
         run_callback_threadsafe(self.hass.loop, vs.async_check_state).result()


### PR DESCRIPTION
## Description:

Add support for icon_template and entity_picture_template support.  Code was pulled from sensor.template and tweak to make work.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4373

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: template
    sensors:
      alarm_chime:
        friendly_name: 'Alarm Chime'
        value_template: "{{ is_state_attr('alarm_control_panel.alarm_panel', 'chime', true) }}"
        icon_template: >-
            {% if is_state_attr('alarm_control_panel.alarm_panel', 'chime', true) %}
              mdi:bell-ring
            {% else %}
              mdi:bell-off
            {% endif %}
```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
  