### PR TITLE
Set flux default stop time to dusk

### DIFF
--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -48,7 +48,7 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_LIGHTS): cv.entity_ids,
     vol.Optional(CONF_NAME, default="Flux"): cv.string,
     vol.Optional(CONF_START_TIME): cv.time,
-    vol.Optional(CONF_STOP_TIME, default=datetime.time(22, 0)): cv.time,
+    vol.Optional(CONF_STOP_TIME): cv.time,
     vol.Optional(CONF_START_CT, default=4000):
         vol.All(vol.Coerce(int), vol.Range(min=1000, max=40000)),
     vol.Optional(CONF_SUNSET_CT, default=3000):
@@ -184,9 +184,7 @@ class FluxSwitch(SwitchDevice):
 
         sunset = get_astral_event_date(self.hass, 'sunset', now.date())
         start_time = self.find_start_time(now)
-        stop_time = now.replace(
-            hour=self._stop_time.hour, minute=self._stop_time.minute,
-            second=0)
+        stop_time = self.find_stop_time(now)
 
         if stop_time <= start_time:
             # stop_time does not happen in the same day as start_time
@@ -270,3 +268,13 @@ class FluxSwitch(SwitchDevice):
         else:
             sunrise = get_astral_event_date(self.hass, 'sunrise', now.date())
         return sunrise
+
+    def find_stop_time(self, now):
+        """Return dusk or stop_time if given."""
+        if self._stop_time:
+            dusk = now.replace(
+                hour=self._stop_time.hour, minute=self._stop_time.minute,
+                second=0)
+        else:
+            dusk = get_astral_event_date(self.hass, 'dusk', now.date())
+        return dusk

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -238,7 +238,8 @@ class TestSwitchFlux(unittest.TestCase):
                     switch.DOMAIN: {
                         'platform': 'flux',
                         'name': 'flux',
-                        'lights': [dev1.entity_id]
+                        'lights': [dev1.entity_id],
+                        'stop_time': '22:00'
                     }
                 })
                 turn_on_calls = mock_service(
@@ -638,7 +639,8 @@ class TestSwitchFlux(unittest.TestCase):
                         'name': 'flux',
                         'lights': [dev1.entity_id],
                         'start_colortemp': '1000',
-                        'stop_colortemp': '6000'
+                        'stop_colortemp': '6000',
+                        'stop_time': '22:00'
                     }
                 })
                 turn_on_calls = mock_service(
@@ -686,7 +688,8 @@ class TestSwitchFlux(unittest.TestCase):
                         'platform': 'flux',
                         'name': 'flux',
                         'lights': [dev1.entity_id],
-                        'brightness': 255
+                        'brightness': 255,
+                        'stop_time': '22:00'
                     }
                 })
                 turn_on_calls = mock_service(


### PR DESCRIPTION
## Description:

Flux defaults to 22:00 as its stop time, but generally light temperature transitions happen from sunrise to sunset and from sunset to dusk.

This sets the default stop_time to dusk, but still allows for a custom configured stop_time.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4553>

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

