### PR TITLE
sensor.deutsche_bahn: add only_direct option

### DIFF
--- a/homeassistant/components/sensor/deutsche_bahn.py
+++ b/homeassistant/components/sensor/deutsche_bahn.py
@@ -99,9 +99,7 @@ class SchieneData(object):
     def update(self):
         """Update the connection data."""
         self.connections = self.schiene.connections(
-            self.start,
-            self.goal,
-            dt_util.as_local(dt_util.utcnow()),
+            self.start, self.goal, dt_util.as_local(dt_util.utcnow()),
             self.only_direct)
 
         for con in self.connections:

--- a/homeassistant/components/sensor/deutsche_bahn.py
+++ b/homeassistant/components/sensor/deutsche_bahn.py
@@ -20,6 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_DESTINATION = 'to'
 CONF_START = 'from'
+CONF_ONLY_DIRECT = 'only_direct'
+DEFAULT_ONLY_DIRECT = False
 
 ICON = 'mdi:train'
 
@@ -28,6 +30,7 @@ SCAN_INTERVAL = timedelta(minutes=2)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DESTINATION): cv.string,
     vol.Required(CONF_START): cv.string,
+    vol.Optional(CONF_ONLY_DIRECT, default=DEFAULT_ONLY_DIRECT): cv.boolean,
 })
 
 
@@ -35,17 +38,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Deutsche Bahn Sensor."""
     start = config.get(CONF_START)
     destination = config.get(CONF_DESTINATION)
+    only_direct = config.get(CONF_ONLY_DIRECT)
 
-    add_devices([DeutscheBahnSensor(start, destination)], True)
+    add_devices([DeutscheBahnSensor(start, destination, only_direct)], True)
 
 
 class DeutscheBahnSensor(Entity):
     """Implementation of a Deutsche Bahn sensor."""
 
-    def __init__(self, start, goal):
+    def __init__(self, start, goal, only_direct):
         """Initialize the sensor."""
         self._name = '{} to {}'.format(start, goal)
-        self.data = SchieneData(start, goal)
+        self.data = SchieneData(start, goal, only_direct)
         self._state = None
 
     @property
@@ -82,19 +86,20 @@ class DeutscheBahnSensor(Entity):
 class SchieneData(object):
     """Pull data from the bahn.de web page."""
 
-    def __init__(self, start, goal):
+    def __init__(self, start, goal, only_direct):
         """Initialize the sensor."""
         import schiene
 
         self.start = start
         self.goal = goal
+        self.only_direct = only_direct
         self.schiene = schiene.Schiene()
         self.connections = [{}]
 
     def update(self):
         """Update the connection data."""
         self.connections = self.schiene.connections(
-            self.start, self.goal, dt_util.as_local(dt_util.utcnow()))
+            self.start, self.goal, dt_util.as_local(dt_util.utcnow()), self.only_direct)
 
         for con in self.connections:
             # Detail info is not useful. Having a more consistent interface

--- a/homeassistant/components/sensor/deutsche_bahn.py
+++ b/homeassistant/components/sensor/deutsche_bahn.py
@@ -99,7 +99,10 @@ class SchieneData(object):
     def update(self):
         """Update the connection data."""
         self.connections = self.schiene.connections(
-            self.start, self.goal, dt_util.as_local(dt_util.utcnow()), self.only_direct)
+            self.start,
+            self.goal,
+            dt_util.as_local(dt_util.utcnow()),
+            self.only_direct)
 
         for con in self.connections:
             # Detail info is not useful. Having a more consistent interface


### PR DESCRIPTION
This adds the `only_direct` option to the HA interface as provided by the schiene class.

## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4542



## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: deutsche_bahn
    from: "Buxtehude"
    to: "Oberammergau"
    only_direct: True
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] No new dependencies
  - [x] No new files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
