### PR TITLE
Eq3btsmart more reliable

### DIFF
--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -179,16 +179,17 @@ class EQ3BTSmartThermostat(ClimateDevice):
         from bluepy.btle import BTLEException
         try:
             self._thermostat.update()
-            if (self._target_temperature and
-                    self._thermostat.target_temperature
-                    != self._target_temperature):
-                self.set_temperature(temperature=self._target_temperature)
-            else:
-                self._target_temperature = None
-            if (self._target_mode and
-                    self.modes[self._thermostat.mode] != self._target_mode):
-                self.set_operation_mode(operation_mode=self._target_mode)
-            else:
-                self._target_mode = None
         except BTLEException as ex:
             _LOGGER.warning("Updating the state failed: %s", ex)
+
+        if (self._target_temperature and
+                self._thermostat.target_temperature
+                != self._target_temperature):
+            self.set_temperature(temperature=self._target_temperature)
+        else:
+            self._target_temperature = None
+        if (self._target_mode and
+                self.modes[self._thermostat.mode] != self._target_mode):
+            self.set_operation_mode(operation_mode=self._target_mode)
+        else:
+            self._target_mode = None

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -180,11 +180,11 @@ class EQ3BTSmartThermostat(ClimateDevice):
         try:
             self._thermostat.update()
             if (self._target_temperature and
-                self._thermostat.target_temperature
-                != self._target_temperature):
+                    self._thermostat.target_temperature
+                    != self._target_temperature):
                 self.set_temperature(temperature=self._target_temperature)
             if (self._target_mode and
-                self.modes[self._thermostat.mode] != self._target_mode):
+                    self.modes[self._thermostat.mode] != self._target_mode):
                 self.set_operation_mode(operation_mode=self._target_mode)
             else:
                 self._target_mode = None

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -183,6 +183,8 @@ class EQ3BTSmartThermostat(ClimateDevice):
                     self._thermostat.target_temperature
                     != self._target_temperature):
                 self.set_temperature(temperature=self._target_temperature)
+            else:
+                self._target_temperature = None
             if (self._target_mode and
                     self.modes[self._thermostat.mode] != self._target_mode):
                 self.set_operation_mode(operation_mode=self._target_mode)

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -75,6 +75,8 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
         self._name = _name
         self._thermostat = eq3.Thermostat(_mac)
+        self._target_temperature = None
+        self._target_mode = None
 
     @property
     def supported_features(self):
@@ -116,6 +118,7 @@ class EQ3BTSmartThermostat(ClimateDevice):
         temperature = kwargs.get(ATTR_TEMPERATURE)
         if temperature is None:
             return
+        self._target_temperature = temperature
         self._thermostat.target_temperature = temperature
 
     @property
@@ -132,6 +135,7 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
     def set_operation_mode(self, operation_mode):
         """Set operation mode."""
+        self._target_mode = operation_mode
         self._thermostat.mode = self.reverse_modes[operation_mode]
 
     def turn_away_mode_off(self):
@@ -175,5 +179,11 @@ class EQ3BTSmartThermostat(ClimateDevice):
         from bluepy.btle import BTLEException
         try:
             self._thermostat.update()
+            if self._target_temperature and self._thermostat.target_temperature != self._target_temperature:
+                self.set_temperature(temperature=self._target_temperature)
+            if self._target_mode and self.modes[self._thermostat.mode] != self._target_mode:
+                self.set_operation_mode(operation_mode=self._target_mode)
+            else:
+                self._target_mode = None
         except BTLEException as ex:
             _LOGGER.warning("Updating the state failed: %s", ex)

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -179,11 +179,11 @@ class EQ3BTSmartThermostat(ClimateDevice):
         from bluepy.btle import BTLEException
         try:
             self._thermostat.update()
-            if (self._target_temperature and 
-                self._thermostat.target_temperature 
-                  != self._target_temperature):
+            if (self._target_temperature and
+                self._thermostat.target_temperature
+                != self._target_temperature):
                 self.set_temperature(temperature=self._target_temperature)
-            if (self._target_mode and 
+            if (self._target_mode and
                 self.modes[self._thermostat.mode] != self._target_mode):
                 self.set_operation_mode(operation_mode=self._target_mode)
             else:

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -179,9 +179,12 @@ class EQ3BTSmartThermostat(ClimateDevice):
         from bluepy.btle import BTLEException
         try:
             self._thermostat.update()
-            if self._target_temperature and self._thermostat.target_temperature != self._target_temperature:
+            if (self._target_temperature and 
+                self._thermostat.target_temperature 
+                  != self._target_temperature):
                 self.set_temperature(temperature=self._target_temperature)
-            if self._target_mode and self.modes[self._thermostat.mode] != self._target_mode:
+            if (self._target_mode and 
+                self.modes[self._thermostat.mode] != self._target_mode):
                 self.set_operation_mode(operation_mode=self._target_mode)
             else:
                 self._target_mode = None


### PR DESCRIPTION
## Description:
Applying these changes makes eq3btsmart thermostat remember the temperature/operation mode set by the user.
During update (performed every minute) it performs a check if the current thermostat settings are the same as user wants them to. If not, temperature/operation mode are changed.

After applying the changes temperature/operation mode are set almost immediately in most cases, as update is performed after every set_temperature/set_operation_mode and repeated in case of failure 2 times.

Code was running on my local HA instance for about 1 week and everything was working much better than before.

**Related issue (if applicable):** fixes #11554 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
