### PR TITLE
Fix effects not appearing in UI due to missing attribute

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -78,7 +78,7 @@ EFFECT_MAP = {
 
 FLUX_EFFECT_LIST = [
     EFFECT_RANDOM,
-    ].extend(EFFECT_MAP.keys())
+    ] + list(EFFECT_MAP)
 
 DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,


### PR DESCRIPTION
## Description:
UI dropdown not showing any available effects for Flux_led devices. Attributes on the device showed that the effect_list attribute was missing.

Discord chat with @armills highlighted the problem in the flux_led component. 

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant-polymer/issues/813 (reported against frontend project, but turned out to be a backend issue)

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**