### PR TITLE
Apple TV should return all supported features

### DIFF
--- a/homeassistant/components/media_player/apple_tv.py
+++ b/homeassistant/components/media_player/apple_tv.py
@@ -25,6 +25,10 @@ DEPENDENCIES = ['apple_tv']
 
 _LOGGER = logging.getLogger(__name__)
 
+SUPPORT_APPLE_TV = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PLAY_MEDIA | \
+                   SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_SEEK | \
+                   SUPPORT_STOP | SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
+
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
@@ -196,14 +200,7 @@ class AppleTvDevice(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        features = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PLAY_MEDIA
-        if self._playing is None or self.state == STATE_IDLE:
-            return features
-
-        features |= SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_SEEK | \
-            SUPPORT_STOP | SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
-
-        return features
+        return SUPPORT_APPLE_TV
 
     @asyncio.coroutine
     def async_turn_on(self):


### PR DESCRIPTION
## Description:

Ensures the Apple TV Media Component always returns the full set of supported features. This is required in order to ensure the `AlexaPlaybackController` capability is included when the media player is discovered.

Note, by doing this the media player controllers are always visible in the HASS UI whereas previously they were hidden if the player was off or idle. Having the controllers visible in these states brings the player in live with other media players e.g. Roku, FireTV, Vizio Smartcast, etc.

Before the change:
<img width="400" alt="screen shot 2018-02-03 at 9 09 29 pm" src="https://user-images.githubusercontent.com/868181/35774511-9a098b9e-0926-11e8-835e-678e3855ca9f.png">

After the change:
<img width="515" alt="screen shot 2018-02-03 at 9 09 42 pm" src="https://user-images.githubusercontent.com/868181/35774512-9a224c42-0926-11e8-98e8-cf6f0a89b98b.png">

**Related issue (if applicable):** fixes #12164

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
 - [x] Local tests with tox run successfully. Your PR cannot be merged unless tests pass
 - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54