### PR TITLE
Test tweaks

### DIFF
--- a/tests/components/notify/test_apns.py
+++ b/tests/components/notify/test_apns.py
@@ -3,7 +3,6 @@ import io
 import unittest
 from unittest.mock import Mock, patch, mock_open
 
-from apns2.errors import Unregistered
 import yaml
 
 import homeassistant.components.notify as notify
@@ -359,6 +358,8 @@ class TestApns(unittest.TestCase):
     @patch('homeassistant.components.notify.apns._write_device')
     def test_disable_when_unregistered(self, mock_write, mock_client):
         """Test disabling a device when it is unregistered."""
+        from apns2.errors import Unregistered
+
         send = mock_client.return_value.send_notification
         send.side_effect = Unregistered()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -797,8 +797,10 @@ class TestConfig(unittest.TestCase):
     def test_is_allowed_path(self):
         """Test is_allowed_path method."""
         with TemporaryDirectory() as tmp_dir:
+            # The created dir is in /tmp. This is a symlink on OS X
+            # causing this test to fail unless we resolve path first.
             self.config.whitelist_external_dirs = set((
-                tmp_dir,
+                os.path.realpath(tmp_dir),
             ))
 
             test_file = os.path.join(tmp_dir, "test.jpg")


### PR DESCRIPTION
## Description:
Really small test tweaks:

 - Fix broken `hass.config.is_allowed_path` test on OS X caused by `/tmp` being a symlink
 - Move `apns2` import in test file into function that uses it. Not required for tests but since `apns2` doesn't install under PyPy and this is the only file that causes my tests not to run under PyPy, a small fix 👍 

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
