### PR TITLE
Weblink - Allow relative urls in config

### DIFF
--- a/homeassistant/components/weblink.py
+++ b/homeassistant/components/weblink.py
@@ -16,14 +16,14 @@ import homeassistant.helpers.config_validation as cv
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ENTITIES = 'entities'
-CONF_ABSOLUTE_PATH_ERROR_MSG = "Invalid absolute path in relative URL"
-CONF_ABSOLUTE_PATH_REGEX = r'\A/'
+CONF_RELATIVE_URL_ERROR_MSG = "Invalid relative URL. Absolute path required."
+CONF_RELATIVE_URL_REGEX = r'\A/'
 
 DOMAIN = 'weblink'
 
 ENTITIES_SCHEMA = vol.Schema({
     vol.Required(CONF_URL): vol.Any(
-        vol.Match(CONF_ABSOLUTE_PATH_REGEX, msg=CONF_ABSOLUTE_PATH_ERROR_MSG),
+        vol.Match(CONF_RELATIVE_URL_REGEX, msg=CONF_RELATIVE_URL_ERROR_MSG),
         cv.url),
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_ICON): cv.icon,

--- a/homeassistant/components/weblink.py
+++ b/homeassistant/components/weblink.py
@@ -20,7 +20,9 @@ CONF_ENTITIES = 'entities'
 DOMAIN = 'weblink'
 
 ENTITIES_SCHEMA = vol.Schema({
-    vol.Required(CONF_URL): cv.string,
+    vol.Required(CONF_URL): vol.Any(
+        vol.Match(r'\A/[a-z0-9]', msg='invalid absolut url'),
+        cv.url),
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_ICON): cv.icon,
 })

--- a/homeassistant/components/weblink.py
+++ b/homeassistant/components/weblink.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_ENTITIES = 'entities'
 CONF_ABSOLUTE_PATH_ERROR_MSG = "Invalid absolute path in relative URL"
-CONF_ABSOLUTE_PATH_REGEX = r'\A/[a-z0-9]'
+CONF_ABSOLUTE_PATH_REGEX = r'\A/'
 
 DOMAIN = 'weblink'
 

--- a/homeassistant/components/weblink.py
+++ b/homeassistant/components/weblink.py
@@ -16,12 +16,14 @@ import homeassistant.helpers.config_validation as cv
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ENTITIES = 'entities'
+CONF_ABSOLUTE_PATH_ERROR_MSG = "Invalid absolute path in relative URL"
+CONF_ABSOLUTE_PATH_REGEX = r'\A/[a-z0-9]'
 
 DOMAIN = 'weblink'
 
 ENTITIES_SCHEMA = vol.Schema({
     vol.Required(CONF_URL): vol.Any(
-        vol.Match(r'\A/[a-z0-9]', msg='invalid absolut url'),
+        vol.Match(CONF_ABSOLUTE_PATH_REGEX, msg=CONF_ABSOLUTE_PATH_ERROR_MSG),
         cv.url),
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_ICON): cv.icon,

--- a/homeassistant/components/weblink.py
+++ b/homeassistant/components/weblink.py
@@ -20,8 +20,7 @@ CONF_ENTITIES = 'entities'
 DOMAIN = 'weblink'
 
 ENTITIES_SCHEMA = vol.Schema({
-    # pylint: disable=no-value-for-parameter
-    vol.Required(CONF_URL): vol.Url(),
+    vol.Required(CONF_URL): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_ICON): cv.icon,
 })
@@ -42,7 +41,6 @@ def setup(hass, config):
              link.get(CONF_ICON))
 
     return True
-
 
 class Link(Entity):
     """Representation of a link."""

--- a/homeassistant/components/weblink.py
+++ b/homeassistant/components/weblink.py
@@ -44,6 +44,7 @@ def setup(hass, config):
 
     return True
 
+
 class Link(Entity):
     """Representation of a link."""
 

--- a/tests/components/test_weblink.py
+++ b/tests/components/test_weblink.py
@@ -26,6 +26,71 @@ class TestComponentWeblink(unittest.TestCase):
             }
         }))
 
+    def test_bad_config_relative_url(self):
+        """Test if new entity is created."""
+        self.assertFalse(setup_component(self.hass, 'weblink', {
+            'weblink': {
+                'entities': [
+                    {
+                        weblink.CONF_NAME: 'My router',
+                        weblink.CONF_URL: '../states/group.bla'
+                    },
+                ],
+            }
+        }))
+
+    def test_bad_config_relative_file(self):
+        """Test if new entity is created."""
+        self.assertFalse(setup_component(self.hass, 'weblink', {
+            'weblink': {
+                'entities': [
+                    {
+                        weblink.CONF_NAME: 'My group',
+                        weblink.CONF_URL: 'group.bla'
+                    },
+                ],
+            }
+        }))
+
+    def test_good_config_absolute_path(self):
+        """Test if new entity is created."""
+        self.assertTrue(setup_component(self.hass, 'weblink', {
+            'weblink': {
+                'entities': [
+                    {
+                        weblink.CONF_NAME: 'My second URL',
+                        weblink.CONF_URL: '/states/group.bla'
+                    },
+                ],
+            }
+        }))
+
+    def test_good_config_path_short(self):
+        """Test if new entity is created."""
+        self.assertTrue(setup_component(self.hass, 'weblink', {
+            'weblink': {
+                'entities': [
+                    {
+                        weblink.CONF_NAME: 'My third URL',
+                        weblink.CONF_URL: '/states'
+                    },
+                ],
+            }
+        }))
+
+    def test_good_config_path_directory(self):
+        """Test if new entity is created."""
+        self.assertTrue(setup_component(self.hass, 'weblink', {
+            'weblink': {
+                'entities': [
+                    {
+                        weblink.CONF_NAME: 'My last URL',
+                        weblink.CONF_URL: '/states/bla/'
+                    },
+                ],
+            }
+        }))
+
     def test_entities_get_created(self):
         """Test if new entity is created."""
         self.assertTrue(setup_component(self.hass, weblink.DOMAIN, {


### PR DESCRIPTION
## Description:
Allow absolute URLs in configuration

**Related issue (if applicable):** fixes #11077

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4465

## Example entry for `configuration.yaml` (if applicable):
```yaml
weblink:
  entities:
    - name: Grafana
      url: /grafana
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
