### PR TITLE
Force update support for mqtt binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -14,8 +14,8 @@ import homeassistant.components.mqtt as mqtt
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, DEVICE_CLASSES_SCHEMA)
 from homeassistant.const import (
-    CONF_NAME, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF,
-    CONF_DEVICE_CLASS)
+    CONF_FORCE_UPDATE, CONF_NAME, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_ON,
+    CONF_PAYLOAD_OFF, CONF_DEVICE_CLASS)
 from homeassistant.components.mqtt import (
     CONF_STATE_TOPIC, CONF_AVAILABILITY_TOPIC, CONF_PAYLOAD_AVAILABLE,
     CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS, MqttAvailability)
@@ -24,8 +24,10 @@ import homeassistant.helpers.config_validation as cv
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'MQTT Binary sensor'
+
 DEFAULT_PAYLOAD_OFF = 'OFF'
 DEFAULT_PAYLOAD_ON = 'ON'
+DEFAULT_FORCE_UPDATE = False
 
 DEPENDENCIES = ['mqtt']
 
@@ -34,6 +36,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
     vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+    vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
@@ -53,6 +56,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_AVAILABILITY_TOPIC),
         config.get(CONF_DEVICE_CLASS),
         config.get(CONF_QOS),
+        config.get(CONF_FORCE_UPDATE),
         config.get(CONF_PAYLOAD_ON),
         config.get(CONF_PAYLOAD_OFF),
         config.get(CONF_PAYLOAD_AVAILABLE),
@@ -65,7 +69,7 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
     """Representation a binary sensor that is updated by MQTT."""
 
     def __init__(self, name, state_topic, availability_topic, device_class,
-                 qos, payload_on, payload_off, payload_available,
+                 qos, force_update, payload_on, payload_off, payload_available,
                  payload_not_available, value_template):
         """Initialize the MQTT binary sensor."""
         super().__init__(availability_topic, qos, payload_available,
@@ -77,6 +81,7 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
         self._payload_on = payload_on
         self._payload_off = payload_off
         self._qos = qos
+        self._force_update = force_update
         self._template = value_template
 
     @asyncio.coroutine
@@ -124,3 +129,8 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
     def device_class(self):
         """Return the class of this sensor."""
         return self._device_class
+
+    @property
+    def force_update(self):
+        """Force update."""
+        return self._force_update


### PR DESCRIPTION
## Description:
Adds 'force_update' option support to the mqttbinary sensor. All the changes made are based on force_update support for mqtt sensor https://github.com/home-assistant/home-assistant/pull/6492

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/4558

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: mqtt
    state_topic: "home-assistant/window/contact"
    force_update: true
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
