### PR TITLE
Add support for Alexa.StepSpeaker

### DIFF
--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -429,6 +429,7 @@ def test_media_player(hass):
         'Alexa.InputController',
         'Alexa.PowerController',
         'Alexa.Speaker',
+        'Alexa.StepSpeaker',
         'Alexa.PlaybackController',
     )
 
@@ -491,6 +492,34 @@ def test_media_player(hass):
         'volume',
         'media_player.volume_set',
         'volume_level')
+
+    call, _ = yield from assert_request_calls_service(
+        'Alexa.StepSpeaker', 'SetMute', 'media_player#test',
+        'media_player.volume_mute',
+        hass,
+        payload={'mute': True})
+    assert call.data['is_volume_muted']
+
+    call, _, = yield from assert_request_calls_service(
+        'Alexa.StepSpeaker', 'SetMute', 'media_player#test',
+        'media_player.volume_mute',
+        hass,
+        payload={'mute': False})
+    assert not call.data['is_volume_muted']
+
+    call, _ = yield from assert_request_calls_service(
+        'Alexa.StepSpeaker', 'AdjustVolume', 'media_player#test',
+        'media_player.volume_set',
+        hass,
+        payload={'volume': 20})
+    assert call.data['volume_level'] == 0.95
+
+    call, _ = yield from assert_request_calls_service(
+        'Alexa.StepSpeaker', 'AdjustVolume', 'media_player#test',
+        'media_player.volume_set',
+        hass,
+        payload={'volume': -20})
+    assert call.data['volume_level'] == 0.55
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

Adds support for Alexa.StepSpeaker as per https://developer.amazon.com/docs/device-apis/alexa-stepspeaker.html

Maps entities that support `SUPPORT_VOLUME_MUTE` and `SUPPORT_VOLUME_STEP` to the Alexa Capability `Alexa.StepSpeaker`

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54