### PR TITLE
Correct use of middleware async handling

### DIFF
--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -23,7 +23,7 @@ def auth_middleware(request, handler):
     # If no password set, just always set authenticated=True
     if request.app['hass'].http.api_password is None:
         request[KEY_AUTHENTICATED] = True
-        return handler(request)
+        return (yield from handler(request))
 
     # Check authentication
     authenticated = False
@@ -46,7 +46,7 @@ def auth_middleware(request, handler):
         authenticated = True
 
     request[KEY_AUTHENTICATED] = authenticated
-    return handler(request)
+    return (yield from handler(request))
 
 
 def is_trusted_ip(request):

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -67,7 +67,7 @@ def staticresource_middleware(request, handler):
     """Middleware to strip out fingerprint from fingerprinted assets."""
     path = request.path
     if not path.startswith('/static/') and not path.startswith('/frontend'):
-        return handler(request)
+        return (yield from handler(request))
 
     fingerprinted = _FINGERPRINT.match(request.match_info['filename'])
 
@@ -75,4 +75,4 @@ def staticresource_middleware(request, handler):
         request.match_info['filename'] = \
             '{}.{}'.format(*fingerprinted.groups())
 
-    return handler(request)
+    return (yield from handler(request))


### PR DESCRIPTION
## Description:

A fairly low-level fix to ensure that the middleware is returning futures.

I found this after quite a significant amount of debugging whilst I was looking at the idea of adding session support with ``aiohttp_session``. ``aiohttp_session`` strongly checks the return type from middleware, and I was getting a

```
ERROR:aiohttp.server:Error handling request
Traceback (most recent call last):
  File "/Users/pelson/miniconda/envs/hass-dev/lib/python3.6/site-packages/aiohttp/web_protocol.py", line 410, in start
    resp = yield from self._request_handler(request)
  File "/Users/pelson/miniconda/envs/hass-dev/lib/python3.6/site-packages/aiohttp/web.py", line 325, in _handle
    resp = yield from handler(request)
  File "/Users/pelson/miniconda/envs/hass-dev/lib/python3.6/site-packages/aiohttp/web_middlewares.py", line 93, in impl
    return (yield from handler(request))
  File "/Users/pelson/dev/aiohttp/aiohttp-session/aiohttp_session/__init__.py", line 142, in factory
    "".format(type(response)))
RuntimeError: Expect response, not <class 'generator'>
```

In the aiohttp_session code at https://github.com/aio-libs/aiohttp-session/blob/v2.1.0/aiohttp_session/__init__.py#L136-L137.

I'll be following this PR up with a proposal for adding session data to the server.




----------

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
