### PR TITLE
Snips - (fix/change) remove response when intent not handled

### DIFF
--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -108,12 +108,13 @@ def async_setup(hass, config):
             _LOGGER.exception("Error while handling intent: %s.", intent_type)
             snips_response = "Error while handling intent"
 
-        notification = {'sessionId': request.get('sessionId', 'default'),
-                        'text': snips_response}
+        if snips_response:
+            notification = {'sessionId': request.get('sessionId', 'default'),
+                            'text': snips_response}
 
-        _LOGGER.debug("send_response %s", json.dumps(notification))
-        mqtt.async_publish(hass, 'hermes/dialogueManager/endSession',
-                           json.dumps(notification))
+            _LOGGER.debug("send_response %s", json.dumps(notification))
+            mqtt.async_publish(hass, 'hermes/dialogueManager/endSession',
+                               json.dumps(notification))
 
     yield from hass.components.mqtt.async_subscribe(
         INTENT_TOPIC, message_received)

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -106,7 +106,6 @@ def async_setup(hass, config):
                             request['intent']['intentName'])
         except intent.IntentError:
             _LOGGER.exception("Error while handling intent: %s.", intent_type)
-            snips_response = "Error while handling intent"
 
         if snips_response:
             notification = {'sessionId': request.get('sessionId', 'default'),


### PR DESCRIPTION
## Description:

Don't send a response to end the session when intent is either unknown or an error

In cases where the intent is handled outside of HA directly we were sending a response (even if empty) which ended the session. This was interfering with intents handled outside of HA, such as within an appdaemon app.

**Related issue (if applicable):** fixes #N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
