### PR TITLE
BME680: Minor fix to configuration validation and related log line.

### DIFF
--- a/homeassistant/components/sensor/bme680.py
+++ b/homeassistant/components/sensor/bme680.py
@@ -70,7 +70,8 @@ FILTER_VALUES = set([0, 1, 3, 7, 15, 31, 63, 127])
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_I2C_ADDRESS, default=DEFAULT_I2C_ADDRESS): cv.string,
+    vol.Optional(CONF_I2C_ADDRESS, default=DEFAULT_I2C_ADDRESS):
+        cv.positive_int,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=DEFAULT_MONITORED):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_I2C_BUS, default=DEFAULT_I2C_BUS): cv.positive_int,
@@ -174,7 +175,7 @@ def _setup_bme680(config):
         else:
             sensor.set_gas_status(bme680.DISABLE_GAS_MEAS)
     except (RuntimeError, IOError):
-        _LOGGER.error("BME680 sensor not detected at %s", i2c_address)
+        _LOGGER.error("BME680 sensor not detected at 0x%02x", i2c_address)
         return None
 
     sensor_handler = BME680Handler(


### PR DESCRIPTION
## Description:
This is a minor fix to a voluptuous configuration type check that was set as string but should have been int.  This did not stop the code from working but may have caused invalid error messages with a string value that could not be converted properly such as a config typo.

Note that the documentation, already states int correctly.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable): N/A no change

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) - Documentation was correct, error was in code.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [N/A] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [N/A] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [N/A] New files were added to `.coveragerc`.