### PR TITLE
device_tracker.asuswrt: Ignore unreachable ip neigh entries

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -63,6 +63,7 @@ _IP_NEIGH_REGEX = re.compile(
     r'\w+\s'
     r'(\w+\s(?P<mac>(([0-9a-f]{2}[:-]){5}([0-9a-f]{2}))))?\s'
     r'\s?(router)?'
+    r'\s?(nud)?'
     r'(?P<status>(\w+))')
 
 _ARP_CMD = 'arp -n'
@@ -212,6 +213,9 @@ class AsusWrtDeviceScanner(DeviceScanner):
         result = _parse_lines(lines, _IP_NEIGH_REGEX)
         devices = {}
         for device in result:
+            status = device['status']
+            if status is None or status.upper() != 'REACHABLE':
+                continue
             if device['mac'] is not None:
                 mac = device['mac'].upper()
                 old_device = cur_devices.get(mac)
@@ -226,7 +230,7 @@ class AsusWrtDeviceScanner(DeviceScanner):
         result = _parse_lines(lines, _ARP_REGEX)
         devices = {}
         for device in result:
-            if device['mac']:
+            if device['mac'] is not None:
                 mac = device['mac'].upper()
                 devices[mac] = Device(mac, device['ip'], None)
         return devices

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -52,8 +52,8 @@ WL_DEVICES = {
 
 ARP_DATA = [
     '? (123.123.123.125) at 01:02:03:04:06:08 [ether]  on eth0\r',
-    '? (123.123.123.126) at 08:09:10:11:12:14 [ether]  on br0\r'
-    '? (123.123.123.127) at <incomplete>  on br0\r'
+    '? (123.123.123.126) at 08:09:10:11:12:14 [ether]  on br0\r',
+    '? (123.123.123.127) at <incomplete>  on br0\r',
 ]
 
 ARP_DEVICES = {
@@ -65,8 +65,10 @@ ARP_DEVICES = {
 
 NEIGH_DATA = [
     '123.123.123.125 dev eth0 lladdr 01:02:03:04:06:08 REACHABLE\r',
-    '123.123.123.126 dev br0 lladdr 08:09:10:11:12:14 STALE\r'
-    '123.123.123.127 dev br0  FAILED\r'
+    '123.123.123.126 dev br0 lladdr 08:09:10:11:12:14 REACHABLE\r',
+    '123.123.123.127 dev br0  FAILED\r',
+    '123.123.123.128 dev br0 lladdr 08:09:15:15:15:15 DELAY\r',
+    'fe80::feff:a6ff:feff:12ff dev br0 lladdr fc:ff:a6:ff:12:ff STALE\r',
 ]
 
 NEIGH_DEVICES = {


### PR DESCRIPTION
## Description:
device_tracker.asuswrt should consider entries in `ip neigh` output with STALE or FAILED status to be unreachable, so it can detect when devices with link-local IPv6 addresses are removed.

**Related issue (if applicable):** fixes #12198 

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**