### PR TITLE
Improve foscam library exception support

### DIFF
--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -76,7 +76,7 @@ class FoscamCam(Camera):
     def enable_motion_detection(self):
         """Enable motion detection in camera."""
         try:
-            ret, err = self._foscam_session.enable_motion_detection()
+            ret = self._foscam_session.enable_motion_detection()
             if ret == FOSCAM_COMM_ERROR:
                 self._motion_status = True
             else:
@@ -89,7 +89,7 @@ class FoscamCam(Camera):
     def disable_motion_detection(self):
         """Disable motion detection."""
         try:
-            ret, err = self._foscam_session.disable_motion_detection()
+            ret = self._foscam_session.disable_motion_detection()
             if ret == FOSCAM_COMM_ERROR:
                 self._motion_status = True
             else:

--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -78,12 +78,10 @@ class FoscamCam(Camera):
         try:
             ret, err = self._foscam_session.enable_motion_detection()
             if ret == FOSCAM_COMM_ERROR:
-                _LOGGER.debug("Unable to communicate "
-                              "with Foscam Camera: %s", err)
                 self._motion_status = True
             else:
                 self._motion_status = False
-        except:
+        except TypeError:
             _LOGGER.debug("An exception occured "
                           "when communicating with the Foscam Camera")
             self._motion_status = False
@@ -93,12 +91,10 @@ class FoscamCam(Camera):
         try:
             ret, err = self._foscam_session.disable_motion_detection()
             if ret == FOSCAM_COMM_ERROR:
-                _LOGGER.debug("Unable to communicate "
-                              "with Foscam Camera: %s", err)
                 self._motion_status = True
             else:
                 self._motion_status = False
-        except:
+        except TypeError:
             _LOGGER.debug("An exception occured "
                           "when communicating with the Foscam Camera")
             self._motion_status = False

--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -44,6 +44,8 @@ class FoscamCam(Camera):
 
     def __init__(self, device_info):
         """Initialize a Foscam camera."""
+        from libpyfoscam import FoscamCamera
+
         super(FoscamCam, self).__init__()
 
         ip_address = device_info.get(CONF_IP)
@@ -53,10 +55,8 @@ class FoscamCam(Camera):
         self._name = device_info.get(CONF_NAME)
         self._motion_status = False
 
-        from libpyfoscam import FoscamCamera
-
-        self._foscam_session = FoscamCamera(ip_address, port, self._username,
-                                            self._password, verbose=False)
+        self._foscam_session = FoscamCamera(
+            ip_address, port, self._username, self._password, verbose=False)
 
     def camera_image(self):
         """Return a still image response from the camera."""
@@ -77,26 +77,18 @@ class FoscamCam(Camera):
         """Enable motion detection in camera."""
         try:
             ret = self._foscam_session.enable_motion_detection()
-            if ret == FOSCAM_COMM_ERROR:
-                self._motion_status = True
-            else:
-                self._motion_status = False
+            self._motion_status = ret == FOSCAM_COMM_ERROR
         except TypeError:
-            _LOGGER.debug("An exception occured "
-                          "when communicating with the Foscam Camera")
+            _LOGGER.debug("Communication problem")
             self._motion_status = False
 
     def disable_motion_detection(self):
         """Disable motion detection."""
         try:
             ret = self._foscam_session.disable_motion_detection()
-            if ret == FOSCAM_COMM_ERROR:
-                self._motion_status = True
-            else:
-                self._motion_status = False
+            self._motion_status = ret == FOSCAM_COMM_ERROR
         except TypeError:
-            _LOGGER.debug("An exception occured "
-                          "when communicating with the Foscam Camera")
+            _LOGGER.debug("Communication problem")
             self._motion_status = False
 
     @property

--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -75,20 +75,28 @@ class FoscamCam(Camera):
 
     def enable_motion_detection(self):
         """Enable motion detection in camera."""
-        ret, err = self._foscam_session.enable_motion_detection()
-        if ret == FOSCAM_COMM_ERROR:
-            _LOGGER.debug("Unable to communicate with Foscam Camera: %s", err)
-            self._motion_status = True
-        else:
+        try:
+            ret, err = self._foscam_session.enable_motion_detection()
+            if ret == FOSCAM_COMM_ERROR:
+                _LOGGER.debug("Unable to communicate with Foscam Camera: %s", err)
+                self._motion_status = True
+            else:
+                self._motion_status = False
+        except:
+            _LOGGER.debug("An exception occured when communicating with the Foscam Camera")
             self._motion_status = False
 
     def disable_motion_detection(self):
         """Disable motion detection."""
-        ret, err = self._foscam_session.disable_motion_detection()
-        if ret == FOSCAM_COMM_ERROR:
-            _LOGGER.debug("Unable to communicate with Foscam Camera: %s", err)
-            self._motion_status = True
-        else:
+        try:
+            ret, err = self._foscam_session.disable_motion_detection()
+            if ret == FOSCAM_COMM_ERROR:
+                _LOGGER.debug("Unable to communicate with Foscam Camera: %s", err)
+                self._motion_status = True
+            else:
+                self._motion_status = False
+        except:
+            _LOGGER.debug("An exception occured when communicating with the Foscam Camera")
             self._motion_status = False
 
     @property

--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -78,12 +78,14 @@ class FoscamCam(Camera):
         try:
             ret, err = self._foscam_session.enable_motion_detection()
             if ret == FOSCAM_COMM_ERROR:
-                _LOGGER.debug("Unable to communicate with Foscam Camera: %s", err)
+                _LOGGER.debug("Unable to communicate "
+                              "with Foscam Camera: %s", err)
                 self._motion_status = True
             else:
                 self._motion_status = False
         except:
-            _LOGGER.debug("An exception occured when communicating with the Foscam Camera")
+            _LOGGER.debug("An exception occured "
+                          "when communicating with the Foscam Camera")
             self._motion_status = False
 
     def disable_motion_detection(self):
@@ -91,12 +93,14 @@ class FoscamCam(Camera):
         try:
             ret, err = self._foscam_session.disable_motion_detection()
             if ret == FOSCAM_COMM_ERROR:
-                _LOGGER.debug("Unable to communicate with Foscam Camera: %s", err)
+                _LOGGER.debug("Unable to communicate "
+                              "with Foscam Camera: %s", err)
                 self._motion_status = True
             else:
                 self._motion_status = False
         except:
-            _LOGGER.debug("An exception occured when communicating with the Foscam Camera")
+            _LOGGER.debug("An exception occured "
+                          "when communicating with the Foscam Camera")
             self._motion_status = False
 
     @property


### PR DESCRIPTION
Catches foscam exceptions that otherwise pollute the log. Many of these exception can safely be ignored

## Description:
The Python Foscam library correctly sets motion detection on my Foscam FI9800P but throws an exception while doing so. I've 'fixed' this by adding an exception handler/logging. This will then allow people to suppress the messages via an entry in their configuration.

The upstream maintainer of the Python Foscam library is AWOL and hasn't responded to the actual problem: https://github.com/quatanium/foscam-python-lib/issues/22

In time Python Foscam should be replaced, it's pretty bad and doesn't support many devices.

**Related issue (if applicable):** fixes #9484

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [Y] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [n/a] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [n/a] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [n/a] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [n/a] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [n/a] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [y] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [n/a] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
