### PR TITLE
Concord232 alarm arm away fix

### DIFF
--- a/homeassistant/components/alarm_control_panel/concord232.py
+++ b/homeassistant/components/alarm_control_panel/concord232.py
@@ -121,4 +121,4 @@ class Concord232Alarm(alarm.AlarmControlPanel):
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
-        self._alarm.arm('auto')
+        self._alarm.arm('away')

--- a/homeassistant/components/alarm_control_panel/concord232.py
+++ b/homeassistant/components/alarm_control_panel/concord232.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['concord232==0.14']
+REQUIREMENTS = ['concord232==0.15']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/binary_sensor/concord232.py
+++ b/homeassistant/components/binary_sensor/concord232.py
@@ -15,7 +15,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import (CONF_HOST, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['concord232==0.14']
+REQUIREMENTS = ['concord232==0.15']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -174,7 +174,7 @@ colorlog==3.0.1
 
 # homeassistant.components.alarm_control_panel.concord232
 # homeassistant.components.binary_sensor.concord232
-concord232==0.14
+concord232==0.15
 
 # homeassistant.scripts.credstash
 # credstash==1.14.0


### PR DESCRIPTION
## Description:

The "arm away" service did not work for the concord232 alarm platform.  This was due to a bug in the external concord232 client/server package which communicates with the alarm system.  That client/server package has been bugfixed, released as v0.15 and incorporated into HA with a very simple change.

https://github.com/JasonCarter80/concord232

**Related issue (if applicable):** fixes #11541

No new documentation needed.  Works as expected now.

## Checklist:
  - [X] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
