### PR TITLE
add delay_arrival

### DIFF
--- a/homeassistant/components/sensor/deutsche_bahn.py
+++ b/homeassistant/components/sensor/deutsche_bahn.py
@@ -116,4 +116,5 @@ class SchieneData(object):
                                           'delay_arrival': 0})
                 # IMHO only delay_departure is useful
                 con['delay'] = delay['delay_departure']
+                con['delay_arrival'] = delay['delay_arrival']
                 con['ontime'] = con.get('ontime', False)


### PR DESCRIPTION
This adds the `delay_arrival` field from the schiene interface.
This field sometimes explains an `ontime=false` with `delay=0`...

This is somewhat in opposition to the comment that only departure delay is useful. I think the otherwise unexplained `ontime=false` is worth to include the new field in the attribute data.

## Checklist:
  - [x] The code change is tested and works locally.

