### PR TITLE
Enable Daikin autodiscovery

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -53,6 +53,7 @@ SERVICE_HANDLERS = {
     SERVICE_TELLDUSLIVE: ('tellduslive', None),
     SERVICE_HUE: ('hue', None),
     SERVICE_DECONZ: ('deconz', None),
+    SERVICE_DAIKIN: ('daikin', None),
     'google_cast': ('media_player', 'cast'),
     'panasonic_viera': ('media_player', 'panasonic_viera'),
     'plex_mediaserver': ('media_player', 'plex'),


### PR DESCRIPTION
## Description:
Daikin was build from the beginning with autodiscovery in mind but since at the moment of the release, the [netdisco fix](https://github.com/home-assistant/netdisco/pull/158) was not released yet I had to disable it as you can see (here)[https://github.com/home-assistant/home-assistant/pull/10983/commits/a87686cfd0ed4b88e831d392361843d5f270baf8].

This 1 line PR simply re-enables the deleted code.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4483

## Example entry for `configuration.yaml` (if applicable):
```yaml
daikin:
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
