### PR TITLE
Nad

### DIFF
--- a/homeassistant/components/media_player/nad.py
+++ b/homeassistant/components/media_player/nad.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['nad_receiver==0.0.6']
+REQUIREMENTS = ['nad_receiver==0.0.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/nadtcp.py
+++ b/homeassistant/components/media_player/nadtcp.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['nad_receiver==0.0.6']
+REQUIREMENTS = ['nad_receiver==0.0.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -501,7 +501,7 @@ myusps==1.2.2
 
 # homeassistant.components.media_player.nad
 # homeassistant.components.media_player.nadtcp
-nad_receiver==0.0.6
+nad_receiver==0.0.9
 
 # homeassistant.components.discovery
 netdisco==1.2.4


### PR DESCRIPTION
## Description:
Update nad_receiver dependency to 0.0.9. 

** fixes:
If the NAD receiver is set to the same state it is already in, then the remote operation interface hangs. This does not happen when using the frontend, but can happen when users make automations. The nad_receiver update will detect this and avoid hanging the receiver.

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
This is unclear for me, I just get endless amounts of strange codes.
