### PR TITLE
Upgrade netdisco

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==1.2.3']
+REQUIREMENTS = ['netdisco==1.2.4']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -504,7 +504,7 @@ myusps==1.2.2
 nad_receiver==0.0.6
 
 # homeassistant.components.discovery
-netdisco==1.2.3
+netdisco==1.2.4
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1


### PR DESCRIPTION
## Description:
Upgrade netdisco

Changelog:

- Add Yeelight Bedside Lamp support (https://github.com/home-assistant/netdisco/pull/160) (@pauln)
- Add Nanoleaf Aurora support (https://github.com/home-assistant/netdisco/pull/161) (@stuwil)
- Daikin: Don't return UTF8 encoded info to HA since it can't handle it yet (https://github.com/home-assistant/netdisco/pull/158) (@rofrantz)
- Allow detecting deCONZ separately from Philips Hue bridges (https://github.com/home-assistant/netdisco/pull/156) (@kroimon)
- Add Ziggo Mediabox XL support (https://github.com/home-assistant/netdisco/pull/155) (@b10m)
- Add support for Konnected Security devices. (https://github.com/home-assistant/netdisco/pull/154) (@emosenkis)

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
