### PR TITLE
zha: Add support for XBee radios

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -78,7 +78,7 @@ class BinarySensor(zha.Entity, BinarySensorDevice):
         """Return the class of this device, from component DEVICE_CLASSES."""
         return self._device_class
 
-    def cluster_command(self, aps_frame, tsn, command_id, args):
+    def cluster_command(self, tsn, command_id, args):
         """Handle commands received to this cluster."""
         if command_id == 0:
             self._state = args[0] & 3

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -26,6 +26,7 @@ DOMAIN = 'zha'
 
 class RadioType(enum.Enum):
     """Possible options for radio type in config."""
+
     ezsp = 'ezsp'
     xbee = 'xbee'
 

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/zha/
 """
 import asyncio
+import enum
 import logging
 
 import voluptuous as vol
@@ -17,13 +18,22 @@ from homeassistant.util import slugify
 REQUIREMENTS = [
     'bellows==0.5.0',
     'zigpy==0.0.1',
+    'zigpy-xbee==0.0.1',
 ]
 
 DOMAIN = 'zha'
 
+
+class RadioType(enum.Enum):
+    """Possible options for radio type in config."""
+    ezsp = 'ezsp'
+    xbee = 'xbee'
+
+
 CONF_BAUDRATE = 'baudrate'
 CONF_DATABASE = 'database_path'
 CONF_DEVICE_CONFIG = 'device_config'
+CONF_RADIO_TYPE = 'radio_type'
 CONF_USB_PATH = 'usb_path'
 DATA_DEVICE_CONFIG = 'zha_device_config'
 
@@ -33,6 +43,8 @@ DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
+        vol.Optional(CONF_RADIO_TYPE, default=RadioType.ezsp):
+            cv.enum(RadioType),
         CONF_USB_PATH: cv.string,
         vol.Optional(CONF_BAUDRATE, default=57600): cv.positive_int,
         CONF_DATABASE: cv.string,
@@ -70,16 +82,22 @@ def async_setup(hass, config):
     """
     global APPLICATION_CONTROLLER
 
-    import bellows.ezsp
-    from bellows.zigbee.application import ControllerApplication
-
-    ezsp_ = bellows.ezsp.EZSP()
     usb_path = config[DOMAIN].get(CONF_USB_PATH)
     baudrate = config[DOMAIN].get(CONF_BAUDRATE)
-    yield from ezsp_.connect(usb_path, baudrate)
+    radio_type = config[DOMAIN].get(CONF_RADIO_TYPE)
+    if radio_type == RadioType.ezsp:
+        import bellows.ezsp
+        from bellows.zigbee.application import ControllerApplication
+        radio = bellows.ezsp.EZSP()
+    elif radio_type == RadioType.xbee:
+        import zigpy_xbee.api
+        from zigpy_xbee.zigbee.application import ControllerApplication
+        radio = zigpy_xbee.api.XBee()
+
+    yield from radio.connect(usb_path, baudrate)
 
     database = config[DOMAIN].get(CONF_DATABASE)
-    APPLICATION_CONTROLLER = ControllerApplication(ezsp_, database)
+    APPLICATION_CONTROLLER = ControllerApplication(radio, database)
     listener = ApplicationListener(hass, config)
     APPLICATION_CONTROLLER.add_listener(listener)
     yield from APPLICATION_CONTROLLER.startup(auto_form=True)
@@ -256,7 +274,7 @@ class Entity(entity.Entity):
         """Handle an attribute updated on this cluster."""
         pass
 
-    def zdo_command(self, aps_frame, tsn, command_id, args):
+    def zdo_command(self, tsn, command_id, args):
         """Handle a ZDO command received on this cluster."""
         pass
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1273,4 +1273,7 @@ zeroconf==0.19.1
 ziggo-mediabox-xl==1.0.0
 
 # homeassistant.components.zha
+zigpy-xbee==0.0.1
+
+# homeassistant.components.zha
 zigpy==0.0.1


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4586

## Example entry for `configuration.yaml` (if applicable):
```yaml
zha:
  radio_type: xbee
  usb_path: /dev/tty.usbserial-A50656IO
  baudrate: 115200
  database_path: /Users/rcloran/.config/bellows/app.db
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
