### PR TITLE
Added support for hourly percent change in coinmarketcap component

### DIFF
--- a/homeassistant/components/sensor/coinmarketcap.py
+++ b/homeassistant/components/sensor/coinmarketcap.py
@@ -106,7 +106,7 @@ class CoinMarketCapSensor(Entity):
                 'market_cap_{}'.format(self.data.display_currency)),
             ATTR_PERCENT_CHANGE_24H: self._ticker.get('percent_change_24h'),
             ATTR_PERCENT_CHANGE_7D: self._ticker.get('percent_change_7d'),
-            ATTR_PERCENT_CHANGE_7D: self._ticker.get('percent_change_1h'),
+            ATTR_PERCENT_CHANGE_1H: self._ticker.get('percent_change_1h'),
             ATTR_SYMBOL: self._ticker.get('symbol'),
             ATTR_TOTAL_SUPPLY: self._ticker.get('total_supply'),
         }

--- a/homeassistant/components/sensor/coinmarketcap.py
+++ b/homeassistant/components/sensor/coinmarketcap.py
@@ -26,6 +26,7 @@ ATTR_MARKET_CAP = 'market_cap'
 ATTR_NAME = 'name'
 ATTR_PERCENT_CHANGE_24H = 'percent_change_24h'
 ATTR_PERCENT_CHANGE_7D = 'percent_change_7d'
+ATTR_PERCENT_CHANGE_1H = 'percent_change_1h'
 ATTR_PRICE = 'price'
 ATTR_SYMBOL = 'symbol'
 ATTR_TOTAL_SUPPLY = 'total_supply'
@@ -105,6 +106,7 @@ class CoinMarketCapSensor(Entity):
                 'market_cap_{}'.format(self.data.display_currency)),
             ATTR_PERCENT_CHANGE_24H: self._ticker.get('percent_change_24h'),
             ATTR_PERCENT_CHANGE_7D: self._ticker.get('percent_change_7d'),
+            ATTR_PERCENT_CHANGE_7D: self._ticker.get('percent_change_1h'),
             ATTR_SYMBOL: self._ticker.get('symbol'),
             ATTR_TOTAL_SUPPLY: self._ticker.get('total_supply'),
         }


### PR DESCRIPTION
## Description:
Adding support to return the hourly percent change of a crypto in the coinmarketcap component.  

Presently, the component only supports 24 and 7 day values.   Adding the support for hourly allows automation to alert the user if a coin is trending up or down within the last hour. (e.g. flash a light)   

I ran this locally and values were returned successfully in the sensor.

## Checklist:
  - [X] The code change is tested and works locally.

- [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


