### PR TITLE
Improved test runtime

### DIFF
--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -98,8 +98,9 @@ def day_to_string(day):
     except IndexError:
         return None
 
+
 def get_date(date):
-    # Method is needed for testing
+    """Return date. Needed for testing."""
     return date
 
 

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -64,7 +64,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     excludes = config.get(CONF_EXCLUDES)
     days_offset = config.get(CONF_OFFSET)
 
-    year = (datetime.now() + timedelta(days=days_offset)).year
+    year = (get_date(datetime.today()) + timedelta(days=days_offset)).year
     obj_holidays = getattr(holidays, country)(years=year)
 
     if province:
@@ -97,6 +97,10 @@ def day_to_string(day):
         return ALLOWED_DAYS[day]
     except IndexError:
         return None
+
+def get_date(date):
+    # Method is needed for testing
+    return date
 
 
 class IsWorkdaySensor(BinarySensorDevice):
@@ -156,7 +160,7 @@ class IsWorkdaySensor(BinarySensorDevice):
         self._state = False
 
         # Get iso day of the week (1 = Monday, 7 = Sunday)
-        date = datetime.today() + timedelta(days=self._days_offset)
+        date = get_date(datetime.today()) + timedelta(days=self._days_offset)
         day = date.isoweekday() - 1
         day_of_week = day_to_string(day)
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -15,4 +15,3 @@ requests_mock==1.4
 mock-open==1.3.1
 flake8-docstrings==1.0.2
 asynctest>=0.11.1
-freezegun==0.3.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -16,7 +16,6 @@ requests_mock==1.4
 mock-open==1.3.1
 flake8-docstrings==1.0.2
 asynctest>=0.11.1
-freezegun==0.3.9
 
 
 # homeassistant.components.notify.html5

--- a/tests/components/binary_sensor/test_workday.py
+++ b/tests/components/binary_sensor/test_workday.py
@@ -2,8 +2,7 @@
 from datetime import date
 from unittest.mock import patch
 
-from homeassistant.components.binary_sensor.workday import (
-    get_date, day_to_string)
+from homeassistant.components.binary_sensor.workday import day_to_string
 from homeassistant.setup import setup_component
 
 from tests.common import (

--- a/tests/components/binary_sensor/test_workday.py
+++ b/tests/components/binary_sensor/test_workday.py
@@ -9,10 +9,11 @@ from tests.common import (
     get_test_home_assistant, assert_setup_component)
 
 
+FUNCTION_PATH = 'homeassistant.components.binary_sensor.workday.get_date'
+
+
 class TestWorkdaySetup(object):
     """Test class for workday sensor."""
-
-    function_path = 'homeassistant.components.binary_sensor.workday.get_date'
 
     def setup_method(self):
         """Setup things to be run when tests are started."""
@@ -105,7 +106,7 @@ class TestWorkdaySetup(object):
         assert entity is not None
 
     # Freeze time to a workday - Mar 15th, 2017
-    @patch(function_path, return_value=date(2017, 3, 15))
+    @patch(FUNCTION_PATH, return_value=date(2017, 3, 15))
     def test_workday_province(self, mock_date):
         """Test if workdays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
@@ -118,7 +119,7 @@ class TestWorkdaySetup(object):
         assert entity.state == 'on'
 
     # Freeze time to a weekend - Mar 12th, 2017
-    @patch(function_path, return_value=date(2017, 3, 12))
+    @patch(FUNCTION_PATH, return_value=date(2017, 3, 12))
     def test_weekend_province(self, mock_date):
         """Test if weekends are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
@@ -131,7 +132,7 @@ class TestWorkdaySetup(object):
         assert entity.state == 'off'
 
     # Freeze time to a public holiday in province BW - Jan 6th, 2017
-    @patch(function_path, return_value=date(2017, 1, 6))
+    @patch(FUNCTION_PATH, return_value=date(2017, 1, 6))
     def test_public_holiday_province(self, mock_date):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
@@ -153,7 +154,7 @@ class TestWorkdaySetup(object):
         assert entity is not None
 
     # Freeze time to a public holiday in province BW - Jan 6th, 2017
-    @patch(function_path, return_value=date(2017, 1, 6))
+    @patch(FUNCTION_PATH, return_value=date(2017, 1, 6))
     def test_public_holiday_noprovince(self, mock_date):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
@@ -166,7 +167,7 @@ class TestWorkdaySetup(object):
         assert entity.state == 'on'
 
     # Freeze time to a public holiday in state CA - Mar 31st, 2017
-    @patch(function_path, return_value=date(2017, 3, 31))
+    @patch(FUNCTION_PATH, return_value=date(2017, 3, 31))
     def test_public_holiday_state(self, mock_date):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
@@ -178,7 +179,7 @@ class TestWorkdaySetup(object):
         assert entity.state == 'off'
 
     # Freeze time to a public holiday in state CA - Mar 31st, 2017
-    @patch(function_path, return_value=date(2017, 3, 31))
+    @patch(FUNCTION_PATH, return_value=date(2017, 3, 31))
     def test_public_holiday_nostate(self, mock_date):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
@@ -199,7 +200,7 @@ class TestWorkdaySetup(object):
         assert entity is None
 
     # Freeze time to a public holiday in province BW - Jan 6th, 2017
-    @patch(function_path, return_value=date(2017, 1, 6))
+    @patch(FUNCTION_PATH, return_value=date(2017, 1, 6))
     def test_public_holiday_includeholiday(self, mock_date):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
@@ -212,7 +213,7 @@ class TestWorkdaySetup(object):
         assert entity.state == 'on'
 
     # Freeze time to a saturday to test offset - Aug 5th, 2017
-    @patch(function_path, return_value=date(2017, 8, 5))
+    @patch(FUNCTION_PATH, return_value=date(2017, 8, 5))
     def test_tomorrow(self, mock_date):
         """Test if tomorrow are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
@@ -225,7 +226,7 @@ class TestWorkdaySetup(object):
         assert entity.state == 'off'
 
     # Freeze time to a saturday to test offset - Aug 5th, 2017
-    @patch(function_path, return_value=date(2017, 8, 5))
+    @patch(FUNCTION_PATH, return_value=date(2017, 8, 5))
     def test_day_after_tomorrow(self, mock_date):
         """Test if the day after tomorrow are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
@@ -238,7 +239,7 @@ class TestWorkdaySetup(object):
         assert entity.state == 'on'
 
     # Freeze time to a saturday to test offset - Aug 5th, 2017
-    @patch(function_path, return_value=date(2017, 8, 5))
+    @patch(FUNCTION_PATH, return_value=date(2017, 8, 5))
     def test_yesterday(self, mock_date):
         """Test if yesterday are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):

--- a/tests/components/binary_sensor/test_workday.py
+++ b/tests/components/binary_sensor/test_workday.py
@@ -1,6 +1,9 @@
 """Tests the HASS workday binary sensor."""
-from freezegun import freeze_time
-from homeassistant.components.binary_sensor.workday import day_to_string
+from datetime import date
+from unittest.mock import patch
+
+from homeassistant.components.binary_sensor.workday import (
+    get_date, day_to_string)
 from homeassistant.setup import setup_component
 
 from tests.common import (
@@ -9,6 +12,8 @@ from tests.common import (
 
 class TestWorkdaySetup(object):
     """Test class for workday sensor."""
+
+    function_path = 'homeassistant.components.binary_sensor.workday.get_date'
 
     def setup_method(self):
         """Setup things to be run when tests are started."""
@@ -100,9 +105,9 @@ class TestWorkdaySetup(object):
         entity = self.hass.states.get('binary_sensor.workday_sensor')
         assert entity is not None
 
-    # Freeze time to a workday
-    @freeze_time("Mar 15th, 2017")
-    def test_workday_province(self):
+    # Freeze time to a workday - Mar 15th, 2017
+    @patch(function_path, return_value=date(2017, 3, 15))
+    def test_workday_province(self, mock_date):
         """Test if workdays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor',
@@ -113,9 +118,9 @@ class TestWorkdaySetup(object):
         entity = self.hass.states.get('binary_sensor.workday_sensor')
         assert entity.state == 'on'
 
-    # Freeze time to a weekend
-    @freeze_time("Mar 12th, 2017")
-    def test_weekend_province(self):
+    # Freeze time to a weekend - Mar 12th, 2017
+    @patch(function_path, return_value=date(2017, 3, 12))
+    def test_weekend_province(self, mock_date):
         """Test if weekends are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor',
@@ -126,9 +131,9 @@ class TestWorkdaySetup(object):
         entity = self.hass.states.get('binary_sensor.workday_sensor')
         assert entity.state == 'off'
 
-    # Freeze time to a public holiday in province BW
-    @freeze_time("Jan 6th, 2017")
-    def test_public_holiday_province(self):
+    # Freeze time to a public holiday in province BW - Jan 6th, 2017
+    @patch(function_path, return_value=date(2017, 1, 6))
+    def test_public_holiday_province(self, mock_date):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor',
@@ -148,9 +153,9 @@ class TestWorkdaySetup(object):
         entity = self.hass.states.get('binary_sensor.workday_sensor')
         assert entity is not None
 
-    # Freeze time to a public holiday in province BW
-    @freeze_time("Jan 6th, 2017")
-    def test_public_holiday_noprovince(self):
+    # Freeze time to a public holiday in province BW - Jan 6th, 2017
+    @patch(function_path, return_value=date(2017, 1, 6))
+    def test_public_holiday_noprovince(self, mock_date):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor',
@@ -161,9 +166,9 @@ class TestWorkdaySetup(object):
         entity = self.hass.states.get('binary_sensor.workday_sensor')
         assert entity.state == 'on'
 
-    # Freeze time to a public holiday in state CA
-    @freeze_time("Mar 31st, 2017")
-    def test_public_holiday_state(self):
+    # Freeze time to a public holiday in state CA - Mar 31st, 2017
+    @patch(function_path, return_value=date(2017, 3, 31))
+    def test_public_holiday_state(self, mock_date):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor', self.config_state)
@@ -173,9 +178,9 @@ class TestWorkdaySetup(object):
         entity = self.hass.states.get('binary_sensor.workday_sensor')
         assert entity.state == 'off'
 
-    # Freeze time to a public holiday in state CA
-    @freeze_time("Mar 31st, 2017")
-    def test_public_holiday_nostate(self):
+    # Freeze time to a public holiday in state CA - Mar 31st, 2017
+    @patch(function_path, return_value=date(2017, 3, 31))
+    def test_public_holiday_nostate(self, mock_date):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor', self.config_nostate)
@@ -194,9 +199,9 @@ class TestWorkdaySetup(object):
         entity = self.hass.states.get('binary_sensor.workday_sensor')
         assert entity is None
 
-    # Freeze time to a public holiday in province BW
-    @freeze_time("Jan 6th, 2017")
-    def test_public_holiday_includeholiday(self):
+    # Freeze time to a public holiday in province BW - Jan 6th, 2017
+    @patch(function_path, return_value=date(2017, 1, 6))
+    def test_public_holiday_includeholiday(self, mock_date):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor',
@@ -207,9 +212,9 @@ class TestWorkdaySetup(object):
         entity = self.hass.states.get('binary_sensor.workday_sensor')
         assert entity.state == 'on'
 
-    # Freeze time to a saturday to test offset
-    @freeze_time("Aug 5th, 2017")
-    def test_tomorrow(self):
+    # Freeze time to a saturday to test offset - Aug 5th, 2017
+    @patch(function_path, return_value=date(2017, 8, 5))
+    def test_tomorrow(self, mock_date):
         """Test if tomorrow are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor',
@@ -220,9 +225,9 @@ class TestWorkdaySetup(object):
         entity = self.hass.states.get('binary_sensor.workday_sensor')
         assert entity.state == 'off'
 
-    # Freeze time to a saturday to test offset
-    @freeze_time("Aug 5th, 2017")
-    def test_day_after_tomorrow(self):
+    # Freeze time to a saturday to test offset - Aug 5th, 2017
+    @patch(function_path, return_value=date(2017, 8, 5))
+    def test_day_after_tomorrow(self, mock_date):
         """Test if the day after tomorrow are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor',
@@ -233,9 +238,9 @@ class TestWorkdaySetup(object):
         entity = self.hass.states.get('binary_sensor.workday_sensor')
         assert entity.state == 'on'
 
-    # Freeze time to a saturday to test offset
-    @freeze_time("Aug 5th, 2017")
-    def test_yesterday(self):
+    # Freeze time to a saturday to test offset - Aug 5th, 2017
+    @patch(function_path, return_value=date(2017, 8, 5))
+    def test_yesterday(self, mock_date):
         """Test if yesterday are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor',

--- a/tests/components/binary_sensor/test_workday.py
+++ b/tests/components/binary_sensor/test_workday.py
@@ -94,18 +94,19 @@ class TestWorkdaySetup(object):
     def test_setup_component_province(self):
         """Setup workday component."""
         with assert_setup_component(1, 'binary_sensor'):
-            setup_component(self.hass, 'binary_sensor', self.config_province)
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_province)
 
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity is not None
 
     # Freeze time to a workday
     @freeze_time("Mar 15th, 2017")
     def test_workday_province(self):
         """Test if workdays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
-            setup_component(self.hass, 'binary_sensor', self.config_province)
-
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_province)
 
         self.hass.start()
 
@@ -117,9 +118,8 @@ class TestWorkdaySetup(object):
     def test_weekend_province(self):
         """Test if weekends are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
-            setup_component(self.hass, 'binary_sensor', self.config_province)
-
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_province)
 
         self.hass.start()
 
@@ -131,9 +131,8 @@ class TestWorkdaySetup(object):
     def test_public_holiday_province(self):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
-            setup_component(self.hass, 'binary_sensor', self.config_province)
-
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_province)
 
         self.hass.start()
 
@@ -143,18 +142,19 @@ class TestWorkdaySetup(object):
     def test_setup_component_noprovince(self):
         """Setup workday component."""
         with assert_setup_component(1, 'binary_sensor'):
-            setup_component(self.hass, 'binary_sensor', self.config_noprovince)
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_noprovince)
 
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity is not None
 
     # Freeze time to a public holiday in province BW
     @freeze_time("Jan 6th, 2017")
     def test_public_holiday_noprovince(self):
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, 'binary_sensor'):
-            setup_component(self.hass, 'binary_sensor', self.config_noprovince)
-
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
+            setup_component(self.hass, 'binary_sensor',
+                            self.config_noprovince)
 
         self.hass.start()
 
@@ -168,8 +168,6 @@ class TestWorkdaySetup(object):
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor', self.config_state)
 
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
-
         self.hass.start()
 
         entity = self.hass.states.get('binary_sensor.workday_sensor')
@@ -182,8 +180,6 @@ class TestWorkdaySetup(object):
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor', self.config_nostate)
 
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
-
         self.hass.start()
 
         entity = self.hass.states.get('binary_sensor.workday_sensor')
@@ -195,7 +191,8 @@ class TestWorkdaySetup(object):
             setup_component(self.hass, 'binary_sensor',
                             self.config_invalidprovince)
 
-        assert self.hass.states.get('binary_sensor.workday_sensor') is None
+        entity = self.hass.states.get('binary_sensor.workday_sensor')
+        assert entity is None
 
     # Freeze time to a public holiday in province BW
     @freeze_time("Jan 6th, 2017")
@@ -204,8 +201,6 @@ class TestWorkdaySetup(object):
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor',
                             self.config_includeholiday)
-
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
 
         self.hass.start()
 
@@ -220,8 +215,6 @@ class TestWorkdaySetup(object):
             setup_component(self.hass, 'binary_sensor',
                             self.config_tomorrow)
 
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
-
         self.hass.start()
 
         entity = self.hass.states.get('binary_sensor.workday_sensor')
@@ -235,8 +228,6 @@ class TestWorkdaySetup(object):
             setup_component(self.hass, 'binary_sensor',
                             self.config_day_after_tomorrow)
 
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
-
         self.hass.start()
 
         entity = self.hass.states.get('binary_sensor.workday_sensor')
@@ -249,8 +240,6 @@ class TestWorkdaySetup(object):
         with assert_setup_component(1, 'binary_sensor'):
             setup_component(self.hass, 'binary_sensor',
                             self.config_yesterday)
-
-        assert self.hass.states.get('binary_sensor.workday_sensor') is not None
 
         self.hass.start()
 

--- a/tests/components/sensor/test_geo_rss_events.py
+++ b/tests/components/sensor/test_geo_rss_events.py
@@ -1,6 +1,7 @@
 """The test for the geo rss events sensor platform."""
 import unittest
 from unittest import mock
+import feedparser
 
 from homeassistant.setup import setup_component
 from tests.common import load_fixture, get_test_home_assistant
@@ -33,7 +34,8 @@ class TestGeoRssServiceUpdater(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def test_setup_with_categories(self):
+    @mock.patch('feedparser.parse', return_value=feedparser.parse(""))
+    def test_setup_with_categories(self, mock_parse):
         """Test the general setup of this sensor."""
         self.config = VALID_CONFIG_WITH_CATEGORIES
         self.assertTrue(
@@ -43,7 +45,8 @@ class TestGeoRssServiceUpdater(unittest.TestCase):
         self.assertIsNotNone(
             self.hass.states.get('sensor.event_service_category_2'))
 
-    def test_setup_without_categories(self):
+    @mock.patch('feedparser.parse', return_value=feedparser.parse(""))
+    def test_setup_without_categories(self, mock_parse):
         """Test the general setup of this sensor."""
         self.assertTrue(
             setup_component(self.hass, 'sensor', {'sensor': self.config}))

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -48,15 +48,12 @@ def test_new_version_shows_entity_after_hour(
         hass, updater.DOMAIN, {updater.DOMAIN: {}})
     assert res, 'Updater failed to setup'
 
-    print(dt_util.utcnow())
-
     with patch('homeassistant.components.updater.current_version',
                MOCK_VERSION):
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
         yield from hass.async_block_till_done()
 
     assert hass.states.is_state(updater.ENTITY_ID, NEW_VERSION)
-    # assert 0
 
 
 @asyncio.coroutine

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -3,7 +3,6 @@ import asyncio
 from datetime import timedelta
 from unittest.mock import patch, Mock
 
-from freezegun import freeze_time
 import pytest
 
 from homeassistant.setup import async_setup_component
@@ -39,7 +38,6 @@ def mock_get_uuid():
 
 
 @asyncio.coroutine
-@freeze_time("Mar 15th, 2017")
 def test_new_version_shows_entity_after_hour(
         hass, mock_get_uuid, mock_get_newest_version):
     """Test if new entity is created if new version is available."""
@@ -50,16 +48,18 @@ def test_new_version_shows_entity_after_hour(
         hass, updater.DOMAIN, {updater.DOMAIN: {}})
     assert res, 'Updater failed to setup'
 
+    print(dt_util.utcnow())
+
     with patch('homeassistant.components.updater.current_version',
                MOCK_VERSION):
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
         yield from hass.async_block_till_done()
 
     assert hass.states.is_state(updater.ENTITY_ID, NEW_VERSION)
+    # assert 0
 
 
 @asyncio.coroutine
-@freeze_time("Mar 15th, 2017")
 def test_same_version_not_show_entity(
         hass, mock_get_uuid, mock_get_newest_version):
     """Test if new entity is created if new version is available."""
@@ -79,7 +79,6 @@ def test_same_version_not_show_entity(
 
 
 @asyncio.coroutine
-@freeze_time("Mar 15th, 2017")
 def test_disable_reporting(hass, mock_get_uuid, mock_get_newest_version):
     """Test if new entity is created if new version is available."""
     mock_get_uuid.return_value = MOCK_HUUID


### PR DESCRIPTION
## Description:
Improved tests for the following components:
- binary_sensor.workday -> replaced `freeze_time` with `@mock.patch`
- updater -> replaced `freeze_time` with `@mock.patch`
- sensor.geo_rss_events -> added `@mock.patch` for `feedparser.parse`

I got an overall improvement from **260s** to about **150s** (tox -e py35)

## Checklist:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**