### PR TITLE
Poll timer for time remaining updates

### DIFF
--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -226,8 +226,9 @@ class Timer(Entity):
                 ATTR_REMAINING: str(timedelta(seconds=
                                               self._remaining.seconds,
                                               microseconds=
-                                              (round(self._remaining.microseconds
-                                                     /1000000))*1000000))
+                                              (round
+                                               (self._remaining.microseconds
+                                                /1000000))*1000000))
             }
         else:
             return {

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -220,17 +220,19 @@ class Timer(Entity):
     def state_attributes(self):
         """Return the state attributes."""
         if self._remaining:
-           return {
-            ATTR_DURATION: str(self._duration),
-            #Round time remaining to nearest second
-            ATTR_REMAINING: str(timedelta(seconds=self._remaining.seconds,
-                                          microseconds=(round(self._remaining.microseconds
-                                          /1000000))*1000000))
+            return {
+                ATTR_DURATION: str(self._duration),
+                #Round time remaining to nearest second
+                ATTR_REMAINING: str(timedelta(seconds =
+                                    self._remaining.seconds,
+                                    microseconds =
+                                    (round(self._remaining.microseconds
+                                     /1000000))*1000000))
             }
         else:
             return {
-            ATTR_DURATION: str(self._duration),
-            ATTR_REMAINING: None
+                ATTR_DURATION: str(self._duration),
+                ATTR_REMAINING: None
             }
 
     @asyncio.coroutine

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -224,10 +224,10 @@ class Timer(Entity):
                 ATTR_DURATION: str(self._duration),
                 # Round time remaining to nearest second
                 ATTR_REMAINING: str(timedelta(seconds=
-                                    self._remaining.seconds,
-                                    microseconds=
-                                    (round(self._remaining.microseconds
-                                     /1000000))*1000000))
+                                              self._remaining.seconds,
+                                              microseconds=
+                                              (round(self._remaining.microseconds
+                                                     /1000000))*1000000))
             }
         else:
             return {

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -228,7 +228,7 @@ class Timer(Entity):
                                               microseconds=
                                               (round
                                                (self._remaining.microseconds
-                                                /1000000))*1000000))
+                                                / 1000000)) * 1000000))
             }
         else:
             return {

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -222,10 +222,10 @@ class Timer(Entity):
         if self._remaining:
             return {
                 ATTR_DURATION: str(self._duration),
-                #Round time remaining to nearest second
-                ATTR_REMAINING: str(timedelta(seconds =
+                # Round time remaining to nearest second
+                ATTR_REMAINING: str(timedelta(seconds=
                                     self._remaining.seconds,
-                                    microseconds =
+                                    microseconds=
                                     (round(self._remaining.microseconds
                                      /1000000))*1000000))
             }


### PR DESCRIPTION
## Description:
Poll timer so time remaining attribute updates every 10-15 seconds

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
timer:
  timer_1:

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
