### PR TITLE
Specify the minimum python version in the setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=REQUIRES,
+    python_requires=">=3.4",
     test_suite='tests',
     keywords=['home', 'automation'],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,16 @@
 """Home Assistant setup script."""
 import os
 from setuptools import setup, find_packages
+import sys
 
-from homeassistant.const import __version__
+import homeassistant.const as hass_const
+
 
 PROJECT_NAME = 'Home Assistant'
 PROJECT_PACKAGE_NAME = 'homeassistant'
 PROJECT_LICENSE = 'Apache License 2.0'
 PROJECT_AUTHOR = 'The Home Assistant Authors'
-PROJECT_COPYRIGHT = ' 2013-2017, {}'.format(PROJECT_AUTHOR)
+PROJECT_COPYRIGHT = ' 2013-2018, {}'.format(PROJECT_AUTHOR)
 PROJECT_URL = 'https://home-assistant.io/'
 PROJECT_EMAIL = 'hello@home-assistant.io'
 PROJECT_DESCRIPTION = ('Open-source home automation platform '
@@ -41,7 +43,7 @@ GITHUB_URL = 'https://github.com/{}'.format(GITHUB_PATH)
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
-DOWNLOAD_URL = '{}/archive/{}.zip'.format(GITHUB_URL, __version__)
+DOWNLOAD_URL = '{}/archive/{}.zip'.format(GITHUB_URL, hass_const.__version__)
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
@@ -61,9 +63,15 @@ REQUIRES = [
     'certifi>=2017.4.17',
 ]
 
+MIN_PY_VERSION = '.'.join(map(
+    str,
+    hass_const.REQUIRED_PYTHON_VER_WIN
+    if sys.platform.startswith('win')
+    else hass_const.REQUIRED_PYTHON_VER))
+
 setup(
     name=PROJECT_PACKAGE_NAME,
-    version=__version__,
+    version=hass_const.__version__,
     license=PROJECT_LICENSE,
     url=PROJECT_URL,
     download_url=DOWNLOAD_URL,
@@ -75,7 +83,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=REQUIRES,
-    python_requires=">=3.4",
+    python_requires='>={}'.format(MIN_PY_VERSION),
     test_suite='tests',
     keywords=['home', 'automation'],
     entry_points={


### PR DESCRIPTION
## Description:

Makes it explicit about which versions of python are supported. If ```pip install homeassistant``` is called from a version of python <= 3.4 the following error comes from pip (pip >= v9.0.1):`

```
(py2) pelson@~/dev/IOT/home-assistant> python --version
Python 2.7.12
(py2) pelson@~/dev/IOT/home-assistant> pip install -e .
Obtaining file:///Users/pelson/dev/IOT/home-assistant
homeassistant requires Python '>=3.4' but the running Python is 2.7.12
```

See also:
 * https://stackoverflow.com/a/45362425/741316
 * http://www.python3statement.org/practicalities/
 * The docs at http://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords


## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
