### PR TITLE
Squeezebox Fix duplicate server from discovery

### DIFF
--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -71,8 +71,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     known_servers = hass.data.get(KNOWN_SERVERS)
     if known_servers is None:
-        known_servers = set()
-        hass.data[KNOWN_SERVERS] = known_servers
+        hass.data[KNOWN_SERVERS] = known_servers = set()
 
     if DATA_SQUEEZEBOX not in hass.data:
         hass.data[DATA_SQUEEZEBOX] = []

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -47,7 +47,7 @@ SERVICE_CALL_METHOD = 'squeezebox_call_method'
 
 DATA_SQUEEZEBOX = 'squeezebox'
 
-KNOWN_SERVERS = []
+KNOWN_SERVERS = 'squeezebox_known_servers'
 
 ATTR_PARAMETERS = 'parameters'
 
@@ -68,6 +68,11 @@ SERVICE_TO_METHOD = {
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the squeezebox platform."""
     import socket
+
+    known_servers = hass.data.get(KNOWN_SERVERS)
+    if known_servers is None:
+        known_servers = set()
+        hass.data[KNOWN_SERVERS] = known_servers
 
     if DATA_SQUEEZEBOX not in hass.data:
         hass.data[DATA_SQUEEZEBOX] = []
@@ -94,10 +99,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             "Could not communicate with %s:%d: %s", host, port, error)
         return False
 
-    if ipaddr in KNOWN_SERVERS:
+    if ipaddr in known_servers:
         return
 
-    KNOWN_SERVERS.append(ipaddr)
+    known_servers.add(ipaddr)
     _LOGGER.debug("Creating LMS object for %s", ipaddr)
     lms = LogitechMediaServer(hass, host, port, username, password)
 

--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -47,6 +47,8 @@ SERVICE_CALL_METHOD = 'squeezebox_call_method'
 
 DATA_SQUEEZEBOX = 'squeezebox'
 
+KNOWN_SERVERS = []
+
 ATTR_PARAMETERS = 'parameters'
 
 SQUEEZEBOX_CALL_METHOD_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
@@ -92,6 +94,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             "Could not communicate with %s:%d: %s", host, port, error)
         return False
 
+    if ipaddr in KNOWN_SERVERS:
+        return
+
+    KNOWN_SERVERS.append(ipaddr)
     _LOGGER.debug("Creating LMS object for %s", ipaddr)
     lms = LogitechMediaServer(hass, host, port, username, password)
 


### PR DESCRIPTION
## Description:
Squeezebox component would create multiple entries if it was defined manually and found with discovery.  This wasn't obvious until the recent Entity registry commit.  These changes fix that behavior.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A



## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
