### PR TITLE
Use API to discover Hue if no bridges specified

### DIFF
--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -93,7 +93,7 @@ def setup(hass, config):
         hosts = requests.get(API_NUPNP).json()
         bridges = [{
             CONF_HOST: entry['internalipaddress'],
-            CONF_FILENAME: 'hue_{}.conf'.format(entry['id']),
+            CONF_FILENAME: '.hue_{}.conf'.format(entry['id']),
         } for entry in hosts]
     else:
         # Component not specified in config, we're loaded via discovery

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -9,6 +9,7 @@ import logging
 import os
 import socket
 
+import requests
 import voluptuous as vol
 
 from homeassistant.components.discovery import SERVICE_HUE
@@ -22,6 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "hue"
 SERVICE_HUE_SCENE = "hue_activate_scene"
+API_NUPNP = 'https://www.meethue.com/api/nupnp'
 
 CONF_BRIDGES = "bridges"
 
@@ -49,7 +51,7 @@ BRIDGE_CONFIG_SCHEMA = vol.Schema([{
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_BRIDGES, default=[]): BRIDGE_CONFIG_SCHEMA,
+        vol.Optional(CONF_BRIDGES): BRIDGE_CONFIG_SCHEMA,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -69,9 +71,9 @@ Press the button on the bridge to register Philips Hue with Home Assistant.
 
 def setup(hass, config):
     """Set up the Hue platform."""
-    config = config.get(DOMAIN)
-    if config is None:
-        config = {}
+    conf = config.get(DOMAIN)
+    if conf is None:
+        conf = {}
 
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
@@ -82,7 +84,21 @@ def setup(hass, config):
         lambda service, discovery_info:
         bridge_discovered(hass, service, discovery_info))
 
-    bridges = config.get(CONF_BRIDGES, [])
+    # User has configured bridges
+    if CONF_BRIDGES in conf:
+        bridges = conf[CONF_BRIDGES]
+    # Component is part of config but no bridges specified, discover.
+    elif DOMAIN in config:
+        # discover from nupnp
+        hosts = requests.get(API_NUPNP).json()
+        bridges = [{
+            CONF_HOST: entry['internalipaddress'],
+            CONF_FILENAME: 'hue_{}.conf'.format(entry['id']),
+        } for entry in hosts]
+    else:
+        # Component not specified in config, we're loaded via discovery
+        bridges = []
+
     for bridge in bridges:
         filename = bridge.get(CONF_FILENAME)
         allow_unreachable = bridge.get(CONF_ALLOW_UNREACHABLE)


### PR DESCRIPTION
## Description:
No longer require the user to configure the Hue bridge. If no bridges specified, query the Philips Hue discovery API and use those bridges instead.

API will only be queried if: user configured the `hue` component to be loaded but did not specify any bridge configs. API will not be queried if Hue is loaded via discovery (because then no entry in the config).

Phue is a bit weird as a dependency because it enforces reading/writing to a file. The config would be a lot easier if we could store all config for all bridges in 1 file.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
