### PR TITLE
Egardia redesign - generic component and sensor support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -76,6 +76,9 @@ omit =
     homeassistant/components/ecobee.py
     homeassistant/components/*/ecobee.py
 
+    homeassistant/components/egardia.py
+    homeassistant/components/*/egardia.py
+
     homeassistant/components/enocean.py
     homeassistant/components/*/enocean.py
 
@@ -287,7 +290,6 @@ omit =
     homeassistant/components/alarm_control_panel/alarmdotcom.py
     homeassistant/components/alarm_control_panel/canary.py
     homeassistant/components/alarm_control_panel/concord232.py
-    homeassistant/components/alarm_control_panel/egardia.py
     homeassistant/components/alarm_control_panel/ialarm.py
     homeassistant/components/alarm_control_panel/manual_mqtt.py
     homeassistant/components/alarm_control_panel/nx584.py

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -18,7 +18,7 @@ from homeassistant.components.egardia import (
     REPORT_SERVER_CODES_IGNORE, CONF_REPORT_SERVER_CODES,
     CONF_REPORT_SERVER_ENABLED, CONF_REPORT_SERVER_PORT
     )
-REQUIREMENTS = ['pythonegardia==1.0.38']
+REQUIREMENTS = ['pythonegardia==1.0.36']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ STATES = {
     'ARM': STATE_ALARM_ARMED_AWAY,
     'DAY HOME': STATE_ALARM_ARMED_HOME,
     'DISARM': STATE_ALARM_DISARMED,
-    'HOME': STATE_ALARM_ARMED_HOME,
+    'ARMHOME': STATE_ALARM_ARMED_HOME,
     'TRIGGERED': STATE_ALARM_TRIGGERED
 }
 
@@ -53,10 +53,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         self._egardiasystem = egardiasystem
         self._status = None
         self._rs_enabled = rs_enabled
-        if rs_codes is not None:
-            self._rs_codes = rs_codes[0]
-        else:
-            self._rs_codes = rs_codes
+        self._rs_codes = rs_codes
         self._rs_port = rs_port
 
     @asyncio.coroutine
@@ -98,7 +95,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         if self._rs_codes is not None:
             statuscode = str(statuscode).strip()
             for i in self._rs_codes:
-                val = str(self._rs_codes[i]).strip()
+                val = str(self._rs_codes[i][0]).strip()
                 if ',' in val:
                     splitted = val.split(',')
                     for code in splitted:
@@ -106,7 +103,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
                         if statuscode == code:
                             status = i.upper()
                             break
-                elif statuscode == val:
+                elif statuscode == str(val).strip():
                     status = i.upper()
                     break
         return status
@@ -116,8 +113,9 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         _LOGGER.debug("Parsing status %s", status)
         # Ignore the statuscode if it is IGNORE
         if status.lower().strip() != REPORT_SERVER_CODES_IGNORE:
-            _LOGGER.debug("Not ignoring status")
+            _LOGGER.debug("Not ignoring status %s", status)
             newstatus = STATES.get(status.upper())
+            _LOGGER.debug("newstatus %s", newstatus)
             self._status = newstatus
         else:
             _LOGGER.error("Ignoring status")

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_TRIGGERED)
 from homeassistant.components.egardia import (
     EGARDIA_DEVICE, EGARDIA_SERVER,
-    CONF_REPORT_SERVER_CODES_IGNORE, CONF_REPORT_SERVER_CODES,
+    REPORT_SERVER_CODES_IGNORE, CONF_REPORT_SERVER_CODES,
     CONF_REPORT_SERVER_ENABLED, CONF_REPORT_SERVER_PORT
     )
 REQUIREMENTS = ['pythonegardia==1.0.36']
@@ -115,7 +115,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         """Parse the status."""
         _LOGGER.debug("Parsing status %s", status)
         # Ignore the statuscode if it is IGNORE
-        if status.lower().strip() != CONF_REPORT_SERVER_CODES_IGNORE:
+        if status.lower().strip() != REPORT_SERVER_CODES_IGNORE:
             _LOGGER.debug("Not ignoring status")
             newstatus = STATES.get(status.upper())
             self._status = newstatus

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -1,4 +1,4 @@
-c"""
+"""
 Interfaces with Egardia/Woonveilig alarm control panel.
 
 For more details about this platform, please refer to the documentation at

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -47,7 +47,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
     """Representation of a Egardia alarm."""
 
     def __init__(self, name, egardiasystem,
-                 rs_enabled=False, rs_codes=None, rs_port=52010):
+                 rs_enabled=False, rs_codes={}, rs_port=52010):
         """Initialize the Egardia alarm."""
         self._name = name
         self._egardiasystem = egardiasystem
@@ -91,16 +91,10 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
 
     def lookupstatusfromcode(self, statuscode):
         """Look at the rs_codes and returns the status from the code."""
-        status = 'UNKNOWN'
-        if self._rs_codes is not None:
-            statuscode = str(statuscode).strip()
-            for statusgroup in self._rs_codes:
-                codes = self._rs_codes[statusgroup]
-                for code in codes:
-                    code = str(code).strip()
-                    if statuscode == code:
-                        status = statusgroup.upper()
-                        break
+        status = next((
+            status_group.upper() for status_group, codes
+            in self._rs_codes.items() for code in codes
+            if statuscode == code), 'UNKNOWN')
         return status
 
     def parsestatus(self, status):

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -24,25 +24,22 @@ STATES = {
     'UNKNOWN': STATE_UNKNOWN,
 }
 
-D_EGARDIASRV = 'egardiaserver'
 D_EGARDIASYS = 'egardiadevice'
-D_EGARDIANM = 'egardianame'
-D_EGARDIARSENABLED = 'egardia_rs_enabled'
-D_EGARDIARSCODES = 'egardia_rs_codes'
 D_EGARDIADEV = 'egardia_dev'
 CONF_REPORT_SERVER_CODES_IGNORE = 'ignore'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Egardia platform."""
-    eg_dev = EgardiaAlarm(
-        hass.data[D_EGARDIANM],
+    device = EgardiaAlarm(
+        discovery_info['name'],
         hass.data[D_EGARDIASYS],
-        hass.data[D_EGARDIARSENABLED],
-        hass.data[D_EGARDIARSCODES])
-    hass.data[D_EGARDIADEV] = eg_dev
+        discovery_info['report_server_enabled'],
+        discovery_info['report_server_codes'] if 'report_server_codes'
+        in discovery_info else None)
+    hass.data[D_EGARDIADEV] = device
     # add egardia alarm device
-    add_devices([eg_dev], True)
+    add_devices([device], True)
 
 
 class EgardiaAlarm(alarm.AlarmControlPanel):
@@ -50,7 +47,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
 
     def __init__(self, name, egardiasystem,
                  rs_enabled=False, rs_codes=None):
-        """Initialize object."""
+        """Initialize the Egardia alarm."""
         self._name = name
         self._egardiasystem = egardiasystem
         self._status = None
@@ -78,7 +75,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         return False
 
     def handle_status_event(self, event):
-        """Handle egardia_system_status_event."""
+        """Handle the Egardia system status event."""
         statuscode = event.get('status')
         if statuscode is not None:
             status = self.lookupstatusfromcode(statuscode)

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -47,7 +47,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
     """Representation of a Egardia alarm."""
 
     def __init__(self, name, egardiasystem,
-                 rs_enabled=False, rs_codes={}, rs_port=52010):
+                 rs_enabled=False, rs_codes=None, rs_port=52010):
         """Initialize the Egardia alarm."""
         self._name = name
         self._egardiasystem = egardiasystem

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -18,7 +18,7 @@ from homeassistant.components.egardia import (
     REPORT_SERVER_CODES_IGNORE, CONF_REPORT_SERVER_CODES,
     CONF_REPORT_SERVER_ENABLED, CONF_REPORT_SERVER_PORT
     )
-REQUIREMENTS = ['pythonegardia==1.0.36']
+REQUIREMENTS = ['pythonegardia==1.0.38']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -94,18 +94,13 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         status = 'UNKNOWN'
         if self._rs_codes is not None:
             statuscode = str(statuscode).strip()
-            for i in self._rs_codes:
-                val = str(self._rs_codes[i][0]).strip()
-                if ',' in val:
-                    splitted = val.split(',')
-                    for code in splitted:
-                        code = str(code).strip()
-                        if statuscode == code:
-                            status = i.upper()
-                            break
-                elif statuscode == str(val).strip():
-                    status = i.upper()
-                    break
+            for statusgroup in self._rs_codes:
+                codes = self._rs_codes[statusgroup]
+                for code in codes:
+                    code = str(code).strip()
+                    if statuscode == code:
+                        status = statusgroup.upper()
+                        break
         return status
 
     def parsestatus(self, status):

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -1,4 +1,4 @@
-"""
+c"""
 Interfaces with Egardia/Woonveilig alarm control panel.
 
 For more details about this platform, please refer to the documentation at
@@ -18,7 +18,7 @@ from homeassistant.components.egardia import (
     REPORT_SERVER_CODES_IGNORE, CONF_REPORT_SERVER_CODES,
     CONF_REPORT_SERVER_ENABLED, CONF_REPORT_SERVER_PORT
     )
-REQUIREMENTS = ['pythonegardia==1.0.36']
+REQUIREMENTS = ['pythonegardia==1.0.38']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -7,37 +7,13 @@ https://home-assistant.io/components/alarm_control_panel.egardia/
 import logging
 
 import requests
-import voluptuous as vol
 
 import homeassistant.components.alarm_control_panel as alarm
-from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT, CONF_USERNAME,
-    EVENT_HOMEASSISTANT_STOP, STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED, STATE_UNKNOWN)
-import homeassistant.exceptions as exc
-import homeassistant.helpers.config_validation as cv
-
-REQUIREMENTS = ['pythonegardia==1.0.26']
+    STATE_UNKNOWN, STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_TRIGGERED)
 
 _LOGGER = logging.getLogger(__name__)
-
-CONF_REPORT_SERVER_CODES = 'report_server_codes'
-CONF_REPORT_SERVER_ENABLED = 'report_server_enabled'
-CONF_REPORT_SERVER_PORT = 'report_server_port'
-CONF_REPORT_SERVER_CODES_IGNORE = 'ignore'
-CONF_VERSION = 'version'
-
-DEFAULT_NAME = 'Egardia'
-DEFAULT_PORT = 80
-DEFAULT_REPORT_SERVER_ENABLED = False
-DEFAULT_REPORT_SERVER_PORT = 52010
-DEFAULT_VERSION = 'GATE-01'
-DOMAIN = 'egardia'
-D_EGARDIASRV = 'egardiaserver'
-
-NOTIFICATION_ID = 'egardia_notification'
-NOTIFICATION_TITLE = 'Egardia'
 
 STATES = {
     'ARM': STATE_ALARM_ARMED_AWAY,
@@ -48,78 +24,33 @@ STATES = {
     'UNKNOWN': STATE_UNKNOWN,
 }
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Optional(CONF_VERSION, default=DEFAULT_VERSION): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_REPORT_SERVER_CODES): vol.All(cv.ensure_list),
-    vol.Optional(CONF_REPORT_SERVER_ENABLED,
-                 default=DEFAULT_REPORT_SERVER_ENABLED): cv.boolean,
-    vol.Optional(CONF_REPORT_SERVER_PORT, default=DEFAULT_REPORT_SERVER_PORT):
-        cv.port,
-})
+D_EGARDIASRV = 'egardiaserver'
+D_EGARDIASYS = 'egardiadevice'
+D_EGARDIANM = 'egardianame'
+D_EGARDIARSENABLED = 'egardia_rs_enabled'
+D_EGARDIARSCODES = 'egardia_rs_codes'
+D_EGARDIADEV = 'egardia_dev'
+CONF_REPORT_SERVER_CODES_IGNORE = 'ignore'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Egardia platform."""
-    from pythonegardia import egardiadevice
-    from pythonegardia import egardiaserver
-
-    name = config.get(CONF_NAME)
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
-    rs_enabled = config.get(CONF_REPORT_SERVER_ENABLED)
-    rs_port = config.get(CONF_REPORT_SERVER_PORT)
-    rs_codes = config.get(CONF_REPORT_SERVER_CODES)
-    version = config.get(CONF_VERSION)
-
-    try:
-        egardiasystem = egardiadevice.EgardiaDevice(
-            host, port, username, password, '', version)
-    except requests.exceptions.RequestException:
-        raise exc.PlatformNotReady()
-    except egardiadevice.UnauthorizedError:
-        _LOGGER.error("Unable to authorize. Wrong password or username")
-        return
-
     eg_dev = EgardiaAlarm(
-        name, egardiasystem, rs_enabled, rs_codes)
-
-    if rs_enabled:
-        # Set up the egardia server
-        _LOGGER.info("Setting up EgardiaServer")
-        try:
-            if D_EGARDIASRV not in hass.data:
-                server = egardiaserver.EgardiaServer('', rs_port)
-                bound = server.bind()
-                if not bound:
-                    raise IOError(
-                        "Binding error occurred while starting EgardiaServer")
-                hass.data[D_EGARDIASRV] = server
-                server.start()
-        except IOError:
-            return
-        hass.data[D_EGARDIASRV].register_callback(eg_dev.handle_status_event)
-
-    def handle_stop_event(event):
-        """Call function for Home Assistant stop event."""
-        hass.data[D_EGARDIASRV].stop()
-
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, handle_stop_event)
-
+        hass.data[D_EGARDIANM],
+        hass.data[D_EGARDIASYS],
+        hass.data[D_EGARDIARSENABLED],
+        hass.data[D_EGARDIARSCODES])
+    hass.data[D_EGARDIADEV] = eg_dev
+    # add egardia alarm device
     add_devices([eg_dev], True)
 
 
 class EgardiaAlarm(alarm.AlarmControlPanel):
     """Representation of a Egardia alarm."""
 
-    def __init__(self, name, egardiasystem, rs_enabled=False, rs_codes=None):
-        """Initialize the Egardia alarm."""
+    def __init__(self, name, egardiasystem,
+                 rs_enabled=False, rs_codes=None):
+        """Initialize object."""
         self._name = name
         self._egardiasystem = egardiasystem
         self._status = None
@@ -147,7 +78,7 @@ class EgardiaAlarm(alarm.AlarmControlPanel):
         return False
 
     def handle_status_event(self, event):
-        """Handle the Egardia system status event."""
+        """Handle egardia_system_status_event."""
         statuscode = event.get('status')
         if statuscode is not None:
             status = self.lookupstatusfromcode(statuscode)

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -2,77 +2,151 @@
 Interfaces with Egardia/Woonveilig alarm control panel.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/binary_sensor.egardia/
+https://home-assistant.io/components/alarm_control_panel.egardia/
 """
 import asyncio
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.const import STATE_ON, STATE_OFF
+import requests
+
+import homeassistant.components.alarm_control_panel as alarm
+from homeassistant.const import (
+    STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_TRIGGERED)
 from homeassistant.components.egardia import (
-    EGARDIA_DEVICE, ATTR_DISCOVER_DEVICES)
+    EGARDIA_DEVICE, EGARDIA_SERVER,
+    REPORT_SERVER_CODES_IGNORE, CONF_REPORT_SERVER_CODES,
+    CONF_REPORT_SERVER_ENABLED, CONF_REPORT_SERVER_PORT
+    )
+REQUIREMENTS = ['pythonegardia==1.0.36']
+
 _LOGGER = logging.getLogger(__name__)
 
-EGARDIA_TYPE_TO_DEVICE_CLASS = {'IR Sensor': 'motion',
-                                'Door Contact': 'opening',
-                                'IR': 'motion'}
+STATES = {
+    'ARM': STATE_ALARM_ARMED_AWAY,
+    'DAY HOME': STATE_ALARM_ARMED_HOME,
+    'DISARM': STATE_ALARM_DISARMED,
+    'HOME': STATE_ALARM_ARMED_HOME,
+    'TRIGGERED': STATE_ALARM_TRIGGERED
+}
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-    """Initialize the platform."""
-    if (discovery_info is None or
-            discovery_info[ATTR_DISCOVER_DEVICES] is None):
-        return
-
-    disc_info = discovery_info[ATTR_DISCOVER_DEVICES]
-    # multiple devices here!
-    async_add_devices(
-        (
-            EgardiaBinarySensor(
-                sensor_id=disc_info[sensor]['id'],
-                name=disc_info[sensor]['name'],
-                egardia_system=hass.data[EGARDIA_DEVICE],
-                device_class=EGARDIA_TYPE_TO_DEVICE_CLASS.get(
-                    disc_info[sensor]['type'], None)
-            )
-            for sensor in disc_info
-        ), True)
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Egardia platform."""
+    device = EgardiaAlarm(
+        discovery_info['name'],
+        hass.data[EGARDIA_DEVICE],
+        discovery_info[CONF_REPORT_SERVER_ENABLED],
+        discovery_info.get(CONF_REPORT_SERVER_CODES),
+        discovery_info[CONF_REPORT_SERVER_PORT])
+    # add egardia alarm device
+    add_devices([device], True)
 
 
-class EgardiaBinarySensor(BinarySensorDevice):
-    """Represents a sensor based on an Egardia sensor (IR, Door Contact)."""
+class EgardiaAlarm(alarm.AlarmControlPanel):
+    """Representation of a Egardia alarm."""
 
-    def __init__(self, sensor_id, name, egardia_system, device_class):
-        """Initialize the sensor device."""
-        self._id = sensor_id
+    def __init__(self, name, egardiasystem,
+                 rs_enabled=False, rs_codes=None, rs_port=52010):
+        """Initialize the Egardia alarm."""
         self._name = name
-        self._state = None
-        self._device_class = device_class
-        self._egardia_system = egardia_system
+        self._egardiasystem = egardiasystem
+        self._status = None
+        self._rs_enabled = rs_enabled
+        if rs_codes is not None:
+            self._rs_codes = rs_codes[0]
+        else:
+            self._rs_codes = rs_codes
+        self._rs_port = rs_port
 
-    def update(self):
-        """Update the status."""
-        egardia_input = self._egardia_system.getsensorstate(self._id)
-        self._state = STATE_ON if egardia_input else STATE_OFF
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Add Egardiaserver callback if enabled."""
+        if self._rs_enabled:
+            _LOGGER.debug("Registering callback to Egardiaserver")
+            self.hass.data[EGARDIA_SERVER].register_callback(
+                self.handle_status_event)
 
     @property
     def name(self):
-        """The name of the device."""
+        """Return the name of the device."""
         return self._name
 
     @property
-    def is_on(self):
-        """Whether the device is switched on."""
-        return self._state == STATE_ON
+    def state(self):
+        """Return the state of the device."""
+        return self._status
 
     @property
-    def hidden(self):
-        """Whether the device is hidden by default."""
-        # these type of sensors are probably mainly used for automations
-        return True
+    def should_poll(self):
+        """Poll if no report server is enabled."""
+        if not self._rs_enabled:
+            return True
+        return False
 
-    @property
-    def device_class(self):
-        """The device class."""
-        return self._device_class
+    def handle_status_event(self, event):
+        """Handle the Egardia system status event."""
+        statuscode = event.get('status')
+        if statuscode is not None:
+            status = self.lookupstatusfromcode(statuscode)
+            self.parsestatus(status)
+            self.schedule_update_ha_state()
+
+    def lookupstatusfromcode(self, statuscode):
+        """Look at the rs_codes and returns the status from the code."""
+        status = 'UNKNOWN'
+        if self._rs_codes is not None:
+            statuscode = str(statuscode).strip()
+            for i in self._rs_codes:
+                val = str(self._rs_codes[i]).strip()
+                if ',' in val:
+                    splitted = val.split(',')
+                    for code in splitted:
+                        code = str(code).strip()
+                        if statuscode == code:
+                            status = i.upper()
+                            break
+                elif statuscode == val:
+                    status = i.upper()
+                    break
+        return status
+
+    def parsestatus(self, status):
+        """Parse the status."""
+        _LOGGER.debug("Parsing status %s", status)
+        # Ignore the statuscode if it is IGNORE
+        if status.lower().strip() != REPORT_SERVER_CODES_IGNORE:
+            _LOGGER.debug("Not ignoring status")
+            newstatus = STATES.get(status.upper())
+            self._status = newstatus
+        else:
+            _LOGGER.error("Ignoring status")
+
+    def update(self):
+        """Update the alarm status."""
+        status = self._egardiasystem.getstate()
+        self.parsestatus(status)
+
+    def alarm_disarm(self, code=None):
+        """Send disarm command."""
+        try:
+            self._egardiasystem.alarm_disarm()
+        except requests.exceptions.RequestException as err:
+            _LOGGER.error("Egardia device exception occurred when "
+                          "sending disarm command: %s", err)
+
+    def alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        try:
+            self._egardiasystem.alarm_arm_home()
+        except requests.exceptions.RequestException as err:
+            _LOGGER.error("Egardia device exception occurred when "
+                          "sending arm home command: %s", err)
+
+    def alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        try:
+            self._egardiasystem.alarm_arm_away()
+        except requests.exceptions.RequestException as err:
+            _LOGGER.error("Egardia device exception occurred when "
+                          "sending arm away command: %s", err)

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -2,151 +2,77 @@
 Interfaces with Egardia/Woonveilig alarm control panel.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/alarm_control_panel.egardia/
+https://home-assistant.io/components/binary_sensor.egardia/
 """
 import asyncio
 import logging
 
-import requests
-
-import homeassistant.components.alarm_control_panel as alarm
-from homeassistant.const import (
-    STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_ARMED_AWAY, STATE_ALARM_TRIGGERED)
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.components.egardia import (
-    EGARDIA_DEVICE, EGARDIA_SERVER,
-    REPORT_SERVER_CODES_IGNORE, CONF_REPORT_SERVER_CODES,
-    CONF_REPORT_SERVER_ENABLED, CONF_REPORT_SERVER_PORT
-    )
-REQUIREMENTS = ['pythonegardia==1.0.36']
-
+    EGARDIA_DEVICE, ATTR_DISCOVER_DEVICES)
 _LOGGER = logging.getLogger(__name__)
 
-STATES = {
-    'ARM': STATE_ALARM_ARMED_AWAY,
-    'DAY HOME': STATE_ALARM_ARMED_HOME,
-    'DISARM': STATE_ALARM_DISARMED,
-    'HOME': STATE_ALARM_ARMED_HOME,
-    'TRIGGERED': STATE_ALARM_TRIGGERED
-}
+EGARDIA_TYPE_TO_DEVICE_CLASS = {'IR Sensor': 'motion',
+                                'Door Contact': 'opening',
+                                'IR': 'motion'}
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the Egardia platform."""
-    device = EgardiaAlarm(
-        discovery_info['name'],
-        hass.data[EGARDIA_DEVICE],
-        discovery_info[CONF_REPORT_SERVER_ENABLED],
-        discovery_info.get(CONF_REPORT_SERVER_CODES),
-        discovery_info[CONF_REPORT_SERVER_PORT])
-    # add egardia alarm device
-    add_devices([device], True)
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Initialize the platform."""
+    if (discovery_info is None or
+            discovery_info[ATTR_DISCOVER_DEVICES] is None):
+        return
+
+    disc_info = discovery_info[ATTR_DISCOVER_DEVICES]
+    # multiple devices here!
+    async_add_devices(
+        (
+            EgardiaBinarySensor(
+                sensor_id=disc_info[sensor]['id'],
+                name=disc_info[sensor]['name'],
+                egardia_system=hass.data[EGARDIA_DEVICE],
+                device_class=EGARDIA_TYPE_TO_DEVICE_CLASS.get(
+                    disc_info[sensor]['type'], None)
+            )
+            for sensor in disc_info
+        ), True)
 
 
-class EgardiaAlarm(alarm.AlarmControlPanel):
-    """Representation of a Egardia alarm."""
+class EgardiaBinarySensor(BinarySensorDevice):
+    """Represents a sensor based on an Egardia sensor (IR, Door Contact)."""
 
-    def __init__(self, name, egardiasystem,
-                 rs_enabled=False, rs_codes=None, rs_port=52010):
-        """Initialize the Egardia alarm."""
+    def __init__(self, sensor_id, name, egardia_system, device_class):
+        """Initialize the sensor device."""
+        self._id = sensor_id
         self._name = name
-        self._egardiasystem = egardiasystem
-        self._status = None
-        self._rs_enabled = rs_enabled
-        if rs_codes is not None:
-            self._rs_codes = rs_codes[0]
-        else:
-            self._rs_codes = rs_codes
-        self._rs_port = rs_port
+        self._state = None
+        self._device_class = device_class
+        self._egardia_system = egardia_system
 
-    @asyncio.coroutine
-    def async_added_to_hass(self):
-        """Add Egardiaserver callback if enabled."""
-        if self._rs_enabled:
-            _LOGGER.debug("Registering callback to Egardiaserver")
-            self.hass.data[EGARDIA_SERVER].register_callback(
-                self.handle_status_event)
+    def update(self):
+        """Update the status."""
+        egardia_input = self._egardia_system.getsensorstate(self._id)
+        self._state = STATE_ON if egardia_input else STATE_OFF
 
     @property
     def name(self):
-        """Return the name of the device."""
+        """The name of the device."""
         return self._name
 
     @property
-    def state(self):
-        """Return the state of the device."""
-        return self._status
+    def is_on(self):
+        """Whether the device is switched on."""
+        return self._state == STATE_ON
 
     @property
-    def should_poll(self):
-        """Poll if no report server is enabled."""
-        if not self._rs_enabled:
-            return True
-        return False
+    def hidden(self):
+        """Whether the device is hidden by default."""
+        # these type of sensors are probably mainly used for automations
+        return True
 
-    def handle_status_event(self, event):
-        """Handle the Egardia system status event."""
-        statuscode = event.get('status')
-        if statuscode is not None:
-            status = self.lookupstatusfromcode(statuscode)
-            self.parsestatus(status)
-            self.schedule_update_ha_state()
-
-    def lookupstatusfromcode(self, statuscode):
-        """Look at the rs_codes and returns the status from the code."""
-        status = 'UNKNOWN'
-        if self._rs_codes is not None:
-            statuscode = str(statuscode).strip()
-            for i in self._rs_codes:
-                val = str(self._rs_codes[i]).strip()
-                if ',' in val:
-                    splitted = val.split(',')
-                    for code in splitted:
-                        code = str(code).strip()
-                        if statuscode == code:
-                            status = i.upper()
-                            break
-                elif statuscode == val:
-                    status = i.upper()
-                    break
-        return status
-
-    def parsestatus(self, status):
-        """Parse the status."""
-        _LOGGER.debug("Parsing status %s", status)
-        # Ignore the statuscode if it is IGNORE
-        if status.lower().strip() != REPORT_SERVER_CODES_IGNORE:
-            _LOGGER.debug("Not ignoring status")
-            newstatus = STATES.get(status.upper())
-            self._status = newstatus
-        else:
-            _LOGGER.error("Ignoring status")
-
-    def update(self):
-        """Update the alarm status."""
-        status = self._egardiasystem.getstate()
-        self.parsestatus(status)
-
-    def alarm_disarm(self, code=None):
-        """Send disarm command."""
-        try:
-            self._egardiasystem.alarm_disarm()
-        except requests.exceptions.RequestException as err:
-            _LOGGER.error("Egardia device exception occurred when "
-                          "sending disarm command: %s", err)
-
-    def alarm_arm_home(self, code=None):
-        """Send arm home command."""
-        try:
-            self._egardiasystem.alarm_arm_home()
-        except requests.exceptions.RequestException as err:
-            _LOGGER.error("Egardia device exception occurred when "
-                          "sending arm home command: %s", err)
-
-    def alarm_arm_away(self, code=None):
-        """Send arm away command."""
-        try:
-            self._egardiasystem.alarm_arm_away()
-        except requests.exceptions.RequestException as err:
-            _LOGGER.error("Egardia device exception occurred when "
-                          "sending arm away command: %s", err)
+    @property
+    def device_class(self):
+        """The device class."""
+        return self._device_class

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -39,9 +39,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     # multiple devices here!
     async_add_devices(
-        _create_sensor(hass, discinfo[sensor])
-        for sensor in discinfo
-        )
+        (
+            _create_sensor(hass, discinfo[sensor])
+            for sensor in discinfo
+        ), True)
 
 
 class EgardiaBinarySensor(BinarySensorDevice):
@@ -54,7 +55,6 @@ class EgardiaBinarySensor(BinarySensorDevice):
         self._state = state
         self._device_class = device_class
         self._egardiasystem = egardiasystem
-        # spc_registry.register_sensor_device(zone_id, self)
 
     def update(self):
         """Update the status."""
@@ -75,11 +75,6 @@ class EgardiaBinarySensor(BinarySensorDevice):
     def hidden(self):
         """Whether the device is hidden by default."""
         # these type of sensors are probably mainly used for automations
-        return True
-
-    @property
-    def should_poll(self):
-        """Polling required."""
         return True
 
     @property

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -27,7 +27,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         return
 
     discinfo = discovery_info[ATTR_DISCOVER_DEVICES]
-    _LOGGER.error(discinfo)
     # multiple devices here!
     async_add_devices(
         (

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -39,7 +39,7 @@ def _create_sensor(hass, sensor):
                                name=sensor['name'],
                                state=_get_sensor_state(sensor['cond']),
                                device_class=_get_device_class(sensor['type'])
-                              )
+                               )
 
 
 @asyncio.coroutine

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -13,13 +13,9 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_DISCOVER_DEVICES = 'egardia_sensor'
 D_EGARDIASYS = 'egardiadevice'
 
-# TODO: add mapping to 'smoke'
 EGARDIA_TYPE_TO_DEVICE_CLASS = {'IR Sensor': 'motion',
                                 'Door Contact': 'opening',
                                 'IR': 'motion'}
-# TODO: add state for triggered motion sensor
-# NOT USED FOR NOW since we do not know state of motion sensor
-EGARDIA_INPUT_TO_STATES = {'': STATE_OFF, 'Open': STATE_ON}
 
 
 def _get_device_class(egardia_type):
@@ -31,20 +27,19 @@ def _get_sensor_state(egardia_input):
         return STATE_ON
     else:
         return STATE_OFF
-#    return EGARDIA_INPUT_TO_STATES.get(egardia_input, STATE_UNAVAILABLE)
 
 
 def _create_sensor(hass, sensor):
-    return EgardiaBinarySensor(hass, senid=sensor["id"],
-                               name=sensor['name'],
-                               state=_get_sensor_state(sensor['cond']),
-                               device_class=_get_device_class(sensor['type'])
-                               )  # pylint: disable=bad-continuation
+    return EgardiaBinarySensor(
+        hass, senid=sensor["id"],
+        name=sensor['name'],
+        state=_get_sensor_state(sensor['cond']),
+        device_class=_get_device_class(sensor['type'])
+        )
 
 
 @asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices,
-                         discovery_info=None):
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Initialize the platform."""
     if (discovery_info is None or
             discovery_info[ATTR_DISCOVER_DEVICES] is None):
@@ -70,12 +65,6 @@ class EgardiaBinarySensor(BinarySensorDevice):
         self._device_class = device_class
         self._hass = hass
         # spc_registry.register_sensor_device(zone_id, self)
-
-    # @asyncio.coroutine
-    # def async_update_from_egardia(self, state, extra):
-    #    """Update the state of the device."""
-    #    self._state = state
-    #    yield from self.async_update_ha_state()
 
     def update(self):
         """Update the status."""

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -39,7 +39,7 @@ def _create_sensor(hass, sensor):
                                name=sensor['name'],
                                state=_get_sensor_state(sensor['cond']),
                                device_class=_get_device_class(sensor['type'])
-                               )
+                               )  # pylint: disable=bad-continuation
 
 
 @asyncio.coroutine
@@ -50,12 +50,12 @@ def async_setup_platform(hass, config, async_add_devices,
             discovery_info[ATTR_DISCOVER_DEVICES] is None):
         return
 
-    di = discovery_info[ATTR_DISCOVER_DEVICES]
+    discinfo = discovery_info[ATTR_DISCOVER_DEVICES]
 
     # multiple devices here!
     async_add_devices(
-        _create_sensor(hass, di[sensor])
-        for sensor in di
+        _create_sensor(hass, discinfo[sensor])
+        for sensor in discinfo
         )
 
 

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -1,0 +1,109 @@
+"""
+Interfaces with Egardia/Woonveilig alarm control panel.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.egardia/
+"""
+import logging
+import asyncio
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.const import (STATE_ON, STATE_OFF)
+_LOGGER = logging.getLogger(__name__)
+ATTR_DISCOVER_DEVICES = 'egardia_sensor'
+D_EGARDIASYS = 'egardiadevice'
+
+# TODO: add mapping to 'smoke'
+EGARDIA_TYPE_TO_DEVICE_CLASS = {'IR Sensor': 'motion',
+                                'Door Contact': 'opening',
+                                'IR': 'motion'}
+# TODO: add state for triggered motion sensor
+# NOT USED FOR NOW since we do not know state of motion sensor
+EGARDIA_INPUT_TO_STATES = {'': STATE_OFF, 'Open': STATE_ON}
+
+
+def _get_device_class(egardia_type):
+    return EGARDIA_TYPE_TO_DEVICE_CLASS.get(egardia_type, None)
+
+
+def _get_sensor_state(egardia_input):
+    if egardia_input:
+        return STATE_ON
+    else:
+        return STATE_OFF
+#    return EGARDIA_INPUT_TO_STATES.get(egardia_input, STATE_UNAVAILABLE)
+
+
+def _create_sensor(hass, sensor):
+    return EgardiaBinarySensor(hass, senid=sensor["id"],
+                               name=sensor['name'],
+                               state=_get_sensor_state(sensor['cond']),
+                               device_class=_get_device_class(sensor['type'])
+                              )
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices,
+                         discovery_info=None):
+    """Initialize the platform."""
+    if (discovery_info is None or
+            discovery_info[ATTR_DISCOVER_DEVICES] is None):
+        return
+
+    di = discovery_info[ATTR_DISCOVER_DEVICES]
+
+    # multiple devices here!
+    async_add_devices(
+        _create_sensor(hass, di[sensor])
+        for sensor in di
+        )
+
+
+class EgardiaBinarySensor(BinarySensorDevice):
+    """Represents a sensor based on an Egardia sensor (IR, Door Contact)."""
+
+    def __init__(self, hass, senid, name, state, device_class):
+        """Initialize the sensor device."""
+        self._id = senid
+        self._name = name
+        self._state = state
+        self._device_class = device_class
+        self._hass = hass
+        # spc_registry.register_sensor_device(zone_id, self)
+
+    # @asyncio.coroutine
+    # def async_update_from_egardia(self, state, extra):
+    #    """Update the state of the device."""
+    #    self._state = state
+    #    yield from self.async_update_ha_state()
+
+    def update(self):
+        """Update the status."""
+        egardia_input = self._hass.data[D_EGARDIASYS].getsensorstate(self._id)
+        self._state = _get_sensor_state(egardia_input)
+
+    @property
+    def name(self):
+        """The name of the device."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Whether the device is switched on."""
+        return self._state == STATE_ON
+
+    @property
+    def hidden(self):
+        """Whether the device is hidden by default."""
+        # these type of sensors are probably mainly used for automations
+        return True
+
+    @property
+    def should_poll(self):
+        """Polling required."""
+        return True
+
+    @property
+    def device_class(self):
+        """The device class."""
+        return self._device_class

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_REPORT_SERVER_CODES = 'report_server_codes'
 CONF_REPORT_SERVER_ENABLED = 'report_server_enabled'
 CONF_REPORT_SERVER_PORT = 'report_server_port'
-CONF_REPORT_SERVER_CODES_IGNORE = 'ignore'
+REPORT_SERVER_CODES_IGNORE = 'ignore'
 CONF_VERSION = 'version'
 
 DEFAULT_NAME = 'Egardia'

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_PORT, CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_NAME,
     EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pythonegardia==1.0.36']
+REQUIREMENTS = ['pythonegardia==1.0.38']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,6 +40,14 @@ NOTIFICATION_ID = 'egardia_notification'
 NOTIFICATION_TITLE = 'Egardia'
 ATTR_DISCOVER_DEVICES = 'egardia_sensor'
 
+SERVER_CODE_SCHEMA = vol.Schema({
+    vol.Optional('arm'): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional('disarm'): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional('home'): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional('triggered'): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional('ignore'): vol.All(cv.ensure_list, [cv.string])
+})
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_HOST): cv.string,
@@ -48,7 +56,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_VERSION, default=DEFAULT_VERSION): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_REPORT_SERVER_CODES): vol.All(cv.ensure_list),
+        vol.Optional(CONF_REPORT_SERVER_CODES): SERVER_CODE_SCHEMA,
         vol.Optional(CONF_REPORT_SERVER_ENABLED,
                      default=DEFAULT_REPORT_SERVER_ENABLED): cv.boolean,
         vol.Optional(CONF_REPORT_SERVER_PORT,

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_PORT, CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_NAME,
     EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pythonegardia==1.0.38']
+REQUIREMENTS = ['pythonegardia==1.0.36']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ ATTR_DISCOVER_DEVICES = 'egardia_sensor'
 SERVER_CODE_SCHEMA = vol.Schema({
     vol.Optional('arm'): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional('disarm'): vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional('home'): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional('armhome'): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional('triggered'): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional('ignore'): vol.All(cv.ensure_list, [cv.string])
 })

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -56,7 +56,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_VERSION, default=DEFAULT_VERSION): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_REPORT_SERVER_CODES): SERVER_CODE_SCHEMA,
+        vol.Optional(CONF_REPORT_SERVER_CODES, default={}): SERVER_CODE_SCHEMA,
         vol.Optional(CONF_REPORT_SERVER_ENABLED,
                      default=DEFAULT_REPORT_SERVER_ENABLED): cv.boolean,
         vol.Optional(CONF_REPORT_SERVER_PORT,

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_PORT, CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_NAME,
     EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pythonegardia==1.0.36']
+REQUIREMENTS = ['pythonegardia==1.0.38']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -41,11 +41,11 @@ NOTIFICATION_TITLE = 'Egardia'
 ATTR_DISCOVER_DEVICES = 'egardia_sensor'
 
 SERVER_CODE_SCHEMA = vol.Schema({
-    vol.Optional('arm'): vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional('disarm'): vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional('armhome'): vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional('triggered'): vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional('ignore'): vol.All(cv.ensure_list, [cv.string])
+    vol.Optional('arm'): vol.All(cv.ensure_list_csv, [cv.string]),
+    vol.Optional('disarm'): vol.All(cv.ensure_list_csv, [cv.string]),
+    vol.Optional('armhome'): vol.All(cv.ensure_list_csv, [cv.string]),
+    vol.Optional('triggered'): vol.All(cv.ensure_list_csv, [cv.string]),
+    vol.Optional('ignore'): vol.All(cv.ensure_list_csv, [cv.string])
 })
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/egardia/
 """
 import logging
+
 import requests
 import voluptuous as vol
 

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -1,0 +1,138 @@
+"""
+Interfaces with Egardia/Woonveilig alarm control panel.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/egardia/
+"""
+import logging
+
+import requests
+import voluptuous as vol
+
+import homeassistant.exceptions as exc
+from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    CONF_PORT, CONF_HOST, CONF_PASSWORD, CONF_USERNAME, STATE_UNKNOWN,
+    CONF_NAME, STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_TRIGGERED, EVENT_HOMEASSISTANT_STOP)
+
+REQUIREMENTS = ['pythonegardia==1.0.36']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_REPORT_SERVER_CODES = 'report_server_codes'
+CONF_REPORT_SERVER_ENABLED = 'report_server_enabled'
+CONF_REPORT_SERVER_PORT = 'report_server_port'
+CONF_REPORT_SERVER_CODES_IGNORE = 'ignore'
+CONF_VERSION = 'version'
+
+DEFAULT_NAME = 'Egardia'
+DEFAULT_PORT = 80
+DEFAULT_REPORT_SERVER_ENABLED = False
+DEFAULT_REPORT_SERVER_PORT = 52010
+DEFAULT_VERSION = 'GATE-01'
+DOMAIN = 'egardia'
+D_EGARDIASRV = 'egardiaserver'
+D_EGARDIASYS = 'egardiadevice'
+D_EGARDIANM = 'egardianame'
+D_EGARDIARSENABLED = 'egardia_rs_enabled'
+D_EGARDIARSCODES = 'egardia_rs_codes'
+D_EGARDIADEV = 'egardia_dev'
+NOTIFICATION_ID = 'egardia_notification'
+NOTIFICATION_TITLE = 'Egardia'
+ATTR_DISCOVER_DEVICES = 'egardia_sensor'
+STATES = {
+    'ARM': STATE_ALARM_ARMED_AWAY,
+    'DAY HOME': STATE_ALARM_ARMED_HOME,
+    'DISARM': STATE_ALARM_DISARMED,
+    'HOME': STATE_ALARM_ARMED_HOME,
+    'TRIGGERED': STATE_ALARM_TRIGGERED,
+    'UNKNOWN': STATE_UNKNOWN,
+}
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_VERSION, default=DEFAULT_VERSION): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_REPORT_SERVER_CODES): vol.All(cv.ensure_list),
+        vol.Optional(CONF_REPORT_SERVER_ENABLED,
+                     default=DEFAULT_REPORT_SERVER_ENABLED): cv.boolean,
+        vol.Optional(CONF_REPORT_SERVER_PORT,
+                     default=DEFAULT_REPORT_SERVER_PORT): cv.port,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Set up the Egardia platform."""
+    from pythonegardia import egardiadevice
+    from pythonegardia import egardiaserver
+
+    name = config[DOMAIN].get(CONF_NAME)
+    hass.data[D_EGARDIANM] = name
+    username = config[DOMAIN].get(CONF_USERNAME)
+    password = config[DOMAIN].get(CONF_PASSWORD)
+    host = config[DOMAIN].get(CONF_HOST)
+    port = config[DOMAIN].get(CONF_PORT)
+    rs_enabled = config[DOMAIN].get(CONF_REPORT_SERVER_ENABLED)
+    hass.data[D_EGARDIARSENABLED] = rs_enabled
+    rs_port = config[DOMAIN].get(CONF_REPORT_SERVER_PORT)
+    rs_codes = config[DOMAIN].get(CONF_REPORT_SERVER_CODES)
+    hass.data[D_EGARDIARSCODES] = rs_codes
+    version = config[DOMAIN].get(CONF_VERSION)
+    try:
+        hass.data[D_EGARDIASYS] = egardiadevice.EgardiaDevice(
+            host, port, username, password, '', version)
+    except requests.exceptions.RequestException:
+        raise exc.PlatformNotReady()
+    except egardiadevice.UnauthorizedError:
+        _LOGGER.error("Unable to authorize. Wrong password or username")
+        return
+
+    # add egardia alarm device
+    def alarm_loaded(event, data=None):
+        """Check if egardia platform has loaded."""
+        if event is DOMAIN:
+            # configure egardia server, including callback
+            if rs_enabled:
+                # Set up the egardia server
+                _LOGGER.info("Setting up EgardiaServer")
+                try:
+                    if D_EGARDIASRV not in hass.data:
+                        server = egardiaserver.EgardiaServer('', rs_port)
+                        bound = server.bind()
+                        if not bound:
+                            raise IOError("Binding error occurred while " +
+                                          "starting EgardiaServer")
+                        hass.data[D_EGARDIASRV] = server
+                        server.start()
+                except IOError:
+                    return
+                hass.data[D_EGARDIASRV].register_callback(hass.data[D_EGARDIADEV].handle_status_event)
+
+    # register for callback since we might need to set up the egardia server
+    discovery.listen_platform(hass, 'alarm_control_panel', alarm_loaded)
+
+    hass.async_add_job(discovery.async_load_platform(
+        hass, 'alarm_control_panel', DOMAIN,
+        discovered=None, hass_config=config))
+
+    def handle_stop_event(event):
+        """Callback function for HA stop event."""
+        hass.data[D_EGARDIASRV].stop()
+
+    # listen to home assistant stop event
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, handle_stop_event)
+
+    # get the sensors from the device and add those
+    sensors = hass.data[D_EGARDIASYS].getsensors()
+    hass.async_add_job(discovery.async_load_platform(
+        hass, 'binary_sensor', DOMAIN,
+        {ATTR_DISCOVER_DEVICES: sensors}, config))
+
+    return True

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -113,7 +113,8 @@ def setup(hass, config):
                         server.start()
                 except IOError:
                     return
-                hass.data[D_EGARDIASRV].register_callback(hass.data[D_EGARDIADEV].handle_status_event)
+                hass.data[D_EGARDIASRV].register_callback(
+                    hass.data[D_EGARDIADEV].handle_status_event)
 
     # register for callback since we might need to set up the egardia server
     discovery.listen_platform(hass, 'alarm_control_panel', alarm_loaded)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -964,7 +964,7 @@ python_openzwave==0.4.0.35
 
 # homeassistant.components.egardia
 # homeassistant.components.alarm_control_panel.egardia
-pythonegardia==1.0.38
+pythonegardia==1.0.36
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -964,7 +964,7 @@ python_openzwave==0.4.0.35
 
 # homeassistant.components.egardia
 # homeassistant.components.alarm_control_panel.egardia
-pythonegardia==1.0.36
+pythonegardia==1.0.38
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -963,6 +963,7 @@ python_opendata_transport==0.0.3
 python_openzwave==0.4.0.35
 
 # homeassistant.components.egardia
+# homeassistant.components.alarm_control_panel.egardia
 pythonegardia==1.0.36
 
 # homeassistant.components.sensor.whois

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -962,8 +962,8 @@ python_opendata_transport==0.0.3
 # homeassistant.components.zwave
 python_openzwave==0.4.0.35
 
-# homeassistant.components.alarm_control_panel.egardia
-pythonegardia==1.0.26
+# homeassistant.components.egardia
+pythonegardia==1.0.36
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3


### PR DESCRIPTION
## Description:
We re-architected the alarm_control_panel.egardia component to be a generic component. Also, adding in sensor support. Replacement of #11871 .

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4803

## Example entry for `configuration.yaml` (if applicable):
```yaml
egardia:
    host: YOUR_HOST
    username: YOUR_USERNAME
    password: YOUR_PASSWORD
```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
