### PR TITLE
Fixes away_mode error on startup

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -156,7 +156,7 @@ class GenericThermostat(ClimateDevice):
             # If we have no initial temperature, restore
             if self._target_temp is None:
                 # If we have a previously saved temperature
-                if old_state.attributes[ATTR_TEMPERATURE] is None:
+                if old_state.attributes.get(ATTR_TEMPERATURE) is None:
                     if self.ac_mode:
                         self._target_temp = self.max_temp
                     else:
@@ -166,8 +166,7 @@ class GenericThermostat(ClimateDevice):
                 else:
                     self._target_temp = float(
                         old_state.attributes[ATTR_TEMPERATURE])
-            if ATTR_AWAY_MODE in old_state.attributes \
-                    and old_state.attributes[ATTR_AWAY_MODE] is not None:
+            if old_state.attributes.get(ATTR_AWAY_MODE) is not None:
                 self._is_away = str(
                     old_state.attributes[ATTR_AWAY_MODE]) == STATE_ON
             if (self._initial_operation_mode is None and

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -166,7 +166,8 @@ class GenericThermostat(ClimateDevice):
                 else:
                     self._target_temp = float(
                         old_state.attributes[ATTR_TEMPERATURE])
-            if old_state.attributes[ATTR_AWAY_MODE] is not None:
+            if ATTR_AWAY_MODE in old_state.attributes \
+                    and old_state.attributes[ATTR_AWAY_MODE] is not None:
                 self._is_away = str(
                     old_state.attributes[ATTR_AWAY_MODE]) == STATE_ON
             if (self._initial_operation_mode is None and


### PR DESCRIPTION
## Description:
Fixes away_mode error on startup for climate/generic_thermostat

**Related issue (if applicable):** fixes #12120

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: generic_thermostat
    name: Office
    heater: switch.office_heater
    target_sensor: sensor.office_feels_temp
    hot_tolerance: 1
    cold_tolerance: 0.5
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

