### PR TITLE
xiaomi_ir (python-miio ChuangmiIr device)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -662,6 +662,7 @@ omit =
     homeassistant/components/switch/tplink.py
     homeassistant/components/switch/transmission.py
     homeassistant/components/switch/xiaomi_miio.py
+    homeassistant/components/switch/xiaomi_ir.py
     homeassistant/components/telegram_bot/*
     homeassistant/components/thingspeak.py
     homeassistant/components/tts/amazon_polly.py

--- a/homeassistant/components/switch/services.yaml
+++ b/homeassistant/components/switch/services.yaml
@@ -35,8 +35,11 @@ xiaomi_miio_learn_command:
   description: 'Learn an IR command, press "Call Service", point the remote at the IR device, and the learned command will be shown as a notification in Overview.'
   fields:
       slot:
-        description: 'Define the slot used to save the IR command (Value from 1 to 1000000)'
-        example: '"slot": "1"'
+        description: 'Define the slot used to save the IR command (Value from 1 to 1000000) (Default: 1)'
+        example: '"slot": 1'
+      timeout:
+        description: 'Define the timeout in seconds, before which the command must be learned. (Default: 10)'
+        example: '"timeout": 30'
 
 xiaomi_miio_send_command:
   description: 'Send one or more IR commands'

--- a/homeassistant/components/switch/services.yaml
+++ b/homeassistant/components/switch/services.yaml
@@ -32,11 +32,15 @@ mysensors_send_ir_code:
       example: '0xC284'
 
 xiaomi_miio_learn_command:
-  description: Learn an IR command, press "Call Service", point the remote at the IR device, and the learned command will be shown as a notification in Overview.
+  description: 'Learn an IR command, press "Call Service", point the remote at the IR device, and the learned command will be shown as a notification in Overview.'
+  fields:
+      slot:
+        description: 'Define the slot used to save the IR command (Value from 1 to 1000000)'
+        example: '"slot": "1"'
 
 xiaomi_miio_send_command:
-  description: Send one or more IR commands
+  description: 'Send one or more IR commands'
   fields:
     command:
-      description: Takes a list of base64 encoded commands to send.
+      description: 'Takes a list of base64 encoded commands to send.'
       example: "[ base64 encoded command, base64 encoded command ]"

--- a/homeassistant/components/switch/services.yaml
+++ b/homeassistant/components/switch/services.yaml
@@ -30,3 +30,13 @@ mysensors_send_ir_code:
     V_IR_SEND:
       description: IR code to send.
       example: '0xC284'
+
+xiaomi_miio_learn_command:
+  description: Learn an IR command, press "Call Service", point the remote at the IR device, and the learned command will be shown as a notification in Overview.
+
+xiaomi_miio_send_command:
+  description: Send one or more IR commands
+  fields:
+    command:
+      description: Takes a list of base64 encoded commands to send.
+      example: "[ base64 encoded command, base64 encoded command ]"

--- a/homeassistant/components/switch/xiaomi_ir.py
+++ b/homeassistant/components/switch/xiaomi_ir.py
@@ -15,7 +15,7 @@ from homeassistant.components.switch import (
     DOMAIN, PLATFORM_SCHEMA, SwitchDevice)
 from homeassistant.const import (
     CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_FRIENDLY_NAME,
-    CONF_SWITCHES, CONF_HOST, CONF_TOKEN, CONF_SLOT, CONF_TIMEOUT)
+    CONF_SWITCHES, CONF_HOST, CONF_TOKEN, CONF_TIMEOUT)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.dt import utcnow
 
@@ -25,6 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_LEARN = 'xiaomi_miio_learn_command'
 SERVICE_SEND = 'xiaomi_miio_send_command'
+
+CONF_SLOT = 'slot'
 
 DEFAULT_TIMEOUT = 10
 DEFAULT_SLOT = 1

--- a/homeassistant/components/switch/xiaomi_ir.py
+++ b/homeassistant/components/switch/xiaomi_ir.py
@@ -60,7 +60,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         try:
             vol.All(int, vol.Range(min=1, max=1000000))(slot)
         except vol.error.MultipleInvalid as ex:
-            _LOGGER.error("slot value should be between 1 and 1000000, but was: %i", slot)
+            _LOGGER.error(
+                "slot value should be between 1 and 1000000, but was: %i",
+                slot)
             return
 
         yield from hass.async_add_job(remote.learn, slot)

--- a/homeassistant/components/switch/xiaomi_ir.py
+++ b/homeassistant/components/switch/xiaomi_ir.py
@@ -168,4 +168,3 @@ class ChuangmiIrSwitch(SwitchDevice):
                 return False
             return self._sendpacket(packet, retry-1)
         return True
-        

--- a/homeassistant/components/switch/xiaomi_ir.py
+++ b/homeassistant/components/switch/xiaomi_ir.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/ir_remote.xiaomi_miio/
 import asyncio
 import logging
 
-from base64 import b64decode, b64encode
 from datetime import timedelta
 
 import voluptuous as vol
@@ -43,6 +42,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SWITCHES, default={}):
         vol.Schema({cv.slug: SWITCH_SCHEMA}),
 }, extra=vol.ALLOW_EXTRA)
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Xiaomi IR Remote (Chuangmi IR) platform."""
@@ -81,10 +81,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             payload = str(packet)
             _LOGGER.info(payload)
             yield from hass.async_add_job(
-                remote.play, payload, 1) #What should this magic constant be?
+                remote.play, payload, 1)  # What should this magic constant be?
 
     host = config.get(CONF_HOST)
-    name = config.get(CONF_NAME)
     token = config.get(CONF_TOKEN)
 
     # Create handler
@@ -97,7 +96,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                            host.replace('.', '_'), _send_packet)
 
     devices = config.get(CONF_SWITCHES)
-    friendly_name = config.get(CONF_FRIENDLY_NAME)
 
     switches = []
     for object_id, device_config in devices.items():
@@ -110,6 +108,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             )
         )
     add_devices(switches)
+
 
 class ChuangmiIrSwitch(SwitchDevice):
     """Representation of a ChuangmiIr switch."""
@@ -162,10 +161,11 @@ class ChuangmiIrSwitch(SwitchDevice):
             _LOGGER.debug("Empty packet")
             return True
         try:
-            self._device.play(packet, 1) #What should this magic constant be?
+            self._device.play(packet, 1)  # What should this magic constant be?
         except DeviceException as exc:
             if retry < 1:
                 _LOGGER.error(exc)
                 return False
             return self._sendpacket(packet, retry-1)
         return True
+        

--- a/homeassistant/components/switch/xiaomi_ir.py
+++ b/homeassistant/components/switch/xiaomi_ir.py
@@ -1,0 +1,171 @@
+"""
+Support for the Xiaomi IR Remote (Chuangmi IR).
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/ir_remote.xiaomi_miio/
+"""
+import asyncio
+import logging
+
+from base64 import b64decode, b64encode
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.switch import (
+    DOMAIN, PLATFORM_SCHEMA, SwitchDevice)
+from homeassistant.const import (
+    CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_FRIENDLY_NAME,
+    CONF_SWITCHES, CONF_HOST, CONF_NAME, CONF_TOKEN)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util.dt import utcnow
+
+REQUIREMENTS = ['python-miio==0.3.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "Chuangmi IR"
+PLATFORM = 'xiaomi_miio'
+
+SERVICE_LEARN = 'chuangmiIr_learn_command'
+SERVICE_SEND = 'chuangmiIr_send_packet'
+
+SWITCH_SCHEMA = vol.Schema({
+    vol.Optional(CONF_COMMAND_OFF, default=None): cv.string,
+    vol.Optional(CONF_COMMAND_ON, default=None): cv.string,
+    vol.Optional(CONF_FRIENDLY_NAME): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_TOKEN): vol.All(str, vol.Length(min=32, max=32)),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SWITCHES, default={}):
+        vol.Schema({cv.slug: SWITCH_SCHEMA}),
+}, extra=vol.ALLOW_EXTRA)
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Xiaomi IR Remote (Chuangmi IR) platform."""
+    from miio import ChuangmiIr
+
+    @asyncio.coroutine
+    def _learn_command(call):
+        """Handle a learn command."""
+        from random import randint
+        slot = randint(1, 1000000)
+
+        yield from hass.async_add_job(remote.learn, slot)
+
+        _LOGGER.info("Press the key you want Home Assistant to learn")
+        start_time = utcnow()
+        while (utcnow() - start_time) < timedelta(seconds=20):
+            packet = yield from hass.async_add_job(
+                remote.read, slot)
+            if packet['code']:
+                log_msg = "Recieved packet is: {}".\
+                          format(packet['code'])
+                _LOGGER.info(log_msg)
+                hass.components.persistent_notification.async_create(
+                    log_msg, title='ChuangmiIr')
+                return
+            yield from asyncio.sleep(1, loop=hass.loop)
+        _LOGGER.error("Did not received any signal")
+        hass.components.persistent_notification.async_create(
+            "Did not received any signal", title='ChuangmiIr')
+
+    @asyncio.coroutine
+    def _send_packet(call):
+        """Send a packet."""
+        packets = call.data.get('packet', [])
+        for packet in packets:
+            payload = str(packet)
+            _LOGGER.info(payload)
+            yield from hass.async_add_job(
+                remote.play, payload, 1) #What should this magic constant be?
+
+    host = config.get(CONF_HOST)
+    name = config.get(CONF_NAME)
+    token = config.get(CONF_TOKEN)
+
+    # Create handler
+    _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
+    remote = ChuangmiIr(host, token)
+
+    hass.services.register(DOMAIN, SERVICE_LEARN + '_' +
+                           host.replace('.', '_'), _learn_command)
+    hass.services.register(DOMAIN, SERVICE_SEND + '_' +
+                           host.replace('.', '_'), _send_packet)
+
+    devices = config.get(CONF_SWITCHES)
+    friendly_name = config.get(CONF_FRIENDLY_NAME)
+
+    switches = []
+    for object_id, device_config in devices.items():
+        switches.append(
+            ChuangmiIrSwitch(
+                device_config.get(CONF_FRIENDLY_NAME, object_id),
+                remote,
+                device_config.get(CONF_COMMAND_ON),
+                device_config.get(CONF_COMMAND_OFF)
+            )
+        )
+    add_devices(switches)
+
+class ChuangmiIrSwitch(SwitchDevice):
+    """Representation of a ChuangmiIr switch."""
+
+    def __init__(self, friendly_name, device, command_on, command_off):
+        """Initialize the switch."""
+        self._name = friendly_name
+        self._state = False
+        self._command_on = command_on if command_on else None
+        self._command_off = command_off if command_off else None
+        self._device = device
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def assumed_state(self):
+        """Return true if unable to access real state of entity."""
+        return True
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        if self._sendpacket(self._command_on):
+            self._state = True
+            self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        if self._sendpacket(self._command_off):
+            self._state = False
+            self.schedule_update_ha_state()
+
+    def _sendpacket(self, packet, retry=2):
+        """Send packet to device."""
+        from miio import DeviceException
+
+        if packet is None:
+            _LOGGER.debug("Empty packet")
+            return True
+        try:
+            self._device.play(packet, 1) #What should this magic constant be?
+        except DeviceException as exc:
+            if retry < 1:
+                _LOGGER.error(exc)
+                return False
+            return self._sendpacket(packet, retry-1)
+        return True

--- a/homeassistant/components/switch/xiaomi_ir.py
+++ b/homeassistant/components/switch/xiaomi_ir.py
@@ -89,7 +89,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         packets = call.data.get('command', [])
         for packet in packets:
             payload = str(packet)
-            _LOGGER.debug(payload)
+            _LOGGER.debug("Sending payload: '%s'", payload)
             try:
                 yield from hass.async_add_job(
                     remote.play, payload, None)
@@ -166,7 +166,7 @@ class ChuangmiIrSwitch(SwitchDevice):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        success = yield from self._sendcommand(self._command_on)
+        success = yield from self._send_command(self._command_on)
         if success:
             self._state = True
             self.async_schedule_update_ha_state()
@@ -174,13 +174,13 @@ class ChuangmiIrSwitch(SwitchDevice):
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the device off."""
-        success = yield from self._sendcommand(self._command_off)
+        success = yield from self._send_command(self._command_off)
         if success:
             self._state = False
             self.async_schedule_update_ha_state()
 
     @asyncio.coroutine
-    def _sendcommand(self, command):
+    def _send_command(self, command):
         """Send packet to device."""
         from miio import DeviceException
 

--- a/homeassistant/components/switch/xiaomi_ir.py
+++ b/homeassistant/components/switch/xiaomi_ir.py
@@ -154,7 +154,7 @@ class ChuangmiIrSwitch(SwitchDevice):
         success = yield from self._sendpacket(self._command_on)
         if success:
             self._state = True
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
@@ -162,7 +162,7 @@ class ChuangmiIrSwitch(SwitchDevice):
         success = yield from self._sendpacket(self._command_off)
         if success:
             self._state = False
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
     @asyncio.coroutine
     def _sendpacket(self, packet):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -149,6 +149,7 @@ CONF_WHITELIST_EXTERNAL_DIRS = 'whitelist_external_dirs'
 CONF_WHITE_VALUE = 'white_value'
 CONF_XY = 'xy'
 CONF_ZONE = 'zone'
+CONF_SLOT = 'slot'
 
 # #### EVENTS ####
 EVENT_HOMEASSISTANT_START = 'homeassistant_start'

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -149,7 +149,6 @@ CONF_WHITELIST_EXTERNAL_DIRS = 'whitelist_external_dirs'
 CONF_WHITE_VALUE = 'white_value'
 CONF_XY = 'xy'
 CONF_ZONE = 'zone'
-CONF_SLOT = 'slot'
 
 # #### EVENTS ####
 EVENT_HOMEASSISTANT_START = 'homeassistant_start'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -897,9 +897,9 @@ python-juicenet==0.0.5
 
 # homeassistant.components.fan.xiaomi_miio
 # homeassistant.components.light.xiaomi_miio
+# homeassistant.components.switch.xiaomi_ir
 # homeassistant.components.switch.xiaomi_miio
 # homeassistant.components.vacuum.xiaomi_miio
-# homeassistant.components.switch.xiaomi_ir
 python-miio==0.3.4
 
 # homeassistant.components.media_player.mpd

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -899,6 +899,7 @@ python-juicenet==0.0.5
 # homeassistant.components.light.xiaomi_miio
 # homeassistant.components.switch.xiaomi_miio
 # homeassistant.components.vacuum.xiaomi_miio
+# homeassistant.components.switch.xiaomi_ir
 python-miio==0.3.4
 
 # homeassistant.components.media_player.mpd


### PR DESCRIPTION
## Description:
I wasn't really sure what to name it, it uses the xiaomi_miio package, but xiaomi_miio is already taken in switches.

Everything is tested and working, not sure if someone can come up with a better name before I start on the docs?

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: xiaomi_ir
    host: 192.0.1.42
    token: 1234xyz
    switches: <--- Optional
      some_switch:
        friendly_name: "Some Switch"
        command_on: "base64 package to send"
        command_off: "base64 package to send"
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
