### PR TITLE
Fix for incorrect xiaomi aqara gateway's "rgb" value parser when it doesn't contain brightness

### DIFF
--- a/homeassistant/components/light/xiaomi_aqara.py
+++ b/homeassistant/components/light/xiaomi_aqara.py
@@ -51,13 +51,13 @@ class XiaomiGatewayLight(XiaomiDevice, Light):
             return True
 
         rgbhexstr = "%x" % value
-        if len(rgbhexstr) == 7:
-            rgbhexstr = '0' + rgbhexstr
-        elif len(rgbhexstr) != 8:
-            _LOGGER.error('Light RGB data error.'
-                          ' Must be 8 characters. Received: %s', rgbhexstr)
+        if len(rgbhexstr) > 8:
+            _LOGGER.error("Light RGB data error."
+                          " Can't be more than 8 characters. Received: %s",
+                          rgbhexstr)
             return False
 
+        rgbhexstr = rgbhexstr.zfill(8)
         rgbhex = bytes.fromhex(rgbhexstr)
         rgba = struct.unpack('BBBB', rgbhex)
         brightness = rgba[0]


### PR DESCRIPTION
## Description:

Several times a month I see the same error in HA logs:
```
ERROR (MainThread) [homeassistant.components.light.xiaomi_aqara] Light RGB data error. Must be 8 characters. Received: ffffff
```
We know gateway sends `"rgb": 0` if light is off. But sometimes it sends `"rgb": 16777215` (=`0xFFFFFF`) which leads to the error above. I think we should add support for this kind of values, because *openhab*'s integration with xiaomi handles this case correctly:  https://github.com/openhab/openhab2-addons/blob/master/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/handler/XiaomiActorGatewayHandler.java#L172

I have refactored and updated the code to add zeros, for string to always be 8 chars. Now we can safely handle values from `0x1` (zero brightness, rgb 000001) to `0xFFFFFFFF` (full brightness, rgb white color).

## Checklist:
  - [x] The code change is tested and works locally.