### PR TITLE
Panel_Iframe - Allow relative urls in config

### DIFF
--- a/homeassistant/components/panel_iframe.py
+++ b/homeassistant/components/panel_iframe.py
@@ -18,7 +18,7 @@ DOMAIN = 'panel_iframe'
 CONF_TITLE = 'title'
 
 CONF_ABSOLUTE_PATH_ERROR_MSG = "Invalid absolute path in relative URL"
-CONF_ABSOLUTE_PATH_REGEX = r'\A/[a-z0-9]'
+CONF_ABSOLUTE_PATH_REGEX = r'\A/'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/panel_iframe.py
+++ b/homeassistant/components/panel_iframe.py
@@ -8,22 +8,28 @@ import asyncio
 
 import voluptuous as vol
 
+from homeassistant.const import (CONF_ICON, CONF_URL)
 import homeassistant.helpers.config_validation as cv
 
-DOMAIN = 'panel_iframe'
 DEPENDENCIES = ['frontend']
 
+DOMAIN = 'panel_iframe'
+
 CONF_TITLE = 'title'
-CONF_ICON = 'icon'
-CONF_URL = 'url'
+
+CONF_ABSOLUTE_PATH_ERROR_MSG = "Invalid absolute path in relative URL"
+CONF_ABSOLUTE_PATH_REGEX = r'\A/[a-z0-9]'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         cv.slug: {
             vol.Optional(CONF_TITLE): cv.string,
             vol.Optional(CONF_ICON): cv.icon,
-            # pylint: disable=no-value-for-parameter
-            vol.Required(CONF_URL): vol.Url(),
+            vol.Required(CONF_URL): vol.Any(
+                vol.Match(
+                    CONF_ABSOLUTE_PATH_REGEX,
+                    msg=CONF_ABSOLUTE_PATH_ERROR_MSG),
+                cv.url),
         }})}, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/components/panel_iframe.py
+++ b/homeassistant/components/panel_iframe.py
@@ -17,8 +17,8 @@ DOMAIN = 'panel_iframe'
 
 CONF_TITLE = 'title'
 
-CONF_ABSOLUTE_PATH_ERROR_MSG = "Invalid absolute path in relative URL"
-CONF_ABSOLUTE_PATH_REGEX = r'\A/'
+CONF_RELATIVE_URL_ERROR_MSG = "Invalid relative URL. Absolute path required."
+CONF_RELATIVE_URL_REGEX = r'\A/'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -27,8 +27,8 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Optional(CONF_ICON): cv.icon,
             vol.Required(CONF_URL): vol.Any(
                 vol.Match(
-                    CONF_ABSOLUTE_PATH_REGEX,
-                    msg=CONF_ABSOLUTE_PATH_ERROR_MSG),
+                    CONF_RELATIVE_URL_REGEX,
+                    msg=CONF_RELATIVE_URL_ERROR_MSG),
                 cv.url),
         }})}, extra=vol.ALLOW_EXTRA)
 

--- a/tests/components/test_panel_iframe.py
+++ b/tests/components/test_panel_iframe.py
@@ -11,11 +11,11 @@ from tests.common import get_test_home_assistant
 class TestPanelIframe(unittest.TestCase):
     """Test the panel_iframe component."""
 
-    def setup_method(self, method):
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def teardown_method(self, method):
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 
@@ -50,6 +50,11 @@ class TestPanelIframe(unittest.TestCase):
                         'title': 'Weather',
                         'url': 'https://www.wunderground.com/us/ca/san-diego',
                     },
+                    'api': {
+                        'icon': 'mdi:weather',
+                        'title': 'Api',
+                        'url': '/api',
+                    },
                 },
             })
 
@@ -71,4 +76,13 @@ class TestPanelIframe(unittest.TestCase):
             'title': 'Weather',
             'url': '/frontend_es5/panels/ha-panel-iframe-md5md5.html',
             'url_path': 'weather',
+        }
+
+        assert panels.get('api').to_response(self.hass, None) == {
+            'component_name': 'iframe',
+            'config': {'url': '/api'},
+            'icon': 'mdi:weather',
+            'title': 'Api',
+            'url': '/frontend_es5/panels/ha-panel-iframe-md5md5.html',
+            'url_path': 'api',
         }


### PR DESCRIPTION
## Description:
Allow relative URL with an absolute path in the configuration

**Related issue (if applicable):** fixes #11077

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4477

## Example entry for `configuration.yaml` (if applicable):
```yaml
panel_iframe:
  router:
    title: My Router
    url: https://192.168.1.5
  grafana:
    title: Grafana
    url: /grafana
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
