### PR TITLE
Fix logger bug on Windows: path contains '\'.

### DIFF
--- a/homeassistant/components/system_log/__init__.py
+++ b/homeassistant/components/system_log/__init__.py
@@ -74,9 +74,9 @@ def _figure_out_source(record, call_stack, hass):
         else:
             stack = call_stack[0:index+1]
 
-    paths_re = r'(?:{})/(.*)'.format('|'.join([re.escape(x) for x in paths]))
     # Iterate through the stack call (in reverse) and find the last call from
     # a file in Home Assistant. Try to figure out where error happened.
+    paths_re = r'(?:{})/(.*)'.format('|'.join([re.escape(x) for x in paths]))
     for pathname in reversed(stack):
 
         # Try to match with a file within Home Assistant

--- a/homeassistant/components/system_log/__init__.py
+++ b/homeassistant/components/system_log/__init__.py
@@ -74,13 +74,13 @@ def _figure_out_source(record, call_stack, hass):
         else:
             stack = call_stack[0:index+1]
 
+    paths_re = r'(?:{})/(.*)'.format('|'.join([re.escape(x) for x in paths]))
     # Iterate through the stack call (in reverse) and find the last call from
     # a file in Home Assistant. Try to figure out where error happened.
     for pathname in reversed(stack):
 
         # Try to match with a file within Home Assistant
-        paths_new = [re.escape(x) for x in paths]
-        match = re.match(r'(?:{})/(.*)'.format('|'.join(paths_new)), pathname)
+        match = re.match(paths_re, pathname)
         if match:
             return match.group(1)
     # Ok, we don't know what this is

--- a/homeassistant/components/system_log/__init__.py
+++ b/homeassistant/components/system_log/__init__.py
@@ -79,7 +79,8 @@ def _figure_out_source(record, call_stack, hass):
     for pathname in reversed(stack):
 
         # Try to match with a file within Home Assistant
-        match = re.match(r'(?:{})/(.*)'.format('|'.join(paths)), pathname)
+        paths_new = [re.escape(x) for x in paths]
+        match = re.match(r'(?:{})/(.*)'.format('|'.join(paths_new)), pathname)
         if match:
             return match.group(1)
     # Ok, we don't know what this is


### PR DESCRIPTION
## Description:
`system_log` not successfully initialized.

Windows using `\` to separate folders, combining it directly without escape will create illegal Regex.
`re.escape` must be called before combine it to regex string.

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.
