### PR TITLE
counter: allow custom increment/decrement amounts

### DIFF
--- a/homeassistant/components/counter/services.yaml
+++ b/homeassistant/components/counter/services.yaml
@@ -6,12 +6,18 @@ decrement:
     entity_id:
       description: Entity id of the counter to decrement.
       example: 'counter.count0'
+    amount:
+      description: The amount to decrement the counter by.
+      exmaple: 5
 increment:
   description: Increment a counter.
   fields:
     entity_id:
       description: Entity id of the counter to increment.
       example: 'counter.count0'
+    amount:
+      description: The amount to increment the counter by.
+      exmaple: 5
 reset:
   description: Reset a counter.
   fields:

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -104,17 +104,35 @@ class TestCounter(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(1, int(state.state))
 
+        increment(self.hass, entity_id, 5)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(6, int(state.state))
+
         increment(self.hass, entity_id)
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)
-        self.assertEqual(2, int(state.state))
+        self.assertEqual(7, int(state.state))
 
         decrement(self.hass, entity_id)
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)
-        self.assertEqual(1, int(state.state))
+        self.assertEqual(6, int(state.state))
+
+        decrement(self.hass, entity_id, 3)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(3, int(state.state))
+
+        decrement(self.hass, entity_id)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(2, int(state.state))
 
         reset(self.hass, entity_id)
         self.hass.block_till_done()
@@ -147,17 +165,35 @@ class TestCounter(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(15, int(state.state))
 
+        increment(self.hass, entity_id, 2)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(17, int(state.state))
+
         increment(self.hass, entity_id)
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)
-        self.assertEqual(20, int(state.state))
+        self.assertEqual(22, int(state.state))
 
         decrement(self.hass, entity_id)
         self.hass.block_till_done()
 
         state = self.hass.states.get(entity_id)
-        self.assertEqual(15, int(state.state))
+        self.assertEqual(17, int(state.state))
+
+        decrement(self.hass, entity_id)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(12, int(state.state))
+
+        decrement(self.hass, entity_id, 2)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(entity_id)
+        self.assertEqual(10, int(state.state))
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description: Allow custom increment/decrement amounts for counters.

One question I have regarding this is that whether `amount` should be an exact value (like it is in this PR as of writing), or a multiplier for steps (i.e. the real amount changed would be `step * amount`). I haven't created a PR for documentation yet as I'm unsure if it currently has the desired functionality.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  increment_default:
    alias: Increment (default)
    sequence:
      - service: counter.increment
        data:
          entity_id: counter.counter
  increment_5:
    alias: Increment (5)
    sequence:
      - service: counter.increment
        data:
          entity_id: counter.counter
          amount: 5
  decrement_default:
    alias: Decrement (default)
    sequence:
      - service: counter.decrement
        data:
          entity_id: counter.counter
  decrement_5:
    alias: Decrement (5)
    sequence:
      - service: counter.decrement
        data:
          entity_id: counter.counter
          amount: 5
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
