### PR TITLE
Update state immediately when turning flux bulb on and off

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -140,7 +140,7 @@ class FluxLight(Light):
         self._protocol = device[CONF_PROTOCOL]
         self._mode = device[ATTR_MODE]
         self._bulb = None
-        self._state = None
+        self._skeep = False
         self._error_reported = False
 
     def _connect(self):
@@ -181,7 +181,7 @@ class FluxLight(Light):
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._state
+        return self._bulb.isOn()
 
     @property
     def brightness(self):
@@ -228,13 +228,19 @@ class FluxLight(Light):
                               random.randint(0, 255))
         elif effect in EFFECT_MAP:
             self._bulb.setPresetPattern(EFFECT_MAP[effect], 50)
+        self._skeep = True
 
     def turn_off(self, **kwargs):
         """Turn the specified or all lights off."""
         self._bulb.turnOff()
+        self._skeep = True
 
     def update(self):
         """Synchronize state with bulb."""
+        if self._skeep:
+            self._skeep = False
+            return
+
         if not self.available:
             try:
                 self._connect()
@@ -247,5 +253,4 @@ class FluxLight(Light):
                     self._error_reported = True
                 return
 
-        self._bulb.update_state(retry=2)
-        self._state = self._bulb.isOn()
+        self._bulb.update_state(retry=2) 

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -227,10 +227,12 @@ class FluxLight(Light):
                               random.randint(0, 255))
         elif effect in EFFECT_MAP:
             self._bulb.setPresetPattern(EFFECT_MAP[effect], 50)
+        self._bulb.update_state(retry=2)
 
     def turn_off(self, **kwargs):
         """Turn the specified or all lights off."""
         self._bulb.turnOff()
+        self._bulb.update_state(retry=2)
 
     def update(self):
         """Synchronize state with bulb."""

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -140,6 +140,7 @@ class FluxLight(Light):
         self._protocol = device[CONF_PROTOCOL]
         self._mode = device[ATTR_MODE]
         self._bulb = None
+        self._state = None
         self._error_reported = False
 
     def _connect(self):
@@ -180,7 +181,7 @@ class FluxLight(Light):
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._bulb.isOn()
+        return self._state
 
     @property
     def brightness(self):
@@ -227,12 +228,10 @@ class FluxLight(Light):
                               random.randint(0, 255))
         elif effect in EFFECT_MAP:
             self._bulb.setPresetPattern(EFFECT_MAP[effect], 50)
-        self._bulb.update_state(retry=2)
 
     def turn_off(self, **kwargs):
         """Turn the specified or all lights off."""
         self._bulb.turnOff()
-        self._bulb.update_state(retry=2)
 
     def update(self):
         """Synchronize state with bulb."""
@@ -249,3 +248,4 @@ class FluxLight(Light):
                 return
 
         self._bulb.update_state(retry=2)
+        self._state = self._bulb.isOn()


### PR DESCRIPTION
## Description:
After turning on or off a bulb, call update_state to try and keep HASS in sync with bulb state. This aims to address the case where the UI state changes then bounces back until an update is later received.

**Related issue (if applicable):** fixes #11565 

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
