### PR TITLE
Handle more file closing using context manager

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -182,7 +182,8 @@ def check_pid(pid_file: str) -> None:
     """Check that Home Assistant is not already running."""
     # Check pid file
     try:
-        pid = int(open(pid_file, 'r').readline())
+        with open(pid_file, 'r') as file:
+            pid = int(file.readline())
     except IOError:
         # PID File does not exist
         return
@@ -204,7 +205,8 @@ def write_pid(pid_file: str) -> None:
     """Create a PID File."""
     pid = os.getpid()
     try:
-        open(pid_file, 'w').write(str(pid))
+        with open(pid_file, 'w') as file:
+            file.write(str(pid))
     except IOError:
         print('Fatal Error: Unable to write pid file {}'.format(pid_file))
         sys.exit(1)

--- a/homeassistant/components/light/greenwave.py
+++ b/homeassistant/components/light/greenwave.py
@@ -38,18 +38,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     tokenfile = hass.config.path('.greenwave')
     if config.get(CONF_VERSION) == 3:
         if os.path.exists(tokenfile):
-            tokenfile = open(tokenfile)
-            token = tokenfile.read()
-            tokenfile.close()
+            with open(tokenfile) as tokenfile:
+                token = tokenfile.read()
         else:
             try:
                 token = greenwave.grab_token(host, 'hass', 'homeassistant')
             except PermissionError:
                 _LOGGER.error('The Gateway Is Not In Sync Mode')
                 raise
-            tokenfile = open(tokenfile, "w+")
-            tokenfile.write(token)
-            tokenfile.close()
+            with open(tokenfile, "w+") as tokenfile:
+                tokenfile.write(token)
     else:
         token = None
     bulbs = greenwave.grab_bulbs(host, token)

--- a/homeassistant/components/notify/gntp.py
+++ b/homeassistant/components/notify/gntp.py
@@ -44,7 +44,8 @@ def get_service(hass, config, discovery_info=None):
     if config.get(CONF_APP_ICON) is None:
         icon_file = os.path.join(os.path.dirname(__file__), "..", "frontend",
                                  "www_static", "icons", "favicon-192x192.png")
-        app_icon = open(icon_file, 'rb').read()
+        with open(icon_file, 'rb') as file:
+            app_icon = file.read()
     else:
         app_icon = config.get(CONF_APP_ICON)
 

--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -66,8 +66,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                           device_file, 'temperature'))
     else:
         for family_file_path in glob(os.path.join(base_dir, '*', 'family')):
-            family_file = open(family_file_path, "r")
-            family = family_file.read()
+            with open(family_file_path, "r") as family_file:
+                family = family_file.read()
             if family in DEVICE_SENSORS:
                 for sensor_key, sensor_value in DEVICE_SENSORS[family].items():
                     sensor_id = os.path.split(


### PR DESCRIPTION
## Description:

For early closing etc.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. (not pylint, it doesn't work locally here)
