### PR TITLE
Update enocean.py

### DIFF
--- a/homeassistant/components/switch/enocean.py
+++ b/homeassistant/components/switch/enocean.py
@@ -18,10 +18,17 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'EnOcean Switch'
 DEPENDENCIES = ['enocean']
+# New parameters for Nodon NOD_SIN-2-2-01 can work
+DEFAULT_COMMAND = [0x00, 0x00, 0x00, 0x00, 0x00]
+DEFAULT_CUSTOMIZE = [0x0]
+
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ID): vol.All(cv.ensure_list, [vol.Coerce(int)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    # New parameters for Nodon NOD_SIN-2-2-01 can work
+    vol.Optional(CONF_COMMAND, default=DEFAULT_COMMAND): vol.All(cv.ensure_list, [vol.Coerce(int)]),
+    vol.Optional(CONF_CUSTOMIZE, default=DEFAULT_CUSTOMIZE): vol.All(cv.ensure_list, [vol.Coerce(int)]),
 })
 
 
@@ -29,18 +36,24 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the EnOcean switch platform."""
     dev_id = config.get(CONF_ID)
     devname = config.get(CONF_NAME)
-
-    add_devices([EnOceanSwitch(dev_id, devname)])
+    # New parameters for Nodon NOD_SIN-2-2-01 can work
+    command = config.get(CONF_COMMAND)
+    entity = config.get(CONF_CUSTOMIZE)
+    add_devices([EnOceanSwitch(dev_id, devname,command,entity)])
 
 
 class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
     """Representation of an EnOcean switch device."""
 
-    def __init__(self, dev_id, devname):
+    def __init__(self, dev_id, devname, command,entity):
         """Initialize the EnOcean switch device."""
         enocean.EnOceanDevice.__init__(self)
         self.dev_id = dev_id
         self._devname = devname
+        # New parameters for Nodon NOD_SIN-2-2-01 can work       
+        self.dev_channel = command
+        self.dev_entity = entity
+        
         self._light = None
         self._on_state = False
         self._on_state2 = False
@@ -61,9 +74,13 @@ class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
         optional = [0x03, ]
         optional.extend(self.dev_id)
         optional.extend([0xff, 0x00])
-        self.send_command(data=[0xD2, 0x01, 0x00, 0x64, 0x00,
-                                0x00, 0x00, 0x00, 0x00], optional=optional,
-                          packet_type=0x01)
+        
+         # Customize Data for Nodon NOD_SIN-2-2-01 can work
+        data 	= [0xD2, 0x01, ]
+        data.extend(self.dev_entity) 
+        data.extend([0x64, ]) 
+        data.extend(self.dev_channel) 
+        self.send_command(data=data, optional=optional,packet_type=0x01)
         self._on_state = True
 
     def turn_off(self, **kwargs):
@@ -71,9 +88,13 @@ class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
         optional = [0x03, ]
         optional.extend(self.dev_id)
         optional.extend([0xff, 0x00])
-        self.send_command(data=[0xD2, 0x01, 0x00, 0x00, 0x00,
-                                0x00, 0x00, 0x00, 0x00], optional=optional,
-                          packet_type=0x01)
+        # Customize Data for Nodon NOD_SIN-2-2-01 can work
+        data 	= [0xD2, 0x01, ]
+        data.extend(self.dev_entity) 
+        data.extend([0x00, ]) 
+        data.extend(self.dev_channel) 
+
+        self.send_command(data=data, optional=optional,packet_type=0x01)
         self._on_state = False
 
     def value_changed(self, val):

--- a/homeassistant/components/switch/enocean.py
+++ b/homeassistant/components/switch/enocean.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_NAME, CONF_ID)
+from homeassistant.const import (CONF_NAME, CONF_ID, CONF_COMMAND, CONF_CUSTOMIZE)
 from homeassistant.components import enocean
 from homeassistant.helpers.entity import ToggleEntity
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/switch/enocean.py
+++ b/homeassistant/components/switch/enocean.py
@@ -80,7 +80,7 @@ class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
         data.extend(self.dev_entity) 
         data.extend([0x64, ]) 
         data.extend(self.dev_channel) 
-        self.send_command(data=data, optional=optional,packet_type=0x01)
+        self.send_command(data=data, optional=optional, packet_type=0x01)
         self._on_state = True
 
     def turn_off(self, **kwargs):
@@ -94,7 +94,7 @@ class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
         data.extend([0x00, ]) 
         data.extend(self.dev_channel) 
 
-        self.send_command(data=data, optional=optional,packet_type=0x01)
+        self.send_command(data=data, optional=optional, packet_type=0x01)
         self._on_state = False
 
     def value_changed(self, val):

--- a/homeassistant/components/switch/enocean.py
+++ b/homeassistant/components/switch/enocean.py
@@ -39,13 +39,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     # New parameters for Nodon NOD_SIN-2-2-01 can work
     command = config.get(CONF_COMMAND)
     entity = config.get(CONF_CUSTOMIZE)
-    add_devices([EnOceanSwitch(dev_id, devname,command,entity)])
+    add_devices([EnOceanSwitch(dev_id, devname, command, entity)])
 
 
 class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
     """Representation of an EnOcean switch device."""
 
-    def __init__(self, dev_id, devname, command,entity):
+    def __init__(self, dev_id, devname, command, entity):
         """Initialize the EnOcean switch device."""
         enocean.EnOceanDevice.__init__(self)
         self.dev_id = dev_id


### PR DESCRIPTION
Add parameters and customize Data packet for Nodon NOD_SIN-2-2-01 can work

## Description:
Encocean switch Nodon NOD_SIN-2-2-01 Compatible,
I put a fork of /components/enocean.py for decrypt the two status by channel.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: enocean
    id: [0x01,0x9D,0x71,0x0A] 
    name: "Switch Channel 1"
    customize: [0x0]
    command: [0xff,0xec,0xef,0x80,0x0]    

  - platform: enocean
    id: [0x01,0x9D,0x71,0x0A]
    name: "Switch Channel 2"
    customize : [0x1]
    command: [0xff,0xec,0xef,0x80,0x0]
```
Customize is the channel of the switch, and command is the spécial data packet for the Nodon 2 switch, need to be the same on all switch.

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
