### PR TITLE
Fix DoorBird push notifications for HA instances with an API password

### DIFF
--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -73,6 +73,7 @@ def setup(hass, config):
 class DoorbirdRequestView(HomeAssistantView):
     """Provide a page for the device to call."""
 
+    requires_auth = False
     url = API_URL
     name = API_URL[1:].replace('/', ':')
     extra_urls = [API_URL + '/{sensor}']


### PR DESCRIPTION
## Description:

Due to testing only on a Home Assistant instance without an API password, I previously overlooked the necessity of the endpoint to accept requests from a DoorBird without authentication.

This change removes the requirement for authentication on calls `/api/doorbird/doorbell`.

**Related issue (if applicable):** https://community.home-assistant.io/t/doorbird-integration/5564/50

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
