### PR TITLE
Catch concurrent.futures.CancelledError in websocket code.

### DIFF
--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -6,6 +6,7 @@ https://home-assistant.io/developers/websocket_api/
 """
 import asyncio
 from contextlib import suppress
+from concurrent.futures import CancelledError
 from functools import partial
 import json
 import logging
@@ -231,7 +232,7 @@ class ActiveConnection:
     def _writer(self):
         """Write outgoing messages."""
         # Exceptions if Socket disconnected or cancelled by connection handler
-        with suppress(RuntimeError, asyncio.CancelledError):
+        with suppress(RuntimeError, asyncio.CancelledError, CancelledError):
             while not self.wsock.closed:
                 message = yield from self.to_write.get()
                 if message is None:
@@ -363,7 +364,7 @@ class ActiveConnection:
             self.log_error(msg)
             self._writer_task.cancel()
 
-        except asyncio.CancelledError:
+        except (asyncio.CancelledError, CancelledError):
             self.debug("Connection cancelled by server")
 
         except asyncio.QueueFull:


### PR DESCRIPTION
## Description:

It isn't clear *why* a concurrent.futures.CancelledError is appearing instead of an asyncio.CancelledError, but #9546 shows that it is (or at least, has done when the connection timed out).

**Related issue (if applicable):** fixes #9546.

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
