### PR TITLE
Fix zha color probe

### DIFF
--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -31,40 +31,21 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         return
 
     endpoint = discovery_info['endpoint']
-    try:
-        discovery_info['color_capabilities'] \
-            = yield from endpoint.light_color['color_capabilities']
-    except (AttributeError, KeyError):
-        pass
-
-    if discovery_info.get('color_capabilities') is None:
-        # ZCL Version 4 devices don't support the color_capabilities attribute.
-        # In this version XY support is mandatory, but we need to probe to
-        # determine if the device supports color temperature.
-        discovery_info['color_capabilities'] = CAPABILITIES_COLOR_XY
-        result = yield from safe_read(
-            endpoint.light_color, ['color_temperature'])
-        if result.get('color_temperature') is not UNSUPPORTED_ATTRIBUTE:
-            discovery_info['color_capabilities'] |= CAPABILITIES_COLOR_TEMP
+    if hasattr(endpoint, 'light_color'):
+        caps = yield from zha.safe_read(
+            endpoint.light_color, ['color_capabilities'])
+        discovery_info['color_capabilities'] = caps.get('color_capabilities')
+        if discovery_info['color_capabilities'] is None:
+            # ZCL Version 4 devices don't support the color_capabilities
+            # attribute. In this version XY support is mandatory, but we need
+            # to probe to determine if the device supports color temperature.
+            discovery_info['color_capabilities'] = CAPABILITIES_COLOR_XY
+            result = yield from zha.safe_read(
+                endpoint.light_color, ['color_temperature'])
+            if result.get('color_temperature') is not UNSUPPORTED_ATTRIBUTE:
+                discovery_info['color_capabilities'] |= CAPABILITIES_COLOR_TEMP
 
     async_add_devices([Light(**discovery_info)], update_before_add=True)
-
-
-@asyncio.coroutine
-def safe_read(cluster, attributes):
-    """Swallow all exceptions from network read.
-
-    If we throw during initialization, setup fails. Rather have an
-    entity that exists, but is in a maybe wrong state, than no entity.
-    """
-    try:
-        result, _ = yield from cluster.read_attributes(
-            attributes,
-            allow_cache=False,
-        )
-        return result
-    except Exception:  # pylint: disable=broad-except
-        return {}
 
 
 class Light(zha.Entity, light.Light):
@@ -174,23 +155,23 @@ class Light(zha.Entity, light.Light):
     @asyncio.coroutine
     def async_update(self):
         """Retrieve latest state."""
-        result = yield from safe_read(self._endpoint.on_off, ['on_off'])
+        result = yield from zha.safe_read(self._endpoint.on_off, ['on_off'])
         self._state = result.get('on_off', self._state)
 
         if self._supported_features & light.SUPPORT_BRIGHTNESS:
-            result = yield from safe_read(self._endpoint.level,
-                                          ['current_level'])
+            result = yield from zha.safe_read(self._endpoint.level,
+                                              ['current_level'])
             self._brightness = result.get('current_level', self._brightness)
 
         if self._supported_features & light.SUPPORT_COLOR_TEMP:
-            result = yield from safe_read(self._endpoint.light_color,
-                                          ['color_temperature'])
+            result = yield from zha.safe_read(self._endpoint.light_color,
+                                              ['color_temperature'])
             self._color_temp = result.get('color_temperature',
                                           self._color_temp)
 
         if self._supported_features & light.SUPPORT_XY_COLOR:
-            result = yield from safe_read(self._endpoint.light_color,
-                                          ['current_x', 'current_y'])
+            result = yield from zha.safe_read(self._endpoint.light_color,
+                                              ['current_x', 'current_y'])
             if 'current_x' in result and 'current_y' in result:
                 self._xy_color = (result['current_x'], result['current_y'])
 

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -315,3 +315,21 @@ def get_discovery_info(hass, discovery_info):
     all_discovery_info = hass.data.get(DISCOVERY_KEY, {})
     discovery_info = all_discovery_info.get(discovery_key, None)
     return discovery_info
+
+
+@asyncio.coroutine
+def safe_read(cluster, attributes):
+    """Swallow all exceptions from network read.
+
+    If we throw during initialization, setup fails. Rather have an entity that
+    exists, but is in a maybe wrong state, than no entity. This method should
+    probably only be used during initialization.
+    """
+    try:
+        result, _ = yield from cluster.read_attributes(
+            attributes,
+            allow_cache=False,
+        )
+        return result
+    except Exception:  # pylint: disable=broad-except
+        return {}


### PR DESCRIPTION
## Description:
#11522 assumed that the `light_color` attribute always existed. This fixes that assumption. 

#9232 read in such a way that during initialization, a ZigBee delivery error exception would  be printed to the log. This fixes that.

In #10495 `safe_read` was copied from `components/light/zha.py`. This puts it in a more central location, since it should be useful to any component using zha.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
