### PR TITLE
Add Unit System Option For Fitbit

### DIFF
--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -147,7 +147,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_CLOCK_FORMAT, default='24H'):
         vol.In(['12H', '24H']),
     vol.Optional(CONF_UNIT_SYSTEM, default='default'):
-        vol.In(['en_GB', 'en_US', 'metric','default'])
+        vol.In(['en_GB', 'en_US', 'metric', 'default'])
 })
 
 
@@ -253,7 +253,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         unit_system = config.get(CONF_UNIT_SYSTEM)
         if unit_system == 'default':
-            authd_client.system = authd_client.user_profile_get()["user"]["locale"]
+            authd_client.system = authd_client. \
+                    user_profile_get()["user"]["locale"]
             if authd_client.system != 'en_GB':
                 if hass.config.units.is_metric:
                     authd_client.system = 'metric'

--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -15,6 +15,7 @@ from homeassistant.core import callback
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.const import CONF_UNIT_SYSTEM
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
 import homeassistant.helpers.config_validation as cv
@@ -34,7 +35,6 @@ ATTR_LAST_SAVED_AT = 'last_saved_at'
 
 CONF_MONITORED_RESOURCES = 'monitored_resources'
 CONF_CLOCK_FORMAT = 'clock_format'
-CONF_UNIT_SYSTEM = 'unit_system'
 CONF_ATTRIBUTION = 'Data provided by Fitbit.com'
 
 DEPENDENCIES = ['http']


### PR DESCRIPTION
## Description:
Allow overriding of the units to be used for the Fitbit sensor, e.g. allowing metric units to be used on an en_GB system.

**Related issue (if applicable):** fixes # n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4469

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: fitbit
    clock_format: 12H
    unit_system: metric
    monitored_resources:
      - "body/weight"
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
