### PR TITLE
Upgrade keyring to 10.3.2

### DIFF
--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -1,11 +1,11 @@
-"""Script to get, set, and delete secrets stored in the keyring."""
-import os
+"""Script to get, set and delete secrets stored in the keyring."""
 import argparse
 import getpass
+import os
 
 from homeassistant.util.yaml import _SECRET_NAMESPACE
 
-REQUIREMENTS = ['keyring>=9.3,<10.0']
+REQUIREMENTS = ['keyring==10.3.2', 'keyrings.alt==2.3']
 
 
 def run(args):
@@ -39,8 +39,8 @@ def run(args):
         return 1
 
     if args.action == 'set':
-        the_secret = getpass.getpass('Please enter the secret for {}: '
-                                     .format(args.name))
+        the_secret = getpass.getpass(
+            'Please enter the secret for {}: '.format(args.name))
         keyring.set_password(_SECRET_NAMESPACE, args.name, the_secret)
         print('Secret {} set successfully'.format(args.name))
     elif args.action == 'get':

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -416,7 +416,10 @@ jsonrpc-async==0.6
 jsonrpc-websocket==0.5
 
 # homeassistant.scripts.keyring
-keyring>=9.3,<10.0
+keyring==10.3.2
+
+# homeassistant.scripts.keyring
+keyrings.alt==2.3
 
 # homeassistant.components.device_tracker.owntracks
 # homeassistant.components.device_tracker.owntracks_http


### PR DESCRIPTION
## Description:
Somewhere around 10.x.x of `keyring` it became necessary to add `keyrings.alt` because some keyring backends (especially `file`) were outsourced.

Full changelog: https://github.com/jaraco/keyring/blob/master/CHANGES.rst

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
  api_password: !secret http_password
```

```bash
$ hass --script keyring set http_password
Please enter the secret for http_password: 
Please set a password for your new keyring: 
Please confirm the password: 
Secret http_password set successfully

$ hass --script keyring info
Keyring version 10.3.2

Active keyring  : keyrings.alt.file
Config location : /home/fab/.local/share/python_keyring/keyringrc.cfg
Data location   : /home/fab/.local/share/python_keyring

(home-assistant) [fab@localhost home-assistant]$ hass
Config directory: /home/fab/.homeassistant
Please enter password for encrypted keyring: 
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
