### PR TITLE
Fix forecast display problem in Firefox

### DIFF
--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -138,7 +138,7 @@ class OpenWeatherMapWeather(WeatherEntity):
     def forecast(self):
         """Return the forecast array."""
         return [{
-            ATTR_FORECAST_TIME: entry.get_reference_time('iso'),
+            ATTR_FORECAST_TIME: entry.get_reference_time('unix') * 1000,
             ATTR_FORECAST_TEMP: entry.get_temperature('celsius').get('temp')}
                 for entry in self.forecast_data.get_weathers()]
 


### PR DESCRIPTION
## Description:
In Firefox the forecast chart is empty because of a not working timestamp format.

**Related issue (if applicable):** fixes #12055

## Example entry for `configuration.yaml` (if applicable):

```yaml
weather:
  - platform: openweathermap
    api_key: !secret owm_api
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
