### PR TITLE
Add Velux Roller Shutter to Tahoma

### DIFF
--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -40,6 +40,7 @@ TAHOMA_TYPES = {
     'rts:RollerShutterRTSComponent': 'cover',
     'rts:CurtainRTSComponent': 'cover',
     'io:RollerShutterWithLowSpeedManagementIOComponent': 'cover',
+    'io:RollerShutterVeluxIOComponent': 'cover',
     'io:WindowOpenerVeluxIOComponent': 'cover',
     'io:LightIOSystemSensor': 'sensor',
 }


### PR DESCRIPTION
## Description:

With #11538  I forgot to add another type of Roller shutters that should be supported.

## Checklist:
  - [x] The code change is tested and works locally.
