### PR TITLE
Store the authentication status as an encrypted session cookie.

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -27,7 +27,7 @@ import homeassistant.remote as rem
 import homeassistant.util as hass_util
 from homeassistant.util.logging import HideSensitiveDataFilter
 
-from .auth import auth_middleware
+from .auth import auth_middleware, session_middleware_factory
 from .ban import ban_middleware
 from .const import (
     KEY_BANS_ENABLED, KEY_AUTHENTICATED, KEY_LOGIN_THRESHOLD,
@@ -182,7 +182,8 @@ class HomeAssistantWSGI(object):
                  use_x_forwarded_for, trusted_networks,
                  login_threshold, is_ban_enabled):
         """Initialize the WSGI Home Assistant server."""
-        middlewares = [auth_middleware, staticresource_middleware]
+        middlewares = [session_middleware_factory(),
+                       auth_middleware, staticresource_middleware]
 
         if is_ban_enabled:
             middlewares.insert(0, ban_middleware)

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -16,6 +16,10 @@ DATA_API_PASSWORD = 'api_password'
 _LOGGER = logging.getLogger(__name__)
 
 
+REQUIREMENTS = ['aiohttp_session==1.2.1',  # Update to vn2 when >=python3.5
+                'cryptography==2.1.4']
+
+
 @middleware
 @asyncio.coroutine
 def auth_middleware(request, handler):
@@ -28,9 +32,13 @@ def auth_middleware(request, handler):
     # Check authentication
     authenticated = False
 
-    if (HTTP_HEADER_HA_AUTH in request.headers and
-            validate_password(
-                request, request.headers[HTTP_HEADER_HA_AUTH])):
+    session = yield from get_session(request)
+
+    if session.get(KEY_AUTHENTICATED, False):
+        authenticated = True
+
+    elif (HTTP_HEADER_HA_AUTH in request.headers and
+          validate_password(request, request.headers[HTTP_HEADER_HA_AUTH])):
         # A valid auth header has been set
         authenticated = True
 
@@ -46,7 +54,35 @@ def auth_middleware(request, handler):
         authenticated = True
 
     request[KEY_AUTHENTICATED] = authenticated
+
+    # Store whether we are authenticated in the session so that
+    # future requests don't require credentials to authenticate.
+    session[KEY_AUTHENTICATED] = authenticated
+
     return (yield from handler(request))
+
+
+@asyncio.coroutine
+def get_session(request):
+    """Get a dictionary for the current session."""
+    from aiohttp_session import get_session as aio_get_session
+    return (yield from aio_get_session(request))
+
+
+def session_middleware_factory():
+    """Construct a aiohttp-session middleware instance."""
+    # Note: Because the secret key is generated on-the-fly, the session
+    # cookie will only be valid for the lifetime of the hass server.
+    # Is is feasible to make the secret_key a configuration item, should
+    # we want to persist session data.
+    from cryptography import fernet
+    from aiohttp_session.cookie_storage import EncryptedCookieStorage
+    from aiohttp_session import session_middleware
+
+    fernet_key = fernet.Fernet.generate_key()
+    secret_key = base64.urlsafe_b64decode(fernet_key)
+
+    return session_middleware(EncryptedCookieStorage(secret_key))
 
 
 def is_trusted_ip(request):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -68,6 +68,9 @@ aiodns==1.1.1
 # homeassistant.components.http
 aiohttp_cors==0.6.0
 
+# homeassistant.components.http.auth
+aiohttp_session==1.2.1
+
 # homeassistant.components.sensor.imap
 aioimaplib==0.7.13
 
@@ -187,6 +190,9 @@ concord232==0.15
 
 # homeassistant.components.sensor.crimereports
 crimereports==1.0.0
+
+# homeassistant.components.http.auth
+cryptography==2.1.4
 
 # homeassistant.components.datadog
 datadog==0.15.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -31,6 +31,9 @@ aioautomatic==0.6.4
 # homeassistant.components.http
 aiohttp_cors==0.6.0
 
+# homeassistant.components.http.auth
+aiohttp_session==1.2.1
+
 # homeassistant.components.notify.apns
 apns2==0.3.0
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -38,6 +38,7 @@ COMMENT_REQUIREMENTS = (
 TEST_REQUIREMENTS = (
     'aioautomatic',
     'aiohttp_cors',
+    'aiohttp_session',
     'apns2',
     'caldav',
     'coinmarketcap',

--- a/tests/common.py
+++ b/tests/common.py
@@ -24,7 +24,8 @@ from homeassistant.const import (
     ATTR_DISCOVERED, SERVER_PORT, EVENT_HOMEASSISTANT_CLOSE)
 from homeassistant.helpers import entity_component, entity_registry
 from homeassistant.components import mqtt, recorder
-from homeassistant.components.http.auth import auth_middleware
+from homeassistant.components.http.auth import (
+    auth_middleware, session_middleware_factory)
 from homeassistant.components.http.const import (
     KEY_USE_X_FORWARDED_FOR, KEY_BANS_ENABLED, KEY_TRUSTED_NETWORKS)
 from homeassistant.util.async import (
@@ -283,7 +284,8 @@ def mock_http_component_app(hass, api_password=None):
     """Create an aiohttp.web.Application instance for testing."""
     if 'http' not in hass.config.components:
         mock_http_component(hass, api_password)
-    app = web.Application(middlewares=[auth_middleware])
+    middleware = [session_middleware_factory(), auth_middleware]
+    app = web.Application(middlewares=middleware)
     app['hass'] = hass
     app[KEY_USE_X_FORWARDED_FOR] = False
     app[KEY_BANS_ENABLED] = False

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -193,3 +193,21 @@ def test_authorization_header_must_be_basic_type(mock_api_client, caplog):
         })
 
     assert req.status == 401
+
+
+@asyncio.coroutine
+def test_session_auth(mock_api_client, caplog):
+    """Test access with session based authentication."""
+    # Unauthorized request -> 401.
+    req = yield from mock_api_client.get(const.URL_API)
+    assert req.status == 401
+
+    # Now authorize -> 200.
+    req = yield from mock_api_client.get(
+        const.URL_API,
+        auth=aiohttp.BasicAuth('homeassistant', API_PASSWORD))
+    assert req.status == 200
+
+    # Session is authorized -> 200.
+    req = yield from mock_api_client.get(const.URL_API)
+    assert req.status == 200


### PR DESCRIPTION
## Description:

Adds session storage to the hass webserver.
  
To try this out (as tested in tests/components/http/test_auth.py):

 * Visit /api/config
    * Get a 401
 * Visit /api/config?api_password=<your_hass_password>
    * Get a 200
 * Visit /api/config
    * Get a 200

Restarting the hass server will require re-authentication as the secret_key is re-generated. Long-term, this could be made configurable so that sessions persist between restarts of hass.

**Note:** the frontend cannot currently correctly identify when it is actually authenticated and therefore that it doesn't actually need to login.

**Note:** the frontend's logout function does not currently wipe the session's authentication (I couldn't find the hook in the backend)


My motivation for doing this are two-fold:

 * I want to be able to visit the api in my browser without needing to pass in the ``api_password`` argument.
 * I will be following this PR up with another PR that ensures /local is authenticated, and that is much harder if the password is always required to be passed around





--------

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] ~Local tests with `tox` run successfully.~ (``py.test tests`` passes on py34) **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] ~New files were added to `.coveragerc`.~ N/A

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
