### PR TITLE
update mypy command line arguments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,4 +41,4 @@ basepython = {env:PYTHON3_PATH:python3}
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
-         mypy --silent-imports homeassistant
+         mypy --ignore-missing-imports --follow-imports=skip homeassistant


### PR DESCRIPTION
## Description:
mypy complains about deprecated command line arguments. I fixed them according to the warning.

`Warning: --silent-imports has been replaced by --ignore-missing-imports --follow-imports=skip`

**Related issue (if applicable):** -

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** -


## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
