### PR TITLE
Component for custom frontend cards

### DIFF
--- a/homeassistant/components/custom_card.py
+++ b/homeassistant/components/custom_card.py
@@ -15,6 +15,7 @@ from homeassistant.const import HTTP_BAD_REQUEST
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = 'custom_card'
+DEPENDENCIES = ['http']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ def async_setup(hass, config):
             entity_id = 'custom_full_card.{}'.format(object_id)
             state = full_card
         else:
-            entity_id = 'custom_sate_card.{}'.format(object_id)
+            entity_id = 'custom_state_card.{}'.format(object_id)
             state = state_card
 
         attributes = {}
@@ -101,4 +102,4 @@ class CustomCardView(http.HomeAssistantView):
             return self.json_message('For this entity is no config available.',
                                      HTTP_BAD_REQUEST)
         else:
-            return '{"config": ' + config + '}'
+            return self.json({'config': config})

--- a/homeassistant/components/custom_card.py
+++ b/homeassistant/components/custom_card.py
@@ -98,6 +98,7 @@ class CustomCardView(http.HomeAssistantView):
         try:
             config = self._card_configs[data['entity_id']]
         except KeyError:
-            return self.json_message('For this entity is no config available.', HTTP_BAD_REQUEST)
+            return self.json_message('For this entity is no config available.',
+                                     HTTP_BAD_REQUEST)
         else:
             return '{"config": ' + config + '}'

--- a/homeassistant/components/custom_card.py
+++ b/homeassistant/components/custom_card.py
@@ -55,11 +55,11 @@ def async_setup(hass, config):
 
         if ha_card is None and state_card is None:
             _LOGGER.error("Entity config must contain ha_card " +
-                "and/or state_card ({}).".format(object_id))
+                          "and/or state_card (%s)", object_id)
             return False
 
         entities.append(CustomCard(object_id, ha_card, state_card,
-            more_info_card, config))
+                        more_info_card, config))
 
     if not entities:
         return False
@@ -80,7 +80,7 @@ class CustomCard(Entity):
         else:
             self.entity_id = ENTITY_ID_FORMAT_STATE_CARD.format(object_id)
             self._state = state_card
-        
+
         self._attributes = {}
         if ha_card:
             self._attributes['ha_card'] = ha_card

--- a/homeassistant/components/custom_card.py
+++ b/homeassistant/components/custom_card.py
@@ -53,12 +53,13 @@ def async_setup(hass, config):
         more_info_card = cfg.get(CONF_MORE_INFO_CARD)
         config = cfg.get(CONF_CONFIG)
 
-        if ha_card == None and state_card == None:
-            _LOGGER.error("Entity config must contain ha_card and/or state_card ({}).".format(object_id))
+        if ha_card is None and state_card is None:
+            _LOGGER.error("Entity config must contain ha_card " +
+                "and/or state_card ({}).".format(object_id))
             return False
 
         entities.append(CustomCard(object_id, ha_card, state_card,
-                                    more_info_card, config))
+            more_info_card, config))
 
     if not entities:
         return False
@@ -72,7 +73,7 @@ class CustomCard(Entity):
     """Representation of a custom card."""
 
     def __init__(self, object_id, ha_card, state_card, more_info_card, config):
-        """Initialize a custom card."""        
+        """Initialize a custom card."""
         if ha_card:
             self.entity_id = ENTITY_ID_FORMAT_HA_CARD.format(object_id)
             self._state = ha_card

--- a/homeassistant/components/custom_card.py
+++ b/homeassistant/components/custom_card.py
@@ -1,5 +1,5 @@
 """
-Show custom full-cards (ha-cards) and sate-cards on Home Assistant frontend
+Show custom full-cards (ha-cards) and sate-cards on Home Assistant frontend.
 
 For more details about this component, please refer to the documentation
 at https://home-assistant.io/components/custom_card/
@@ -37,7 +37,6 @@ CONFIG_SCHEMA = vol.Schema({
 @asyncio.coroutine
 def async_setup(hass, config):
     """Initialize custom card."""
-
     card_configs = {}
 
     for object_id, cfg in config[DOMAIN].items():
@@ -86,6 +85,7 @@ class CustomCardView(http.HomeAssistantView):
     name = 'api:custom_card'
 
     def __init__(self, card_configs):
+        """Initialize a custom card view."""
         self._card_configs = card_configs
 
     @http.RequestDataValidator(vol.Schema({

--- a/homeassistant/components/custom_card.py
+++ b/homeassistant/components/custom_card.py
@@ -1,5 +1,5 @@
 """
-Show custom ha-cards and sate-cards on Home Assistant frontend
+Show custom full-cards (ha-cards) and sate-cards on Home Assistant frontend
 
 For more details about this component, please refer to the documentation
 at https://home-assistant.io/components/custom_card/
@@ -9,18 +9,15 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_component import EntityComponent
+from aiohttp import web
+from homeassistant.components import http
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = 'custom_card'
 
-ENTITY_ID_FORMAT_HA_CARD = 'custom_ha_card' + '.{}'
-ENTITY_ID_FORMAT_STATE_CARD = 'custom_state_card' + '.{}'
-
 _LOGGER = logging.getLogger(__name__)
 
-CONF_HA_CARD = 'ha_card'
+CONF_FULL_CARD = 'full_card'
 CONF_STATE_CARD = 'state_card'
 CONF_MORE_INFO_CARD = 'more_info_card'
 CONF_CONFIG = 'config'
@@ -28,7 +25,7 @@ CONF_CONFIG = 'config'
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         cv.slug: vol.Any({
-            vol.Optional(CONF_HA_CARD): cv.string,
+            vol.Optional(CONF_FULL_CARD): cv.string,
             vol.Optional(CONF_STATE_CARD): cv.string,
             vol.Optional(CONF_MORE_INFO_CARD): cv.string,
             vol.Optional(CONF_CONFIG): cv.match_all,
@@ -40,63 +37,75 @@ CONFIG_SCHEMA = vol.Schema({
 @asyncio.coroutine
 def async_setup(hass, config):
     """Initialize custom card."""
-    component = EntityComponent(_LOGGER, DOMAIN, hass)
 
-    entities = []
+    card_configs = {}
 
     for object_id, cfg in config[DOMAIN].items():
         if not cfg:
             cfg = {}
 
-        ha_card = cfg.get(CONF_HA_CARD)
+        full_card = cfg.get(CONF_FULL_CARD)
         state_card = cfg.get(CONF_STATE_CARD)
         more_info_card = cfg.get(CONF_MORE_INFO_CARD)
         config = cfg.get(CONF_CONFIG)
 
-        if ha_card is None and state_card is None:
-            _LOGGER.error("Entity config must contain ha_card " +
+        if full_card is None and state_card is None:
+            _LOGGER.error("Entity config must contain full_card " +
                           "and/or state_card (%s)", object_id)
             return False
 
-        entities.append(CustomCard(object_id, ha_card, state_card,
-                        more_info_card, config))
+        if full_card:
+            entity_id = 'custom_full_card.{}'.format(object_id)
+            state = full_card
+        else:
+            entity_id = 'custom_sate_card.{}'.format(object_id)
+            state = state_card
 
-    if not entities:
-        return False
+        attributes = {}
+        if full_card:
+            attributes['full_card'] = full_card
+        if state_card:
+            attributes['state_card'] = state_card
+        if more_info_card:
+            attributes['more_info_card'] = more_info_card
 
-    yield from component.async_add_entities(entities)
+        if config:
+            card_configs[entity_id] = config
+
+        hass.states.async_set(entity_id, state, attributes)
+        
+    hass.http.register_view(CustomCardView(card_configs))
 
     return True
 
 
-class CustomCard(Entity):
-    """Representation of a custom card."""
+class CustomCardView(http.HomeAssistantView):
+    """API to request card config."""
 
-    def __init__(self, object_id, ha_card, state_card, more_info_card, config):
-        """Initialize a custom card."""
-        if ha_card:
-            self.entity_id = ENTITY_ID_FORMAT_HA_CARD.format(object_id)
-            self._state = ha_card
+    url = '/api/custom_card'
+    name = 'api:custom_card'
+
+    def __init__(self, card_configs):
+        self._card_configs = card_configs
+
+    @http.RequestDataValidator(vol.Schema({
+        vol.Required('entity_id'): str,
+    }))
+
+    @asyncio.coroutine
+    def post(self, request, data):
+        """Handle a config request."""
+        try:
+            config = self._card_configs[data['entity_id']]
+        except KeyError:
+            res = { "config": None }
+            state = 400
         else:
-            self.entity_id = ENTITY_ID_FORMAT_STATE_CARD.format(object_id)
-            self._state = state_card
+            res = { "config": config }
+            state = 200
 
-        self._attributes = {}
-        if ha_card:
-            self._attributes['ha_card'] = ha_card
-        if state_card:
-            self._attributes['state_card'] = state_card
-        if more_info_card:
-            self._attributes['more_info_card'] = more_info_card
-        if config:
-            self._attributes['config'] = config
-
-    @property
-    def state(self):
-        """Return card as state."""
-        return self._state
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return self._attributes
+        return web.Response(
+            body = str(res),
+            status = state,
+            content_type = 'application/json',
+        )

--- a/homeassistant/components/custom_card.py
+++ b/homeassistant/components/custom_card.py
@@ -1,0 +1,95 @@
+"""
+Show custom ha-cards and sate-cards on Home Assistant frontend
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+import homeassistant.helpers.config_validation as cv
+
+DOMAIN = 'custom_card'
+
+ENTITY_ID_FORMAT_HA_CARD = 'custom_ha_card' + '.{}'
+ENTITY_ID_FORMAT_STATE_CARD = 'custom_state_card' + '.{}'
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_HA_CARD = 'ha_card'
+CONF_STATE_CARD = 'state_card'
+CONF_MORE_INFO_CARD = 'more_info_card'
+CONF_CONFIG = 'config'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        cv.slug: vol.Any({
+            vol.Optional(CONF_HA_CARD): cv.string,
+            vol.Optional(CONF_STATE_CARD): cv.string,
+            vol.Optional(CONF_MORE_INFO_CARD): cv.string,
+            vol.Optional(CONF_CONFIG): cv.match_all,
+        }, None)
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Initialize custom card."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    entities = []
+
+    for object_id, cfg in config[DOMAIN].items():
+        if not cfg:
+            cfg = {}
+
+        ha_card = cfg.get(CONF_HA_CARD)
+        state_card = cfg.get(CONF_STATE_CARD)
+        more_info_card = cfg.get(CONF_MORE_INFO_CARD)
+        config = cfg.get(CONF_CONFIG)
+        entities.append(CustomCard(object_id, ha_card, state_card, more_info_card, config))
+
+
+    if not entities:
+        return False    
+
+    yield from component.async_add_entities(entities)
+
+    return True
+
+class CustomCard(Entity):
+    """Representation of a custom card."""
+
+    def __init__(self, object_id, ha_card, state_card, more_info_card, config):
+        """Initialize a boolean input."""
+        self._ha_card = ha_card
+        self._state_card = state_card
+        if self._ha_card:
+            self.entity_id = ENTITY_ID_FORMAT_HA_CARD.format(object_id)
+        else:
+            self.entity_id = ENTITY_ID_FORMAT_STATE_CARD.format(object_id)
+        self._more_info_card = more_info_card
+        self._config = config
+
+    @property
+    def state(self):
+        """Return card as state."""
+        if self._ha_card:
+            return self._ha_card
+        return self._state_card
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        _attributes = {}
+        if self._ha_card:
+            _attributes['ha_card'] = self._ha_card
+        if self._state_card:
+            _attributes['state_card'] = self._state_card
+        if self._more_info_card:
+            _attributes['more_info_card'] = self._more_info_card
+        if self._config:
+            _attributes['config'] = self._config
+        return _attributes

--- a/homeassistant/components/custom_card.py
+++ b/homeassistant/components/custom_card.py
@@ -73,7 +73,7 @@ def async_setup(hass, config):
             card_configs[entity_id] = config
 
         hass.states.async_set(entity_id, state, attributes)
-        
+
     hass.http.register_view(CustomCardView(card_configs))
 
     return True
@@ -91,21 +91,20 @@ class CustomCardView(http.HomeAssistantView):
     @http.RequestDataValidator(vol.Schema({
         vol.Required('entity_id'): str,
     }))
-
     @asyncio.coroutine
     def post(self, request, data):
         """Handle a config request."""
         try:
             config = self._card_configs[data['entity_id']]
         except KeyError:
-            res = { "config": None }
+            res = {"config": None}
             state = 400
         else:
-            res = { "config": config }
+            res = {"config": config}
             state = 200
 
         return web.Response(
-            body = str(res),
-            status = state,
-            content_type = 'application/json',
+            body=str(res),
+            status=state,
+            content_type='application/json',
         )

--- a/tests/components/test_custom_card.py
+++ b/tests/components/test_custom_card.py
@@ -1,0 +1,86 @@
+"""The tests the custom cards component."""
+# pylint: disable=protected-access
+import asyncio
+import unittest
+import logging
+
+from homeassistant.core import CoreState, State
+from homeassistant.setup import setup_component, async_setup_component
+from homeassistant.components.custom_card import DOMAIN
+
+from tests.common import get_test_home_assistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TestCustomCard(unittest.TestCase):
+    """Test the custom card module."""
+
+    # pylint: disable=invalid-name
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    # pylint: disable=invalid-name
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_config(self):
+        """Test config."""
+        invalid_configs = [
+            None,
+            1,
+            {},
+            {'name with space': None},
+            {'noCardsDefined': None},
+            {'moreInfoOnly': {'more_info_card': 'test-card'}},
+        ]
+
+        for cfg in invalid_configs:
+            self.assertFalse(
+                setup_component(self.hass, DOMAIN, {DOMAIN: cfg}))
+
+
+    def test_config_options(self):
+        """Test configuration options."""
+        count_start = len(self.hass.states.entity_ids())
+
+        _LOGGER.debug('ENTITIES @ start: %s', self.hass.states.entity_ids())
+
+        self.assertTrue(setup_component(self.hass, DOMAIN, {DOMAIN: {
+            'test_1': {
+                'full_card': 'full-card',
+            },
+            'test_2': {
+                'state_card': 'state-card',                
+            },
+            'test_3': {
+                'full_card': 'full-card',
+                'state_card': 'state-card',
+                'more_info_card': 'more-info-card',
+            },
+        }}))
+
+        _LOGGER.debug('ENTITIES: %s', self.hass.states.entity_ids())
+
+        self.assertEqual(count_start + 3, len(self.hass.states.entity_ids()))
+
+        state_1 = self.hass.states.get('custom_card.test_1')
+        state_2 = self.hass.states.get('custom_card.test_2')
+        state_3 = self.hass.states.get('custom_card.test_3')
+
+        self.assertIsNotNone(state_1)
+        self.assertIsNotNone(state_2)
+        self.assertIsNotNone(state_3)
+
+        self.assertEqual('full-card', state_1.state)
+        self.assertEqual('state-card', state_2.state)
+        self.assertEqual('full-card', state_3.state)
+
+        self.assertEqual('full-card',
+                         state_3.attributes.get('full_card'))
+        self.assertEqual('state-card',
+                         state_3.attributes.get('state_card'))                         
+        self.assertEqual('more-info-card',
+                         state_3.attributes.get('more_info_card'))

--- a/tests/components/test_custom_card.py
+++ b/tests/components/test_custom_card.py
@@ -63,9 +63,9 @@ class TestCustomCard(unittest.TestCase):
 
         self.assertEqual(count_start + 3, len(self.hass.states.entity_ids()))
 
-        state_1 = self.hass.states.get('custom_card.test_1')
-        state_2 = self.hass.states.get('custom_card.test_2')
-        state_3 = self.hass.states.get('custom_card.test_3')
+        state_1 = self.hass.states.get('custom_full_card.test_1')
+        state_2 = self.hass.states.get('custom_state_card.test_2')
+        state_3 = self.hass.states.get('custom_full_card.test_3')
 
         self.assertIsNotNone(state_1)
         self.assertIsNotNone(state_2)
@@ -75,9 +75,9 @@ class TestCustomCard(unittest.TestCase):
         self.assertEqual('state-card', state_2.state)
         self.assertEqual('full-card', state_3.state)
 
-        self.assertEqual('custom_ui_full-card',
-                         state_3.attributes.get('full_card'))
-        self.assertEqual('custom_ui_state-card',
-                         state_3.attributes.get('state_card'))
-        self.assertEqual('custom_ui_more-info-card',
-                         state_3.attributes.get('more_info_card'))
+        self.assertEqual('full-card',
+                         state_3.attributes.get('custom_ui_full_card'))
+        self.assertEqual('state-card',
+                         state_3.attributes.get('custom_ui_state_card'))
+        self.assertEqual('more-info-card',
+                         state_3.attributes.get('custom_ui_more_info_card'))

--- a/tests/components/test_custom_card.py
+++ b/tests/components/test_custom_card.py
@@ -1,11 +1,9 @@
 """The tests the custom cards component."""
 # pylint: disable=protected-access
-import asyncio
 import unittest
 import logging
 
-from homeassistant.core import CoreState, State
-from homeassistant.setup import setup_component, async_setup_component
+from homeassistant.setup import setup_component
 from homeassistant.components.custom_card import DOMAIN
 
 from tests.common import get_test_home_assistant
@@ -41,7 +39,6 @@ class TestCustomCard(unittest.TestCase):
             self.assertFalse(
                 setup_component(self.hass, DOMAIN, {DOMAIN: cfg}))
 
-
     def test_config_options(self):
         """Test configuration options."""
         count_start = len(self.hass.states.entity_ids())
@@ -53,7 +50,7 @@ class TestCustomCard(unittest.TestCase):
                 'full_card': 'full-card',
             },
             'test_2': {
-                'state_card': 'state-card',                
+                'state_card': 'state-card',
             },
             'test_3': {
                 'full_card': 'full-card',
@@ -78,9 +75,9 @@ class TestCustomCard(unittest.TestCase):
         self.assertEqual('state-card', state_2.state)
         self.assertEqual('full-card', state_3.state)
 
-        self.assertEqual('full-card',
+        self.assertEqual('custom_ui_full-card',
                          state_3.attributes.get('full_card'))
-        self.assertEqual('state-card',
-                         state_3.attributes.get('state_card'))                         
-        self.assertEqual('more-info-card',
+        self.assertEqual('custom_ui_state-card',
+                         state_3.attributes.get('state_card'))
+        self.assertEqual('custom_ui_more-info-card',
                          state_3.attributes.get('more_info_card'))


### PR DESCRIPTION
## Description:
Show custom ha-cards and sate-cards on Home Assistant frontend (custom ui)

For more details or discussion please check the frontend PR.

Frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/831
Docs PR: https://github.com/home-assistant/home-assistant.github.io/pull/4552

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.