### PR TITLE
Nissan Leaf (Carwings/Nissan Connect EV) Platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -166,6 +166,9 @@ omit =
     homeassistant/components/netatmo.py
     homeassistant/components/*/netatmo.py
 
+    homeassistant/components/nissan_leaf.py
+    homeassistant/components/*/nissan_leaf.py
+
     homeassistant/components/octoprint.py
     homeassistant/components/*/octoprint.py
 

--- a/homeassistant/components/binary_sensor/nissan_leaf.py
+++ b/homeassistant/components/binary_sensor/nissan_leaf.py
@@ -1,5 +1,7 @@
 """
-Plugged In Sensor for Nissan Leaf
+Plugged In Status Support for the Nissan Leaf Carwings/Nissan Connect API.
+
+Documentation pending, please refer to the main platform API f
 """
 
 import logging
@@ -35,7 +37,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class LeafPluggedInSensor(LeafCore.LeafEntity):
     @property
     def name(self):
-        return "Leaf Plugged In"
+        return self.car.leaf.nickname + " Plug Status"
 
     def log_registration(self):
         _LOGGER.debug(

--- a/homeassistant/components/binary_sensor/nissan_leaf.py
+++ b/homeassistant/components/binary_sensor/nissan_leaf.py
@@ -1,19 +1,14 @@
 """
 Plugged In Status Support for the Nissan Leaf Carwings/Nissan Connect API.
 
-Documentation pending, please refer to the main platform API f
+Documentation pending, please refer to the main platform component for configuration details
 """
 
 import logging
-from datetime import timedelta
 
-from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from .. import nissan_leaf as LeafCore
 from ..nissan_leaf import LeafEntity
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect, dispatcher_send)
-import asyncio
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/binary_sensor/nissan_leaf.py
+++ b/homeassistant/components/binary_sensor/nissan_leaf.py
@@ -1,0 +1,46 @@
+"""
+Plugged In Sensor for Nissan Leaf
+"""
+
+import logging
+from datetime import timedelta
+
+from homeassistant.components.sensor import ENTITY_ID_FORMAT
+from .. import nissan_leaf as LeafCore
+from ..nissan_leaf import LeafEntity
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect, dispatcher_send)
+import asyncio
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['nissan_leaf']
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    devices = []
+
+    _LOGGER.debug("Adding sensors")
+
+    for key, value in hass.data[LeafCore.DATA_LEAF].items():
+        devices.append(LeafPluggedInSensor(value))
+
+    add_devices(devices, True)
+
+    return True
+
+
+class LeafPluggedInSensor(LeafCore.LeafEntity):
+    @property
+    def name(self):
+        return "Leaf Plugged In"
+
+    def log_registration(self):
+        _LOGGER.debug(
+            "Registered LeafPluggedInSensor component with HASS for VIN " + self.car.leaf.vin)
+
+    @property
+    def state(self):
+        return self.car.data[LeafCore.DATA_PLUGGED_IN]

--- a/homeassistant/components/binary_sensor/nissan_leaf.py
+++ b/homeassistant/components/binary_sensor/nissan_leaf.py
@@ -40,3 +40,10 @@ class LeafPluggedInSensor(LeafCore.LeafEntity):
     @property
     def state(self):
         return self.car.data[LeafCore.DATA_PLUGGED_IN]
+
+    @property
+    def icon(self):
+        if self.car.data[LeafCore.DATA_PLUGGED_IN]:
+            return 'mdi:power-plug'
+        else:
+            return 'mdi:power-plug-off'

--- a/homeassistant/components/binary_sensor/nissan_leaf.py
+++ b/homeassistant/components/binary_sensor/nissan_leaf.py
@@ -1,15 +1,13 @@
 """
-Plugged In Status Support for the Nissan Leaf Carwings/Nissan Connect API.
+Plugged In Status Support for the Nissan Leaf
 
-Documentation pending, please refer to the main platform component for configuration details
+Documentation pending.
+Please refer to the main platform component for configuration details
 """
 
 import logging
 
 from .. import nissan_leaf as LeafCore
-from ..nissan_leaf import LeafEntity
-from homeassistant.helpers.entity import Entity
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +34,8 @@ class LeafPluggedInSensor(LeafCore.LeafEntity):
 
     def log_registration(self):
         _LOGGER.debug(
-            "Registered LeafPluggedInSensor component with HASS for VIN " + self.car.leaf.vin)
+            "Registered LeafPluggedInSensor component with HASS for VIN %s",
+            self.car.leaf.vin)
 
     @property
     def state(self):

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -205,7 +205,9 @@ class LeafDataStore:
 
         if battery_response.answer['status'] == 200:
             if int(battery_response.battery_capacity) > 100:
-                self.data[DATA_BATTERY] = battery_response.battery_percent * 0.05
+                self.data[DATA_BATTERY] = (
+                    battery_response.battery_percent * 0.05
+                )
             else:
                 self.data[DATA_BATTERY] = battery_response.battery_percent
 

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -22,7 +22,7 @@ DATA_CHARGING = 'charging'
 DATA_CLIMATE = 'climate'
 
 CONF_INTERVAL = 'update_interval'
-DEFAULT_INTERVAL = 1
+DEFAULT_INTERVAL = 30
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -204,7 +204,11 @@ class LeafDataStore:
         _LOGGER.debug("Got battery data for Leaf")
 
         if battery_response.answer['status'] == 200:
-            self.data[DATA_BATTERY] = battery_response.battery_percent
+            if int(battery_response.battery_capacity) > 100:
+                self.data[DATA_BATTERY] = battery_response.battery_percent * 0.05
+            else:
+                self.data[DATA_BATTERY] = battery_response.battery_percent
+
             self.data[DATA_CHARGING] = battery_response.is_charging
             self.data[DATA_PLUGGED_IN] = battery_response.is_connected
             self.data[DATA_RANGE_AC] = battery_response.cruising_range_ac_on_km
@@ -254,8 +258,11 @@ class LeafDataStore:
         return battery_status
 
     def get_climate(self):
-        request = self.leaf.get_latest_hvac_status()
-        return request
+        try:
+            request = self.leaf.get_latest_hvac_status()
+            return request
+        except TypeError:
+            return None
 
     def set_climate(self, toggle):
         if toggle:

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -1,0 +1,127 @@
+import voluptuous as vol
+import logging
+from datetime import timedelta
+import urllib
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.helpers.discovery import load_platform
+
+REQUIREMENTS = ['https://github.com/BenWoodford/pycarwings2/archive/master.zip'
+                '#pycarwings']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'nissan_leaf'
+DATA_LEAF = 'nissan_leaf_data'
+
+DATA_BATTERY = 'battery'
+DATA_LOCATION = 'location'
+DATA_CHARGING = 'charging'
+DATA_CLIMATE = 'climate'
+
+CONF_INTERVAL = 'update_interval'
+DEFAULT_INTERVAL = 1
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_INTERVAL, default=DEFAULT_INTERVAL): cv.positive_int
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+LEAF_COMPONENTS = [
+    'sensor', 'switch'#, 'device_tracker',
+]
+
+def setup(hass, config):
+    username = config[DOMAIN][CONF_USERNAME]
+    password = config[DOMAIN][CONF_PASSWORD]
+
+    import pycarwings2
+
+    try:
+        s = pycarwings2.Session(username, password, "NE")
+        _LOGGER.info("Logging into CarWings/NissanConnect Account")
+        leaf = s.get_leaf()
+    except(RuntimeError, urllib.error.HTTPError):
+        _LOGGER.error("Unable to connect to Nissan Connect with username and password")
+        return False
+    except(KeyError):
+        _LOGGER.error("Unable to fetch car details... do you actually have a Leaf connected to your account?")
+        return False
+
+    hass.data[DATA_LEAF] = LeafDataStore(leaf)
+
+    for component in LEAF_COMPONENTS:
+        load_platform(hass, component, DOMAIN, {}, config)
+
+    return True
+
+class LeafDataStore:
+
+    def __init__(self, leaf):
+        self.leaf = leaf
+        self.data = {}
+
+    @Throttle(timedelta(minutes=DEFAULT_INTERVAL))
+    def update(self):
+        batteryResponse = self.get_battery()
+        if batteryResponse.answer == 200:
+            self.data[DATA_BATTERY] = 0
+            self.data[DATA_CHARGING] = batteryResponse.is_charging
+
+        climateResponse = self.get_climate()
+        self.data[DATA_CLIMATE] = climateResponse.is_hvac_running
+
+        locationResponse = self.get_location()
+        self.data[DATA_LOCATION] = locationResponse
+
+    def get_battery(self):
+        request = self.leaf.request_update()
+        battery_status = self.leaf.get_status_from_update(request)
+        while battery_status is None:
+            time.sleep(5)
+            battery_status = self.leaf.get_status_from_update(request)
+
+        _LOGGER.info(battery_status)
+
+        return battery_status
+
+    def get_climate(self):
+        return None
+
+    def set_climate(self, toggle):
+        if toggle:
+            request = self.leaf.start_climate_control()
+            climate_result = self.leaf.get_start_climate_control_result(request)
+            
+            while climate_result is None:
+                time.sleep(5)
+                climate_result = self.leaf.get_start_climate_control_result(request)
+
+            return climate_result.is_hvac_running
+        else:
+            request = self.leaf.stop_climate_control()
+            climate_result = self.leaf.get_stop_climate_control_result(request)
+            
+            while climate_result is None:
+                time.sleep(5)
+                climate_result = self.leaf.get_stop_climate_control_result(request)
+
+            return not climate_result.is_hvac_running
+
+    def get_location(self):
+        request = self.left.request_location()
+        location_status = self.leaf.get_status_from_location(request)
+
+        while location_status is None:
+            time.sleep(5)
+            location_status = self.leaf.get_status_from_location(request)
+        
+        return location_status
+    
+    def start_charging(self):
+        return self.leaf.start_charging()

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -53,6 +53,8 @@ def setup(hass, config):
         _LOGGER.error("Unable to fetch car details... do you actually have a Leaf connected to your account?")
         return False
 
+    _LOGGER.Info("WARNING: This component may poll your Leaf too often, and drain the 12V. If you drain your car's 12V it won't start as the drive train battery won't connect, so you have been warned.")
+
     hass.data[DATA_LEAF] = LeafDataStore(leaf)
 
     for component in LEAF_COMPONENTS:

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -153,7 +153,9 @@ class LeafDataStore:
         self.data[DATA_PLUGGED_IN] = False
         self.last_check = None
         track_time_interval(
-            hass, self.refresh_leaf_if_necessary, timedelta(seconds=CHECK_INTERVAL))
+            hass,
+            self.refresh_leaf_if_necessary,
+            timedelta(seconds=CHECK_INTERVAL))
 
     def refresh_leaf_if_necessary(self, event_time):
         result = False
@@ -324,5 +326,4 @@ class LeafEntity(Entity):
 
     def _update_callback(self):
         """Callback update method."""
-        #_LOGGER.debug("Got dispatcher update from Leaf platform")
         self.schedule_update_ha_state(True)

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -1,13 +1,20 @@
 import voluptuous as vol
 import logging
 from datetime import timedelta
+import time
 import urllib
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect, dispatcher_send)
+from homeassistant.helpers.entity import Entity
 import asyncio
+import sys
+from homeassistant.helpers.event import track_time_interval
+from homeassistant.util.async import fire_coroutine_threadsafe
 
 
 REQUIREMENTS = ['https://github.com/BenWoodford/pycarwings2/archive/master.zip'
@@ -23,23 +30,27 @@ DATA_LOCATION = 'location'
 DATA_CHARGING = 'charging'
 DATA_CLIMATE = 'climate'
 
+CONF_NCONNECT = 'nissan_connect'
 CONF_INTERVAL = 'update_interval'
-DEFAULT_INTERVAL = 30
+DEFAULT_INTERVAL = timedelta(minutes=30)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_NCONNECT, default=True): cv.boolean,
         vol.Optional(CONF_INTERVAL, default=DEFAULT_INTERVAL): cv.positive_int
     })
 }, extra=vol.ALLOW_EXTRA)
 
 LEAF_COMPONENTS = [
-    'sensor', 'switch'#, 'device_tracker',
+    'sensor', 'switch', 'device_tracker',
 ]
 
-@asyncio.coroutine
-def async_setup(hass, config):
+SIGNAL_UPDATE_LEAF = 'nissan_leaf_update'
+
+
+def setup(hass, config):
     username = config[DOMAIN][CONF_USERNAME]
     password = config[DOMAIN][CONF_PASSWORD]
 
@@ -49,89 +60,164 @@ def async_setup(hass, config):
 
     try:
         s = pycarwings2.Session(username, password, "NE")
-        _LOGGER.Info("Fetching Leaf Data")
+        _LOGGER.debug("Fetching Leaf Data")
         leaf = s.get_leaf()
     except(RuntimeError, urllib.error.HTTPError):
-        _LOGGER.error("Unable to connect to Nissan Connect with username and password")
+        _LOGGER.error(
+            "Unable to connect to Nissan Connect with username and password")
         return False
     except(KeyError):
-        _LOGGER.error("Unable to fetch car details... do you actually have a Leaf connected to your account?")
+        _LOGGER.error(
+            "Unable to fetch car details... do you actually have a Leaf connected to your account?")
         return False
     except:
-        _LOGGER.error("An unknown error occurred while connecting to Nissan's servers: " + sys.exc_info()[0])
+        _LOGGER.error(
+            "An unknown error occurred while connecting to Nissan's servers: ", sys.exc_info()[0])
 
-    _LOGGER.Info("Successfully logged in and fetched Leaf info")
-    _LOGGER.Info("WARNING: This component may poll your Leaf too often, and drain the 12V. If you drain your car's 12V it won't start as the drive train battery won't connect, so you have been warned.")
+    _LOGGER.info("Successfully logged in and fetched Leaf info")
+    _LOGGER.info("WARNING: This component may poll your Leaf too often, and drain the 12V. If you drain your car's 12V it won't start as the drive train battery won't connect, so you have been warned.")
 
-    hass.data[DATA_LEAF] = LeafDataStore(leaf)
+    hass.data[DATA_LEAF] = {}
+    hass.data[DATA_LEAF][leaf.vin] = LeafDataStore(
+        leaf, hass, config[DOMAIN][CONF_NCONNECT])
 
     for component in LEAF_COMPONENTS:
-        load_platform(hass, component, DOMAIN, {}, config)
+        if (component != 'device_tracker') or (config[DOMAIN][CONF_NCONNECT] == True):
+            load_platform(hass, component, DOMAIN, {}, config)
+
+    def refresh_leaf_if_necessary(event_time):
+        _LOGGER.debug("Interval fired, refreshing data...")
+        fire_coroutine_threadsafe(
+            hass.data[DATA_LEAF][leaf.vin].async_update_leaf(), hass.loop)
+
+    track_time_interval(
+        hass, refresh_leaf_if_necessary, DEFAULT_INTERVAL)
+
+    refresh_leaf_if_necessary(0)
 
     return True
 
+
 class LeafDataStore:
 
-    def __init__(self, leaf):
+    def __init__(self, leaf, hass, use_nissan_connect):
         self.leaf = leaf
+        self.nissan_connect = use_nissan_connect
+        self.hass = hass
         self.data = {}
+        self.data[DATA_CLIMATE] = False
+        self.data[DATA_BATTERY] = 0
+        self.data[DATA_CHARGING] = False
+        self.data[DATA_LOCATION] = False
 
-    @Throttle(timedelta(minutes=DEFAULT_INTERVAL))
-    def update(self):
-        batteryResponse = self.get_battery()
+    @asyncio.coroutine
+    def async_update_leaf(self):
+        _LOGGER.debug("Updating Nissan Leaf Data")
+
+        batteryResponse = yield from self.get_battery()
+        _LOGGER.debug("Got battery data for Leaf")
+
         if batteryResponse.answer == 200:
-            self.data[DATA_BATTERY] = 0
+            self.data[DATA_BATTERY] = round(batteryResponse.battery_percent, 0)
+            #self.data[DATA_BATTERY] = 1
             self.data[DATA_CHARGING] = batteryResponse.is_charging
 
+        _LOGGER.debug("Battery Response: ")
+        _LOGGER.debug(batteryResponse.__dict__)
+
         climateResponse = self.get_climate()
-        self.data[DATA_CLIMATE] = climateResponse.is_hvac_running
+        _LOGGER.debug("Got climate data for Leaf")
+        self.data[DATA_CLIMATE] = climateResponse
 
-        locationResponse = self.get_location()
-        self.data[DATA_LOCATION] = locationResponse
+        if self.nissan_connect:
+            try:
+                locationResponse = self.get_location()
 
+                if locationResponse is None:
+                    _LOGGER.debug("Empty Location Response Received")
+                    self.data[DATA_LOCATION] = None
+                else:
+                    LOGGER.debug("Got location data for Leaf")
+                    self.data[DATA_LOCATION] = locationResponse
+
+                    _LOGGER.debug("Location Response: ")
+                    _LOGGER.debug(locationResponse.__dict__)
+            except Exception as e:
+                _LOGGER.error("Error fetching location info")
+
+        _LOGGER.debug("Notifying Components")
+        dispatcher_send(self.hass, SIGNAL_UPDATE_LEAF)
+
+    @asyncio.coroutine
     def get_battery(self):
         request = self.leaf.request_update()
         battery_status = self.leaf.get_status_from_update(request)
         while battery_status is None:
-            time.sleep(5)
+            _LOGGER.debug("Battery data not in yet.")
+            yield from asyncio.sleep(5)
             battery_status = self.leaf.get_status_from_update(request)
-
-        _LOGGER.info(battery_status)
 
         return battery_status
 
     def get_climate(self):
-        return None
+        request = self.leaf.get_latest_hvac_status()
+        if request is None:
+            return False
+        else:
+            return request.is_hvac_running
 
     def set_climate(self, toggle):
         if toggle:
             request = self.leaf.start_climate_control()
-            climate_result = self.leaf.get_start_climate_control_result(request)
-            
+            climate_result = self.leaf.get_start_climate_control_result(
+                request)
+
             while climate_result is None:
+                _LOGGER.debug("Climate data not in yet.")
                 time.sleep(5)
-                climate_result = self.leaf.get_start_climate_control_result(request)
+                climate_result = self.leaf.get_start_climate_control_result(
+                    request)
 
             return climate_result.is_hvac_running
         else:
             request = self.leaf.stop_climate_control()
             climate_result = self.leaf.get_stop_climate_control_result(request)
-            
-            while climate_result is None:
-                time.sleep(5)
-                climate_result = self.leaf.get_stop_climate_control_result(request)
 
-            return not climate_result.is_hvac_running
+            while climate_result is None:
+                _LOGGER.debug("Climate data not in yet.")
+                time.sleep(5)
+                climate_result = self.leaf.get_stop_climate_control_result(
+                    request)
+
+            return climate_result.is_hvac_running
 
     def get_location(self):
-        request = self.left.request_location()
+        request = self.leaf.request_location()
         location_status = self.leaf.get_status_from_location(request)
 
         while location_status is None:
-            time.sleep(5)
+            _LOGGER.debug("Location data not in yet.")
+            yield from asyncio.sleep(5)
             location_status = self.leaf.get_status_from_location(request)
-        
+
         return location_status
-    
+
     def start_charging(self):
         return self.leaf.start_charging()
+
+
+class LeafEntity(Entity):
+    def __init__(self, controller, data):
+        self.controller = controller
+        self.data = data
+
+    def added_to_hass(self):
+        """Register callbacks."""
+        self.log_registration()
+        async_dispatcher_connect(
+            self.data.hass, SIGNAL_UPDATE_LEAF, self._update_callback)
+
+    def _update_callback(self):
+        """Callback update method."""
+        _LOGGER.debug("Got dispatcher update from Leaf platform")
+        self.schedule_update_ha_state(True)

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -118,7 +118,7 @@ def setup(hass, config):
         leaf, hass, config)
 
     for component in LEAF_COMPONENTS:
-        if (component != 'device_tracker') or (config[DOMAIN][CONF_NCONNECT] == True):
+        if (component != 'device_tracker') or (config[DOMAIN][CONF_NCONNECT] is True):
             load_platform(hass, component, DOMAIN, {}, config)
 
     # hass.data[DATA_LEAF][leaf.vin].refresh_leaf_if_necessary(0)
@@ -131,7 +131,8 @@ class LeafDataStore:
     def __init__(self, leaf, hass, config):
         self.leaf = leaf
         self.config = config
-        self.nissan_connect = config[DOMAIN][CONF_NCONNECT]
+        #self.nissan_connect = config[DOMAIN][CONF_NCONNECT]
+        self.nissan_connect = False  # Disabled until tested and implemented
         self.hass = hass
         self.data = {}
         self.data[DATA_CLIMATE] = False
@@ -157,16 +158,16 @@ class LeafDataStore:
             _LOGGER.debug("Firing Refresh on " + self.leaf.vin +
                           " as the interval has passed.")
             result = True
-        elif self.data[DATA_CHARGING] == True and self.lastCheck + timedelta(minutes=self.config[DOMAIN][CONF_CHARGING_INTERVAL]) < now:
+        elif self.data[DATA_CHARGING] is True and self.lastCheck + timedelta(minutes=self.config[DOMAIN][CONF_CHARGING_INTERVAL]) < now:
             _LOGGER.debug("Firing Refresh on " + self.leaf.vin +
                           " as it's charging and the charging interval has passed.")
             result = True
-        elif self.data[DATA_CLIMATE] == True and self.lastCheck + timedelta(minutes=self.config[DOMAIN][CONF_CLIMATE_INTERVAL]) < now:
+        elif self.data[DATA_CLIMATE] is True and self.lastCheck + timedelta(minutes=self.config[DOMAIN][CONF_CLIMATE_INTERVAL]) < now:
             _LOGGER.debug("Firing Refresh on " + self.leaf.vin +
                           " as climate control is on and the interval has passed.")
             result = True
 
-        if result == True:
+        if result is True:
             self.refresh_data()
 
     def refresh_data(self):
@@ -194,10 +195,6 @@ class LeafDataStore:
             _LOGGER.debug(climateResponse.__dict__)
             self.data[DATA_CLIMATE] = climateResponse.is_hvac_running
 
-
-"""
-# Removing this block for now, as I do not have a Leaf with Nissan Connect to test it with.
-
         if self.nissan_connect:
             try:
                 locationResponse = self.get_location()
@@ -213,8 +210,6 @@ class LeafDataStore:
                     _LOGGER.debug(locationResponse.__dict__)
             except Exception as e:
                 _LOGGER.error("Error fetching location info")
-
-"""
 
         self.signal_components()
 
@@ -266,7 +261,7 @@ class LeafDataStore:
 
             self.signal_components()
 
-            return climate_result.is_hvac_running == False
+            return climate_result.is_hvac_running is False
 
     def get_location(self):
         request = self.leaf.request_location()

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -156,6 +156,9 @@ class LeafDataStore:
                 _LOGGER.error("Error fetching location info")
 
         _LOGGER.debug("Notifying Components")
+        self.signal_components()
+
+    def signal_components(self):
         dispatcher_send(self.hass, SIGNAL_UPDATE_LEAF)
 
     def get_battery(self):
@@ -184,6 +187,10 @@ class LeafDataStore:
                 climate_result = self.leaf.get_start_climate_control_result(
                     request)
 
+            _LOGGER.debug(climate_result.__dict__)
+
+            self.signal_components()
+
             return climate_result.is_hvac_running
         else:
             request = self.leaf.stop_climate_control()
@@ -194,6 +201,10 @@ class LeafDataStore:
                 time.sleep(5)
                 climate_result = self.leaf.get_stop_climate_control_result(
                     request)
+
+            _LOGGER.debug(climate_result.__dict__)
+
+            self.signal_components()
 
             return climate_result.is_hvac_running
 

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -1,3 +1,22 @@
+"""
+Support for the Nissan Leaf Carwings/Nissan Connect API.
+
+Please note this is the pre-2018 API, which is still functional in the US.
+The old API should continue to work as the new one is not being released outside the US.
+
+Documentation pages have not been created yet, here is an example configuration block:
+
+nissan_leaf:
+  username: "username"
+  password: "password"
+  nissan_connect: false
+  region: 'NE'
+  update_interval: 30
+  update_interval_charging: 15
+  update_interval_climate: 5
+  force_miles: true
+"""
+
 import voluptuous as vol
 import logging
 from datetime import timedelta, datetime
@@ -5,7 +24,6 @@ import time
 import urllib
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import Throttle
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import (
@@ -14,8 +32,9 @@ from homeassistant.helpers.entity import Entity
 import asyncio
 import sys
 from homeassistant.helpers.event import track_time_interval
-from homeassistant.util.async import fire_coroutine_threadsafe
 
+# Currently waiting on the pycarwings2 author to pull this PR in and update pip, so using my fork for now.
+# https://github.com/jdhorne/pycarwings2/pull/28
 
 REQUIREMENTS = ['https://github.com/BenWoodford/pycarwings2/archive/master.zip'
                 '#pycarwings']
@@ -148,7 +167,6 @@ class LeafDataStore:
             result = True
 
         if result == True:
-            _LOGGER.debug("Interval fired, refreshing data...")
             self.refresh_data()
 
     def refresh_data(self):
@@ -176,6 +194,10 @@ class LeafDataStore:
             _LOGGER.debug(climateResponse.__dict__)
             self.data[DATA_CLIMATE] = climateResponse.is_hvac_running
 
+
+"""
+# Removing this block for now, as I do not have a Leaf with Nissan Connect to test it with.
+
         if self.nissan_connect:
             try:
                 locationResponse = self.get_location()
@@ -192,7 +214,8 @@ class LeafDataStore:
             except Exception as e:
                 _LOGGER.error("Error fetching location info")
 
-        _LOGGER.debug("Notifying Components")
+"""
+
         self.signal_components()
 
     def signal_components(self):

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -206,7 +206,7 @@ class LeafDataStore:
 
             self.signal_components()
 
-            return climate_result.is_hvac_running
+            return climate_result.is_hvac_running == False
 
     def get_location(self):
         request = self.leaf.request_location()

--- a/homeassistant/components/sensor/nissan_leaf.py
+++ b/homeassistant/components/sensor/nissan_leaf.py
@@ -1,5 +1,7 @@
 """
-Battery Level Sensor for Nissan Leaf
+Battery Charge and Range Support for the Nissan Leaf Carwings/Nissan Connect API.
+
+Documentation pending, please refer to the main platform component for configuration details
 """
 
 import logging
@@ -37,7 +39,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class LeafBatterySensor(LeafCore.LeafEntity):
     @property
     def name(self):
-        return "Leaf Charge"
+        return self.car.leaf.nickname + " Charge"
 
     def log_registration(self):
         _LOGGER.debug(
@@ -60,9 +62,9 @@ class LeafRangeSensor(LeafCore.LeafEntity):
     @property
     def name(self):
         if self.ac_on == True:
-            return "Leaf Range (AC)"
+            return self.car.leaf.nickname + " Range (AC)"
         else:
-            return "Leaf Range"
+            return self.car.leaf.nickname + " Range"
 
     def log_registration(self):
         _LOGGER.debug(

--- a/homeassistant/components/sensor/nissan_leaf.py
+++ b/homeassistant/components/sensor/nissan_leaf.py
@@ -7,6 +7,7 @@ Please refer to the main platform component for configuration details
 
 import logging
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.helpers.icon import icon_for_battery_level
 from .. import nissan_leaf as LeafCore
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,6 +47,14 @@ class LeafBatterySensor(LeafCore.LeafEntity):
     @property
     def unit_of_measurement(self):
         return '%'
+
+    @property
+    def icon(self):
+        chargeState = self.car.data[LeafCore.DATA_CHARGING]
+        return icon_for_battery_level(
+            battery_level=self.state,
+            charging=chargeState
+        )
 
 
 class LeafRangeSensor(LeafCore.LeafEntity):
@@ -87,3 +96,7 @@ class LeafRangeSensor(LeafCore.LeafEntity):
             return "mi"
         else:
             return "km"
+
+    @property
+    def icon(self):
+        return 'mdi:speedometer'

--- a/homeassistant/components/sensor/nissan_leaf.py
+++ b/homeassistant/components/sensor/nissan_leaf.py
@@ -26,7 +26,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for key, value in hass.data[LeafCore.DATA_LEAF].items():
         devices.append(LeafBatterySensor(value))
-        devices.append(LeafPluggedInSensor(value))
         devices.append(LeafRangeSensor(value, True))
         devices.append(LeafRangeSensor(value, False))
 
@@ -51,20 +50,6 @@ class LeafBatterySensor(LeafCore.LeafEntity):
     @property
     def unit_of_measurement(self):
         return '%'
-
-
-class LeafPluggedInSensor(LeafCore.LeafEntity):
-    @property
-    def name(self):
-        return "Leaf Plugged In"
-
-    def log_registration(self):
-        _LOGGER.debug(
-            "Registered LeafPluggedInSensor component with HASS for VIN " + self.car.leaf.vin)
-
-    @property
-    def state(self):
-        return self.car.data[LeafCore.DATA_PLUGGED_IN]
 
 
 class LeafRangeSensor(LeafCore.LeafEntity):
@@ -92,14 +77,14 @@ class LeafRangeSensor(LeafCore.LeafEntity):
         else:
             ret = self.car.data[LeafCore.DATA_RANGE_AC_OFF]
 
-        if self.car.hass.config.units.is_metric == False:
+        if self.car.hass.config.units.is_metric == False or self.car.config[LeafCore.DOMAIN][LeafCore.CONF_FORCE_MILES] == True:
             ret = IMPERIAL_SYSTEM.length(ret, METRIC_SYSTEM.length_unit)
 
         return round(ret, 0)
 
     @property
     def unit_of_measurement(self):
-        if self.car.hass.config.units.is_metric:
-            return "km"
-        else:
+        if self.car.hass.config.units.is_metric == False or self.car.config[LeafCore.DOMAIN][LeafCore.CONF_FORCE_MILES] == True:
             return "mi"
+        else:
+            return "km"

--- a/homeassistant/components/sensor/nissan_leaf.py
+++ b/homeassistant/components/sensor/nissan_leaf.py
@@ -1,0 +1,42 @@
+"""
+Battery Level Sensor for Nissan Leaf
+"""
+
+import logging
+from datetime import timedelta
+
+from homeassistant.components.sensor import ENTITY_ID_FORMAT
+import custom_components.leaf as LeafCore
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['nissan_leaf']
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    controller = hass.data[LeafCore.DATA_LEAF].leaf
+    devices = []
+
+    devices.append(LeafSensor(controller, hass.data[LeafCore.DATA_LEAF]))
+
+    add_devices(devices, True)
+
+class LeafSensor(Entity):
+    def __init__(self, controller, data):
+        self.controller = controller
+        self.data = data
+
+    @property
+    def name(self):
+        return "Leaf Charge %"
+    
+    @property
+    def state(self):
+        return self.data[LeafCore.DATA_BATTERY]
+
+    @property
+    def unit_of_measurement(self):
+        return '%'
+
+    def update(self):
+        self.data.update()

--- a/homeassistant/components/sensor/nissan_leaf.py
+++ b/homeassistant/components/sensor/nissan_leaf.py
@@ -6,13 +6,13 @@ import logging
 from datetime import timedelta
 
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
-import homeassistant.components.nissan_leaf as LeafCore
-from homeassistant.components.nissan_leaf import LeafEntity
+from .. import nissan_leaf as LeafCore
+from ..nissan_leaf import LeafEntity
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, dispatcher_send)
 import asyncio
-
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,10 +22,13 @@ DEPENDENCIES = ['nissan_leaf']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     devices = []
 
-    for key, value in hass.data[LeafCore.DATA_LEAF].items():
-        devices.append(LeafBatterySensor(value.leaf, value))
-
     _LOGGER.debug("Adding sensors")
+
+    for key, value in hass.data[LeafCore.DATA_LEAF].items():
+        devices.append(LeafBatterySensor(value))
+        devices.append(LeafPluggedInSensor(value))
+        devices.append(LeafRangeSensor(value, True))
+        devices.append(LeafRangeSensor(value, False))
 
     add_devices(devices, True)
 
@@ -39,12 +42,61 @@ class LeafBatterySensor(LeafCore.LeafEntity):
 
     def log_registration(self):
         _LOGGER.debug(
-            "Registered LeafBatterySensor component with HASS for VIN " + self.controller.vin)
+            "Registered LeafBatterySensor component with HASS for VIN " + self.car.leaf.vin)
 
     @property
     def state(self):
-        return self.data.data[LeafCore.DATA_BATTERY]
+        return round(self.car.data[LeafCore.DATA_BATTERY], 0)
 
     @property
     def unit_of_measurement(self):
         return '%'
+
+
+class LeafPluggedInSensor(LeafCore.LeafEntity):
+    @property
+    def name(self):
+        return "Leaf Plugged In"
+
+    def log_registration(self):
+        _LOGGER.debug(
+            "Registered LeafPluggedInSensor component with HASS for VIN " + self.car.leaf.vin)
+
+    @property
+    def state(self):
+        return self.car.data[LeafCore.DATA_PLUGGED_IN]
+
+
+class LeafRangeSensor(LeafCore.LeafEntity):
+    def __init__(self, car, ac_on):
+        self.ac_on = ac_on
+        super().__init__(car)
+
+    @property
+    def name(self):
+        return "Range (" + ("AC On" if self.ac_on == True else "AC Off") + ")"
+
+    def log_registration(self):
+        _LOGGER.debug(
+            "Registered LeafRangeSensor component with HASS for VIN " + self.car.leaf.vin)
+
+    @property
+    def state(self):
+        ret = 0
+
+        if self.ac_on == True:
+            ret = self.car.data[LeafCore.DATA_RANGE_AC]
+        else:
+            ret = self.car.data[LeafCore.DATA_RANGE_AC_OFF]
+
+        if self.car.hass.config.units.is_metric == False:
+            ret = IMPERIAL_SYSTEM.length(ret, METRIC_SYSTEM.length_unit)
+
+        return round(ret, 0)
+
+    @property
+    def unit_of_measurement(self):
+        if self.car.hass.config.units.is_metric:
+            return "km"
+        else:
+            return "mi"

--- a/homeassistant/components/sensor/nissan_leaf.py
+++ b/homeassistant/components/sensor/nissan_leaf.py
@@ -1,16 +1,13 @@
 """
-Battery Charge and Range Support for the Nissan Leaf Carwings/Nissan Connect API.
+Battery Charge and Range Support for the Nissan Leaf
 
-Documentation pending, please refer to the main platform component for configuration details
+Documentation pending.
+Please refer to the main platform component for configuration details
 """
 
 import logging
-from .. import nissan_leaf as LeafCore
-from ..nissan_leaf import LeafEntity
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect, dispatcher_send)
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from .. import nissan_leaf as LeafCore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +36,8 @@ class LeafBatterySensor(LeafCore.LeafEntity):
 
     def log_registration(self):
         _LOGGER.debug(
-            "Registered LeafBatterySensor component with HASS for VIN " + self.car.leaf.vin)
+            "Registered LeafBatterySensor component with HASS for VIN %s",
+            self.car.leaf.vin)
 
     @property
     def state(self):
@@ -64,7 +62,8 @@ class LeafRangeSensor(LeafCore.LeafEntity):
 
     def log_registration(self):
         _LOGGER.debug(
-            "Registered LeafRangeSensor component with HASS for VIN " + self.car.leaf.vin)
+            "Registered LeafRangeSensor component with HASS for VIN %s",
+            self.car.leaf.vin)
 
     @property
     def state(self):
@@ -75,14 +74,16 @@ class LeafRangeSensor(LeafCore.LeafEntity):
         else:
             ret = self.car.data[LeafCore.DATA_RANGE_AC_OFF]
 
-        if self.car.hass.config.units.is_metric is False or self.car.config[LeafCore.DOMAIN][LeafCore.CONF_FORCE_MILES] is True:
+        if (self.car.hass.config.units.is_metric is False or
+                self.car.force_miles is True):
             ret = IMPERIAL_SYSTEM.length(ret, METRIC_SYSTEM.length_unit)
 
         return round(ret, 0)
 
     @property
     def unit_of_measurement(self):
-        if self.car.hass.config.units.is_metric is False or self.car.config[LeafCore.DOMAIN][LeafCore.CONF_FORCE_MILES] is True:
+        if (self.car.hass.config.units.is_metric is False or
+                self.car.force_miles is True):
             return "mi"
         else:
             return "km"

--- a/homeassistant/components/sensor/nissan_leaf.py
+++ b/homeassistant/components/sensor/nissan_leaf.py
@@ -38,7 +38,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class LeafBatterySensor(LeafCore.LeafEntity):
     @property
     def name(self):
-        return "Leaf Charge %"
+        return "Leaf Charge"
 
     def log_registration(self):
         _LOGGER.debug(
@@ -74,7 +74,10 @@ class LeafRangeSensor(LeafCore.LeafEntity):
 
     @property
     def name(self):
-        return "Range (" + ("AC On" if self.ac_on == True else "AC Off") + ")"
+        if self.ac_on == True:
+            return "Leaf Range (AC)"
+        else:
+            return "Leaf Range"
 
     def log_registration(self):
         _LOGGER.debug(

--- a/homeassistant/components/sensor/nissan_leaf.py
+++ b/homeassistant/components/sensor/nissan_leaf.py
@@ -5,15 +5,11 @@ Documentation pending, please refer to the main platform component for configura
 """
 
 import logging
-from datetime import timedelta
-
-from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from .. import nissan_leaf as LeafCore
 from ..nissan_leaf import LeafEntity
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, dispatcher_send)
-import asyncio
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,7 +57,7 @@ class LeafRangeSensor(LeafCore.LeafEntity):
 
     @property
     def name(self):
-        if self.ac_on == True:
+        if self.ac_on is True:
             return self.car.leaf.nickname + " Range (AC)"
         else:
             return self.car.leaf.nickname + " Range"
@@ -74,19 +70,19 @@ class LeafRangeSensor(LeafCore.LeafEntity):
     def state(self):
         ret = 0
 
-        if self.ac_on == True:
+        if self.ac_on is True:
             ret = self.car.data[LeafCore.DATA_RANGE_AC]
         else:
             ret = self.car.data[LeafCore.DATA_RANGE_AC_OFF]
 
-        if self.car.hass.config.units.is_metric == False or self.car.config[LeafCore.DOMAIN][LeafCore.CONF_FORCE_MILES] == True:
+        if self.car.hass.config.units.is_metric is False or self.car.config[LeafCore.DOMAIN][LeafCore.CONF_FORCE_MILES] is True:
             ret = IMPERIAL_SYSTEM.length(ret, METRIC_SYSTEM.length_unit)
 
         return round(ret, 0)
 
     @property
     def unit_of_measurement(self):
-        if self.car.hass.config.units.is_metric == False or self.car.config[LeafCore.DOMAIN][LeafCore.CONF_FORCE_MILES] == True:
+        if self.car.hass.config.units.is_metric is False or self.car.config[LeafCore.DOMAIN][LeafCore.CONF_FORCE_MILES] is True:
             return "mi"
         else:
             return "km"

--- a/homeassistant/components/switch/nissan_leaf.py
+++ b/homeassistant/components/switch/nissan_leaf.py
@@ -1,5 +1,7 @@
 """
-Charge and Climate Switch for Nissan Leaf
+Charge and Climate Control Support for the Nissan Leaf Carwings/Nissan Connect API.
+
+Documentation pending, please refer to the main platform component for configuration details
 """
 
 import logging
@@ -31,7 +33,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class LeafClimateSwitch(LeafCore.LeafEntity, ToggleEntity):
     @property
     def name(self):
-        return "Leaf Climate Control"
+        return self.car.leaf.nickname + " Climate Control"
 
     def log_registration(self):
         _LOGGER.debug(
@@ -57,7 +59,7 @@ class LeafClimateSwitch(LeafCore.LeafEntity, ToggleEntity):
 class LeafChargeSwitch(LeafCore.LeafEntity, ToggleEntity):
     @property
     def name(self):
-        return "Leaf Charging Status"
+        return self.car.leaf.nickname + " Charging Status"
 
     def log_registration(self):
         _LOGGER.debug(

--- a/homeassistant/components/switch/nissan_leaf.py
+++ b/homeassistant/components/switch/nissan_leaf.py
@@ -51,6 +51,13 @@ class LeafClimateSwitch(LeafCore.LeafEntity, ToggleEntity):
 
         self._update_callback()
 
+    @property
+    def icon(self):
+        if self.car.data[LeafCore.DATA_CLIMATE]:
+            return 'mdi:fan'
+        else:
+            return 'mdi:fan-off'
+
 
 class LeafChargeSwitch(LeafCore.LeafEntity, ToggleEntity):
     @property
@@ -61,6 +68,13 @@ class LeafChargeSwitch(LeafCore.LeafEntity, ToggleEntity):
         _LOGGER.debug(
             "Registered LeafChargeSwitch component with HASS for VIN %s",
             self.car.leaf.vin)
+
+    @property
+    def icon(self):
+        if self.car.data[LeafCore.DATA_CHARGING]:
+            return 'mdi:flash'
+        else:
+            return 'mdi:flash-off'
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/nissan_leaf.py
+++ b/homeassistant/components/switch/nissan_leaf.py
@@ -6,66 +6,71 @@ import logging
 from datetime import timedelta
 
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
-import custom_components.leaf as LeafCore
+import homeassistant.components.nissan_leaf as LeafCore
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect, dispatcher_send)
+import asyncio
+
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['nissan_leaf']
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    controller = hass.data[LeafCore.DATA_LEAF].leaf
     devices = []
 
-    devices.append(LeafChargeSwitch(controller, hass.data[LeafCore.DATA_LEAF]))
-    devices.append(LeafClimateSwitch(controller, hass.data[LeafCore.DATA_LEAF]))
+    for key, value in hass.data[LeafCore.DATA_LEAF].items():
+        devices.append(LeafChargeSwitch(value.leaf, value))
+        devices.append(LeafClimateSwitch(
+            value.leaf, value))
 
     add_devices(devices, True)
 
-class LeafClimateSwitch(Entity):
-    def __init__(self, controller, data):
-        self.controller = controller
-        self.data = data
 
+class LeafClimateSwitch(LeafCore.LeafEntity):
     @property
     def name(self):
         return "Leaf Climate Control"
-    
+
+    def log_registration(self):
+        _LOGGER.debug(
+            "Registered LeafClimateSwitch component with HASS for VIN " + self.controller.vin)
+
     @property
     def is_on(self):
-        return self.data[LeafCore.DATA_CLIMATE]
+        return self.data.data[LeafCore.DATA_CLIMATE]
 
     def turn_on(self):
-        if self.controller.set_climate(True):
-            self.data[LeafCore.DATA_CLIMATE] = True
+        # if self.controller.set_climate(True):
+            #self.data[LeafCore.DATA_CLIMATE] = True
+        _LOGGER.info("Climate Control is not implemented yet.")
 
     def turn_off(self):
-        if self.controller.set_climate(False):
-            self.data[LeafCore.DATA_CLIMATE] = False
-    
-    def update(self):
-        self.data.update()
+        _LOGGER.info("Climate Control is not implemented yet.")
+        # if self.controller.set_climate(False):
+        #self.data[LeafCore.DATA_CLIMATE] = False
 
 
-class LeafChargeSwitch(Entity):
-    def __init__(self, controller, data):
-        self.controller = controller
-        self.data = data
-
+class LeafChargeSwitch(LeafCore.LeafEntity):
     @property
     def name(self):
         return "Leaf Charging Status"
-    
+
+    def log_registration(self):
+        _LOGGER.debug(
+            "Registered LeafChargeSwitch component with HASS for VIN " + self.controller.vin)
+
     @property
     def is_on(self):
-        return self.data[LeafCore.DATA_CHARGING]
+        return self.data.data[LeafCore.DATA_CHARGING]
 
     def turn_on(self):
-        if self.controller.start_charging()
-            self.data[LeafCore.DATA_CHARGING] = True
+        _LOGGER.info("Charging is not implemented yet.")
+        # if self.controller.start_charging():
+        #self.data[LeafCore.DATA_CHARGING] = True
 
     def turn_off(self):
-        _LOGGER.debug("Cannot turn off Leaf charging - Nissan does not support that remotely.")
-    
-    def update(self):
-        self.data.update()
+        _LOGGER.debug(
+            "Cannot turn off Leaf charging - Nissan does not support that remotely.")

--- a/homeassistant/components/switch/nissan_leaf.py
+++ b/homeassistant/components/switch/nissan_leaf.py
@@ -1,12 +1,13 @@
 """
-Charge and Climate Control Support for the Nissan Leaf Carwings/Nissan Connect API.
+Charge and Climate Control Support for the Nissan Leaf
 
-Documentation pending, please refer to the main platform component for configuration details
+Documentation pending.
+Please refer to the main platform component for configuration details
 """
 
 import logging
-from .. import nissan_leaf as LeafCore
 from homeassistant.helpers.entity import ToggleEntity
+from .. import nissan_leaf as LeafCore
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +32,8 @@ class LeafClimateSwitch(LeafCore.LeafEntity, ToggleEntity):
 
     def log_registration(self):
         _LOGGER.debug(
-            "Registered LeafClimateSwitch component with HASS for VIN " + self.car.leaf.vin)
+            "Registered LeafClimateSwitch component with HASS for VIN %s",
+            self.car.leaf.vin)
 
     @property
     def is_on(self):
@@ -57,7 +59,8 @@ class LeafChargeSwitch(LeafCore.LeafEntity, ToggleEntity):
 
     def log_registration(self):
         _LOGGER.debug(
-            "Registered LeafChargeSwitch component with HASS for VIN " + self.car.leaf.vin)
+            "Registered LeafChargeSwitch component with HASS for VIN %s",
+            self.car.leaf.vin)
 
     @property
     def is_on(self):
@@ -71,4 +74,5 @@ class LeafChargeSwitch(LeafCore.LeafEntity, ToggleEntity):
 
     def turn_off(self, **kwargs):
         _LOGGER.debug(
-            "Cannot turn off Leaf charging - Nissan does not support that remotely.")
+            "Cannot turn off Leaf charging -"
+            " Nissan does not support that remotely.")

--- a/homeassistant/components/switch/nissan_leaf.py
+++ b/homeassistant/components/switch/nissan_leaf.py
@@ -6,8 +6,8 @@ import logging
 from datetime import timedelta
 
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
-import homeassistant.components.nissan_leaf as LeafCore
-from homeassistant.helpers.entity import Entity
+from .. import nissan_leaf as LeafCore
+from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, dispatcher_send)
 import asyncio
@@ -22,55 +22,54 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     devices = []
 
     for key, value in hass.data[LeafCore.DATA_LEAF].items():
-        devices.append(LeafChargeSwitch(value.leaf, value))
-        devices.append(LeafClimateSwitch(
-            value.leaf, value))
+        devices.append(LeafChargeSwitch(value))
+        devices.append(LeafClimateSwitch(value))
 
     add_devices(devices, True)
 
 
-class LeafClimateSwitch(LeafCore.LeafEntity):
+class LeafClimateSwitch(LeafCore.LeafEntity, ToggleEntity):
     @property
     def name(self):
         return "Leaf Climate Control"
 
     def log_registration(self):
         _LOGGER.debug(
-            "Registered LeafClimateSwitch component with HASS for VIN " + self.controller.vin)
+            "Registered LeafClimateSwitch component with HASS for VIN " + self.car.leaf.vin)
 
     @property
     def is_on(self):
-        return self.data.data[LeafCore.DATA_CLIMATE]
+        return self.car.data[LeafCore.DATA_CLIMATE] == True
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         # if self.controller.set_climate(True):
-            #self.data[LeafCore.DATA_CLIMATE] = True
+            # self.data[LeafCore.DATA_CLIMATE] = True
         _LOGGER.info("Climate Control is not implemented yet.")
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         _LOGGER.info("Climate Control is not implemented yet.")
         # if self.controller.set_climate(False):
-        #self.data[LeafCore.DATA_CLIMATE] = False
+        # self.data[LeafCore.DATA_CLIMATE] = False
 
 
-class LeafChargeSwitch(LeafCore.LeafEntity):
+class LeafChargeSwitch(LeafCore.LeafEntity, ToggleEntity):
     @property
     def name(self):
         return "Leaf Charging Status"
 
     def log_registration(self):
         _LOGGER.debug(
-            "Registered LeafChargeSwitch component with HASS for VIN " + self.controller.vin)
+            "Registered LeafChargeSwitch component with HASS for VIN " + self.car.leaf.vin)
 
     @property
     def is_on(self):
-        return self.data.data[LeafCore.DATA_CHARGING]
+        return self.car.data[LeafCore.DATA_CHARGING] == True
 
-    def turn_on(self):
+    def turn_on(self, entity_id):
         _LOGGER.info("Charging is not implemented yet.")
         # if self.controller.start_charging():
-        #self.data[LeafCore.DATA_CHARGING] = True
+        # self.data[LeafCore.DATA_CHARGING] = True
 
-    def turn_off(self):
+    def turn_off(self, entity_id):
         _LOGGER.debug(
             "Cannot turn off Leaf charging - Nissan does not support that remotely.")

--- a/homeassistant/components/switch/nissan_leaf.py
+++ b/homeassistant/components/switch/nissan_leaf.py
@@ -42,14 +42,16 @@ class LeafClimateSwitch(LeafCore.LeafEntity, ToggleEntity):
         return self.car.data[LeafCore.DATA_CLIMATE] == True
 
     def turn_on(self, **kwargs):
-        # if self.controller.set_climate(True):
-            # self.data[LeafCore.DATA_CLIMATE] = True
-        _LOGGER.info("Climate Control is not implemented yet.")
+        if self.car.set_climate(True):
+            self.car.data[LeafCore.DATA_CLIMATE] = True
+
+        self._update_callback()
 
     def turn_off(self, **kwargs):
-        _LOGGER.info("Climate Control is not implemented yet.")
-        # if self.controller.set_climate(False):
-        # self.data[LeafCore.DATA_CLIMATE] = False
+        if self.car.set_climate(False):
+            self.car.data[LeafCore.DATA_CLIMATE] = False
+
+        self._update_callback()
 
 
 class LeafChargeSwitch(LeafCore.LeafEntity, ToggleEntity):
@@ -65,11 +67,12 @@ class LeafChargeSwitch(LeafCore.LeafEntity, ToggleEntity):
     def is_on(self):
         return self.car.data[LeafCore.DATA_CHARGING] == True
 
-    def turn_on(self, entity_id):
-        _LOGGER.info("Charging is not implemented yet.")
-        # if self.controller.start_charging():
-        # self.data[LeafCore.DATA_CHARGING] = True
+    def turn_on(self, **kwargs):
+        if self.car.start_charging():
+            self.car.data[LeafCore.DATA_CHARGING] = True
 
-    def turn_off(self, entity_id):
+        self._update_callback()
+
+    def turn_off(self, **kwargs):
         _LOGGER.debug(
             "Cannot turn off Leaf charging - Nissan does not support that remotely.")

--- a/homeassistant/components/switch/nissan_leaf.py
+++ b/homeassistant/components/switch/nissan_leaf.py
@@ -1,0 +1,71 @@
+"""
+Charge and Climate Switch for Nissan Leaf
+"""
+
+import logging
+from datetime import timedelta
+
+from homeassistant.components.sensor import ENTITY_ID_FORMAT
+import custom_components.leaf as LeafCore
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['nissan_leaf']
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    controller = hass.data[LeafCore.DATA_LEAF].leaf
+    devices = []
+
+    devices.append(LeafChargeSwitch(controller, hass.data[LeafCore.DATA_LEAF]))
+    devices.append(LeafClimateSwitch(controller, hass.data[LeafCore.DATA_LEAF]))
+
+    add_devices(devices, True)
+
+class LeafClimateSwitch(Entity):
+    def __init__(self, controller, data):
+        self.controller = controller
+        self.data = data
+
+    @property
+    def name(self):
+        return "Leaf Climate Control"
+    
+    @property
+    def is_on(self):
+        return self.data[LeafCore.DATA_CLIMATE]
+
+    def turn_on(self):
+        if self.controller.set_climate(True):
+            self.data[LeafCore.DATA_CLIMATE] = True
+
+    def turn_off(self):
+        if self.controller.set_climate(False):
+            self.data[LeafCore.DATA_CLIMATE] = False
+    
+    def update(self):
+        self.data.update()
+
+
+class LeafChargeSwitch(Entity):
+    def __init__(self, controller, data):
+        self.controller = controller
+        self.data = data
+
+    @property
+    def name(self):
+        return "Leaf Charging Status"
+    
+    @property
+    def is_on(self):
+        return self.data[LeafCore.DATA_CHARGING]
+
+    def turn_on(self):
+        if self.controller.start_charging()
+            self.data[LeafCore.DATA_CHARGING] = True
+
+    def turn_off(self):
+        _LOGGER.debug("Cannot turn off Leaf charging - Nissan does not support that remotely.")
+    
+    def update(self):
+        self.data.update()

--- a/homeassistant/components/switch/nissan_leaf.py
+++ b/homeassistant/components/switch/nissan_leaf.py
@@ -5,14 +5,8 @@ Documentation pending, please refer to the main platform component for configura
 """
 
 import logging
-from datetime import timedelta
-
-from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from .. import nissan_leaf as LeafCore
 from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect, dispatcher_send)
-import asyncio
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,7 +35,7 @@ class LeafClimateSwitch(LeafCore.LeafEntity, ToggleEntity):
 
     @property
     def is_on(self):
-        return self.car.data[LeafCore.DATA_CLIMATE] == True
+        return self.car.data[LeafCore.DATA_CLIMATE] is True
 
     def turn_on(self, **kwargs):
         if self.car.set_climate(True):
@@ -67,7 +61,7 @@ class LeafChargeSwitch(LeafCore.LeafEntity, ToggleEntity):
 
     @property
     def is_on(self):
-        return self.car.data[LeafCore.DATA_CHARGING] == True
+        return self.car.data[LeafCore.DATA_CHARGING] is True
 
     def turn_on(self, **kwargs):
         if self.car.start_charging():


### PR DESCRIPTION
## Description:

Adds support for monitoring and controlling the Nissan Leaf remote control platform.

Currently introduces two switches (climate control and charging, charging can only be turned on as per the weird API limitation), 3 sensors (battery charge and range with and without AC on) and a binary sensor for if the car is currently plugged in.

Further work needed at some point to add the device tracker, I have a 2015 Leaf so do not have this functionality on my car, right now the `nissan_connect` config option does not do anything as it is used to enable the device tracker.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** documentation pending

## Example entry for `configuration.yaml` (if applicable):
```yaml
nissan_leaf:
  username: "username"
  password: "password"
  region: 'NE'
  update_interval: 30
  update_interval_charging: 15
  update_interval_climate: 5
  force_miles: true
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

Pending docs.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

Currently using a GitHub URL, as the library's author is MIA and I had to fix up the library to get it working in HASS. Checked with @armills before submitting and have added a note to the code with the PR on `pycarwings2` (https://github.com/jdhorne/pycarwings2/pull/28)

  - [x] New files were added to `.coveragerc`.
