### PR TITLE
emulated_hue: allow customization within emulated_hue configuration

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -24,9 +24,6 @@ from homeassistant.components.http import HomeAssistantView
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_EMULATED_HUE = 'emulated_hue'
-ATTR_EMULATED_HUE_NAME = 'emulated_hue_name'
-
 HUE_API_STATE_ON = 'on'
 HUE_API_STATE_BRI = 'bri'
 
@@ -77,7 +74,7 @@ class HueAllLightsStateView(HomeAssistantView):
 
                 number = self.config.entity_id_to_number(entity.entity_id)
                 json_response[number] = entity_to_json(
-                    entity, state, brightness)
+                    self.config, entity, state, brightness)
 
         return self.json(json_response)
 
@@ -110,7 +107,7 @@ class HueOneLightStateView(HomeAssistantView):
 
         state, brightness = get_entity_state(self.config, entity)
 
-        json_response = entity_to_json(entity, state, brightness)
+        json_response = entity_to_json(self.config, entity, state, brightness)
 
         return self.json(json_response)
 
@@ -344,10 +341,8 @@ def get_entity_state(config, entity):
     return (final_state, final_brightness)
 
 
-def entity_to_json(entity, is_on=None, brightness=None):
+def entity_to_json(config, entity, is_on=None, brightness=None):
     """Convert an entity to its Hue bridge JSON representation."""
-    name = entity.attributes.get(ATTR_EMULATED_HUE_NAME, entity.name)
-
     return {
         'state':
         {
@@ -356,7 +351,7 @@ def entity_to_json(entity, is_on=None, brightness=None):
             'reachable': True
         },
         'type': 'Dimmable light',
-        'name': name,
+        'name': config.get_entity_name(entity),
         'modelid': 'HASS123',
         'uniqueid': entity.entity_id,
         'swversion': '123'

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -121,7 +121,14 @@ def hass_hue(loop, hass):
 def hue_client(loop, hass_hue, test_client):
     """Create web client for emulated hue api."""
     web_app = hass_hue.http.app
-    config = Config(None, {'type': 'alexa'})
+    config = Config(None, {
+        emulated_hue.CONF_TYPE: emulated_hue.TYPE_ALEXA,
+        emulated_hue.CONF_ENTITIES: {
+            'light.bed_light': {
+                emulated_hue.CONF_ENTITY_HIDDEN: True
+            }
+        }
+    })
 
     HueUsernameView().register(web_app.router)
     HueAllLightsStateView(config).register(web_app.router)
@@ -145,7 +152,7 @@ def test_discover_lights(hue_client):
 
     # Make sure the lights we added to the config are there
     assert 'light.ceiling_lights' in devices
-    assert 'light.bed_light' in devices
+    assert 'light.bed_light' not in devices
     assert 'script.set_kitchen_light' in devices
     assert 'light.kitchen_lights' not in devices
     assert 'media_player.living_room' in devices
@@ -186,19 +193,23 @@ def test_get_light_state(hass_hue, hue_client):
     assert result_json['light.ceiling_lights']['state'][HUE_API_STATE_BRI] == \
         127
 
-    # Turn bedroom light off
+    # Turn office light off
     yield from hass_hue.services.async_call(
         light.DOMAIN, const.SERVICE_TURN_OFF,
         {
-            const.ATTR_ENTITY_ID: 'light.bed_light'
+            const.ATTR_ENTITY_ID: 'light.ceiling_lights'
         },
         blocking=True)
 
-    bedroom_json = yield from perform_get_light_state(
-        hue_client, 'light.bed_light', 200)
+    office_json = yield from perform_get_light_state(
+        hue_client, 'light.ceiling_lights', 200)
 
-    assert bedroom_json['state'][HUE_API_STATE_ON] is False
-    assert bedroom_json['state'][HUE_API_STATE_BRI] == 0
+    assert office_json['state'][HUE_API_STATE_ON] is False
+    assert office_json['state'][HUE_API_STATE_BRI] == 0
+
+    # Make sure bedroom light isn't accessible
+    yield from perform_get_light_state(
+        hue_client, 'light.bed_light', 404)
 
     # Make sure kitchen light isn't accessible
     yield from perform_get_light_state(
@@ -213,29 +224,35 @@ def test_put_light_state(hass_hue, hue_client):
     # Turn the bedroom light on first
     yield from hass_hue.services.async_call(
         light.DOMAIN, const.SERVICE_TURN_ON,
-        {const.ATTR_ENTITY_ID: 'light.bed_light',
+        {const.ATTR_ENTITY_ID: 'light.ceiling_lights',
          light.ATTR_BRIGHTNESS: 153},
         blocking=True)
 
-    bed_light = hass_hue.states.get('light.bed_light')
-    assert bed_light.state == STATE_ON
-    assert bed_light.attributes[light.ATTR_BRIGHTNESS] == 153
+    ceiling_lights = hass_hue.states.get('light.ceiling_lights')
+    assert ceiling_lights.state == STATE_ON
+    assert ceiling_lights.attributes[light.ATTR_BRIGHTNESS] == 153
 
     # Go through the API to turn it off
-    bedroom_result = yield from perform_put_light_state(
+    ceiling_result = yield from perform_put_light_state(
         hass_hue, hue_client,
-        'light.bed_light', False)
+        'light.ceiling_lights', False)
 
-    bedroom_result_json = yield from bedroom_result.json()
+    ceiling_result_json = yield from ceiling_result.json()
 
-    assert bedroom_result.status == 200
-    assert 'application/json' in bedroom_result.headers['content-type']
+    assert ceiling_result.status == 200
+    assert 'application/json' in ceiling_result.headers['content-type']
 
-    assert len(bedroom_result_json) == 1
+    assert len(ceiling_result_json) == 1
 
     # Check to make sure the state changed
-    bed_light = hass_hue.states.get('light.bed_light')
-    assert bed_light.state == STATE_OFF
+    ceiling_lights = hass_hue.states.get('light.ceiling_lights')
+    assert ceiling_lights.state == STATE_OFF
+
+    # Make sure we can't change the bedroom light state
+    bedroom_result = yield from perform_put_light_state(
+        hass_hue, hue_client,
+        'light.bed_light', True)
+    assert bedroom_result.status == 404
 
     # Make sure we can't change the kitchen light state
     kitchen_result = yield from perform_put_light_state(


### PR DESCRIPTION
## Description:
This PR adds an `entities` section to the `emulated_hue` configuration, (hopefully) eventually replacing the `emulated_hue_name` and `emulated_hue_hidden` configuration options under `homeassistant.customize`.

**Related issue (if applicable):** suggested by @balloob in home-assistant/home-assistant-polymer#827

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4538

## Example entry for `configuration.yaml` (if applicable):
```yaml
emulated_hue:
  entities:
    light.bedroom_light:
      name: "Bedside Lamp"
    light.ceiling_lights:
      hidden: true
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
