### PR TITLE
[SMALL-PR] Enabled WebOS LG Tv autodiscovery

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -71,6 +71,7 @@ SERVICE_HANDLERS = {
     'sabnzbd': ('sensor', 'sabnzbd'),
     'bose_soundtouch': ('media_player', 'soundtouch'),
     'bluesound': ('media_player', 'bluesound'),
+    'webos_tv': ('media_player', 'webostv'),
 }
 
 CONF_IGNORE = 'ignore'

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/media_player.webostv/
 import asyncio
 from datetime import timedelta
 import logging
-from urllib.parse import urlparse
 
 # pylint: disable=unused-import
 from typing import Dict  # noqa: F401


### PR DESCRIPTION
## Description:

Enabled WebOS LG Tv autodiscovery.

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: webostv
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

CC: @TheRealLink 