### PR TITLE
Clarify emulated hue warning

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -130,8 +130,9 @@ class Config(object):
         self.cached_states = {}
 
         if self.type == TYPE_ALEXA:
-            _LOGGER.warning("Alexa type is deprecated and will be removed in a"
-                            " future version")
+            _LOGGER.warning(
+                'Emulated Hue running in legacy mode because type has been '
+                'specified. More info at https://goo.gl/M6tgz8')
 
         # Get the IP address that will be passed to the Echo during discovery
         self.host_ip_addr = conf.get(CONF_HOST_IP)


### PR DESCRIPTION
## Description:
Update emulated hue deprecation warning and add link to [blog post](https://home-assistant.io/blog/2018/01/21/clarification-emulated-hue/).

**Related issue (if applicable):** fixes a lot of people making incorrect assumptions and accusations.
