### PR TITLE
Fix Xeoma camera platform to allow different admin/viewer credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,9 @@ Icon
 # Thumbnails
 ._*
 
+# IntelliJ IDEA
 .idea
+*.iml
 
 # pytest
 .cache

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1014,7 +1014,7 @@ pywebpush==1.5.0
 pywemo==0.4.25
 
 # homeassistant.components.camera.xeoma
-pyxeoma==1.2
+pyxeoma==1.3
 
 # homeassistant.components.zabbix
 pyzabbix==0.7.4


### PR DESCRIPTION
## Description:
Adds support for configuring Xeoma to use different credentials for the admin user and each camera's viewer user. This platform will now discover the viewing credentials for each camera if they are configured and use them when fetching images.

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
