### PR TITLE
bump roku version

### DIFF
--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_HOST, STATE_IDLE, STATE_PLAYING, STATE_UNKNOWN, STATE_HOME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-roku==3.1.3']
+REQUIREMENTS = ['python-roku==3.1.5']
 
 KNOWN_HOSTS = []
 DEFAULT_PORT = 8060

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -915,7 +915,7 @@ python-pushover==0.3
 python-ripple-api==0.0.3
 
 # homeassistant.components.media_player.roku
-python-roku==3.1.3
+python-roku==3.1.5
 
 # homeassistant.components.sensor.sochain
 python-sochain-api==0.0.2


### PR DESCRIPTION
## Description:
Updates version of python-roku used by HA.

There were a number of methods made a available on the roku instance now.

After this I would like to create a service that would allow for calling arbitrary command on an entity.

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
