### PR TITLE
Fix clear playlist in Volumio component

### DIFF
--- a/homeassistant/components/media_player/volumio.py
+++ b/homeassistant/components/media_player/volumio.py
@@ -3,6 +3,8 @@ Volumio Platform.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.volumio/
+
+Volumio rest API: https://volumio.github.io/docs/API/REST_API.html
 """
 from datetime import timedelta
 import logging
@@ -247,9 +249,9 @@ class Volumio(MediaPlayerDevice):
 
     def async_clear_playlist(self):
         """Clear players playlist."""
-        # FIXME
         self._currentplaylist = None
-        return self.send_volumio_msg('clearQueue')
+        return self.send_volumio_msg('commands',
+                                     params={'cmd': 'clearQueue'})
 
     @asyncio.coroutine
     @Throttle(PLAYLIST_UPDATE_INTERVAL)


### PR DESCRIPTION
## Description:
Just fix clear playlist function in Volumio component


If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
