### PR TITLE
Fix state for trigger with forced updates

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -55,7 +55,7 @@ def async_trigger(hass, config, action):
 
         # Ignore changes to state attributes if from/to is in use
         if (not match_all and from_s is not None and to_s is not None and
-                from_s.last_changed == to_s.last_changed):
+                from_s.state == to_s.state):
             return
 
         if not time_delta:


### PR DESCRIPTION
## Description:
This PR fixes a bug with the automation state trigger. When a platform pushes force updates the state change listener previously created a new time tracking callback.

Another possible fix would be to not update last_changed on forced updates. I'm not 100% sure how we want last_changed to operate.

https://github.com/home-assistant/home-assistant/blob/4883036789603064b1301ef6ea918d1fc27b79c5/homeassistant/core.py#L744