### PR TITLE
Adding xy_color attribute support to deconz lights

### DIFF
--- a/homeassistant/components/light/deconz.py
+++ b/homeassistant/components/light/deconz.py
@@ -9,7 +9,7 @@ import asyncio
 from homeassistant.components.deconz import DOMAIN as DECONZ_DATA
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_FLASH, ATTR_RGB_COLOR,
-    ATTR_TRANSITION, EFFECT_COLORLOOP, FLASH_LONG, FLASH_SHORT,
+    ATTR_TRANSITION, ATTR_XY_COLOR, EFFECT_COLORLOOP, FLASH_LONG, FLASH_SHORT,
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_EFFECT, SUPPORT_FLASH,
     SUPPORT_RGB_COLOR, SUPPORT_TRANSITION, SUPPORT_XY_COLOR, Light)
 from homeassistant.core import callback
@@ -133,6 +133,9 @@ class DeconzLight(Light):
                 *(int(val) for val in kwargs[ATTR_RGB_COLOR]))
             data['xy'] = xyb[0], xyb[1]
             data['bri'] = xyb[2]
+
+        if ATTR_XY_COLOR in kwargs:
+            data['xy'] = kwargs[ATTR_XY_COLOR]
 
         if ATTR_BRIGHTNESS in kwargs:
             data['bri'] = kwargs[ATTR_BRIGHTNESS]


### PR DESCRIPTION
## Description:

Small fix to allow deconz lights to process xy_color updates. These type of updates are produced by homekit/homebridge.

## Checklist:
  - [ * ] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [ * ] Local tests with `tox` run successfully.