### PR TITLE
Uvc don't handle null as username

### DIFF
--- a/homeassistant/components/camera/uvc.py
+++ b/homeassistant/components/camera/uvc.py
@@ -127,6 +127,9 @@ class UnifiVideoCamera(Camera):
         else:
             client_cls = uvc_camera.UVCCameraClient
 
+        if caminfo['username'] is None:
+            caminfo['username'] = 'ubnt'
+
         camera = None
         for addr in addrs:
             try:


### PR DESCRIPTION
## Description:
The default username is 'ubnt' for cameras. When the camera is managed by an NVR, the username from the API calls might be "null" in some situations. When it's null in the API response, its actually the default username (ubnt).

**Related issue (if applicable):** fixes #11982 

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
