### PR TITLE
Upgrade influxdb to 5.0.0

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -39,6 +39,7 @@ CONF_RETRY_QUEUE = 'retry_queue_limit'
 DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_VERIFY_SSL = True
 DOMAIN = 'influxdb'
+
 TIMEOUT = 5
 
 COMPONENT_CONFIG_SCHEMA_ENTRY = vol.Schema({

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -21,7 +21,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_values import EntityValues
 from homeassistant.util import utcnow
 
-REQUIREMENTS = ['influxdb==4.1.1']
+REQUIREMENTS = ['influxdb==5.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ def setup(hass, config):
         _LOGGER.error("Database host is not accessible due to '%s', please "
                       "check your entries in the configuration file (host, "
                       "port, etc.) and verify that the database exists and is "
-                      "READ/WRITE.", exc)
+                      "READ/WRITE", exc)
         return False
 
     def influx_event_listener(event):
@@ -145,8 +145,7 @@ def setup(hass, config):
         state = event.data.get('new_state')
         if state is None or state.state in (
                 STATE_UNKNOWN, '', STATE_UNAVAILABLE) or \
-                state.entity_id in blacklist_e or \
-                state.domain in blacklist_d:
+                state.entity_id in blacklist_e or state.domain in blacklist_d:
             return
 
         try:
@@ -301,11 +300,9 @@ class RetryOnError(object):
 
                     target = utcnow() + self.retry_delay
                     tracking = {'target': target}
-                    remove = track_point_in_utc_time(self.hass,
-                                                     partial(scheduled,
-                                                             retry + 1,
-                                                             tracking),
-                                                     target)
+                    remove = track_point_in_utc_time(
+                        self.hass, partial(scheduled, retry + 1, tracking),
+                        target)
                     tracking['remove'] = remove
                     tracking["exc"] = ex
                     wrapper._retry_queue.append(tracking)

--- a/homeassistant/components/sensor/influxdb.py
+++ b/homeassistant/components/sensor/influxdb.py
@@ -4,25 +4,25 @@ InfluxDB component which allows you to get data from an Influx database.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/sensor.influxdb/
 """
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_USERNAME,
-                                 CONF_PASSWORD, CONF_SSL, CONF_VERIFY_SSL,
-                                 CONF_NAME, CONF_UNIT_OF_MEASUREMENT,
-                                 CONF_VALUE_TEMPLATE)
-from homeassistant.const import STATE_UNKNOWN
-from homeassistant.util import Throttle
 
+from homeassistant.components.influxdb import CONF_DB_NAME
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT, CONF_SSL,
+    CONF_UNIT_OF_MEASUREMENT, CONF_USERNAME, CONF_VALUE_TEMPLATE,
+    CONF_VERIFY_SSL, STATE_UNKNOWN)
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['influxdb==4.1.1']
+REQUIREMENTS = ['influxdb==5.0.0']
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 8086
@@ -32,13 +32,13 @@ DEFAULT_VERIFY_SSL = False
 DEFAULT_GROUP_FUNCTION = 'mean'
 DEFAULT_FIELD = 'value'
 
-CONF_DB_NAME = 'database'
 CONF_QUERIES = 'queries'
 CONF_GROUP_FUNCTION = 'group_function'
 CONF_FIELD = 'field'
 CONF_MEASUREMENT_NAME = 'measurement'
 CONF_WHERE = 'where'
 
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 _QUERY_SCHEME = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
@@ -61,9 +61,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean
 })
-
-# Return cached results if last scan was less then this time ago
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -122,7 +119,7 @@ class InfluxSensor(Entity):
         except exceptions.InfluxDBClientError as exc:
             _LOGGER.error("Database host is not accessible due to '%s', please"
                           " check your entries in the configuration file and"
-                          " that the database exists and is READ/WRITE.", exc)
+                          " that the database exists and is READ/WRITE", exc)
             self.connected = False
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -404,10 +404,8 @@ iglo==1.1.3
 # homeassistant.components.ihc
 ihcsdk==2.1.1
 
-# homeassistant.components.sensor.influxdb
-influxdb==4.1.1
-
 # homeassistant.components.influxdb
+# homeassistant.components.sensor.influxdb
 influxdb==5.0.0
 
 # homeassistant.components.insteon_local

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -404,9 +404,11 @@ iglo==1.1.3
 # homeassistant.components.ihc
 ihcsdk==2.1.1
 
-# homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
 influxdb==4.1.1
+
+# homeassistant.components.influxdb
+influxdb==5.0.0
 
 # homeassistant.components.insteon_local
 insteonlocal==0.53

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -77,9 +77,11 @@ holidays==0.9.3
 # homeassistant.components.frontend
 home-assistant-frontend==20180130.0
 
-# homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
 influxdb==4.1.1
+
+# homeassistant.components.influxdb
+influxdb==5.0.0
 
 # homeassistant.components.dyson
 libpurecoollink==0.4.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -77,10 +77,8 @@ holidays==0.9.3
 # homeassistant.components.frontend
 home-assistant-frontend==20180130.0
 
-# homeassistant.components.sensor.influxdb
-influxdb==4.1.1
-
 # homeassistant.components.influxdb
+# homeassistant.components.sensor.influxdb
 influxdb==5.0.0
 
 # homeassistant.components.dyson


### PR DESCRIPTION
## Description:
* Fixed failing tags match in get_points() on a ResultSet:
    - This is a breaking change. Older influxdb servers that do not return tags as fields are not compatible with this change. This would result in the get_points() filters no longer working.
* Added pool size parameter to client constructor
* Added ping method to the client.
* Added support for not including all fields when using the series helper.
* Fixed typo in Content-Type header.
* Data arg in write() can now be a single string.
* Added method close to InfluxDBClient class.
* Added chunked query support for DataFrameClient.

## Example entry for `configuration.yaml` (if applicable):
```yaml
influxdb:
```
Output:

```bash
$ influx
Connected to http://localhost:8086 version 1.4.2
InfluxDB shell version: 1.4.2
> show databases
name: databases
name
----
_internal
home_assistant
> use home_assistant
Using database home_assistant
> SELECT "value" FROM "sensor.random_sensor"
name: sensor.random_sensor
time                value
----                -----
1517674286108212992 1
1517674317107270912 3
1517674379106669056 20
1517674410112139008 14
1517674441104921088 16
1517674503108457984 7
> SELECT mean("value") AS "mean_value" FROM "sensor.random_sensor"
name: sensor.random_sensor
time mean_value
---- ----------
0    10.166666666666666
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
