### PR TITLE
History order bugfix and opt-in option

### DIFF
--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -248,7 +248,7 @@ def async_setup(hass, config):
         filters.included_entities = include[CONF_ENTITIES]
         filters.included_domains = include[CONF_DOMAINS]
     use_include_order = config[DOMAIN].get(CONF_ORDER)
-    
+
     hass.http.register_view(HistoryPeriodView(filters, use_include_order))
     yield from hass.components.frontend.async_register_built_in_panel(
         'history', 'history', 'mdi:poll-box')
@@ -326,7 +326,7 @@ class HistoryPeriodView(HomeAssistantView):
                         break
             sorted_result.extend(result)
             result = sorted_result
-            
+
         return self.json(result)
 
 

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -20,14 +20,19 @@ from homeassistant.components import recorder, script
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import ATTR_HIDDEN
 from homeassistant.components.recorder.util import session_scope, execute
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'history'
 DEPENDENCIES = ['recorder', 'http']
 
+CONF_ORDER = 'use_include_order'
+
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: recorder.FILTER_SCHEMA,
+    DOMAIN: recorder.FILTER_SCHEMA.extend({
+        vol.Optional(CONF_ORDER, default='false'): cv.boolean,
+    })
 }, extra=vol.ALLOW_EXTRA)
 
 SIGNIFICANT_DOMAINS = ('thermostat', 'climate')
@@ -242,8 +247,9 @@ def async_setup(hass, config):
     if include:
         filters.included_entities = include[CONF_ENTITIES]
         filters.included_domains = include[CONF_DOMAINS]
-
-    hass.http.register_view(HistoryPeriodView(filters))
+    use_include_order = config[DOMAIN].get(CONF_ORDER)
+    
+    hass.http.register_view(HistoryPeriodView(filters, use_include_order))
     yield from hass.components.frontend.async_register_built_in_panel(
         'history', 'history', 'mdi:poll-box')
 
@@ -257,9 +263,10 @@ class HistoryPeriodView(HomeAssistantView):
     name = 'api:history:view-period'
     extra_urls = ['/api/history/period/{datetime}']
 
-    def __init__(self, filters):
+    def __init__(self, filters, use_include_order):
         """Initialize the history period view."""
         self.filters = filters
+        self.use_include_order = use_include_order
 
     @asyncio.coroutine
     def get(self, request, datetime=None):
@@ -305,19 +312,22 @@ class HistoryPeriodView(HomeAssistantView):
             _LOGGER.debug(
                 'Extracted %d states in %fs', sum(map(len, result)), elapsed)
 
-        # Reorder the result to respect the ordering given by any
-        # entities explicitly included in the configuration.
+        # Optionally reorder the result to respect the ordering given
+        # by any entities explicitly included in the configuration.
 
-        sorted_result = []
-        for order_entity in self.filters.included_entities:
-            for state_list in result:
-                if state_list[0].entity_id == order_entity:
-                    sorted_result.append(state_list)
-                    result.remove(state_list)
-                    break
-        sorted_result.extend(result)
-
-        return self.json(sorted_result)
+        if self.use_include_order:
+            result = list(result)
+            sorted_result = []
+            for order_entity in self.filters.included_entities:
+                for state_list in result:
+                    if state_list[0].entity_id == order_entity:
+                        sorted_result.append(state_list)
+                        result.remove(state_list)
+                        break
+            sorted_result.extend(result)
+            result = sorted_result
+            
+        return self.json(result)
 
 
 class Filters(object):

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -31,7 +31,7 @@ CONF_ORDER = 'use_include_order'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: recorder.FILTER_SCHEMA.extend({
-        vol.Optional(CONF_ORDER, default='false'): cv.boolean,
+        vol.Optional(CONF_ORDER, default=False): cv.boolean,
     })
 }, extra=vol.ALLOW_EXTRA)
 


### PR DESCRIPTION
## Description:

This fix does two things:

1.  Makes the new feature of ordering sensors in the history view optional and opt-in.
2.  Should also fix the bug which was in the original implementation.  But since the original feature had issues, I'm being conservative by making it opt-in for now.

**Related issue (if applicable):** fixes #11671 

If someone wants to use the new history ordering feature, they would add the configuration parameter as shown below:

## Example entry for `configuration.yaml` (if applicable):
```yaml

history:
    use_include_order: True
...
```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io#4426)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
