### PR TITLE
Snips add say and say_actions services (new)

### DIFF
--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -371,10 +371,10 @@ snips:
       text:
         description: Text to say.
         example: My name is snips
-      siteId:
+      site_id:
         description: Site to use to start session, defaults to default (optional)
         example: bedroom
-      customData:
+      custom_data:
         description: custom data that will be included with all messages in this session
         example: user=UserName
   say_action:
@@ -383,16 +383,16 @@ snips:
       text:
         description: Text to say
         example: My name is snips
-      siteId:
+      site_id:
         description: Site to use to start session, defaults to default (optional)
         example: bedroom
-      customData:
+      custom_data:
         description: custom data that will be included with all messages in this session
         example: user=UserName
-      canBeEnqueued:
+      can_be_enqueued:
         description: If True, session waits for an open session to end, if False session is dropped if one is running
         example: True
-      intentFilter:
+      intent_filter:
         description: Optional Array of Strings - A list of intents names to restrict the NLU resolution to on the first query.
         example: turnOnLights, turnOffLights
 

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -450,6 +450,38 @@ input_number:
         description: Entity id of the input number the should be decremented.
         example: 'input_number.threshold'
 
+input_select:
+  select_option:
+    description: Select an option of an input select entity.
+    fields:
+      entity_id:
+        description: Entity id of the input select to select the value.
+        example: 'input_select.my_select'
+      option:
+        description: Option to be selected.
+        example: '"Item A"'
+  set_options:
+    description: Set the options of an input select entity.
+    fields:
+      entity_id:
+        description: Entity id of the input select to set the new options for.
+        example: 'input_select.my_select'
+      options:
+        description: Options for the input select entity.
+        example: '["Item A", "Item B", "Item C"]'
+  select_previous:
+    description: Select the previous options of an input select entity.
+    fields:
+      entity_id:
+        description: Entity id of the input select to select the previous value for.
+        example: 'input_select.my_select'
+  select_next:
+    description: Select the next options of an input select entity.
+    fields:
+      entity_id:
+        description: Entity id of the input select to select the next value for.
+        example: 'input_select.my_select'
+
 homeassistant:
   check_config:
     description: Check the Home Assistant configuration files for errors. Errors will be displayed in the Home Assistant log.

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -364,6 +364,38 @@ abode:
         description: Entity id of the quick action to trigger.
         example: 'binary_sensor.home_quick_action'
 
+snips:
+  say:
+    description: Send a TTS message to Snips.
+    fields:
+      text:
+        description: Text to say.
+        example: My name is snips
+      siteId:
+        description: Site to use to start session, defaults to default (optional)
+        example: bedroom
+      customData:
+        description: custom data that will be included with all messages in this session
+        example: user=UserName
+  say_action:
+    description: Send a TTS message to Snips to listen for a response.
+    fields:
+      text:
+        description: Text to say
+        example: My name is snips
+      siteId:
+        description: Site to use to start session, defaults to default (optional)
+        example: bedroom
+      customData:
+        description: custom data that will be included with all messages in this session
+        example: user=UserName
+      canBeEnqueued:
+        description: If True, session waits for an open session to end, if False session is dropped if one is running
+        example: True
+      intentFilter:
+        description: Optional Array of Strings - A list of intents names to restrict the NLU resolution to on the first query.
+        example: turnOnLights, turnOffLights
+
 input_boolean:
   toggle:
     description: Toggles an input boolean.
@@ -417,38 +449,6 @@ input_number:
       entity_id:
         description: Entity id of the input number the should be decremented.
         example: 'input_number.threshold'
-
-input_select:
-  select_option:
-    description: Select an option of an input select entity.
-    fields:
-      entity_id:
-        description: Entity id of the input select to select the value.
-        example: 'input_select.my_select'
-      option:
-        description: Option to be selected.
-        example: '"Item A"'
-  set_options:
-    description: Set the options of an input select entity.
-    fields:
-      entity_id:
-        description: Entity id of the input select to set the new options for.
-        example: 'input_select.my_select'
-      options:
-        description: Options for the input select entity.
-        example: '["Item A", "Item B", "Item C"]'
-  select_previous:
-    description: Select the previous options of an input select entity.
-    fields:
-      entity_id:
-        description: Entity id of the input select to select the previous value for.
-        example: 'input_select.my_select'
-  select_next:
-    description: Select the next options of an input select entity.
-    fields:
-      entity_id:
-        description: Entity id of the input select to select the next value for.
-        example: 'input_select.my_select'
 
 homeassistant:
   check_config:

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -81,12 +81,11 @@ def async_setup(hass, config):
             _LOGGER.error('Intent has invalid schema: %s. %s', err, request)
             return
 
-        snips_response = None
-
         if request['intent']['intentName'].startswith('user_'):
             intent_type = request['intent']['intentName'].split('__')[-1]
         else:
             intent_type = request['intent']['intentName'].split(':')[-1]
+        snips_response = None
         slots = {}
         for slot in request.get('slots', []):
             slots[slot['slotName']] = {'value': resolve_slot_values(slot)}

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -16,12 +16,20 @@ import homeassistant.components.mqtt as mqtt
 
 DOMAIN = 'snips'
 DEPENDENCIES = ['mqtt']
+
 CONF_INTENTS = 'intents'
 CONF_ACTION = 'action'
+
 SERVICE_SAY = 'say'
 SERVICE_SAY_ACTION = 'say_action'
 
 INTENT_TOPIC = 'hermes/intent/#'
+
+ATTR_TEXT = 'text'
+ATTR_SITE_ID = 'site_id'
+ATTR_CUSTOM_DATA = 'custom_data'
+ATTR_CAN_BE_ENQUEUED = 'can_be_enqueued'
+ATTR_INTENT_FILTER = 'intent_filter'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,17 +53,17 @@ INTENT_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 SERVICE_SCHEMA_SAY = vol.Schema({
-    vol.Required('text'): str,
-    vol.Optional('siteId', default='default'): str,
-    vol.Optional('customData', default=''): str
+    vol.Required(ATTR_TEXT): str,
+    vol.Optional(ATTR_SITE_ID, default='default'): str,
+    vol.Optional(ATTR_CUSTOM_DATA, default=''): str
 })
 
 SERVICE_SCHEMA_SAY_ACTION = vol.Schema({
-    vol.Required('text'): str,
-    vol.Optional('siteId', default='default'): str,
-    vol.Optional('customData', default=''): str,
-    vol.Optional('canBeEnqueued', default=True): cv.boolean,
-    vol.Optional('intentFilter'): vol.All(cv.ensure_list),
+    vol.Required(ATTR_TEXT): str,
+    vol.Optional(ATTR_SITE_ID, default='default'): str,
+    vol.Optional(ATTR_CUSTOM_DATA, default=''): str,
+    vol.Optional(ATTR_CAN_BE_ENQUEUED, default=True): cv.boolean,
+    vol.Optional(ATTR_INTENT_FILTER): vol.All(cv.ensure_list),
 })
 
 
@@ -114,10 +122,10 @@ def async_setup(hass, config):
     @asyncio.coroutine
     def snips_say(call):
         """Send a Snips notification message."""
-        notification = {'siteId': call.data.get('siteId', 'default'),
-                        'customData': call.data.get('customData', ''),
+        notification = {'siteId': call.data.get(ATTR_SITE_ID, 'default'),
+                        'customData': call.data.get(ATTR_CUSTOM_DATA, ''),
                         'init': {'type': 'notification',
-                                 'text': call.data.get('text')}}
+                                 'text': call.data.get(ATTR_TEXT)}}
         mqtt.async_publish(hass, 'hermes/dialogueManager/startSession',
                            json.dumps(notification))
         return
@@ -125,14 +133,14 @@ def async_setup(hass, config):
     @asyncio.coroutine
     def snips_say_action(call):
         """Send a Snips action message."""
-        notification = {'siteId': call.data.get('siteId', 'default'),
-                        'customData': call.data.get('customData', ''),
+        notification = {'siteId': call.data.get(ATTR_SITE_ID, 'default'),
+                        'customData': call.data.get(ATTR_CUSTOM_DATA, ''),
                         'init': {'type': 'action',
-                                 'text': call.data.get('text'),
+                                 'text': call.data.get(ATTR_TEXT),
                                  'canBeEnqueued': call.data.get(
-                                     'canBeEnqueued', True),
+                                     ATTR_CAN_BE_ENQUEUED, True),
                                  'intentFilter':
-                                     call.data.get('intentFilter', [])}}
+                                     call.data.get(ATTR_INTENT_FILTER, [])}}
         mqtt.async_publish(hass, 'hermes/dialogueManager/startSession',
                            json.dumps(notification))
         return

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -117,19 +117,17 @@ def async_setup(hass, config):
     @asyncio.coroutine
     def snips_say(call):
         """Send a Snips notification message."""
-        _LOGGER.debug("snips_say {}".format(call.data))
         notification = {'siteId': call.data.get('siteId', 'default'),
                         'customData': call.data.get('customData', ''),
                         'init': {'type': 'notification',
                                  'text': call.data.get('text')}}
         mqtt.async_publish(hass, 'hermes/dialogueManager/startSession',
-                                   json.dumps(notification))
+                           json.dumps(notification))
         return
 
     @asyncio.coroutine
     def snips_say_action(call):
         """Send a Snips action message."""
-        _LOGGER.debug("snips_say_action {}".format(call.data))
         notification = {'siteId': call.data.get('siteId', 'default'),
                         'customData': call.data.get('customData', ''),
                         'init': {'type': 'action',
@@ -138,9 +136,8 @@ def async_setup(hass, config):
                                      'canBeEnqueued', True),
                                  'intentFilter':
                                      call.data.get('intentFilter', [])}}
-        _LOGGER.debug("send_response %s", json.dumps(notification))
         mqtt.async_publish(hass, 'hermes/dialogueManager/startSession',
-                                   json.dumps(notification))
+                           json.dumps(notification))
         return
 
     descriptions = load_yaml_config_file(

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -12,7 +12,6 @@ from os import path
 
 import voluptuous as vol
 
-from homeassistant.config import load_yaml_config_file
 from homeassistant.helpers import intent, config_validation as cv
 import homeassistant.components.mqtt as mqtt
 
@@ -139,16 +138,11 @@ def async_setup(hass, config):
                            json.dumps(notification))
         return
 
-    descriptions = load_yaml_config_file(
-        path.join(path.dirname(__file__), 'services.yaml'))
-
     hass.services.async_register(
         DOMAIN, SERVICE_SAY, snips_say,
-        description=descriptions[DOMAIN][SERVICE_SAY],
         schema=SERVICE_SCHEMA_SAY)
     hass.services.async_register(
         DOMAIN, SERVICE_SAY_ACTION, snips_say_action,
-        description=descriptions[DOMAIN][SERVICE_SAY_ACTION],
         schema=SERVICE_SCHEMA_SAY_ACTION)
 
     return True

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -8,7 +8,6 @@ import asyncio
 import json
 import logging
 from datetime import timedelta
-from os import path
 
 import voluptuous as vol
 

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -265,7 +265,7 @@ def test_snips_say_action(hass, caplog):
     calls = async_mock_service(hass, 'snips', 'say_action',
                                SERVICE_SCHEMA_SAY_ACTION)
 
-    data = {'text': 'Hello', 'intentFilter': ['myIntent']}
+    data = {'text': 'Hello', 'intent_filter': ['myIntent']}
     yield from hass.services.async_call('snips', 'say_action', data)
     yield from hass.async_block_till_done()
 
@@ -273,7 +273,7 @@ def test_snips_say_action(hass, caplog):
     assert calls[0].domain == 'snips'
     assert calls[0].service == 'say_action'
     assert calls[0].data['text'] == 'Hello'
-    assert calls[0].data['intentFilter'] == ['myIntent']
+    assert calls[0].data['intent_filter'] == ['myIntent']
 
 
 @asyncio.coroutine
@@ -297,7 +297,7 @@ def test_snips_say_action_invalid_config(hass, caplog):
     calls = async_mock_service(hass, 'snips', 'say_action',
                                SERVICE_SCHEMA_SAY_ACTION)
 
-    data = {'text': 'Hello', 'canBeEnqueued': 'notabool'}
+    data = {'text': 'Hello', 'can_be_enqueued': 'notabool'}
     yield from hass.services.async_call('snips', 'say_action', data)
     yield from hass.async_block_till_done()
 

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -4,7 +4,10 @@ import json
 
 from homeassistant.core import callback
 from homeassistant.bootstrap import async_setup_component
-from tests.common import async_fire_mqtt_message, async_mock_intent
+from tests.common import (async_fire_mqtt_message, async_mock_intent,
+    async_mock_service)
+from homeassistant.components.snips import (SERVICE_SCHEMA_SAY,
+    SERVICE_SCHEMA_SAY_ACTION)
 
 
 @asyncio.coroutine
@@ -238,3 +241,66 @@ def test_snips_intent_username(hass, mqtt_mock):
     intent = intents[0]
     assert intent.platform == 'snips'
     assert intent.intent_type == 'Lights'
+
+
+@asyncio.coroutine
+def test_snips_say(hass, caplog):
+    """Test snips say with invalid config."""
+    calls = async_mock_service(hass, 'snips', 'say',
+                               SERVICE_SCHEMA_SAY)
+
+    data = {'text': 'Hello'}
+    yield from hass.services.async_call('snips', 'say', data)
+    yield from hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].domain == 'snips'
+    assert calls[0].service == 'say'
+    assert calls[0].data['text'] == 'Hello'
+
+
+@asyncio.coroutine
+def test_snips_say_action(hass, caplog):
+    """Test snips say_action with invalid config."""
+    calls = async_mock_service(hass, 'snips', 'say_action',
+                               SERVICE_SCHEMA_SAY_ACTION)
+
+    data = {'text': 'Hello', 'intentFilter': ['myIntent']}
+    yield from hass.services.async_call('snips', 'say_action', data)
+    yield from hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].domain == 'snips'
+    assert calls[0].service == 'say_action'
+    assert calls[0].data['text'] == 'Hello'
+    assert calls[0].data['intentFilter'] == ['myIntent']
+
+
+@asyncio.coroutine
+def test_snips_say_invalid_config(hass, caplog):
+    """Test snips say with invalid config."""
+    calls = async_mock_service(hass, 'snips', 'say',
+                               SERVICE_SCHEMA_SAY)
+
+    data = {'text': 'Hello', 'badKey': 'boo'}
+    yield from hass.services.async_call('snips', 'say', data)
+    yield from hass.async_block_till_done()
+
+    assert len(calls) == 0
+    assert 'ERROR' in caplog.text
+    assert 'Invalid service data' in caplog.text
+
+
+@asyncio.coroutine
+def test_snips_say_action_invalid_config(hass, caplog):
+    """Test snips say_action with invalid config."""
+    calls = async_mock_service(hass, 'snips', 'say_action',
+                               SERVICE_SCHEMA_SAY_ACTION)
+
+    data = {'text': 'Hello', 'canBeEnqueued': 'notabool'}
+    yield from hass.services.async_call('snips', 'say_action', data)
+    yield from hass.async_block_till_done()
+
+    assert len(calls) == 0
+    assert 'ERROR' in caplog.text
+    assert 'Invalid service data' in caplog.text

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -5,9 +5,9 @@ import json
 from homeassistant.core import callback
 from homeassistant.bootstrap import async_setup_component
 from tests.common import (async_fire_mqtt_message, async_mock_intent,
-    async_mock_service)
+                          async_mock_service)
 from homeassistant.components.snips import (SERVICE_SCHEMA_SAY,
-    SERVICE_SCHEMA_SAY_ACTION)
+                                            SERVICE_SCHEMA_SAY_ACTION)
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

- Added say service that can be used to send a TTS notification to snips
- Added say_action that can be used to send a TTS message and wait for a response from  the user

Implemented this way since it didn't make sense to do it as a TTS component because it doesn't 
have the ability to send to an arbitrary media_player, but only the snips server itself.

**Related issue (if applicable):** fixes #N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4399

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  turn_on_light:
    sequence:
      service: script.turn_on_light
      service: snips.say
        data:
          text: 'OK, the light is now on'

automation:
  query_garage_door:
    trigger:
     - platform: state
        entity_id: binary_sensor.my_garage_door_sensor
        from: 'off'
        to: 'on'
        for:
          minutes: 10
    sequence:
      service: snips.say_action
        data:
          text: 'Garage door has been open 10 minutes, would you like me to close it?'
          intentFilter:
            - closeGarageDoor

intent_script:
  closeGarageDoor:
    speech:
      type: plain
      text: 'OK, closing the garage door'
    action:
      - service: script.garage_door_close
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
