### PR TITLE
Add Bluetooth and NFC card/tag Alarm types

### DIFF
--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -61,7 +61,7 @@ LOCK_ALARM_TYPE = {
     '112': 'Master code changed or User added: ',
     '113': 'Duplicate Pin-code: ',
     '130': 'RF module, power restored',
-    '144': 'Unlocked by NFC Tag or Card by user ',	
+    '144': 'Unlocked by NFC Tag or Card by user ',
     '161': 'Tamper Alarm: ',
     '167': 'Low Battery',
     '168': 'Critical Battery Level',

--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -49,6 +49,7 @@ LOCK_NOTIFICATION = {
 
 LOCK_ALARM_TYPE = {
     '9': 'Deadbolt Jammed',
+    '16': 'Unlocked by Bluetooth ',
     '18': 'Locked with Keypad by user ',
     '19': 'Unlocked with Keypad by user ',
     '21': 'Manually Locked ',
@@ -60,6 +61,7 @@ LOCK_ALARM_TYPE = {
     '112': 'Master code changed or User added: ',
     '113': 'Duplicate Pin-code: ',
     '130': 'RF module, power restored',
+    '144': 'Unlocked by NFC Tag or Card by user ',	
     '161': 'Tamper Alarm: ',
     '167': 'Low Battery',
     '168': 'Critical Battery Level',
@@ -98,7 +100,8 @@ ALARM_TYPE_STD = [
     '19',
     '33',
     '112',
-    '113'
+    '113',
+    '144'
 ]
 
 SET_USERCODE_SCHEMA = vol.Schema({


### PR DESCRIPTION
## Description:
Adding more Alarm types will show the correct status of the lock rather than blank information.
Alarm Type 144 is unlocked by NFC Tag or Card on 2 Yale locks that I have tested Conexis L1 and Yale Touchscreen Deadbolt
Alarm Type 16 is unlocked by Bluetooth Tested on 1 Yale Lock Conexis L1

## Checklist:
  - [x] The code change is tested and works locally.




If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
