### PR TITLE
Fix error on entity_config missing

### DIFF
--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -39,7 +39,7 @@ def async_register_http(hass, cfg):
     expose_by_default = cfg.get(CONF_EXPOSE_BY_DEFAULT)
     exposed_domains = cfg.get(CONF_EXPOSED_DOMAINS)
     agent_user_id = cfg.get(CONF_AGENT_USER_ID)
-    entity_config = cfg.get(CONF_ENTITY_CONFIG)
+    entity_config = cfg.get(CONF_ENTITY_CONFIG) or {}
 
     def is_exposed(entity) -> bool:
         """Determine if an entity should be exposed to Google Assistant."""


### PR DESCRIPTION
If the `google_assistant` key exists in the config but has no `entity_config` key under it you'll get an error.

```
  File "/Users/pkates/src/home-assistant/homeassistant/components/google_assistant/http.py", line 51, in is_exposed
    entity_config.get(entity.entity_id, {}).get(CONF_EXPOSE)
AttributeError: 'NoneType' object has no attribute 'get'
```

@balloob related to #11499 

## Checklist:
  - [x] The code change is tested and works locally.