### PR TITLE
Add missing availability schema to MQTT alarm panel

### DIFF
--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -42,7 +42,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PAYLOAD_ARM_AWAY, default=DEFAULT_ARM_AWAY): cv.string,
     vol.Optional(CONF_PAYLOAD_ARM_HOME, default=DEFAULT_ARM_HOME): cv.string,
     vol.Optional(CONF_PAYLOAD_DISARM, default=DEFAULT_DISARM): cv.string,
-})
+}).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
 @asyncio.coroutine

--- a/tests/components/alarm_control_panel/test_mqtt.py
+++ b/tests/components/alarm_control_panel/test_mqtt.py
@@ -192,6 +192,34 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(call_count, self.mock_publish.call_count)
 
+    def test_default_availability_payload(self):
+        """Test availability by default payload with defined topic."""
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
+            alarm_control_panel.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'alarm/state',
+                'command_topic': 'alarm/command',
+                'code': '1234',
+                'availability_topic': 'availability-topic'
+            }
+        })
+
+        state = self.hass.states.get('alarm_control_panel.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'online')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test')
+        self.assertNotEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'offline')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
     def test_custom_availability_payload(self):
         """Test availability by custom payload with defined topic."""
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
@@ -211,13 +239,3 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         self.assertEqual(STATE_UNAVAILABLE, state.state)
 
         fire_mqtt_message(self.hass, 'availability-topic', 'good')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('alarm_control_panel.test')
-        self.assertNotEqual(STATE_UNAVAILABLE, state.state)
-
-        fire_mqtt_message(self.hass, 'availability-topic', 'nogood')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('alarm_control_panel.test')
-        self.assertEqual(STATE_UNAVAILABLE, state.state)

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -796,6 +796,34 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual(('test_light/bright', 50, 0, False),
                          self.mock_publish.mock_calls[-2][1])
 
+    def test_default_availability_payload(self):
+        """Test availability by default payload with defined topic."""
+        self.assertTrue(setup_component(self.hass, light.DOMAIN, {
+            light.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'command_topic': 'test_light/set',
+                'brightness_command_topic': 'test_light/bright',
+                'rgb_command_topic': "test_light/rgb",
+                'availability_topic': 'availability-topic'
+            }
+        }))
+
+        state = self.hass.states.get('light.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'online')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('light.test')
+        self.assertNotEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'offline')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('light.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
     def test_custom_availability_payload(self):
         """Test availability by custom payload with defined topic."""
         self.assertTrue(setup_component(self.hass, light.DOMAIN, {

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -522,6 +522,33 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertEqual(STATE_ON, state.state)
         self.assertEqual(255, state.attributes.get('white_value'))
 
+    def test_default_availability_payload(self):
+        """Test availability by default payload with defined topic."""
+        self.assertTrue(setup_component(self.hass, light.DOMAIN, {
+            light.DOMAIN: {
+                'platform': 'mqtt_json',
+                'name': 'test',
+                'state_topic': 'test_light_rgb',
+                'command_topic': 'test_light_rgb/set',
+                'availability_topic': 'availability-topic'
+            }
+        }))
+
+        state = self.hass.states.get('light.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'online')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('light.test')
+        self.assertNotEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'offline')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('light.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
     def test_custom_availability_payload(self):
         """Test availability by custom payload with defined topic."""
         self.assertTrue(setup_component(self.hass, light.DOMAIN, {

--- a/tests/components/lock/test_mqtt.py
+++ b/tests/components/lock/test_mqtt.py
@@ -112,6 +112,35 @@ class TestLockMQTT(unittest.TestCase):
         state = self.hass.states.get('lock.test')
         self.assertEqual(STATE_UNLOCKED, state.state)
 
+    def test_default_availability_payload(self):
+        """Test availability by default payload with defined topic."""
+        self.assertTrue(setup_component(self.hass, lock.DOMAIN, {
+            lock.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'payload_lock': 'LOCK',
+                'payload_unlock': 'UNLOCK',
+                'availability_topic': 'availability-topic'
+            }
+        }))
+
+        state = self.hass.states.get('lock.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'online')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('lock.test')
+        self.assertNotEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'offline')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('lock.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
     def test_custom_availability_payload(self):
         """Test availability by custom payload with defined topic."""
         self.assertTrue(setup_component(self.hass, lock.DOMAIN, {

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -185,6 +185,32 @@ class TestSensorMQTT(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(2, len(events))
 
+    def test_default_availability_payload(self):
+        """Test availability by default payload with defined topic."""
+        self.assertTrue(setup_component(self.hass, sensor.DOMAIN, {
+            sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'availability_topic': 'availability-topic'
+            }
+        }))
+
+        state = self.hass.states.get('sensor.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'online')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('sensor.test')
+        self.assertNotEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'offline')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('sensor.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
     def test_custom_availability_payload(self):
         """Test availability by custom payload with defined topic."""
         self.assertTrue(setup_component(self.hass, sensor.DOMAIN, {

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -156,6 +156,48 @@ class TestSwitchMQTT(unittest.TestCase):
         state = self.hass.states.get('switch.test')
         self.assertEqual(STATE_ON, state.state)
 
+    def test_default_availability_payload(self):
+        """Test the availability payload."""
+        assert setup_component(self.hass, switch.DOMAIN, {
+            switch.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'state-topic',
+                'command_topic': 'command-topic',
+                'availability_topic': 'availability_topic',
+                'payload_on': 1,
+                'payload_off': 0
+            }
+        })
+
+        state = self.hass.states.get('switch.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability_topic', 'online')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.test')
+        self.assertEqual(STATE_OFF, state.state)
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
+
+        fire_mqtt_message(self.hass, 'availability_topic', 'offline')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'state-topic', '1')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.test')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability_topic', 'online')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('switch.test')
+        self.assertEqual(STATE_ON, state.state)
+
     def test_custom_availability_payload(self):
         """Test the availability payload."""
         assert setup_component(self.hass, switch.DOMAIN, {

--- a/tests/components/vacuum/test_mqtt.py
+++ b/tests/components/vacuum/test_mqtt.py
@@ -199,6 +199,31 @@ class TestVacuumMQTT(unittest.TestCase):
         self.assertEqual(STATE_OFF, state.state)
         self.assertEqual("Stopped", state.attributes.get(ATTR_STATUS))
 
+    def test_default_availability_payload(self):
+        """Test availability by default payload with defined topic."""
+        self.default_config.update({
+            'availability_topic': 'availability-topic'
+        })
+
+        self.assertTrue(setup_component(self.hass, vacuum.DOMAIN, {
+            vacuum.DOMAIN: self.default_config,
+        }))
+
+        state = self.hass.states.get('vacuum.mqtttest')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'online')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('vacuum.mqtttest')
+        self.assertNotEqual(STATE_UNAVAILABLE, state.state)
+
+        fire_mqtt_message(self.hass, 'availability-topic', 'offline')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('vacuum.mqtttest')
+        self.assertEqual(STATE_UNAVAILABLE, state.state)
+
     def test_custom_availability_payload(self):
         """Test availability by custom payload with defined topic."""
         self.default_config.update({


### PR DESCRIPTION
## Description:

Adds missing availability schema to MQTT Alarm Control Panel.

85dbf7dc3015b895eaa9846a41fed70fcd5682ba adds unit tests for default availability payloads for all MQTT components that didn't have such a test.

28d658e713544a87edc9d71a1da53ab09a2b733a fixes the missing availability schema for MQTT alarm panel.

Checking out only 85dbf7dc3015b895eaa9846a41fed70fcd5682ba shows the failing test for MQTT alarm panel.

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: mqtt
    state_topic: "home/alarm"
    command_topic: "home/alarm/set"
    availability_topic: "/home/alarm/online"
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] ~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  - [ ] ~New dependencies are only imported inside functions that use them ([example][ex-import]).~
  - [ ] ~New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  - [ ] ~New files were added to `.coveragerc`.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
