### PR TITLE
fix for #6375 SamsungTV spams out "Updating samsungtv media_player took longer than the scheduled update interval 0:00:10"

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -121,9 +121,14 @@ class SamsungTVDevice(MediaPlayerDevice):
             self._config['method'] = 'legacy'
 
     def update(self):
-        """Retrieve the latest data."""
-        # Send an empty key to see if we are still connected
-        self.send_key('KEY')
+        """Update state of device."""
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(5)
+            sock.connect((self._config['host'], self._config['port']))
+            self._state = STATE_ON
+        except socket.error:
+            self._state = STATE_OFF
 
     def get_remote(self):
         """Create or return a remote control instance."""

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -124,7 +124,7 @@ class SamsungTVDevice(MediaPlayerDevice):
         """Update state of device."""
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(5)
+            sock.settimeout(self._config[CONF_TIMEOUT])
             sock.connect((self._config['host'], self._config['port']))
             self._state = STATE_ON
         except socket.error:


### PR DESCRIPTION
## Description:
Cant get state from an empty key no more, this will check if host:port is open

**Related issue (if applicable):** fixes #6375 

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
