### PR TITLE
Fix Unifi direct errors caused by AP reboot.

### DIFF
--- a/homeassistant/components/device_tracker/unifi_direct.py
+++ b/homeassistant/components/device_tracker/unifi_direct.py
@@ -105,11 +105,11 @@ class UnifiDeviceScanner(DeviceScanner):
                 self._connect()
             # If we still aren't connected at this point
             # don't try to send anything to the AP.
-            if self.connected:
-                self.ssh.sendline(UNIFI_COMMAND)
-                self.ssh.prompt()
-                return self.ssh.before
-            return None
+            if not self.connected:
+                return None
+            self.ssh.sendline(UNIFI_COMMAND)
+            self.ssh.prompt()
+            return self.ssh.before
         except pxssh.ExceptionPxssh as err:
             _LOGGER.error("Unexpected SSH error: %s", str(err))
             self._disconnect()


### PR DESCRIPTION
## Description:
If the AP rebooted while HA was running an HA reboot would be required to get it working again. This was because the exception wasn't being caught and _disconnect wasn't being called. This made the code think that it was still connected and didn't need to reconnect.

## Checklist:
  - [X] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
