### PR TITLE
OpenALPR Cloud API - transfer image in body of POST request

### DIFF
--- a/homeassistant/components/image_processing/openalpr_cloud.py
+++ b/homeassistant/components/image_processing/openalpr_cloud.py
@@ -109,13 +109,14 @@ class OpenAlprCloudEntity(ImageProcessingAlprEntity):
         websession = async_get_clientsession(self.hass)
         params = self._params.copy()
 
-        image_to_send = {}
-        image_to_send['image_bytes'] = str(b64encode(image), 'utf-8')
+        body = {
+            'image_bytes': str(b64encode(image), 'utf-8')
+        }
 
         try:
             with async_timeout.timeout(self.timeout, loop=self.hass.loop):
                 request = yield from websession.post(
-                    OPENALPR_API_URL, params=params, data=image_to_send
+                    OPENALPR_API_URL, params=params, data=body
                 )
 
                 data = yield from request.json()

--- a/homeassistant/components/image_processing/openalpr_cloud.py
+++ b/homeassistant/components/image_processing/openalpr_cloud.py
@@ -109,12 +109,13 @@ class OpenAlprCloudEntity(ImageProcessingAlprEntity):
         websession = async_get_clientsession(self.hass)
         params = self._params.copy()
 
-        params['image_bytes'] = str(b64encode(image), 'utf-8')
+        image_to_send = {}
+        image_to_send['image_bytes'] = str(b64encode(image), 'utf-8')
 
         try:
             with async_timeout.timeout(self.timeout, loop=self.hass.loop):
                 request = yield from websession.post(
-                    OPENALPR_API_URL, params=params
+                    OPENALPR_API_URL, params=params, data=image_to_send
                 )
 
                 data = yield from request.json()

--- a/tests/components/image_processing/test_openalpr_cloud.py
+++ b/tests/components/image_processing/test_openalpr_cloud.py
@@ -149,8 +149,7 @@ class TestOpenAlprCloud(object):
             'secret_key': "sk_abcxyz123456",
             'tasks': "plate",
             'return_image': 0,
-            'country': 'eu',
-            'image_bytes': "aW1hZ2U="
+            'country': 'eu'
         }
 
     def teardown_method(self):


### PR DESCRIPTION
## Description:
image_bytes should be sent in the body of the request.  The API responds with [414 Request-URI Too Large] if the image gets to large. Based on the proposed change of @tomhash2

**Related issue (if applicable):** fixes #11855

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been modified to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
