### PR TITLE
Add UpCloud platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -235,6 +235,9 @@ omit =
     homeassistant/components/notify/twilio_sms.py
     homeassistant/components/notify/twilio_call.py
 
+    homeassistant/components/upcloud.py
+    homeassistant/components/*/upcloud.py
+
     homeassistant/components/usps.py
     homeassistant/components/*/usps.py
 

--- a/homeassistant/components/binary_sensor/upcloud.py
+++ b/homeassistant/components/binary_sensor/upcloud.py
@@ -1,0 +1,42 @@
+"""
+Support for monitoring the state of UpCloud servers.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.upcloud/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.components.upcloud import (
+    UpCloudServerMixin, CONF_SERVERS, DATA_UPCLOUD)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['upcloud']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SERVERS): vol.All(cv.ensure_list, [cv.string]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the UpCloud server binary sensor."""
+    upcloud = hass.data[DATA_UPCLOUD]
+
+    servers = config.get(CONF_SERVERS)
+
+    devices = [UpCloudBinarySensor(upcloud, uuid) for uuid in servers]
+
+    add_devices(devices, True)
+
+
+class UpCloudBinarySensor(UpCloudServerMixin, BinarySensorDevice):
+    """Representation of an UpCloud server sensor."""
+
+    def __init__(self, upcloud, uuid):
+        """Initialize a new UpCloud sensor."""
+        UpCloudServerMixin.__init__(self, upcloud, uuid)

--- a/homeassistant/components/binary_sensor/upcloud.py
+++ b/homeassistant/components/binary_sensor/upcloud.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, PLATFORM_SCHEMA)
 from homeassistant.components.upcloud import (
-    UpCloudServerMixin, CONF_SERVERS, DATA_UPCLOUD)
+    UpCloudServerEntity, CONF_SERVERS, DATA_UPCLOUD)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,9 +34,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(devices, True)
 
 
-class UpCloudBinarySensor(UpCloudServerMixin, BinarySensorDevice):
+class UpCloudBinarySensor(UpCloudServerEntity, BinarySensorDevice):
     """Representation of an UpCloud server sensor."""
 
     def __init__(self, upcloud, uuid):
         """Initialize a new UpCloud sensor."""
-        UpCloudServerMixin.__init__(self, upcloud, uuid)
+        UpCloudServerEntity.__init__(self, upcloud, uuid)

--- a/homeassistant/components/switch/upcloud.py
+++ b/homeassistant/components/switch/upcloud.py
@@ -8,10 +8,11 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.const import STATE_OFF
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.components.upcloud import (
-    UpCloudServerMixin, CONF_SERVERS, DATA_UPCLOUD)
+    UpCloudServerEntity, CONF_SERVERS, DATA_UPCLOUD)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,27 +34,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(devices, True)
 
 
-class UpCloudSwitch(UpCloudServerMixin, SwitchDevice):
+class UpCloudSwitch(UpCloudServerEntity, SwitchDevice):
     """Representation of an UpCloud server switch."""
 
     def __init__(self, upcloud, uuid):
         """Initialize a new UpCloud server switch."""
-        UpCloudServerMixin.__init__(self, upcloud, uuid)
+        UpCloudServerEntity.__init__(self, upcloud, uuid)
 
     def turn_on(self, **kwargs):
         """Start the server."""
-        try:
-            state = self.data.state
-        except AttributeError:
-            return
-        if state == 'stopped':
+        if self.state == STATE_OFF:
             self.data.start()
 
     def turn_off(self, **kwargs):
         """Stop the server."""
-        try:
-            state = self.data.state
-        except AttributeError:
-            return
-        if state == 'started':
+        if self.is_on:
             self.data.stop()

--- a/homeassistant/components/switch/upcloud.py
+++ b/homeassistant/components/switch/upcloud.py
@@ -1,0 +1,64 @@
+"""
+Support for interacting with UpCloud servers.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/switch.upcloud/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.components.upcloud import (
+    UpCloudServerMixin, CONF_SERVERS, DATA_UPCLOUD)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['upcloud']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SERVERS): vol.All(cv.ensure_list, [cv.string]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the UpCloud server switch."""
+    upcloud = hass.data[DATA_UPCLOUD]
+
+    servers = config.get(CONF_SERVERS)
+
+    devices = [UpCloudSwitch(upcloud, uuid) for uuid in servers]
+
+    add_devices(devices, True)
+
+
+class UpCloudSwitch(UpCloudServerMixin, SwitchDevice):
+    """Representation of an UpCloud server switch."""
+
+    def __init__(self, upcloud, uuid):
+        """Initialize a new UpCloud server switch."""
+        UpCloudServerMixin.__init__(self, upcloud, uuid)
+
+    def turn_on(self, **kwargs):
+        """Start the server."""
+        try:
+            state = self.data.state
+        except AttributeError:
+            return
+        if state == 'stopped':
+            old_timeout = self.data.cloud_manager.timeout
+            try:
+                self.data.cloud_manager.timeout = None
+                self.data.start()
+            finally:
+                self.data.cloud_manager.timeout = old_timeout
+
+    def turn_off(self, **kwargs):
+        """Stop the server."""
+        try:
+            state = self.data.state
+        except AttributeError:
+            return
+        if state == 'started':
+            self.data.stop()

--- a/homeassistant/components/switch/upcloud.py
+++ b/homeassistant/components/switch/upcloud.py
@@ -47,12 +47,7 @@ class UpCloudSwitch(UpCloudServerMixin, SwitchDevice):
         except AttributeError:
             return
         if state == 'stopped':
-            old_timeout = self.data.cloud_manager.timeout
-            try:
-                self.data.cloud_manager.timeout = None
-                self.data.start()
-            finally:
-                self.data.cloud_manager.timeout = old_timeout
+            self.data.start()
 
     def turn_off(self, **kwargs):
         """Stop the server."""

--- a/homeassistant/components/upcloud.py
+++ b/homeassistant/components/upcloud.py
@@ -113,6 +113,7 @@ class UpCloudServerEntity(Entity):
         """Initialize the UpCloud server entity."""
         self._upcloud = upcloud
         self.uuid = uuid
+        self.data = None
 
     @property
     def name(self):

--- a/homeassistant/components/upcloud.py
+++ b/homeassistant/components/upcloud.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['upcloud-api==0.3.9']
+REQUIREMENTS = ['upcloud-api==0.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/upcloud.py
+++ b/homeassistant/components/upcloud.py
@@ -1,0 +1,133 @@
+"""
+Support for UpCloud.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/upcloud/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['upcloud-api==0.3.9']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_CORE_NUMBER = 'core_number'
+ATTR_HOSTNAME = 'hostname'
+ATTR_MEMORY_AMOUNT = 'memory_amount'
+ATTR_STATE = 'state'
+ATTR_TITLE = 'title'
+ATTR_UUID = 'uuid'
+ATTR_ZONE = 'zone'
+
+CONF_SERVERS = 'servers'
+
+DATA_UPCLOUD = 'data_upcloud'
+DOMAIN = 'upcloud'
+
+DEFAULT_COMPONENT_NAME = 'UpCloud {}'
+DEFAULT_COMPONENT_DEVICE_CLASS = 'power'
+
+UPCLOUD_PLATFORMS = ['binary_sensor', 'switch']
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Set up the UpCloud component."""
+    import upcloud_api
+
+    conf = config[DOMAIN]
+    username = conf.get(CONF_USERNAME)
+    password = conf.get(CONF_PASSWORD)
+
+    manager = upcloud_api.CloudManager(username, password)
+
+    try:
+        manager.authenticate()
+    except upcloud_api.UpCloudAPIError:
+        _LOGGER.error("Authentication failed.")
+        return False
+
+    hass.data[DATA_UPCLOUD] = UpCloud(manager)
+    hass.data[DATA_UPCLOUD].update()
+
+    return True
+
+
+class UpCloud(object):
+    """Handle all communication with the UpCloud API."""
+
+    def __init__(self, manager):
+        """Initialize the UpCloud connection."""
+        self.data = {}
+        self.manager = manager
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Use the data from UpCloud API."""
+        self.data = {
+            server.uuid: server for server in self.manager.get_servers()
+        }
+
+
+class UpCloudServerMixin(object):
+    """Common properties for UpCloud server components."""
+
+    def __init__(self, upcloud, uuid):
+        """Initialize a new UpCloud server mixin."""
+        self._upcloud = upcloud
+        self.uuid = uuid
+        self.data = None
+
+    @property
+    def name(self):
+        """Return the name of the component."""
+        try:
+            return DEFAULT_COMPONENT_NAME.format(self.data.title)
+        except (AttributeError, KeyError, TypeError):
+            return DEFAULT_COMPONENT_NAME.format(self.uuid)
+
+    @property
+    def icon(self):
+        """Return the icon of this server."""
+        return 'mdi:server' if self.is_on else 'mdi:server-off'
+
+    @property
+    def is_on(self):
+        """Return true if the server is on."""
+        try:
+            return self.data.state == 'started'
+        except AttributeError:
+            return False
+
+    @property
+    def device_class(self):
+        """Return the class of this server."""
+        return DEFAULT_COMPONENT_DEVICE_CLASS
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the UpCloud server."""
+        return {
+            x: getattr(self.data, x, None)
+            for x in (ATTR_UUID, ATTR_TITLE, ATTR_HOSTNAME, ATTR_ZONE,
+                      ATTR_STATE, ATTR_CORE_NUMBER, ATTR_MEMORY_AMOUNT)
+        }
+
+    def update(self):
+        """Update state of sensor."""
+        self._upcloud.update()
+        self.data = self._upcloud.data.get(self.uuid)

--- a/homeassistant/components/upcloud.py
+++ b/homeassistant/components/upcloud.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['upcloud-api==0.4.1']
+REQUIREMENTS = ['upcloud-api==0.4.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1181,7 +1181,7 @@ twilio==5.7.0
 uber_rides==0.6.0
 
 # homeassistant.components.upcloud
-upcloud-api==0.3.9
+upcloud-api==0.4.1
 
 # homeassistant.components.sensor.ups
 upsmychoice==1.0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1181,7 +1181,7 @@ twilio==5.7.0
 uber_rides==0.6.0
 
 # homeassistant.components.upcloud
-upcloud-api==0.4.1
+upcloud-api==0.4.2
 
 # homeassistant.components.sensor.ups
 upsmychoice==1.0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1180,6 +1180,9 @@ twilio==5.7.0
 # homeassistant.components.sensor.uber
 uber_rides==0.6.0
 
+# homeassistant.components.upcloud
+upcloud-api==0.3.9
+
 # homeassistant.components.sensor.ups
 upsmychoice==1.0.6
 


### PR DESCRIPTION
## Description:

Add UpCloud platform.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4543

## Example entry for `configuration.yaml` (if applicable):
```yaml
upcloud:
  username: YOUR_API_USERNAME
  password: YOUR_API_PASSWORD

binary_sensor:
  - platform: upcloud
    servers:
      - 002167b7-4cb1-44b7-869f-e0900ddeeae1
      - 00886296-6137-4074-afe3-068e16d89d00

switch:
  - platform: upcloud
    servers:
      - 002167b7-4cb1-44b7-869f-e0900ddeeae1
      - 00886296-6137-4074-afe3-068e16d89d00
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
