### PR TITLE
Fix recorder purge

### DIFF
--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -12,7 +12,8 @@ _LOGGER = logging.getLogger(__name__)
 def purge_old_data(instance, purge_days):
     """Purge events and states older than purge_days ago."""
     from .models import States, Events
-    from sqlalchemy import func
+    from sqlalchemy import orm
+    from sqlalchemy.sql import exists
 
     purge_before = dt_util.utcnow() - timedelta(days=purge_days)
 
@@ -20,9 +21,14 @@ def purge_old_data(instance, purge_days):
         # For each entity, the most recent state is protected from deletion
         # s.t. we can properly restore state even if the entity has not been
         # updated in a long time
-        protected_states = session.query(States.state_id, States.event_id,
-                                         func.max(States.last_updated)) \
-                              .group_by(States.entity_id).all()
+        states_alias = orm.aliased(States, name='StatesAlias')
+        protected_states = session.query(States.state_id, States.event_id)\
+            .filter(~exists()
+                    .where(States.entity_id ==
+                           states_alias.entity_id)
+                    .where(states_alias.last_updated >
+                           States.last_updated))\
+            .all()
 
         protected_state_ids = tuple((state[0] for state in protected_states))
         protected_event_ids = tuple((state[1] for state in protected_states))

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -31,7 +31,8 @@ def purge_old_data(instance, purge_days):
             .all()
 
         protected_state_ids = tuple((state[0] for state in protected_states))
-        protected_event_ids = tuple((state[1] for state in protected_states))
+        protected_event_ids = tuple((state[1] for state in protected_states
+                                     if state[1] is not None))
 
         deleted_rows = session.query(States) \
                               .filter((States.last_updated < purge_before)) \


### PR DESCRIPTION
## Description:

While 0.61.1 fixed the problem with MySQL not understanding our subqueries, it introduced another (less severe) one: The query we use for purging the recorder apparently never was valid SQL, as there are non-aggregated fields in a aggregate query. SQLite as well as older versions of MySQL / MariaDB swallow this, but MySQL has changed this behavior. 

This query now is verified against SQLite as well as MySQL 5.7.

**Related issue (if applicable):** fixes #11734 

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
