### PR TITLE
logger: Add dump_config, list_loggers, allow changing default logger

### DIFF
--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -18,6 +18,7 @@ DATA_LOGGER = 'logger'
 
 SERVICE_SET_LEVEL = 'set_level'
 SERVICE_DUMP_CONFIG = 'dump_config'
+SERVICE_LIST_LOGGERS = 'list_loggers'
 
 LOGSEVERITY = {
     'CRITICAL': 50,
@@ -137,5 +138,18 @@ def async_setup(hass, config):
 
     hass.services.async_register(
         DOMAIN, SERVICE_DUMP_CONFIG, async_dump_config)
+
+    @asyncio.coroutine
+    def async_list_loggers(service):
+        """Returns a list of available loggers."""
+        loggers = {k: v.getEffectiveLevel()
+                   for k, v in logging.Logger.manager.loggerDict.items()
+                   if isinstance(v, logging.Logger)}
+
+        logger.info("Available loggers: %s", loggers)
+        return loggers
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_LIST_LOGGERS, async_list_loggers)
 
     return True

--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -17,6 +17,7 @@ DOMAIN = 'logger'
 DATA_LOGGER = 'logger'
 
 SERVICE_SET_LEVEL = 'set_level'
+SERVICE_DUMP_CONFIG = 'dump_config'
 
 LOGSEVERITY = {
     'CRITICAL': 50,
@@ -95,6 +96,9 @@ def async_setup(hass, config):
 
         # Add new logpoints mapped to correc severity
         for key, value in logpoints.items():
+            if LOGGER_DEFAULT == key:  # default key is stored on top-level
+                logfilter[LOGGER_DEFAULT] = LOGSEVERITY[value]
+
             logs[key] = LOGSEVERITY[value]
 
         logfilter[LOGGER_LOGS] = OrderedDict(
@@ -124,5 +128,14 @@ def async_setup(hass, config):
     hass.services.async_register(
         DOMAIN, SERVICE_SET_LEVEL, async_service_handler,
         schema=SERVICE_SET_LEVEL_SCHEMA)
+
+    @asyncio.coroutine
+    def async_dump_config(service):
+        """Dump current config to the log."""
+        logger.info("Current logger config: %s", logfilter)
+        return logfilter
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_DUMP_CONFIG, async_dump_config)
 
     return True

--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -141,7 +141,7 @@ def async_setup(hass, config):
 
     @asyncio.coroutine
     def async_list_loggers(service):
-        """Returns a list of available loggers."""
+        """Return a dictionary of available loggers with their log levels."""
         loggers = {k: v.getEffectiveLevel()
                    for k, v in logging.Logger.manager.loggerDict.items()
                    if isinstance(v, logging.Logger)}

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -182,7 +182,9 @@ logger:
         description: A dictionary presenting the logging levels to be set.
         example: '{"homeassistant": "DEBUG", "homeassistant.components.media_player": "ERROR"}'
   dump_config:
-    description: Dumps logger configuration.
+    description: Dumps home-assistant's logger configuration.
+  list_loggers:
+    description: Returns a dictionary of all available loggers with their log level.
 
 hassio:
   host_reboot:

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -177,6 +177,12 @@ ffmpeg:
 logger:
   set_level:
     description: Set log level for components.
+    fields:
+      config:
+        description: A dictionary presenting the logging levels to be set.
+        example: '{"homeassistant": "DEBUG", "homeassistant.components.media_player": "ERROR"}'
+  dump_config:
+    description: Dumps logger configuration.
 
 hassio:
   host_reboot:


### PR DESCRIPTION
## Description:
* Add dump_config for printing out the current log configuration
* Add list_loggers to return all available logger instances and their log levels.
* Allow configuration of the default log level
* Add documentation to the services.yaml.

This combination will allow API users to introspect the available loggers and provide an intuitive interface for enabling & disabling logging, changing the log levels etc. The end-goal would be to allow toggling these settings also from the UI in a straight-forward manner, which can be useful for both developers and users alike.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4479

```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
