### PR TITLE
Round values to only one decimal for Xiaomi Aqara sensors

### DIFF
--- a/homeassistant/components/sensor/xiaomi_aqara.py
+++ b/homeassistant/components/sensor/xiaomi_aqara.py
@@ -77,5 +77,5 @@ class XiaomiSensor(XiaomiDevice):
             return False
         elif self._data_key == 'pressure' and value == 0:
             return False
-        self._state = round(value, 2)
+        self._state = round(value, 1)
         return True


### PR DESCRIPTION
## Description:
The manufactures states the accuracy below. For this reason two decimals is a bit too much and I kindly suggest to round the value to one decimal. This will also make the text a bit more visible in the top badges.
Temperature detection range: -20 - 60 Deg.C ( + / - 0.3 Deg.C )
Humidity detection range: 0 - 100pct RH ( + / - 0.3pct )
Atmospheric pressure detection range: 30 - 110KPa ( + / - 120Pa )


## Checklist:
  - [x ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
