### PR TITLE
added media_stop

### DIFF
--- a/homeassistant/components/media_player/vlc.py
+++ b/homeassistant/components/media_player/vlc.py
@@ -9,8 +9,10 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA,SUPPORT_STOP, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
-    SUPPORT_PLAY, MediaPlayerDevice, PLATFORM_SCHEMA, MEDIA_TYPE_MUSIC)
+    SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA, SUPPORT_STOP, SUPPORT_VOLUME_MUTE,
+	SUPPORT_VOLUME_SET, SUPPORT_PLAY, MediaPlayerDevice, PLATFORM_SCHEMA, 
+	MEDIA_TYPE_MUSIC)
+	
 from homeassistant.const import (CONF_NAME, STATE_IDLE, STATE_PAUSED,
                                  STATE_PLAYING)
 import homeassistant.helpers.config_validation as cv
@@ -24,7 +26,7 @@ CONF_ARGUMENTS = 'arguments'
 DEFAULT_NAME = 'Vlc'
 
 SUPPORT_VLC = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
-    SUPPORT_PLAY_MEDIA | SUPPORT_PLAY
+    SUPPORT_PLAY_MEDIA | SUPPORT_PLAY | SUPPORT_STOP
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
@@ -147,7 +149,7 @@ class VlcDevice(MediaPlayerDevice):
         self._state = STATE_PAUSED
 
     def media_stop(self):
-        """Send pause command."""
+        """Send stop command."""
         self._vlc.stop()
         self._state = STATE_IDLE
 

--- a/homeassistant/components/media_player/vlc.py
+++ b/homeassistant/components/media_player/vlc.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import (
     SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA, SUPPORT_STOP, SUPPORT_VOLUME_MUTE,
-    SUPPORT_VOLUME_SET, SUPPORT_PLAY, MediaPlayerDevice, PLATFORM_SCHEMA, 
+    SUPPORT_VOLUME_SET, SUPPORT_PLAY, MediaPlayerDevice, PLATFORM_SCHEMA,
     MEDIA_TYPE_MUSIC)
 
 from homeassistant.const import (CONF_NAME, STATE_IDLE, STATE_PAUSED,

--- a/homeassistant/components/media_player/vlc.py
+++ b/homeassistant/components/media_player/vlc.py
@@ -10,9 +10,9 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import (
     SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA, SUPPORT_STOP, SUPPORT_VOLUME_MUTE,
-	SUPPORT_VOLUME_SET, SUPPORT_PLAY, MediaPlayerDevice, PLATFORM_SCHEMA, 
-	MEDIA_TYPE_MUSIC)
-	
+    SUPPORT_VOLUME_SET, SUPPORT_PLAY, MediaPlayerDevice, PLATFORM_SCHEMA, 
+    MEDIA_TYPE_MUSIC)
+
 from homeassistant.const import (CONF_NAME, STATE_IDLE, STATE_PAUSED,
                                  STATE_PLAYING)
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/media_player/vlc.py
+++ b/homeassistant/components/media_player/vlc.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
+    SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA,SUPPORT_STOP, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_PLAY, MediaPlayerDevice, PLATFORM_SCHEMA, MEDIA_TYPE_MUSIC)
 from homeassistant.const import (CONF_NAME, STATE_IDLE, STATE_PAUSED,
                                  STATE_PLAYING)
@@ -145,6 +145,11 @@ class VlcDevice(MediaPlayerDevice):
         """Send pause command."""
         self._vlc.pause()
         self._state = STATE_PAUSED
+
+    def media_stop(self):
+        """Send pause command."""
+        self._vlc.stop()
+        self._state = STATE_IDLE
 
     def play_media(self, media_type, media_id, **kwargs):
         """Play media from a URL or file."""


### PR DESCRIPTION
VLC was missing the media_stop. The pause was present, but starting the same file result in resuming the file instead of start over new

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
