### PR TITLE
Add more workday sensor countries and update holidays library to version 0.9.3

### DIFF
--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -17,17 +17,21 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['holidays==0.8.1']
+REQUIREMENTS = ['holidays==0.9.3']
 
 # List of all countries currently supported by holidays
 # There seems to be no way to get the list out at runtime
-ALL_COUNTRIES = ['Australia', 'AU', 'Austria', 'AT', 'Canada', 'CA',
-                 'Colombia', 'CO', 'Czech', 'CZ', 'Denmark', 'DK', 'England',
-                 'EuropeanCentralBank', 'ECB', 'TAR', 'Germany', 'DE',
-                 'Ireland', 'Isle of Man', 'Mexico', 'MX', 'Netherlands', 'NL',
-                 'NewZealand', 'NZ', 'Northern Ireland', 'Norway', 'NO',
-                 'Portugal', 'PT', 'PortugalExt', 'PTE', 'Scotland', 'Spain',
-                 'ES', 'UnitedKingdom', 'UK', 'UnitedStates', 'US', 'Wales']
+ALL_COUNTRIES = ['Australia', 'AU', 'Austria', 'AT', 'Belgium', 'BE', 'Canada',
+                 'CA', 'Colombia', 'CO', 'Czech', 'CZ', 'Denmark', 'DK',
+                 'England', 'EuropeanCentralBank', 'ECB', 'TAR', 'Finland',
+                 'FI', 'France', 'FRA', 'Germany', 'DE', 'Ireland',
+                 'Isle of Man', 'Italy', 'IT', 'Japan', 'JP', 'Mexico', 'MX',
+                 'Netherlands', 'NL', 'NewZealand', 'NZ', 'Northern Ireland',
+                 'Norway', 'NO', 'Polish', 'PL', 'Portugal', 'PT',
+                 'PortugalExt', 'PTE', 'Scotland', 'Slovenia', 'SI',
+                 'Slovakia', 'SK', 'South Africa', 'ZA', 'Spain', 'ES',
+                 'Sweden', 'SE', 'UnitedKingdom', 'UK', 'UnitedStates', 'US',
+                 'Wales']
 CONF_COUNTRY = 'country'
 CONF_PROVINCE = 'province'
 CONF_WORKDAYS = 'workdays'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -346,7 +346,7 @@ hikvision==0.4
 hipnotify==1.0.8
 
 # homeassistant.components.binary_sensor.workday
-holidays==0.8.1
+holidays==0.9.3
 
 # homeassistant.components.frontend
 home-assistant-frontend==20180119.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -72,7 +72,7 @@ haversine==0.4.5
 hbmqtt==0.9.1
 
 # homeassistant.components.binary_sensor.workday
-holidays==0.8.1
+holidays==0.9.3
 
 # homeassistant.components.frontend
 home-assistant-frontend==20180119.0


### PR DESCRIPTION
## Description:
Added countries:
* Belgium
* Finland
* France
* Italy
* Japan
* Poland
* Slovenia
* Slovakia
* South Africa

Holidays library upated to 0.9.3

**Related issue (if applicable):** fixes N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/4475

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
