### PR TITLE
Fix for hive aux_heat target temperature display

### DIFF
--- a/homeassistant/components/hive.py
+++ b/homeassistant/components/hive.py
@@ -12,7 +12,7 @@ from homeassistant.const import (CONF_PASSWORD, CONF_SCAN_INTERVAL,
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 
-REQUIREMENTS = ['pyhiveapi==0.2.10']
+REQUIREMENTS = ['pyhiveapi==0.2.11']
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'hive'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -723,7 +723,7 @@ pyharmony==1.0.18
 pyhik==0.1.4
 
 # homeassistant.components.hive
-pyhiveapi==0.2.10
+pyhiveapi==0.2.11
 
 # homeassistant.components.homematic
 pyhomematic==0.1.37


### PR DESCRIPTION
## Description:
Update the `pyhiveapi` library version from `0.2.10` to `0.2.11`
Fixes a bug where turning on the `Aux Heat` would not return the correct new target temperature, even though functionally it had changed

This fix is just an update to the library version, and the only update to the library is a fix to return the correct target temperature when `Aux Heat` is turned on

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
N/A

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
