### PR TITLE
Egardia redesign - generic component and sensor support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -76,6 +76,9 @@ omit =
     homeassistant/components/ecobee.py
     homeassistant/components/*/ecobee.py
 
+    homeassistant/components/egardia.py
+    homeassistant/components/*/egardia.py
+
     homeassistant/components/enocean.py
     homeassistant/components/*/enocean.py
 
@@ -284,7 +287,6 @@ omit =
     homeassistant/components/alarm_control_panel/alarmdotcom.py
     homeassistant/components/alarm_control_panel/canary.py
     homeassistant/components/alarm_control_panel/concord232.py
-    homeassistant/components/alarm_control_panel/egardia.py
     homeassistant/components/alarm_control_panel/ialarm.py
     homeassistant/components/alarm_control_panel/manual_mqtt.py
     homeassistant/components/alarm_control_panel/nx584.py

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -7,37 +7,13 @@ https://home-assistant.io/components/alarm_control_panel.egardia/
 import logging
 
 import requests
-import voluptuous as vol
 
 import homeassistant.components.alarm_control_panel as alarm
-from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT, CONF_USERNAME,
-    EVENT_HOMEASSISTANT_STOP, STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED, STATE_UNKNOWN)
-import homeassistant.exceptions as exc
-import homeassistant.helpers.config_validation as cv
-
-REQUIREMENTS = ['pythonegardia==1.0.26']
+    STATE_UNKNOWN, STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_TRIGGERED)
 
 _LOGGER = logging.getLogger(__name__)
-
-CONF_REPORT_SERVER_CODES = 'report_server_codes'
-CONF_REPORT_SERVER_ENABLED = 'report_server_enabled'
-CONF_REPORT_SERVER_PORT = 'report_server_port'
-CONF_REPORT_SERVER_CODES_IGNORE = 'ignore'
-CONF_VERSION = 'version'
-
-DEFAULT_NAME = 'Egardia'
-DEFAULT_PORT = 80
-DEFAULT_REPORT_SERVER_ENABLED = False
-DEFAULT_REPORT_SERVER_PORT = 52010
-DEFAULT_VERSION = 'GATE-01'
-DOMAIN = 'egardia'
-D_EGARDIASRV = 'egardiaserver'
-
-NOTIFICATION_ID = 'egardia_notification'
-NOTIFICATION_TITLE = 'Egardia'
 
 STATES = {
     'ARM': STATE_ALARM_ARMED_AWAY,
@@ -48,78 +24,33 @@ STATES = {
     'UNKNOWN': STATE_UNKNOWN,
 }
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Optional(CONF_VERSION, default=DEFAULT_VERSION): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_REPORT_SERVER_CODES): vol.All(cv.ensure_list),
-    vol.Optional(CONF_REPORT_SERVER_ENABLED,
-                 default=DEFAULT_REPORT_SERVER_ENABLED): cv.boolean,
-    vol.Optional(CONF_REPORT_SERVER_PORT, default=DEFAULT_REPORT_SERVER_PORT):
-        cv.port,
-})
+D_EGARDIASRV = 'egardiaserver'
+D_EGARDIASYS = 'egardiadevice'
+D_EGARDIANM = 'egardianame'
+D_EGARDIARSENABLED = 'egardia_rs_enabled'
+D_EGARDIARSCODES = 'egardia_rs_codes'
+D_EGARDIADEV = 'egardia_dev'
+CONF_REPORT_SERVER_CODES_IGNORE = 'ignore'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Egardia platform."""
-    from pythonegardia import egardiadevice
-    from pythonegardia import egardiaserver
-
-    name = config.get(CONF_NAME)
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
-    rs_enabled = config.get(CONF_REPORT_SERVER_ENABLED)
-    rs_port = config.get(CONF_REPORT_SERVER_PORT)
-    rs_codes = config.get(CONF_REPORT_SERVER_CODES)
-    version = config.get(CONF_VERSION)
-
-    try:
-        egardiasystem = egardiadevice.EgardiaDevice(
-            host, port, username, password, '', version)
-    except requests.exceptions.RequestException:
-        raise exc.PlatformNotReady()
-    except egardiadevice.UnauthorizedError:
-        _LOGGER.error("Unable to authorize. Wrong password or username")
-        return
-
     eg_dev = EgardiaAlarm(
-        name, egardiasystem, rs_enabled, rs_codes)
-
-    if rs_enabled:
-        # Set up the egardia server
-        _LOGGER.info("Setting up EgardiaServer")
-        try:
-            if D_EGARDIASRV not in hass.data:
-                server = egardiaserver.EgardiaServer('', rs_port)
-                bound = server.bind()
-                if not bound:
-                    raise IOError(
-                        "Binding error occurred while starting EgardiaServer")
-                hass.data[D_EGARDIASRV] = server
-                server.start()
-        except IOError:
-            return
-        hass.data[D_EGARDIASRV].register_callback(eg_dev.handle_status_event)
-
-    def handle_stop_event(event):
-        """Call function for Home Assistant stop event."""
-        hass.data[D_EGARDIASRV].stop()
-
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, handle_stop_event)
-
+        hass.data[D_EGARDIANM],
+        hass.data[D_EGARDIASYS],
+        hass.data[D_EGARDIARSENABLED],
+        hass.data[D_EGARDIARSCODES])
+    hass.data[D_EGARDIADEV] = eg_dev
+    # add egardia alarm device
     add_devices([eg_dev], True)
 
 
 class EgardiaAlarm(alarm.AlarmControlPanel):
     """Representation of a Egardia alarm."""
 
-    def __init__(self, name, egardiasystem, rs_enabled=False, rs_codes=None):
-        """Initialize the Egardia alarm."""
+    def __init__(self, name, egardiasystem,
+                 rs_enabled=False, rs_codes=None):
+        """Initialize object."""
         self._name = name
         self._egardiasystem = egardiasystem
         self._status = None
@@ -147,7 +78,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         return False
 
     def handle_status_event(self, event):
-        """Handle the Egardia system status event."""
+        """Handle egardia_system_status_event."""
         statuscode = event.get('status')
         if statuscode is not None:
             status = self.lookupstatusfromcode(statuscode)

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -39,7 +39,7 @@ def _create_sensor(hass, sensor):
                                name=sensor['name'],
                                state=_get_sensor_state(sensor['cond']),
                                device_class=_get_device_class(sensor['type'])
-                              )
+                               )
 
 
 @asyncio.coroutine

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -1,0 +1,109 @@
+"""
+Interfaces with Egardia/Woonveilig alarm control panel.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.egardia/
+"""
+import logging
+import asyncio
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.const import (STATE_ON, STATE_OFF)
+_LOGGER = logging.getLogger(__name__)
+ATTR_DISCOVER_DEVICES = 'egardia_sensor'
+D_EGARDIASYS = 'egardiadevice'
+
+# TODO: add mapping to 'smoke'
+EGARDIA_TYPE_TO_DEVICE_CLASS = {'IR Sensor': 'motion',
+                                'Door Contact': 'opening',
+                                'IR': 'motion'}
+# TODO: add state for triggered motion sensor
+# NOT USED FOR NOW since we do not know state of motion sensor
+EGARDIA_INPUT_TO_STATES = {'': STATE_OFF, 'Open': STATE_ON}
+
+
+def _get_device_class(egardia_type):
+    return EGARDIA_TYPE_TO_DEVICE_CLASS.get(egardia_type, None)
+
+
+def _get_sensor_state(egardia_input):
+    if len(egardia_input) > 0:
+        return STATE_ON
+    else:
+        return STATE_OFF
+#    return EGARDIA_INPUT_TO_STATES.get(egardia_input, STATE_UNAVAILABLE)
+
+
+def _create_sensor(hass, sensor):
+    return EgardiaBinarySensor(hass, senid=sensor["id"],
+                               name=sensor['name'],
+                               state=_get_sensor_state(sensor['cond']),
+                               device_class=_get_device_class(sensor['type'])
+                              )
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices,
+                         discovery_info=None):
+    """Initialize the platform."""
+    if (discovery_info is None or
+            discovery_info[ATTR_DISCOVER_DEVICES] is None):
+        return
+
+    di = discovery_info[ATTR_DISCOVER_DEVICES]
+
+    # multiple devices here!
+    async_add_devices(
+        _create_sensor(hass, di[sensor])
+        for sensor in di
+        )
+
+
+class EgardiaBinarySensor(BinarySensorDevice):
+    """Represents a sensor based on an Egardia sensor (IR, Door Contact)."""
+
+    def __init__(self, hass, senid, name, state, device_class):
+        """Initialize the sensor device."""
+        self._id = senid
+        self._name = name
+        self._state = state
+        self._device_class = device_class
+        self._hass = hass
+        # spc_registry.register_sensor_device(zone_id, self)
+
+    # @asyncio.coroutine
+    # def async_update_from_egardia(self, state, extra):
+    #    """Update the state of the device."""
+    #    self._state = state
+    #    yield from self.async_update_ha_state()
+
+    def update(self):
+        """Update the status."""
+        egardia_input = self._hass.data[D_EGARDIASYS].getsensorstate(self._id)
+        self._state = _get_sensor_state(egardia_input)
+
+    @property
+    def name(self):
+        """The name of the device."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Whether the device is switched on."""
+        return self._state == STATE_ON
+
+    @property
+    def hidden(self):
+        """Whether the device is hidden by default."""
+        # these type of sensors are probably mainly used for automations
+        return True
+
+    @property
+    def should_poll(self):
+        """Polling required."""
+        return True
+
+    @property
+    def device_class(self):
+        """The device class."""
+        return self._device_class

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -1,0 +1,138 @@
+"""
+Interfaces with Egardia/Woonveilig alarm control panel.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/egardia/
+"""
+import logging
+
+import requests
+import voluptuous as vol
+
+import homeassistant.exceptions as exc
+from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    CONF_PORT, CONF_HOST, CONF_PASSWORD, CONF_USERNAME, STATE_UNKNOWN,
+    CONF_NAME, STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_TRIGGERED, EVENT_HOMEASSISTANT_STOP)
+
+REQUIREMENTS = ['pythonegardia==1.0.34']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_REPORT_SERVER_CODES = 'report_server_codes'
+CONF_REPORT_SERVER_ENABLED = 'report_server_enabled'
+CONF_REPORT_SERVER_PORT = 'report_server_port'
+CONF_REPORT_SERVER_CODES_IGNORE = 'ignore'
+CONF_VERSION = 'version'
+
+DEFAULT_NAME = 'Egardia'
+DEFAULT_PORT = 80
+DEFAULT_REPORT_SERVER_ENABLED = False
+DEFAULT_REPORT_SERVER_PORT = 52010
+DEFAULT_VERSION = 'GATE-01'
+DOMAIN = 'egardia'
+D_EGARDIASRV = 'egardiaserver'
+D_EGARDIASYS = 'egardiadevice'
+D_EGARDIANM = 'egardianame'
+D_EGARDIARSENABLED = 'egardia_rs_enabled'
+D_EGARDIARSCODES = 'egardia_rs_codes'
+D_EGARDIADEV = 'egardia_dev'
+NOTIFICATION_ID = 'egardia_notification'
+NOTIFICATION_TITLE = 'Egardia'
+ATTR_DISCOVER_DEVICES = 'egardia_sensor'
+STATES = {
+    'ARM': STATE_ALARM_ARMED_AWAY,
+    'DAY HOME': STATE_ALARM_ARMED_HOME,
+    'DISARM': STATE_ALARM_DISARMED,
+    'HOME': STATE_ALARM_ARMED_HOME,
+    'TRIGGERED': STATE_ALARM_TRIGGERED,
+    'UNKNOWN': STATE_UNKNOWN,
+}
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_VERSION, default=DEFAULT_VERSION): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_REPORT_SERVER_CODES): vol.All(cv.ensure_list),
+        vol.Optional(CONF_REPORT_SERVER_ENABLED,
+                     default=DEFAULT_REPORT_SERVER_ENABLED): cv.boolean,
+        vol.Optional(CONF_REPORT_SERVER_PORT,
+                     default=DEFAULT_REPORT_SERVER_PORT): cv.port,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Set up the Egardia platform."""
+    from pythonegardia import egardiadevice
+    from pythonegardia import egardiaserver
+
+    name = config[DOMAIN].get(CONF_NAME)
+    hass.data[D_EGARDIANM] = name
+    username = config[DOMAIN].get(CONF_USERNAME)
+    password = config[DOMAIN].get(CONF_PASSWORD)
+    host = config[DOMAIN].get(CONF_HOST)
+    port = config[DOMAIN].get(CONF_PORT)
+    rs_enabled = config[DOMAIN].get(CONF_REPORT_SERVER_ENABLED)
+    hass.data[D_EGARDIARSENABLED] = rs_enabled
+    rs_port = config[DOMAIN].get(CONF_REPORT_SERVER_PORT)
+    rs_codes = config[DOMAIN].get(CONF_REPORT_SERVER_CODES)
+    hass.data[D_EGARDIARSCODES] = rs_codes
+    version = config[DOMAIN].get(CONF_VERSION)
+    try:
+        hass.data[D_EGARDIASYS] = egardiadevice.EgardiaDevice(
+            host, port, username, password, '', version)
+    except requests.exceptions.RequestException:
+        raise exc.PlatformNotReady()
+    except egardiadevice.UnauthorizedError:
+        _LOGGER.error("Unable to authorize. Wrong password or username")
+        return
+
+    # add egardia alarm device
+    def alarm_loaded(event, data=None):
+        """Check if egardia platform has loaded."""
+        if event is DOMAIN:
+            # configure egardia server, including callback
+            if rs_enabled:
+                # Set up the egardia server
+                _LOGGER.info("Setting up EgardiaServer")
+                try:
+                    if D_EGARDIASRV not in hass.data:
+                        server = egardiaserver.EgardiaServer('', rs_port)
+                        bound = server.bind()
+                        if not bound:
+                            raise IOError("Binding error occurred while " +
+                                          "starting EgardiaServer")
+                        hass.data[D_EGARDIASRV] = server
+                        server.start()
+                except IOError:
+                    return
+                hass.data[D_EGARDIASRV].register_callback(hass.data[D_EGARDIADEV].handle_status_event)
+
+    # register for callback since we might need to set up the egardia server
+    discovery.listen_platform(hass, 'alarm_control_panel', alarm_loaded)
+
+    hass.async_add_job(discovery.async_load_platform(
+        hass, 'alarm_control_panel', DOMAIN,
+        discovered=None, hass_config=config))
+
+    def handle_stop_event(event):
+        """Callback function for HA stop event."""
+        hass.data[D_EGARDIASRV].stop()
+
+    # listen to home assistant stop event
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, handle_stop_event)
+
+    # get the sensors from the device and add those
+    sensors = hass.data[D_EGARDIASYS].getsensors()
+    hass.async_add_job(discovery.async_load_platform(
+        hass, 'binary_sensor', DOMAIN,
+        {ATTR_DISCOVER_DEVICES: sensors}, config))
+
+    return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -954,7 +954,7 @@ python_opendata_transport==0.0.3
 python_openzwave==0.4.0.35
 
 # homeassistant.components.alarm_control_panel.egardia
-pythonegardia==1.0.26
+pythonegardia==1.0.34
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3


### PR DESCRIPTION
## Description:
We re-architected the alarm_control_panel.egardia component to be a generic component. Also, adding in sensor support. Docs not yet written, code is not high quality yet: works but needs some review! Will write docs after code is in good shape.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
egardia:
    host: YOUR_HOST
    username: YOUR_USERNAME
    password: YOUR_PASSWORD
```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
