### PR TITLE
Fix MQTT last will on graceful disconnect

### DIFF
--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -553,7 +553,24 @@ def test_birth_message(hass):
     mqtt_client.publish = lambda *args: calls.append(args)
     hass.data['mqtt']._mqtt_on_connect(None, None, 0, 0)
     yield from hass.async_block_till_done()
+    assert len(calls) == 1
     assert calls[-1] == ('birth', 'birth', 0, False)
+
+
+@asyncio.coroutine
+def test_last_will_message_on_graceful_disconnect(hass):
+    """Test sending last will message on graceful disconnect."""
+    mqtt_client = yield from mock_mqtt_client(hass, {
+        mqtt.CONF_BROKER: 'mock-broker',
+        mqtt.CONF_WILL_MESSAGE: {mqtt.ATTR_TOPIC: 'will',
+                                 mqtt.ATTR_PAYLOAD: 'will'}
+    })
+    calls = []
+    mqtt_client.publish = lambda *args: calls.append(args)
+    yield from hass.data['mqtt'].async_disconnect()
+    yield from hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[-1] == ('will', 'will', 0, False)
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

See linked issues. In a nutshell, the MQTT client only sends the last will message if the connection is dropped, but not on a graceful disconnect.

* **Expected behavior:** The MQTT client also sends the last will message on a "graceful" disconnect / Home Assistant shutdown. 
* **Actual behavior:** The MQTT client only sends the last will message on a connection drop.

Note: There's a point to be made in favor of the current behavior. Sometimes we want to know when a disconnect was "ungraceful". I would say though that in most cases, the last will message is used to determine whether Home Assistant is `online` or `offline` (even the [docs](https://home-assistant.io/docs/mqtt/birth_will/) are using it this way)

**Related issue (if applicable):** fixes #6240, fixes #9017

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4566

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt:
  birth_message:
    topic: 'hass/status'
    payload: 'online'
  will_message:
    topic: 'hass/status'
    payload: 'offline'
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
