### PR TITLE
Xiaomi MiIO Light: Brightness mapping improved

### DIFF
--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/light.xiaomi_miio/
 import asyncio
 from functools import partial
 import logging
+from math import ceil
 
 import voluptuous as vol
 
@@ -204,11 +205,11 @@ class XiaomiPhilipsGenericLight(Light):
         """Turn the light on."""
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
-            percent_brightness = int(100 * brightness / 255)
+            percent_brightness = int(ceil(100 * brightness / 255.0))
 
             _LOGGER.debug(
                 "Setting brightness: %s %s%%",
-                self.brightness, percent_brightness)
+                brightness, percent_brightness)
 
             result = yield from self._try_command(
                 "Setting brightness failed: %s",
@@ -235,7 +236,7 @@ class XiaomiPhilipsGenericLight(Light):
             _LOGGER.debug("Got new state: %s", state)
 
             self._state = state.is_on
-            self._brightness = int(255 * 0.01 * state.brightness)
+            self._brightness = int(ceil((255/100.0) * state.brightness))
 
         except DeviceException as ex:
             _LOGGER.error("Got exception while fetching the state: %s", ex)
@@ -306,11 +307,11 @@ class XiaomiPhilipsLightBall(XiaomiPhilipsGenericLight, Light):
 
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
-            percent_brightness = int(100 * brightness / 255)
+            percent_brightness = int(ceil(100 * brightness / 255.0))
 
             _LOGGER.debug(
                 "Setting brightness: %s %s%%",
-                self.brightness, percent_brightness)
+                brightness, percent_brightness)
 
             result = yield from self._try_command(
                 "Setting brightness failed: %s",
@@ -331,7 +332,7 @@ class XiaomiPhilipsLightBall(XiaomiPhilipsGenericLight, Light):
             _LOGGER.debug("Got new state: %s", state)
 
             self._state = state.is_on
-            self._brightness = int(255 * 0.01 * state.brightness)
+            self._brightness = int(ceil((255/100.0) * state.brightness))
             self._color_temp = self.translate(
                 state.color_temperature,
                 CCT_MIN, CCT_MAX,

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -205,7 +205,7 @@ class XiaomiPhilipsGenericLight(Light):
         """Turn the light on."""
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
-            percent_brightness = int(ceil(100 * brightness / 255.0))
+            percent_brightness = ceil(100 * brightness / 255.0)
 
             _LOGGER.debug(
                 "Setting brightness: %s %s%%",
@@ -236,7 +236,7 @@ class XiaomiPhilipsGenericLight(Light):
             _LOGGER.debug("Got new state: %s", state)
 
             self._state = state.is_on
-            self._brightness = int(ceil((255/100.0) * state.brightness))
+            self._brightness = ceil((255/100.0) * state.brightness)
 
         except DeviceException as ex:
             _LOGGER.error("Got exception while fetching the state: %s", ex)
@@ -307,7 +307,7 @@ class XiaomiPhilipsLightBall(XiaomiPhilipsGenericLight, Light):
 
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
-            percent_brightness = int(ceil(100 * brightness / 255.0))
+            percent_brightness = ceil(100 * brightness / 255.0)
 
             _LOGGER.debug(
                 "Setting brightness: %s %s%%",
@@ -332,7 +332,7 @@ class XiaomiPhilipsLightBall(XiaomiPhilipsGenericLight, Light):
             _LOGGER.debug("Got new state: %s", state)
 
             self._state = state.is_on
-            self._brightness = int(ceil((255/100.0) * state.brightness))
+            self._brightness = ceil((255/100.0) * state.brightness)
             self._color_temp = self.translate(
                 state.color_temperature,
                 CCT_MIN, CCT_MAX,


### PR DESCRIPTION
Xiaomi Philips Lights accepts a brightness between 1 and 100 percent. HA has a brightness range of [1,255]. In the past the HA brightness 1, 2 and 3 was mapped to 0 percent. The mapping is shifted a bit now to improve the user experience.