### PR TITLE
device tracker - tomato https support

### DIFF
--- a/homeassistant/components/device_tracker/tomato.py
+++ b/homeassistant/components/device_tracker/tomato.py
@@ -14,7 +14,9 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT, CONF_SSL, CONF_VERIFY_SSL,
+    CONF_PASSWORD, CONF_USERNAME)
 
 CONF_HTTP_ID = 'http_id'
 
@@ -22,6 +24,9 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=80): cv.port,
+    vol.Optional(CONF_SSL, default=False): cv.boolean,
+    vol.Optional(CONF_VERIFY_SSL, default=""): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_HTTP_ID): cv.string
@@ -39,10 +44,20 @@ class TomatoDeviceScanner(DeviceScanner):
     def __init__(self, config):
         """Initialize the scanner."""
         host, http_id = config[CONF_HOST], config[CONF_HTTP_ID]
+        port = config[CONF_PORT]
         username, password = config[CONF_USERNAME], config[CONF_PASSWORD]
+        self.ssl, self.verify_ssl = config[CONF_SSL], config[CONF_VERIFY_SSL]
+
+        if self.ssl:
+            try:
+                self.verify_ssl = cv.boolean(self.verify_ssl)
+            except vol.Invalid:
+                pass
 
         self.req = requests.Request(
-            'POST', 'http://{}/update.cgi'.format(host),
+            'POST', 'http{}://{}:{}/update.cgi'.format(
+                "s" if self.ssl else "", host, port
+            ),
             data={'_http_id': http_id, 'exec': 'devlist'},
             auth=requests.auth.HTTPBasicAuth(username, password)).prepare()
 
@@ -77,7 +92,13 @@ class TomatoDeviceScanner(DeviceScanner):
         self.logger.info("Scanning")
 
         try:
-            response = requests.Session().send(self.req, timeout=3)
+            if self.ssl:
+                response = requests.Session().send(self.req,
+                                                   timeout=3,
+                                                   verify=self.verify_ssl)
+            else:
+                response = requests.Session().send(self.req, timeout=3)
+
             # Calling and parsing the Tomato api here. We only need the
             # wldev and dhcpd_lease values.
             if response.status_code == 200:

--- a/homeassistant/components/device_tracker/tomato.py
+++ b/homeassistant/components/device_tracker/tomato.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_PORT, default=80): cv.port,
+    vol.Optional(CONF_PORT, default=-1): cv.port,
     vol.Optional(CONF_SSL, default=False): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=True): vol.Any(
         cv.boolean, cv.isfile),
@@ -48,6 +48,10 @@ class TomatoDeviceScanner(DeviceScanner):
         port = config[CONF_PORT]
         username, password = config[CONF_USERNAME], config[CONF_PASSWORD]
         self.ssl, self.verify_ssl = config[CONF_SSL], config[CONF_VERIFY_SSL]
+        if port == -1:
+            port = 80
+            if self.ssl:
+                port = 443
 
         self.req = requests.Request(
             'POST', 'http{}://{}:{}/update.cgi'.format(

--- a/homeassistant/components/device_tracker/tomato.py
+++ b/homeassistant/components/device_tracker/tomato.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 
 CONF_HTTP_ID = 'http_id'
 
-_LOGGER = logging.getLogger("{}.{}".format(__name__, "Tomato"))
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,

--- a/tests/components/device_tracker/test_tomato.py
+++ b/tests/components/device_tracker/test_tomato.py
@@ -125,7 +125,8 @@ def test_config_valid_verify_ssl_path(hass, mock_session_send):
         'Content-Type': 'application/x-www-form-urlencoded',
         'Authorization': 'Basic YmFyOmZvbw=='
         }
-    assert result.req.body == "_http_id=0987654321&exec=devlist"
+    assert "_http_id=0987654321" in result.req.body
+    assert "exec=devlist" in result.req.body
     assert mock_session_send.call_count == 1
     assert mock_session_send.mock_calls[0] == \
         mock.call(result.req, timeout=3, verify="/tmp/tomato.crt")
@@ -152,7 +153,8 @@ def test_config_valid_verify_ssl_bool(hass, mock_session_send):
         'Content-Type': 'application/x-www-form-urlencoded',
         'Authorization': 'Basic YmFyOmZvbw=='
         }
-    assert result.req.body == "_http_id=0987654321&exec=devlist"
+    assert "_http_id=0987654321" in result.req.body
+    assert "exec=devlist" in result.req.body
     assert mock_session_send.call_count == 1
     assert mock_session_send.mock_calls[0] == \
         mock.call(result.req, timeout=3, verify=False)

--- a/tests/components/device_tracker/test_tomato.py
+++ b/tests/components/device_tracker/test_tomato.py
@@ -75,6 +75,41 @@ def test_config_missing_optional_params(hass, mock_session_send):
 
 @mock.patch('os.access', return_value=True)
 @mock.patch('os.path.isfile', mock.Mock(return_value=True))
+def test_config_default_nonssl_port(hass, mock_session_send):
+    """Test the setup with a string with ssl_verify but ssl not enabled."""
+    config = {
+        DOMAIN: tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_USERNAME: 'foo',
+            CONF_PASSWORD: 'password',
+            tomato.CONF_HTTP_ID: '1234567890'
+        })
+    }
+    result = tomato.get_scanner(hass, config)
+    assert result.req.url == "http://tomato-router:80/update.cgi"
+
+
+@mock.patch('os.access', return_value=True)
+@mock.patch('os.path.isfile', mock.Mock(return_value=True))
+def test_config_default_ssl_port(hass, mock_session_send):
+    """Test the setup with a string with ssl_verify but ssl not enabled."""
+    config = {
+        DOMAIN: tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_SSL: True,
+            CONF_USERNAME: 'foo',
+            CONF_PASSWORD: 'password',
+            tomato.CONF_HTTP_ID: '1234567890'
+        })
+    }
+    result = tomato.get_scanner(hass, config)
+    assert result.req.url == "https://tomato-router:443/update.cgi"
+
+
+@mock.patch('os.access', return_value=True)
+@mock.patch('os.path.isfile', mock.Mock(return_value=True))
 def test_config_verify_ssl_but_no_ssl_enabled(hass, mock_session_send):
     """Test the setup with a string with ssl_verify but ssl not enabled."""
     config = {

--- a/tests/components/device_tracker/test_tomato.py
+++ b/tests/components/device_tracker/test_tomato.py
@@ -10,6 +10,7 @@ from homeassistant.const import (CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
 
 
 def mock_session_response(*args, **kwargs):
+    """Mock data generation for session response."""
     class MockSessionResponse:
         def __init__(self, text, status_code):
             self.text = text

--- a/tests/components/device_tracker/test_tomato.py
+++ b/tests/components/device_tracker/test_tomato.py
@@ -67,7 +67,8 @@ def test_config_missing_optional_params(hass, mock_session_send):
         'Content-Type': 'application/x-www-form-urlencoded',
         'Authorization': 'Basic Zm9vOnBhc3N3b3Jk'
         }
-    assert result.req.body == "_http_id=1234567890&exec=devlist"
+    assert "_http_id=1234567890" in result.req.body
+    assert "exec=devlist" in result.req.body
 
 
 @mock.patch('os.access', return_value=True)
@@ -93,7 +94,8 @@ def test_config_verify_ssl_but_no_ssl_enabled(hass, mock_session_send):
         'Content-Type': 'application/x-www-form-urlencoded',
         'Authorization': 'Basic Zm9vOnBhc3N3b3Jk'
         }
-    assert result.req.body == "_http_id=1234567890&exec=devlist"
+    assert "_http_id=1234567890" in result.req.body
+    assert "exec=devlist" in result.req.body
     assert mock_session_send.call_count == 1
     assert mock_session_send.mock_calls[0] == \
         mock.call(result.req, timeout=3)

--- a/tests/components/device_tracker/test_tomato.py
+++ b/tests/components/device_tracker/test_tomato.py
@@ -76,7 +76,7 @@ def test_config_missing_optional_params(hass, mock_session_send):
 @mock.patch('os.access', return_value=True)
 @mock.patch('os.path.isfile', mock.Mock(return_value=True))
 def test_config_default_nonssl_port(hass, mock_session_send):
-    """Test the setup with a string with ssl_verify but ssl not enabled."""
+    """Test the setup without a default port set without ssl enabled."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA({
             CONF_PLATFORM: tomato.DOMAIN,
@@ -93,7 +93,7 @@ def test_config_default_nonssl_port(hass, mock_session_send):
 @mock.patch('os.access', return_value=True)
 @mock.patch('os.path.isfile', mock.Mock(return_value=True))
 def test_config_default_ssl_port(hass, mock_session_send):
-    """Test the setup with a string with ssl_verify but ssl not enabled."""
+    """Test the setup without a default port set with ssl enabled."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA({
             CONF_PLATFORM: tomato.DOMAIN,

--- a/tests/components/device_tracker/test_tomato.py
+++ b/tests/components/device_tracker/test_tomato.py
@@ -1,0 +1,280 @@
+"""The tests for the Tomato device tracker platform."""
+from unittest import mock
+import pytest
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import DOMAIN, tomato as tomato
+from homeassistant.const import (CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
+                                 CONF_PORT, CONF_SSL, CONF_PLATFORM,
+                                 CONF_VERIFY_SSL)
+
+
+def mock_session_response(*args, **kwargs):
+    class MockSessionResponse:
+        def __init__(self, text, status_code):
+            self.text = text
+            self.status_code = status_code
+
+    # Username: foo
+    # Password: bar
+    if args[0].headers['Authorization'] != 'Basic Zm9vOmJhcg==':
+        return MockSessionResponse(None, 401)
+    elif "gimmie_bad_data" in args[0].body:
+        return MockSessionResponse('This shouldn\'t (wldev = be here.;', 200)
+    elif "gimmie_good_data" in args[0].body:
+        return MockSessionResponse("wldev = [ ['eth1','F4:F5:D8:AA:AA:AA',"
+            "-42,5500,1000,7043,0],['eth1','58:EF:68:00:00:00',"
+            "-42,5500,1000,7043,0]];\n"
+            "dhcpd_lease = [ ['chromecast','172.10.10.5','F4:F5:D8:AA:AA:AA',"
+            "'0 days, 16:17:08'],['wemo','172.10.10.6','58:EF:68:00:00:00',"
+            "'0 days, 12:09:08']];", 200)
+
+    return MockSessionResponse(None, 200)
+
+
+@pytest.fixture
+def mock_exception_logger():
+    """Mock pyunifi."""
+    with mock.patch('homeassistant.components.device_tracker'
+                    '.tomato._LOGGER.exception') as mock_exception_logger:
+        yield mock_exception_logger
+
+
+@pytest.fixture
+def mock_session_send():
+    """Mock requests.Session().send."""
+    with mock.patch('requests.Session.send') as mock_session_send:
+        yield mock_session_send
+
+
+def test_config_missing_optional_params(hass, mock_session_send):
+    """Test the setup without optional parameters."""
+    config = {
+        DOMAIN: tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_USERNAME: 'foo',
+            CONF_PASSWORD: 'password',
+            tomato.CONF_HTTP_ID: '1234567890'
+        })
+    }
+    result = tomato.get_scanner(hass, config)
+    assert result.req.url == "http://tomato-router:80/update.cgi"
+    assert result.req.headers == {
+        'Content-Length': '32',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': 'Basic Zm9vOnBhc3N3b3Jk'
+        }
+    assert result.req.body == "_http_id=1234567890&exec=devlist"
+
+
+@mock.patch('os.access', return_value=True)
+@mock.patch('os.path.isfile', mock.Mock(return_value=True))
+def test_config_verify_ssl_but_no_ssl_enabled(hass, mock_session_send):
+    """Test the setup with a string with ssl_verify but ssl not enabled."""
+    config = {
+        DOMAIN: tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_PORT: 1234,
+            CONF_SSL: False,
+            CONF_VERIFY_SSL: "/tmp/tomato.crt",
+            CONF_USERNAME: 'foo',
+            CONF_PASSWORD: 'password',
+            tomato.CONF_HTTP_ID: '1234567890'
+        })
+    }
+    result = tomato.get_scanner(hass, config)
+    assert result.req.url == "http://tomato-router:1234/update.cgi"
+    assert result.req.headers == {
+        'Content-Length': '32',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': 'Basic Zm9vOnBhc3N3b3Jk'
+        }
+    assert result.req.body == "_http_id=1234567890&exec=devlist"
+    assert mock_session_send.call_count == 1
+    assert mock_session_send.mock_calls[0] == \
+        mock.call(result.req, timeout=3)
+
+
+@mock.patch('os.access', return_value=True)
+@mock.patch('os.path.isfile', mock.Mock(return_value=True))
+def test_config_valid_verify_ssl_path(hass, mock_session_send):
+    """Test the setup with a string for ssl_verify.
+
+    Representing the absolute path to a CA certificate bundle.
+    """
+    config = {
+        DOMAIN: tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_PORT: 1234,
+            CONF_SSL: True,
+            CONF_VERIFY_SSL: "/tmp/tomato.crt",
+            CONF_USERNAME: 'bar',
+            CONF_PASSWORD: 'foo',
+            tomato.CONF_HTTP_ID: '0987654321'
+        })
+    }
+    result = tomato.get_scanner(hass, config)
+    assert result.req.url == "https://tomato-router:1234/update.cgi"
+    assert result.req.headers == {
+        'Content-Length': '32',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': 'Basic YmFyOmZvbw=='
+        }
+    assert result.req.body == "_http_id=0987654321&exec=devlist"
+    assert mock_session_send.call_count == 1
+    assert mock_session_send.mock_calls[0] == \
+        mock.call(result.req, timeout=3, verify="/tmp/tomato.crt")
+
+
+def test_config_valid_verify_ssl_bool(hass, mock_session_send):
+    """Test the setup with a bool for ssl_verify."""
+    config = {
+        DOMAIN: tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_PORT: 1234,
+            CONF_SSL: True,
+            CONF_VERIFY_SSL: "False",
+            CONF_USERNAME: 'bar',
+            CONF_PASSWORD: 'foo',
+            tomato.CONF_HTTP_ID: '0987654321'
+        })
+    }
+    result = tomato.get_scanner(hass, config)
+    assert result.req.url == "https://tomato-router:1234/update.cgi"
+    assert result.req.headers == {
+        'Content-Length': '32',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': 'Basic YmFyOmZvbw=='
+        }
+    assert result.req.body == "_http_id=0987654321&exec=devlist"
+    assert mock_session_send.call_count == 1
+    assert mock_session_send.mock_calls[0] == \
+        mock.call(result.req, timeout=3, verify=False)
+
+
+def test_config_errors():
+    """Test for configuration errors."""
+    with pytest.raises(vol.Invalid):
+        tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            # No Host,
+            CONF_PORT: 1234,
+            CONF_SSL: True,
+            CONF_VERIFY_SSL: "False",
+            CONF_USERNAME: 'bar',
+            CONF_PASSWORD: 'foo',
+            tomato.CONF_HTTP_ID: '0987654321'
+        })
+    with pytest.raises(vol.Invalid):
+        tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_PORT: -123456789,  # Bad Port
+            CONF_SSL: True,
+            CONF_VERIFY_SSL: "False",
+            CONF_USERNAME: 'bar',
+            CONF_PASSWORD: 'foo',
+            tomato.CONF_HTTP_ID: '0987654321'
+        })
+    with pytest.raises(vol.Invalid):
+        tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_PORT: 1234,
+            CONF_SSL: True,
+            CONF_VERIFY_SSL: "False",
+            # No Username
+            CONF_PASSWORD: 'foo',
+            tomato.CONF_HTTP_ID: '0987654321'
+        })
+    with pytest.raises(vol.Invalid):
+        tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_PORT: 1234,
+            CONF_SSL: True,
+            CONF_VERIFY_SSL: "False",
+            CONF_USERNAME: 'bar',
+            # No Password
+            tomato.CONF_HTTP_ID: '0987654321'
+        })
+    with pytest.raises(vol.Invalid):
+        tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_PORT: 1234,
+            CONF_SSL: True,
+            CONF_VERIFY_SSL: "False",
+            CONF_USERNAME: 'bar',
+            CONF_PASSWORD: 'foo',
+            # No HTTP_ID
+        })
+
+
+@mock.patch('requests.Session.send', side_effect=mock_session_response)
+def test_config_bad_credentials(hass, mock_exception_logger):
+    """Test the setup with bad credentials.
+
+    Representing the absolute path to a CA certificate bundle.
+    """
+    config = {
+        DOMAIN: tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_USERNAME: 'i_am',
+            CONF_PASSWORD: 'an_imposter',
+            tomato.CONF_HTTP_ID: '1234'
+        })
+    }
+
+    tomato.get_scanner(hass, config)
+
+    assert mock_exception_logger.call_count == 1
+    assert mock_exception_logger.mock_calls[0] == \
+        mock.call("Failed to authenticate, "
+                  "please check your username and password")
+
+
+@mock.patch('requests.Session.send', side_effect=mock_session_response)
+def test_scan_devices(hass, mock_exception_logger):
+    """Test the setup with bad credentials.
+
+    Representing the absolute path to a CA certificate bundle.
+    """
+    config = {
+        DOMAIN: tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_USERNAME: 'foo',
+            CONF_PASSWORD: 'bar',
+            tomato.CONF_HTTP_ID: 'gimmie_good_data'
+        })
+    }
+
+    scanner = tomato.get_scanner(hass, config)
+    assert scanner.scan_devices() == ['F4:F5:D8:AA:AA:AA', '58:EF:68:00:00:00']
+
+
+@mock.patch('requests.Session.send', side_effect=mock_session_response)
+def test_get_device_name(hass, mock_exception_logger):
+    """Test the setup with bad credentials.
+
+    Representing the absolute path to a CA certificate bundle.
+    """
+    config = {
+        DOMAIN: tomato.PLATFORM_SCHEMA({
+            CONF_PLATFORM: tomato.DOMAIN,
+            CONF_HOST: 'tomato-router',
+            CONF_USERNAME: 'foo',
+            CONF_PASSWORD: 'bar',
+            tomato.CONF_HTTP_ID: 'gimmie_good_data'
+        })
+    }
+
+    scanner = tomato.get_scanner(hass, config)
+    assert scanner.get_device_name('F4:F5:D8:AA:AA:AA') == 'chromecast'
+    assert scanner.get_device_name('58:EF:68:00:00:00') == 'wemo'

--- a/tests/components/device_tracker/test_tomato.py
+++ b/tests/components/device_tracker/test_tomato.py
@@ -22,7 +22,8 @@ def mock_session_response(*args, **kwargs):
     elif "gimmie_bad_data" in args[0].body:
         return MockSessionResponse('This shouldn\'t (wldev = be here.;', 200)
     elif "gimmie_good_data" in args[0].body:
-        return MockSessionResponse("wldev = [ ['eth1','F4:F5:D8:AA:AA:AA',"
+        return MockSessionResponse(
+            "wldev = [ ['eth1','F4:F5:D8:AA:AA:AA',"
             "-42,5500,1000,7043,0],['eth1','58:EF:68:00:00:00',"
             "-42,5500,1000,7043,0]];\n"
             "dhcpd_lease = [ ['chromecast','172.10.10.5','F4:F5:D8:AA:AA:AA',"


### PR DESCRIPTION
## Description:
Adding https support to the tomato device tracker.  ~~Still need to update documentation in other repo.~~

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4389

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
