### PR TITLE
Added password mode to input_text (obscure content of text box)

### DIFF
--- a/homeassistant/components/input_text.py
+++ b/homeassistant/components/input_text.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    ATTR_ENTITY_ID, ATTR_UNIT_OF_MEASUREMENT, CONF_ICON, CONF_NAME)
+    ATTR_ENTITY_ID, ATTR_UNIT_OF_MEASUREMENT, CONF_ICON, CONF_NAME, CONF_MODE)
 from homeassistant.loader import bind_hass
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
@@ -26,10 +26,14 @@ CONF_INITIAL = 'initial'
 CONF_MIN = 'min'
 CONF_MAX = 'max'
 
+MODE_TEXT = 'text'
+MODE_PASSWORD = 'password'
+
 ATTR_VALUE = 'value'
 ATTR_MIN = 'min'
 ATTR_MAX = 'max'
 ATTR_PATTERN = 'pattern'
+ATTR_MODE = 'mode'
 
 SERVICE_SET_VALUE = 'set_value'
 
@@ -63,6 +67,8 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Optional(CONF_ICON): cv.icon,
             vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
             vol.Optional(ATTR_PATTERN): cv.string,
+            vol.Optional(CONF_MODE, default=MODE_TEXT):
+                vol.In([MODE_TEXT, MODE_PASSWORD]),
         }, _cv_input_text)
     })
 }, required=True, extra=vol.ALLOW_EXTRA)
@@ -92,10 +98,11 @@ def async_setup(hass, config):
         icon = cfg.get(CONF_ICON)
         unit = cfg.get(ATTR_UNIT_OF_MEASUREMENT)
         pattern = cfg.get(ATTR_PATTERN)
+        mode = cfg.get(CONF_MODE)
 
         entities.append(InputText(
             object_id, name, initial, minimum, maximum, icon, unit,
-            pattern))
+            pattern, mode))
 
     if not entities:
         return False
@@ -122,7 +129,7 @@ class InputText(Entity):
     """Represent a text box."""
 
     def __init__(self, object_id, name, initial, minimum, maximum, icon,
-                 unit, pattern):
+                 unit, pattern, mode):
         """Initialize a text input."""
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)
         self._name = name
@@ -132,6 +139,7 @@ class InputText(Entity):
         self._icon = icon
         self._unit = unit
         self._pattern = pattern
+        self._mode = mode
 
     @property
     def should_poll(self):
@@ -165,6 +173,7 @@ class InputText(Entity):
             ATTR_MIN: self._minimum,
             ATTR_MAX: self._maximum,
             ATTR_PATTERN: self._pattern,
+            ATTR_MODE: self._mode,
         }
 
     @asyncio.coroutine

--- a/homeassistant/components/sensor/xiaomi_aqara.py
+++ b/homeassistant/components/sensor/xiaomi_aqara.py
@@ -77,5 +77,5 @@ class XiaomiSensor(XiaomiDevice):
             return False
         elif self._data_key == 'pressure' and value == 0:
             return False
-        self._state = round(value, 2)
+        self._state = round(value, 1)
         return True

--- a/homeassistant/components/sensor/xiaomi_aqara.py
+++ b/homeassistant/components/sensor/xiaomi_aqara.py
@@ -77,5 +77,5 @@ class XiaomiSensor(XiaomiDevice):
             return False
         elif self._data_key == 'pressure' and value == 0:
             return False
-        self._state = round(value, 1)
+        self._state = round(value, 2)
         return True

--- a/tests/components/test_input_text.py
+++ b/tests/components/test_input_text.py
@@ -64,6 +64,40 @@ class TestInputText(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual('testing', str(state.state))
 
+    def test_mode(self):
+        """Test mode settings."""
+        self.assertTrue(
+            setup_component(self.hass, DOMAIN, {DOMAIN: {
+                'test_default_text': {
+                    'initial': 'test',
+                    'min': 3,
+                    'max': 10,
+                },
+                'test_explicit_text': {
+                    'initial': 'test',
+                    'min': 3,
+                    'max': 10,
+                    'mode': 'text',
+                },
+                'test_explicit_password': {
+                    'initial': 'test',
+                    'min': 3,
+                    'max': 10,
+                    'mode': 'password',
+                },
+            }}))
+
+        state = self.hass.states.get('input_text.test_default_text')
+        assert state
+        self.assertEqual('text', state.attributes['mode'])
+
+        state = self.hass.states.get('input_text.test_explicit_text')
+        assert state
+        self.assertEqual('text', state.attributes['mode'])
+
+        state = self.hass.states.get('input_text.test_explicit_password')
+        assert state
+        self.assertEqual('password', state.attributes['mode'])
 
 @asyncio.coroutine
 def test_restore_state(hass):

--- a/tests/components/test_input_text.py
+++ b/tests/components/test_input_text.py
@@ -99,6 +99,7 @@ class TestInputText(unittest.TestCase):
         assert state
         self.assertEqual('password', state.attributes['mode'])
 
+
 @asyncio.coroutine
 def test_restore_state(hass):
     """Ensure states are restored on startup."""


### PR DESCRIPTION
## Description:
Provide an optional way for the user to securely enter a password/text value.
In combination with:
https://github.com/home-assistant/home-assistant-polymer/pull/837
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
https://github.com/home-assistant/home-assistant.github.io/pull/4489

## Example entry for `configuration.yaml` (if applicable):
```yaml
input_text:
  text1:
    name: Text 1
    initial: Some Text
    mode: password (optional, default is text)
```

## Checklist:
  - [x] The code change is tested and works locally.
   - [x] Local tests with tox run successfully. Your PR cannot be merged unless tests pass
  - [x] Tests have been added to verify that the new code works.
If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in:
https://github.com/home-assistant/home-assistant.github.io/pull/4489

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54