### PR TITLE
Fix for Neato D3 and D5

### DIFF
--- a/homeassistant/components/neato.py
+++ b/homeassistant/components/neato.py
@@ -17,8 +17,8 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['https://github.com/jabesq/pybotvac/archive/v0.0.4.zip'
-                '#pybotvac==0.0.4']
+REQUIREMENTS = ['https://github.com/jabesq/pybotvac/archive/v0.0.5.zip'
+                '#pybotvac==0.0.5']
 
 DOMAIN = 'neato'
 NEATO_ROBOTS = 'neato_robots'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -370,7 +370,7 @@ https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f8
 https://github.com/jabesq/netatmo-api-python/archive/v0.9.2.1.zip#lnetatmo==0.9.2.1
 
 # homeassistant.components.neato
-https://github.com/jabesq/pybotvac/archive/v0.0.4.zip#pybotvac==0.0.4
+https://github.com/jabesq/pybotvac/archive/v0.0.5.zip#pybotvac==0.0.5
 
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1


### PR DESCRIPTION
## Description:
Neato D3 and D5 vacuums currently doesn't support start/pause/resume actions.
In a matter of fact they could support it, we're just using it in a wrong version. Changes made to pybotvac by @kvermilion allowed him to control his Botvac D5. Changes were made with my review, as a user of D3. @jabesq who is an owner of pybotvac repository has Botvac. So all 3 robots are covered and they work fine. Let's update!

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4456

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
