### PR TITLE
Reinstall packages in tox/venv when requirements file changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ config
 
 # Test related files
 .tox
+.mypy_cache
 
 # Other virtualization methods
 venv

--- a/tox.ini
+++ b/tox.ini
@@ -5,40 +5,44 @@ skip_missing_interpreters = True
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/homeassistant
-; both temper-python and XBee modules have utf8 in their README files
+; Both temper-python and XBee modules have utf8 in their README files
 ; which get read in from setup.py. If we don't force our locale to a
 ; utf8 one, tox's env is reset. And the install of these 2 packages
 ; fail.
 whitelist_externals = /usr/bin/env
-install_command = /usr/bin/env LANG=C.UTF-8 pip install {opts} {packages}
+base_install_command = /usr/bin/env LANG=C.UTF-8 pip install
+install_command = {[testenv]base_install_command} {opts} {packages}
+; Explicitly call pip install instead of relying on tox's "deps" functionality,
+; because "deps" does not reinstall packages if the requirements file changes
+; (see https://github.com/tox-dev/tox/issues/149#issuecomment-353505669).
 commands =
+     {[testenv]base_install_command} \
+        -r{toxinidir}/requirements_test_all.txt \
+        -c{toxinidir}/homeassistant/package_constraints.txt
      py.test --timeout=9 --duration=10 --cov --cov-report= {posargs}
-deps =
-     -r{toxinidir}/requirements_test_all.txt
-     -c{toxinidir}/homeassistant/package_constraints.txt
 
 [testenv:pylint]
 basepython = {env:PYTHON3_PATH:python3}
 ignore_errors = True
-deps =
-     -r{toxinidir}/requirements_all.txt
-     -r{toxinidir}/requirements_test.txt
-     -c{toxinidir}/homeassistant/package_constraints.txt
 commands =
+     {[testenv]base_install_command} \
+        -r{toxinidir}/requirements_all.txt \
+        -r{toxinidir}/requirements_test.txt \
+        -c{toxinidir}/homeassistant/package_constraints.txt
      pylint homeassistant
 
 [testenv:lint]
 basepython = {env:PYTHON3_PATH:python3}
-deps =
-     -r{toxinidir}/requirements_test.txt
 commands =
-         python script/gen_requirements_all.py validate
-         flake8
-         pydocstyle homeassistant tests
+     {[testenv]base_install_command} \
+        -r{toxinidir}/requirements_test.txt
+     python script/gen_requirements_all.py validate
+     flake8
+     pydocstyle homeassistant tests
 
 [testenv:typing]
 basepython = {env:PYTHON3_PATH:python3}
-deps =
-     -r{toxinidir}/requirements_test.txt
 commands =
-         mypy --ignore-missing-imports --follow-imports=skip homeassistant
+     {[testenv]base_install_command} \
+        -r{toxinidir}/requirements_test.txt
+     mypy --ignore-missing-imports --follow-imports=skip homeassistant

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -40,14 +40,6 @@ RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
 # Install tox
 RUN pip3 install --no-cache-dir tox
 
-# Copy over everything required to run tox
-COPY requirements_test_all.txt setup.cfg setup.py tox.ini ./
-COPY homeassistant/const.py homeassistant/const.py
-
-# Prefetch dependencies for tox
-COPY homeassistant/package_constraints.txt homeassistant/package_constraints.txt
-RUN tox -e py36 --notest
-
 # END: Development additions
 
 # Copy source


### PR DESCRIPTION
## Description:

tox fails to reinstall / update dependencies from a requirements file when the
requirements file changes. This means that dependencies may be stale
in testing. The bug has existed in tox for quite some time now, with no apparent fix
tox-dev/tox#149

One of the comments suggests that this behavior can be worked around by
explicitly calling pip with the requirements:
https://github.com/tox-dev/tox/issues/149#issuecomment-353505669

Also, stop prefetching dependencies for tox in the dev docker image build.
Prefetching dependencies for tox in the dev docker image is a useless step
since the dependencies get prefetched into the container's local .tox folder,
however, when this image is used (e.g. by the script/lint_docker script),
the external/host .tox folder is mounted over the local .tox folder, so the
local folder is totally unused.

**Related issue (if applicable):** 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** 

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
