### PR TITLE
Remove automatic sqlite vacuuming

### DIFF
--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -52,14 +52,3 @@ def purge_old_data(instance, purge_days):
             )) \
             .delete(synchronize_session=False)
         _LOGGER.debug("Deleted %s events", deleted_rows)
-
-    # Execute sqlite vacuum command to free up space on disk
-    _LOGGER.debug("DB engine driver: %s", instance.engine.driver)
-    if instance.engine.driver == 'pysqlite':
-        from sqlalchemy import exc
-
-        _LOGGER.info("Vacuuming SQLite to free space")
-        try:
-            instance.engine.execute("VACUUM")
-        except exc.OperationalError as err:
-            _LOGGER.error("Error vacuuming SQLite: %s.", err)


### PR DESCRIPTION
Why are we doing VACUUM for SQLite (only)?

* The vacuum will rewrite the entire database, requiring double disk space to be available.
* I beleive the database is locked during the entire rewrite (which can last for minutes).
* Big writes potentially wear down SD cards even quicker than usual.
* The heavy operation gives "timer out of sync" errors on my (Raspberry Pi) Hass.io install.
* For a normal periodic purge, any recovered space will be filled up with new events very soon anyway.
* SQLite databases in particular are likely to run on low-powered devices where this huge operation will hurt the most.

The vacuum was not introduced due to performance issues but has been present since purging was implemented (#1681), likely "because we can". However, vacuum was apparently broken from 02-Jul-2016 (#2377) to 17-Sep-2017 (#9469) so it appears that missing out is not a big deal.
