### PR TITLE
broadlink support new devices, add send_by_id

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -43,7 +43,7 @@ RM_TYPES = ['rm', 'rm2', 'rm_mini', 'rm_pro_phicomm', 'rm2_home_plus',
             'rm2_home_plus_gdt', 'rm2_pro_plus', 'rm2_pro_plus2',
             'rm2_pro_plus_bl', 'rm_mini_shate', 'rm_mini_3']
 SP1_TYPES = ['sp1']
-SP2_TYPES = ['sp2', 'honeywell_sp2', 'sp3', 'spmini2', 'spminiplus', 'sp3mini']
+SP2_TYPES = ['sp2', 'honeywell_sp2', 'sp3', 'spmini2', 'spminiplus', 'spmini3']
 MP1_TYPES = ['mp1']
 
 SWITCH_TYPES = RM_TYPES + SP1_TYPES + SP2_TYPES + MP1_TYPES
@@ -73,6 +73,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 SAVE_PATH = 'known_packets.json'
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Broadlink switches."""
@@ -140,7 +141,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     @asyncio.coroutine
     def _send_packet_by_id(call):
-        """Send a packet by id in file """
+        """Send a packet by id in file."""
         try:
             auth = yield from hass.async_add_job(broadlink_device.auth)
         except socket.timeout:
@@ -158,16 +159,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 if each_id == packet_id:
                     payload = b64decode(each_data)
                     yield from hass.async_add_job(
-                                broadlink_device.send_data, payload)
+                        broadlink_device.send_data, payload)
                     _LOGGER.info("Send '%s' successfully.", packet_id)
                     return
             _LOGGER.error("Cannot find %s in %s.", packet_id, SAVE_PATH)
         else:
             _LOGGER.error("Need the 'packet_id' in body.")
 
-    '''auto save the packet when packet_id is set'''
+    """Auto save the packet when packet_id is set"""
     def _save_packet(call, data, title):
-        """save a packet by id in file """
+        """Save a packet by id in file."""
         packet_id = call.data.get(CONF_PACKET_ID)
         path = hass.config.path(SAVE_PATH)
         if packet_id:

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -178,7 +178,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 fs.close()
             _LOGGER.info("Save packet to 'known_packets.yaml' by id:"+packet_id)
             title = title + " and Saved"
-
         hass.components.persistent_notification.async_create(
         data, title=title)
 

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -166,9 +166,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         else:
             _LOGGER.error("Need the 'packet_id' in body.")
 
-    '''Auto save the packet when packet_id is set'''
     def _save_packet(call, data, title):
-        """Save a packet by id in file."""
+        """Save a packet by id in file  when packet_id is set."""
         packet_id = call.data.get(CONF_PACKET_ID)
         path = hass.config.path(SAVE_PATH)
         if packet_id:

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -39,9 +39,9 @@ CONF_SLOTS = 'slots'
 
 RM_TYPES = ['rm', 'rm2', 'rm_mini', 'rm_pro_phicomm', 'rm2_home_plus',
             'rm2_home_plus_gdt', 'rm2_pro_plus', 'rm2_pro_plus2',
-            'rm2_pro_plus_bl', 'rm_mini_shate','rm_mini_3']
+            'rm2_pro_plus_bl', 'rm_mini_shate', 'rm_mini_3']
 SP1_TYPES = ['sp1']
-SP2_TYPES = ['sp2', 'honeywell_sp2', 'sp3', 'spmini2', 'spminiplus','sp3mini']
+SP2_TYPES = ['sp2', 'honeywell_sp2', 'sp3', 'spmini2', 'spminiplus', 'sp3mini']
 MP1_TYPES = ['mp1']
 
 SWITCH_TYPES = RM_TYPES + SP1_TYPES + SP2_TYPES + MP1_TYPES
@@ -108,7 +108,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 data = format(b64encode(packet).decode('utf8'))
                 log_msg = "Recieved packet is: " + data
                 _LOGGER.info(log_msg)
-                _save_packet(call,data,title)
+                _save_packet(call, data, title)
                 return
             yield from asyncio.sleep(1, loop=hass.loop)
         _LOGGER.error("Did not received any signal")
@@ -148,7 +148,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if not auth:
             _LOGGER.error("Failed to connect to device")
             return
-        
+
         packet_id = call.data.get('packet_id')
         if packet_id:
             with open(SAVE_PATH, 'r') as fs:
@@ -166,7 +166,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             _LOGGER.error("Need the 'packet_id' in body.")
 
     '''auto save the packet when packet_id is set'''
-    def _save_packet(call,data,title):
+    def _save_packet(call, data, title):
         """save a packet by id in known_packets.yaml """
         packet_id = call.data.get('packet_id')
         if packet_id:
@@ -178,7 +178,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 fs.close()
             _LOGGER.info("Save packet to 'known_packets.yaml' by id:"+packet_id)
             title = title + " and Saved"
-        
+
         hass.components.persistent_notification.async_create(
         data, title=title)
 
@@ -198,7 +198,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         hass.services.register(DOMAIN, device_id + '_' +
                                SERVICE_SEND, _send_packet)
         hass.services.register(DOMAIN, device_id + '_' +
-                               SERVICE_SEND_BY_ID , _send_packet_by_id)
+                               SERVICE_SEND_BY_ID, _send_packet_by_id)
         switches = []
         for object_id, device_config in devices.items():
             switches.append(
@@ -265,7 +265,7 @@ class BroadlinkRMSwitch(SwitchDevice):
         """Return true if device is on."""
         self.update()
         return self._state
-    
+
     def update(self):
         """Synchronize state with switch."""
         pass

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -166,7 +166,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         else:
             _LOGGER.error("Need the 'packet_id' in body.")
 
-    """Auto save the packet when packet_id is set"""
+    '''Auto save the packet when packet_id is set'''
     def _save_packet(call, data, title):
         """Save a packet by id in file."""
         packet_id = call.data.get(CONF_PACKET_ID)

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 from homeassistant.util.dt import utcnow
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.json import load_json, save_json
 
 REQUIREMENTS = ['broadlink==0.5']
@@ -153,12 +154,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         path = hass.config.path(SAVE_PATH)
         if packet_id:
             packets = _load_packets(path)
-            for each_id,each_data in packets.items():
+            for each_id, each_data in packets.items():
                 if each_id == packet_id:
                     payload = b64decode(each_data)
                     yield from hass.async_add_job(
                                 broadlink_device.send_data, payload)
-                    _LOGGER.info("Send '%s' successfully.",packet_id)
+                    _LOGGER.info("Send '%s' successfully.", packet_id)
                     return
             _LOGGER.error("Cannot find %s in %s.", packet_id, SAVE_PATH)
         else:

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -10,7 +10,6 @@ import binascii
 from datetime import timedelta
 import logging
 import socket
-import os
 
 import voluptuous as vol
 
@@ -70,8 +69,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int
 })
 
-SAVE_PATH = os.path.expanduser('~')+'/.homeassistant/known_packets.yaml'
-
+SAVE_PATH = 'known_packets.yaml'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Broadlink switches."""
@@ -150,8 +148,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             return
 
         packet_id = call.data.get('packet_id')
+        path = hass.config.path(SAVE_PATH)
         if packet_id:
-            with open(SAVE_PATH, 'r') as fs:
+            with open(path, 'r') as fs:
                 for line in fs:
                     if line[:line.index(': ')] == str(packet_id):
                         packet = line[line.index(': ') + 2:line.index('  ')]
@@ -169,8 +168,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     def _save_packet(call, data, title):
         """save a packet by id in known_packets.yaml """
         packet_id = call.data.get('packet_id')
+        path = hass.config.path(SAVE_PATH)
         if packet_id:
-            with open(SAVE_PATH, 'a+') as fs:
+            with open(path, 'a+') as fs:
                 fs.write(packet_id)
                 fs.write(': ')
                 fs.write(str(data))
@@ -263,12 +263,7 @@ class BroadlinkRMSwitch(SwitchDevice):
     @property
     def is_on(self):
         """Return true if device is on."""
-        self.update()
         return self._state
-
-    def update(self):
-        """Synchronize state with switch."""
-        pass
 
     def turn_on(self, **kwargs):
         """Turn the device on."""


### PR DESCRIPTION
recently i bougt two broadlink devices ,the `rm_mini_3` and `sp3mini`. so i did some modified on `broadlink.py` and those code works well on my local Raspi server

## Description: 

1. add devices support for `rm_mini_3` and `sp3mini`
2. regist service with `friendly_name` if exist
3. save packet in `known_packets.yaml` when call `SERVICE_LEARN` with `packet_id`
4. regist a NEW service `SERVICE_SEND_BY_ID` for quickly send packet
5. fix `is_on(self)` never call `update(self)` even reboot

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4505

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: broadlink
    friendly_name: 'IRcontroler'
    host: 10.10.10.200 
    mac: '34:ea:34:00:00:00'
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
