### PR TITLE
fix generic_thermostat bug when restore state from HA start up

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -173,8 +173,8 @@ class GenericThermostat(ClimateDevice):
                     old_state.attributes[ATTR_OPERATION_MODE] is not None):
                 self._current_operation = \
                     old_state.attributes[ATTR_OPERATION_MODE]
-                if self._current_operation != STATE_OFF:
-                    self._enabled = True
+                self._enabled = self._current_operation != STATE_OFF
+
         else:
             # No previous state, try and restore defaults
             if self._target_temp is None:

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -993,3 +993,83 @@ def test_no_restore_state(hass):
     state = hass.states.get('climate.test_thermostat')
     assert(state.attributes[ATTR_TEMPERATURE] == 22)
     assert(state.state == STATE_OFF)
+
+
+class TestClimateGenericThermostatRestoreState(unittest.TestCase):
+    """Test generic thermostat when restore state from HA startup."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.config.temperature_unit = TEMP_CELSIUS
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_restore_state_uncoherence_case(self):
+        """
+        Test restore from a strange state.
+
+        - Turn the generic thermostat off
+        - Restart HA and restore state from DB
+        """
+        self._mock_restore_cache(temperature=20)
+
+        self._setup_switch(False)
+        self._setup_sensor(15)
+        self._setup_climate()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(20, state.attributes[ATTR_TEMPERATURE])
+        self.assertEqual(STATE_OFF,
+                         state.attributes[climate.ATTR_OPERATION_MODE])
+        self.assertEqual(STATE_OFF, state.state)
+        self.assertEqual(0, len(self.calls))
+
+        self._setup_switch(False)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(STATE_OFF,
+                         state.attributes[climate.ATTR_OPERATION_MODE])
+        self.assertEqual(STATE_OFF, state.state)
+
+    def _setup_climate(self):
+        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
+            'platform': 'generic_thermostat',
+            'name': 'test',
+            'cold_tolerance': 2,
+            'hot_tolerance': 4,
+            'away_temp': 30,
+            'heater': ENT_SWITCH,
+            'target_sensor': ENT_SENSOR,
+            'ac_mode': True
+        }})
+
+    def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
+        """Setup the test sensor."""
+        self.hass.states.set(ENT_SENSOR, temp, {
+            ATTR_UNIT_OF_MEASUREMENT: unit
+        })
+
+    def _setup_switch(self, is_on):
+        """Setup the test switch."""
+        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
+        self.calls = []
+
+        @callback
+        def log_call(call):
+            """Log service calls."""
+            self.calls.append(call)
+
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
+
+    def _mock_restore_cache(self, temperature=20, operation_mode=STATE_OFF):
+        mock_restore_cache(self.hass, (
+            State(ENTITY, '0', {
+                ATTR_TEMPERATURE: str(temperature),
+                climate.ATTR_OPERATION_MODE: operation_mode,
+                ATTR_AWAY_MODE: "on"}),
+        ))

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_ON,
     STATE_OFF,
+    STATE_IDLE,
     TEMP_CELSIUS,
     ATTR_TEMPERATURE
 )
@@ -170,7 +171,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
 
     def test_setup_defaults_to_unknown(self):
         """Test the setting of defaults to unknown."""
-        self.assertEqual('idle', self.hass.states.get(ENTITY).state)
+        self.assertEqual(STATE_IDLE, self.hass.states.get(ENTITY).state)
 
     def test_default_setup_params(self):
         """Test the setup with default parameters."""
@@ -964,6 +965,7 @@ def test_restore_state(hass):
     state = hass.states.get('climate.test_thermostat')
     assert(state.attributes[ATTR_TEMPERATURE] == 20)
     assert(state.attributes[climate.ATTR_OPERATION_MODE] == "off")
+    assert(state.state == STATE_OFF)
 
 
 @asyncio.coroutine
@@ -990,3 +992,4 @@ def test_no_restore_state(hass):
 
     state = hass.states.get('climate.test_thermostat')
     assert(state.attributes[ATTR_TEMPERATURE] == 22)
+    assert(state.state == STATE_OFF)


### PR DESCRIPTION
This is a special case:
1. Turn the generic thermostat off
3. Restart HA
4. HA restarted and generic thermostat restored state from db (old state)
5. You get a special generic thermostat with `self._current_operation = STATE_OFF` and `self._enabled = True`

If you don't set "initial_operation_mode" in config, you will get
`self._enabled = True` when init GenericThermostat. And then you will
miss the `if self._current_operation != STATE_OFF` statement and the
self._enabled still keep `True`. That's the problem

## Description:


**Related issue (if applicable):** no

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** no

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: generic_thermostat
  name: heat_living_room
  heater: group.heat_living_room
  target_sensor: sensor.temperature_158d00015740d2
  min_temp: 10
  max_temp: 30
  keep_alive:
    minutes: 5
  away_temp: 10

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
