### PR TITLE
maxcube: Set MAX! Window Sensor's class to 'window'

### DIFF
--- a/homeassistant/components/binary_sensor/maxcube.py
+++ b/homeassistant/components/binary_sensor/maxcube.py
@@ -36,7 +36,7 @@ class MaxCubeShutter(BinarySensorDevice):
     def __init__(self, hass, name, rf_address):
         """Initialize MAX! Cube BinarySensorDevice."""
         self._name = name
-        self._sensor_type = 'opening'
+        self._sensor_type = 'window'
         self._rf_address = rf_address
         self._cubehandle = hass.data[MAXCUBE_HANDLE]
         self._state = STATE_UNKNOWN


### PR DESCRIPTION
## Description:

The sensors are meant to be put on windows to shut down the heating when windows are open. Having `window` device class instead of `opening` is much more logical here.

## Checklist:
  - [X] The code change is tested and works locally.