### PR TITLE
Move several local services to their right domain

### DIFF
--- a/homeassistant/components/calendar/todoist.py
+++ b/homeassistant/components/calendar/todoist.py
@@ -13,7 +13,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.calendar import (
-    CalendarEventDevice, PLATFORM_SCHEMA)
+    CalendarEventDevice, DOMAIN, PLATFORM_SCHEMA)
 from homeassistant.components.google import (
     CONF_DEVICE_ID)
 from homeassistant.const import (
@@ -26,7 +26,6 @@ from homeassistant.util import Throttle
 REQUIREMENTS = ['todoist-python==7.0.17']
 
 _LOGGER = logging.getLogger(__name__)
-DOMAIN = 'todoist'
 
 # Calendar Platform: Does this calendar event last all day?
 ALL_DAY = 'all_day'
@@ -78,7 +77,7 @@ SUMMARY = 'summary'
 # Todoist API: Fetch all Tasks
 TASKS = 'items'
 
-SERVICE_NEW_TASK = 'new_task'
+SERVICE_NEW_TASK = 'todoist_new_task'
 NEW_TASK_SERVICE_SCHEMA = vol.Schema({
     vol.Required(CONTENT): cv.string,
     vol.Optional(PROJECT_NAME, default='inbox'): vol.All(cv.string, vol.Lower),

--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import (
     SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_SELECT_SOURCE,
-    PLATFORM_SCHEMA, MediaPlayerDevice)
+    DOMAIN, PLATFORM_SCHEMA, MediaPlayerDevice)
 from homeassistant.const import (
     STATE_ON, STATE_OFF, STATE_IDLE, STATE_PLAYING, STATE_UNKNOWN, CONF_HOST,
     CONF_PORT, ATTR_ENTITY_ID)
@@ -22,7 +22,7 @@ REQUIREMENTS = ['snapcast==2.0.8']
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = 'snapcast'
+DATA_KEY = 'snapcast'
 
 SERVICE_SNAPSHOT = 'snapcast_snapshot'
 SERVICE_RESTORE = 'snapcast_restore'
@@ -59,7 +59,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     def _handle_service(service):
         """Handle services."""
         entity_ids = service.data.get(ATTR_ENTITY_ID)
-        devices = [device for device in hass.data[DOMAIN]
+        devices = [device for device in hass.data[DATA_KEY]
                    if device.entity_id in entity_ids]
         for device in devices:
             if service.service == SERVICE_SNAPSHOT:
@@ -84,7 +84,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     groups = [SnapcastGroupDevice(group) for group in server.groups]
     clients = [SnapcastClientDevice(client) for client in server.clients]
     devices = groups + clients
-    hass.data[DOMAIN] = devices
+    hass.data[DATA_KEY] = devices
     async_add_devices(devices)
     return True
 

--- a/homeassistant/components/media_player/soundtouch.py
+++ b/homeassistant/components/media_player/soundtouch.py
@@ -14,7 +14,7 @@ from homeassistant.components.media_player import (
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
     SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
     SUPPORT_VOLUME_SET, SUPPORT_TURN_ON, SUPPORT_PLAY, MediaPlayerDevice,
-    PLATFORM_SCHEMA)
+    DOMAIN, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_HOST, CONF_NAME, STATE_OFF, CONF_PORT,
                                  STATE_PAUSED, STATE_PLAYING,
                                  STATE_UNAVAILABLE)
@@ -23,7 +23,6 @@ REQUIREMENTS = ['libsoundtouch==0.7.2']
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = 'media_player'
 SERVICE_PLAY_EVERYWHERE = 'soundtouch_play_everywhere'
 SERVICE_CREATE_ZONE = 'soundtouch_create_zone'
 SERVICE_ADD_ZONE_SLAVE = 'soundtouch_add_zone_slave'

--- a/homeassistant/components/sensor/mopar.py
+++ b/homeassistant/components/sensor/mopar.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.sensor import DOMAIN, PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD, CONF_PIN,
                                  ATTR_ATTRIBUTION, ATTR_COMMAND,
@@ -23,9 +23,8 @@ REQUIREMENTS = ['motorparts==1.0.2']
 _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(days=7)
-DOMAIN = 'mopar'
 ATTR_VEHICLE_INDEX = 'vehicle_index'
-SERVICE_REMOTE_COMMAND = 'remote_command'
+SERVICE_REMOTE_COMMAND = 'mopar_remote_command'
 COOKIE_FILE = 'mopar_cookies.pickle'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -15,8 +15,8 @@ import voluptuous as vol
 
 from homeassistant.util.dt import utcnow
 from homeassistant.util import Throttle
-from homeassistant.components.switch import (SwitchDevice, DOMAIN,
-    PLATFORM_SCHEMA)
+from homeassistant.components.switch import (
+    SwitchDevice, DOMAIN, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_FRIENDLY_NAME, CONF_SWITCHES,
     CONF_COMMAND_OFF, CONF_COMMAND_ON,

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -15,7 +15,8 @@ import voluptuous as vol
 
 from homeassistant.util.dt import utcnow
 from homeassistant.util import Throttle
-from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.components.switch import (SwitchDevice, DOMAIN,
+    PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_FRIENDLY_NAME, CONF_SWITCHES,
     CONF_COMMAND_OFF, CONF_COMMAND_ON,
@@ -28,12 +29,11 @@ _LOGGER = logging.getLogger(__name__)
 
 TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
-DOMAIN = 'broadlink'
 DEFAULT_NAME = 'Broadlink switch'
 DEFAULT_TIMEOUT = 10
 DEFAULT_RETRY = 3
-SERVICE_LEARN = 'learn_command'
-SERVICE_SEND = 'send_packet'
+SERVICE_LEARN = 'broadlink_learn_command'
+SERVICE_SEND = 'broadlink_send_packet'
 CONF_SLOTS = 'slots'
 
 RM_TYPES = ['rm', 'rm2', 'rm_mini', 'rm_pro_phicomm', 'rm2_home_plus',

--- a/homeassistant/components/switch/scsgate.py
+++ b/homeassistant/components/switch/scsgate.py
@@ -23,8 +23,6 @@ CONF_SCENARIO = 'scenario'
 
 CONF_SCS_ID = 'scs_id'
 
-DOMAIN = 'scsgate'
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DEVICES): vol.Schema({cv.slug: scsgate.SCSGATE_SCHEMA}),
 })


### PR DESCRIPTION
## Description:

Since #11479 we try to load `services.yaml` based on the domain of registered services. This has now revealed several platforms that register services outside their own domain, causing an exception during the `services.yaml` loading.

This PR renames the services to follow the usual convention of keeping the domain and prepending the platform to the service name:

```
todoist.new_task -> calendar.todoist_new_task

snapcast.snapcast_snapshot -> media_player.snapcast_snapshot
snapcast.snapcast_restore -> media_player.snapcast_restore

mopar.remote_command -> sensor.mopar_remote_command

broadlink.learn_command_192_168_0_107 -> switch.broadlink_learn_command_192_168_0_107
broadlink.send_packet_192_168_0_107 -> switch.broadlink_send_packet_192_168_0_107
```

The affected platforms were located with this command:

    git grep -l 'register(' homeassistant/components/*/[a-z]*.py | xargs grep 'DOMAIN = '

I do not use any of these platforms so this is currently completely untested.

**Related issue (if applicable):** fixes #11654

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4424

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).</s>
  - [ ] <s>New dependencies are only imported inside functions that use them ([example][ex-import]).</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54