### PR TITLE
Fix MQTT cover availability subscription

### DIFF
--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -214,16 +214,6 @@ class MqttCover(MqttAvailability, CoverDevice):
 
             self.async_schedule_update_ha_state()
 
-        @callback
-        def availability_message_received(topic, payload, qos):
-            """Handle new MQTT availability messages."""
-            if payload == self._payload_available:
-                self._available = True
-            elif payload == self._payload_not_available:
-                self._available = False
-
-            self.async_schedule_update_ha_state()
-
         if self._state_topic is None:
             # Force into optimistic mode.
             self._optimistic = True
@@ -231,11 +221,6 @@ class MqttCover(MqttAvailability, CoverDevice):
             yield from mqtt.async_subscribe(
                 self.hass, self._state_topic,
                 state_message_received, self._qos)
-
-        if self._availability_topic is not None:
-            yield from mqtt.async_subscribe(
-                self.hass, self._availability_topic,
-                availability_message_received, self._qos)
 
         if self._tilt_status_topic is None:
             self._tilt_optimistic = True


### PR DESCRIPTION
## Description:

Removes an obsolete subscription to the `availability_topic` in MQTT covers.

With #11336, MQTT component availability code has been refactored into the `MqttAvailability` class - so the subscription in the cover component is no longer necessary.

It should be noted that the code, as it currently is in Home Assistant, works fine - this is just removing the unnecessary subscription.

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  - platform: mqtt
    name: "MQTT Cover"
    command_topic: "cover/set"
    availability_topic: "cover/status"
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
