### PR TITLE
Add missing mock call for test_minimal_config

### DIFF
--- a/tests/components/switch/test_wake_on_lan.py
+++ b/tests/components/switch/test_wake_on_lan.py
@@ -98,6 +98,7 @@ class TestWOLSwitch(unittest.TestCase):
         self.assertEqual(STATE_ON, state.state)
 
     @patch('wakeonlan.wol.send_magic_packet', new=send_magic_packet)
+    @patch('subprocess.call', new=call)
     def test_minimal_config(self):
         """Test with minimal config."""
         self.assertTrue(setup_component(self.hass, switch.DOMAIN, {


### PR DESCRIPTION
In local testing py36 always fails on test_minimal_config on a wait
call that never completes. One difference between this test and others
in the class is the lack of a mock on `call`. With this added, the
test passes locally 100%.