### PR TITLE
[WIP] Allow custom order from config for Daikin list of operation, fan modes and swing modes

### DIFF
--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -75,9 +75,9 @@ class DaikinClimate(ClimateDevice):
         self._api = api
         self._force_refresh = False
         self._list = {
-            ATTR_OPERATION_MODE: list(
+            ATTR_OPERATION_MODE: sorted(list(
                 map(str.title, set(HA_STATE_TO_DAIKIN.values()))
-            ),
+            )),
             ATTR_FAN_MODE: list(
                 map(
                     str.title,

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -78,18 +78,18 @@ class DaikinClimate(ClimateDevice):
             ATTR_OPERATION_MODE: sorted(list(
                 map(str.title, set(HA_STATE_TO_DAIKIN.values()))
             )),
-            ATTR_FAN_MODE: list(
+            ATTR_FAN_MODE: sorted(list(
                 map(
                     str.title,
                     appliance.daikin_values(HA_ATTR_TO_DAIKIN[ATTR_FAN_MODE])
                 )
-            ),
-            ATTR_SWING_MODE: list(
+            )),
+            ATTR_SWING_MODE: sorted(list(
                 map(
                     str.title,
                     appliance.daikin_values(HA_ATTR_TO_DAIKIN[ATTR_SWING_MODE])
                 )
-            ),
+            )),
         }
 
         self._supported_features = SUPPORT_TARGET_TEMPERATURE \


### PR DESCRIPTION
## Description:
Just sort alphabetically those dropdowns.

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
