### PR TITLE
Services (small_pr)(fix): Added missing return on data template error

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -74,6 +74,7 @@ def async_call_from_config(hass, config, blocking=False, variables=None,
                 config[CONF_SERVICE_DATA_TEMPLATE], variables))
         except TemplateError as ex:
             _LOGGER.error('Error rendering data template: %s', ex)
+            return
 
     if CONF_SERVICE_ENTITY_ID in config:
         service_data[ATTR_ENTITY_ID] = config[CONF_SERVICE_ENTITY_ID]

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -28,7 +28,7 @@ class TestServiceHelpers(unittest.TestCase):
         self.hass.stop()
 
     def test_template_service_call(self):
-        """Test service call with templating."""
+        """Test service call with tempating."""
         config = {
             'service_template': '{{ \'test_domain.test_service\' }}',
             'entity_id': 'hello.world',
@@ -68,6 +68,24 @@ class TestServiceHelpers(unittest.TestCase):
 
         self.assertEqual('goodbye', self.calls[0].data['hello'])
 
+    def test_bad_template(self):
+        """Test passing bad template."""
+        config = {
+            'service_template': '{{ var_service }}',
+            'entity_id': 'hello.world',
+            'data_template': {
+                'hello': '{{ states + unknown_var }}'
+            }
+        }
+
+        service.call_from_config(self.hass, config, variables={
+            'var_service': 'test_domain.test_service',
+            'var_data': 'goodbye',
+        })
+        self.hass.block_till_done()
+
+        self.assertEqual(len(self.calls), 0)
+
     def test_split_entity_string(self):
         """Test splitting of entity string."""
         service.call_from_config(self.hass, {
@@ -102,7 +120,7 @@ class TestServiceHelpers(unittest.TestCase):
 
     @patch('homeassistant.helpers.service._LOGGER.error')
     def test_fail_silently_if_no_service(self, mock_log):
-        """Test failing if service is missing."""
+        """Test failling if service is missing."""
         service.call_from_config(self.hass, None)
         self.assertEqual(1, mock_log.call_count)
 

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -28,7 +28,7 @@ class TestServiceHelpers(unittest.TestCase):
         self.hass.stop()
 
     def test_template_service_call(self):
-        """Test service call with tempating."""
+        """Test service call with templating."""
         config = {
             'service_template': '{{ \'test_domain.test_service\' }}',
             'entity_id': 'hello.world',
@@ -120,7 +120,7 @@ class TestServiceHelpers(unittest.TestCase):
 
     @patch('homeassistant.helpers.service._LOGGER.error')
     def test_fail_silently_if_no_service(self, mock_log):
-        """Test failling if service is missing."""
+        """Test failing if service is missing."""
         service.call_from_config(self.hass, None)
         self.assertEqual(1, mock_log.call_count)
 


### PR DESCRIPTION
## Description:
Added missing return on data template error

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
