### PR TITLE
Spelling fixes

### DIFF
--- a/homeassistant/components/plant.py
+++ b/homeassistant/components/plant.py
@@ -92,7 +92,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 
 # Flag for enabling/disabling the loading of the history from the database.
-# This feature is turned off right now as it's tests are not 100% stable.
+# This feature is turned off right now as its tests are not 100% stable.
 ENABLE_LOAD_HISTORY = False
 
 

--- a/homeassistant/components/switch/pulseaudio_loopback.py
+++ b/homeassistant/components/switch/pulseaudio_loopback.py
@@ -131,7 +131,7 @@ class PAServer():
         self._send_command(str.format(UNLOAD_CMD, module_idx), False)
 
     def get_module_idx(self, sink_name, source_name):
-        """For a sink/source, return it's module id in our cache, if found."""
+        """For a sink/source, return its module id in our cache, if found."""
         result = re.search(str.format(MOD_REGEX, re.escape(sink_name),
                                       re.escape(source_name)),
                            self._current_module_state)

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -8,7 +8,7 @@ def deprecated_substitute(substitute_name):
 
     When a property is added to replace an older property, this decorator can
     be added to the new property, listing the old property as the substitute.
-    If the old property is defined, it's value will be used instead, and a log
+    If the old property is defined, its value will be used instead, and a log
     warning will be issued alerting the user of the impending change.
     """
     def decorator(func):


### PR DESCRIPTION
## Description:

Trivial comment spelling fixes.

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
