### PR TITLE
[SMALL-PR] Set default values for Daikin devices that don't support certain features

### DIFF
--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -98,10 +98,16 @@ class DaikinClimate(ClimateDevice):
         daikin_attr = HA_ATTR_TO_DAIKIN[ATTR_FAN_MODE]
         if self._api.device.values.get(daikin_attr) is not None:
             self._supported_features |= SUPPORT_FAN_MODE
+        else:
+            # even devices without support must have a default valid value
+            self._api.device.values[daikin_attr] = 'A'
 
         daikin_attr = HA_ATTR_TO_DAIKIN[ATTR_SWING_MODE]
         if self._api.device.values.get(daikin_attr) is not None:
             self._supported_features |= SUPPORT_SWING_MODE
+        else:
+            # even devices without support must have a default valid value
+            self._api.device.values[daikin_attr] = '0'
 
     def get(self, key):
         """Retrieve device settings from API library cache."""


### PR DESCRIPTION
## Description:
While a previous fixed was made and tested locally on a device that supported fan mode and fan direction there's still an error in the external pydaikin library that we use that is not aware if a device supports those features and still tries to perform reads on some values that are not set since they dont exist on those devices. This causes an error in HA so we had to set some default valid values for those props so it won't complain about them anymore.

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/daikin-component-no-climate-entities-created-task-exception/39608/47

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
