### PR TITLE
Fix asuswrt AttributeError on neigh for unknown device

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -214,7 +214,8 @@ class AsusWrtDeviceScanner(DeviceScanner):
         for device in result:
             if device['mac'] is not None:
                 mac = device['mac'].upper()
-                old_ip = cur_devices.get(mac, {}).ip or None
+                old_device = cur_devices.get(mac)
+                old_ip = old_device.ip if old_device else None
                 devices[mac] = Device(mac, device.get('ip', old_ip), None)
         return devices
 

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -447,6 +447,9 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         scanner = get_scanner(self.hass, VALID_CONFIG_ROUTER_SSH)
         scanner.connection = mocked_ssh
         self.assertEqual(NEIGH_DEVICES, scanner._get_neigh(ARP_DEVICES.copy()))
+        self.assertEqual(NEIGH_DEVICES, scanner._get_neigh({
+            'UN:KN:WN:DE:VI:CE': Device('UN:KN:WN:DE:VI:CE', None, None),
+        }))
         mocked_ssh.run_command.return_value = ''
         self.assertEqual({}, scanner._get_neigh(ARP_DEVICES.copy()))
 


### PR DESCRIPTION
## Description:

Fixes _get_neigh for unknown device coughing ` AttributeError: 'dict' object has no attribute 'ip'`

**Related issue (if applicable):**
fixes #11957 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
