### PR TITLE
Fixes and enhancements for the Tahoma platform

### DIFF
--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -52,12 +52,15 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
         0 is closed, 100 is fully open.
         """
-        position = 100 - self.tahoma_device.active_states['core:ClosureState']
-        if position <= 5:
-            return 0
-        if position >= 95:
-            return 100
-        return position
+        try:
+            position = 100 - self.tahoma_device.active_states['core:ClosureState']
+            if position <= 5:
+                return 0
+            if position >= 95:
+                return 100
+            return position
+        except KeyError:
+            return None
 
     def set_cover_position(self, position, **kwargs):
         """Move the cover to a specific position."""

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -33,7 +33,13 @@ class TahomaCover(TahomaDevice, CoverDevice):
     def __init__(self, tahoma_device, controller):
         """Initialize the Tahoma device."""
         super().__init__(tahoma_device, controller)
-        self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
+        eid = ENTITY_ID_FORMAT.format(self.unique_id)
+        # strip off the RTS or the IO ID from the entity ID
+        if eid.rfind('_rts') > 0:
+            eid = eid[:eid.rfind('_rts')]
+        elif eid.rfind('_io') > 0:
+            eid = eid[:eid.rfind('_io')]
+        self.entity_id = eid
 
     def update(self):
         """Update method."""

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -53,7 +53,8 @@ class TahomaCover(TahomaDevice, CoverDevice):
         0 is closed, 100 is fully open.
         """
         try:
-            position = 100 - self.tahoma_device.active_states['core:ClosureState']
+            position = 100 - \
+                self.tahoma_device.active_states['core:ClosureState']
             if position <= 5:
                 return 0
             if position >= 95:

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/cover.tahoma/
 import logging
 from datetime import timedelta
 
-from homeassistant.components.cover import CoverDevice, ENTITY_ID_FORMAT
+from homeassistant.components.cover import CoverDevice
 from homeassistant.components.tahoma import (
     DOMAIN as TAHOMA_DOMAIN, TahomaDevice)
 
@@ -29,17 +29,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 class TahomaCover(TahomaDevice, CoverDevice):
     """Representation a Tahoma Cover."""
-
-    def __init__(self, tahoma_device, controller):
-        """Initialize the Tahoma device."""
-        super().__init__(tahoma_device, controller)
-        eid = ENTITY_ID_FORMAT.format(self.unique_id)
-        # strip off the RTS or the IO ID from the entity ID
-        if eid.rfind('_rts') > 0:
-            eid = eid[:eid.rfind('_rts')]
-        elif eid.rfind('_io') > 0:
-            eid = eid[:eid.rfind('_io')]
-        self.entity_id = eid
 
     def update(self):
         """Update method."""

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -117,4 +117,4 @@ class TahomaDevice(Entity):
         from tahoma_api import Action
         action = Action(self.tahoma_device.url)
         action.add_command(cmd_name, *args)
-        self.controller.apply_actions('', [action])
+        self.controller.apply_actions('HomeAssistant', [action])


### PR DESCRIPTION
## Description:

Hi there,

Related to PR #11538, here you find a few more fixes and enhancements. They all work on my installation, will follow up for the automated linting/CI tests.

A breaking change is commit 963b34e that changes the entity IDs in HA. For this, I appreciate some feedback from @philklei as the original author and @bakedraccoon as the contributor of the above-mentioned PR.

**Related issue (if applicable):**

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**

## Example entry for `configuration.yaml` (if applicable):

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
