### PR TITLE
Fix Alphavantage sensor to round off exchange rates

### DIFF
--- a/homeassistant/components/sensor/alpha_vantage.py
+++ b/homeassistant/components/sensor/alpha_vantage.py
@@ -191,7 +191,7 @@ class AlphaVantageForeignExchange(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self.values['5. Exchange Rate']
+        return round(float(self.values['5. Exchange Rate']), 4)
 
     @property
     def icon(self):


### PR DESCRIPTION
Description: Currently, the sensor returns a string with 8 decimals (mostly zeros), e.g., 63.89610000. This PR converts the string to `float` to remove the unnecessary zeros and then rounds off the exchange rate to 4 decimals to return 63.8961, in line with other platforms. 


## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: alpha_vantage
    api_key: !secret alphavantage_key
    foreign_exchange:
      - from: USD
        to: INR
        name: USDINR  
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with tox run successfully. Your PR cannot be merged unless tests pass