### PR TITLE
Goalfeed channel

### DIFF
--- a/homeassistant/components/goalfeed.py
+++ b/homeassistant/components/goalfeed.py
@@ -54,7 +54,7 @@ def setup(hass, config):
         channel.bind('goal', goal_handler)
 
     pusher = pysher.Pusher(GOALFEED_APP_ID, secure=False, port=8080,
-                           custom_host=GOALFEED_HOST, timeout=30)
+                           custom_host=GOALFEED_HOST)
 
     pusher.connection.bind('pusher:connection_established', connect_handler)
     pusher.connect()

--- a/homeassistant/components/goalfeed.py
+++ b/homeassistant/components/goalfeed.py
@@ -51,7 +51,7 @@ def setup(hass, config):
                              timeout=30).json()
 
         channel = pusher.subscribe('private-goals', resp['auth'])
-        channel.bind('goalfeed_goal', goal_handler)
+        channel.bind('goal', goal_handler)
 
     pusher = pysher.Pusher(GOALFEED_APP_ID, secure=False, port=8080,
                            custom_host=GOALFEED_HOST, timeout=30)


### PR DESCRIPTION
## Description:
Accidentally added this timeout here when I added it to all the requests. Also a fix for the channel name which I thought should have been merged already

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
