### PR TITLE
Add deCONZ entities in a predicitive order

### DIFF
--- a/homeassistant/components/binary_sensor/deconz.py
+++ b/homeassistant/components/binary_sensor/deconz.py
@@ -25,8 +25,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     sensors = hass.data[DECONZ_DATA].sensors
     entities = []
 
-    for sensor in sensors.values():
-        if sensor.type in DECONZ_BINARY_SENSOR:
+    for key in sorted(sensors.keys(), key=int):
+        sensor = sensors[key]
+        if sensor and sensor.type in DECONZ_BINARY_SENSOR:
             entities.append(DeconzBinarySensor(sensor))
     async_add_devices(entities, True)
 

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['pydeconz==24']
+REQUIREMENTS = ['pydeconz==25']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -90,6 +90,7 @@ def async_setup_deconz(hass, config, deconz_config):
     Load config, group, light and sensor data for server information.
     Start websocket for push notification of state changes from deCONZ.
     """
+    _LOGGER.debug('deCONZ config %s', deconz_config)
     from pydeconz import DeconzSession
     websession = async_get_clientsession(hass)
     deconz = DeconzSession(hass.loop, websession, **deconz_config)

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -29,8 +29,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     sensors = hass.data[DECONZ_DATA].sensors
     entities = []
 
-    for sensor in sensors.values():
-        if sensor.type in DECONZ_SENSOR:
+    for key in sorted(sensors.keys(), key=int):
+        sensor = sensors[key]
+        if sensor and sensor.type in DECONZ_SENSOR:
             if sensor.type in DECONZ_REMOTE:
                 DeconzEvent(hass, sensor)
                 if sensor.battery:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -681,7 +681,7 @@ pycsspeechtts==1.0.2
 pydaikin==0.4
 
 # homeassistant.components.deconz
-pydeconz==24
+pydeconz==25
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Description:
deCONZ generates devices with multiple sensors with the same name, hass will load these in the random order the dict gets listed in which makes it hard to use entities in any way. 

**Related issue:**
fixes #11642, fixes #11697

## Checklist:
  - [x] The code change is tested and works locally.
