### PR TITLE
Prepare for recorder purge to be active by default

### DIFF
--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -55,11 +55,12 @@ def purge_old_data(instance, purge_days):
 
     # Execute sqlite vacuum command to free up space on disk
     _LOGGER.debug("DB engine driver: %s", instance.engine.driver)
-    if instance.engine.driver == 'pysqlite':
+    if instance.engine.driver == 'pysqlite' and not instance.did_vacuum:
         from sqlalchemy import exc
 
         _LOGGER.info("Vacuuming SQLite to free space")
         try:
             instance.engine.execute("VACUUM")
+            instance.did_vacuum = True
         except exc.OperationalError as err:
             _LOGGER.error("Error vacuuming SQLite: %s.", err)


### PR DESCRIPTION
## Breaking change note

From version 0.64, Home Assistant will by default purge recorded state history that is older than 10 days. If you want to keep your recorded data for longer than that, you must configure the number of days to retain:
```yaml
recorder:
  purge_keep_days: 30
```

If you want to keep the previous default of never deleting history, use this configuration:
```yaml
recorder:
  purge_interval: 0
```

## Description:

[As discussed elsewhere](https://github.com/home-assistant/home-assistant/pull/11903#issuecomment-360892485), this sets the stage for changing the recorder `purge_keep_days` default from `None` to `10`.

Because purging is surprisingly cheap and vacuuming is surprisingly expensive, the `purge_interval` now defaults to `1` and vacuuming is only done with the first purge after startup. This is to lower the performance impact on new adopters.

The vacuum will be fully removed one release after purge is active by default.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4534

## Example entry for `configuration.yaml` (if applicable):
```yaml
recorder:
  purge_keep_days: 7
```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [ ] Tests have been added to verify that the new code works.