### PR TITLE
Add ERC20 tokens to etherscan.io sensor

### DIFF
--- a/homeassistant/components/sensor/etherscan.py
+++ b/homeassistant/components/sensor/etherscan.py
@@ -13,18 +13,20 @@ from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-etherscan-api==0.0.2']
+REQUIREMENTS = ['python-etherscan-api==0.0.3']
 
 CONF_ADDRESS = 'address'
+CONF_TOKEN = 'token'
+CONF_TOKEN_ADDRESS = 'token_address'
 CONF_ATTRIBUTION = "Data provided by etherscan.io"
-
-DEFAULT_NAME = 'Ethereum Balance'
 
 SCAN_INTERVAL = timedelta(minutes=5)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ADDRESS): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_TOKEN): cv.string,
+    vol.Optional(CONF_TOKEN_ADDRESS): cv.string,
 })
 
 
@@ -32,19 +34,30 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Etherscan.io sensors."""
     address = config.get(CONF_ADDRESS)
     name = config.get(CONF_NAME)
+    token = config.get(CONF_TOKEN)
+    token_address = config.get(CONF_TOKEN_ADDRESS)
 
-    add_devices([EtherscanSensor(name, address)], True)
+    if token:
+        token = token.upper()
+        if not name:
+            name = "%s Balance" % token
+    if not name:
+        name = "ETH Balance"
+
+    add_devices([EtherscanSensor(name, address, token, token_address)], True)
 
 
 class EtherscanSensor(Entity):
     """Representation of an Etherscan.io sensor."""
 
-    def __init__(self, name, address):
+    def __init__(self, name, address, token, token_address):
         """Initialize the sensor."""
         self._name = name
-        self.address = address
+        self._address = address
+        self._token_address = token_address
+        self._token = token
         self._state = None
-        self._unit_of_measurement = 'ETH'
+        self._unit_of_measurement = self._token or "ETH"
 
     @property
     def name(self):
@@ -71,4 +84,9 @@ class EtherscanSensor(Entity):
     def update(self):
         """Get the latest state of the sensor."""
         from pyetherscan import get_balance
-        self._state = get_balance(self.address)
+        if self._token_address:
+            self._state = get_balance(self._address, self._token_address)
+        elif self._token:
+            self._state = get_balance(self._address, self._token)
+        else:
+            self._state = get_balance(self._address)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -879,7 +879,7 @@ python-ecobee-api==0.0.15
 # python-eq3bt==0.1.8
 
 # homeassistant.components.sensor.etherscan
-python-etherscan-api==0.0.2
+python-etherscan-api==0.0.3
 
 # homeassistant.components.sensor.darksky
 # homeassistant.components.weather.darksky


### PR DESCRIPTION
## Description:
Add ability to track ERC20 token balances to etherscan.io sensor.

You can provide a token symbol and ethereum address to fetch a, address' token balance.  If the token symbol is not found, you can also provide the token's contract address and symbol manually.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4523

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: etherscan
    address: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
  - platform: etherscan
    address: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
    token: OMG
  - platform: etherscan
    address: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
    token_address: "0xef68e7c694f40c8202821edf525de3782458639f"
    token: LRC
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
