### PR TITLE
Fix MQTT embedded broker for Windows

### DIFF
--- a/homeassistant/components/mqtt/server.py
+++ b/homeassistant/components/mqtt/server.py
@@ -39,7 +39,8 @@ def async_start(hass, server_config):
 
     try:
         # Create a temporary file to store the (hashed) credentials for HBMQTT.
-        # NOTE: Must use delete=False, otherwise Windows won't allow HBMQTT to open the file while we have it open.
+        # NOTE: Must use delete=False, otherwise Windows won't allow HBMQTT to
+        # open the file while we have it open.
         passwd = tempfile.NamedTemporaryFile(delete=False)
 
         if server_config is None:

--- a/homeassistant/components/mqtt/server.py
+++ b/homeassistant/components/mqtt/server.py
@@ -37,7 +37,7 @@ def async_start(hass, server_config):
     from hbmqtt.broker import Broker, BrokerException
 
     try:
-        passwd = tempfile.NamedTemporaryFile()
+        passwd = tempfile.NamedTemporaryFile(delete=False)
 
         if server_config is None:
             server_config, client_config = generate_config(hass, passwd)


### PR DESCRIPTION
See Issue #10939 for details. 

Basically this allows you to use the Embedded MQTT broker on Windows, which currently doesn't work due to a bug in how the password/configuration is passed via temporary file.

The only side effect is now this temporary file won't be deleted. (Though according to python documentation, it wouldn't have been deleted on Linux anyway)

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
