### PR TITLE
Pr/11430

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -35,7 +35,7 @@ def generate_entity_id(entity_id_format: str, name: Optional[str],
                 current_ids, hass
             ).result()
 
-    name = (slugify(name) or DEVICE_DEFAULT_NAME).lower()
+    name = (slugify(name) or slugify(DEVICE_DEFAULT_NAME)).lower()
 
     return ensure_unique_string(
         entity_id_format.format(name), current_ids)

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -35,10 +35,10 @@ def generate_entity_id(entity_id_format: str, name: Optional[str],
                 current_ids, hass
             ).result()
 
-    name = (name or DEVICE_DEFAULT_NAME).lower()
+    name = (slugify(name) or DEVICE_DEFAULT_NAME).lower()
 
     return ensure_unique_string(
-        entity_id_format.format(slugify(name)), current_ids)
+        entity_id_format.format(name), current_ids)
 
 
 @callback

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -31,6 +31,14 @@ def test_generate_entity_id_given_keys():
             'test.another_entity']) == 'test.overwrite_hidden_true'
 
 
+def test_generate_entity_id_with_nonlatin_name():
+    """Test generate_entity_id given a name containing non-latin characters."""
+    fmt = 'test.{}'
+    assert entity.generate_entity_id(
+        fmt, 'ホームアシスタント', current_ids=[]
+    ) == 'test.unnamed_device'
+
+
 def test_async_update_support(hass):
     """Test async update getting called."""
     sync_update = []


### PR DESCRIPTION
## Description:
Replaces #11430

Handle generating entity ids for devices that only contain non latin characters.

**Related issue (if applicable):** fixes #11430

## Checklist:

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
