### PR TITLE
Upgrade keyring to 11.0.0

### DIFF
--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -29,7 +29,7 @@ def run(args):
 
     if args.action == 'info':
         keyr = keyring.get_keyring()
-        print('Keyring version {}\n'.format(keyring.__version__))
+        print('Keyring version {}\n'.format(REQUIREMENTS[0].split('==')[1]))
         print('Active keyring  : {}'.format(keyr.__module__))
         config_name = os.path.join(platform.config_root(), 'keyringrc.cfg')
         print('Config location : {}'.format(config_name))

--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -5,7 +5,7 @@ import os
 
 from homeassistant.util.yaml import _SECRET_NAMESPACE
 
-REQUIREMENTS = ['keyring==10.6.0', 'keyrings.alt==2.3']
+REQUIREMENTS = ['keyring==11.0.0', 'keyrings.alt==2.3']
 
 
 def run(args):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -425,7 +425,7 @@ jsonrpc-async==0.6
 jsonrpc-websocket==0.5
 
 # homeassistant.scripts.keyring
-keyring==10.6.0
+keyring==11.0.0
 
 # homeassistant.scripts.keyring
 keyrings.alt==2.3


### PR DESCRIPTION
## Description:
- No longer expose `keyring.__version__` (added in 8.1) to avoid performance hit loading pkg_resources.

```bash
$ hass --script keyring --help
INFO:homeassistant.util.package:Attempting install of keyring==11.0.0
usage: hass [-h] [--script {keyring}] {get,set,del,info} [name]

Modify Home Assistant secrets in the default keyring. Use the secrets in
configuration files with: !secret <name>

positional arguments:
  {get,set,del,info}  Get, set or delete a secret
  name                Name of the secret

optional arguments:
  -h, --help          show this help message and exit
  --script {keyring}
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
