### PR TITLE
Avoid influxdb filling connection pool

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -4,10 +4,11 @@ A component which allows you to send data to an Influx database.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/influxdb/
 """
-from datetime import timedelta
-from functools import partial, wraps
 import logging
 import re
+import queue
+import threading
+import time
 
 import requests.exceptions
 import voluptuous as vol
@@ -15,11 +16,11 @@ import voluptuous as vol
 from homeassistant.const import (
     CONF_DOMAINS, CONF_ENTITIES, CONF_EXCLUDE, CONF_HOST, CONF_INCLUDE,
     CONF_PASSWORD, CONF_PORT, CONF_SSL, CONF_USERNAME, CONF_VERIFY_SSL,
-    EVENT_STATE_CHANGED, STATE_UNAVAILABLE, STATE_UNKNOWN)
+    EVENT_STATE_CHANGED, EVENT_HOMEASSISTANT_STOP, STATE_UNAVAILABLE,
+    STATE_UNKNOWN)
 from homeassistant.helpers import state as state_helper
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_values import EntityValues
-from homeassistant.util import utcnow
 
 REQUIREMENTS = ['influxdb==5.0.0']
 
@@ -65,7 +66,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_PORT): cv.port,
         vol.Optional(CONF_SSL): cv.boolean,
         vol.Optional(CONF_RETRY_COUNT, default=0): cv.positive_int,
-        vol.Optional(CONF_RETRY_QUEUE, default=20): cv.positive_int,
+        vol.Optional(CONF_RETRY_QUEUE, default=100): cv.positive_int,
         vol.Optional(CONF_DEFAULT_MEASUREMENT): cv.string,
         vol.Optional(CONF_OVERRIDE_MEASUREMENT): cv.string,
         vol.Optional(CONF_TAGS, default={}):
@@ -141,8 +142,8 @@ def setup(hass, config):
                       "READ/WRITE", exc)
         return False
 
-    def influx_event_listener(event):
-        """Listen for new messages on the bus and sends them to Influx."""
+    def influx_handle_event(event):
+        """Send an event to Influx."""
         state = event.data.get('new_state')
         if state is None or state.state in (
                 STATE_UNKNOWN, '', STATE_UNAVAILABLE) or \
@@ -222,91 +223,59 @@ def setup(hass, config):
 
         json_body[0]['tags'].update(tags)
 
-        _write_data(json_body)
+        for retry in range(max_tries+1):
+            try:
+                influx.write_points(json_body)
+                break
+            except (exceptions.InfluxDBClientError, IOError):
+                if retry == max_tries:
+                    _LOGGER.debug(
+                        "Error saving event %s, retry=%d", json_body, retry)
+                else:
+                    time.sleep(20)
 
-    @RetryOnError(hass, retry_limit=max_tries, retry_delay=20,
-                  queue_limit=queue_limit)
-    def _write_data(json_body):
-        """Write the data."""
-        try:
-            influx.write_points(json_body)
-        except exceptions.InfluxDBClientError:
-            _LOGGER.exception("Error saving event %s to InfluxDB", json_body)
+    instance = hass.data[DOMAIN] = InfluxThread(
+        hass, influx_handle_event, queue_limit)
+    instance.start()
 
-    hass.bus.listen(EVENT_STATE_CHANGED, influx_event_listener)
+    def shutdown(event):
+        """Shut down the thread."""
+        instance.queue.put(None)
+        instance.join()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, shutdown)
 
     return True
 
 
-class RetryOnError(object):
-    """A class for retrying a failed task a certain amount of tries.
+class InfluxThread(threading.Thread):
+    """A threaded event handler class."""
 
-    This method decorator makes a method retrying on errors. If there was an
-    uncaught exception, it schedules another try to execute the task after a
-    retry delay. It does this up to the maximum number of retries.
+    def __init__(self, hass, event_handler, max_size):
+        """Initialize the listener."""
+        threading.Thread.__init__(self, name='InfluxDB')
+        self.queue = queue.Queue(maxsize=max_size)
+        self.event_handler = event_handler
+        hass.bus.listen(EVENT_STATE_CHANGED, self._event_listener)
 
-    It can be used for all probable "self-healing" problems like network
-    outages. The task will be rescheduled using HAs scheduling mechanism.
+    def _event_listener(self, event):
+        """Listen for new messages on the bus and queue them for Influx."""
+        try:
+            self.queue.put_nowait(event)
+        except queue.Full:
+            _LOGGER.warning("Queue full, dropping event")
 
-    It takes a Hass instance, a maximum number of retries and a retry delay
-    in seconds as arguments.
+    def run(self):
+        """Process incoming events."""
+        event = True
+        while event:
+            event = self.queue.get()
 
-    The queue limit defines the maximum number of calls that are allowed to
-    be queued at a time. If this number is reached, every new call discards
-    an old one.
-    """
+            if event:
+                self.event_handler(event)
 
-    def __init__(self, hass, retry_limit=0, retry_delay=20, queue_limit=100):
-        """Initialize the decorator."""
-        self.hass = hass
-        self.retry_limit = retry_limit
-        self.retry_delay = timedelta(seconds=retry_delay)
-        self.queue_limit = queue_limit
+            self.queue.task_done()
 
-    def __call__(self, method):
-        """Decorate the target method."""
-        from homeassistant.helpers.event import track_point_in_utc_time
-
-        @wraps(method)
-        def wrapper(*args, **kwargs):
-            """Wrap method."""
-            # pylint: disable=protected-access
-            if not hasattr(wrapper, "_retry_queue"):
-                wrapper._retry_queue = []
-
-            def scheduled(retry=0, untrack=None, event=None):
-                """Call the target method.
-
-                It is called directly at the first time and then called
-                scheduled within the Hass mainloop.
-                """
-                if untrack is not None:
-                    wrapper._retry_queue.remove(untrack)
-
-                # pylint: disable=broad-except
-                try:
-                    method(*args, **kwargs)
-                except Exception as ex:
-                    if retry == self.retry_limit:
-                        raise
-                    if len(wrapper._retry_queue) >= self.queue_limit:
-                        last = wrapper._retry_queue.pop(0)
-                        if 'remove' in last:
-                            func = last['remove']
-                            func()
-                        if 'exc' in last:
-                            _LOGGER.error(
-                                "Retry queue overflow, drop oldest entry: %s",
-                                str(last['exc']))
-
-                    target = utcnow() + self.retry_delay
-                    tracking = {'target': target}
-                    remove = track_point_in_utc_time(
-                        self.hass, partial(scheduled, retry + 1, tracking),
-                        target)
-                    tracking['remove'] = remove
-                    tracking["exc"] = ex
-                    wrapper._retry_queue.append(tracking)
-
-            scheduled()
-        return wrapper
+    def block_till_done(self):
+        """Block till all events processed."""
+        self.queue.join()

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -35,6 +35,7 @@ CONF_COMPONENT_CONFIG = 'component_config'
 CONF_COMPONENT_CONFIG_GLOB = 'component_config_glob'
 CONF_COMPONENT_CONFIG_DOMAIN = 'component_config_domain'
 CONF_RETRY_COUNT = 'max_retries'
+CONF_RETRY_QUEUE = 'retry_queue_limit'
 
 DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_VERIFY_SSL = True
@@ -49,7 +50,7 @@ COMPONENT_CONFIG_SCHEMA_ENTRY = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
+    DOMAIN: vol.All(cv.deprecated(CONF_RETRY_QUEUE), vol.Schema({
         vol.Optional(CONF_HOST): cv.string,
         vol.Inclusive(CONF_USERNAME, 'authentication'): cv.string,
         vol.Inclusive(CONF_PASSWORD, 'authentication'): cv.string,
@@ -67,6 +68,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_PORT): cv.port,
         vol.Optional(CONF_SSL): cv.boolean,
         vol.Optional(CONF_RETRY_COUNT, default=0): cv.positive_int,
+        vol.Optional(CONF_RETRY_QUEUE, default=20): cv.positive_int,
         vol.Optional(CONF_DEFAULT_MEASUREMENT): cv.string,
         vol.Optional(CONF_OVERRIDE_MEASUREMENT): cv.string,
         vol.Optional(CONF_TAGS, default={}):
@@ -80,7 +82,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Schema({cv.string: COMPONENT_CONFIG_SCHEMA_ENTRY}),
         vol.Optional(CONF_COMPONENT_CONFIG_DOMAIN, default={}):
             vol.Schema({cv.string: COMPONENT_CONFIG_SCHEMA_ENTRY}),
-    }),
+    })),
 }, extra=vol.ALLOW_EXTRA)
 
 RE_DIGIT_TAIL = re.compile(r'^[^\.]*\d+\.?\d+[^\.]*$')

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -260,8 +260,11 @@ class InfluxThread(threading.Thread):
 
     def run(self):
         """Process incoming events."""
+        queue_seconds = QUEUE_BACKLOG_SECONDS + self.max_tries*RETRY_DELAY
+
         write_error = False
         dropped = False
+
         while True:
             item = self.queue.get()
 
@@ -272,7 +275,6 @@ class InfluxThread(threading.Thread):
             timestamp, event = item
             age = time.monotonic() - timestamp
 
-            queue_seconds = QUEUE_BACKLOG_SECONDS + self.max_tries*RETRY_DELAY
             if age < queue_seconds:
                 for retry in range(self.max_tries+1):
                     if self.event_handler(event):

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -224,8 +224,8 @@ def setup(hass, config):
 
         json_body[0]['tags'].update(tags)
 
+        nonlocal write_error
         for retry in range(max_tries+1):
-            nonlocal write_error
             try:
                 influx.write_points(json_body)
                 if write_error:

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -2,14 +2,10 @@
 import unittest
 import datetime
 from unittest import mock
-
-from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import influxdb as influx_client
 
-from homeassistant.util import dt as dt_util
-from homeassistant import core as ha
 from homeassistant.setup import setup_component
 import homeassistant.components.influxdb as influxdb
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON, \
@@ -169,6 +165,8 @@ class TestInfluxDB(unittest.TestCase):
                 body[0]['fields']['value'] = out[1]
 
             self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
+
             self.assertEqual(
                 mock_client.return_value.write_points.call_count, 1
             )
@@ -203,6 +201,7 @@ class TestInfluxDB(unittest.TestCase):
                 },
             }]
             self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
             self.assertEqual(
                 mock_client.return_value.write_points.call_count, 1
             )
@@ -245,6 +244,7 @@ class TestInfluxDB(unittest.TestCase):
                 },
             }]
             self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
             if state_state == 1:
                 self.assertEqual(
                     mock_client.return_value.write_points.call_count, 1
@@ -278,6 +278,7 @@ class TestInfluxDB(unittest.TestCase):
                 },
             }]
             self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
             if entity_id == 'ok':
                 self.assertEqual(
                     mock_client.return_value.write_points.call_count, 1
@@ -312,6 +313,7 @@ class TestInfluxDB(unittest.TestCase):
                 },
             }]
             self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
             if domain == 'ok':
                 self.assertEqual(
                     mock_client.return_value.write_points.call_count, 1
@@ -356,6 +358,7 @@ class TestInfluxDB(unittest.TestCase):
                 },
             }]
             self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
             if entity_id == 'included':
                 self.assertEqual(
                     mock_client.return_value.write_points.call_count, 1
@@ -401,6 +404,7 @@ class TestInfluxDB(unittest.TestCase):
                 },
             }]
             self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
             if domain == 'fake':
                 self.assertEqual(
                     mock_client.return_value.write_points.call_count, 1
@@ -456,6 +460,7 @@ class TestInfluxDB(unittest.TestCase):
                 body[0]['fields']['value'] = out[1]
 
             self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
             self.assertEqual(
                 mock_client.return_value.write_points.call_count, 1
             )
@@ -498,6 +503,7 @@ class TestInfluxDB(unittest.TestCase):
                 },
             }]
             self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
             if entity_id == 'ok':
                 self.assertEqual(
                     mock_client.return_value.write_points.call_count, 1
@@ -543,6 +549,7 @@ class TestInfluxDB(unittest.TestCase):
             },
         }]
         self.handler_method(event)
+        self.hass.data[influxdb.DOMAIN].block_till_done()
         self.assertEqual(
             mock_client.return_value.write_points.call_count, 1
         )
@@ -588,6 +595,7 @@ class TestInfluxDB(unittest.TestCase):
             },
         }]
         self.handler_method(event)
+        self.hass.data[influxdb.DOMAIN].block_till_done()
         self.assertEqual(
             mock_client.return_value.write_points.call_count, 1
         )
@@ -648,6 +656,7 @@ class TestInfluxDB(unittest.TestCase):
                 },
             }]
             self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
             self.assertEqual(
                 mock_client.return_value.write_points.call_count, 1
             )
@@ -659,7 +668,16 @@ class TestInfluxDB(unittest.TestCase):
 
     def test_scheduled_write(self, mock_client):
         """Test the event listener to retry after write failures."""
-        self._setup(max_retries=1)
+        config = {
+            'influxdb': {
+                'host': 'host',
+                'username': 'user',
+                'password': 'pass',
+                'max_retries': 1
+            }
+        }
+        assert setup_component(self.hass, influxdb.DOMAIN, config)
+        self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
 
         state = mock.MagicMock(
             state=1, domain='fake', entity_id='entity.id', object_id='entity',
@@ -668,152 +686,10 @@ class TestInfluxDB(unittest.TestCase):
         mock_client.return_value.write_points.side_effect = \
             IOError('foo')
 
-        start = dt_util.utcnow()
-
-        self.handler_method(event)
+        with patch.object(influxdb.time, 'sleep') as mock_sleep:
+            self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
+            assert mock_sleep.called
         json_data = mock_client.return_value.write_points.call_args[0][0]
-        self.assertEqual(mock_client.return_value.write_points.call_count, 1)
-
-        shifted_time = start + (timedelta(seconds=20 + 1))
-        self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
-                           {ha.ATTR_NOW: shifted_time})
-        self.hass.block_till_done()
         self.assertEqual(mock_client.return_value.write_points.call_count, 2)
         mock_client.return_value.write_points.assert_called_with(json_data)
-
-        shifted_time = shifted_time + (timedelta(seconds=20 + 1))
-        self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
-                           {ha.ATTR_NOW: shifted_time})
-        self.hass.block_till_done()
-        self.assertEqual(mock_client.return_value.write_points.call_count, 2)
-
-
-class TestRetryOnErrorDecorator(unittest.TestCase):
-    """Test the RetryOnError decorator."""
-
-    def setUp(self):
-        """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-
-    def tearDown(self):
-        """Clear data."""
-        self.hass.stop()
-
-    def test_no_retry(self):
-        """Test that it does not retry if configured."""
-        mock_method = MagicMock()
-        wrapped = influxdb.RetryOnError(self.hass)(mock_method)
-        wrapped(1, 2, test=3)
-        self.assertEqual(mock_method.call_count, 1)
-        mock_method.assert_called_with(1, 2, test=3)
-
-        mock_method.side_effect = Exception()
-        self.assertRaises(Exception, wrapped, 1, 2, test=3)
-        self.assertEqual(mock_method.call_count, 2)
-        mock_method.assert_called_with(1, 2, test=3)
-
-    def test_single_retry(self):
-        """Test that retry stops after a single try if configured."""
-        mock_method = MagicMock()
-        retryer = influxdb.RetryOnError(self.hass, retry_limit=1)
-        wrapped = retryer(mock_method)
-        wrapped(1, 2, test=3)
-        self.assertEqual(mock_method.call_count, 1)
-        mock_method.assert_called_with(1, 2, test=3)
-
-        start = dt_util.utcnow()
-        shifted_time = start + (timedelta(seconds=20 + 1))
-        self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
-                           {ha.ATTR_NOW: shifted_time})
-        self.hass.block_till_done()
-        self.assertEqual(mock_method.call_count, 1)
-
-        mock_method.side_effect = Exception()
-        wrapped(1, 2, test=3)
-        self.assertEqual(mock_method.call_count, 2)
-        mock_method.assert_called_with(1, 2, test=3)
-
-        for _ in range(3):
-            start = dt_util.utcnow()
-            shifted_time = start + (timedelta(seconds=20 + 1))
-            self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
-                               {ha.ATTR_NOW: shifted_time})
-            self.hass.block_till_done()
-            self.assertEqual(mock_method.call_count, 3)
-            mock_method.assert_called_with(1, 2, test=3)
-
-    def test_multi_retry(self):
-        """Test that multiple retries work."""
-        mock_method = MagicMock()
-        retryer = influxdb.RetryOnError(self.hass, retry_limit=4)
-        wrapped = retryer(mock_method)
-        mock_method.side_effect = Exception()
-
-        wrapped(1, 2, test=3)
-        self.assertEqual(mock_method.call_count, 1)
-        mock_method.assert_called_with(1, 2, test=3)
-
-        for cnt in range(3):
-            start = dt_util.utcnow()
-            shifted_time = start + (timedelta(seconds=20 + 1))
-            self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
-                               {ha.ATTR_NOW: shifted_time})
-            self.hass.block_till_done()
-            self.assertEqual(mock_method.call_count, cnt + 2)
-            mock_method.assert_called_with(1, 2, test=3)
-
-    def test_max_queue(self):
-        """Test the maximum queue length."""
-        # make a wrapped method
-        mock_method = MagicMock()
-        retryer = influxdb.RetryOnError(
-            self.hass, retry_limit=4, queue_limit=3)
-        wrapped = retryer(mock_method)
-        mock_method.side_effect = Exception()
-
-        # call it once, call fails, queue fills to 1
-        wrapped(1, 2, test=3)
-        self.assertEqual(mock_method.call_count, 1)
-        mock_method.assert_called_with(1, 2, test=3)
-        self.assertEqual(len(wrapped._retry_queue), 1)
-
-        # two more calls that failed. queue is 3
-        wrapped(1, 2, test=3)
-        wrapped(1, 2, test=3)
-        self.assertEqual(mock_method.call_count, 3)
-        self.assertEqual(len(wrapped._retry_queue), 3)
-
-        # another call, queue gets limited to 3
-        wrapped(1, 2, test=3)
-        self.assertEqual(mock_method.call_count, 4)
-        self.assertEqual(len(wrapped._retry_queue), 3)
-
-        # time passes
-        start = dt_util.utcnow()
-        shifted_time = start + (timedelta(seconds=20 + 1))
-        self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
-                           {ha.ATTR_NOW: shifted_time})
-        self.hass.block_till_done()
-
-        # only the three queued calls where repeated
-        self.assertEqual(mock_method.call_count, 7)
-        self.assertEqual(len(wrapped._retry_queue), 3)
-
-        # another call, queue stays limited
-        wrapped(1, 2, test=3)
-        self.assertEqual(mock_method.call_count, 8)
-        self.assertEqual(len(wrapped._retry_queue), 3)
-
-        # disable the side effect
-        mock_method.side_effect = None
-
-        # time passes, all calls should succeed
-        start = dt_util.utcnow()
-        shifted_time = start + (timedelta(seconds=20 + 1))
-        self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
-                           {ha.ATTR_NOW: shifted_time})
-        self.hass.block_till_done()
-
-        # three queued calls succeeded, queue empty.
-        self.assertEqual(mock_method.call_count, 11)
-        self.assertEqual(len(wrapped._retry_queue), 0)


### PR DESCRIPTION
## Breaking change note:

The influxdb `retry_queue_limit` configuration variable no longer has any effect and can be removed.

## Description:

The influxdb event listener currently processes events immediately. When many events happen at the same time, we can run out of resources:
```
2018-02-03 14:22:06 WARNING (Thread-13) [urllib3.connectionpool] Connection pool is full, discarding connection: 192.168.3.45
```
This PR makes all events go through a queue that is consumed by a dedicated thread. Events are thus handled one by one, hopefully getting rid of the above warning and its ill effects.

(Any similarity to the recorder is not completely coincidental).

**Related issue (if applicable):** fixes #9734, fixes #10461

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4598

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [X] Tests have been added to verify that the new code works.
