### PR TITLE
Owntracks: Use bluetooth_le as source_type if beacon was used for location change.

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -15,7 +15,9 @@ import voluptuous as vol
 import homeassistant.components.mqtt as mqtt
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components import zone as zone_comp
-from homeassistant.components.device_tracker import PLATFORM_SCHEMA
+from homeassistant.components.device_tracker import (
+    PLATFORM_SCHEMA, ATTR_SOURCE_TYPE, SOURCE_TYPE_BLUETOOTH_LE
+)
 from homeassistant.const import STATE_HOME
 from homeassistant.core import callback
 from homeassistant.util import slugify, decorator
@@ -140,6 +142,9 @@ def _parse_see_args(message, subscribe_topic):
         kwargs['attributes']['tid'] = message['tid']
     if 'addr' in message:
         kwargs['attributes']['address'] = message['addr']
+    if 't' in message:
+        if message['t'] == 'b':
+            kwargs['attributes'][ATTR_SOURCE_TYPE] = SOURCE_TYPE_BLUETOOTH_LE
 
     return dev_id, kwargs
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -16,7 +16,8 @@ import homeassistant.components.mqtt as mqtt
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components import zone as zone_comp
 from homeassistant.components.device_tracker import (
-    PLATFORM_SCHEMA, ATTR_SOURCE_TYPE, SOURCE_TYPE_BLUETOOTH_LE
+    PLATFORM_SCHEMA, ATTR_SOURCE_TYPE, SOURCE_TYPE_BLUETOOTH_LE,
+    SOURCE_TYPE_GPS
 )
 from homeassistant.const import STATE_HOME
 from homeassistant.core import callback
@@ -142,8 +143,11 @@ def _parse_see_args(message, subscribe_topic):
         kwargs['attributes']['tid'] = message['tid']
     if 'addr' in message:
         kwargs['attributes']['address'] = message['addr']
-    if 't' in message and message['t'] == 'b':
-        kwargs['attributes'][ATTR_SOURCE_TYPE] = SOURCE_TYPE_BLUETOOTH_LE
+    if 't' in message:
+        if message['t'] == 'c':
+            kwargs['attributes'][ATTR_SOURCE_TYPE] = SOURCE_TYPE_GPS
+        if message['t'] == 'b':
+            kwargs['attributes'][ATTR_SOURCE_TYPE] = SOURCE_TYPE_BLUETOOTH_LE
 
     return dev_id, kwargs
 

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -142,9 +142,8 @@ def _parse_see_args(message, subscribe_topic):
         kwargs['attributes']['tid'] = message['tid']
     if 'addr' in message:
         kwargs['attributes']['address'] = message['addr']
-    if 't' in message:
-        if message['t'] == 'b':
-            kwargs['attributes'][ATTR_SOURCE_TYPE] = SOURCE_TYPE_BLUETOOTH_LE
+    if 't' in message and message['t'] == 'b':
+        kwargs['attributes'][ATTR_SOURCE_TYPE] = SOURCE_TYPE_BLUETOOTH_LE
 
     return dev_id, kwargs
 

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -684,7 +684,6 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
         # source_type should be gps when enterings using gps.
         self.assert_location_source_type('gps')
 
-
         self.send_message(EVENT_TOPIC, REGION_GPS_LEAVE_MESSAGE)
 
         # Exit switches back to GPS
@@ -697,7 +696,6 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
 
         # source_type should be gps when leaving using gps.
         self.assert_location_source_type('gps')
-
 
     # Region Beacon based event entry / exit testing
 

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -671,31 +671,31 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
         # Location update processed
         self.assert_location_state('outer')
 
-    def test_event_gps_source_type_entry_exit(self):
-        """Test the entry event of gps source type."""
+    def test_event_source_type_entry_exit(self):
+        """Test the entry and exit events of source type."""
         # Entering the owntrack circular region named "inner"
         self.send_message(EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE)
-
-        # Enter uses the zone's gps co-ords
-        self.assert_location_latitude(INNER_ZONE['latitude'])
-        self.assert_location_accuracy(INNER_ZONE['radius'])
-        self.assert_location_state('inner')
 
         # source_type should be gps when enterings using gps.
         self.assert_location_source_type('gps')
 
+        # owntracks shouldn't send beacon events with acc = 0
+        self.send_message(EVENT_TOPIC, build_message(
+            {'acc': 1}, REGION_BEACON_ENTER_MESSAGE))
+
+        # We should be able to enter a beacon zone even inside a gps zone
+        self.assert_location_source_type('bluetooth_le')
+
         self.send_message(EVENT_TOPIC, REGION_GPS_LEAVE_MESSAGE)
-
-        # Exit switches back to GPS
-        self.assert_location_latitude(REGION_GPS_LEAVE_MESSAGE['lat'])
-        self.assert_location_accuracy(REGION_GPS_LEAVE_MESSAGE['acc'])
-        self.assert_location_state('outer')
-
-        # Left clean zone state
-        self.assertFalse(self.context.regions_entered[USER])
 
         # source_type should be gps when leaving using gps.
         self.assert_location_source_type('gps')
+
+        # owntracks shouldn't send beacon events with acc = 0
+        self.send_message(EVENT_TOPIC, build_message(
+            {'acc': 1}, REGION_BEACON_LEAVE_MESSAGE))
+
+        self.assert_location_source_type('bluetooth_le')
 
     # Region Beacon based event entry / exit testing
 
@@ -872,34 +872,6 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
             REGION_BEACON_ENTER_MESSAGE)
         self.send_message(EVENT_TOPIC, message)
         self.assert_location_state('inner')
-
-    def test_event_beacon_source_type_region_entry_exit(self):
-        """Test the entry event."""
-        # Seeing a beacon named "inner"
-        self.send_message(EVENT_TOPIC, REGION_BEACON_ENTER_MESSAGE)
-
-        # Enter uses the zone's gps co-ords
-        self.assert_location_latitude(INNER_ZONE['latitude'])
-        self.assert_location_accuracy(INNER_ZONE['radius'])
-        self.assert_location_state('inner')
-
-        # source_type should be bluetooth_le when entering using beacon.
-        self.assert_location_source_type('bluetooth_le')
-
-        self.send_message(EVENT_TOPIC, REGION_BEACON_LEAVE_MESSAGE)
-
-        # Exit switches back to GPS but the beacon has no coords
-        # so I am still located at the center of the inner region
-        # until I receive a location update.
-        self.assert_location_latitude(INNER_ZONE['latitude'])
-        self.assert_location_accuracy(INNER_ZONE['radius'])
-        self.assert_location_state('inner')
-
-        # source_type should be bluetooth_le when leaving using beacon.
-        self.assert_location_source_type('bluetooth_le')
-
-        # Left clean zone state
-        self.assertFalse(self.context.regions_entered[USER])
 
     # ------------------------------------------------------------------------
     # Mobile Beacon based event entry / exit testing


### PR DESCRIPTION
## Description:
Using the source_types added in a23f60315fbeec0cac0f2487c2e998cae13cab5b we can now set the source_type to bluetooth_le instead of gps in case the location change happen because of a beacon.

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54