### PR TITLE
Pushbullet email support (fix)

### DIFF
--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -156,7 +156,7 @@ class PushBulletNotificationService(BaseNotificationService):
                 if not file_url.startswith('http'):
                     _LOGGER.error("URL should start with http or https")
                     return
-                pusher.push_file(title=title, body=message, **email_kwargs,
+                pusher.push_file(title=title, body=message, email=email,
                                  file_name=file_url, file_url=file_url,
                                  file_type=(mimetypes
                                             .guess_type(file_url)[0]))

--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -22,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_URL = 'url'
 ATTR_FILE = 'file'
 ATTR_FILE_URL = 'file_url'
+ATTR_LIST = 'list'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
@@ -99,7 +100,7 @@ class PushBulletNotificationService(BaseNotificationService):
                 continue
 
             # Target is email, send directly, don't use a target object.
-            # This also seems works to send to all devices in own account.
+            # This also seems to work to send to all devices in own account.
             if ttype == 'email':
                 self._push_data(message, title, data, self.pushbullet, tname)
                 _LOGGER.info("Sent notification to email %s", tname)
@@ -127,20 +128,21 @@ class PushBulletNotificationService(BaseNotificationService):
                 _LOGGER.error("No such target: %s/%s", ttype, tname)
                 continue
 
-    def _push_data(self, message, title, data, pusher, tname=None):
+    def _push_data(self, message, title, data, pusher, email=None):
         """Helper for creating the message content."""
         from pushbullet import PushError
         if data is None:
             data = {}
+        data_list = data.get(ATTR_LIST)
         url = data.get(ATTR_URL)
         filepath = data.get(ATTR_FILE)
         file_url = data.get(ATTR_FILE_URL)
         try:
+            email_kwargs = {}
+            if email:
+                email_kwargs['email'] = email
             if url:
-                if tname:
-                    pusher.push_link(title, url, body=message, email=tname)
-                else:
-                    pusher.push_link(title, url, body=message)
+                pusher.push_link(title, url, body=message, **email_kwargs)
             elif filepath:
                 if not self.hass.config.is_allowed_path(filepath):
                     _LOGGER.error("Filepath is not valid or allowed")
@@ -150,18 +152,20 @@ class PushBulletNotificationService(BaseNotificationService):
                     if filedata.get('file_type') == 'application/x-empty':
                         _LOGGER.error("Can not send an empty file")
                         return
-                    pusher.push_file(title=title, body=message, **filedata)
+
+                    pusher.push_file(title=title, body=message,
+                                     **email_kwargs, **filedata)
             elif file_url:
                 if not file_url.startswith('http'):
                     _LOGGER.error("URL should start with http or https")
                     return
-                pusher.push_file(title=title, body=message, file_name=file_url,
-                                 file_url=file_url,
-                                 file_type=mimetypes.guess_type(file_url)[0])
+                pusher.push_file(title=title, body=message, **email_kwargs,
+                                 file_name=file_url, file_url=file_url,
+                                 file_type=(mimetypes
+                                            .guess_type(file_url)[0]))
+            elif data_list:
+                pusher.push_note(title, data_list, **email_kwargs)
             else:
-                if tname:
-                    pusher.push_note(title, message, email=tname)
-                else:
-                    pusher.push_note(title, message)
+                pusher.push_note(title, message, **email_kwargs)
         except PushError as err:
             _LOGGER.error("Notify failed: %s", err)

--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -138,11 +138,8 @@ class PushBulletNotificationService(BaseNotificationService):
         filepath = data.get(ATTR_FILE)
         file_url = data.get(ATTR_FILE_URL)
         try:
-            email_kwargs = {}
-            if email:
-                email_kwargs['email'] = email
             if url:
-                pusher.push_link(title, url, body=message, **email_kwargs)
+                pusher.push_link(title, url, body=message, email=email)
             elif filepath:
                 if not self.hass.config.is_allowed_path(filepath):
                     _LOGGER.error("Filepath is not valid or allowed")
@@ -154,7 +151,7 @@ class PushBulletNotificationService(BaseNotificationService):
                         return
 
                     pusher.push_file(title=title, body=message,
-                                     **email_kwargs, **filedata)
+                                     email=email, **filedata)
             elif file_url:
                 if not file_url.startswith('http'):
                     _LOGGER.error("URL should start with http or https")
@@ -164,8 +161,8 @@ class PushBulletNotificationService(BaseNotificationService):
                                  file_type=(mimetypes
                                             .guess_type(file_url)[0]))
             elif data_list:
-                pusher.push_note(title, data_list, **email_kwargs)
+                pusher.push_note(title, data_list, email=email)
             else:
-                pusher.push_note(title, message, **email_kwargs)
+                pusher.push_note(title, message, email=email)
         except PushError as err:
             _LOGGER.error("Notify failed: %s", err)

--- a/tests/components/notify/test_pushbullet.py
+++ b/tests/components/notify/test_pushbullet.py
@@ -1,0 +1,42 @@
+"""The tests for the pushbullet notification platform."""
+
+import unittest
+
+from homeassistant.setup import setup_component
+import homeassistant.components.notify as notify
+from tests.common import assert_setup_component, get_test_home_assistant
+
+
+class TestPushbullet(unittest.TestCase):
+    """Test the pushbullet notifications."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_setup(self):
+        """Test setup."""
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, 'notify', {
+                'notify': {
+                    'name': 'test',
+                    'platform': 'pushbullet',
+                    'api_key': 'MYFAKEKEY', }
+            })
+        assert handle_config[notify.DOMAIN]
+
+    def test_bad_config(self):
+        """Test set up the platform with bad/missing configuration."""
+        config = {
+            notify.DOMAIN: {
+                'name': 'test',
+                'platform': 'pushbullet',
+            }
+        }
+        with assert_setup_component(0) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert not handle_config[notify.DOMAIN]


### PR DESCRIPTION
## Description:

Recreated from https://github.com/home-assistant/home-assistant/pull/11367 since I munged up the rebase and I am too tired to fix it right now.

- Enable email notifications for all push types, previously only worked for notes.
- Enable list as a data parameter, to pass lists as well as files,
- Added super basic unittest, can't do much more without API KEY, emailed pushbullet to see if
  they make a test api available, will add more tests if they do.

**Related issue (if applicable):** fixes #11198

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io# N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
test_pushbullet_file:
  sequence:
    service: notify.pushbullet
    data:
      title: Test File Title
      message: Test File
      target:
        - "device/User's iPhone"
        - email/user@host.net
      data:
        file: /tmp/tv_check_doc.jpg

test_pushbullet_note:
  sequence:
    service: notify.pushbullet
    data:
      title: Test Note Title
      message: Test Note

test_pushbullet_list:
  sequence:
    service: notify.pushbullet
    data:
      title: Test List Title
      message: Test List
      data:
        list:
          - item1
          - item2

test_pushbullet_template_list:
  sequence:
    service: notify.pushbullet
    data_template:
      title: Test Template List Title
      message: Test Template List
      data:
        list:
          - "{{ testvar| default('item3') }}"
          - "{{ testvar | default('item4') }}"
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
