### PR TITLE
Fix #8475 device tracker ubus tracks unauthenticated and unassociated…

### DIFF
--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -122,13 +122,18 @@ class UbusDeviceScanner(DeviceScanner):
 
         self.last_results = []
         results = 0
+        # for each access point
         for hostapd in self.hostapd:
             result = _req_json_rpc(
                 self.url, self.session_id, 'call', hostapd, 'get_clients')
 
             if result:
                 results = results + 1
-                self.last_results.extend(result['clients'].keys())
+                # Check for each device is authorized (valid wpa key)
+                for key in result['clients'].keys():
+                    device = result['clients'][key]
+                    if device['authorized']:
+                        self.last_results.append(key)
 
         return bool(results)
 


### PR DESCRIPTION
## Description:


**Related issue:** fixes #8475 device tracker ubus tracks unauthenticated and unassociated…

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
