### PR TITLE
Intent: (change) Moved TurnOn/Off Intents to component

### DIFF
--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -30,6 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 SERVICE_RELOAD_CORE_CONFIG = 'reload_core_config'
 SERVICE_CHECK_CONFIG = 'check_config'
 
+
 def is_on(hass, entity_id=None):
     """Load up the module to call the is_on method.
 
@@ -160,7 +161,6 @@ def async_setup(hass, config):
         ha.DOMAIN, SERVICE_TOGGLE, async_handle_turn_service)
     hass.helpers.intent.async_register(TurnOnIntent())
     hass.helpers.intent.async_register(TurnOffIntent())
-
 
     @asyncio.coroutine
     def async_handle_core_service(call):

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/conversation/
 import asyncio
 import logging
 import re
-import warnings
 
 import voluptuous as vol
 
@@ -71,7 +70,6 @@ def async_register(hass, intent_type, utterances):
 @asyncio.coroutine
 def async_setup(hass, config):
     """Register the process service."""
-
     config = config.get(DOMAIN, {})
     intents = hass.data.get(DOMAIN)
 
@@ -146,7 +144,6 @@ def _process(hass, text):
 
 class ConversationProcessView(http.HomeAssistantView):
     """View to retrieve shopping list content."""
-
     url = '/api/conversation/process'
     name = "api:conversation:process"
 

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -13,8 +13,7 @@ import voluptuous as vol
 
 from homeassistant import core
 from homeassistant.components import http
-from homeassistant.const import (
-    ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON)
+from homeassistant.const import INTENT_TURN_ON, INTENT_TURN_OFF
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import intent
 from homeassistant.loader import bind_hass
@@ -27,9 +26,6 @@ ATTR_TEXT = 'text'
 
 DEPENDENCIES = ['http']
 DOMAIN = 'conversation'
-
-INTENT_TURN_OFF = 'HassTurnOff'
-INTENT_TURN_ON = 'HassTurnOn'
 
 REGEX_TURN_COMMAND = re.compile(r'turn (?P<name>(?: |\w)+) (?P<command>\w+)')
 REGEX_TYPE = type(re.compile(''))
@@ -50,7 +46,7 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({
 @core.callback
 @bind_hass
 def async_register(hass, intent_type, utterances):
-    """Register an intent.
+    """Register utterances and any custom intents.
 
     Registrations don't require conversations to be loaded. They will become
     active once the conversation component is loaded.
@@ -75,7 +71,6 @@ def async_register(hass, intent_type, utterances):
 @asyncio.coroutine
 def async_setup(hass, config):
     """Register the process service."""
-    warnings.filterwarnings('ignore', module='fuzzywuzzy')
 
     config = config.get(DOMAIN, {})
     intents = hass.data.get(DOMAIN)
@@ -102,8 +97,6 @@ def async_setup(hass, config):
 
     hass.http.register_view(ConversationProcessView)
 
-    hass.helpers.intent.async_register(TurnOnIntent())
-    hass.helpers.intent.async_register(TurnOffIntent())
     async_register(hass, INTENT_TURN_ON,
                    ['Turn {name} on', 'Turn on {name}'])
     async_register(hass, INTENT_TURN_OFF, [
@@ -149,79 +142,6 @@ def _process(hass, text):
                 {key: {'value': value} for key, value
                  in match.groupdict().items()}, text)
             return response
-
-
-@core.callback
-def _match_entity(hass, name):
-    """Match a name to an entity."""
-    from fuzzywuzzy import process as fuzzyExtract
-    entities = {state.entity_id: state.name for state
-                in hass.states.async_all()}
-    entity_id = fuzzyExtract.extractOne(
-        name, entities, score_cutoff=65)[2]
-    return hass.states.get(entity_id) if entity_id else None
-
-
-class TurnOnIntent(intent.IntentHandler):
-    """Handle turning item on intents."""
-
-    intent_type = INTENT_TURN_ON
-    slot_schema = {
-        'name': cv.string,
-    }
-
-    @asyncio.coroutine
-    def async_handle(self, intent_obj):
-        """Handle turn on intent."""
-        hass = intent_obj.hass
-        slots = self.async_validate_slots(intent_obj.slots)
-        name = slots['name']['value']
-        entity = _match_entity(hass, name)
-
-        if not entity:
-            _LOGGER.error("Could not find entity id for %s", name)
-            return None
-
-        yield from hass.services.async_call(
-            core.DOMAIN, SERVICE_TURN_ON, {
-                ATTR_ENTITY_ID: entity.entity_id,
-            }, blocking=True)
-
-        response = intent_obj.create_response()
-        response.async_set_speech(
-            'Turned on {}'.format(entity.name))
-        return response
-
-
-class TurnOffIntent(intent.IntentHandler):
-    """Handle turning item off intents."""
-
-    intent_type = INTENT_TURN_OFF
-    slot_schema = {
-        'name': cv.string,
-    }
-
-    @asyncio.coroutine
-    def async_handle(self, intent_obj):
-        """Handle turn off intent."""
-        hass = intent_obj.hass
-        slots = self.async_validate_slots(intent_obj.slots)
-        name = slots['name']['value']
-        entity = _match_entity(hass, name)
-
-        if not entity:
-            _LOGGER.error("Could not find entity id for %s", name)
-            return None
-
-        yield from hass.services.async_call(
-            core.DOMAIN, SERVICE_TURN_OFF, {
-                ATTR_ENTITY_ID: entity.entity_id,
-            }, blocking=True)
-
-        response = intent_obj.create_response()
-        response.async_set_speech(
-            'Turned off {}'.format(entity.name))
-        return response
 
 
 class ConversationProcessView(http.HomeAssistantView):

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -144,6 +144,7 @@ def _process(hass, text):
 
 class ConversationProcessView(http.HomeAssistantView):
     """View to retrieve shopping list content."""
+
     url = '/api/conversation/process'
     name = "api:conversation:process"
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -165,6 +165,10 @@ EVENT_SERVICE_REMOVED = 'service_removed'
 EVENT_LOGBOOK_ENTRY = 'logbook_entry'
 EVENT_THEMES_UPDATED = 'themes_updated'
 
+# #### INTENTS ####
+INTENT_TURN_OFF = 'HassTurnOff'
+INTENT_TURN_ON = 'HassTurnOn'
+
 # #### STATES ####
 STATE_ON = 'on'
 STATE_OFF = 'off'

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -6,7 +6,9 @@ import pytest
 
 from homeassistant.setup import async_setup_component
 from homeassistant.components import conversation
+import homeassistant.components as component
 from homeassistant.helpers import intent
+from homeassistant.util.async import run_coroutine_threadsafe
 
 from tests.common import async_mock_intent, async_mock_service
 
@@ -15,6 +17,9 @@ from tests.common import async_mock_intent, async_mock_service
 def test_calling_intent(hass):
     """Test calling an intent from a conversation."""
     intents = async_mock_intent(hass, 'OrderBeer')
+
+    result = yield from component.async_setup(hass, {})
+    assert result
 
     result = yield from async_setup_component(hass, 'conversation', {
         'conversation': {
@@ -45,6 +50,9 @@ def test_calling_intent(hass):
 def test_register_before_setup(hass):
     """Test calling an intent from a conversation."""
     intents = async_mock_intent(hass, 'OrderBeer')
+
+    result = yield from component.async_setup(hass, {})
+    assert result
 
     hass.components.conversation.async_register('OrderBeer', [
         'A {type} beer, please'
@@ -107,6 +115,9 @@ def test_http_processing_intent(hass, test_client):
 
     intent.async_register(hass, TestIntentHandler())
 
+    result = yield from component.async_setup(hass, {})
+    assert result
+
     result = yield from async_setup_component(hass, 'conversation', {
         'conversation': {
             'intents': {
@@ -145,6 +156,9 @@ def test_http_processing_intent(hass, test_client):
 @pytest.mark.parametrize('sentence', ('turn on kitchen', 'turn kitchen on'))
 def test_turn_on_intent(hass, sentence):
     """Test calling the turn on intent."""
+    result = yield from component.async_setup(hass, {})
+    assert result
+
     result = yield from async_setup_component(hass, 'conversation', {})
     assert result
 
@@ -168,6 +182,9 @@ def test_turn_on_intent(hass, sentence):
 @pytest.mark.parametrize('sentence', ('turn off kitchen', 'turn kitchen off'))
 def test_turn_off_intent(hass, sentence):
     """Test calling the turn on intent."""
+    result = yield from component.async_setup(hass, {})
+    assert result
+
     result = yield from async_setup_component(hass, 'conversation', {})
     assert result
 
@@ -190,6 +207,9 @@ def test_turn_off_intent(hass, sentence):
 @asyncio.coroutine
 def test_http_api(hass, test_client):
     """Test the HTTP conversation API."""
+    result = yield from component.async_setup(hass, {})
+    assert result
+
     result = yield from async_setup_component(hass, 'conversation', {})
     assert result
 
@@ -212,6 +232,9 @@ def test_http_api(hass, test_client):
 @asyncio.coroutine
 def test_http_api_wrong_data(hass, test_client):
     """Test the HTTP conversation API."""
+    result = yield from component.async_setup(hass, {})
+    assert result
+
     result = yield from async_setup_component(hass, 'conversation', {})
     assert result
 

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -8,7 +8,6 @@ from homeassistant.setup import async_setup_component
 from homeassistant.components import conversation
 import homeassistant.components as component
 from homeassistant.helpers import intent
-from homeassistant.util.async import run_coroutine_threadsafe
 
 from tests.common import async_mock_intent, async_mock_service
 


### PR DESCRIPTION
## Description:

Moved TurnOn/Off Intent into component setup to remove dependency on conversation.

Not breaking change. This is a small change in preparation to adding Intents to other components.

**Related issue (if applicable):** fixes #12087

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
