### PR TITLE
Upgrade sphinx-autodoc-typehints to 1.2.4

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
 Sphinx==1.6.6
-sphinx-autodoc-typehints==1.2.3
+sphinx-autodoc-typehints==1.2.4
 sphinx-autodoc-annotation==1.0.post1


### PR DESCRIPTION
## Description:
- Added tests
- Avoid adding rtype directive if specified after return

## Checklist:
  - [x] The code change is tested and works locally.
