### PR TITLE
Add Huawei HiLink router device tracker

### DIFF
--- a/homeassistant/components/device_tracker/huawei_hilink.py
+++ b/homeassistant/components/device_tracker/huawei_hilink.py
@@ -1,0 +1,217 @@
+"""
+Support for Huawei HiLink routers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.huawei_hilink/
+"""
+import base64
+import hashlib
+import logging
+from collections import namedtuple
+
+import requests
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
+REQUIREMENTS = ['defusedxml==0.5.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_HOST = '192.168.8.1'
+DEFAULT_USERNAME = 'admin'
+DEFAULT_PASSWORD = 'admin'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string
+})
+
+SESSION_ID_COOKIE = 'SessionID'
+VERIFICATION_TOKEN_HEADER = '__RequestVerificationToken'
+
+
+# pylint: disable=unused-argument
+def get_scanner(hass, config):
+    """Validate the configuration and return a Huawei HiLink scanner."""
+    scanner = HuaweiHiLinkDeviceScanner(config[DOMAIN])
+    success_init = scanner.update_info()
+
+    return scanner if success_init else None
+
+
+Device = namedtuple('Device', ['name', 'mac', 'ip'])
+AuthInfo = namedtuple('AuthInfo', ['session_id', 'verification_token'])
+
+
+class HuaweiHiLinkDeviceScanner(DeviceScanner):
+    """This class queries a Huawei HiLink router for wlan connected devices."""
+
+    def __init__(self, config):
+        """Initialize the scanner."""
+        self.host = config[CONF_HOST]
+        self.username = config[CONF_USERNAME]
+        self.password = config[CONF_PASSWORD]
+
+        self.api_location = 'http://{}/api'.format(self.host)
+        self.auth_info = AuthInfo(session_id='wrong',
+                                  verification_token='wrong')
+
+        self.last_results = []
+        _LOGGER.info("Scanner initialized")
+
+    def scan_devices(self):
+        """Scan for new devices."""
+        self.update_info()
+        return [device.mac for device in self.last_results]
+
+    def get_device_name(self, mac):
+        """Get device name from mac."""
+        names = [device.name for device in self.last_results
+                 if device.mac == mac]
+        if names:
+            return names[0]
+        return None
+
+    def update_info(self):
+        """Ensure the information from the router is up to date.
+
+        Retry once if fetching devices fails with fresh login. Return True if
+        scanning successful.
+        """
+        _LOGGER.info("Scanning...")
+        devices = _fetch_devices(self.api_location, self.auth_info)
+        if devices is None:
+            _LOGGER.info("Obtaining devices failed. Try to login")
+            success_login = self._login()
+            if not success_login:
+                return False
+            devices = _fetch_devices(self.api_location, self.auth_info)
+            if devices is None:
+                _LOGGER.warning("Fetching devices failed again. Stop")
+                return False
+
+        self.last_results = devices
+        return True
+
+    def _login(self):
+        """Login and update authorization info.
+
+        Retry once with fresh authorization info. Return True if login
+        successful.
+        """
+        self.auth_info = _login(self.api_location,
+                                self.username,
+                                self.password,
+                                self.auth_info)
+        if self.auth_info is None:
+            _LOGGER.info("Logging in failed. Try to obtain auth info again")
+            self._obtain_auth_info()
+            self.auth_info = _login(self.api_location,
+                                    self.username,
+                                    self.password,
+                                    self.auth_info)
+            if self.auth_info is None:
+                _LOGGER.warning("Logging in failed with fresh auth info. Stop")
+                return False
+
+        return True
+
+    def _obtain_auth_info(self):
+        """Obtain and update authorization info."""
+        self.auth_info = _obtain_auth_info(self.api_location)
+
+
+def _obtain_auth_info(api_location):
+    """Return authorization info with session id and verification token.
+
+    Return None if operation not successful.
+    """
+    import defusedxml.ElementTree as ET
+
+    _LOGGER.info("Obtaining session id and verification token")
+
+    response = requests.get('{}/webserver/SesTokInfo'.format(api_location))
+    xml_root = ET.fromstring(response.text)
+    session_id_cookie = xml_root.findtext('SesInfo')
+    session_id = session_id_cookie[len('{}='.format(SESSION_ID_COOKIE)):] \
+        if session_id_cookie else None
+    verification_token = xml_root.findtext('TokInfo')
+    return AuthInfo(session_id, verification_token) \
+        if session_id and verification_token else None
+
+
+def _login(api_location, username, password, auth_info):
+    """Login and return authorization with updated session id.
+
+    Return None if login not successful.
+    """
+    _LOGGER.info("Logging in")
+
+    password_hash = _hash_password(username,
+                                   password,
+                                   auth_info.verification_token)
+    payload = """<?xml version="1.0" encoding="UTF-8"?>
+<request>
+    <Username>{}</Username>
+    <Password>{}</Password>
+    <password_type>4</password_type>
+</request>""".format(username, password_hash)
+
+    response = requests.post(
+        '{}/user/login'.format(api_location),
+        data=payload,
+        cookies={SESSION_ID_COOKIE: auth_info.session_id},
+        headers={VERIFICATION_TOKEN_HEADER: auth_info.verification_token}
+    )
+
+    success = '<response>OK</response>' in response.text
+    return AuthInfo(
+        response.cookies[SESSION_ID_COOKIE],
+        auth_info.verification_token
+    ) if success else None
+
+
+def _hash_password(username, password, token):
+    """Hash password."""
+    # Reversed engineered based on main.js router script.
+    result = hashlib.sha256(password.encode()).hexdigest()
+    result = base64.b64encode(result.encode()).decode()
+    result = username + result + token
+    result = hashlib.sha256(result.encode()).hexdigest()
+    result = base64.b64encode(result.encode()).decode()
+    return result
+
+
+def _fetch_devices(api_location, auth_info):
+    """Fetch devices list.
+
+    Return None if response cannot not be parsed.
+    """
+    import defusedxml.ElementTree as ET
+
+    _LOGGER.info("Fetching devices")
+
+    response = requests.get(
+        '{}/wlan/host-list'.format(api_location),
+        cookies={SESSION_ID_COOKIE: auth_info.session_id}
+    )
+
+    xml_root = ET.fromstring(response.text)
+    hosts = xml_root.find('Hosts')
+    if not hosts:
+        return None
+    return [_parse_device(host) for host in hosts]
+
+
+def _parse_device(host):
+    """Parse device information from host XML element."""
+    return Device(
+        name=host.findtext('HostName'),
+        mac=host.findtext('MacAddress'),
+        ip=host.findtext('IpAddress')
+    )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -201,6 +201,7 @@ datapoint==0.4.3
 # homeassistant.components.light.decora_wifi
 # decora_wifi==1.3
 
+# homeassistant.components.device_tracker.huawei_hilink
 # homeassistant.components.device_tracker.upc_connect
 defusedxml==0.5.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -40,6 +40,7 @@ caldav==0.5.0
 # homeassistant.components.sensor.coinmarketcap
 coinmarketcap==4.1.2
 
+# homeassistant.components.device_tracker.huawei_hilink
 # homeassistant.components.device_tracker.upc_connect
 defusedxml==0.5.0
 

--- a/tests/components/device_tracker/test_huawei_hilink.py
+++ b/tests/components/device_tracker/test_huawei_hilink.py
@@ -1,0 +1,191 @@
+"""The tests for the Huawei HiLink router device tracker platform."""
+import logging
+import unittest
+from unittest import mock
+
+import requests_mock
+
+from homeassistant.components.device_tracker import DOMAIN, huawei_hilink
+from homeassistant.const import (CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
+                                 CONF_PLATFORM)
+from tests.common import load_fixture
+
+_LOGGER = logging.getLogger(__name__)
+
+TEST_USERNAME = 'usernameTest'
+
+TEST_CONFIG = {
+    DOMAIN: huawei_hilink.PLATFORM_SCHEMA({
+        CONF_PLATFORM: huawei_hilink.DOMAIN,
+        CONF_HOST: '192.168.8.2',
+        CONF_USERNAME: TEST_USERNAME,
+        CONF_PASSWORD: 'passwordTest'
+    })
+}
+
+HOST_LIST_URL = 'http://192.168.8.2/api/wlan/host-list'
+LOGIN_URL = 'http://192.168.8.2/api/user/login'
+AUTH_INFO_URL = 'http://192.168.8.2/api/webserver/SesTokInfo'
+
+TEST_AUTH_INFO = huawei_hilink.AuthInfo(session_id='test_session_id',
+                                        verification_token='test_token')
+
+# Computed with 'usernameTest', 'passwordTest' and 'test_token'
+PASSWORD_HASH = ("NTBhYzQxNmMzMGZjYWMwY2QyNTUwODg4OWIxMTc1MGE1OWJkZmJhYzNiYjA3"
+                 "MGQ5ZDQyNjNlNGNhNzgyMGVmOA==")
+
+AUTH_INFO_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
+<response>
+<SesInfo>SessionID=test_session_id</SesInfo>
+<TokInfo>test_token</TokInfo>
+</response>
+"""
+
+OK_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
+<response>OK</response>
+"""
+
+ERROR_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
+<error>
+<code>125002</code>
+<message></message>
+</error>
+"""
+
+HOST_LIST_FIXTURE = load_fixture('huawei_hilink_host_list.xml')
+
+
+class TestHuaweiHiLinkDeviceScanner(unittest.TestCase):
+    """Huawei HiLink device scanner test class."""
+
+    @mock.patch('homeassistant.components.device_tracker.huawei_hilink.'
+                'HuaweiHiLinkDeviceScanner')
+    def test_config(self, scanner_mock):
+        """Testing configuration."""
+        config = {
+            DOMAIN: huawei_hilink.PLATFORM_SCHEMA({
+                CONF_PLATFORM: huawei_hilink.DOMAIN,
+                CONF_HOST: '192.168.8.2',
+                CONF_USERNAME: 'usernameTest',
+                CONF_PASSWORD: 'passwordTest'
+            })
+        }
+
+        huawei_hilink.get_scanner(hass=None, config=config)
+
+        scanner_mock.assert_called_once_with(config[DOMAIN])
+
+    @mock.patch('homeassistant.components.device_tracker.huawei_hilink.'
+                'HuaweiHiLinkDeviceScanner')
+    def test_default_config(self, scanner_mock):
+        """Testing default configuration."""
+        config = {
+            DOMAIN: huawei_hilink.PLATFORM_SCHEMA({
+                CONF_PLATFORM: huawei_hilink.DOMAIN
+            })
+        }
+
+        huawei_hilink.get_scanner(hass=None, config=config)
+
+        scanner_mock.assert_called_once_with(config[DOMAIN])
+        config_arg = scanner_mock.call_args[0][0]
+        self.assertEqual(config_arg[CONF_HOST],
+                         huawei_hilink.DEFAULT_HOST)
+        self.assertEqual(config_arg[CONF_USERNAME],
+                         huawei_hilink.DEFAULT_USERNAME)
+        self.assertEqual(config_arg[CONF_PASSWORD],
+                         huawei_hilink.DEFAULT_PASSWORD)
+
+    @requests_mock.Mocker()
+    def test_scan_devices(self, mock_req):
+        """Testing successful devices scanning."""
+        mock_req.get(HOST_LIST_URL, text=HOST_LIST_FIXTURE)
+        scanner = huawei_hilink.get_scanner(hass=None, config=TEST_CONFIG)
+
+        devices = scanner.scan_devices()
+
+        assert len(devices) == 3
+        assert devices == ['0C:70:E0:2B:9A:F6', '6A:94:88:F6:C0:7B',
+                           'C7:D7:D8:CB:E0:D0']
+
+    @requests_mock.Mocker()
+    def test_get_device_name(self, mock_req):
+        """Testing getting device's name for MAC."""
+        mock_req.get(HOST_LIST_URL, text=HOST_LIST_FIXTURE)
+        scanner = huawei_hilink.get_scanner(hass=None, config=TEST_CONFIG)
+
+        scanner.scan_devices()
+
+        assert scanner.get_device_name('6A:94:88:F6:C0:7B') \
+            == 'second-host-name'
+        assert scanner.get_device_name('unknown') is None
+
+    @requests_mock.Mocker()
+    def test_login_when_host_list_failed(self, mock_req):
+        """Testing login retry when retrieving host list fails."""
+        mock_req.get(HOST_LIST_URL, [{'text': ERROR_RESPONSE},
+                                     {'text': HOST_LIST_FIXTURE}])
+        new_session_id = 'new_session_id'
+        mock_req.post(LOGIN_URL,
+                      text=OK_RESPONSE,
+                      cookies={
+                          huawei_hilink.SESSION_ID_COOKIE: new_session_id
+                      })
+        scanner = huawei_hilink.HuaweiHiLinkDeviceScanner(TEST_CONFIG[DOMAIN])
+        scanner.auth_info = TEST_AUTH_INFO
+
+        devices = scanner.scan_devices()
+
+        assert len(devices) == 3
+        assert len(mock_req.request_history) == 3
+        login_req = mock_req.request_history[-2]
+        assert login_req.url == LOGIN_URL
+        assert TEST_USERNAME in login_req.text
+        assert PASSWORD_HASH in login_req.text
+        assert login_req.headers['Cookie'] == '{}={}'.format(
+            huawei_hilink.SESSION_ID_COOKIE, TEST_AUTH_INFO.session_id)
+        host_list_req = mock_req.last_request
+        assert host_list_req.url == HOST_LIST_URL
+        assert host_list_req.headers['Cookie'] == '{}={}'.format(
+            huawei_hilink.SESSION_ID_COOKIE, new_session_id)
+
+    @requests_mock.Mocker()
+    def test_obtain_auth_info_when_login_failed(self, mock_req):
+        """Testing obtaining fresh authorization info if login fails."""
+        mock_req.get(HOST_LIST_URL, [{'text': ERROR_RESPONSE},
+                                     {'text': HOST_LIST_FIXTURE}])
+        mock_req.post(LOGIN_URL, [
+            {'text': ERROR_RESPONSE},
+            {'text': OK_RESPONSE, 'cookies': {
+                huawei_hilink.SESSION_ID_COOKIE: TEST_AUTH_INFO.session_id
+            }}
+        ])
+        mock_req.get(AUTH_INFO_URL, text=AUTH_INFO_RESPONSE)
+        scanner = huawei_hilink.HuaweiHiLinkDeviceScanner(TEST_CONFIG[DOMAIN])
+
+        devices = scanner.scan_devices()
+
+        assert len(devices) == 3
+        assert len(mock_req.request_history) == 5
+        auth_info_req = mock_req.request_history[-3]
+        assert auth_info_req.url == AUTH_INFO_URL
+        login_req = mock_req.request_history[-2]
+        assert login_req.url == LOGIN_URL
+        assert login_req.headers['Cookie'] == '{}={}'.format(
+            huawei_hilink.SESSION_ID_COOKIE, TEST_AUTH_INFO.session_id)
+        assert login_req.headers[huawei_hilink.VERIFICATION_TOKEN_HEADER] \
+            == TEST_AUTH_INFO.verification_token
+
+    @requests_mock.Mocker()
+    def test_exhaust_scan_devices_if_login_failed_again(self, mock_req):
+        """Testing exhausted devices scanning if login fails two times."""
+        mock_req.get(HOST_LIST_URL, text=ERROR_RESPONSE)
+        mock_req.post(LOGIN_URL, [{'text': ERROR_RESPONSE}] * 2)
+        mock_req.get(AUTH_INFO_URL, text=AUTH_INFO_RESPONSE)
+        scanner = huawei_hilink.HuaweiHiLinkDeviceScanner(TEST_CONFIG[DOMAIN])
+
+        devices = scanner.scan_devices()
+
+        assert not devices
+        assert len(mock_req.request_history) == 4
+        assert mock_req.last_request.url == LOGIN_URL

--- a/tests/fixtures/huawei_hilink_host_list.xml
+++ b/tests/fixtures/huawei_hilink_host_list.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+<Hosts>
+<Host>
+<ID>1</ID>
+<MacAddress>0C:70:E0:2B:9A:F6</MacAddress>
+<IpAddress>192.168.8.101</IpAddress>
+<HostName>first-host-name</HostName>
+<AssociatedTime>11111</AssociatedTime>
+<AssociatedSsid>ssid name</AssociatedSsid>
+</Host>
+<Host>
+<ID>2</ID>
+<MacAddress>6A:94:88:F6:C0:7B</MacAddress>
+<IpAddress>192.168.8.102</IpAddress>
+<HostName>second-host-name</HostName>
+<AssociatedTime>22222</AssociatedTime>
+<AssociatedSsid>ssid name</AssociatedSsid>
+</Host>
+<Host>
+<ID>3</ID>
+<MacAddress>C7:D7:D8:CB:E0:D0</MacAddress>
+<IpAddress>192.168.8.103</IpAddress>
+<HostName>third-host-name</HostName>
+<AssociatedTime>33333</AssociatedTime>
+<AssociatedSsid>ssid name</AssociatedSsid>
+</Host>
+</Hosts>
+</response>


### PR DESCRIPTION
## Description:

This PR adds support for Huawei HiLink routers. The change was developed and tested under Huawei B315 device. Home Assistant already has support for some Huawei routers but the component was not compatible with my device.

The router exposes an API to communicate with. The API can be reverse engineered by logging in with the web interface and tracing requests. Apart from that the API description, made by some people, can be found in the Internet. I encountered difficulties with login since my device requires at first to obtain a session and verification token. Then logging in have to be performed with hashed password. I managed to recrete the hashing algorithm based on JS device's libraries.

Mentioned resources:
- https://github.com/knq/hilink
- https://www.mrt-prodz.com/blog/view/2015/05/huawei-modem-api-and-data-plan-monitor
- http://forum.jdtech.pl/Watek-hilink-api-dla-urzadzen-huawei (a thread from Polish forum)

Do you have any suggestions about the code, logging statements and level or handling network exceptions? I don't catch them at all now.

I have not started writing any documentation yet since I would like to know if the PR makes sense. If so, I will create corresponding PR in documentation repository later.

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable.
  - [X] New dependencies are only imported inside functions that use them.
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.