### PR TITLE
Fix for None object access attempt

### DIFF
--- a/homeassistant/components/arlo.py
+++ b/homeassistant/components/arlo.py
@@ -12,7 +12,7 @@ from requests.exceptions import HTTPError, ConnectTimeout
 from homeassistant.helpers import config_validation as cv
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
-REQUIREMENTS = ['pyarlo==0.1.0']
+REQUIREMENTS = ['pyarlo==0.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/camera/arlo.py
+++ b/homeassistant/components/camera/arlo.py
@@ -76,7 +76,8 @@ class ArloCam(Camera):
         self._ffmpeg_arguments = device_info.get(CONF_FFMPEG_ARGUMENTS)
         self._last_refresh = None
         if self._camera.base_station:
-            self._camera.base_station.refresh_rate = SCAN_INTERVAL.total_seconds()
+            self._camera.base_station.refresh_rate = \
+                SCAN_INTERVAL.total_seconds()
         self.attrs = {}
 
     def camera_image(self):

--- a/homeassistant/components/camera/arlo.py
+++ b/homeassistant/components/camera/arlo.py
@@ -75,7 +75,8 @@ class ArloCam(Camera):
         self._ffmpeg = hass.data[DATA_FFMPEG]
         self._ffmpeg_arguments = device_info.get(CONF_FFMPEG_ARGUMENTS)
         self._last_refresh = None
-        self._camera.base_station.refresh_rate = SCAN_INTERVAL.total_seconds()
+        if self._camera.base_station:
+            self._camera.base_station.refresh_rate = SCAN_INTERVAL.total_seconds()
         self.attrs = {}
 
     def camera_image(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -634,7 +634,7 @@ pyairvisual==1.0.0
 pyalarmdotcom==0.3.0
 
 # homeassistant.components.arlo
-pyarlo==0.1.0
+pyarlo==0.1.2
 
 # homeassistant.components.notify.xmpp
 pyasn1-modules==0.1.5


### PR DESCRIPTION
## Description:
When camera has no base station we shouldn't try to access it.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
