### PR TITLE
Override default name for TP-Link devices

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -78,9 +78,7 @@ class TPLinkSmartBulb(Light):
     def __init__(self, smartbulb: 'SmartBulb', name):
         """Initialize the bulb."""
         self.smartbulb = smartbulb
-        self._name = None
-        if name is not None:
-            self._name = name
+        self._name = name
         self._state = None
         self._available = True
         self._color_temp = None
@@ -149,22 +147,30 @@ class TPLinkSmartBulb(Light):
         from pyHS100 import SmartDeviceException
         try:
             self._available = True
+
             if self._supported_features == 0:
                 self.get_features()
+
             self._state = (
                 self.smartbulb.state == self.smartbulb.BULB_STATE_ON)
-            if self._name is None:
+
+            # Pull the name from the device if a name was not specified
+            if self._name == DEFAULT_NAME:
                 self._name = self.smartbulb.alias
+
             if self._supported_features & SUPPORT_BRIGHTNESS:
                 self._brightness = brightness_from_percentage(
                     self.smartbulb.brightness)
+
             if self._supported_features & SUPPORT_COLOR_TEMP:
                 if (self.smartbulb.color_temp is not None and
                         self.smartbulb.color_temp != 0):
                     self._color_temp = kelvin_to_mired(
                         self.smartbulb.color_temp)
+
             if self._supported_features & SUPPORT_RGB_COLOR:
                 self._rgb = hsv_to_rgb(self.smartbulb.hsv)
+
             if self.smartbulb.has_emeter:
                 self._emeter_params[ATTR_CURRENT_POWER_W] = '{:.1f}'.format(
                     self.smartbulb.current_consumption())

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -90,10 +90,12 @@ class SmartPlugSwitch(SwitchDevice):
         from pyHS100 import SmartDeviceException
         try:
             self._available = True
+
             self._state = self.smartplug.state == \
                 self.smartplug.SWITCH_STATE_ON
 
-            if self._name is None:
+            # Pull the name from the device if a name was not specified
+            if self._name == DEFAULT_NAME:
                 self._name = self.smartplug.alias
 
             if self.smartplug.has_emeter:


### PR DESCRIPTION
## Description:

Corrects a bug introduced that prevents the names of TP-LInk devices from being pulled from the devices themselves.

**Related issue (if applicable):** fixes #11706

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: tplink
    host: xxx.xxx.xxx.xxx

light:
  - platform: tplink
    host: xxx.xxx.xxx.xxx
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] ~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  - [ ] ~New dependencies are only imported inside functions that use them ([example][ex-import]).~
  - [ ] ~New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  - [ ] ~New files were added to `.coveragerc`.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
