### PR TITLE
python-miio remote.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -510,6 +510,7 @@ omit =
     homeassistant/components/remember_the_milk/__init__.py
     homeassistant/components/remote/harmony.py
     homeassistant/components/remote/itach.py
+    homeassistant/components/remote/xiaomi_miio.py
     homeassistant/components/scene/hunterdouglas_powerview.py
     homeassistant/components/scene/lifx_cloud.py
     homeassistant/components/sensor/airvisual.py

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -57,8 +57,8 @@ xiaomi_miio_learn_command:
       description: 'Name of the entity to learn command from.'
       example: 'remote.xiaomi_miio'
     slot:
-      description: 'Define the slot used to save the IR command (Value from 1 to 1000000) (Default: 1)'
-      example: '"slot": 1'
+      description: 'Define the slot used to save the IR command (Value from 1 to 1000000)'
+      example: '1'
     timeout:
-      description: 'Define the timeout in seconds, before which the command must be learned. (Default: 10)'
-      example: '"timeout": 30'
+      description: 'Define the timeout in seconds, before which the command must be learned.'
+      example: '30'

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -49,3 +49,16 @@ harmony_sync:
     entity_id:
       description: Name(s) of entities to sync.
       example: 'remote.family_room'
+
+xiaomi_miio_learn_command:
+  description: 'Learn an IR command, press "Call Service", point the remote at the IR device, and the learned command will be shown as a notification in Overview.'
+  fields:
+    entity_id:
+      description: 'Name of the entity to learn command from.'
+      example: 'remote.xiaomi_miio'
+    slot:
+      description: 'Define the slot used to save the IR command (Value from 1 to 1000000) (Default: 1)'
+      example: '"slot": 1'
+    timeout:
+      description: 'Define the timeout in seconds, before which the command must be learned. (Default: 10)'
+      example: '"timeout": 30'

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -188,8 +188,8 @@ class XiaomiMiioRemote(Entity):
             return False
 
     @property
-    def should_poll(self)
-        """We should be polled for device up state"""
+    def should_poll(self):
+        """We should be polled for device up state."""
         return True
 
     @property
@@ -238,4 +238,4 @@ class XiaomiMiioRemote(Entity):
                         yield from self._send_command(local_payload)
                 else:
                     yield from self._send_command(payload)
-                yield from asyncio.sleep(delay, loop=hass.loop)
+                yield from asyncio.sleep(delay, loop=self.hass.loop)

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.dt import utcnow
 
-REQUIREMENTS = ['python-miio==0.3.5']
+REQUIREMENTS = ['python-miio==0.3.4']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -234,12 +234,10 @@ class XiaomiMiioRemote(RemoteDevice):
         _LOGGER.debug("Sending payload: '%s'", payload)
         try:
             self.device.play(payload)
-            return True
         except DeviceException as ex:
             _LOGGER.error(
                 "Transmit of IR command failed, %s, exception: %s",
                 payload, ex)
-            return False
 
     def send_command(self, command, **kwargs):
         """Wrapper for _send_command."""

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -106,9 +106,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             return
 
         entity_id = service.data.get(ATTR_ENTITY_ID)
-
         entity = None
-
         for remote in hass.data[PLATFORM].values():
             if remote.entity_id == entity_id:
                 entity = remote
@@ -131,17 +129,20 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             message = yield from hass.async_add_job(
                 device.read, slot)
             _LOGGER.debug("Message recieved from device: '%s'", message)
+
             if 'code' in message and message['code']:
-                log_msg = "Received command is: {}".\
-                          format(message['code'])
+                log_msg = "Received command is: {}".format(message['code'])
                 _LOGGER.info(log_msg)
                 hass.components.persistent_notification.async_create(
                     log_msg, title='Xiaomi Miio Remote')
                 return
+
             if ('error' in message and
                     message['error']['message'] == "learn timeout"):
                 yield from hass.async_add_job(device.learn, slot)
+
             yield from asyncio.sleep(1, loop=hass.loop)
+
         _LOGGER.error("Timeout. No infrared command captured")
         hass.components.persistent_notification.async_create(
             "Timeout. No infrared command captured",
@@ -216,10 +217,16 @@ class XiaomiMiioRemote(Entity):
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the device on."""
+        _LOGGER.error("Device does not support turn_on, " +
+                      "please use remote.send_command, to send commands.")
+        pass
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the device off."""
+        _LOGGER.error("Device does not support turn_off, " +
+                      "please use remote.send_command, to send commands.")
+        pass
 
     @asyncio.coroutine
     def _send_command(self, payload):

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -2,7 +2,7 @@
 Support for the Xiaomi IR Remote (Chuangmi IR).
 
 For more details about this platform, please refer to the documentation
-https://home-assistant.io/components/ir_remote.xiaomi_miio/
+https://home-assistant.io/components/remote.xiaomi_miio/
 """
 import asyncio
 import logging
@@ -103,6 +103,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         """Handle a learn command."""
         entity_id = call.data.get('entity_id').split('.')[1]
 
+        if entity_id not in hass.data[PLATFORM]:
+            _LOGGER.error("entity_id: '%s' not found", entity_id)
+            return
+
         entity = hass.data[PLATFORM][entity_id]
 
         device = entity.device
@@ -202,7 +206,7 @@ class XiaomiMiioRemote(Entity):
 
     @asyncio.coroutine
     def _send_command(self, payload):
-        """Send a packet."""
+        """Send a command."""
         from miio import DeviceException
 
         _LOGGER.debug("Sending payload: '%s'", payload)

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -232,19 +232,19 @@ class XiaomiMiioRemote(RemoteDevice):
         """Send a command."""
         from miio import DeviceException
 
-        if ':' in payload:
+        if ':' in payload and len(payload.split(':')) >= 2:
             command_list = payload.split(':')
             command_type = command_list[0]
             command = command_list[1]
             if len(command_list) == 3:
-                command_optional = command_list[3]
+                command_optional = command_list[2]
             else:
                 command_optional = None
 
             _LOGGER.debug("Sending command: '%s'", command)
             if command_type == 'raw':
                 try:
-                    self.device.play(command, command_optional)
+                    self.device.play(command, int(command_optional))
                     return True
                 except DeviceException as ex:
                     _LOGGER.error(
@@ -254,7 +254,8 @@ class XiaomiMiioRemote(RemoteDevice):
             if command_type == 'pronto':
                 try:
                     self.device.play_pronto(command,
-                                            repeats=(command_optional or 0))
+                                            repeats=int((
+                                                command_optional or 0)))
                     return True
                 except DeviceException as ex:
                     _LOGGER.error(

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -204,7 +204,7 @@ class XiaomiMiioRemote(Entity):
     @property
     def should_poll(self):
         """We should be polled for device up state."""
-        return True
+        return False
 
     @property
     def device_state_attributes(self):
@@ -214,20 +214,20 @@ class XiaomiMiioRemote(Entity):
         else:
             return
 
+    # pylint: disable=R0201
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the device on."""
         _LOGGER.error("Device does not support turn_on, " +
                       "please use remote.send_command, to send commands.")
-        pass
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the device off."""
         _LOGGER.error("Device does not support turn_off, " +
                       "please use remote.send_command, to send commands.")
-        pass
 
+    # pylint: enable=R0201
     @asyncio.coroutine
     def _send_command(self, payload):
         """Send a command."""

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -214,20 +214,22 @@ class XiaomiMiioRemote(Entity):
         else:
             return
 
-    # pylint: disable=R0201
+    # pylint: disable=R0201, W0107
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the device on."""
         _LOGGER.error("Device does not support turn_on, " +
                       "please use remote.send_command, to send commands.")
+        pass
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the device off."""
         _LOGGER.error("Device does not support turn_off, " +
                       "please use remote.send_command, to send commands.")
+        pass
 
-    # pylint: enable=R0201
+    # pylint: enable=R0201, W0107
     @asyncio.coroutine
     def _send_command(self, payload):
         """Send a command."""

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -1,0 +1,227 @@
+"""
+Support for the Xiaomi IR Remote (Chuangmi IR).
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/ir_remote.xiaomi_miio/
+"""
+import asyncio
+import logging
+
+from datetime import timedelta
+
+import voluptuous as vol
+
+import homeassistant.components.remote as remote
+from homeassistant.helpers.entity import Entity
+from homeassistant.const import (
+    CONF_NAME, CONF_HOST, CONF_TOKEN, CONF_TIMEOUT,
+    ATTR_ENTITY_ID, ATTR_HIDDEN, CONF_COMMAND)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util.dt import utcnow
+
+REQUIREMENTS = ['python-miio==0.3.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_LEARN = 'xiaomi_miio_learn_command'
+SERVICE_SEND = 'xiaomi_miio_send_command'
+PLATFORM = 'python_miio'
+
+CONF_SLOT = 'slot'
+CONF_COMMANDS = 'commands'
+
+DEFAULT_TIMEOUT = 10
+DEFAULT_SLOT = 1
+
+LEARN_COMMAND_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=10):
+        vol.All(int, vol.Range(min=0)),
+    vol.Optional(CONF_SLOT, default=1):
+        vol.All(int, vol.Range(min=1, max=1000000)),
+})
+
+COMMAND_SCHEMA = vol.Schema({
+    vol.Required(CONF_COMMAND): cv.ensure_list
+    })
+
+PLATFORM_SCHEMA = remote.PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=10):
+        vol.All(int, vol.Range(min=0)),
+    vol.Optional(CONF_SLOT, default=1):
+        vol.All(int, vol.Range(min=1, max=1000000)),
+    vol.Optional(ATTR_HIDDEN, default=True): cv.boolean,
+    vol.Required(CONF_TOKEN): vol.All(str, vol.Length(min=32, max=32)),
+    vol.Optional(CONF_COMMANDS, default={}):
+        vol.Schema({cv.slug: COMMAND_SCHEMA}),
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Xiaomi IR Remote (Chuangmi IR) platform."""
+    from miio import ChuangmiIr
+    from construct import ChecksumError
+
+    host = config.get(CONF_HOST)
+    token = config.get(CONF_TOKEN)
+
+    # Create handler
+    _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
+    device = ChuangmiIr(host, token)
+
+    try:
+        device.info()
+
+    # This should be DeviceError but python-miio returns wrong except.
+    except ChecksumError as ex:
+        _LOGGER.error("Token not accepted by device : %s", ex)
+        return
+
+    if PLATFORM not in hass.data:
+        hass.data[PLATFORM] = {}
+
+    entity_id = config.get(CONF_NAME, "xiaomi_miio_" +
+                           host.replace('.', '_'))
+    slot = config.get(CONF_SLOT)
+    timeout = config.get(CONF_TIMEOUT)
+
+    hidden = config.get(ATTR_HIDDEN)
+
+    xiaomi_miio_remote = XiaomiMiioRemote(
+        entity_id, device, slot, timeout, hidden, config.get(CONF_COMMANDS))
+
+    hass.data[PLATFORM][
+        entity_id.replace(' ', '_').lower()] = xiaomi_miio_remote
+
+    async_add_devices([xiaomi_miio_remote])
+
+    @asyncio.coroutine
+    def _learn_command(call):
+        """Handle a learn command."""
+        entity_id = call.data.get('entity_id').split('.')[1]
+
+        entity = hass.data[PLATFORM][entity_id]
+
+        device = entity.device
+
+        slot = call.data.get(CONF_SLOT, entity.slot)
+
+        yield from hass.async_add_job(device.learn, slot)
+
+        timeout = call.data.get(CONF_TIMEOUT, entity.timeout)
+
+        _LOGGER.info("Press the key you want Home Assistant to learn")
+        start_time = utcnow()
+        while (utcnow() - start_time) < timedelta(seconds=timeout):
+            command = yield from hass.async_add_job(
+                device.read, slot)
+            if command['code']:
+                log_msg = "Received command is: {}".\
+                          format(command['code'])
+                _LOGGER.info(log_msg)
+                hass.components.persistent_notification.async_create(
+                    log_msg, title='Xiaomi Miio Remote')
+                return
+            yield from asyncio.sleep(1, loop=hass.loop)
+        _LOGGER.error("Timeout. No infrared command captured")
+        hass.components.persistent_notification.async_create(
+            "Timeout. No infrared command captured",
+            title='Xiaomi Miio Remote')
+
+    hass.services.async_register(remote.DOMAIN, SERVICE_LEARN, _learn_command,
+                                 schema=LEARN_COMMAND_SCHEMA)
+
+
+class XiaomiMiioRemote(Entity):
+    """Representation of a Xiaomi Miio Remote device."""
+
+    def __init__(self, friendly_name, device,
+                 slot, timeout, hidden, commands):
+        """Initialize the remote."""
+        self._name = friendly_name
+        self._device = device
+        self._is_hidden = hidden
+        self._slot = slot
+        self._timeout = timeout
+        self._state = False
+        self._commands = commands
+
+    @property
+    def name(self):
+        """Return the name of the remote."""
+        return self._name
+
+    @property
+    def device(self):
+        """Return the remote object."""
+        return self._device
+
+    @property
+    def hidden(self):
+        """Return if we should hide entity."""
+        return self._is_hidden
+
+    @property
+    def slot(self):
+        """Return the slot to save learned command."""
+        return self._slot
+
+    @property
+    def timeout(self):
+        """Return the timeout for learning command."""
+        return self._timeout
+
+    @property
+    def is_on(self):
+        """Return False if device is unreachable, else True."""
+        from miio import DeviceException
+        try:
+            self.device.info()
+            return True
+        except DeviceException:
+            return False
+
+    @property
+    def device_state_attributes(self):
+        """Hide remote by default."""
+        if self._is_hidden:
+            return {'hidden': 'true'}
+        else:
+            return
+
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+
+    @asyncio.coroutine
+    def _send_command(self, payload):
+        """Send a packet."""
+        from miio import DeviceException
+
+        _LOGGER.debug("Sending payload: '%s'", payload)
+        try:
+            yield from self.hass.async_add_job(
+                self.device.play, payload, None)
+            return True
+        except DeviceException as e:
+            _LOGGER.error(
+                "Transmit of IR command failed, %s, exception: %s",
+                payload, e)
+            return False
+
+    @asyncio.coroutine
+    def async_send_command(self, command, **kwargs):
+        """Wrapper for _send_command."""
+        for payload in command:
+            if payload in self._commands:
+                for local_payload in self._commands[payload][CONF_COMMAND]:
+                    yield from self._send_command(local_payload)
+            else:
+                yield from self._send_command(payload)

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -210,10 +210,10 @@ class XiaomiMiioRemote(Entity):
             yield from self.hass.async_add_job(
                 self.device.play, payload, None)
             return True
-        except DeviceException as e:
+        except DeviceException as ex:
             _LOGGER.error(
                 "Transmit of IR command failed, %s, exception: %s",
-                payload, e)
+                payload, ex)
             return False
 
     @asyncio.coroutine

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.dt import utcnow
 
-REQUIREMENTS = ['python-miio==0.3.4']
+REQUIREMENTS = ['python-miio==0.3.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -232,43 +232,15 @@ class XiaomiMiioRemote(RemoteDevice):
         """Send a command."""
         from miio import DeviceException
 
-        if ':' in payload and len(payload.split(':')) >= 2:
-            command_list = payload.split(':')
-            command_type = command_list[0]
-            command = command_list[1]
-            if len(command_list) == 3:
-                command_optional = command_list[2]
-            else:
-                command_optional = None
-
-            _LOGGER.debug("Sending command: '%s'", command)
-            if command_type == 'raw':
-                try:
-                    self.device.play(command, int(command_optional))
-                    return True
-                except DeviceException as ex:
-                    _LOGGER.error(
-                        "Transmit of IR command failed, %s, exception: %s",
-                        payload, ex)
-                    return False
-            if command_type == 'pronto':
-                try:
-                    self.device.play_pronto(command,
-                                            repeats=int((
-                                                command_optional or 0)))
-                    return True
-                except DeviceException as ex:
-                    _LOGGER.error(
-                        "Transmit of IR command failed, %s, exception: %s",
-                        payload, ex)
-                    return False
-            _LOGGER.error("command_type: '%s' not supported", command_type)
+        _LOGGER.debug("Sending payload: '%s'", payload)
+        try:
+            self.device.play(payload, None)
+            return True
+        except DeviceException as ex:
+            _LOGGER.error(
+                "Transmit of IR command failed, %s, exception: %s",
+                payload, ex)
             return False
-
-        _LOGGER.error("command: '%s' is not the correct format, " +
-                      "format should be " +
-                      "command_type:command[:command_optional]", payload)
-        return False
 
     def send_command(self, command, **kwargs):
         """Wrapper for _send_command."""

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -203,7 +203,7 @@ class XiaomiMiioRemote(Entity):
 
     @property
     def should_poll(self):
-        """We should be polled for device up state."""
+        """We should not be polled for device up state."""
         return False
 
     @property
@@ -214,22 +214,20 @@ class XiaomiMiioRemote(Entity):
         else:
             return
 
-    # pylint: disable=R0201, W0107
+    # pylint: disable=R0201
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn the device on."""
         _LOGGER.error("Device does not support turn_on, " +
-                      "please use remote.send_command, to send commands.")
-        pass
+                      "please use 'remote.send_command' to send commands.")
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Turn the device off."""
         _LOGGER.error("Device does not support turn_off, " +
-                      "please use remote.send_command, to send commands.")
-        pass
+                      "please use 'remote.send_command' to send commands.")
 
-    # pylint: enable=R0201, W0107
+    # pylint: enable=R0201
     @asyncio.coroutine
     def _send_command(self, payload):
         """Send a command."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -918,6 +918,7 @@ python-juicenet==0.0.5
 
 # homeassistant.components.fan.xiaomi_miio
 # homeassistant.components.light.xiaomi_miio
+# homeassistant.components.remote.xiaomi_miio
 # homeassistant.components.switch.xiaomi_miio
 # homeassistant.components.vacuum.xiaomi_miio
 python-miio==0.3.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -918,11 +918,9 @@ python-juicenet==0.0.5
 
 # homeassistant.components.fan.xiaomi_miio
 # homeassistant.components.light.xiaomi_miio
+# homeassistant.components.remote.xiaomi_miio
 # homeassistant.components.switch.xiaomi_miio
 # homeassistant.components.vacuum.xiaomi_miio
-python-miio==0.3.5
-
-# homeassistant.components.remote.xiaomi_miio
 python-miio==0.3.5
 
 # homeassistant.components.media_player.mpd

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -918,9 +918,11 @@ python-juicenet==0.0.5
 
 # homeassistant.components.fan.xiaomi_miio
 # homeassistant.components.light.xiaomi_miio
-# homeassistant.components.remote.xiaomi_miio
 # homeassistant.components.switch.xiaomi_miio
 # homeassistant.components.vacuum.xiaomi_miio
+python-miio==0.3.5
+
+# homeassistant.components.remote.xiaomi_miio
 python-miio==0.3.5
 
 # homeassistant.components.media_player.mpd


### PR DESCRIPTION
## Description:
Original PR: https://github.com/home-assistant/home-assistant/pull/11856

I ended up changing the code so much that I'm pretty sure it warrants a new PR.

This implements the ChuangmiIr device from python-miio as a remote device.

It adds a new service called: remote.xiaomi_miio_learn_command which takes an entity_id of the device to learn commands from.

A service call to remote.send_command can either be one of the commands from config by name or a base64 command directly.

The reason for defaulting to hide the entity, is that it really just acts as a "bridge" to send commands from, so there is no reason to expose it in the UI by default.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4513

## Example entry for `configuration.yaml` (if applicable):
```yaml
remote:
  - platform: xiaomi_miio
    name: "some nice name" (Optional)
    host: [ip]
    token: [token]
    slot: 1 (Optional)
    timeout: 30 (Optional)
    hidden: false (Optional)
    commands: (Optional)
      some_command_callable_from_remote.send_command:
        command:
          - [base64 encoded string]
      some_other_command_callable_from_remote.send_command:
        command:
          - [base64 encoded string]
          - [base64 encoded string]
```
You could then create an actual UI button in this way:
```yaml
script:
  some_command:
    sequence:
      - service: remote.send_command
        entity_id: 'remote.some_nice_name'
        data:
          command:
            - 'some_command_callable_from_remote.send_command'
```
This allows us to save arbitrary commands as part of the remote and give them easy, readable names. 

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
