### PR TITLE
Fix demo platform support

### DIFF
--- a/homeassistant/components/climate/demo.py
+++ b/homeassistant/components/climate/demo.py
@@ -14,6 +14,8 @@ from homeassistant.components.climate import (
     SUPPORT_ON_OFF)
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_TEMPERATURE
 
+SUPPORT_FLAGS = SUPPORT_TARGET_HUMIDITY_LOW | SUPPORT_TARGET_HUMIDITY_HIGH
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Demo climate devices."""
@@ -38,7 +40,7 @@ class DemoClimate(ClimateDevice):
                  is_on):
         """Initialize the climate device."""
         self._name = name
-        self._support_flags = 0
+        self._support_flags = SUPPORT_FLAGS
         if target_temperature is not None:
             self._support_flags = \
                 self._support_flags | SUPPORT_TARGET_TEMPERATURE
@@ -50,8 +52,7 @@ class DemoClimate(ClimateDevice):
             self._support_flags = self._support_flags | SUPPORT_FAN_MODE
         if target_humidity is not None:
             self._support_flags = \
-                self._support_flags | SUPPORT_TARGET_HUMIDITY | \
-                SUPPORT_TARGET_HUMIDITY_LOW | SUPPORT_TARGET_HUMIDITY_HIGH
+                self._support_flags | SUPPORT_TARGET_HUMIDITY
         if current_swing_mode is not None:
             self._support_flags = self._support_flags | SUPPORT_SWING_MODE
         if current_operation is not None:

--- a/homeassistant/components/climate/demo.py
+++ b/homeassistant/components/climate/demo.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/demo/
 from homeassistant.components.climate import (
     ClimateDevice, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY,
+    SUPPORT_TARGET_HUMIDITY_LOW, SUPPORT_TARGET_HUMIDITY_HIGH,
     SUPPORT_AWAY_MODE, SUPPORT_HOLD_MODE, SUPPORT_FAN_MODE,
     SUPPORT_OPERATION_MODE, SUPPORT_AUX_HEAT, SUPPORT_SWING_MODE,
     SUPPORT_TARGET_TEMPERATURE_HIGH, SUPPORT_TARGET_TEMPERATURE_LOW,
@@ -22,7 +23,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                     None, None),
         DemoClimate('Hvac', 21, TEMP_CELSIUS, True, None, 22, 'On High',
                     67, 54, 'Off', 'cool', False, None, None, True),
-        DemoClimate('Ecobee', None, TEMP_CELSIUS, None, None, 23, 'Auto Low',
+        DemoClimate('Ecobee', None, TEMP_CELSIUS, None, 'home', 23, 'Auto Low',
                     None, None, 'Auto', 'auto', None, 24, 21, None)
     ])
 
@@ -49,7 +50,8 @@ class DemoClimate(ClimateDevice):
             self._support_flags = self._support_flags | SUPPORT_FAN_MODE
         if target_humidity is not None:
             self._support_flags = \
-                self._support_flags | SUPPORT_TARGET_HUMIDITY
+                self._support_flags | SUPPORT_TARGET_HUMIDITY | \
+                SUPPORT_TARGET_HUMIDITY_LOW | SUPPORT_TARGET_HUMIDITY_HIGH
         if current_swing_mode is not None:
             self._support_flags = self._support_flags | SUPPORT_SWING_MODE
         if current_operation is not None:

--- a/homeassistant/components/climate/demo.py
+++ b/homeassistant/components/climate/demo.py
@@ -7,30 +7,23 @@ https://home-assistant.io/components/demo/
 from homeassistant.components.climate import (
     ClimateDevice, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY,
-    SUPPORT_TARGET_HUMIDITY_LOW, SUPPORT_TARGET_HUMIDITY_HIGH,
     SUPPORT_AWAY_MODE, SUPPORT_HOLD_MODE, SUPPORT_FAN_MODE,
     SUPPORT_OPERATION_MODE, SUPPORT_AUX_HEAT, SUPPORT_SWING_MODE,
     SUPPORT_TARGET_TEMPERATURE_HIGH, SUPPORT_TARGET_TEMPERATURE_LOW,
     SUPPORT_ON_OFF)
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_TEMPERATURE
 
-SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_HUMIDITY |
-                 SUPPORT_TARGET_HUMIDITY_LOW | SUPPORT_TARGET_HUMIDITY_HIGH |
-                 SUPPORT_AWAY_MODE | SUPPORT_HOLD_MODE | SUPPORT_FAN_MODE |
-                 SUPPORT_OPERATION_MODE | SUPPORT_AUX_HEAT |
-                 SUPPORT_SWING_MODE | SUPPORT_TARGET_TEMPERATURE_HIGH |
-                 SUPPORT_TARGET_TEMPERATURE_LOW | SUPPORT_ON_OFF)
-
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Demo climate devices."""
     add_devices([
         DemoClimate('HeatPump', 68, TEMP_FAHRENHEIT, None, None, 77,
-                    'Auto Low', None, None, 'Auto', 'heat', None, None, None),
+                    'Auto Low', None, None, 'Auto', 'heat', None, None,
+                    None, None),
         DemoClimate('Hvac', 21, TEMP_CELSIUS, True, None, 22, 'On High',
-                    67, 54, 'Off', 'cool', False, None, None),
+                    67, 54, 'Off', 'cool', False, None, None, True),
         DemoClimate('Ecobee', None, TEMP_CELSIUS, None, None, 23, 'Auto Low',
-                    None, None, 'Auto', 'auto', None, 24, 21)
+                    None, None, 'Auto', 'auto', None, 24, 21, None)
     ])
 
 
@@ -40,9 +33,37 @@ class DemoClimate(ClimateDevice):
     def __init__(self, name, target_temperature, unit_of_measurement,
                  away, hold, current_temperature, current_fan_mode,
                  target_humidity, current_humidity, current_swing_mode,
-                 current_operation, aux, target_temp_high, target_temp_low):
+                 current_operation, aux, target_temp_high, target_temp_low,
+                 is_on):
         """Initialize the climate device."""
         self._name = name
+        self._support_flags = 0
+        if target_temperature is not None:
+            self._support_flags = \
+                self._support_flags | SUPPORT_TARGET_TEMPERATURE
+        if away is not None:
+            self._support_flags = self._support_flags | SUPPORT_AWAY_MODE
+        if hold is not None:
+            self._support_flags = self._support_flags | SUPPORT_HOLD_MODE
+        if current_fan_mode is not None:
+            self._support_flags = self._support_flags | SUPPORT_FAN_MODE
+        if target_humidity is not None:
+            self._support_flags = \
+                self._support_flags | SUPPORT_TARGET_HUMIDITY
+        if current_swing_mode is not None:
+            self._support_flags = self._support_flags | SUPPORT_SWING_MODE
+        if current_operation is not None:
+            self._support_flags = self._support_flags | SUPPORT_OPERATION_MODE
+        if aux is not None:
+            self._support_flags = self._support_flags | SUPPORT_AUX_HEAT
+        if target_temp_high is not None:
+            self._support_flags = \
+                self._support_flags | SUPPORT_TARGET_TEMPERATURE_HIGH
+        if target_temp_low is not None:
+            self._support_flags = \
+                self._support_flags | SUPPORT_TARGET_TEMPERATURE_LOW
+        if is_on is not None:
+            self._support_flags = self._support_flags | SUPPORT_ON_OFF
         self._target_temperature = target_temperature
         self._target_humidity = target_humidity
         self._unit_of_measurement = unit_of_measurement
@@ -59,12 +80,12 @@ class DemoClimate(ClimateDevice):
         self._swing_list = ['Auto', '1', '2', '3', 'Off']
         self._target_temperature_high = target_temp_high
         self._target_temperature_low = target_temp_low
-        self._on = True
+        self._on = is_on
 
     @property
     def supported_features(self):
         """Return the list of supported features."""
-        return SUPPORT_FLAGS
+        return self._support_flags
 
     @property
     def should_poll(self):

--- a/homeassistant/components/climate/demo.py
+++ b/homeassistant/components/climate/demo.py
@@ -21,10 +21,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Demo climate devices."""
     add_devices([
         DemoClimate('HeatPump', 68, TEMP_FAHRENHEIT, None, None, 77,
-                    'Auto Low', None, None, 'Auto', 'heat', None, None,
-                    None, None),
+                    None, None, None, None, 'heat', None, None,
+                    None, True),
         DemoClimate('Hvac', 21, TEMP_CELSIUS, True, None, 22, 'On High',
-                    67, 54, 'Off', 'cool', False, None, None, True),
+                    67, 54, 'Off', 'cool', False, None, None, None),
         DemoClimate('Ecobee', None, TEMP_CELSIUS, None, 'home', 23, 'Auto Low',
                     None, None, 'Auto', 'auto', None, 24, 21, None)
     ])

--- a/tests/components/climate/test_demo.py
+++ b/tests/components/climate/test_demo.py
@@ -224,10 +224,10 @@ class TestDemoClimate(unittest.TestCase):
 
     def test_set_hold_mode_none(self):
         """Test setting the hold mode off/false."""
-        climate.set_hold_mode(self.hass, None, ENTITY_ECOBEE)
+        climate.set_hold_mode(self.hass, 'off', ENTITY_ECOBEE)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_ECOBEE)
-        self.assertEqual(None, state.attributes.get('hold_mode'))
+        self.assertEqual('off', state.attributes.get('hold_mode'))
 
     def test_set_aux_heat_bad_attr(self):
         """Test setting the auxiliary heater without required attribute."""


### PR DESCRIPTION
## Description:
Add support for supported_features inside demo component. This will be paired with https://github.com/home-assistant/home-assistant-polymer/pull/849

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: demo
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
