### PR TITLE
zha: Update to bellows 0.5.0+zigpy

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -32,7 +32,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    from bellows.zigbee.zcl.clusters.security import IasZone
+    from zigpy.zcl.clusters.security import IasZone
 
     in_clusters = discovery_info['in_clusters']
 
@@ -63,7 +63,7 @@ class BinarySensor(zha.Entity, BinarySensorDevice):
         """Initialize the ZHA binary sensor."""
         super().__init__(**kwargs)
         self._device_class = device_class
-        from bellows.zigbee.zcl.clusters.security import IasZone
+        from zigpy.zcl.clusters.security import IasZone
         self._ias_zone_cluster = self._in_clusters[IasZone.cluster_id]
 
     @property

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -61,7 +61,7 @@ class Light(zha.Entity, light.Light):
         self._xy_color = None
         self._brightness = None
 
-        import bellows.zigbee.zcl.clusters as zcl_clusters
+        import zigpy.zcl.clusters as zcl_clusters
         if zcl_clusters.general.LevelControl.cluster_id in self._in_clusters:
             self._supported_features |= light.SUPPORT_BRIGHTNESS
             self._supported_features |= light.SUPPORT_TRANSITION

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -31,7 +31,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 @asyncio.coroutine
 def make_sensor(discovery_info):
     """Create ZHA sensors factory."""
-    from bellows.zigbee.zcl.clusters.measurement import TemperatureMeasurement
+    from zigpy.zcl.clusters.measurement import TemperatureMeasurement
     in_clusters = discovery_info['in_clusters']
     if TemperatureMeasurement.cluster_id in in_clusters:
         sensor = TemperatureSensor(**discovery_info)

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -14,7 +14,10 @@ from homeassistant import const as ha_const
 from homeassistant.helpers import discovery, entity
 from homeassistant.util import slugify
 
-REQUIREMENTS = ['bellows==0.4.0']
+REQUIREMENTS = [
+    'bellows==0.5.0',
+    'zigpy==0.0.1',
+]
 
 DOMAIN = 'zha'
 
@@ -130,7 +133,7 @@ class ApplicationListener:
     @asyncio.coroutine
     def async_device_initialized(self, device, join):
         """Handle device joined and basic information discovered (async)."""
-        import bellows.zigbee.profiles
+        import zigpy.profiles
         import homeassistant.components.zha.const as zha_const
         zha_const.populate_data()
 
@@ -146,8 +149,8 @@ class ApplicationListener:
             node_config = self._config[DOMAIN][CONF_DEVICE_CONFIG].get(
                 device_key, {})
 
-            if endpoint.profile_id in bellows.zigbee.profiles.PROFILES:
-                profile = bellows.zigbee.profiles.PROFILES[endpoint.profile_id]
+            if endpoint.profile_id in zigpy.profiles.PROFILES:
+                profile = zigpy.profiles.PROFILES[endpoint.profile_id]
                 if zha_const.DEVICE_CLASS.get(endpoint.profile_id,
                                               {}).get(endpoint.device_type,
                                                       None):

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -11,8 +11,8 @@ def populate_data():
     These cannot be module level, as importing bellows must be done in a
     in a function.
     """
-    from bellows.zigbee import zcl
-    from bellows.zigbee.profiles import PROFILES, zha, zll
+    from zigpy import zcl
+    from zigpy.profiles import PROFILES, zha, zll
 
     DEVICE_CLASS[zha.PROFILE_ID] = {
         zha.DeviceType.ON_OFF_SWITCH: 'switch',

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -126,7 +126,7 @@ batinfo==0.4.2
 beautifulsoup4==4.6.0
 
 # homeassistant.components.zha
-bellows==0.4.0
+bellows==0.5.0
 
 # homeassistant.components.blink
 blinkpy==0.6.0
@@ -1272,3 +1272,6 @@ zeroconf==0.19.1
 
 # homeassistant.components.media_player.ziggo_mediabox_xl
 ziggo-mediabox-xl==1.0.0
+
+# homeassistant.components.zha
+zigpy==0.0.1


### PR DESCRIPTION
## Description:
`bellows` has been split into `bellows` (the EmberZNet code), and `zigpy` (the Zigbee code).


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
