### PR TITLE
Add a default username to UVC camera compontent, use if detected user…

### DIFF
--- a/homeassistant/components/camera/uvc.py
+++ b/homeassistant/components/camera/uvc.py
@@ -22,6 +22,7 @@ CONF_NVR = 'nvr'
 CONF_KEY = 'key'
 CONF_PASSWORD = 'password'
 
+DEFAULT_USERNAME = 'ubnt'
 DEFAULT_PASSWORD = 'ubnt'
 DEFAULT_PORT = 7080
 
@@ -127,11 +128,15 @@ class UnifiVideoCamera(Camera):
         else:
             client_cls = uvc_camera.UVCCameraClient
 
+        username = caminfo['username']
+        if not username:
+            username = DEFAULT_USERNAME
+
         camera = None
         for addr in addrs:
             try:
                 camera = client_cls(
-                    addr, caminfo['username'], self._password)
+                    addr, username, self._password)
                 camera.login()
                 _LOGGER.debug("Logged into UVC camera %(name)s via %(addr)s",
                               dict(name=self._name, addr=addr))


### PR DESCRIPTION
…name is null

## Description:


**Related issue (if applicable):** fixes #11919 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
