### PR TITLE
Adding support for Lutron covers

### DIFF
--- a/homeassistant/components/cover/lutron.py
+++ b/homeassistant/components/cover/lutron.py
@@ -65,7 +65,8 @@ class LutronCover(LutronDevice, CoverDevice):
         """Call when forcing a refresh of the device."""
         # Reading the property (rather than last_level()) fetchs value
         level = self._lutron_device.level
-        _LOGGER.debug("Lutron ID: %d updated to %f", self._lutron_device.id, level)
+        _LOGGER.debug("Lutron ID: %d updated to %f",
+                      self._lutron_device.id, level)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/cover/lutron.py
+++ b/homeassistant/components/cover/lutron.py
@@ -1,0 +1,75 @@
+"""
+Support for Lutron shades.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/cover.lutron/
+"""
+import logging
+
+from homeassistant.components.cover import (
+    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_SET_POSITION,
+    ATTR_POSITION)
+from homeassistant.components.lutron import (
+    LutronDevice, LUTRON_DEVICES, LUTRON_CONTROLLER)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['lutron']
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Lutron shades."""
+    devs = []
+    for (area_name, device) in hass.data[LUTRON_DEVICES]['cover']:
+        dev = LutronCover(area_name, device, hass.data[LUTRON_CONTROLLER])
+        devs.append(dev)
+
+    add_devices(devs, True)
+    return True
+
+
+class LutronCover(LutronDevice, CoverDevice):
+    """Representation of a Lutron shade."""
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return self._lutron_device.last_level() < 1
+
+    @property
+    def current_cover_position(self):
+        """Return the current position of cover."""
+        return self._lutron_device.last_level()
+
+    def close_cover(self, **kwargs):
+        """Close the cover."""
+        self._lutron_device.level = 0
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        self._lutron_device.level = 100
+
+    def set_cover_position(self, **kwargs):
+        """Move the shade to a specific position."""
+        if ATTR_POSITION in kwargs:
+            position = kwargs[ATTR_POSITION]
+            self._lutron_device.level = position
+
+    def update(self):
+        """Call when forcing a refresh of the device."""
+        # Reading the property (rather than last_level()) fetchs value
+        level = self._lutron_device.level
+        _LOGGER.debug("Lutron ID: %d updated to %f", self._lutron_device.id, level)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attr = {}
+        attr['Lutron Integration ID'] = self._lutron_device.id
+        return attr

--- a/homeassistant/components/lutron.py
+++ b/homeassistant/components/lutron.py
@@ -37,7 +37,7 @@ def setup(hass, base_config):
     from pylutron import Lutron
 
     hass.data[LUTRON_CONTROLLER] = None
-    hass.data[LUTRON_DEVICES] = {'light': []}
+    hass.data[LUTRON_DEVICES] = {'light': [], 'cover': []}
 
     config = base_config.get(DOMAIN)
     hass.data[LUTRON_CONTROLLER] = Lutron(
@@ -50,9 +50,12 @@ def setup(hass, base_config):
     # Sort our devices into types
     for area in hass.data[LUTRON_CONTROLLER].areas:
         for output in area.outputs:
-            hass.data[LUTRON_DEVICES]['light'].append((area.name, output))
+            if output.type == 'SYSTEM_SHADE':
+                hass.data[LUTRON_DEVICES]['cover'].append((area.name, output))
+            else:
+                hass.data[LUTRON_DEVICES]['light'].append((area.name, output))
 
-    for component in ('light',):
+    for component in ('light', 'cover'):
         discovery.load_platform(hass, component, DOMAIN, None, base_config)
     return True
 


### PR DESCRIPTION
## Description:

This patch adds support for controlling roller shades through the cover component on the Lutron platform. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
https://github.com/home-assistant/home-assistant.github.io/#4400

## Configuration
As with the Lutron light component, no configuration is necessary (or available) as shades are detected automatically.

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54