### PR TITLE
Update plex.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 Home Assistant |Build Status| |Coverage Status| |Chat Status|
 =============================================================
 
+
 Home Assistant is a home automation platform running on Python 3. It is able to track and control all devices at home and offer a platform for automating control.
 
 To get started:

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,6 @@
 Home Assistant |Build Status| |Coverage Status| |Chat Status|
 =============================================================
 
-
 Home Assistant is a home automation platform running on Python 3. It is able to track and control all devices at home and offer a platform for automating control.
 
 To get started:

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -119,46 +119,37 @@ class PlexSensor(Entity):
             device = sess.players[0].title
             now_playing_user = "{0} - {1}".format(user, device)
             now_playing_title = ""
+            
             if sess.TYPE == 'episode':
                 # example:
                 # "Supernatural (2005) - S01 · E13 - Route 666"
                 season_title = sess.grandparentTitle
-
                 if sess.show().year is not None:
                     season_title += " ({0})".format(sess.show().year)
-
                 season_episode = "S{0}".format(sess.parentIndex)
                 if sess.index is not None:
                     season_episode += " · E{1}".format(sess.index)
-
                 episode_title = sess.title
-
                 now_playing_title = "{0} - {1} - {2}".format(season_title,
                                                              season_episode,
                                                              episode_title)
-
             elif sess.TYPE == 'track':
                 # example:
                 # "Billy Talent - Afraid of Heights - Afraid of Heights"
                 track_artist = sess.grandparentTitle
-
                 track_album = sess.parentTitle
-
                 track_title = sess.title
-
                 now_playing_title = "{0} - {1} - {2}".format(track_artist,
                                                              track_album,
                                                              track_title)
-
             else:
                 # example:
                 # "picture_of_last_summer_camp (2015)"
                 # "The Incredible Hulk (2008)"
                 now_playing_title = sess.title
-
                 if sess.year is not None:
                     now_playing_title += " ({0})".format(sess.year)
-
+                    
             now_playing.append((now_playing_user, now_playing_title))
         self._state = len(sessions)
         self._now_playing = now_playing

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -119,7 +119,7 @@ class PlexSensor(Entity):
             device = sess.players[0].title
             now_playing_user = "{0} - {1}".format(user, device)
             now_playing_title = ""
-            
+
             if sess.TYPE == 'episode':
                 # example:
                 # "Supernatural (2005) - S01 · E13 - Route 666"
@@ -149,7 +149,7 @@ class PlexSensor(Entity):
                 now_playing_title = sess.title
                 if sess.year is not None:
                     now_playing_title += " ({0})".format(sess.year)
-                    
+
             now_playing.append((now_playing_user, now_playing_title))
         self._state = len(sessions)
         self._now_playing = now_playing

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -122,17 +122,17 @@ class PlexSensor(Entity):
                 now_playing.append((user, "{0} ({1})".format(title, year)))
             elif sess.TYPE == 'episode':
                 season_year = (str(sess.show().year)
-                              if sess.show().year is not None
-                              else "")
-                season_title = (sess.grandparentTitle
-                               if sess.grandparentTitle is not None
+                               if sess.show().year is not None
                                else "")
-                season_episode = (sess.seasonEpisode
-                                 if sess.seasonEpisode is not None
-                                 else "")
-                episode_title = (sess.title
-                                if sess.title is not None
+                season_title = (sess.grandparentTitle
+                                if sess.grandparentTitle is not None
                                 else "")
+                season_episode = (sess.seasonEpisode
+                                  if sess.seasonEpisode is not None
+                                  else "")
+                episode_title = (sess.title
+                                 if sess.title is not None
+                                 else "")
                 title = season_title + ' (' + season_year + ')' + ' - ' + \
                     season_episode + ' - ' + episode_title
                 now_playing.append((user, "{0}".format(title)))

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -121,11 +121,21 @@ class PlexSensor(Entity):
                 year = sess.year if sess.year is not None else ""
                 now_playing.append((user, "{0} ({1})".format(title, year)))
             elif sess.TYPE == 'episode':
-                seasonYear = str(sess.show().year) if sess.show().year is not None else ""
-                seasonTitle = sess.grandparentTitle if sess.grandparentTitle is not None else ""
-                seasonEpisode = sess.seasonEpisode if sess.seasonEpisode is not None else ""
-                episodeTitle = sess.title if sess.title is not None else ""
-                title = seasonTitle + ' (' + seasonYear + ')' + ' - ' + seasonEpisode + ' - ' + episodeTitle
+                seasonYear = (str(sess.show().year)
+                                 if sess.show().year is not None
+                                 else "")
+                seasonTitle = (sess.grandparentTitle
+                                  if sess.grandparentTitle is not None
+                                  else "")
+                seasonEpisode = (sess.seasonEpisode
+                                    if sess.seasonEpisode is not None
+                                    else "")
+                episodeTitle = (sess.title
+                                   if sess.title is not None
+                                   else "")
+                title = seasonTitle + \
+                    ' (' + seasonYear + ')' + ' - ' + \
+                    seasonEpisode + ' - ' + episodeTitle
                 now_playing.append((user, "{0}".format(title)))
         self._state = len(sessions)
         self._now_playing = now_playing

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -121,21 +121,20 @@ class PlexSensor(Entity):
                 year = sess.year if sess.year is not None else ""
                 now_playing.append((user, "{0} ({1})".format(title, year)))
             elif sess.TYPE == 'episode':
-                seasonYear = (str(sess.show().year)
+                season_year = (str(sess.show().year)
                               if sess.show().year is not None
                               else "")
-                seasonTitle = (sess.grandparentTitle
+                season_title = (sess.grandparentTitle
                                if sess.grandparentTitle is not None
                                else "")
-                seasonEpisode = (sess.seasonEpisode
+                season_episode = (sess.seasonEpisode
                                  if sess.seasonEpisode is not None
                                  else "")
-                episodeTitle = (sess.title
+                episode_title = (sess.title
                                 if sess.title is not None
                                 else "")
-                title = seasonTitle + \
-                    ' (' + seasonYear + ')' + ' - ' + \
-                    seasonEpisode + ' - ' + episodeTitle
+                title = season_title + ' (' + season_year + ')' + ' - ' + \
+                    season_episode + ' - ' + episode_title
                 now_playing.append((user, "{0}".format(title)))
         self._state = len(sessions)
         self._now_playing = now_playing

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -27,7 +27,7 @@ DEFAULT_NAME = 'Plex'
 DEFAULT_PORT = 32400
 DEFAULT_SSL = False
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
@@ -116,8 +116,16 @@ class PlexSensor(Entity):
         now_playing = []
         for sess in sessions:
             user = sess.usernames[0] if sess.usernames is not None else ""
-            title = sess.title if sess.title is not None else ""
-            year = sess.year if sess.year is not None else ""
-            now_playing.append((user, "{0} ({1})".format(title, year)))
+            if sess.TYPE == 'movie':
+                title = sess.title if sess.title is not None else ""
+                year = sess.year if sess.year is not None else ""
+                now_playing.append((user, "{0} ({1})".format(title, year)))
+            elif sess.TYPE == 'episode':
+                seasonYear = str(sess.show().year) if sess.show().year is not None else ""
+                seasonTitle = sess.grandparentTitle if sess.grandparentTitle is not None else ""
+                seasonEpisode = sess.seasonEpisode if sess.seasonEpisode is not None else ""
+                episodeTitle = sess.title if sess.title is not None else ""
+                title = seasonTitle + ' (' + seasonYear + ')' + ' - ' + seasonEpisode + ' - ' + episodeTitle
+                now_playing.append((user, "{0}".format(title)))
         self._state = len(sessions)
         self._now_playing = now_playing

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -122,17 +122,17 @@ class PlexSensor(Entity):
                 now_playing.append((user, "{0} ({1})".format(title, year)))
             elif sess.TYPE == 'episode':
                 seasonYear = (str(sess.show().year)
-                                 if sess.show().year is not None
-                                 else "")
+                              if sess.show().year is not None
+                              else "")
                 seasonTitle = (sess.grandparentTitle
-                                  if sess.grandparentTitle is not None
-                                  else "")
+                               if sess.grandparentTitle is not None
+                               else "")
                 seasonEpisode = (sess.seasonEpisode
-                                    if sess.seasonEpisode is not None
-                                    else "")
+                                 if sess.seasonEpisode is not None
+                                 else "")
                 episodeTitle = (sess.title
-                                   if sess.title is not None
-                                   else "")
+                                if sess.title is not None
+                                else "")
                 title = seasonTitle + \
                     ' (' + seasonYear + ')' + ' - ' + \
                     seasonEpisode + ' - ' + episodeTitle


### PR DESCRIPTION
show information about media depending if it is a movie, an episode, audio or picture
set time_between_scans to 10 s to match with plex media_player component

## Description:
![plex_activity_monitor](https://user-images.githubusercontent.com/8616693/36974355-ad944a5c-2076-11e8-8800-fc7458551356.PNG)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
