### PR TITLE
Support for future dates when calculating age

### DIFF
--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -189,7 +189,7 @@ def get_age(date: dt.datetime) -> str:
         return first // second, first % second
 
     if date > now():
-        delta = date - now()
+        delta = date + timedelta(seconds=0.9) - now()
     else:
         delta = now() - date
 

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -175,7 +175,6 @@ def get_age(date: dt.datetime) -> str:
     The age can be in second, minute, hour, day, month or year. Only the
     biggest unit is considered, e.g. if it's 2 days and 3 hours, "2 days" will
     be returned.
-    Make sure date is not in the future, or else it won't work.
     """
     def formatn(number: int, unit: str) -> str:
         """Add "unit" if it's plural."""
@@ -189,7 +188,13 @@ def get_age(date: dt.datetime) -> str:
         """Return quotient and remaining."""
         return first // second, first % second
 
-    delta = now() - date
+    
+    # Check if the date is in the future or the past
+    if(date > now()):
+      delta = date - now()
+    else:
+      delta = now() - date
+    
     day = delta.days
     second = delta.seconds
 

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -188,8 +188,7 @@ def get_age(date: dt.datetime) -> str:
         """Return quotient and remaining."""
         return first // second, first % second
 
-    """ Check if the date is in the future or the past """
-    if(date > now()):
+    if date > now():
         delta = date - now()
     else:
         delta = now() - date

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -188,8 +188,7 @@ def get_age(date: dt.datetime) -> str:
         """Return quotient and remaining."""
         return first // second, first % second
 
-    
-    # Check if the date is in the future or the past
+    """ Check if the date is in the future or the past """
     if(date > now()):
         delta = date - now()
     else:

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -191,10 +191,10 @@ def get_age(date: dt.datetime) -> str:
     
     # Check if the date is in the future or the past
     if(date > now()):
-      delta = date - now()
+        delta = date - now()
     else:
-      delta = now() - date
-    
+        delta = now() - date
+
     day = delta.days
     second = delta.seconds
 

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -1,6 +1,7 @@
 """Test Home Assistant date util methods."""
 import unittest
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import homeassistant.util.dt as dt_util
 

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -164,3 +164,15 @@ class TestDateUtil(unittest.TestCase):
 
         diff = dt_util.now() - timedelta(minutes=365*60*24)
         self.assertEqual(dt_util.get_age(diff), "1 year")
+        
+        diff = dt_util.now() + timedelta(seconds=1)
+        self.assertEqual(dt_util.get_age(diff), "1 second")
+
+        diff = dt_util.now() + timedelta(seconds=30)
+        self.assertEqual(dt_util.get_age(diff), "30 seconds")
+
+        diff = dt_util.now() + timedelta(minutes=5)
+        self.assertEqual(dt_util.get_age(diff), "5 minutes")
+
+        diff = dt_util.now() + timedelta(minutes=1)
+        self.assertEqual(dt_util.get_age(diff), "1 minute")

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -164,7 +164,7 @@ class TestDateUtil(unittest.TestCase):
 
         diff = dt_util.now() - timedelta(minutes=365*60*24)
         self.assertEqual(dt_util.get_age(diff), "1 year")
-        
+
         diff = dt_util.now() + timedelta(seconds=1)
         self.assertEqual(dt_util.get_age(diff), "1 second")
 

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -135,44 +135,45 @@ class TestDateUtil(unittest.TestCase):
 
     def test_get_age(self):
         """Test get_age."""
-        diff = dt_util.now() - timedelta(seconds=0)
-        self.assertEqual(dt_util.get_age(diff), "0 seconds")
+        with patch('homeassistant.util.utcnow', return_value=dt_util.now()):
+            diff = dt_util.now() - timedelta(seconds=0)
+            self.assertEqual(dt_util.get_age(diff), "0 seconds")
 
-        diff = dt_util.now() - timedelta(seconds=1)
-        self.assertEqual(dt_util.get_age(diff), "1 second")
+            diff = dt_util.now() - timedelta(seconds=1)
+            self.assertEqual(dt_util.get_age(diff), "1 second")
 
-        diff = dt_util.now() - timedelta(seconds=30)
-        self.assertEqual(dt_util.get_age(diff), "30 seconds")
+            diff = dt_util.now() - timedelta(seconds=30)
+            self.assertEqual(dt_util.get_age(diff), "30 seconds")
 
-        diff = dt_util.now() - timedelta(minutes=5)
-        self.assertEqual(dt_util.get_age(diff), "5 minutes")
+            diff = dt_util.now() - timedelta(minutes=5)
+            self.assertEqual(dt_util.get_age(diff), "5 minutes")
 
-        diff = dt_util.now() - timedelta(minutes=1)
-        self.assertEqual(dt_util.get_age(diff), "1 minute")
+            diff = dt_util.now() - timedelta(minutes=1)
+            self.assertEqual(dt_util.get_age(diff), "1 minute")
 
-        diff = dt_util.now() - timedelta(minutes=300)
-        self.assertEqual(dt_util.get_age(diff), "5 hours")
+            diff = dt_util.now() - timedelta(minutes=300)
+            self.assertEqual(dt_util.get_age(diff), "5 hours")
 
-        diff = dt_util.now() - timedelta(minutes=320)
-        self.assertEqual(dt_util.get_age(diff), "5 hours")
+            diff = dt_util.now() - timedelta(minutes=320)
+            self.assertEqual(dt_util.get_age(diff), "5 hours")
 
-        diff = dt_util.now() - timedelta(minutes=2*60*24)
-        self.assertEqual(dt_util.get_age(diff), "2 days")
+            diff = dt_util.now() - timedelta(minutes=2*60*24)
+            self.assertEqual(dt_util.get_age(diff), "2 days")
 
-        diff = dt_util.now() - timedelta(minutes=32*60*24)
-        self.assertEqual(dt_util.get_age(diff), "1 month")
+            diff = dt_util.now() - timedelta(minutes=32*60*24)
+            self.assertEqual(dt_util.get_age(diff), "1 month")
 
-        diff = dt_util.now() - timedelta(minutes=365*60*24)
-        self.assertEqual(dt_util.get_age(diff), "1 year")
+            diff = dt_util.now() - timedelta(minutes=365*60*24)
+            self.assertEqual(dt_util.get_age(diff), "1 year")
 
-        diff = dt_util.now() + timedelta(seconds=1)
-        self.assertEqual(dt_util.get_age(diff), "1 second")
+            diff = dt_util.now() + timedelta(seconds=1)
+            self.assertEqual(dt_util.get_age(diff), "1 second")
 
-        diff = dt_util.now() + timedelta(seconds=30)
-        self.assertEqual(dt_util.get_age(diff), "30 seconds")
+            diff = dt_util.now() + timedelta(seconds=30)
+            self.assertEqual(dt_util.get_age(diff), "30 seconds")
 
-        diff = dt_util.now() + timedelta(minutes=5)
-        self.assertEqual(dt_util.get_age(diff), "5 minutes")
+            diff = dt_util.now() + timedelta(minutes=5)
+            self.assertEqual(dt_util.get_age(diff), "5 minutes")
 
-        diff = dt_util.now() + timedelta(minutes=1)
-        self.assertEqual(dt_util.get_age(diff), "1 minute")
+            diff = dt_util.now() + timedelta(minutes=1)
+            self.assertEqual(dt_util.get_age(diff), "1 minute")


### PR DESCRIPTION
`relative_time` will work using future dates, rather than just dates in the past.

## Description:
Ït was previously impossible to use `relative_time` to get string time differences for future events, for example:

```
Take the bins out in {{ relative_time(strptime(states.sensor.bin_days.attributes.date, "%d/%m/%Y")) }}
```

This would previously not render anything.

**Related issue (if applicable):** fixes #9617

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
    - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
- [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
