### PR TITLE
Pushbullet (fix) invalid keyword, added unittests

### DIFF
--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -138,8 +138,11 @@ class PushBulletNotificationService(BaseNotificationService):
         filepath = data.get(ATTR_FILE)
         file_url = data.get(ATTR_FILE_URL)
         try:
+            email_kwargs = {}
+            if email:
+                email_kwargs['email'] = email
             if url:
-                pusher.push_link(title, url, body=message, email=email)
+                pusher.push_link(title, url, body=message, **email_kwargs)
             elif filepath:
                 if not self.hass.config.is_allowed_path(filepath):
                     _LOGGER.error("Filepath is not valid or allowed")
@@ -149,20 +152,21 @@ class PushBulletNotificationService(BaseNotificationService):
                     if filedata.get('file_type') == 'application/x-empty':
                         _LOGGER.error("Can not send an empty file")
                         return
-
+                    filedata.update(email_kwargs)
                     pusher.push_file(title=title, body=message,
-                                     email=email, **filedata)
+                                     **filedata)
             elif file_url:
                 if not file_url.startswith('http'):
                     _LOGGER.error("URL should start with http or https")
                     return
-                pusher.push_file(title=title, body=message, email=email,
+                pusher.push_file(title=title, body=message,
                                  file_name=file_url, file_url=file_url,
                                  file_type=(mimetypes
-                                            .guess_type(file_url)[0]))
+                                            .guess_type(file_url)[0]),
+                                 **email_kwargs)
             elif data_list:
-                pusher.push_note(title, data_list, email=email)
+                pusher.push_list(title, data_list, **email_kwargs)
             else:
-                pusher.push_note(title, message, email=email)
+                pusher.push_note(title, message, **email_kwargs)
         except PushError as err:
             _LOGGER.error("Notify failed: %s", err)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ PyMVGLive==1.1.4
 PyMata==2.14
 
 # homeassistant.components.xiaomi_aqara
-PyXiaomiGateway==0.7.0
+PyXiaomiGateway==0.7.1
 
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.1
@@ -170,7 +170,7 @@ ciscosparkapi==0.4.2
 coinbase==2.0.6
 
 # homeassistant.components.sensor.coinmarketcap
-coinmarketcap==4.1.1
+coinmarketcap==4.1.2
 
 # homeassistant.scripts.check_config
 colorlog==3.0.1
@@ -275,7 +275,7 @@ fitbit==0.3.0
 fixerio==0.1.1
 
 # homeassistant.components.light.flux_led
-flux_led==0.20
+flux_led==0.21
 
 # homeassistant.components.notify.free_mobile
 freesms==0.1.2
@@ -286,7 +286,7 @@ freesms==0.1.2
 # fritzconnection==0.6.5
 
 # homeassistant.components.switch.fritzdect
-fritzhome==1.0.3
+fritzhome==1.0.4
 
 # homeassistant.components.media_player.frontier_silicon
 fsapi==0.0.7
@@ -370,7 +370,7 @@ https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f8
 https://github.com/jabesq/netatmo-api-python/archive/v0.9.2.1.zip#lnetatmo==0.9.2.1
 
 # homeassistant.components.neato
-https://github.com/jabesq/pybotvac/archive/v0.0.4.zip#pybotvac==0.0.4
+https://github.com/jabesq/pybotvac/archive/v0.0.5.zip#pybotvac==0.0.5
 
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
@@ -419,7 +419,7 @@ jsonrpc-async==0.6
 jsonrpc-websocket==0.5
 
 # homeassistant.scripts.keyring
-keyring==10.3.2
+keyring==10.6.0
 
 # homeassistant.scripts.keyring
 keyrings.alt==2.3
@@ -490,6 +490,9 @@ motorparts==1.0.2
 # homeassistant.components.tts
 mutagen==1.39
 
+# homeassistant.components.mychevy
+mychevy==0.1.1
+
 # homeassistant.components.mycroft
 mycroftapi==2.0
 
@@ -501,7 +504,7 @@ myusps==1.2.2
 nad_receiver==0.0.6
 
 # homeassistant.components.discovery
-netdisco==1.2.3
+netdisco==1.2.4
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1
@@ -595,11 +598,9 @@ psutil==5.4.3
 # homeassistant.components.wink
 pubnubsub-handler==1.0.2
 
+# homeassistant.components.notify.pushbullet
 # homeassistant.components.sensor.pushbullet
 pushbullet.py==0.11.0
-
-# homeassistant.components.notify.pushbullet
-pushbullet==0.11.0
 
 # homeassistant.components.notify.pushetta
 pushetta==1.0.15
@@ -680,7 +681,7 @@ pycsspeechtts==1.0.2
 pydaikin==0.4
 
 # homeassistant.components.deconz
-pydeconz==23
+pydeconz==25
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5
@@ -752,10 +753,10 @@ pykira==0.1.1
 pykwb==0.0.8
 
 # homeassistant.components.sensor.lacrosse
-pylacrosse==0.2.7
+pylacrosse==0.3.1
 
 # homeassistant.components.sensor.lastfm
-pylast==2.0.0
+pylast==2.1.0
 
 # homeassistant.components.media_player.webostv
 # homeassistant.components.notify.webostv
@@ -1097,7 +1098,7 @@ speedtest-cli==1.0.7
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator
-sqlalchemy==1.2.0
+sqlalchemy==1.2.1
 
 # homeassistant.components.statsd
 statsd==3.2.1
@@ -1130,7 +1131,7 @@ tellduslive==0.10.4
 temperusb==1.5.3
 
 # homeassistant.components.tesla
-teslajsonpy==0.0.18
+teslajsonpy==0.0.19
 
 # homeassistant.components.thingspeak
 thingspeak==0.4.1
@@ -1227,7 +1228,7 @@ yeelight==0.3.3
 yeelightsunflower==0.0.8
 
 # homeassistant.components.media_extractor
-youtube_dl==2017.12.28
+youtube_dl==2018.01.14
 
 # homeassistant.components.light.zengge
 zengge==0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ PyMVGLive==1.1.4
 PyMata==2.14
 
 # homeassistant.components.xiaomi_aqara
-PyXiaomiGateway==0.7.1
+PyXiaomiGateway==0.7.0
 
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.1
@@ -170,7 +170,7 @@ ciscosparkapi==0.4.2
 coinbase==2.0.6
 
 # homeassistant.components.sensor.coinmarketcap
-coinmarketcap==4.1.2
+coinmarketcap==4.1.1
 
 # homeassistant.scripts.check_config
 colorlog==3.0.1
@@ -275,7 +275,7 @@ fitbit==0.3.0
 fixerio==0.1.1
 
 # homeassistant.components.light.flux_led
-flux_led==0.21
+flux_led==0.20
 
 # homeassistant.components.notify.free_mobile
 freesms==0.1.2
@@ -286,7 +286,7 @@ freesms==0.1.2
 # fritzconnection==0.6.5
 
 # homeassistant.components.switch.fritzdect
-fritzhome==1.0.4
+fritzhome==1.0.3
 
 # homeassistant.components.media_player.frontier_silicon
 fsapi==0.0.7
@@ -370,7 +370,7 @@ https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f8
 https://github.com/jabesq/netatmo-api-python/archive/v0.9.2.1.zip#lnetatmo==0.9.2.1
 
 # homeassistant.components.neato
-https://github.com/jabesq/pybotvac/archive/v0.0.5.zip#pybotvac==0.0.5
+https://github.com/jabesq/pybotvac/archive/v0.0.4.zip#pybotvac==0.0.4
 
 # homeassistant.components.sensor.sabnzbd
 https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
@@ -419,7 +419,7 @@ jsonrpc-async==0.6
 jsonrpc-websocket==0.5
 
 # homeassistant.scripts.keyring
-keyring==10.6.0
+keyring==10.3.2
 
 # homeassistant.scripts.keyring
 keyrings.alt==2.3
@@ -490,9 +490,6 @@ motorparts==1.0.2
 # homeassistant.components.tts
 mutagen==1.39
 
-# homeassistant.components.mychevy
-mychevy==0.1.1
-
 # homeassistant.components.mycroft
 mycroftapi==2.0
 
@@ -504,7 +501,7 @@ myusps==1.2.2
 nad_receiver==0.0.6
 
 # homeassistant.components.discovery
-netdisco==1.2.4
+netdisco==1.2.3
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1
@@ -598,9 +595,11 @@ psutil==5.4.3
 # homeassistant.components.wink
 pubnubsub-handler==1.0.2
 
-# homeassistant.components.notify.pushbullet
 # homeassistant.components.sensor.pushbullet
 pushbullet.py==0.11.0
+
+# homeassistant.components.notify.pushbullet
+pushbullet==0.11.0
 
 # homeassistant.components.notify.pushetta
 pushetta==1.0.15
@@ -681,7 +680,7 @@ pycsspeechtts==1.0.2
 pydaikin==0.4
 
 # homeassistant.components.deconz
-pydeconz==25
+pydeconz==23
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5
@@ -753,10 +752,10 @@ pykira==0.1.1
 pykwb==0.0.8
 
 # homeassistant.components.sensor.lacrosse
-pylacrosse==0.3.1
+pylacrosse==0.2.7
 
 # homeassistant.components.sensor.lastfm
-pylast==2.1.0
+pylast==2.0.0
 
 # homeassistant.components.media_player.webostv
 # homeassistant.components.notify.webostv
@@ -1098,7 +1097,7 @@ speedtest-cli==1.0.7
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator
-sqlalchemy==1.2.1
+sqlalchemy==1.2.0
 
 # homeassistant.components.statsd
 statsd==3.2.1
@@ -1131,7 +1130,7 @@ tellduslive==0.10.4
 temperusb==1.5.3
 
 # homeassistant.components.tesla
-teslajsonpy==0.0.19
+teslajsonpy==0.0.18
 
 # homeassistant.components.thingspeak
 thingspeak==0.4.1
@@ -1228,7 +1227,7 @@ yeelight==0.3.3
 yeelightsunflower==0.0.8
 
 # homeassistant.components.media_extractor
-youtube_dl==2018.01.14
+youtube_dl==2017.12.28
 
 # homeassistant.components.light.zengge
 zengge==0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -38,7 +38,7 @@ apns2==0.3.0
 caldav==0.5.0
 
 # homeassistant.components.sensor.coinmarketcap
-coinmarketcap==4.1.1
+coinmarketcap==4.1.2
 
 # homeassistant.components.device_tracker.upc_connect
 defusedxml==0.5.0
@@ -116,9 +116,6 @@ pmsensor==0.4
 # homeassistant.components.prometheus
 prometheus_client==0.1.0
 
-# homeassistant.components.sensor.pushbullet
-pushbullet.py==0.11.0
-
 # homeassistant.components.canary
 py-canary==0.2.3
 
@@ -168,7 +165,7 @@ somecomfort==0.5.0
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator
-sqlalchemy==1.2.0
+sqlalchemy==1.2.1
 
 # homeassistant.components.statsd
 statsd==3.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -116,6 +116,9 @@ pmsensor==0.4
 # homeassistant.components.prometheus
 prometheus_client==0.1.0
 
+# homeassistant.components.notify.pushbullet
+pushbullet.py==0.11.0
+
 # homeassistant.components.canary
 py-canary==0.2.3
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -38,7 +38,7 @@ apns2==0.3.0
 caldav==0.5.0
 
 # homeassistant.components.sensor.coinmarketcap
-coinmarketcap==4.1.2
+coinmarketcap==4.1.1
 
 # homeassistant.components.device_tracker.upc_connect
 defusedxml==0.5.0
@@ -116,6 +116,9 @@ pmsensor==0.4
 # homeassistant.components.prometheus
 prometheus_client==0.1.0
 
+# homeassistant.components.sensor.pushbullet
+pushbullet.py==0.11.0
+
 # homeassistant.components.canary
 py-canary==0.2.3
 
@@ -165,7 +168,7 @@ somecomfort==0.5.0
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator
-sqlalchemy==1.2.1
+sqlalchemy==1.2.0
 
 # homeassistant.components.statsd
 statsd==3.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -117,6 +117,7 @@ pmsensor==0.4
 prometheus_client==0.1.0
 
 # homeassistant.components.notify.pushbullet
+# homeassistant.components.sensor.pushbullet
 pushbullet.py==0.11.0
 
 # homeassistant.components.canary

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -62,6 +62,7 @@ TEST_REQUIREMENTS = (
     'pilight',
     'pmsensor',
     'prometheus_client',
+    'pushbullet.py',
     'py-canary',
     'pydispatcher',
     'PyJWT',

--- a/tests/components/notify/test_pushbullet.py
+++ b/tests/components/notify/test_pushbullet.py
@@ -1,42 +1,243 @@
 """The tests for the pushbullet notification platform."""
-
+import json
 import unittest
+from unittest.mock import patch
+
+from pushbullet import PushBullet
+import requests_mock
 
 from homeassistant.setup import setup_component
 import homeassistant.components.notify as notify
-from tests.common import assert_setup_component, get_test_home_assistant
+from tests.common import (
+    assert_setup_component, get_test_home_assistant, load_fixture)
 
 
-class TestPushbullet(unittest.TestCase):
-    """Test the pushbullet notifications."""
+class TestPushBullet(unittest.TestCase):
+    """Tests the Pushbullet Component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
-        """Setup things to be run when tests are started."""
+    def setUp(self):
+        """Initialize values for this test case class."""
         self.hass = get_test_home_assistant()
 
     def tearDown(self):  # pylint: disable=invalid-name
-        """Stop down everything that was started."""
+        """Stop everything that we started."""
         self.hass.stop()
 
-    def test_setup(self):
+    @patch.object(PushBullet, '_get_data',
+                  return_value=json.loads(load_fixture(
+                      'pushbullet_devices.json')))
+    def test_pushbullet_config(self, mock__get_data):
         """Test setup."""
+        config = {notify.DOMAIN: {'name': 'test',
+                                  'platform': 'pushbullet',
+                                  'api_key': 'MYFAKEKEY'}}
         with assert_setup_component(1) as handle_config:
-            assert setup_component(self.hass, 'notify', {
-                'notify': {
-                    'name': 'test',
-                    'platform': 'pushbullet',
-                    'api_key': 'MYFAKEKEY', }
-            })
+            assert setup_component(self.hass, notify.DOMAIN, config)
         assert handle_config[notify.DOMAIN]
 
-    def test_bad_config(self):
+    def test_pushbullet_config_bad(self):
         """Test set up the platform with bad/missing configuration."""
         config = {
             notify.DOMAIN: {
-                'name': 'test',
                 'platform': 'pushbullet',
             }
         }
         with assert_setup_component(0) as handle_config:
             assert setup_component(self.hass, notify.DOMAIN, config)
         assert not handle_config[notify.DOMAIN]
+
+    @requests_mock.Mocker()
+    @patch.object(PushBullet, '_get_data',
+                  return_value=json.loads(load_fixture(
+                      'pushbullet_devices.json')))
+    def test_pushbullet_push_default(self, mock, mock__get_data):
+        """Test pushbullet push to default target."""
+        config = {notify.DOMAIN: {'name': 'test',
+                                  'platform': 'pushbullet',
+                                  'api_key': 'MYFAKEKEY'}}
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert handle_config[notify.DOMAIN]
+        mock.register_uri(
+            requests_mock.POST,
+            'https://api.pushbullet.com/v2/pushes',
+            status_code=200,
+            json={'mock_response': 'Ok'}
+        )
+        data = {'title': 'Test Title',
+                'message': 'Test Message'}
+        self.hass.services.call(notify.DOMAIN, 'test', data)
+        self.hass.block_till_done()
+        self.assertTrue(mock.called)
+        self.assertEqual(mock.call_count, 1)
+
+        expected_body = {'body': 'Test Message',
+                         'title': 'Test Title',
+                         'type': 'note'}
+        self.assertEqual(mock.last_request.json(), expected_body)
+
+    @requests_mock.Mocker()
+    @patch.object(PushBullet, '_get_data',
+                  return_value=json.loads(load_fixture(
+                      'pushbullet_devices.json')))
+    def test_pushbullet_push_device(self, mock, mock__get_data):
+        """Test pushbullet push to default target."""
+        config = {notify.DOMAIN: {'name': 'test',
+                                  'platform': 'pushbullet',
+                                  'api_key': 'MYFAKEKEY'}}
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert handle_config[notify.DOMAIN]
+        mock.register_uri(
+            requests_mock.POST,
+            'https://api.pushbullet.com/v2/pushes',
+            status_code=200,
+            json={'mock_response': 'Ok'}
+        )
+        data = {'title': 'Test Title',
+                'message': 'Test Message',
+                'target': ['device/DESKTOP']}
+        self.hass.services.call(notify.DOMAIN, 'test', data)
+        self.hass.block_till_done()
+        self.assertTrue(mock.called)
+        self.assertEqual(mock.call_count, 1)
+
+        expected_body = {'body': 'Test Message',
+                         'device_iden': 'identity1',
+                         'title': 'Test Title',
+                         'type': 'note'}
+        self.assertEqual(mock.last_request.json(), expected_body)
+
+    @requests_mock.Mocker()
+    @patch.object(PushBullet, '_get_data',
+                  return_value=json.loads(load_fixture(
+                      'pushbullet_devices.json')))
+    def test_pushbullet_push_devices(self, mock, mock__get_data):
+        """Test pushbullet push to default target."""
+        config = {notify.DOMAIN: {'name': 'test',
+                                  'platform': 'pushbullet',
+                                  'api_key': 'MYFAKEKEY'}}
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert handle_config[notify.DOMAIN]
+        mock.register_uri(
+            requests_mock.POST,
+            'https://api.pushbullet.com/v2/pushes',
+            status_code=200,
+            json={'mock_response': 'Ok'}
+        )
+        data = {'title': 'Test Title',
+                'message': 'Test Message',
+                'target': ['device/DESKTOP', 'device/My iPhone']}
+        self.hass.services.call(notify.DOMAIN, 'test', data)
+        self.hass.block_till_done()
+        self.assertTrue(mock.called)
+        self.assertEqual(mock.call_count, 2)
+        self.assertEqual(len(mock.request_history), 2)
+
+        expected_body = {'body': 'Test Message',
+                         'device_iden': 'identity1',
+                         'title': 'Test Title',
+                         'type': 'note'}
+        self.assertEqual(mock.request_history[0].json(), expected_body)
+        expected_body = {'body': 'Test Message',
+                         'device_iden': 'identity2',
+                         'title': 'Test Title',
+                         'type': 'note'}
+        self.assertEqual(mock.request_history[1].json(), expected_body)
+
+    @requests_mock.Mocker()
+    @patch.object(PushBullet, '_get_data',
+                  return_value=json.loads(load_fixture(
+                      'pushbullet_devices.json')))
+    def test_pushbullet_push_email(self, mock, mock__get_data):
+        """Test pushbullet push to default target."""
+        config = {notify.DOMAIN: {'name': 'test',
+                                  'platform': 'pushbullet',
+                                  'api_key': 'MYFAKEKEY'}}
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert handle_config[notify.DOMAIN]
+        mock.register_uri(
+            requests_mock.POST,
+            'https://api.pushbullet.com/v2/pushes',
+            status_code=200,
+            json={'mock_response': 'Ok'}
+        )
+        data = {'title': 'Test Title',
+                'message': 'Test Message',
+                'target': ['email/user@host.net']}
+        self.hass.services.call(notify.DOMAIN, 'test', data)
+        self.hass.block_till_done()
+        self.assertTrue(mock.called)
+        self.assertEqual(mock.call_count, 1)
+        self.assertEqual(len(mock.request_history), 1)
+
+        expected_body = {'body': 'Test Message',
+                         'email': 'user@host.net',
+                         'title': 'Test Title',
+                         'type': 'note'}
+        self.assertEqual(mock.request_history[0].json(), expected_body)
+
+    @requests_mock.Mocker()
+    @patch.object(PushBullet, '_get_data',
+                  return_value=json.loads(load_fixture(
+                      'pushbullet_devices.json')))
+    def test_pushbullet_push_mixed(self, mock, mock__get_data):
+        """Test pushbullet push to default target."""
+        config = {notify.DOMAIN: {'name': 'test',
+                                  'platform': 'pushbullet',
+                                  'api_key': 'MYFAKEKEY'}}
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert handle_config[notify.DOMAIN]
+        mock.register_uri(
+            requests_mock.POST,
+            'https://api.pushbullet.com/v2/pushes',
+            status_code=200,
+            json={'mock_response': 'Ok'}
+        )
+        data = {'title': 'Test Title',
+                'message': 'Test Message',
+                'target': ['device/DESKTOP', 'email/user@host.net']}
+        self.hass.services.call(notify.DOMAIN, 'test', data)
+        self.hass.block_till_done()
+        self.assertTrue(mock.called)
+        self.assertEqual(mock.call_count, 2)
+        self.assertEqual(len(mock.request_history), 2)
+
+        expected_body = {'body': 'Test Message',
+                         'device_iden': 'identity1',
+                         'title': 'Test Title',
+                         'type': 'note'}
+        self.assertEqual(mock.request_history[0].json(), expected_body)
+        expected_body = {'body': 'Test Message',
+                         'email': 'user@host.net',
+                         'title': 'Test Title',
+                         'type': 'note'}
+        self.assertEqual(mock.request_history[1].json(), expected_body)
+
+    @requests_mock.Mocker()
+    @patch.object(PushBullet, '_get_data',
+                  return_value=json.loads(load_fixture(
+                      'pushbullet_devices.json')))
+    def test_pushbullet_push_no_file(self, mock, mock__get_data):
+        """Test pushbullet push to default target."""
+        config = {notify.DOMAIN: {'name': 'test',
+                                  'platform': 'pushbullet',
+                                  'api_key': 'MYFAKEKEY'}}
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert handle_config[notify.DOMAIN]
+        mock.register_uri(
+            requests_mock.POST,
+            'https://api.pushbullet.com/v2/pushes',
+            status_code=200,
+            json={'mock_response': 'Ok'}
+        )
+        data = {'title': 'Test Title',
+                'message': 'Test Message',
+                'target': ['device/DESKTOP', 'device/My iPhone'],
+                'data': {'file': 'not_a_file'}}
+        assert not self.hass.services.call(notify.DOMAIN, 'test', data)
+        self.hass.block_till_done()

--- a/tests/fixtures/pushbullet_devices.json
+++ b/tests/fixtures/pushbullet_devices.json
@@ -1,0 +1,43 @@
+{
+	"accounts": [],
+	"blocks": [],
+	"channels": [],
+	"chats": [],
+	"clients": [],
+	"contacts": [],
+	"devices": [{
+		"active": true,
+		"iden": "identity1",
+		"created": 1.514520333770855e+09,
+		"modified": 1.5151951594363022e+09,
+		"type": "windows",
+		"kind": "windows",
+		"nickname": "DESKTOP",
+		"manufacturer": "Microsoft",
+		"model": "Windows 10 Home",
+		"app_version": 396,
+		"fingerprint": "{\"cpu\":\"AMD\",\"computer_name\":\"DESKTOP\"}",
+		"pushable": true,
+		"icon": "desktop",
+		"remote_files": "disabled"
+	}, {
+		"active": true,
+		"iden": "identity2",
+		"created": 1.5144974875448499e+09,
+		"modified": 1.514574792288634e+09,
+		"type": "ios",
+		"kind": "ios",
+		"nickname": "My iPhone",
+		"manufacturer": "Apple",
+		"model": "iPhone",
+		"app_version": 8646,
+		"push_token": "production:mytoken",
+		"pushable": true,
+		"icon": "phone"
+	}],
+	"grants": [],
+	"pushes": [],
+	"profiles": [],
+	"subscriptions": [],
+	"texts": []
+}


### PR DESCRIPTION
## Description:

Fix for invalid email keyword

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
