### PR TITLE
Reduce bandwidth of images from cameras on frontend

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -62,14 +62,6 @@ CAMERA_SERVICE_SNAPSHOT = CAMERA_SERVICE_SCHEMA.extend({
     vol.Required(ATTR_FILENAME): cv.template
 })
 
-CONF_REQUEST_IMAGE_WIDTH = 'request_image_width'
-REQUEST_IMAGE_WIDTH = "camera_request_image_width"
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_REQUEST_IMAGE_WIDTH): int,
-})
-
-
 @bind_hass
 def enable_motion_detection(hass, entity_id=None):
     """Enable Motion Detection."""
@@ -134,8 +126,6 @@ def async_setup(hass, config):
 
     hass.http.register_view(CameraImageView(component.entities))
     hass.http.register_view(CameraMjpegStream(component.entities))
-
-    hass.data[REQUEST_IMAGE_WIDTH] = 360
 
     yield from component.async_setup(config)
 
@@ -230,12 +220,6 @@ class Camera(Entity):
     def entity_picture(self):
         """Return a link to the camera feed as entity picture."""
         return ENTITY_IMAGE_URL.format(self.entity_id, self.access_tokens[-1])
-
-    @property
-    def request_image_width(self):
-        """Return the default image width to request."""
-        print("Image Width: {}".format(self.hass.data[REQUEST_IMAGE_WIDTH]))
-        return self.hass.data[REQUEST_IMAGE_WIDTH]
 
     @property
     def is_recording(self):

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -31,7 +31,6 @@ import homeassistant.helpers.config_validation as cv
 
 DOMAIN = 'camera'
 DEPENDENCIES = ['http']
-REQUIREMENTS = ['Pillow==5.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/resize_image.py
+++ b/homeassistant/components/resize_image.py
@@ -1,0 +1,91 @@
+"""
+Component that will enable resizing images to reduce bandwidth.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/resize_image
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+REQUIREMENTS = ['pillow==5.0.0']
+
+DOMAIN = 'resize_image'
+
+_LOGGER = logging.getLogger(__name__)
+
+
+CONF_MAX_WIDTH = 'max_width'
+CONF_QUALITY = 'quality'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_MAX_WIDTH, default=0): int,
+        vol.Optional(CONF_QUALITY, default=75): int,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up the resize_image component."""
+    conf = config.get(DOMAIN, {})
+
+    resizer = ImageResizer(
+        hass,
+        conf.get(CONF_MAX_WIDTH),
+        conf.get(CONF_QUALITY)
+    )
+
+    hass.data[DOMAIN] = resizer
+    return True
+
+
+class ImageResizer(object):
+    """Helper for resize_image."""
+
+    def __init__(self, hass, max_width, quality):
+        """Initialize helper."""
+        self.hass = hass
+        self._max_width = max_width
+        self._quality = quality
+
+    def resize_image(self, image, requested_width):
+        """Resize image."""
+        from PIL import Image
+        import io
+
+        if self._max_width and requested_width > self._max_width:
+            new_width = self._max_width
+        else:
+            new_width = requested_width
+        if new_width == 0:
+            _LOGGER.debug("No resize width requested")
+            return image
+
+        img = Image.open(io.BytesIO(image))
+        imgfmt = str(img.format)
+        if imgfmt != 'PNG' and imgfmt != 'JPEG':
+            _LOGGER.debug("Image is of unsupported type: %s", imgfmt)
+            return image
+
+        (old_width, old_height) = img.size
+        old_size = len(image)
+        if old_width <= new_width:
+            _LOGGER.debug("Image is smaller than requested width")
+            return image
+
+        scale = new_width / float(old_width)
+        new_height = int((float(old_height)*float(scale)))
+
+        img = img.resize((new_width, new_height), Image.ANTIALIAS)
+        imgbuf = io.BytesIO()
+        img.save(imgbuf, "JPEG", optimize=True, quality=self._quality)
+        image = imgbuf.getvalue()
+        _LOGGER.debug("Resized image "
+                      "from (%dx%d - %d bytes) "
+                      "to (%dx%d - %d bytes)",
+                      old_width, old_height, old_size,
+                      new_width, new_height, len(image))
+        return image

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -22,9 +22,6 @@ certifi>=2017.4.17
 # homeassistant.components.doorbird
 DoorBirdPy==0.1.2
 
-# homeassistant.components.camera
-Pillow==5.0.0
-
 # homeassistant.components.isy994
 PyISY==1.1.0
 
@@ -571,6 +568,9 @@ piglow==1.2.4
 
 # homeassistant.components.pilight
 pilight==0.1.1
+
+# homeassistant.components.resize_image
+pillow==5.0.0
 
 # homeassistant.components.dominos
 pizzapi==0.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -22,6 +22,9 @@ certifi>=2017.4.17
 # homeassistant.components.doorbird
 DoorBirdPy==0.1.2
 
+# homeassistant.components.camera
+Pillow==5.0.0
+
 # homeassistant.components.isy994
 PyISY==1.1.0
 


### PR DESCRIPTION
## Description:
I have several cameras connected to Home-Assistant, and do not have a high-bandwidth upload rate from my server.  I also tend to have several users looking at the home page remotely at any given time.

The current camera code sends the highest resolution image available to the frontend.

This change allows the frontend to request a lower resolution image to match the current requirements.

The new component 'resize_image' (if enabled) will use PIL to resize the image.  Note that resizing only occurs if enabled in the configuration AND if the frontend requests it (the current implementation has the frontend request camera images be resized when the camera-card is displayed, but not in the more-info view)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Pull request in frontend:** https://github.com/home-assistant/home-assistant-polymer/pull/795

## Example entry for `configuration.yaml` (if applicable): 
```yaml
resize_image:
    max_width: 360 (optional)
    quality: 75 (optional)
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
