### PR TITLE
Update min js=latest version

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -585,9 +585,9 @@ def _is_latest(js_option, request):
         return useragent.os.version[0] >= 12
 
     family_min_version = {
-        'Chrome': 50,   # Probably can reduce this
-        'Firefox': 43,  # Array.prototype.includes added in 43
-        'Opera': 40,    # Probably can reduce this
+        'Chrome': 54,   # Object.values
+        'Firefox': 47,  # Object.values
+        'Opera': 41,    # Object.values
         'Edge': 14,     # Array.prototype.includes added in 14
         'Safari': 10,   # many features not supported by 9
     }


### PR DESCRIPTION
## Description:

Update min js=latest version:
Require Chrome 54, FF 47, Opera 41 for `Object.values`

## Checklist:
  - [ ] The code change is tested and works locally.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
