### PR TITLE
miflora - fix for exception handling bug

### DIFF
--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -16,8 +16,7 @@ from homeassistant.const import (
 )
 
 
-REQUIREMENTS = ['https://github.com/ChristianKuehnel/miflora/archive/'
-                'exception_handling.zip#miflora==0.2.1']
+REQUIREMENTS = ['miflora==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -16,7 +16,8 @@ from homeassistant.const import (
 )
 
 
-REQUIREMENTS = ['miflora==0.2.0']
+REQUIREMENTS = ['https://github.com/ChristianKuehnel/miflora/archive/'
+                'exception_handling.zip#miflora==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -138,11 +139,15 @@ class MiFloraSensor(Entity):
 
         This uses a rolling median over 3 values to filter out outliers.
         """
+        from miflora.backends import BluetoothBackendException
         try:
             _LOGGER.debug("Polling data for %s", self.name)
             data = self.poller.parameter_value(self.parameter)
         except IOError as ioerr:
             _LOGGER.info("Polling error %s", ioerr)
+            return
+        except BluetoothBackendException as bterror:
+            _LOGGER.info("Polling error %s", bterror)
             return
 
         if data is not None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -488,7 +488,7 @@ messagebird==1.2.0
 mficlient==0.3.0
 
 # homeassistant.components.sensor.miflora
-miflora==0.2.0
+miflora==https://github.com/ChristianKuehnel/miflora/archive/exception_handling.zip
 
 # homeassistant.components.upnp
 miniupnpc==2.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -360,9 +360,6 @@ http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b89974819
 # homeassistant.components.remember_the_milk
 httplib2==0.10.3
 
-# homeassistant.components.sensor.miflora
-https://github.com/ChristianKuehnel/miflora/archive/exception_handling.zip#miflora==0.2.1
-
 # homeassistant.components.sensor.dht
 # https://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.2
 
@@ -489,6 +486,9 @@ messagebird==1.2.0
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi
 mficlient==0.3.0
+
+# homeassistant.components.sensor.miflora
+miflora==0.3.0
 
 # homeassistant.components.upnp
 miniupnpc==2.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -360,6 +360,9 @@ http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b89974819
 # homeassistant.components.remember_the_milk
 httplib2==0.10.3
 
+# homeassistant.components.sensor.miflora
+https://github.com/ChristianKuehnel/miflora/archive/exception_handling.zip#miflora==0.2.1
+
 # homeassistant.components.sensor.dht
 # https://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.2
 
@@ -486,9 +489,6 @@ messagebird==1.2.0
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi
 mficlient==0.3.0
-
-# homeassistant.components.sensor.miflora
-miflora==https://github.com/ChristianKuehnel/miflora/archive/exception_handling.zip
 
 # homeassistant.components.upnp
 miniupnpc==2.0.2


### PR DESCRIPTION
## Description:
With the release of miflora 0.2 there were two bugs in the exception handling. These are fixed in a development branch of miflora now. This PR pulls in this development branch and also handles the new exception type. 

Once a the new release of miflora is out, we can switch back to the official releases: https://github.com/open-homeautomation/miflora/issues/83

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/11815 https://github.com/home-assistant/home-assistant/issues/9048

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
