### PR TITLE
Disable installing Telldus in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM python:3.6
 LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 
 # Uncomment any of the following lines to disable the installation.
-#ENV INSTALL_TELLSTICK no
+ENV INSTALL_TELLSTICK no
 #ENV INSTALL_OPENALPR no
 #ENV INSTALL_FFMPEG no
 #ENV INSTALL_LIBCEC no


### PR DESCRIPTION
## Description:
Telldus public key is no longer available at http://download.telldus.se/debian/telldus-public.key (still the link refered to in their [docs](https://developer.telldus.com/wiki/TellStickInstallationUbuntu)). Because it's no longer available, it breaks our Docker installation.

So I'm disabling installing Tellstick for now as our Docker hasn't been building for last 24 hours.

[Failing Docker build logs](https://hastebin.com/lizezojesi.erl)