### PR TITLE
Deconz use entity registry

### DIFF
--- a/homeassistant/components/binary_sensor/deconz.py
+++ b/homeassistant/components/binary_sensor/deconz.py
@@ -66,6 +66,11 @@ class DeconzBinarySensor(BinarySensorDevice):
         return self._sensor.name
 
     @property
+    def unique_id(self):
+        """Return a unique identifier for this sensor."""
+        return self._sensor.uniqueid
+
+    @property
     def device_class(self):
         """Return the class of the sensor."""
         return self._sensor.sensor_class

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['pydeconz==25']
+REQUIREMENTS = ['pydeconz==27']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ SERVICE_DATA = 'data'
 
 SERVICE_SCHEMA = vol.Schema({
     vol.Required(SERVICE_FIELD): cv.string,
-    vol.Required(SERVICE_DATA): cv.string,
+    vol.Required(SERVICE_DATA): dict,
 })
 
 CONFIG_INSTRUCTIONS = """

--- a/homeassistant/components/light/deconz.py
+++ b/homeassistant/components/light/deconz.py
@@ -101,6 +101,11 @@ class DeconzLight(Light):
         return self._light.name
 
     @property
+    def unique_id(self):
+        """Return a unique identifier for this sensor."""
+        return self._light.uniqueid
+
+    @property
     def supported_features(self):
         """Flag supported features."""
         return self._features

--- a/homeassistant/components/light/deconz.py
+++ b/homeassistant/components/light/deconz.py
@@ -102,7 +102,7 @@ class DeconzLight(Light):
 
     @property
     def unique_id(self):
-        """Return a unique identifier for this sensor."""
+        """Return a unique identifier for this light."""
         return self._light.uniqueid
 
     @property

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -75,6 +75,11 @@ class DeconzSensor(Entity):
         return self._sensor.name
 
     @property
+    def unique_id(self):
+        """Return a unique identifier for this sensor."""
+        return self._sensor.uniqueid
+
+    @property
     def device_class(self):
         """Return the class of the sensor."""
         return self._sensor.sensor_class
@@ -138,6 +143,11 @@ class DeconzBattery(Entity):
     def name(self):
         """Return the name of the battery."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return a unique identifier for this sensor."""
+        return self._device.uniqueid
 
     @property
     def device_class(self):

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -146,7 +146,7 @@ class DeconzBattery(Entity):
 
     @property
     def unique_id(self):
-        """Return a unique identifier for this sensor."""
+        """Return a unique identifier for the device."""
         return self._device.uniqueid
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -687,7 +687,7 @@ pycsspeechtts==1.0.2
 pydaikin==0.4
 
 # homeassistant.components.deconz
-pydeconz==25
+pydeconz==27
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Description:
Use entity registry to safe guard from entity names with randomised suffix for multi sensor devices.
Fixes so the service data stays as a dict.
Fixes a situation where deconz would report a faulty IP and web sockets would use that address to communicate over rather than the already configured IP.

## Checklist:
  - [x] The code change is tested and works locally.