### PR TITLE
Properly handle thresholds of zero

### DIFF
--- a/homeassistant/components/binary_sensor/threshold.py
+++ b/homeassistant/components/binary_sensor/threshold.py
@@ -126,11 +126,12 @@ class ThresholdSensor(BinarySensorDevice):
     @property
     def threshold_type(self):
         """Return the type of threshold this sensor represents."""
-        if self._threshold_lower and self._threshold_upper:
+        if self._threshold_lower is not None and \
+                self._threshold_upper is not None:
             return TYPE_RANGE
-        elif self._threshold_lower:
+        elif self._threshold_lower is not None:
             return TYPE_LOWER
-        elif self._threshold_upper:
+        elif self._threshold_upper is not None:
             return TYPE_UPPER
 
     @property

--- a/tests/components/binary_sensor/test_threshold.py
+++ b/tests/components/binary_sensor/test_threshold.py
@@ -333,3 +333,63 @@ class TestThresholdSensor(unittest.TestCase):
 
         self.assertEqual('unknown', state.attributes.get('position'))
         assert state.state == 'off'
+
+    def test_sensor_lower_zero_threshold(self):
+        """Test if a lower threshold of zero is set."""
+        config = {
+            'binary_sensor': {
+                'platform': 'threshold',
+                'lower': '0',
+                'entity_id': 'sensor.test_monitored',
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.states.set('sensor.test_monitored', 16)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.threshold')
+
+        self.assertEqual('lower', state.attributes.get('type'))
+        self.assertEqual(float(config['binary_sensor']['lower']),
+                         state.attributes.get('lower'))
+
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', -3)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.threshold')
+
+        assert state.state == 'on'
+
+    def test_sensor_upper_zero_threshold(self):
+        """Test if an upper threshold of zero is set."""
+        config = {
+            'binary_sensor': {
+                'platform': 'threshold',
+                'upper': '0',
+                'entity_id': 'sensor.test_monitored',
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.states.set('sensor.test_monitored', -10)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.threshold')
+
+        self.assertEqual('upper', state.attributes.get('type'))
+        self.assertEqual(float(config['binary_sensor']['upper']),
+                         state.attributes.get('upper'))
+
+        assert state.state == 'off'
+
+        self.hass.states.set('sensor.test_monitored', 2)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.threshold')
+
+        assert state.state == 'on'


### PR DESCRIPTION
## Description:

Explicitly test for thresholds to be None rather than truth value testing (which for number types returns False for zero values).

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: threshold
  entity_id: sensor.test
  lower: 0
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
