### PR TITLE
Fix detection of mobile browsers

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -591,5 +591,6 @@ def _is_latest(js_option, request):
         'Edge': 14,     # Array.prototype.includes added in 14
         'Safari': 10,   # many features not supported by 9
     }
-    version = family_min_version.get(useragent.browser.family)
+    version = family_min_version.get(useragent.browser.family
+                                     .replace('Mobile', '').strip())
     return version and useragent.browser.version[0] >= version

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -591,6 +591,6 @@ def _is_latest(js_option, request):
         'Edge': 14,     # Array.prototype.includes added in 14
         'Safari': 10,   # many features not supported by 9
     }
-    version = family_min_version.get(useragent.browser.family
-                                     .replace('Mobile', '').strip())
+    version = family_min_version.get(
+        useragent.browser.family.replace('Mobile', '').strip())
     return version and useragent.browser.version[0] >= version

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -586,11 +586,12 @@ def _is_latest(js_option, request):
 
     family_min_version = {
         'Chrome': 50,   # Probably can reduce this
+        'Chrome Mobile': 50,
         'Firefox': 43,  # Array.prototype.includes added in 43
+        'Firefox Mobile': 43,
         'Opera': 40,    # Probably can reduce this
         'Edge': 14,     # Array.prototype.includes added in 14
         'Safari': 10,   # many features not supported by 9
     }
-    version = family_min_version.get(
-        useragent.browser.family.replace('Mobile', '').strip())
+    version = family_min_version.get(useragent.browser.family)
     return version and useragent.browser.version[0] >= version


### PR DESCRIPTION
## Description:

Mobile browsers have "Mobile" in their family name like "Chrome Mobile".
fix by @mhofman

**Related issue (if applicable):** fixes #12068

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
