### PR TITLE
Fix for iTunes media player not updating artwork

### DIFF
--- a/homeassistant/components/media_player/itunes.py
+++ b/homeassistant/components/media_player/itunes.py
@@ -5,7 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.itunes/
 """
 import logging
-import time
+
 import requests
 import voluptuous as vol
 
@@ -131,7 +131,7 @@ class Itunes(object):
 
     def artwork_url(self):
         """Return a URL of the current track's album art."""
-        return self._base_url + '/artwork?time=' + str(time.time())
+        return self._base_url + '/artwork'
 
     def airplay_devices(self):
         """Return a list of AirPlay devices."""
@@ -280,7 +280,7 @@ class ItunesDevice(MediaPlayerDevice):
         """Image url of current playing media."""
         if self.player_state in (STATE_PLAYING, STATE_IDLE, STATE_PAUSED) and \
            self.current_title is not None:
-            return self.client.artwork_url()
+            return self.client.artwork_url() + '?id=' + self.content_id
 
         return 'https://cloud.githubusercontent.com/assets/260/9829355' \
             '/33fab972-58cf-11e5-8ea2-2ca74bdaae40.png'

--- a/homeassistant/components/media_player/itunes.py
+++ b/homeassistant/components/media_player/itunes.py
@@ -5,10 +5,9 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.itunes/
 """
 import logging
-
+import time
 import requests
 import voluptuous as vol
-import time
 
 from homeassistant.components.media_player import (
     MEDIA_TYPE_MUSIC, MEDIA_TYPE_PLAYLIST, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE,

--- a/homeassistant/components/media_player/itunes.py
+++ b/homeassistant/components/media_player/itunes.py
@@ -8,6 +8,7 @@ import logging
 
 import requests
 import voluptuous as vol
+import time
 
 from homeassistant.components.media_player import (
     MEDIA_TYPE_MUSIC, MEDIA_TYPE_PLAYLIST, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE,
@@ -131,7 +132,7 @@ class Itunes(object):
 
     def artwork_url(self):
         """Return a URL of the current track's album art."""
-        return self._base_url + '/artwork'
+        return self._base_url + '/artwork?time=' + str(time.time())
 
     def airplay_devices(self):
         """Return a list of AirPlay devices."""


### PR DESCRIPTION
Appended content_id to media file URL so that it's not cached, as the URL exposed by the API never changes

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
