### PR TITLE
Parallelize PyLint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
      -r{toxinidir}/requirements_test.txt
      -c{toxinidir}/homeassistant/package_constraints.txt
 commands =
-     pylint homeassistant
+     pylint -j0 homeassistant
 
 [testenv:lint]
 basepython = {env:PYTHON3_PATH:python3}

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
      -r{toxinidir}/requirements_test.txt
      -c{toxinidir}/homeassistant/package_constraints.txt
 commands =
-     pylint -j0 homeassistant
+     pylint -j 0 homeassistant
 
 [testenv:lint]
 basepython = {env:PYTHON3_PATH:python3}


### PR DESCRIPTION
## Description:

Pylint's `-j0` option will run pylint with as many sub-processes as there are CPU cores.

Documentation: https://pylint.readthedocs.io/en/latest/user_guide/run.html#parallel-execution

On my hex-core machine, this brings down pylint run-time from ~10 min to ~7 min -- 30% improvement!

Hopefully, this will improve TravisCI's time for pylint (currently the slowest part of the CI process), but I'm not sure that the process on Travis has access to more than 1 cpu


**Related issue (if applicable):** 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
