### PR TITLE
Move TP-Link socket LED state setting to update()

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -48,10 +48,14 @@ class SmartPlugSwitch(SwitchDevice):
 
     def __init__(self, smartplug, name, leds_on):
         """Initialize the switch."""
+        from pyHS100 import SmartDeviceException
         self.smartplug = smartplug
         self._name = name
         if leds_on is not None:
-            self.smartplug.led = leds_on
+            try:
+                self.smartplug.led = leds_on
+            except (SmartDeviceException, OSError) as ex:
+                _LOGGER.warning('Could not set LED state for %s: %s', name, ex)
         self._state = None
         self._available = True
         # Set up emeter cache

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -48,14 +48,9 @@ class SmartPlugSwitch(SwitchDevice):
 
     def __init__(self, smartplug, name, leds_on):
         """Initialize the switch."""
-        from pyHS100 import SmartDeviceException
         self.smartplug = smartplug
         self._name = name
-        if leds_on is not None:
-            try:
-                self.smartplug.led = leds_on
-            except (SmartDeviceException, OSError) as ex:
-                _LOGGER.warning('Could not set LED state for %s: %s', name, ex)
+        self._leds_on = leds_on
         self._state = None
         self._available = True
         # Set up emeter cache
@@ -97,6 +92,10 @@ class SmartPlugSwitch(SwitchDevice):
 
             self._state = self.smartplug.state == \
                 self.smartplug.SWITCH_STATE_ON
+
+            if self._leds_on is not None:
+                self.smartplug.led = self._leds_on
+                self._leds_on = None
 
             # Pull the name from the device if a name was not specified
             if self._name == DEFAULT_NAME:


### PR DESCRIPTION
## Description:

LED state setting will still only occur on the first `update()` then the device is available.

Handles errors when setting the LED state of TP-Link sockets.

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: tplink
  host: xxx.xxx.xxx.xxx
  enable_leds: False
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
