### PR TITLE
Snips: (change) Removed unknown intent speech response

### DIFF
--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -104,7 +104,6 @@ def async_setup(hass, config):
         except intent.UnknownIntent as err:
             _LOGGER.warning("Received unknown intent %s",
                             request['intent']['intentName'])
-            snips_response = "Unknown Intent"
         except intent.IntentError:
             _LOGGER.exception("Error while handling intent: %s.", intent_type)
             snips_response = "Error while handling intent"

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -1,6 +1,7 @@
 """Test the Snips component."""
 import asyncio
 import json
+import logging
 
 from homeassistant.core import callback
 from homeassistant.bootstrap import async_setup_component
@@ -151,42 +152,27 @@ def test_intent_speech_response(hass, mqtt_mock):
 
 
 @asyncio.coroutine
-def test_snips_unknown_intent(hass, mqtt_mock):
-    """Test calling unknown Intent via Snips."""
-    event = 'call_service'
-    events = []
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
+def test_unknown_intent(hass, mqtt_mock, caplog):
+    """Test unknown intent."""
+    caplog.set_level(logging.WARNING)
     result = yield from async_setup_component(hass, "snips", {
         "snips": {},
     })
     assert result
     payload = """
     {
-        "input": "what to do",
+        "input": "I don't know what I am supposed to do",
+        "sessionId": "abcdef1234567890",
         "intent": {
             "intentName": "unknownIntent"
         },
         "slots": []
     }
     """
-    intents = async_mock_intent(hass, 'knownIntent')
-    hass.bus.async_listen(event, record_event)
-    async_fire_mqtt_message(hass, 'hermes/intent/unknownIntent',
-                            payload)
+    async_fire_mqtt_message(hass,
+                          'hermes/intent/unknownIntent', payload)
     yield from hass.async_block_till_done()
-
-    assert not intents
-    assert len(events) == 1
-    assert events[0].data['domain'] == 'mqtt'
-    assert events[0].data['service'] == 'publish'
-    payload = json.loads(events[0].data['service_data']['payload'])
-    topic = events[0].data['service_data']['topic']
-    assert payload['text'] == 'Unknown Intent'
-    assert topic == 'hermes/dialogueManager/endSession'
+    assert 'Received unknown intent unknownIntent' in caplog.text
 
 
 @asyncio.coroutine

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -170,7 +170,7 @@ def test_unknown_intent(hass, mqtt_mock, caplog):
     }
     """
     async_fire_mqtt_message(hass,
-                          'hermes/intent/unknownIntent', payload)
+                            'hermes/intent/unknownIntent', payload)
     yield from hass.async_block_till_done()
     assert 'Received unknown intent unknownIntent' in caplog.text
 


### PR DESCRIPTION
## Description:

With the last change hass will trigger speech on snips if it doesn't recognize an intent along with the log warning. This is unwanted since intents could be handled outside hass and we shouldn't be triggering actions based on that. I have chided the developer/myself for it 👎 

One liner fix

**Related issue (if applicable):** fixes #N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
