### PR TITLE
Return all attributes that are not None in base lock entity class

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -161,12 +161,12 @@ class LockDevice(Entity):
     @property
     def state_attributes(self):
         """Return the state attributes."""
-        data = {}
+        state_attr = {}
         for prop, attr in PROP_TO_ATTR.items():
             value = getattr(self, prop)
             if value is not None:
-                data[attr] = value
-        return data
+                state_attr[attr] = value
+        return state_attr
 
     @property
     def state(self):

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -41,6 +41,11 @@ LOCK_SERVICE_SCHEMA = vol.Schema({
 
 _LOGGER = logging.getLogger(__name__)
 
+PROP_TO_ATTR = {
+    'changed_by': ATTR_CHANGED_BY,
+    'code_format': ATTR_CODE_FORMAT,
+}
+
 
 @bind_hass
 def is_locked(hass, entity_id=None):
@@ -156,13 +161,12 @@ class LockDevice(Entity):
     @property
     def state_attributes(self):
         """Return the state attributes."""
-        if self.code_format is None:
-            return None
-        state_attr = {
-            ATTR_CODE_FORMAT: self.code_format,
-            ATTR_CHANGED_BY: self.changed_by
-        }
-        return state_attr
+        data = {}
+        for prop, attr in PROP_TO_ATTR.items():
+            value = getattr(self, prop)
+            if value is not None:
+                data[attr] = value
+        return data
 
     @property
     def state(self):


### PR DESCRIPTION
## Description:
Base lock entity class is only allowing state attributes to be reported if the code_format property returns something. It should return all attributes that are not None.

This is report based on PR comment from https://github.com/home-assistant/home-assistant/pull/11124

## Checklist:
  - [ ] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
