### PR TITLE
Xbox sensor - Extend error handling 

### DIFF
--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -34,15 +34,25 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     api = xbox_api.XboxApi(config.get(CONF_API_KEY))
     devices = []
 
+    # request personal profile to check api connection
+    profile = api.get_profile()
+    if profile.get('error_code', None) != None:
+        _LOGGER.error("Can't setup XboxAPI connection. Check your account or "
+                      + " api key on xboxapi.com. Code: %s Description: %s ",
+                      profile.get('error_code', STATE_UNKNOWN),
+                      profile.get('error_message', STATE_UNKNOWN))
+        return False
+
     for xuid in config.get(CONF_XUID):
         new_device = XboxSensor(hass, api, xuid)
         if new_device.success_init:
             devices.append(new_device)
 
     if devices:
-        add_devices(devices)
-    else:
-        return False
+        add_devices(devices, True)
+        return True
+
+    return False
 
 
 class XboxSensor(Entity):
@@ -59,11 +69,16 @@ class XboxSensor(Entity):
         # get profile info
         profile = self._api.get_user_gamercard(self._xuid)
 
-        if profile.get('success', True) and profile.get('code', 0) != 28:
+        if profile.get('success', True) and profile.get('code', None) is None:
             self.success_init = True
             self._gamertag = profile.get('gamertag')
             self._picture = profile.get('gamerpicSmallSslImagePath')
         else:
+            _LOGGER.error("Can't get user profile %s. "
+                          + "Error Code: %s Description: %s",
+                          self._xuid,
+                          profile.get('code', STATE_UNKNOWN),
+                          profile.get('description', STATE_UNKNOWN))
             self.success_init = False
 
     @property

--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -36,12 +36,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     # request personal profile to check api connection
     profile = api.get_profile()
-    if profile.get('error_code', None) is not None:
+    if profile.get('error_code') is not None:
         _LOGGER.error("Can't setup XboxAPI connection. Check your account or "
-                      + " api key on xboxapi.com. Code: %s Description: %s ",
+                      " api key on xboxapi.com. Code: %s Description: %s ",
                       profile.get('error_code', STATE_UNKNOWN),
                       profile.get('error_message', STATE_UNKNOWN))
-        return False
+        return
 
     for xuid in config.get(CONF_XUID):
         new_device = XboxSensor(hass, api, xuid)
@@ -50,9 +50,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if devices:
         add_devices(devices, True)
-        return True
 
-    return False
+    return
 
 
 class XboxSensor(Entity):
@@ -69,13 +68,13 @@ class XboxSensor(Entity):
         # get profile info
         profile = self._api.get_user_gamercard(self._xuid)
 
-        if profile.get('success', True) and profile.get('code', None) is None:
+        if profile.get('success', True) and profile.get('code') is None:
             self.success_init = True
             self._gamertag = profile.get('gamertag')
             self._picture = profile.get('gamerpicSmallSslImagePath')
         else:
             _LOGGER.error("Can't get user profile %s. "
-                          + "Error Code: %s Description: %s",
+                          "Error Code: %s Description: %s",
                           self._xuid,
                           profile.get('code', STATE_UNKNOWN),
                           profile.get('description', STATE_UNKNOWN))

--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -51,8 +51,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if devices:
         add_devices(devices, True)
 
-    return
-
 
 class XboxSensor(Entity):
     """A class for the Xbox account."""

--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -36,7 +36,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     # request personal profile to check api connection
     profile = api.get_profile()
-    if profile.get('error_code', None) != None:
+    if profile.get('error_code', None) is not None:
         _LOGGER.error("Can't setup XboxAPI connection. Check your account or "
                       + " api key on xboxapi.com. Code: %s Description: %s ",
                       profile.get('error_code', STATE_UNKNOWN),


### PR DESCRIPTION
## Description:
Add error handling for wrong api key and wrong xuid

**Related issue (if applicable):** fixes #9016

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
