### PR TITLE
Generalize alarm_control_panel service interface, use to implement new arming options for concord232

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -24,6 +24,11 @@ DOMAIN = 'alarm_control_panel'
 SCAN_INTERVAL = timedelta(seconds=30)
 ATTR_CHANGED_BY = 'changed_by'
 
+_LOGGER = logging.getLogger(__name__)
+
+# Platform specific data
+ATTR_DATA = 'data'
+
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 SERVICE_TO_METHOD = {
@@ -43,77 +48,90 @@ ATTR_TO_PROPERTY = [
 ALARM_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Optional(ATTR_CODE): cv.string,
+    vol.Optional(ATTR_DATA): dict,
 })
 
 
 @bind_hass
-def alarm_disarm(hass, code=None, entity_id=None):
+def alarm_disarm(hass, code=None, entity_id=None, params=None):
     """Send the alarm the command for disarm."""
     data = {}
     if code:
         data[ATTR_CODE] = code
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
+    if params:
+        data[ATTR_DATA] = params
 
     hass.services.call(DOMAIN, SERVICE_ALARM_DISARM, data)
 
 
 @bind_hass
-def alarm_arm_home(hass, code=None, entity_id=None):
+def alarm_arm_home(hass, code=None, entity_id=None, params=None):
     """Send the alarm the command for arm home."""
     data = {}
     if code:
         data[ATTR_CODE] = code
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
+    if params:
+        data[ATTR_DATA] = params
 
     hass.services.call(DOMAIN, SERVICE_ALARM_ARM_HOME, data)
 
 
 @bind_hass
-def alarm_arm_away(hass, code=None, entity_id=None):
+def alarm_arm_away(hass, code=None, entity_id=None, params=None):
     """Send the alarm the command for arm away."""
     data = {}
     if code:
         data[ATTR_CODE] = code
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
+    if params:
+        data[ATTR_DATA] = params
 
     hass.services.call(DOMAIN, SERVICE_ALARM_ARM_AWAY, data)
 
 
 @bind_hass
-def alarm_arm_night(hass, code=None, entity_id=None):
+def alarm_arm_night(hass, code=None, entity_id=None, params=None):
     """Send the alarm the command for arm night."""
     data = {}
     if code:
         data[ATTR_CODE] = code
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
+    if params:
+        data[ATTR_DATA] = params
 
     hass.services.call(DOMAIN, SERVICE_ALARM_ARM_NIGHT, data)
 
 
 @bind_hass
-def alarm_trigger(hass, code=None, entity_id=None):
+def alarm_trigger(hass, code=None, entity_id=None, params=None):
     """Send the alarm the command for trigger."""
     data = {}
     if code:
         data[ATTR_CODE] = code
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
+    if params:
+        data[ATTR_DATA] = params
 
     hass.services.call(DOMAIN, SERVICE_ALARM_TRIGGER, data)
 
 
 @bind_hass
-def alarm_arm_custom_bypass(hass, code=None, entity_id=None):
+def alarm_arm_custom_bypass(hass, code=None, entity_id=None, params=None):
     """Send the alarm the command for arm custom bypass."""
     data = {}
     if code:
         data[ATTR_CODE] = code
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
+    if params:
+        data[ATTR_DATA] = params
 
     hass.services.call(DOMAIN, SERVICE_ALARM_ARM_CUSTOM_BYPASS, data)
 
@@ -132,12 +150,20 @@ def async_setup(hass, config):
         target_alarms = component.async_extract_from_service(service)
 
         code = service.data.get(ATTR_CODE)
+        params = service.data.get(ATTR_DATA)
+
+        _LOGGER.error("async_alarm_service_handler code: %s type:%s", code, type(code))
+        _LOGGER.error("async_alarm_service_handler data: %s type:%s", params, type(params))
 
         method = "async_{}".format(SERVICE_TO_METHOD[service.service])
 
         update_tasks = []
         for alarm in target_alarms:
-            yield from getattr(alarm, method)(code)
+            if params==None:
+                yield from getattr(alarm, method)(code)
+            else:
+                yield from getattr(alarm, method)(code, params)
+
 
             if not alarm.should_poll:
                 continue
@@ -168,66 +194,66 @@ class AlarmControlPanel(Entity):
         """Last change triggered by."""
         return None
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         raise NotImplementedError()
 
-    def async_alarm_disarm(self, code=None):
+    def async_alarm_disarm(self, code=None, params=None):
         """Send disarm command.
 
         This method must be run in the event loop and returns a coroutine.
         """
         return self.hass.async_add_job(self.alarm_disarm, code)
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         raise NotImplementedError()
 
-    def async_alarm_arm_home(self, code=None):
+    def async_alarm_arm_home(self, code=None, params=None):
         """Send arm home command.
 
         This method must be run in the event loop and returns a coroutine.
         """
         return self.hass.async_add_job(self.alarm_arm_home, code)
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         raise NotImplementedError()
 
-    def async_alarm_arm_away(self, code=None):
+    def async_alarm_arm_away(self, code=None, params=None):
         """Send arm away command.
 
         This method must be run in the event loop and returns a coroutine.
         """
         return self.hass.async_add_job(self.alarm_arm_away, code)
 
-    def alarm_arm_night(self, code=None):
+    def alarm_arm_night(self, code=None, params=None):
         """Send arm night command."""
         raise NotImplementedError()
 
-    def async_alarm_arm_night(self, code=None):
+    def async_alarm_arm_night(self, code=None, params=None):
         """Send arm night command.
 
         This method must be run in the event loop and returns a coroutine.
         """
         return self.hass.async_add_job(self.alarm_arm_night, code)
 
-    def alarm_trigger(self, code=None):
+    def alarm_trigger(self, code=None, params=None):
         """Send alarm trigger command."""
         raise NotImplementedError()
 
-    def async_alarm_trigger(self, code=None):
+    def async_alarm_trigger(self, code=None, params=None):
         """Send alarm trigger command.
 
         This method must be run in the event loop and returns a coroutine.
         """
         return self.hass.async_add_job(self.alarm_trigger, code)
 
-    def alarm_arm_custom_bypass(self, code=None):
+    def alarm_arm_custom_bypass(self, code=None, params=None):
         """Send arm custom bypass command."""
         raise NotImplementedError()
 
-    def async_alarm_arm_custom_bypass(self, code=None):
+    def async_alarm_arm_custom_bypass(self, code=None, params=None):
         """Send arm custom bypass command.
 
         This method must be run in the event loop and returns a coroutine.

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -24,8 +24,6 @@ DOMAIN = 'alarm_control_panel'
 SCAN_INTERVAL = timedelta(seconds=30)
 ATTR_CHANGED_BY = 'changed_by'
 
-_LOGGER = logging.getLogger(__name__)
-
 # Platform specific data
 ATTR_DATA = 'params'
 
@@ -151,9 +149,6 @@ def async_setup(hass, config):
 
         code = service.data.get(ATTR_CODE)
         params = service.data.get(ATTR_DATA)
-
-        _LOGGER.error("async_alarm_service_handler code: %s type:%s", code, type(code))
-        _LOGGER.error("async_alarm_service_handler data: %s type:%s", params, type(params))
 
         method = "async_{}".format(SERVICE_TO_METHOD[service.service])
 

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -250,7 +250,8 @@ class AlarmControlPanel(Entity):
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.async_add_job(self.alarm_arm_custom_bypass, code, params)
+        return self.hass.async_add_job(self.alarm_arm_custom_bypass, code,
+                                       params)
 
     @property
     def state_attributes(self):

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -27,7 +27,7 @@ ATTR_CHANGED_BY = 'changed_by'
 _LOGGER = logging.getLogger(__name__)
 
 # Platform specific data
-ATTR_DATA = 'data'
+ATTR_DATA = 'params'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
@@ -159,10 +159,7 @@ def async_setup(hass, config):
 
         update_tasks = []
         for alarm in target_alarms:
-            if params==None:
-                yield from getattr(alarm, method)(code)
-            else:
-                yield from getattr(alarm, method)(code, params)
+            yield from getattr(alarm, method)(code, params)
 
 
             if not alarm.should_poll:
@@ -203,7 +200,7 @@ class AlarmControlPanel(Entity):
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.async_add_job(self.alarm_disarm, code)
+        return self.hass.async_add_job(self.alarm_disarm, code, params)
 
     def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
@@ -214,7 +211,7 @@ class AlarmControlPanel(Entity):
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.async_add_job(self.alarm_arm_home, code)
+        return self.hass.async_add_job(self.alarm_arm_home, code, params)
 
     def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
@@ -225,7 +222,7 @@ class AlarmControlPanel(Entity):
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.async_add_job(self.alarm_arm_away, code)
+        return self.hass.async_add_job(self.alarm_arm_away, code, params)
 
     def alarm_arm_night(self, code=None, params=None):
         """Send arm night command."""
@@ -236,7 +233,7 @@ class AlarmControlPanel(Entity):
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.async_add_job(self.alarm_arm_night, code)
+        return self.hass.async_add_job(self.alarm_arm_night, code, params)
 
     def alarm_trigger(self, code=None, params=None):
         """Send alarm trigger command."""
@@ -247,7 +244,7 @@ class AlarmControlPanel(Entity):
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.async_add_job(self.alarm_trigger, code)
+        return self.hass.async_add_job(self.alarm_trigger, code, params)
 
     def alarm_arm_custom_bypass(self, code=None, params=None):
         """Send arm custom bypass command."""
@@ -258,7 +255,7 @@ class AlarmControlPanel(Entity):
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.async_add_job(self.alarm_arm_custom_bypass, code)
+        return self.hass.async_add_job(self.alarm_arm_custom_bypass, code, params)
 
     @property
     def state_attributes(self):

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -156,7 +156,6 @@ def async_setup(hass, config):
         for alarm in target_alarms:
             yield from getattr(alarm, method)(code, params)
 
-
             if not alarm.should_poll:
                 continue
             update_tasks.append(alarm.async_update_ha_state(True))

--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -57,15 +57,15 @@ class AbodeAlarm(AbodeDevice, AlarmControlPanel):
             state = None
         return state
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         self._device.set_standby()
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         self._device.set_home()
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         self._device.set_away()
 

--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -123,22 +123,22 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
             'zone_bypassed': self._zone_bypassed
         }
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         if code:
             self.hass.data[DATA_AD].send("{!s}1".format(code))
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         if code:
             self.hass.data[DATA_AD].send("{!s}2".format(code))
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         if code:
             self.hass.data[DATA_AD].send("{!s}3".format(code))
 
-    def alarm_toggle_chime(self, code=None):
+    def alarm_toggle_chime(self, code=None, params=None):
         """Send toggle chime command."""
         if code:
             self.hass.data[DATA_AD].send("{!s}9".format(code))

--- a/homeassistant/components/alarm_control_panel/alarmdotcom.py
+++ b/homeassistant/components/alarm_control_panel/alarmdotcom.py
@@ -95,19 +95,19 @@ class AlarmDotCom(alarm.AlarmControlPanel):
         return STATE_UNKNOWN
 
     @asyncio.coroutine
-    def async_alarm_disarm(self, code=None):
+    def async_alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         if self._validate_code(code):
             yield from self._alarm.async_alarm_disarm()
 
     @asyncio.coroutine
-    def async_alarm_arm_home(self, code=None):
+    def async_alarm_arm_home(self, code=None, params=None):
         """Send arm hom command."""
         if self._validate_code(code):
             yield from self._alarm.async_alarm_arm_home()
 
     @asyncio.coroutine
-    def async_alarm_arm_away(self, code=None):
+    def async_alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         if self._validate_code(code):
             yield from self._alarm.async_alarm_arm_away()

--- a/homeassistant/components/alarm_control_panel/arlo.py
+++ b/homeassistant/components/alarm_control_panel/arlo.py
@@ -88,17 +88,17 @@ class ArloBaseStation(AlarmControlPanel):
         self._state = None
 
     @asyncio.coroutine
-    def async_alarm_disarm(self, code=None):
+    def async_alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         self._base_station.mode = DISARMED
 
     @asyncio.coroutine
-    def async_alarm_arm_away(self, code=None):
+    def async_alarm_arm_away(self, code=None, params=None):
         """Send arm away command. Uses custom mode."""
         self._base_station.mode = self._away_mode_name
 
     @asyncio.coroutine
-    def async_alarm_arm_home(self, code=None):
+    def async_alarm_arm_home(self, code=None, params=None):
         """Send arm home command. Uses custom mode."""
         self._base_station.mode = self._home_mode_name
 

--- a/homeassistant/components/alarm_control_panel/canary.py
+++ b/homeassistant/components/alarm_control_panel/canary.py
@@ -70,23 +70,23 @@ class CanaryAlarm(AlarmControlPanel):
             'private': location.is_private
         }
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         location = self._data.get_location(self._location_id)
         self._data.set_location_mode(self._location_id, location.mode.name,
                                      True)
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         from canary.api import LOCATION_MODE_HOME
         self._data.set_location_mode(self._location_id, LOCATION_MODE_HOME)
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         from canary.api import LOCATION_MODE_AWAY
         self._data.set_location_mode(self._location_id, LOCATION_MODE_AWAY)
 
-    def alarm_arm_night(self, code=None):
+    def alarm_arm_night(self, code=None, params=None):
         """Send arm night command."""
         from canary.api import LOCATION_MODE_NIGHT
         self._data.set_location_mode(self._location_id, LOCATION_MODE_NIGHT)

--- a/homeassistant/components/alarm_control_panel/concord232.py
+++ b/homeassistant/components/alarm_control_panel/concord232.py
@@ -117,8 +117,20 @@ class Concord232Alarm(alarm.AlarmControlPanel):
 
     def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
-        self._alarm.arm('stay')
+        option = None
+        if params is not None:
+            if params['arming_option'] is not None:
+                option = params['arming_option']
+            else:
+                _LOGGER.error("Unknown parameter(s) sent to concord232 alarm_arm_home: %s", params)
+        self._alarm.arm('stay',option)
 
     def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
-        self._alarm.arm('away')
+        option = None
+        if params is not None:
+            if params['arming_option'] is not None:
+                option = params['arming_option']
+            else:
+                _LOGGER.error("Unknown parameter(s) sent to concord232 alarm_arm_away: %s", params)
+        self._alarm.arm('away',option)

--- a/homeassistant/components/alarm_control_panel/concord232.py
+++ b/homeassistant/components/alarm_control_panel/concord232.py
@@ -111,14 +111,14 @@ class Concord232Alarm(alarm.AlarmControlPanel):
             self._state = newstate
         return self._state
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         self._alarm.disarm(code)
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         self._alarm.arm('stay')
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         self._alarm.arm('away')

--- a/homeassistant/components/alarm_control_panel/concord232.py
+++ b/homeassistant/components/alarm_control_panel/concord232.py
@@ -133,6 +133,6 @@ class Concord232Alarm(alarm.AlarmControlPanel):
             if params['arming_option'] is not None:
                 option = params['arming_option']
             else:
-                _LOGGER.error("Unknown parameter in concord232 alarm_arm_away: %s",
+                _LOGGER.error("Unknown param in concord232 alarm_arm_away: %s",
                               params)
         self._alarm.arm('away', option)

--- a/homeassistant/components/alarm_control_panel/concord232.py
+++ b/homeassistant/components/alarm_control_panel/concord232.py
@@ -122,7 +122,8 @@ class Concord232Alarm(alarm.AlarmControlPanel):
             if params['arming_option'] is not None:
                 option = params['arming_option']
             else:
-                _LOGGER.error("Unknown parameter(s) in concord232 alarm_arm_home: %s", params)
+                _LOGGER.error("Unknown param in concord232 alarm_arm_home: %s",
+                              params)
         self._alarm.arm('stay', option)
 
     def alarm_arm_away(self, code=None, params=None):
@@ -132,5 +133,6 @@ class Concord232Alarm(alarm.AlarmControlPanel):
             if params['arming_option'] is not None:
                 option = params['arming_option']
             else:
-                _LOGGER.error("Unknown parameter(s) in concord232 alarm_arm_away: %s", params)
+                _LOGGER.error("Unknown parameter in concord232 alarm_arm_away: %s",
+                              params)
         self._alarm.arm('away', option)

--- a/homeassistant/components/alarm_control_panel/concord232.py
+++ b/homeassistant/components/alarm_control_panel/concord232.py
@@ -122,8 +122,8 @@ class Concord232Alarm(alarm.AlarmControlPanel):
             if params['arming_option'] is not None:
                 option = params['arming_option']
             else:
-                _LOGGER.error("Unknown parameter(s) sent to concord232 alarm_arm_home: %s", params)
-        self._alarm.arm('stay',option)
+                _LOGGER.error("Unknown parameter(s) in concord232 alarm_arm_home: %s", params)
+        self._alarm.arm('stay', option)
 
     def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
@@ -132,5 +132,5 @@ class Concord232Alarm(alarm.AlarmControlPanel):
             if params['arming_option'] is not None:
                 option = params['arming_option']
             else:
-                _LOGGER.error("Unknown parameter(s) sent to concord232 alarm_arm_away: %s", params)
-        self._alarm.arm('away',option)
+                _LOGGER.error("Unknown parameter(s) in concord232 alarm_arm_away: %s", params)
+        self._alarm.arm('away', option)

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -192,7 +192,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         status = self._egardiasystem.getstate()
         self.parsestatus(status)
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         try:
             self._egardiasystem.alarm_disarm()
@@ -200,7 +200,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
             _LOGGER.error("Egardia device exception occurred when "
                           "sending disarm command: %s", err)
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         try:
             self._egardiasystem.alarm_arm_home()
@@ -208,7 +208,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
             _LOGGER.error("Egardia device exception occurred when "
                           "sending arm home command: %s", err)
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         try:
             self._egardiasystem.alarm_arm_away()

--- a/homeassistant/components/alarm_control_panel/envisalink.py
+++ b/homeassistant/components/alarm_control_panel/envisalink.py
@@ -128,7 +128,7 @@ class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
         return state
 
     @asyncio.coroutine
-    def async_alarm_disarm(self, code=None):
+    def async_alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         if code:
             self.hass.data[DATA_EVL].disarm_partition(
@@ -138,7 +138,7 @@ class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
                 str(self._code), self._partition_number)
 
     @asyncio.coroutine
-    def async_alarm_arm_home(self, code=None):
+    def async_alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         if code:
             self.hass.data[DATA_EVL].arm_stay_partition(
@@ -148,7 +148,7 @@ class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
                 str(self._code), self._partition_number)
 
     @asyncio.coroutine
-    def async_alarm_arm_away(self, code=None):
+    def async_alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         if code:
             self.hass.data[DATA_EVL].arm_away_partition(
@@ -158,7 +158,7 @@ class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
                 str(self._code), self._partition_number)
 
     @asyncio.coroutine
-    def async_alarm_trigger(self, code=None):
+    def async_alarm_trigger(self, code=None, params=None):
         """Alarm trigger command. Will be used to trigger a panic alarm."""
         self.hass.data[DATA_EVL].panic_alarm(self._panic_type)
 

--- a/homeassistant/components/alarm_control_panel/ialarm.py
+++ b/homeassistant/components/alarm_control_panel/ialarm.py
@@ -94,14 +94,14 @@ class IAlarmPanel(alarm.AlarmControlPanel):
 
         self._state = state
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         self._client.disarm()
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         self._client.arm_away()
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         self._client.arm_stay()

--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -201,7 +201,7 @@ class ManualAlarm(alarm.AlarmControlPanel):
         """One or more characters."""
         return None if self._code is None else '.+'
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         if not self._validate_code(code, STATE_ALARM_DISARMED):
             return
@@ -210,35 +210,35 @@ class ManualAlarm(alarm.AlarmControlPanel):
         self._state_ts = dt_util.utcnow()
         self.schedule_update_ha_state()
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         if not self._validate_code(code, STATE_ALARM_ARMED_HOME):
             return
 
         self._update_state(STATE_ALARM_ARMED_HOME)
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         if not self._validate_code(code, STATE_ALARM_ARMED_AWAY):
             return
 
         self._update_state(STATE_ALARM_ARMED_AWAY)
 
-    def alarm_arm_night(self, code=None):
+    def alarm_arm_night(self, code=None, params=None):
         """Send arm night command."""
         if not self._validate_code(code, STATE_ALARM_ARMED_NIGHT):
             return
 
         self._update_state(STATE_ALARM_ARMED_NIGHT)
 
-    def alarm_arm_custom_bypass(self, code=None):
+    def alarm_arm_custom_bypass(self, code=None, params=None):
         """Send arm custom bypass command."""
         if not self._validate_code(code, STATE_ALARM_ARMED_CUSTOM_BYPASS):
             return
 
         self._update_state(STATE_ALARM_ARMED_CUSTOM_BYPASS)
 
-    def alarm_trigger(self, code=None):
+    def alarm_trigger(self, code=None, params=None):
         """
         Send alarm trigger command.
 

--- a/homeassistant/components/alarm_control_panel/manual_mqtt.py
+++ b/homeassistant/components/alarm_control_panel/manual_mqtt.py
@@ -238,7 +238,7 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
         """One or more characters."""
         return None if self._code is None else '.+'
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         if not self._validate_code(code, STATE_ALARM_DISARMED):
             return
@@ -247,28 +247,28 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
         self._state_ts = dt_util.utcnow()
         self.schedule_update_ha_state()
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         if not self._validate_code(code, STATE_ALARM_ARMED_HOME):
             return
 
         self._update_state(STATE_ALARM_ARMED_HOME)
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         if not self._validate_code(code, STATE_ALARM_ARMED_AWAY):
             return
 
         self._update_state(STATE_ALARM_ARMED_AWAY)
 
-    def alarm_arm_night(self, code=None):
+    def alarm_arm_night(self, code=None, params=None):
         """Send arm night command."""
         if not self._validate_code(code, STATE_ALARM_ARMED_NIGHT):
             return
 
         self._update_state(STATE_ALARM_ARMED_NIGHT)
 
-    def alarm_trigger(self, code=None):
+    def alarm_trigger(self, code=None, params=None):
         """
         Send alarm trigger command.
 

--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -121,7 +121,7 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         return None if self._code is None else '.+'
 
     @asyncio.coroutine
-    def async_alarm_disarm(self, code=None):
+    def async_alarm_disarm(self, code=None, params=None):
         """Send disarm command.
 
         This method is a coroutine.
@@ -132,7 +132,7 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
             self.hass, self._command_topic, self._payload_disarm, self._qos)
 
     @asyncio.coroutine
-    def async_alarm_arm_home(self, code=None):
+    def async_alarm_arm_home(self, code=None, params=None):
         """Send arm home command.
 
         This method is a coroutine.
@@ -143,7 +143,7 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
             self.hass, self._command_topic, self._payload_arm_home, self._qos)
 
     @asyncio.coroutine
-    def async_alarm_arm_away(self, code=None):
+    def async_alarm_arm_away(self, code=None, params=None):
         """Send arm away command.
 
         This method is a coroutine.

--- a/homeassistant/components/alarm_control_panel/nx584.py
+++ b/homeassistant/components/alarm_control_panel/nx584.py
@@ -107,14 +107,14 @@ class NX584Alarm(alarm.AlarmControlPanel):
         else:
             self._state = STATE_ALARM_ARMED_AWAY
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         self._alarm.disarm(code)
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         self._alarm.arm('stay')
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         self._alarm.arm('exit')

--- a/homeassistant/components/alarm_control_panel/satel_integra.py
+++ b/homeassistant/components/alarm_control_panel/satel_integra.py
@@ -75,19 +75,19 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
         return self._state
 
     @asyncio.coroutine
-    def async_alarm_disarm(self, code=None):
+    def async_alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         if code:
             yield from self.hass.data[DATA_SATEL].disarm(code)
 
     @asyncio.coroutine
-    def async_alarm_arm_away(self, code=None):
+    def async_alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         if code:
             yield from self.hass.data[DATA_SATEL].arm(code)
 
     @asyncio.coroutine
-    def async_alarm_arm_home(self, code=None):
+    def async_alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         if code:
             yield from self.hass.data[DATA_SATEL].arm(code,

--- a/homeassistant/components/alarm_control_panel/services.yaml
+++ b/homeassistant/components/alarm_control_panel/services.yaml
@@ -10,8 +10,8 @@ alarm_disarm:
       description: An optional code to disarm the alarm control panel with.
       example: 1234
     params:
-      description: Optional platform-specific parameters
-      example: 'silent'
+      description: Optional platform specific parameter dict
+      example: platform specific
 
 alarm_arm_home:
   description: Send the alarm the command for arm home.
@@ -23,8 +23,8 @@ alarm_arm_home:
       description: An optional code to arm home the alarm control panel with.
       example: 1234
     params:
-      description: Optional platform-specific parameters
-      example: 'silent'
+      description: Optional platform specific parameter dict
+      example: platform specific
 
 alarm_arm_away:
   description: Send the alarm the command for arm away.
@@ -36,8 +36,8 @@ alarm_arm_away:
       description: An optional code to arm away the alarm control panel with.
       example: 1234
     params:
-      description: Optional platform-specific parameters
-      example: 'silent'
+      description: Optional platform specific parameter dict
+      example: platform specific
 
 alarm_arm_night:
   description: Send the alarm the command for arm night.
@@ -49,8 +49,8 @@ alarm_arm_night:
       description: An optional code to arm night the alarm control panel with.
       example: 1234
     params:
-      description: Optional platform-specific parameters
-      example: 'silent'
+      description: Optional platform specific parameter dict
+      example: platform specific
 
 alarm_trigger:
   description: Send the alarm the command for trigger.
@@ -62,8 +62,8 @@ alarm_trigger:
       description: An optional code to trigger the alarm control panel with.
       example: 1234
     params:
-      description: Optional platform-specific parameters
-      example: 'silent'
+      description: Optional platform specific parameter dict
+      example: platform specific
 
 envisalink_alarm_keypress:
   description: Send custom keypresses to the alarm.

--- a/homeassistant/components/alarm_control_panel/services.yaml
+++ b/homeassistant/components/alarm_control_panel/services.yaml
@@ -9,6 +9,9 @@ alarm_disarm:
     code:
       description: An optional code to disarm the alarm control panel with.
       example: 1234
+    params:
+      description: Optional platform-specific parameters
+      example: 'silent'
 
 alarm_arm_home:
   description: Send the alarm the command for arm home.
@@ -19,6 +22,9 @@ alarm_arm_home:
     code:
       description: An optional code to arm home the alarm control panel with.
       example: 1234
+    params:
+      description: Optional platform-specific parameters
+      example: 'silent'
 
 alarm_arm_away:
   description: Send the alarm the command for arm away.
@@ -29,6 +35,9 @@ alarm_arm_away:
     code:
       description: An optional code to arm away the alarm control panel with.
       example: 1234
+    params:
+      description: Optional platform-specific parameters
+      example: 'silent'
 
 alarm_arm_night:
   description: Send the alarm the command for arm night.
@@ -39,6 +48,9 @@ alarm_arm_night:
     code:
       description: An optional code to arm night the alarm control panel with.
       example: 1234
+    params:
+      description: Optional platform-specific parameters
+      example: 'silent'
 
 alarm_trigger:
   description: Send the alarm the command for trigger.
@@ -49,6 +61,9 @@ alarm_trigger:
     code:
       description: An optional code to trigger the alarm control panel with.
       example: 1234
+    params:
+      description: Optional platform-specific parameters
+      example: 'silent'
 
 envisalink_alarm_keypress:
   description: Send custom keypresses to the alarm.

--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -115,21 +115,21 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
         """Update alarm status."""
         self.simplisafe.update()
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         if not self._validate_code(code, 'disarming'):
             return
         self.simplisafe.set_state('off')
         _LOGGER.info("SimpliSafe alarm disarming")
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         if not self._validate_code(code, 'arming home'):
             return
         self.simplisafe.set_state('home')
         _LOGGER.info("SimpliSafe alarm arming home")
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         if not self._validate_code(code, 'arming away'):
             return

--- a/homeassistant/components/alarm_control_panel/spc.py
+++ b/homeassistant/components/alarm_control_panel/spc.py
@@ -89,19 +89,19 @@ class SpcAlarm(alarm.AlarmControlPanel):
         return self._state
 
     @asyncio.coroutine
-    def async_alarm_disarm(self, code=None):
+    def async_alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         yield from self._api.send_area_command(
             self._area_id, SpcWebGateway.AREA_COMMAND_UNSET)
 
     @asyncio.coroutine
-    def async_alarm_arm_home(self, code=None):
+    def async_alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         yield from self._api.send_area_command(
             self._area_id, SpcWebGateway.AREA_COMMAND_PART_SET)
 
     @asyncio.coroutine
-    def async_alarm_arm_away(self, code=None):
+    def async_alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         yield from self._api.send_area_command(
             self._area_id, SpcWebGateway.AREA_COMMAND_SET)

--- a/homeassistant/components/alarm_control_panel/totalconnect.py
+++ b/homeassistant/components/alarm_control_panel/totalconnect.py
@@ -89,18 +89,18 @@ class TotalConnect(alarm.AlarmControlPanel):
 
         self._state = state
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         self._client.disarm()
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         self._client.arm_stay()
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         self._client.arm_away()
 
-    def alarm_arm_night(self, code=None):
+    def alarm_arm_night(self, code=None, params=None):
         """Send arm night command."""
         self._client.arm_stay_night()

--- a/homeassistant/components/alarm_control_panel/verisure.py
+++ b/homeassistant/components/alarm_control_panel/verisure.py
@@ -82,14 +82,14 @@ class VerisureAlarm(alarm.AlarmControlPanel):
             _LOGGER.error('Unknown alarm state %s', status)
         self._changed_by = hub.get_first("$.armState.name")
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         set_arm_state('DISARMED', code)
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         set_arm_state('ARMED_HOME', code)
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         set_arm_state('ARMED_AWAY', code)

--- a/homeassistant/components/alarm_control_panel/wink.py
+++ b/homeassistant/components/alarm_control_panel/wink.py
@@ -58,15 +58,15 @@ class WinkCameraDevice(WinkDevice, alarm.AlarmControlPanel):
             state = STATE_UNKNOWN
         return state
 
-    def alarm_disarm(self, code=None):
+    def alarm_disarm(self, code=None, params=None):
         """Send disarm command."""
         self.wink.set_mode("home")
 
-    def alarm_arm_home(self, code=None):
+    def alarm_arm_home(self, code=None, params=None):
         """Send arm home command."""
         self.wink.set_mode("night")
 
-    def alarm_arm_away(self, code=None):
+    def alarm_arm_away(self, code=None, params=None):
         """Send arm away command."""
         self.wink.set_mode("away")
 


### PR DESCRIPTION
## Description:

The concord232 alarm supports two platform-specific arming options: silent arming and instant arming.  The service interface for the alarm control panel had no facility for passing platform-specific data like this into these calls.

In order to support these in home assistant, there were a couple options:

1. Write concord specific services for arming and disarming.
This path would have been fairly insulated from the rest of the alarm panel code, but the result would have been somewhat awkward and confusing.

2.  Expand the interface for the alarm services, allowing these as optional parameters.
I chose this path. This required (small) changes to all of the submodules to accept a new parameter in the service calls, but the new parameter is a dict accommodating any platform-specific options in a general way.  Honeywell and Vivint alarms have the same options, for example, and I'm sure there are more.  I just don't have more than one alarm to test with.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4418

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
