### PR TITLE
Support for performance mode on Rheem water heaters.

### DIFF
--- a/homeassistant/components/climate/econet.py
+++ b/homeassistant/components/climate/econet.py
@@ -17,6 +17,7 @@ from homeassistant.components.climate import (
     STATE_HEAT_PUMP, STATE_HIGH_DEMAND,
     STATE_OFF, SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_OPERATION_MODE,
+    STATE_PERFORMANCE,
     ClimateDevice)
 from homeassistant.config import load_yaml_config_file
 from homeassistant.const import (ATTR_ENTITY_ID,
@@ -61,6 +62,7 @@ HA_STATE_TO_ECONET = {
     STATE_GAS: 'gas',
     STATE_HIGH_DEMAND: 'High Demand',
     STATE_OFF: 'Off',
+    STATE_PERFORMANCE: 'Performance'
 }
 
 ECONET_STATE_TO_HA = {value: key for key, value in HA_STATE_TO_ECONET.items()}


### PR DESCRIPTION
## Description:
Some Rheem water heaters support Performance mode. Adding the Performance mode mapping.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://community.home-assistant.io/t/rheem-hotwater-heater-econet/26387/82

## Checklist:
  - [X] The code change is tested and works locally.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
