### PR TITLE
Tahoma stop command temporary workaround

### DIFF
--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -15,11 +15,6 @@ DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
-TAHOMA_STOP_COMMAND = {
-    'io:RollerShutterWithLowSpeedManagementIOComponent': 'my',
-    'io:RollerShutterVeluxIOComponent': 'my',
-}
-
 SCAN_INTERVAL = timedelta(seconds=60)
 
 
@@ -78,8 +73,11 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
-        self.apply_action(TAHOMA_STOP_COMMAND.get(self.tahoma_device.type,
-                                                  'stopIdentify'))
+        if self.tahoma_device.type == \
+           'io:RollerShutterWithLowSpeedManagementIOComponent':
+            self.apply_action('setPosition', 'secured')
+        else:
+            self.apply_action('stopIdentify')
 
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""


### PR DESCRIPTION
## Description:

Hey,

I'm sorry for this pull request coming so quickly after my 'fix'. I thought my fix worked, but upon further testing it seemed to not be the right stop command and not reliable. Turns out there are no explicit stop command with the API we are currently using.

After lot's of testing I managed to find a stop command for one type of roller shutter I have. This is 100% confirmed working. Unfortunately I can't explain why it is like this but it works, for this reason I have kept the standard command in place.

I might start working on a new api interface that uses the documented API. This will however take some time which I currently do not have lot's of.

## Checklist:
  - [x] The code change is tested and works locally.
