### PR TITLE
Handling of payload not for this entity.

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -95,6 +95,9 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
             elif payload == self._payload_off:
                 self._state = False
             else:  # Payload is not for this entity
+                _LOGGER.warning('No matching payload found'
+                                ' for entity: %s with state_topic: %s',
+                                self._name, self._state_topic)
                 return
 
             self.async_schedule_update_ha_state()

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -94,7 +94,7 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
                 self._state = True
             elif payload == self._payload_off:
                 self._state = False
-            else: #Payload is not for this entity
+            else:  # Payload is not for this entity
                 return
 
             self.async_schedule_update_ha_state()

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -94,6 +94,8 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
                 self._state = True
             elif payload == self._payload_off:
                 self._state = False
+            else: #Payload is not for this entity
+                return
 
             self.async_schedule_update_ha_state()
 


### PR DESCRIPTION


## Description:
The update state-method should not be called if the payload is not intended for this entity.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
