### PR TITLE
scripts: respect --skip-pip

### DIFF
--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -41,14 +41,17 @@ def run(args: List) -> int:
     mount_local_lib_path(config_dir)
     pip_kwargs = requirements.pip_kwargs(config_dir)
 
+    skip_pip = extract_skip_pip()
+
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
-    for req in getattr(script, 'REQUIREMENTS', []):
-        returncode = install_package(req, **pip_kwargs)
+    if not skip_pip:
+        for req in getattr(script, 'REQUIREMENTS', []):
+            returncode = install_package(req, **pip_kwargs)
 
-        if not returncode:
-            print('Aborting script, could not install dependency', req)
-            return 1
+            if not returncode:
+                print('Aborting script, could not install dependency', req)
+                return 1
 
     return script.run(args[1:])  # type: ignore
 
@@ -60,3 +63,10 @@ def extract_config_dir(args=None) -> str:
     args = parser.parse_known_args(args)[0]
     return (os.path.join(os.getcwd(), args.config) if args.config
             else get_default_config_dir())
+
+
+def extract_skip_pip(args=None) -> bool:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('--skip-pip', action='store_true')
+    args = parser.parse_known_args(args)[0]
+    return args.skip_pip

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -23,6 +23,10 @@ def run(args):
         description=("Run a Home Assistant benchmark."))
     parser.add_argument('name', choices=BENCHMARKS)
     parser.add_argument('--script', choices=['benchmark'])
+    parser.add_argument(
+        '--skip-pip',
+        action='store_true',
+        help='Skips pip install of required packages on startup')
 
     args = parser.parse_args()
 

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -70,6 +70,10 @@ def run(script_args: List) -> int:
         default=config_util.get_default_config_dir(),
         help="Directory that contains the Home Assistant configuration")
     parser.add_argument(
+        '--skip-pip',
+        action='store_true',
+        help='Skips pip install of required packages on startup')
+    parser.add_argument(
         '-i', '--info',
         default=None,
         help="Show a portion of the config")

--- a/homeassistant/scripts/credstash.py
+++ b/homeassistant/scripts/credstash.py
@@ -16,6 +16,10 @@ def run(args):
     parser.add_argument(
         '--script', choices=['credstash'])
     parser.add_argument(
+        '--skip-pip',
+        action='store_true',
+        help='Skips pip install of required packages on startup')
+    parser.add_argument(
         'action', choices=['get', 'put', 'del', 'list'],
         help="Get, put or delete a secret, or list all available secrets")
     parser.add_argument(

--- a/homeassistant/scripts/db_migrator.py
+++ b/homeassistant/scripts/db_migrator.py
@@ -61,6 +61,10 @@ def run(script_args: List) -> int:
         default=config_util.get_default_config_dir(),
         help="Directory that contains the Home Assistant configuration")
     parser.add_argument(
+        '--skip-pip',
+        action='store_true',
+        help='Skips pip install of required packages on startup')
+    parser.add_argument(
         '-a', '--append',
         action='store_true',
         default=False,

--- a/homeassistant/scripts/ensure_config.py
+++ b/homeassistant/scripts/ensure_config.py
@@ -16,6 +16,10 @@ def run(args):
         default=config_util.get_default_config_dir(),
         help="Directory that contains the Home Assistant configuration")
     parser.add_argument(
+        '--skip-pip',
+        action='store_true',
+        help='Skips pip install of required packages on startup')
+    parser.add_argument(
         '--script',
         choices=['ensure_config'])
 

--- a/homeassistant/scripts/influxdb_import.py
+++ b/homeassistant/scripts/influxdb_import.py
@@ -25,6 +25,10 @@ def run(script_args: List) -> int:
         default=config_util.get_default_config_dir(),
         help="Directory that contains the Home Assistant configuration")
     parser.add_argument(
+        '--skip-pip',
+        action='store_true',
+        help='Skips pip install of required packages on startup')
+    parser.add_argument(
         '--uri',
         type=str,
         help="Connect to URI and import (if other than default sqlite) "

--- a/homeassistant/scripts/influxdb_migrator.py
+++ b/homeassistant/scripts/influxdb_migrator.py
@@ -38,6 +38,10 @@ def run(script_args: List) -> int:
     parser = argparse.ArgumentParser(
         description="Migrate legacy influxDB.")
     parser.add_argument(
+        '--skip-pip',
+        action='store_true',
+        help='Skips pip install of required packages on startup')
+    parser.add_argument(
         '-d', '--dbname',
         metavar='dbname',
         required=True,

--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -17,6 +17,10 @@ def run(args):
     parser.add_argument(
         '--script', choices=['keyring'])
     parser.add_argument(
+        '--skip-pip',
+        action='store_true',
+        help='Skips pip install of required packages on startup')
+    parser.add_argument(
         'action', choices=['get', 'set', 'del', 'info'],
         help="Get, set or delete a secret")
     parser.add_argument(


### PR DESCRIPTION
## Description:
Make all scripts provide a `--skip-pip` option.

This has three benefits:
- Being able to run the scripts with *newer* versions of the requirements installed.
- Being able to run the scripts without an internet connection, even if the requirements do not match versions.
- Being able to restrict a home-assistant system service's privileges to read-only except for the config directory. (A service may want to check the config before starting.)

**Related issue (if applicable):** fixes #11917

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated: No need because one can call `--help`

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] ~Tests have been added to verify that the new code works.~ Can't be tested in a meaningful way.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
