### PR TITLE
Downgrade Sonarr and Radarr 'Host is not avaliable' errors to warnings

### DIFF
--- a/homeassistant/components/sensor/radarr.py
+++ b/homeassistant/components/sensor/radarr.py
@@ -162,7 +162,7 @@ class RadarrSensor(Entity):
                     self.ssl, self.host, self.port, self.urlbase, start, end),
                 headers={'X-Api-Key': self.apikey}, timeout=10)
         except OSError:
-            _LOGGER.error("Host %s is not available", self.host)
+            _LOGGER.warning("Host %s is not available", self.host)
             self._available = False
             self._state = None
             return

--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -181,7 +181,7 @@ class SonarrSensor(Entity):
                 headers={'X-Api-Key': self.apikey},
                 timeout=10)
         except OSError:
-            _LOGGER.error("Host %s is not available", self.host)
+            _LOGGER.warning("Host %s is not available", self.host)
             self._available = False
             self._state = None
             return


### PR DESCRIPTION
## Description:
Downgrades the logged errors for Sonarr and Radarr sensors to warnings instead of errors. If the user does not have their server online at all times, the error log is flooded with these errors. This downgrades these errors to warnings to stop this.

## Checklist:
  - [x] The code change is tested and works locally.
