### PR TITLE
Add conditions to forecast

### DIFF
--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -21,12 +21,14 @@ REQUIREMENTS = ['pyowm==2.8.0']
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_FORECAST_CONDITION = 'condition'
 ATTRIBUTION = 'Data provided by OpenWeatherMap'
 
 DEFAULT_NAME = 'OpenWeatherMap'
 
 MIN_TIME_BETWEEN_FORECAST_UPDATES = timedelta(minutes=30)
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=10)
+MIN_OFFSET_BETWEEN_FORECAST_CONDITIONS = 3
 
 CONDITION_CLASSES = {
     'cloudy': [804],
@@ -137,10 +139,16 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        return [{
-            ATTR_FORECAST_TIME: entry.get_reference_time('iso'),
-            ATTR_FORECAST_TEMP: entry.get_temperature('celsius').get('temp')}
-                for entry in self.forecast_data.get_weathers()]
+        data = []
+        for entry in self.forecast_data.get_weathers():
+            data.append({
+                ATTR_FORECAST_TIME: entry.get_reference_time('iso'),
+                ATTR_FORECAST_TEMP: entry.get_temperature('celsius').get('temp')
+            })
+            if (len(data) - 1) % MIN_OFFSET_BETWEEN_FORECAST_CONDITIONS == 0:
+               data[len(data) - 1][ATTR_FORECAST_CONDITION] = \
+                   [k for k, v in CONDITION_CLASSES.items() if entry.get_weather_code() in v][0]
+        return data
 
     def update(self):
         """Get the latest data from OWM and updates the states."""

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -147,9 +147,9 @@ class OpenWeatherMapWeather(WeatherEntity):
                     entry.get_temperature('celsius').get('temp')
             })
             if (len(data) - 1) % MIN_OFFSET_BETWEEN_FORECAST_CONDITIONS == 0:
-               data[len(data) - 1][ATTR_FORECAST_CONDITION] = \
-                   [k for k, v in CONDITION_CLASSES.items() 
-                    if entry.get_weather_code() in v][0]
+                data[len(data) - 1][ATTR_FORECAST_CONDITION] = \
+                    [k for k, v in CONDITION_CLASSES.items()
+                     if entry.get_weather_code() in v][0]
         return data
 
     def update(self):


### PR DESCRIPTION
## Description:
Currently no conditions are shown in the forecast of the weather.openweathermap component.
This pull request changes this.

## Example entry for `configuration.yaml` (if applicable):

```yaml
weather:
  - platform: openweathermap
    api_key: !secret owm_api
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
