### PR TITLE
Hyperion: Add brightness, HDMI and effect support

### DIFF
--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -11,7 +11,8 @@ import socket
 import voluptuous as vol
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_EFFECT, SUPPORT_BRIGHTNESS, SUPPORT_RGB_COLOR, SUPPORT_EFFECT, Light, PLATFORM_SCHEMA)
+    ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_EFFECT, SUPPORT_BRIGHTNESS,
+    SUPPORT_RGB_COLOR, SUPPORT_EFFECT, Light, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
@@ -27,7 +28,14 @@ DEFAULT_NAME = 'Hyperion'
 DEFAULT_PORT = 19444
 DEFAULT_PRIORITY = 128
 DEFAULT_HDMI_PRIORITY = 880
-DEFAULT_EFFECT_LIST = ['HDMI', 'Cinema brighten lights', 'Cinema dim lights', 'Knight rider', 'Blue mood blobs', 'Cold mood blobs', 'Full color mood blobs', 'Green mood blobs', 'Red mood blobs', 'Warm mood blobs', 'Police Lights Single', 'Police Lights Solid', 'Rainbow mood', 'Rainbow swirl fast', 'Rainbow swirl', 'Random', 'Running dots', 'System Shutdown', 'Snake', 'Sparks Color', 'Sparks', 'Strobe blue', 'Strobe Raspbmc', 'Strobe white', 'Color traces', 'UDP multicast listener', 'UDP listener', 'X-Mas']
+DEFAULT_EFFECT_LIST = ['HDMI', 'Cinema brighten lights', 'Cinema dim lights',
+    'Knight rider', 'Blue mood blobs', 'Cold mood blobs',
+    'Full color mood blobs', 'Green mood blobs', 'Red mood blobs',
+    'Warm mood blobs', 'Police Lights Single', 'Police Lights Solid',
+    'Rainbow mood', 'Rainbow swirl fast', 'Rainbow swirl', 'Random',
+    'Running dots', 'System Shutdown', 'Snake', 'Sparks Color', 'Sparks',
+    'Strobe blue', 'Strobe Raspbmc', 'Strobe white', 'Color traces',
+    'UDP multicast listener', 'UDP listener', 'X-Mas']
 
 SUPPORT_HYPERION = (SUPPORT_RGB_COLOR | SUPPORT_BRIGHTNESS | SUPPORT_EFFECT)
 
@@ -39,8 +47,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
             [vol.All(vol.Coerce(int), vol.Range(min=0, max=255))]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PRIORITY, default=DEFAULT_PRIORITY): cv.positive_int,
-    vol.Optional(CONF_HDMI_PRIORITY, default=DEFAULT_HDMI_PRIORITY): cv.positive_int,
-    vol.Optional(CONF_EFFECT_LIST, default=DEFAULT_EFFECT_LIST): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_HDMI_PRIORITY,
+            default=DEFAULT_HDMI_PRIORITY): cv.positive_int,
+    vol.Optional(CONF_EFFECT_LIST,
+            default=DEFAULT_EFFECT_LIST): vol.All(cv.ensure_list, [cv.string]),
 })
 
 
@@ -65,7 +75,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class Hyperion(Light):
     """Representation of a Hyperion remote."""
 
-    def __init__(self, name, host, port, priority, default_color, hdmi_priority, effect_list):
+    def __init__(self, name, host, port, priority, default_color,
+        hdmi_priority, effect_list):
         """Initialize the light."""
         self._host = host
         self._port = port
@@ -150,11 +161,12 @@ class Hyperion(Light):
                     'effect': {'name': self._effect}
                 })
                 self._icon = 'mdi:lava-lamp'
-                self._rgb_color = [175,0,255]
+                self._rgb_color = [175, 0, 255]
                 self._skip_check = True
             return
 
-        cal_color = [int(round(x*float(self._brightness)/255)) for x in self._rgb_color]
+        cal_color = [int(round(x*float(self._brightness)/255))
+            for x in self._rgb_color]
         self.json_request({
             'command': 'color',
             'priority': self._priority,
@@ -174,7 +186,7 @@ class Hyperion(Light):
     def update(self):
         """Get the lights status."""
         # postpone the immediate state check for changes that take time
-        if self._skip_check == True:
+        if self._skip_check:
             self._skip_check = False
             return
         response = self.json_request({'command': 'serverinfo'})
@@ -189,7 +201,8 @@ class Hyperion(Light):
                 return
             # Check if Hyperion is in ambilight mode trough an HDMI grabber
             try:
-                if (response['info']['priorities'][0]['priority']) == self._hdmi_priority:
+                active_priority = response['info']['priorities'][0]['priority']
+                if active_priority == self._hdmi_priority:
                     self._brightness = 255
                     self._rgb_color = [125, 125, 125]
                     self._icon = 'mdi:video-input-hdmi'
@@ -197,16 +210,17 @@ class Hyperion(Light):
                     return
             except:
                 pass
-            
+
             if response['info']['activeLedColor'] == []:
                 # Get the active effect
                 if response['info']['activeEffects'] != []:
-                    self._rgb_color = [175,0,255]
+                    self._rgb_color = [175, 0, 255]
                     self._icon = 'mdi:lava-lamp'
                     try:
-                        effect_script = response['info']['activeEffects'][0]["script"]
-                        effect_script = effect_script.split('/')[-1][:-3].split("-")[0]
-                        self._effect = [x for x in self._effect_list if (effect_script.lower() in x.lower())][0]
+                        A = response['info']['activeEffects'][0]["script"]
+                        A = A.split('/')[-1][:-3].split("-")[0]
+                        self._effect = [x for x in self._effect_list
+                            if (effect_script.lower() in x.lower())][0]
                     except:
                         self._effect = 'none'
                 # Bulb off state
@@ -219,7 +233,8 @@ class Hyperion(Light):
                 self._rgb_color =\
                     response['info']['activeLedColor'][0]['RGB Value']
                 self._brightness = max(self._rgb_color)
-                self._rgb_mem = [int(round(float(x)*255/self._brightness)) for x in self._rgb_color]
+                self._rgb_mem = [int(round(float(x)*255/self._brightness))
+                    for x in self._rgb_color]
                 self._icon = 'mdi:lightbulb'
                 self._effect = 'none'
 

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -212,7 +212,7 @@ class Hyperion(Light):
                     self._icon = 'mdi:video-input-hdmi'
                     self._effect = 'HDMI'
                     return
-            except:
+            except (KeyError, IndexError):
                 pass
 
             if response['info']['activeLedColor'] == []:
@@ -224,8 +224,8 @@ class Hyperion(Light):
                         s_name = response['info']['activeEffects'][0]["script"]
                         s_name = s_name.split('/')[-1][:-3].split("-")[0]
                         self._effect = [x for x in self._effect_list
-                                        if (s_name.lower() in x.lower())][0]
-                    except:
+                                        if s_name.lower() in x.lower()][0]
+                    except (KeyError, IndexError):
                         self._effect = 'none'
                 # Bulb off state
                 else:

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -211,9 +211,9 @@ class Hyperion(Light):
             except (KeyError, IndexError):
                 pass
 
-            if response['info']['activeLedColor'] == []:
+            if not response['info']['activeLedColor']:
                 # Get the active effect
-                if response['info']['activeEffects'] != []:
+                if response['info']['activeEffects']:
                     self._rgb_color = [175, 0, 255]
                     self._icon = 'mdi:lava-lamp'
                     try:

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -29,16 +29,16 @@ DEFAULT_PORT = 19444
 DEFAULT_PRIORITY = 128
 DEFAULT_HDMI_PRIORITY = 880
 DEFAULT_EFFECT_LIST = ['HDMI', 'Cinema brighten lights', 'Cinema dim lights',
-                    'Knight rider', 'Blue mood blobs', 'Cold mood blobs',
-                    'Full color mood blobs', 'Green mood blobs',
-                    'Red mood blobs', 'Warm mood blobs',
-                    'Police Lights Single', 'Police Lights Solid',
-                    'Rainbow mood', 'Rainbow swirl fast',
-                    'Rainbow swirl', 'Random', 'Running dots',
-                    'System Shutdown', 'Snake', 'Sparks Color', 'Sparks',
-                    'Strobe blue', 'Strobe Raspbmc', 'Strobe white',
-                    'Color traces', 'UDP multicast listener',
-                    'UDP listener', 'X-Mas']
+                       'Knight rider', 'Blue mood blobs', 'Cold mood blobs',
+                       'Full color mood blobs', 'Green mood blobs',
+                       'Red mood blobs', 'Warm mood blobs',
+                       'Police Lights Single', 'Police Lights Solid',
+                       'Rainbow mood', 'Rainbow swirl fast',
+                       'Rainbow swirl', 'Random', 'Running dots',
+                       'System Shutdown', 'Snake', 'Sparks Color', 'Sparks',
+                       'Strobe blue', 'Strobe Raspbmc', 'Strobe white',
+                       'Color traces', 'UDP multicast listener',
+                       'UDP listener', 'X-Mas']
 
 SUPPORT_HYPERION = (SUPPORT_RGB_COLOR | SUPPORT_BRIGHTNESS | SUPPORT_EFFECT)
 
@@ -51,10 +51,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PRIORITY, default=DEFAULT_PRIORITY): cv.positive_int,
     vol.Optional(CONF_HDMI_PRIORITY,
-                default=DEFAULT_HDMI_PRIORITY): cv.positive_int,
+                 default=DEFAULT_HDMI_PRIORITY): cv.positive_int,
     vol.Optional(CONF_EFFECT_LIST,
-                default=DEFAULT_EFFECT_LIST): vol.All(cv.ensure_list,
-                                                    [cv.string]),
+                 default=DEFAULT_EFFECT_LIST): vol.All(cv.ensure_list,
+                                                       [cv.string]),
 })
 
 
@@ -80,7 +80,7 @@ class Hyperion(Light):
     """Representation of a Hyperion remote."""
 
     def __init__(self, name, host, port, priority, default_color,
-                hdmi_priority, effect_list):
+                 hdmi_priority, effect_list):
         """Initialize the light."""
         self._host = host
         self._port = port
@@ -170,7 +170,7 @@ class Hyperion(Light):
             return
 
         cal_color = [int(round(x*float(self._brightness)/255))
-                    for x in self._rgb_color]
+                     for x in self._rgb_color]
         self.json_request({
             'command': 'color',
             'priority': self._priority,
@@ -238,7 +238,7 @@ class Hyperion(Light):
                     response['info']['activeLedColor'][0]['RGB Value']
                 self._brightness = max(self._rgb_color)
                 self._rgb_mem = [int(round(float(x)*255/self._brightness))
-                                for x in self._rgb_color]
+                                 for x in self._rgb_color]
                 self._icon = 'mdi:lightbulb'
                 self._effect = 'none'
 

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -150,7 +150,7 @@ class Hyperion(Light):
 
         if ATTR_EFFECT in kwargs:
             self._skip_check = True
-			self._effect = kwargs[ATTR_EFFECT]
+            self._effect = kwargs[ATTR_EFFECT]
             if self._effect == 'HDMI':
                 self.json_request({'command': 'clearall'})
                 self._icon = 'mdi:video-input-hdmi'

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -221,10 +221,10 @@ class Hyperion(Light):
                     self._rgb_color = [175, 0, 255]
                     self._icon = 'mdi:lava-lamp'
                     try:
-                        A = response['info']['activeEffects'][0]["script"]
-                        A = A.split('/')[-1][:-3].split("-")[0]
+                        s_name = response['info']['activeEffects'][0]["script"]
+                        s_name = s_name.split('/')[-1][:-3].split("-")[0]
                         self._effect = [x for x in self._effect_list
-                                        if (A.lower() in x.lower())][0]
+                                        if (s_name.lower() in x.lower())][0]
                     except:
                         self._effect = 'none'
                 # Bulb off state

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -139,25 +139,23 @@ class Hyperion(Light):
     def turn_on(self, **kwargs):
         """Turn the lights on."""
         if ATTR_RGB_COLOR in kwargs:
-            self._rgb_color = kwargs[ATTR_RGB_COLOR]
-            self._rgb_mem = kwargs[ATTR_RGB_COLOR]
+            rgb_color = kwargs[ATTR_RGB_COLOR]
         elif self._rgb_mem == [0, 0, 0]:
-            self._rgb_color = self._default_color
-            self._rgb_mem = self._default_color
+            rgb_color = self._default_color
         else:
-            self._rgb_color = self._rgb_mem
+            rgb_color = self._rgb_mem
 
         if ATTR_BRIGHTNESS in kwargs:
-            self._brightness = kwargs[ATTR_BRIGHTNESS]
+            brightness = kwargs[ATTR_BRIGHTNESS]
 
         if ATTR_EFFECT in kwargs:
-            self._effect = kwargs[ATTR_EFFECT]
+            self._skip_check = True
+			self._effect = kwargs[ATTR_EFFECT]
             if self._effect == 'HDMI':
                 self.json_request({'command': 'clearall'})
                 self._icon = 'mdi:video-input-hdmi'
                 self._brightness = 255
                 self._rgb_color = [125, 125, 125]
-                self._skip_check = True
             else:
                 self.json_request({
                     'command': 'effect',
@@ -166,11 +164,10 @@ class Hyperion(Light):
                 })
                 self._icon = 'mdi:lava-lamp'
                 self._rgb_color = [175, 0, 255]
-                self._skip_check = True
             return
 
-        cal_color = [int(round(x*float(self._brightness)/255))
-                     for x in self._rgb_color]
+        cal_color = [int(round(x*float(brightness)/255))
+                     for x in rgb_color]
         self.json_request({
             'command': 'color',
             'priority': self._priority,
@@ -185,7 +182,6 @@ class Hyperion(Light):
             'priority': self._priority,
             'color': [0, 0, 0]
         })
-        self._rgb_color = [0, 0, 0]
 
     def update(self):
         """Get the lights status."""

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -29,13 +29,16 @@ DEFAULT_PORT = 19444
 DEFAULT_PRIORITY = 128
 DEFAULT_HDMI_PRIORITY = 880
 DEFAULT_EFFECT_LIST = ['HDMI', 'Cinema brighten lights', 'Cinema dim lights',
-    'Knight rider', 'Blue mood blobs', 'Cold mood blobs',
-    'Full color mood blobs', 'Green mood blobs', 'Red mood blobs',
-    'Warm mood blobs', 'Police Lights Single', 'Police Lights Solid',
-    'Rainbow mood', 'Rainbow swirl fast', 'Rainbow swirl', 'Random',
-    'Running dots', 'System Shutdown', 'Snake', 'Sparks Color', 'Sparks',
-    'Strobe blue', 'Strobe Raspbmc', 'Strobe white', 'Color traces',
-    'UDP multicast listener', 'UDP listener', 'X-Mas']
+                        'Knight rider', 'Blue mood blobs', 'Cold mood blobs',
+                        'Full color mood blobs', 'Green mood blobs',
+                        'Red mood blobs', 'Warm mood blobs',
+                        'Police Lights Single', 'Police Lights Solid',
+                        'Rainbow mood', 'Rainbow swirl fast',
+                        'Rainbow swirl', 'Random', 'Running dots',
+                        'System Shutdown', 'Snake', 'Sparks Color', 'Sparks',
+                        'Strobe blue', 'Strobe Raspbmc', 'Strobe white',
+                        'Color traces', 'UDP multicast listener',
+                        'UDP listener', 'X-Mas']
 
 SUPPORT_HYPERION = (SUPPORT_RGB_COLOR | SUPPORT_BRIGHTNESS | SUPPORT_EFFECT)
 
@@ -48,9 +51,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PRIORITY, default=DEFAULT_PRIORITY): cv.positive_int,
     vol.Optional(CONF_HDMI_PRIORITY,
-            default=DEFAULT_HDMI_PRIORITY): cv.positive_int,
-    vol.Optional(CONF_EFFECT_LIST,
-            default=DEFAULT_EFFECT_LIST): vol.All(cv.ensure_list, [cv.string]),
+                    default=DEFAULT_HDMI_PRIORITY): cv.positive_int,
+    vol.Optional(CONF_EFFECT_LIST, default=DEFAULT_EFFECT_LIST):
+                    vol.All(cv.ensure_list, [cv.string]),
 })
 
 
@@ -76,7 +79,7 @@ class Hyperion(Light):
     """Representation of a Hyperion remote."""
 
     def __init__(self, name, host, port, priority, default_color,
-        hdmi_priority, effect_list):
+                    hdmi_priority, effect_list):
         """Initialize the light."""
         self._host = host
         self._port = port
@@ -166,7 +169,7 @@ class Hyperion(Light):
             return
 
         cal_color = [int(round(x*float(self._brightness)/255))
-            for x in self._rgb_color]
+                        for x in self._rgb_color]
         self.json_request({
             'command': 'color',
             'priority': self._priority,
@@ -220,7 +223,7 @@ class Hyperion(Light):
                         A = response['info']['activeEffects'][0]["script"]
                         A = A.split('/')[-1][:-3].split("-")[0]
                         self._effect = [x for x in self._effect_list
-                            if (effect_script.lower() in x.lower())][0]
+                                        if (A.lower() in x.lower())][0]
                     except:
                         self._effect = 'none'
                 # Bulb off state
@@ -234,7 +237,7 @@ class Hyperion(Light):
                     response['info']['activeLedColor'][0]['RGB Value']
                 self._brightness = max(self._rgb_color)
                 self._rgb_mem = [int(round(float(x)*255/self._brightness))
-                    for x in self._rgb_color]
+                                    for x in self._rgb_color]
                 self._icon = 'mdi:lightbulb'
                 self._effect = 'none'
 

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -93,8 +93,8 @@ class Hyperion(Light):
         self._brightness = 255
         self._icon = 'mdi:lightbulb'
         self._effect_list = effect_list
-        self._effect = 'none'
-        self._skip_check = False
+        self._effect = None
+        self._skip_update = False
 
     @property
     def name(self):
@@ -149,7 +149,7 @@ class Hyperion(Light):
             brightness = kwargs[ATTR_BRIGHTNESS]
 
         if ATTR_EFFECT in kwargs:
-            self._skip_check = True
+            self._skip_update = True
             self._effect = kwargs[ATTR_EFFECT]
             if self._effect == 'HDMI':
                 self.json_request({'command': 'clearall'})
@@ -186,8 +186,8 @@ class Hyperion(Light):
     def update(self):
         """Get the lights status."""
         # postpone the immediate state check for changes that take time
-        if self._skip_check:
-            self._skip_check = False
+        if self._skip_update:
+            self._skip_update = False
             return
         response = self.json_request({'command': 'serverinfo'})
         if response:
@@ -197,7 +197,7 @@ class Hyperion(Light):
                 self._rgb_mem = self._default_color
                 self._brightness = 255
                 self._icon = 'mdi:lightbulb'
-                self._effect = 'none'
+                self._effect = None
                 return
             # Check if Hyperion is in ambilight mode trough an HDMI grabber
             try:
@@ -222,12 +222,12 @@ class Hyperion(Light):
                         self._effect = [x for x in self._effect_list
                                         if s_name.lower() in x.lower()][0]
                     except (KeyError, IndexError):
-                        self._effect = 'none'
+                        self._effect = None
                 # Bulb off state
                 else:
                     self._rgb_color = [0, 0, 0]
                     self._icon = 'mdi:lightbulb'
-                    self._effect = 'none'
+                    self._effect = None
             else:
                 # Get the RGB color
                 self._rgb_color =\
@@ -236,7 +236,7 @@ class Hyperion(Light):
                 self._rgb_mem = [int(round(float(x)*255/self._brightness))
                                  for x in self._rgb_color]
                 self._icon = 'mdi:lightbulb'
-                self._effect = 'none'
+                self._effect = None
 
     def setup(self):
         """Get the hostname of the remote."""

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -11,7 +11,7 @@ import socket
 import voluptuous as vol
 
 from homeassistant.components.light import (
-    ATTR_RGB_COLOR, SUPPORT_RGB_COLOR, Light, PLATFORM_SCHEMA)
+    ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_EFFECT, SUPPORT_BRIGHTNESS, SUPPORT_RGB_COLOR, SUPPORT_EFFECT, Light, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
@@ -19,13 +19,17 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_DEFAULT_COLOR = 'default_color'
 CONF_PRIORITY = 'priority'
+CONF_HDMI_PRIORITY = 'hdmi_priority'
+CONF_EFFECT_LIST = 'effect_list'
 
 DEFAULT_COLOR = [255, 255, 255]
 DEFAULT_NAME = 'Hyperion'
 DEFAULT_PORT = 19444
 DEFAULT_PRIORITY = 128
+DEFAULT_HDMI_PRIORITY = 880
+DEFAULT_EFFECT_LIST = ['HDMI', 'Cinema brighten lights', 'Cinema dim lights', 'Knight rider', 'Blue mood blobs', 'Cold mood blobs', 'Full color mood blobs', 'Green mood blobs', 'Red mood blobs', 'Warm mood blobs', 'Police Lights Single', 'Police Lights Solid', 'Rainbow mood', 'Rainbow swirl fast', 'Rainbow swirl', 'Random', 'Running dots', 'System Shutdown', 'Snake', 'Sparks Color', 'Sparks', 'Strobe blue', 'Strobe Raspbmc', 'Strobe white', 'Color traces', 'UDP multicast listener', 'UDP listener', 'X-Mas']
 
-SUPPORT_HYPERION = SUPPORT_RGB_COLOR
+SUPPORT_HYPERION = (SUPPORT_RGB_COLOR | SUPPORT_BRIGHTNESS | SUPPORT_EFFECT)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -35,6 +39,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
             [vol.All(vol.Coerce(int), vol.Range(min=0, max=255))]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PRIORITY, default=DEFAULT_PRIORITY): cv.positive_int,
+    vol.Optional(CONF_HDMI_PRIORITY, default=DEFAULT_HDMI_PRIORITY): cv.positive_int,
+    vol.Optional(CONF_EFFECT_LIST, default=DEFAULT_EFFECT_LIST): vol.All(cv.ensure_list, [cv.string]),
 })
 
 
@@ -43,10 +49,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
     priority = config.get(CONF_PRIORITY)
+    hdmi_priority = config.get(CONF_HDMI_PRIORITY)
     default_color = config.get(CONF_DEFAULT_COLOR)
+    effect_list = config.get(CONF_EFFECT_LIST)
 
     device = Hyperion(config.get(CONF_NAME), host, port, priority,
-                      default_color)
+                      default_color, hdmi_priority, effect_list)
 
     if device.setup():
         add_devices([device])
@@ -57,19 +65,31 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class Hyperion(Light):
     """Representation of a Hyperion remote."""
 
-    def __init__(self, name, host, port, priority, default_color):
+    def __init__(self, name, host, port, priority, default_color, hdmi_priority, effect_list):
         """Initialize the light."""
         self._host = host
         self._port = port
         self._name = name
         self._priority = priority
+        self._hdmi_priority = hdmi_priority
         self._default_color = default_color
         self._rgb_color = [0, 0, 0]
+        self._rgb_mem = [0, 0, 0]
+        self._brightness = 255
+        self._icon = 'mdi:lightbulb'
+        self._effect_list = effect_list
+        self._effect = 'none'
+        self._skip_check = False
 
     @property
     def name(self):
         """Return the name of the light."""
         return self._name
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return self._brightness
 
     @property
     def rgb_color(self):
@@ -82,6 +102,21 @@ class Hyperion(Light):
         return self._rgb_color != [0, 0, 0]
 
     @property
+    def icon(self):
+        """Return state specific icon."""
+        return self._icon
+
+    @property
+    def effect(self):
+        """Return the current effect."""
+        return self._effect
+
+    @property
+    def effect_list(self):
+        """Return the list of supported effects."""
+        return self._effect_list
+
+    @property
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_HYPERION
@@ -90,34 +125,103 @@ class Hyperion(Light):
         """Turn the lights on."""
         if ATTR_RGB_COLOR in kwargs:
             self._rgb_color = kwargs[ATTR_RGB_COLOR]
-        else:
+            self._rgb_mem = kwargs[ATTR_RGB_COLOR]
+        elif self._rgb_mem == [0, 0, 0]:
             self._rgb_color = self._default_color
+            self._rgb_mem = self._default_color
+        else:
+            self._rgb_color = self._rgb_mem
 
+        if ATTR_BRIGHTNESS in kwargs:
+            self._brightness = kwargs[ATTR_BRIGHTNESS]
+
+        if ATTR_EFFECT in kwargs:
+            self._effect = kwargs[ATTR_EFFECT]
+            if self._effect == 'HDMI':
+                self.json_request({'command': 'clearall'})
+                self._icon = 'mdi:video-input-hdmi'
+                self._brightness = 255
+                self._rgb_color = [125, 125, 125]
+                self._skip_check = True
+            else:
+                self.json_request({
+                    'command': 'effect',
+                    'priority': self._priority,
+                    'effect': {'name': self._effect}
+                })
+                self._icon = 'mdi:lava-lamp'
+                self._rgb_color = [175,0,255]
+                self._skip_check = True
+            return
+
+        cal_color = [int(round(x*float(self._brightness)/255)) for x in self._rgb_color]
         self.json_request({
             'command': 'color',
             'priority': self._priority,
-            'color': self._rgb_color
+            'color': cal_color
         })
 
     def turn_off(self, **kwargs):
         """Disconnect all remotes."""
         self.json_request({'command': 'clearall'})
+        self.json_request({
+            'command': 'color',
+            'priority': self._priority,
+            'color': [0, 0, 0]
+        })
         self._rgb_color = [0, 0, 0]
 
     def update(self):
-        """Get the remote's active color."""
+        """Get the lights status."""
+        # postpone the immediate state check for changes that take time
+        if self._skip_check == True:
+            self._skip_check = False
+            return
         response = self.json_request({'command': 'serverinfo'})
         if response:
             # workaround for outdated Hyperion
             if 'activeLedColor' not in response['info']:
                 self._rgb_color = self._default_color
+                self._rgb_mem = self._default_color
+                self._brightness = 255
+                self._icon = 'mdi:lightbulb'
+                self._effect = 'none'
                 return
-
+            # Check if Hyperion is in ambilight mode trough an HDMI grabber
+            try:
+                if (response['info']['priorities'][0]['priority']) == self._hdmi_priority:
+                    self._brightness = 255
+                    self._rgb_color = [125, 125, 125]
+                    self._icon = 'mdi:video-input-hdmi'
+                    self._effect = 'HDMI'
+                    return
+            except:
+                pass
+            
             if response['info']['activeLedColor'] == []:
-                self._rgb_color = [0, 0, 0]
+                # Get the active effect
+                if response['info']['activeEffects'] != []:
+                    self._rgb_color = [175,0,255]
+                    self._icon = 'mdi:lava-lamp'
+                    try:
+                        effect_script = response['info']['activeEffects'][0]["script"]
+                        effect_script = effect_script.split('/')[-1][:-3].split("-")[0]
+                        self._effect = [x for x in self._effect_list if (effect_script.lower() in x.lower())][0]
+                    except:
+                        self._effect = 'none'
+                # Bulb off state
+                else:
+                    self._rgb_color = [0, 0, 0]
+                    self._icon = 'mdi:lightbulb'
+                    self._effect = 'none'
             else:
+                # Get the RGB color
                 self._rgb_color =\
                     response['info']['activeLedColor'][0]['RGB Value']
+                self._brightness = max(self._rgb_color)
+                self._rgb_mem = [int(round(float(x)*255/self._brightness)) for x in self._rgb_color]
+                self._icon = 'mdi:lightbulb'
+                self._effect = 'none'
 
     def setup(self):
         """Get the hostname of the remote."""

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -29,16 +29,16 @@ DEFAULT_PORT = 19444
 DEFAULT_PRIORITY = 128
 DEFAULT_HDMI_PRIORITY = 880
 DEFAULT_EFFECT_LIST = ['HDMI', 'Cinema brighten lights', 'Cinema dim lights',
-                        'Knight rider', 'Blue mood blobs', 'Cold mood blobs',
-                        'Full color mood blobs', 'Green mood blobs',
-                        'Red mood blobs', 'Warm mood blobs',
-                        'Police Lights Single', 'Police Lights Solid',
-                        'Rainbow mood', 'Rainbow swirl fast',
-                        'Rainbow swirl', 'Random', 'Running dots',
-                        'System Shutdown', 'Snake', 'Sparks Color', 'Sparks',
-                        'Strobe blue', 'Strobe Raspbmc', 'Strobe white',
-                        'Color traces', 'UDP multicast listener',
-                        'UDP listener', 'X-Mas']
+                    'Knight rider', 'Blue mood blobs', 'Cold mood blobs',
+                    'Full color mood blobs', 'Green mood blobs',
+                    'Red mood blobs', 'Warm mood blobs',
+                    'Police Lights Single', 'Police Lights Solid',
+                    'Rainbow mood', 'Rainbow swirl fast',
+                    'Rainbow swirl', 'Random', 'Running dots',
+                    'System Shutdown', 'Snake', 'Sparks Color', 'Sparks',
+                    'Strobe blue', 'Strobe Raspbmc', 'Strobe white',
+                    'Color traces', 'UDP multicast listener',
+                    'UDP listener', 'X-Mas']
 
 SUPPORT_HYPERION = (SUPPORT_RGB_COLOR | SUPPORT_BRIGHTNESS | SUPPORT_EFFECT)
 
@@ -51,9 +51,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PRIORITY, default=DEFAULT_PRIORITY): cv.positive_int,
     vol.Optional(CONF_HDMI_PRIORITY,
-                    default=DEFAULT_HDMI_PRIORITY): cv.positive_int,
-    vol.Optional(CONF_EFFECT_LIST, default=DEFAULT_EFFECT_LIST):
-                    vol.All(cv.ensure_list, [cv.string]),
+                default=DEFAULT_HDMI_PRIORITY): cv.positive_int,
+    vol.Optional(CONF_EFFECT_LIST,
+                default=DEFAULT_EFFECT_LIST): vol.All(cv.ensure_list,
+                                                    [cv.string]),
 })
 
 
@@ -79,7 +80,7 @@ class Hyperion(Light):
     """Representation of a Hyperion remote."""
 
     def __init__(self, name, host, port, priority, default_color,
-                    hdmi_priority, effect_list):
+                hdmi_priority, effect_list):
         """Initialize the light."""
         self._host = host
         self._port = port
@@ -169,7 +170,7 @@ class Hyperion(Light):
             return
 
         cal_color = [int(round(x*float(self._brightness)/255))
-                        for x in self._rgb_color]
+                    for x in self._rgb_color]
         self.json_request({
             'command': 'color',
             'priority': self._priority,
@@ -237,7 +238,7 @@ class Hyperion(Light):
                     response['info']['activeLedColor'][0]['RGB Value']
                 self._brightness = max(self._rgb_color)
                 self._rgb_mem = [int(round(float(x)*255/self._brightness))
-                                    for x in self._rgb_color]
+                                for x in self._rgb_color]
                 self._icon = 'mdi:lightbulb'
                 self._effect = 'none'
 


### PR DESCRIPTION
## Description:

- added brightness support to dim the hyperion light
- changed the "OFF" command to set the color to [0,0,0] after clearing all priorities.
    This is neccesary to keep the light turned off when an HDMI grabber is used for ambilight with hyperion.
- added HDMI ambilight mode recognition and control.
    by setting the "hdmi_priority" in your "configuration.yaml" file (defaults to 880), home assistant will now be able to recognize when the hyperion light is in HDMI ambilight mode and will change its icon to an HDMI symbol and set the status to ON.
- Switching the hyperion light to HDMI ambilight mode can be done through the effect option (clears all priorities such that the HDMI grabber remains).
- added effect support for the default effects of hyperion, a custom list can be defined in the "configuration.yaml" file by using the "effect_list" option.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4376

## Example entry for `configuration.yaml` (if applicable):
```yaml
 - platform: hyperion
   host: IP_ADRESS
   port: 19444
   name: hyperion light
   priority: 100
   hdmi_priority: 880
   default_color: [0,0,255]
   effect_list: ['HDMI', 'Blue mood blobs']
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
