### PR TITLE
Change telldus domain to download.telldus.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM python:3.6
 LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 
 # Uncomment any of the following lines to disable the installation.
-ENV INSTALL_TELLSTICK no
+#ENV INSTALL_TELLSTICK no
 #ENV INSTALL_OPENALPR no
 #ENV INSTALL_FFMPEG no
 #ENV INSTALL_LIBCEC no

--- a/virtualization/Docker/scripts/tellstick
+++ b/virtualization/Docker/scripts/tellstick
@@ -11,7 +11,7 @@ PACKAGES=(
 
 # Add Tellstick repository
 echo "deb http://download.telldus.com/debian/ stable main" >> /etc/apt/sources.list.d/telldus.list
-wget -qO - http://download.telldus.se/debian/telldus-public.key | apt-key add -
+wget -qO - http://download.telldus.com/debian/telldus-public.key | apt-key add -
 
 apt-get update
 apt-get install -y --no-install-recommends ${PACKAGES[@]}


### PR DESCRIPTION
## Description:
The domain was changed from download.telldus.se to download.telldus.com.

My local docker build is still building, but I guess that should go fine. I'll update this issue when it's done.

**Related issue (if applicable):** see #11806

