### PR TITLE
Allow setting climate devices to AUTO mode via Google Assistant

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.components.nest import DATA_NEST
 from homeassistant.components.climate import (
-    STATE_AUTO, STATE_COOL, STATE_HEAT, ClimateDevice,
+    STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_ECO, ClimateDevice,
     PLATFORM_SCHEMA, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
     ATTR_TEMPERATURE, SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_HIGH, SUPPORT_TARGET_TEMPERATURE_LOW,
@@ -27,7 +27,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(vol.Coerce(int), vol.Range(min=1)),
 })
 
-STATE_ECO = 'eco'
 STATE_HEAT_COOL = 'heat-cool'
 
 SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_HIGH |

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -27,7 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(vol.Coerce(int), vol.Range(min=1)),
 })
 
-STATE_HEAT_COOL = 'heat-cool'
+NEST_MODE_HEAT_COOL = 'heat-cool'
 
 SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_HIGH |
                  SUPPORT_TARGET_TEMPERATURE_LOW | SUPPORT_OPERATION_MODE |
@@ -117,14 +117,14 @@ class NestThermostat(ClimateDevice):
         """Return current operation ie. heat, cool, idle."""
         if self._mode in [STATE_HEAT, STATE_COOL, STATE_OFF, STATE_ECO]:
             return self._mode
-        elif self._mode == STATE_HEAT_COOL:
+        elif self._mode == NEST_MODE_HEAT_COOL:
             return STATE_AUTO
         return STATE_UNKNOWN
 
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        if self._mode != STATE_HEAT_COOL and not self.is_away_mode_on:
+        if self._mode != NEST_MODE_HEAT_COOL and not self.is_away_mode_on:
             return self._target_temperature
         return None
 
@@ -135,7 +135,7 @@ class NestThermostat(ClimateDevice):
                 self._eco_temperature[0]:
             # eco_temperature is always a low, high tuple
             return self._eco_temperature[0]
-        if self._mode == STATE_HEAT_COOL:
+        if self._mode == NEST_MODE_HEAT_COOL:
             return self._target_temperature[0]
         return None
 
@@ -146,7 +146,7 @@ class NestThermostat(ClimateDevice):
                 self._eco_temperature[1]:
             # eco_temperature is always a low, high tuple
             return self._eco_temperature[1]
-        if self._mode == STATE_HEAT_COOL:
+        if self._mode == NEST_MODE_HEAT_COOL:
             return self._target_temperature[1]
         return None
 
@@ -159,7 +159,7 @@ class NestThermostat(ClimateDevice):
         """Set new target temperature."""
         target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
         target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-        if self._mode == STATE_HEAT_COOL:
+        if self._mode == NEST_MODE_HEAT_COOL:
             if target_temp_low is not None and target_temp_high is not None:
                 temp = (target_temp_low, target_temp_high)
         else:
@@ -172,7 +172,7 @@ class NestThermostat(ClimateDevice):
         if operation_mode in [STATE_HEAT, STATE_COOL, STATE_OFF, STATE_ECO]:
             device_mode = operation_mode
         elif operation_mode == STATE_AUTO:
-            device_mode = STATE_HEAT_COOL
+            device_mode = NEST_MODE_HEAT_COOL
         self.device.mode = device_mode
 
     @property

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -18,7 +18,8 @@ DEFAULT_EXPOSE_BY_DEFAULT = True
 DEFAULT_EXPOSED_DOMAINS = [
     'switch', 'light', 'group', 'media_player', 'fan', 'cover', 'climate'
 ]
-CLIMATE_SUPPORTED_MODES = {'heat', 'cool', 'off', 'on', 'heatcool'}
+CLIMATE_MODE_HEATCOOL = 'heatcool'
+CLIMATE_SUPPORTED_MODES = {'heat', 'cool', 'off', 'on', CLIMATE_MODE_HEATCOOL}
 
 PREFIX_TRAITS = 'action.devices.traits.'
 TRAIT_ONOFF = PREFIX_TRAITS + 'OnOff'

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -33,7 +33,7 @@ from .const import (
     TRAIT_ONOFF, TRAIT_BRIGHTNESS, TRAIT_COLOR_TEMP,
     TRAIT_RGB_COLOR, TRAIT_SCENE, TRAIT_TEMPERATURE_SETTING,
     TYPE_LIGHT, TYPE_SCENE, TYPE_SWITCH, TYPE_THERMOSTAT,
-    CONF_ALIASES, CLIMATE_SUPPORTED_MODES
+    CONF_ALIASES, CLIMATE_SUPPORTED_MODES, CLIMATE_MODE_HEATCOOL
 )
 
 HANDLERS = Registry()
@@ -147,12 +147,17 @@ def entity_to_device(entity: Entity, config: Config, units: UnitSystem):
                                 entity.attributes.get(light.ATTR_MIN_MIREDS))))
 
     if entity.domain == climate.DOMAIN:
-        modes = ','.join(
-            m.lower() for m in entity.attributes.get(
-                climate.ATTR_OPERATION_LIST, [])
-            if m.lower() in CLIMATE_SUPPORTED_MODES)
+        modes = []
+        for mode in entity.attributes.get(climate.ATTR_OPERATION_LIST, []):
+            mode = mode.lower()
+
+            if mode in CLIMATE_SUPPORTED_MODES:
+                modes.append(mode)
+            elif mode == climate.STATE_AUTO:
+                modes.append(CLIMATE_MODE_HEATCOOL)
+
         device['attributes'] = {
-            'availableThermostatModes': modes,
+            'availableThermostatModes': ','.join(modes),
             'thermostatTemperatureUnit':
             'F' if units.temperature_unit == TEMP_FAHRENHEIT else 'C',
         }
@@ -323,9 +328,9 @@ def determine_service(
     # special climate handling
     if domain == climate.DOMAIN:
         if command == COMMAND_THERMOSTAT_TEMPERATURE_SETPOINT:
-            service_data['temperature'] = units.temperature(
-                params.get('thermostatTemperatureSetpoint', 25),
-                TEMP_CELSIUS)
+            service_data['temperature'] = \
+                units.temperature(
+                    params['thermostatTemperatureSetpoint'], TEMP_CELSIUS)
             return (climate.SERVICE_SET_TEMPERATURE, service_data)
         if command == COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE:
             service_data['target_temp_high'] = units.temperature(
@@ -336,8 +341,12 @@ def determine_service(
                 TEMP_CELSIUS)
             return (climate.SERVICE_SET_TEMPERATURE, service_data)
         if command == COMMAND_THERMOSTAT_SET_MODE:
-            service_data['operation_mode'] = params.get(
-                'thermostatMode', 'off')
+            mode = params['thermostatMode']
+
+            if mode == CLIMATE_MODE_HEATCOOL:
+                mode = climate.STATE_AUTO
+
+            service_data['operation_mode'] = mode
             return (climate.SERVICE_SET_OPERATION_MODE, service_data)
 
     if command == COMMAND_BRIGHTNESS:

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -149,8 +149,6 @@ def entity_to_device(entity: Entity, config: Config, units: UnitSystem):
     if entity.domain == climate.DOMAIN:
         modes = []
         for mode in entity.attributes.get(climate.ATTR_OPERATION_LIST, []):
-            mode = mode.lower()
-
             if mode in CLIMATE_SUPPORTED_MODES:
                 modes.append(mode)
             elif mode == climate.STATE_AUTO:

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -211,7 +211,7 @@ DEMO_DEVICES = [{
     'type': 'action.devices.types.THERMOSTAT',
     'willReportState': False,
     'attributes': {
-        'availableThermostatModes': 'heat,cool,off',
+        'availableThermostatModes': 'heat,cool,heatcool,off',
         'thermostatTemperatureUnit': 'C',
     },
 }, {


### PR DESCRIPTION
## Description:
We did not correctly support the AUTO operation mode of climate devices.

The old behavior would take all operation modes, lowercase them and see if they are one of the supported modes. Because of this, we missed the mapping between our AUTO mode and the Google Assistant "heat-cool" mode. This PR fixes it.

- I've removed the casting to lowercase, as the operation list attribute should only use operations defined in `climate.__init__.py`, which are all lowercase.
- I've removed the defaulting to 'off' if no mode was passed in. If Google violates their own message format, we should raise an error instead of trying to interpret intention. That will always backfire.

Tested new code locally with the Nest Home Simulator.

CC @philk 

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
