### PR TITLE
Fix Tahoma stop command for 2 types of shutters

### DIFF
--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -79,7 +79,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
     def stop_cover(self, **kwargs):
         """Stop the cover."""
         self.apply_action(TAHOMA_STOP_COMMAND.get(self.tahoma_device.type,
-                          'stopIdentify'))
+                                                  'stopIdentify'))
 
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -78,7 +78,8 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
-        self.apply_action(TAHOMA_STOP_COMMAND.get(self.tahoma_device.type, 'stopIdentify'))
+        self.apply_action(TAHOMA_STOP_COMMAND.get(self.tahoma_device.type,
+                      'stopIdentify'))
 
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -15,6 +15,11 @@ DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
+TAHOMA_STOP_COMMAND = {
+    'io:RollerShutterWithLowSpeedManagementIOComponent': 'my',
+    'io:RollerShutterVeluxIOComponent': 'my',
+}
+
 SCAN_INTERVAL = timedelta(seconds=60)
 
 
@@ -73,7 +78,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
-        self.apply_action('stopIdentify')
+        self.apply_action(TAHOMA_STOP_COMMAND.get(self.tahoma_device.type, 'stopIdentify'))
 
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -79,7 +79,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
     def stop_cover(self, **kwargs):
         """Stop the cover."""
         self.apply_action(TAHOMA_STOP_COMMAND.get(self.tahoma_device.type,
-                      'stopIdentify'))
+                          'stopIdentify'))
 
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""


### PR DESCRIPTION
## Description:

Continuation of #11536 . The stop command for these 2 shutters is ```my```. I can't say what the stop command for the other devices is, it's kind of a mess on somfy's part.

By doing it like this I keep the original functionality intact (the original one doesn't work for these two shutters). Later on if someone wants to specify the stop command for their device this could be added very easily.

## Checklist:
  - [x] The code change is tested and works locally.