### PR TITLE
Upgrade lightify to 1.0.6.1

### DIFF
--- a/homeassistant/components/light/osramlightify.py
+++ b/homeassistant/components/light/osramlightify.py
@@ -4,33 +4,35 @@ Support for Osram Lightify.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.osramlightify/
 """
-import logging
-import socket
-import random
 from datetime import timedelta
+import logging
+import random
+import socket
 
 import voluptuous as vol
 
 from homeassistant import util
-from homeassistant.const import CONF_HOST
 from homeassistant.components.light import (
-    Light, ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_RGB_COLOR,
-    ATTR_XY_COLOR, ATTR_TRANSITION, EFFECT_RANDOM, SUPPORT_BRIGHTNESS,
-    SUPPORT_EFFECT, SUPPORT_XY_COLOR, SUPPORT_COLOR_TEMP, SUPPORT_RGB_COLOR,
-    SUPPORT_TRANSITION, PLATFORM_SCHEMA)
-from homeassistant.util.color import (
-    color_temperature_mired_to_kelvin, color_temperature_kelvin_to_mired,
-    color_xy_brightness_to_RGB)
+    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_RGB_COLOR,
+    ATTR_TRANSITION, ATTR_XY_COLOR, EFFECT_RANDOM, PLATFORM_SCHEMA,
+    SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_EFFECT, SUPPORT_RGB_COLOR,
+    SUPPORT_TRANSITION, SUPPORT_XY_COLOR, Light)
+from homeassistant.const import CONF_HOST
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.color import (
+    color_temperature_kelvin_to_mired, color_temperature_mired_to_kelvin,
+    color_xy_brightness_to_RGB)
 
-REQUIREMENTS = ['lightify==1.0.6']
+REQUIREMENTS = ['lightify==1.0.6.1']
 
 _LOGGER = logging.getLogger(__name__)
 
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
-MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
-CONF_ALLOW_LIGHTIFY_GROUPS = "allow_lightify_groups"
+CONF_ALLOW_LIGHTIFY_GROUPS = 'allow_lightify_groups'
+
 DEFAULT_ALLOW_LIGHTIFY_GROUPS = True
+
+MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 SUPPORT_OSRAMLIGHTIFY = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP |
                          SUPPORT_EFFECT | SUPPORT_RGB_COLOR |
@@ -46,20 +48,19 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Osram Lightify lights."""
     import lightify
+
     host = config.get(CONF_HOST)
     add_groups = config.get(CONF_ALLOW_LIGHTIFY_GROUPS)
-    if host:
-        try:
-            bridge = lightify.Lightify(host)
-        except socket.error as err:
-            msg = "Error connecting to bridge: {} due to: {}".format(
-                host, str(err))
-            _LOGGER.exception(msg)
-            return False
-        setup_bridge(bridge, add_devices, add_groups)
-    else:
-        _LOGGER.error("No host found in configuration")
-        return False
+
+    try:
+        bridge = lightify.Lightify(host)
+    except socket.error as err:
+        msg = "Error connecting to bridge: {} due to: {}".format(
+            host, str(err))
+        _LOGGER.exception(msg)
+        return
+
+    setup_bridge(bridge, add_devices, add_groups)
 
 
 def setup_bridge(bridge, add_devices_callback, add_groups):
@@ -73,17 +74,16 @@ def setup_bridge(bridge, add_devices_callback, add_groups):
             bridge.update_all_light_status()
             bridge.update_group_list()
         except TimeoutError:
-            _LOGGER.error('Timeout during updating of lights.')
+            _LOGGER.error("Timeout during updating of lights")
         except OSError:
-            _LOGGER.error('OSError during updating of lights.')
+            _LOGGER.error("OSError during updating of lights")
 
         new_lights = []
 
         for (light_id, light) in bridge.lights().items():
             if light_id not in lights:
-                osram_light = OsramLightifyLight(light_id, light,
-                                                 update_lights)
-
+                osram_light = OsramLightifyLight(
+                    light_id, light, update_lights)
                 lights[light_id] = osram_light
                 new_lights.append(osram_light)
             else:
@@ -92,8 +92,8 @@ def setup_bridge(bridge, add_devices_callback, add_groups):
         if add_groups:
             for (group_name, group) in bridge.groups().items():
                 if group_name not in lights:
-                    osram_group = OsramLightifyGroup(group, bridge,
-                                                     update_lights)
+                    osram_group = OsramLightifyGroup(
+                        group, bridge, update_lights)
                     lights[group_name] = osram_group
                     new_lights.append(osram_group)
                 else:
@@ -106,10 +106,10 @@ def setup_bridge(bridge, add_devices_callback, add_groups):
 
 
 class Luminary(Light):
-    """ABS for Lightify Lights and Groups."""
+    """Representation of Luminary Lights and Groups."""
 
     def __init__(self, luminary, update_lights):
-        """Init Luminary object."""
+        """Initize a Luminary light."""
         self.update_lights = update_lights
         self._luminary = luminary
         self._brightness = None
@@ -141,7 +141,7 @@ class Luminary(Light):
 
     @property
     def is_on(self):
-        """Update Status to True if device is on."""
+        """Update status to True if device is on."""
         return self._state
 
     @property
@@ -170,8 +170,7 @@ class Luminary(Light):
             _LOGGER.debug("turn_on requested brightness for light: %s is: %s ",
                           self._name, self._brightness)
             self._luminary.set_luminance(
-                int(self._brightness / 2.55),
-                transition)
+                int(self._brightness / 2.55), transition)
         else:
             self._luminary.set_onoff(1)
 
@@ -187,8 +186,7 @@ class Luminary(Light):
             _LOGGER.debug("turn_on requested ATTR_XY_COLOR for light:"
                           " %s is: %s,%s", self._name, x_mired, y_mired)
             red, green, blue = color_xy_brightness_to_RGB(
-                x_mired, y_mired, self._brightness
-            )
+                x_mired, y_mired, self._brightness)
             self._luminary.set_rgb(red, green, blue, transition)
 
         if ATTR_COLOR_TEMP in kwargs:
@@ -201,10 +199,9 @@ class Luminary(Light):
         if ATTR_EFFECT in kwargs:
             effect = kwargs.get(ATTR_EFFECT)
             if effect == EFFECT_RANDOM:
-                self._luminary.set_rgb(random.randrange(0, 255),
-                                       random.randrange(0, 255),
-                                       random.randrange(0, 255),
-                                       transition)
+                self._luminary.set_rgb(
+                    random.randrange(0, 255), random.randrange(0, 255),
+                    random.randrange(0, 255), transition)
                 _LOGGER.debug("turn_on requested random effect for light: "
                               "%s with transition %s", self._name, transition)
 
@@ -212,19 +209,16 @@ class Luminary(Light):
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        _LOGGER.debug("turn_off Attempting to turn off light: %s ",
-                      self._name)
+        _LOGGER.debug("Attempting to turn off light: %s", self._name)
         if ATTR_TRANSITION in kwargs:
             transition = int(kwargs[ATTR_TRANSITION] * 10)
             _LOGGER.debug("turn_off requested transition time for light:"
-                          " %s is: %s ",
-                          self._name, transition)
+                          " %s is: %s ", self._name, transition)
             self._luminary.set_luminance(0, transition)
         else:
             transition = 0
             _LOGGER.debug("turn_off requested transition time for light:"
-                          " %s is: %s ",
-                          self._name, transition)
+                          " %s is: %s ", self._name, transition)
         self._luminary.set_onoff(0)
         self.schedule_update_ha_state()
 
@@ -238,12 +232,12 @@ class OsramLightifyLight(Luminary):
     """Representation of an Osram Lightify Light."""
 
     def __init__(self, light_id, light, update_lights):
-        """Initialize the light."""
+        """Initialize the Lightify light."""
         self._light_id = light_id
         super().__init__(light, update_lights)
 
     def update(self):
-        """Update status of a Light."""
+        """Update status of a light."""
         super().update()
         self._state = self._luminary.on()
         self._rgb = self._luminary.rgb()
@@ -252,8 +246,7 @@ class OsramLightifyLight(Luminary):
             self._temperature = None
         else:
             self._temperature = color_temperature_kelvin_to_mired(
-                self._luminary.temp()
-            )
+                self._luminary.temp())
         self._brightness = int(self._luminary.lum() * 2.55)
 
 
@@ -261,16 +254,13 @@ class OsramLightifyGroup(Luminary):
     """Representation of an Osram Lightify Group."""
 
     def __init__(self, group, bridge, update_lights):
-        """Init light group."""
+        """Initialize the Lightify light group."""
         self._bridge = bridge
         self._light_ids = []
         super().__init__(group, update_lights)
 
     def _get_state(self):
-        """Get state of group.
-
-        The group is on, if any of the lights is on.
-        """
+        """Get state of group."""
         lights = self._bridge.lights()
         return any(lights[light_id].on() for light_id in self._light_ids)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -438,7 +438,7 @@ libsoundtouch==0.7.2
 liffylights==0.9.4
 
 # homeassistant.components.light.osramlightify
-lightify==1.0.6
+lightify==1.0.6.1
 
 # homeassistant.components.light.limitlessled
 limitlessled==1.0.8


### PR DESCRIPTION
## Description:
- Set light power state to "off" if the connection between the gateway and the light was interrupted

This PR also removes a check that is already performed by voluptuous.

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: osramlightify
    host: 192.168.0.230
```

Gateway firmware: 1.2.2.6

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
