### PR TITLE
Fix universal media player templated select_source bug

### DIFF
--- a/homeassistant/components/media_player/universal.py
+++ b/homeassistant/components/media_player/universal.py
@@ -154,7 +154,8 @@ class UniversalMediaPlayer(MediaPlayerDevice):
         if allow_override and service_name in self._cmds:
             yield from async_call_from_config(
                 self.hass, self._cmds[service_name],
-                variables=service_data, blocking=True)
+                variables=service_data, blocking=True,
+                validate_config=False)
             return
 
         active_child = self._child_state

--- a/tests/components/media_player/test_universal.py
+++ b/tests/components/media_player/test_universal.py
@@ -143,7 +143,7 @@ class MockMediaPlayer(media_player.MediaPlayerDevice):
 
     def select_source(self, source):
         """Set the input source."""
-        self._state = source
+        self._source = source
 
     def clear_playlist(self):
         """Clear players playlist."""


### PR DESCRIPTION
## Description:

With PR [#10395](https://github.com/home-assistant/home-assistant/pull/10395), the universal media player component received formal schema definition and validation using `PLATFORM_SCHEMA`.  It introduced a bug where the select_source command would fail described by issue #10981.

To execute a command, a universal media player passes the relevant portion of its config object (a dictionary which has already been processed and validated) to the helper `async_call_from_config` which by default validates the config parameter before doing anything else.  In this case, the relevant portion is he select_source portion of the config which contains a data_template, so the processed config object will contain `Template ` objects instead of the original strings.  However, `async_call_from_config` expects its config parameter to be a dictionary full of strings.  In other words, because the config object has already been processed, it fails validation, as the config parameter is presumably expected to not have been processed.  The fix then is to disable validation for this particular call, as we know that the config object has already been validated at setup.

I also found and corrected a typo in the related test.

**Related issue (if applicable):** fixes #10981 

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
