### PR TITLE
Fix Tahoma cover stop command

### DIFF
--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -73,4 +73,4 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
-        self.apply_action('stopIdentify')
+        self.apply_action('my')


### PR DESCRIPTION
## Description:
Using the stop button for a Tahoma Cover currently does nothing. This fixes that. According to the API this is the command that stops a cover. The 'my' button is also the button on the remotes that stop the covers.

## Checklist:
  - [x] The code change is tested and works locally.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
