### PR TITLE
Flake8 35

### DIFF
--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -153,8 +153,7 @@ class StoredData(object):
                 with self._lock, open(self._data_file, 'rb') as myfile:
                     self._data = pickle.load(myfile) or {}
                     self._cache_outdated = False
-            # pylint: disable=bare-except
-            except:
+            except:  # pylint: disable=bare-except  # noqa: E722
                 _LOGGER.error("Error loading data from pickled file %s",
                               self._data_file)
 
@@ -172,8 +171,7 @@ class StoredData(object):
                           url, self._data_file)
             try:
                 pickle.dump(self._data, myfile)
-            # pylint: disable=bare-except
-            except:
+            except:  # pylint: disable=bare-except  # noqa: E722
                 _LOGGER.error(
                     "Error saving pickled data to %s", self._data_file)
         self._cache_outdated = True

--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -153,7 +153,7 @@ class StoredData(object):
                 with self._lock, open(self._data_file, 'rb') as myfile:
                     self._data = pickle.load(myfile) or {}
                     self._cache_outdated = False
-            except:  # pylint: disable=bare-except  # noqa: E722
+            except:  # noqa: E722  # pylint: disable=bare-except
                 _LOGGER.error("Error loading data from pickled file %s",
                               self._data_file)
 
@@ -171,7 +171,7 @@ class StoredData(object):
                           url, self._data_file)
             try:
                 pickle.dump(self._data, myfile)
-            except:  # pylint: disable=bare-except  # noqa: E722
+            except:  # noqa: E722  # pylint: disable=bare-except
                 _LOGGER.error(
                     "Error saving pickled data to %s", self._data_file)
         self._cache_outdated = True

--- a/homeassistant/components/media_player/bluesound.py
+++ b/homeassistant/components/media_player/bluesound.py
@@ -165,7 +165,7 @@ class BluesoundPlayer(MediaPlayerDevice):
         try:
             resp = yield from self.send_bluesound_command(
                 'SyncStatus', raise_timeout, raise_timeout)
-        except:
+        except Exception:
             raise
 
         if not resp:
@@ -202,7 +202,7 @@ class BluesoundPlayer(MediaPlayerDevice):
 
         except CancelledError:
             _LOGGER.debug("Stopping the polling of node %s", self._name)
-        except:
+        except Exception:
             _LOGGER.exception("Unexpected error in %s", self._name)
             raise
 
@@ -229,7 +229,7 @@ class BluesoundPlayer(MediaPlayerDevice):
             _LOGGER.info("Node %s is offline, retrying later", self.host)
             self._retry_remove = async_track_time_interval(
                 self._hass, self.async_init, NODE_RETRY_INITIATION)
-        except:
+        except Exception:
             _LOGGER.exception("Unexpected when initiating error in %s",
                               self.host)
             raise

--- a/homeassistant/components/media_player/clementine.py
+++ b/homeassistant/components/media_player/clementine.py
@@ -97,7 +97,7 @@ class ClementineDevice(MediaPlayerDevice):
                 self._track_artist = client.current_track['track_artist']
                 self._track_album_name = client.current_track['track_album']
 
-        except:
+        except Exception:
             self._state = STATE_OFF
             raise
 

--- a/homeassistant/components/sensor/fritzbox_callmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_callmonitor.py
@@ -70,8 +70,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         phonebook = FritzBoxPhonebook(
             host=host, port=port, username=username, password=password,
             phonebook_id=phonebook_id, prefixes=prefixes)
-    # pylint: disable=bare-except
-    except:
+    except:  # pylint: disable=bare-except  # noqa: E722
         phonebook = None
         _LOGGER.warning("Phonebook with ID %s not found on Fritz!Box",
                         phonebook_id)

--- a/homeassistant/components/sensor/fritzbox_callmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_callmonitor.py
@@ -70,7 +70,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         phonebook = FritzBoxPhonebook(
             host=host, port=port, username=username, password=password,
             phonebook_id=phonebook_id, prefixes=prefixes)
-    except:  # pylint: disable=bare-except  # noqa: E722
+    except:  # noqa: E722  # pylint: disable=bare-except
         phonebook = None
         _LOGGER.warning("Phonebook with ID %s not found on Fritz!Box",
                         phonebook_id)

--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -206,7 +206,7 @@ class QNAPStatsAPI(object):
             self.data["smart_drive_health"] = self._api.get_smart_disk_health()
             self.data["volumes"] = self._api.get_volumes()
             self.data["bandwidth"] = self._api.get_bandwidth()
-        except:  # pylint: disable=bare-except  # noqa: E722
+        except:  # noqa: E722  # pylint: disable=bare-except
             _LOGGER.exception("Failed to fetch QNAP stats from the NAS")
 
 

--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -197,7 +197,6 @@ class QNAPStatsAPI(object):
 
         self.data = {}
 
-    # pylint: disable=bare-except
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update API information and store locally."""
@@ -207,7 +206,7 @@ class QNAPStatsAPI(object):
             self.data["smart_drive_health"] = self._api.get_smart_disk_health()
             self.data["volumes"] = self._api.get_volumes()
             self.data["bandwidth"] = self._api.get_bandwidth()
-        except:
+        except:  # pylint: disable=bare-except  # noqa: E722
             _LOGGER.exception("Failed to fetch QNAP stats from the NAS")
 
 

--- a/homeassistant/components/sensor/synologydsm.py
+++ b/homeassistant/components/sensor/synologydsm.py
@@ -136,7 +136,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class SynoApi(object):
     """Class to interface with Synology DSM API."""
 
-    # pylint: disable=bare-except
     def __init__(self, host, port, username, password, temp_unit):
         """Initialize the API wrapper class."""
         from SynologyDSM import SynologyDSM
@@ -144,7 +143,7 @@ class SynoApi(object):
 
         try:
             self._api = SynologyDSM(host, port, username, password)
-        except:
+        except:  # pylint: disable=bare-except  # noqa: E722
             _LOGGER.error("Error setting up Synology DSM")
 
         # Will be updated when update() gets called.

--- a/homeassistant/components/sensor/synologydsm.py
+++ b/homeassistant/components/sensor/synologydsm.py
@@ -143,7 +143,7 @@ class SynoApi(object):
 
         try:
             self._api = SynologyDSM(host, port, username, password)
-        except:  # pylint: disable=bare-except  # noqa: E722
+        except:  # noqa: E722  # pylint: disable=bare-except
             _LOGGER.error("Error setting up Synology DSM")
 
         # Will be updated when update() gets called.

--- a/homeassistant/components/spc.py
+++ b/homeassistant/components/spc.py
@@ -151,7 +151,7 @@ def _ws_process_message(message, async_callback, *args):
             "Unsuccessful websocket message delivered, ignoring: %s", message)
     try:
         yield from async_callback(message['data']['sia'], *args)
-    except:    # pylint: disable=bare-except
+    except:    # pylint: disable=bare-except  # noqa: E722
         _LOGGER.exception("Exception in callback, ignoring")
 
 

--- a/homeassistant/components/spc.py
+++ b/homeassistant/components/spc.py
@@ -151,7 +151,7 @@ def _ws_process_message(message, async_callback, *args):
             "Unsuccessful websocket message delivered, ignoring: %s", message)
     try:
         yield from async_callback(message['data']['sia'], *args)
-    except:    # pylint: disable=bare-except  # noqa: E722
+    except:  # noqa: E722  # pylint: disable=bare-except
         _LOGGER.exception("Exception in callback, ignoring")
 
 

--- a/homeassistant/monkey_patch.py
+++ b/homeassistant/monkey_patch.py
@@ -37,7 +37,7 @@ def patch_weakref_tasks():
     asyncio.tasks.Task._all_tasks = IgnoreCalls()
     try:
         del asyncio.tasks.Task.__del__
-    except Exception:
+    except:  # noqa: E722
         pass
 
 

--- a/homeassistant/monkey_patch.py
+++ b/homeassistant/monkey_patch.py
@@ -37,7 +37,7 @@ def patch_weakref_tasks():
     asyncio.tasks.Task._all_tasks = IgnoreCalls()
     try:
         del asyncio.tasks.Task.__del__
-    except:
+    except Exception:
         pass
 
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 # linters such as flake8 and pylint should be pinned, as new releases
 # make new things fail. Manually update these pins when pulling in a
 # new version
-flake8==3.3
+flake8==3.5
 pylint==1.6.5
 mypy==0.560
 pydocstyle==1.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2,7 +2,7 @@
 # linters such as flake8 and pylint should be pinned, as new releases
 # make new things fail. Manually update these pins when pulling in a
 # new version
-flake8==3.3
+flake8==3.5
 pylint==1.6.5
 mypy==0.560
 pydocstyle==1.1.1

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -87,10 +87,9 @@ class TestEmulatedHue(unittest.TestCase):
         self.assertTrue('text/xml' in result.headers['content-type'])
 
         # Make sure the XML is parsable
-        # pylint: disable=bare-except
         try:
             ET.fromstring(result.text)
-        except:
+        except:  # pylint: disable=bare-except  # noqa: E722
             self.fail('description.xml is not valid XML!')
 
     def test_create_username(self):

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -89,7 +89,7 @@ class TestEmulatedHue(unittest.TestCase):
         # Make sure the XML is parsable
         try:
             ET.fromstring(result.text)
-        except:  # pylint: disable=bare-except  # noqa: E722
+        except:  # noqa: E722  # pylint: disable=bare-except
             self.fail('description.xml is not valid XML!')
 
     def test_create_username(self):

--- a/tests/components/test_system_log.py
+++ b/tests/components/test_system_log.py
@@ -34,7 +34,7 @@ def get_error_log(hass, test_client, expected_count):
 def _generate_and_log_exception(exception, log):
     try:
         raise Exception(exception)
-    except:  # pylint: disable=bare-except
+    except:  # pylint: disable=bare-except  # noqa: E722
         _LOGGER.exception(log)
 
 

--- a/tests/components/test_system_log.py
+++ b/tests/components/test_system_log.py
@@ -34,7 +34,7 @@ def get_error_log(hass, test_client, expected_count):
 def _generate_and_log_exception(exception, log):
     try:
         raise Exception(exception)
-    except:  # pylint: disable=bare-except  # noqa: E722
+    except:  # noqa: E722  # pylint: disable=bare-except
         _LOGGER.exception(log)
 
 


### PR DESCRIPTION
## Description:

Upgrade flake8 to 3.5, address new errors.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
