### PR TITLE
Axis discovery fails to save conf

### DIFF
--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -101,6 +101,7 @@ def request_configuration(hass, config, name, host, serialnumber):
             return False
 
         if setup_device(hass, config, device_config):
+            del device_config['signal']
             config_file = load_json(hass.config.path(CONFIG_FILE))
             config_file[serialnumber] = dict(device_config)
             save_json(hass.config.path(CONFIG_FILE), config_file)

--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -101,6 +101,7 @@ def request_configuration(hass, config, name, host, serialnumber):
             return False
 
         if setup_device(hass, config, device_config):
+            del device_config['events']
             del device_config['signal']
             config_file = load_json(hass.config.path(CONFIG_FILE))
             config_file[serialnumber] = dict(device_config)


### PR DESCRIPTION
## Description:
Remove items from axis.conf that doesnt belong there.

## Checklist:
  - [x] The code change is tested and works locally.