### PR TITLE
Sound mode support media_player general and denonavr

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -10,7 +10,6 @@ import functools as ft
 import collections
 import hashlib
 import logging
-import os
 from random import SystemRandom
 
 from aiohttp import web
@@ -19,7 +18,6 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
-from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (
     STATE_OFF, STATE_IDLE, STATE_PLAYING, STATE_UNKNOWN, ATTR_ENTITY_ID,
     SERVICE_TOGGLE, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_VOLUME_UP,
@@ -93,6 +91,7 @@ MEDIA_TYPE_VIDEO = 'movie'
 MEDIA_TYPE_EPISODE = 'episode'
 MEDIA_TYPE_CHANNEL = 'channel'
 MEDIA_TYPE_PLAYLIST = 'playlist'
+MEDIA_TYPE_URL = 'url'
 
 SUPPORT_PAUSE = 1
 SUPPORT_SEEK = 2
@@ -392,13 +391,9 @@ def async_setup(hass, config):
     component = EntityComponent(
         logging.getLogger(__name__), DOMAIN, hass, SCAN_INTERVAL)
 
-    hass.http.register_view(MediaPlayerImageView(component.entities))
+    hass.http.register_view(MediaPlayerImageView(component))
 
     yield from component.async_setup(config)
-
-    descriptions = yield from hass.async_add_job(
-        load_yaml_config_file, os.path.join(
-            os.path.dirname(__file__), 'services.yaml'))
 
     @asyncio.coroutine
     def async_service_handler(service):
@@ -444,7 +439,7 @@ def async_setup(hass, config):
             'schema', MEDIA_PLAYER_SCHEMA)
         hass.services.async_register(
             DOMAIN, service, async_service_handler,
-            descriptions.get(service), schema=schema)
+            schema=schema)
 
     return True
 
@@ -987,14 +982,14 @@ class MediaPlayerImageView(HomeAssistantView):
     url = '/api/media_player_proxy/{entity_id}'
     name = 'api:media_player:image'
 
-    def __init__(self, entities):
+    def __init__(self, component):
         """Initialize a media player view."""
-        self.entities = entities
+        self.component = component
 
     @asyncio.coroutine
     def get(self, request, entity_id):
         """Start a get request."""
-        player = self.entities.get(entity_id)
+        player = self.component.get_entity(entity_id)
         if player is None:
             status = 404 if request[KEY_AUTHENTICATED] else 401
             return web.Response(status=status)

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -57,6 +57,7 @@ ENTITY_IMAGE_CACHE = {
 
 SERVICE_PLAY_MEDIA = 'play_media'
 SERVICE_SELECT_SOURCE = 'select_source'
+SERVICE_SELECT_SOUND_MODE = 'select_sound_mode'
 SERVICE_CLEAR_PLAYLIST = 'clear_playlist'
 
 ATTR_MEDIA_VOLUME_LEVEL = 'volume_level'
@@ -81,6 +82,8 @@ ATTR_APP_ID = 'app_id'
 ATTR_APP_NAME = 'app_name'
 ATTR_INPUT_SOURCE = 'source'
 ATTR_INPUT_SOURCE_LIST = 'source_list'
+ATTR_SOUND_MODE = 'sound_mode'
+ATTR_SOUND_MODE_LIST = 'sound_mode_list'
 ATTR_MEDIA_ENQUEUE = 'enqueue'
 ATTR_MEDIA_SHUFFLE = 'shuffle'
 
@@ -107,6 +110,7 @@ SUPPORT_STOP = 4096
 SUPPORT_CLEAR_PLAYLIST = 8192
 SUPPORT_PLAY = 16384
 SUPPORT_SHUFFLE_SET = 32768
+SUPPORT_SELECT_SOUND_MODE = 65536
 
 # Service call validation schemas
 MEDIA_PLAYER_SCHEMA = vol.Schema({
@@ -128,6 +132,10 @@ MEDIA_PLAYER_MEDIA_SEEK_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
 
 MEDIA_PLAYER_SELECT_SOURCE_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
     vol.Required(ATTR_INPUT_SOURCE): cv.string,
+})
+
+MEDIA_PLAYER_SELECT_SOUND_MODE_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
+    vol.Required(ATTR_SOUND_MODE): cv.string,
 })
 
 MEDIA_PLAYER_PLAY_MEDIA_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
@@ -165,6 +173,9 @@ SERVICE_TO_METHOD = {
     SERVICE_SELECT_SOURCE: {
         'method': 'async_select_source',
         'schema': MEDIA_PLAYER_SELECT_SOURCE_SCHEMA},
+    SERVICE_SELECT_SOUND_MODE: {
+        'method': 'async_select_sound_mode',
+        'schema': MEDIA_PLAYER_SELECT_SOUND_MODE_SCHEMA},
     SERVICE_PLAY_MEDIA: {
         'method': 'async_play_media',
         'schema': MEDIA_PLAYER_PLAY_MEDIA_SCHEMA},
@@ -195,6 +206,8 @@ ATTR_TO_PROPERTY = [
     ATTR_APP_NAME,
     ATTR_INPUT_SOURCE,
     ATTR_INPUT_SOURCE_LIST,
+    ATTR_SOUND_MODE,
+    ATTR_SOUND_MODE_LIST,
     ATTR_MEDIA_SHUFFLE,
 ]
 
@@ -345,6 +358,17 @@ def select_source(hass, source, entity_id=None):
 
 
 @bind_hass
+def select_sound_mode(hass, sound_mode, entity_id=None):
+    """Send the media player the command to select sound mode."""
+    data = {ATTR_SOUND_MODE: sound_mode}
+
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    hass.services.call(DOMAIN, SERVICE_SELECT_SOUND_MODE, data)
+
+
+@bind_hass
 def clear_playlist(hass, entity_id=None):
     """Send the media player the command for clear playlist."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
@@ -392,6 +416,8 @@ def async_setup(hass, config):
             params['position'] = service.data.get(ATTR_MEDIA_SEEK_POSITION)
         elif service.service == SERVICE_SELECT_SOURCE:
             params['source'] = service.data.get(ATTR_INPUT_SOURCE)
+        elif service.service == SERVICE_SELECT_SOUND_MODE:
+            params['sound_mode'] = service.data.get(ATTR_SOUND_MODE)
         elif service.service == SERVICE_PLAY_MEDIA:
             params['media_type'] = \
                 service.data.get(ATTR_MEDIA_CONTENT_TYPE)
@@ -575,6 +601,16 @@ class MediaPlayerDevice(Entity):
         return None
 
     @property
+    def sound_mode(self):
+        """Name of the current sound mode."""
+        return None
+
+    @property
+    def sound_mode_list(self):
+        """List of available sound modes."""
+        return None
+
+    @property
     def shuffle(self):
         """Boolean if shuffle is enabled."""
         return None
@@ -717,6 +753,17 @@ class MediaPlayerDevice(Entity):
         """
         return self.hass.async_add_job(self.select_source, source)
 
+    def select_sound_mode(self, sound_mode):
+        """Select sound mode."""
+        raise NotImplementedError()
+
+    def async_select_sound_mode(self, sound_mode):
+        """Select sound mode.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.async_add_job(self.select_sound_mode, sound_mode)
+
     def clear_playlist(self):
         """Clear players playlist."""
         raise NotImplementedError()
@@ -789,6 +836,11 @@ class MediaPlayerDevice(Entity):
     def support_select_source(self):
         """Boolean if select source command supported."""
         return bool(self.supported_features & SUPPORT_SELECT_SOURCE)
+
+    @property
+    def support_select_sound_mode(self):
+        """Boolean if select sound mode command supported."""
+        return bool(self.supported_features & SUPPORT_SELECT_SOUND_MODE)
 
     @property
     def support_clear_playlist(self):

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -200,7 +200,7 @@ class DenonDevice(MediaPlayerDevice):
                 url = ('http://' + str(self._host) +
                        '/goform/formMainZone_MainZoneXml.xml')
                 XML_data = urllib.request.urlopen(url)
-            except URLError:
+            except urllib.error.URLError:
                 return
             parsed_data = ET.parse(XML_data).getroot()
             sound_mode_raw = parsed_data.find('selectSurround/value')

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -201,6 +201,7 @@ class DenonDevice(MediaPlayerDevice):
                        '/goform/formMainZone_MainZoneXml.xml')
                 xml_data = urllib.request.urlopen(url)
             except urllib.error.URLError:
+                _LOGGER.info("Denon receiver failed to get sound mode, URL-Error")
                 return
             parsed_data = ET.parse(xml_data).getroot()
             sound_mode_raw = parsed_data.find('selectSurround/value')

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -7,9 +7,9 @@ https://home-assistant.io/components/media_player.denon/
 
 import logging
 from collections import (namedtuple, OrderedDict)
-import voluptuous as vol
 import urllib
 import xml.etree.ElementTree as ET
+import voluptuous as vol
 
 from homeassistant.components.media_player import (
     SUPPORT_PAUSE, SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK,
@@ -199,16 +199,16 @@ class DenonDevice(MediaPlayerDevice):
             try:
                 url = ('http://' + str(self._host) +
                        '/goform/formMainZone_MainZoneXml.xml')
-                XML_data = urllib.request.urlopen(url)
+                xml_data = urllib.request.urlopen(url)
             except urllib.error.URLError:
                 return
-            parsed_data = ET.parse(XML_data).getroot()
+            parsed_data = ET.parse(xml_data).getroot()
             sound_mode_raw = parsed_data.find('selectSurround/value')
             sound_mode_raw = sound_mode_raw.text.rstrip()
             try:
                 mode_list = list(self._sound_mode_dict.values())
-                Index = mode_list.index(sound_mode_raw.upper())
-                sound_mode = list(self._sound_mode_dict.keys())[Index]
+                mode_index = mode_list.index(sound_mode_raw.upper())
+                sound_mode = list(self._sound_mode_dict.keys())[mode_index]
                 self._current_sound_mode = sound_mode
             except ValueError:
                 self._current_sound_mode = sound_mode_raw

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -201,7 +201,8 @@ class DenonDevice(MediaPlayerDevice):
                        '/goform/formMainZone_MainZoneXml.xml')
                 xml_data = urllib.request.urlopen(url)
             except urllib.error.URLError:
-                _LOGGER.info("Denon receiver failed to get sound mode, URL-Error")
+                err = "Denon receiver failed to get sound mode, URL-Error"
+                _LOGGER.error(err)
                 return
             parsed_data = ET.parse(xml_data).getroot()
             sound_mode_raw = parsed_data.find('selectSurround/value')

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -107,6 +107,20 @@ media_seek:
       description: Position to seek to. The format is platform dependent.
       example: 100
 
+monoprice_snapshot:
+  description: Take a snapshot of the media player zone.
+  fields:
+    entity_id:
+      description: Name(s) of entities that will be snapshot. Platform dependent.
+      example: 'media_player.living_room'
+
+monoprice_restore:
+  description: Restore a snapshot of the media player zone.
+  fields:
+    entity_id:
+      description: Name(s) of entities that will be restored. Platform dependent.
+      example: 'media_player.living_room'
+
 play_media:
   description: Send the media player the command for playing media.
   fields:
@@ -303,3 +317,30 @@ kodi_call_method:
     method:
       description: Name of the Kodi JSONRPC API method to be called.
       example: 'VideoLibrary.GetRecentlyAddedEpisodes'
+
+squeezebox_call_method:
+  description: 'Call a Squeezebox JSON/RPC API method.'
+  fields:
+    entity_id:
+      description: Name(s) of the Squeexebox entities where to run the API method.
+      example: 'media_player.squeezebox_radio'
+    command:
+      description: Name of the Squeezebox command.
+      example: 'playlist'
+    parameters:
+      description: Optional array of parameters to be appended to the command. See 'Command Line Interface' official help page from Logitech for details.
+      example: '["loadtracks", "track.titlesearch=highway to hell"]'
+
+yamaha_enable_output:
+  description: Enable or disable an output port
+
+  fields:
+    entity_id:
+      description: Name(s) of entites to enable/disable port on.
+      example: 'media_player.yamaha'
+    port:
+      description: Name of port to enable/disable.
+      example: 'hdmi1'
+    enabled:
+      description: Boolean indicating if port should be enabled or not.
+      example: true

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -135,9 +135,9 @@ select_sound_mode:
   fields:
     entity_id:
       description: Name(s) of entities to change sound mode on.
-      example: 'media_player.media_player.txnr535_0009b0d81f82'
+      example: 'media_player.marantz'
     sound_mode:
-      description: Name of the sound mode to switch to. Platform dependent.
+      description: Name of the sound mode to switch to.
       example: 'Music'
 
 clear_playlist:

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -130,6 +130,16 @@ select_source:
       description: Name of the source to switch to. Platform dependent.
       example: 'video1'
 
+select_sound_mode:
+  description: Send the media player the command to change sound mode.
+  fields:
+    entity_id:
+      description: Name(s) of entities to change sound mode on.
+      example: 'media_player.media_player.txnr535_0009b0d81f82'
+    sound_mode:
+      description: Name of the sound mode to switch to. Platform dependent.
+      example: 'Music'
+
 clear_playlist:
   description: Send the media player the command to clear players playlist.
   fields:


### PR DESCRIPTION
## Description:
Added backend support for selecting the sound mode and updating the sound mode status.
This is general support for all media_player components.
This box is not shown in media_players that did not (yet) implement sound mode support in the backend.
I implemented the sound mode support (backend) for the denonavr platform and that one works perfictly.
I already have a pull request for the frontend to have a dropdown select box in the user interface if the media_player supports sound mode.
https://github.com/home-assistant/home-assistant-polymer/pull/815

I tested this code and it works on Hassbian on my pi.

On the home assistant chat I heard that other platforms like onkyo and sonos could also implement sound mode support and probably most receivers could support this, this also provides a base for other platforms to simply implement sound mode support.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4470

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: denonavr
    host: IP_ADRESS
    name: "Marantz"
    show_all_sources: False
    timeout: 2
    sound_mode: True
    sound_mode_dict: {'MUSIC':'PLII MUSIC', 'MOVIE':'PLII MOVIE', 'GAME':'PLII GAME', 'PURE DIRECT':'DIRECT', 'AUTO':'None', 'DOLBY DIGITAL':'DOLBY DIGITAL', 'MCH STEREO':'MULTI CH STEREO', 'STEREO':'STEREO'}
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
