### PR TITLE
Respond to Alexa scene activation correctly

### DIFF
--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -739,7 +739,9 @@ def test_api_activate(hass, domain):
 
     assert len(call) == 1
     assert call[0].data['entity_id'] == '{}.test'.format(domain)
-    assert msg['header']['name'] == 'Response'
+    assert msg['header']['name'] == 'ActivationStarted'
+    assert msg['payload']['cause']['type'] == 'VOICE_INTERACTION'
+    assert 'timestamp' in msg['payload']
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

The [API documentation][1] specifies that Alexa.SceneController Activate
must get a ActivationStarted response. Responding with just a `Response`
will elicit a "Hmm... $scene is not responding" from Alexa.

[1]: https://developer.amazon.com/docs/smarthome/provide-scenes-in-a-smart-home-skill.html

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
