### PR TITLE
Adds filesize component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -550,6 +550,7 @@ omit =
     homeassistant/components/sensor/etherscan.py
     homeassistant/components/sensor/fastdotcom.py
     homeassistant/components/sensor/fedex.py
+    homeassistant/components/sensor/filesize.py
     homeassistant/components/sensor/fitbit.py
     homeassistant/components/sensor/fixer.py
     homeassistant/components/sensor/fritzbox_callmonitor.py

--- a/homeassistant/components/sensor/filesize.py
+++ b/homeassistant/components/sensor/filesize.py
@@ -30,12 +30,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the file size sensor."""
     sensors = []
     for path in config.get(CONF_FILE_PATHS):
-            if not hass.config.is_allowed_path(path):
-                _LOGGER.error(
-                    "Filepath {} is not valid or allowed".format(path))
-                return
-            else:
-                sensors.append(Filesize(path))
+        if not hass.config.is_allowed_path(path):
+            _LOGGER.error(
+                "Filepath {} is not valid or allowed".format(path))
+            return
+        else:
+            sensors.append(Filesize(path))
 
     if sensors:
         add_devices(sensors, True)

--- a/homeassistant/components/sensor/filesize.py
+++ b/homeassistant/components/sensor/filesize.py
@@ -52,12 +52,14 @@ class Filesize(Entity):
         self._size = self.get_file_size(self._path)
 
     def get_file_size(self, path):
+        """Returns the size of the file in MB."""
         statinfo = os.stat(path)
         decimals = 2
         file_size = round(statinfo.st_size/1e6, decimals)
         return file_size
 
     def get_last_updated(self, path):
+        """Returns the time the file was last modified."""
         statinfo = os.stat(path)
         last_updated = datetime.datetime.fromtimestamp(statinfo.st_mtime)
         last_updated = last_updated.strftime(DATE_STR_FORMAT)

--- a/homeassistant/components/sensor/filesize.py
+++ b/homeassistant/components/sensor/filesize.py
@@ -26,21 +26,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def get_file_size(path):
-    """Return the size of the file in bytes."""
-    statinfo = os.stat(path)
-    file_size_bytes = statinfo.st_size
-    return file_size_bytes
-
-
-def get_last_updated(path):
-    """Return the time the file was last modified."""
-    statinfo = os.stat(path)
-    last_updated = datetime.datetime.fromtimestamp(statinfo.st_mtime)
-    last_updated = last_updated.isoformat(' ')
-    return last_updated
-
-
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the file size sensor."""
     sensors = []
@@ -48,7 +33,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if not hass.config.is_allowed_path(path):
             _LOGGER.error(
                 "Filepath %s is not valid or allowed", path)
-            return
+            continue
         else:
             sensors.append(Filesize(path))
 
@@ -69,8 +54,10 @@ class Filesize(Entity):
 
     def update(self):
         """Update the sensor."""
-        self._size = get_file_size(self._path)
-        self._last_updated = get_last_updated(self._path)
+        statinfo = os.stat(self._path)
+        self._size = statinfo.st_size
+        last_updated = datetime.datetime.fromtimestamp(statinfo.st_mtime)
+        self._last_updated = last_updated.isoformat()
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/filesize.py
+++ b/homeassistant/components/sensor/filesize.py
@@ -26,13 +26,28 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
+def get_file_size(path):
+    """Return the size of the file in bytes."""
+    statinfo = os.stat(path)
+    file_size_bytes = statinfo.st_size
+    return file_size_bytes
+
+
+def get_last_updated(path):
+    """Return the time the file was last modified."""
+    statinfo = os.stat(path)
+    last_updated = datetime.datetime.fromtimestamp(statinfo.st_mtime)
+    last_updated = last_updated.isoformat(' ')
+    return last_updated
+
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the file size sensor."""
     sensors = []
     for path in config.get(CONF_FILE_PATHS):
         if not hass.config.is_allowed_path(path):
             _LOGGER.error(
-                "Filepath {} is not valid or allowed".format(path))
+                "Filepath %s is not valid or allowed", path)
             return
         else:
             sensors.append(Filesize(path))
@@ -54,21 +69,8 @@ class Filesize(Entity):
 
     def update(self):
         """Update the sensor."""
-        self._size = self.get_file_size(self._path)
-        self._last_updated = self.get_last_updated(self._path)
-
-    def get_file_size(self, path):
-        """Return the size of the file in bytes."""
-        statinfo = os.stat(path)
-        file_size_bytes = statinfo.st_size
-        return file_size_bytes
-
-    def get_last_updated(self, path):
-        """Return the time the file was last modified."""
-        statinfo = os.stat(path)
-        last_updated = datetime.datetime.fromtimestamp(statinfo.st_mtime)
-        last_updated = last_updated.isoformat(' ')
-        return last_updated
+        self._size = get_file_size(self._path)
+        self._last_updated = get_last_updated(self._path)
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/filesize.py
+++ b/homeassistant/components/sensor/filesize.py
@@ -1,0 +1,92 @@
+"""
+Sensor for monitoring the size of a file.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.filesize/
+"""
+import datetime
+import logging
+import os
+import voluptuous as vol
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.template import DATE_STR_FORMAT
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+
+_LOGGER = logging.getLogger(__name__)
+
+
+CONF_FILE_PATHS = 'file_paths'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_FILE_PATHS): [cv.isfile],
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the file size sensor."""
+    sensors = []
+    for path in config.get(CONF_FILE_PATHS):
+        sensors.append(Filesize(path))
+
+    add_devices(sensors, True)
+
+
+class Filesize(Entity):
+    """Representation of the HA database."""
+
+    ICON = 'mdi:file'
+
+    def __init__(self, path):
+        """Initialize the data object."""
+        self._path = path   # Need to check its a valid path
+        self._size = None
+        self._last_updated = None
+        self._name = path.split("/")[-1]
+        self._unit_of_measurement = 'MB'
+        self.update()
+
+    def update(self):
+        """Get the size of the file."""
+        self._size = self.get_file_size(self._path)
+
+    def get_file_size(self, path):
+        statinfo = os.stat(path)
+        decimals = 2
+        file_size = round(statinfo.st_size/1e6, decimals)
+        return file_size
+
+    def get_last_updated(self, path):
+        statinfo = os.stat(path)
+        last_updated = datetime.datetime.fromtimestamp(statinfo.st_mtime)
+        last_updated = last_updated.strftime(DATE_STR_FORMAT)
+        return last_updated
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._size
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self.ICON
+
+    @property
+    def device_state_attributes(self):
+        """Return other details about the sensor state."""
+        attrs = {}
+        attrs['path'] = self._path
+        attrs['last_updated'] = self.get_last_updated(self._path)
+        return attrs
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit_of_measurement

--- a/tests/components/sensor/test_filesize.py
+++ b/tests/components/sensor/test_filesize.py
@@ -4,14 +4,9 @@ from unittest.mock import Mock, patch
 
 from homeassistant.components.sensor.filesize import CONF_FILE_PATHS
 from homeassistant.setup import setup_component
-from tests.common import get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_registry
 
 PATH = '/Users/robincole/.homeassistant/home-assistant_v2.db'
-
-VALID_CONFIG = {
-    'platform': 'filesize',
-    CONF_FILE_PATHS: [PATH]
-    }
 
 
 class FakeObj():
@@ -26,21 +21,30 @@ FAKE = FakeObj(37990000, 1518126363.5514238, 33188)
 
 
 class TestFileSensor(unittest.TestCase):
-    """Test the File sensor."""
+    """Test the filesize sensor."""
 
     def setup_method(self, method):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.config = VALID_CONFIG
+        mock_registry(self.hass)
 
     def teardown_method(self, method):
         """Stop everything that was started."""
         self.hass.stop()
 
+    @patch('os.path.isfile', Mock(return_value=True))
+    @patch('os.access', Mock(return_value=True))
     @patch('os.stat', Mock(return_value=FAKE))
     def test_filesize_class(self):
+
+        config = {
+            'sensor': {
+                'platform': 'filesize',
+                CONF_FILE_PATHS: [PATH]}
+        }
+
         self.assertTrue(
-            setup_component(self.hass, 'sensor', {'sensor': self.config}))
+            setup_component(self.hass, 'sensor', config))
 
         state = self.hass.states.get('sensor.homeassistant_v2db')
 

--- a/tests/components/sensor/test_filesize.py
+++ b/tests/components/sensor/test_filesize.py
@@ -1,0 +1,51 @@
+"""The tests for the filesize sensor."""
+import unittest
+from unittest.mock import Mock, patch
+
+from homeassistant.components.sensor.filesize import CONF_FILE_PATHS
+from homeassistant.setup import setup_component
+from tests.common import get_test_home_assistant
+
+PATH = '/Users/robincole/.homeassistant/home-assistant_v2.db'
+
+VALID_CONFIG = {
+    'platform': 'filesize',
+    CONF_FILE_PATHS: [PATH]
+    }
+
+
+class FakeObj():
+    '''Fake object for testing.'''
+    def __init__(self, stat, mtime, st_mode):
+        self.st_size = stat
+        self.st_mtime = mtime
+        self.st_mode = st_mode
+
+
+FAKE = FakeObj(37990000, 1518126363.5514238, 33188)
+
+
+class TestFileSensor(unittest.TestCase):
+    """Test the File sensor."""
+
+    def setup_method(self, method):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.config = VALID_CONFIG
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @patch('os.stat', Mock(return_value=FAKE))
+    def test_filesize_class(self):
+        self.assertTrue(
+            setup_component(self.hass, 'sensor', {'sensor': self.config}))
+
+        state = self.hass.states.get('sensor.homeassistant_v2db')
+
+        assert state.state == 37.99
+        assert state.attributes.get('bytes') == 37990000
+        assert state.attributes.get(
+            'last_updated') == '2018-02-08 21:46:03.551424'
+        assert state.attributes.get('path') == PATH

--- a/tests/components/sensor/test_filesize.py
+++ b/tests/components/sensor/test_filesize.py
@@ -53,12 +53,15 @@ class TestFileSensor(unittest.TestCase):
                 CONF_FILE_PATHS: ['/tests/components/sensor/test_filesize.py']}
         }
 
-        self.config.whitelist_external_dirs = set(('/tests/components/sensor/'))
+        self.config.whitelist_external_dirs = set(
+            ('/tests/components/sensor/'))
         self.assertTrue(
             setup_component(self.hass, 'sensor', config))
 
         assert len(self.hass.states.entity_ids()) == 1
 
+
+"""
         #state = self.hass.states.get('sensor.test_api_streamspy')
 
     #    assert state.state == 37.99
@@ -66,3 +69,4 @@ class TestFileSensor(unittest.TestCase):
     #    assert state.attributes.get(
     #        'last_updated') == '2018-02-08 21:46:03.551424'
     #    assert state.attributes.get('path') == PATH
+"""

--- a/tests/components/sensor/test_filesize.py
+++ b/tests/components/sensor/test_filesize.py
@@ -1,46 +1,34 @@
 """The tests for the filesize sensor."""
 import unittest
 import os
-from unittest.mock import Mock, patch
 
 from homeassistant.components.sensor.filesize import CONF_FILE_PATHS
 from homeassistant.setup import setup_component
-import homeassistant.core as ha
-from tests.common import get_test_home_assistant, mock_registry
+from tests.common import get_test_home_assistant
 
 
 TEST_DIR = os.path.join(os.path.dirname(__file__))
 TEST_FILE = os.path.join(TEST_DIR, 'mock_file_test_filesize.txt')
+
 
 def create_file(path):
     """Create a test file."""
     with open(path, 'w') as test_file:
         test_file.write("test")
 
-class FakeObj():
-    '''Fake object for testing.'''
-    def __init__(self, stat, mtime, st_mode):
-        self.st_size = stat
-        self.st_mtime = mtime
-        self.st_mode = st_mode
-
 
 class TestFileSensor(unittest.TestCase):
     """Test the filesize sensor."""
-
-    FAKE = FakeObj(37990000, 1518126363.5514238, 33188)
 
     def setup_method(self, method):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.whitelist_external_dirs = set((TEST_DIR))
-        mock_registry(self.hass)
 
     def teardown_method(self, method):
         """Stop everything that was started."""
         if os.path.isfile(TEST_FILE):
             os.remove(TEST_FILE)
-        
         self.hass.stop()
 
     def test_invalid_path(self):
@@ -48,36 +36,23 @@ class TestFileSensor(unittest.TestCase):
         config = {
             'sensor': {
                 'platform': 'filesize',
-                CONF_FILE_PATHS: ['mock.file1']}
+                CONF_FILE_PATHS: ['invalid_path']}
         }
-
         self.assertTrue(
             setup_component(self.hass, 'sensor', config))
-
         assert len(self.hass.states.entity_ids()) == 0
 
     def test_valid_path(self):
         """Test for a valid path."""
         create_file(TEST_FILE)
-
         config = {
             'sensor': {
                 'platform': 'filesize',
                 CONF_FILE_PATHS: [TEST_FILE]}
         }
-
         self.assertTrue(
             setup_component(self.hass, 'sensor', config))
-
         assert len(self.hass.states.entity_ids()) == 1
-
-
-"""
-        #state = self.hass.states.get('sensor.test_api_streamspy')
-
-    #    assert state.state == 37.99
-    #    assert state.attributes.get('bytes') == 37990000
-    #    assert state.attributes.get(
-    #        'last_updated') == '2018-02-08 21:46:03.551424'
-    #    assert state.attributes.get('path') == PATH
-"""
+        state = self.hass.states.get('sensor.mock_file_test_filesizetxt')
+        assert state.state == '0.0'
+        assert state.attributes.get('bytes') == 4

--- a/tests/components/sensor/test_filesize.py
+++ b/tests/components/sensor/test_filesize.py
@@ -30,7 +30,7 @@ class TestFileSensor(unittest.TestCase):
         self.hass.stop()
 
     def test_invalid_path(self):
-        """Test the filesize class."""
+        """Test that an invalid path is caught."""
         config = {
             'sensor': {
                 'platform': 'filesize',
@@ -44,11 +44,11 @@ class TestFileSensor(unittest.TestCase):
 
     @patch('os.stat', Mock(return_value=FAKE))
     def test_valid_path(self):
-        """Test the filesize class."""
+        """Test for a valid path."""
         config = {
             'sensor': {
                 'platform': 'filesize',
-                CONF_FILE_PATHS: ['/tmp']}
+                CONF_FILE_PATHS: ['tests/components/sensor/test_filesize.py']}
         }
 
         self.assertTrue(

--- a/tests/components/sensor/test_filesize.py
+++ b/tests/components/sensor/test_filesize.py
@@ -1,5 +1,6 @@
 """The tests for the filesize sensor."""
 import unittest
+import os
 from unittest.mock import Mock, patch
 
 from homeassistant.components.sensor.filesize import CONF_FILE_PATHS
@@ -7,6 +8,14 @@ from homeassistant.setup import setup_component
 import homeassistant.core as ha
 from tests.common import get_test_home_assistant, mock_registry
 
+
+TEST_DIR = os.path.join(os.path.dirname(__file__))
+TEST_FILE = os.path.join(TEST_DIR, 'mock_file_test_filesize.txt')
+
+def create_file(path):
+    """Create a test file."""
+    with open(path, 'w') as test_file:
+        test_file.write("test")
 
 class FakeObj():
     '''Fake object for testing.'''
@@ -24,11 +33,14 @@ class TestFileSensor(unittest.TestCase):
     def setup_method(self, method):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.config = ha.Config()
+        self.hass.config.whitelist_external_dirs = set((TEST_DIR))
         mock_registry(self.hass)
 
     def teardown_method(self, method):
         """Stop everything that was started."""
+        if os.path.isfile(TEST_FILE):
+            os.remove(TEST_FILE)
+        
         self.hass.stop()
 
     def test_invalid_path(self):
@@ -44,17 +56,16 @@ class TestFileSensor(unittest.TestCase):
 
         assert len(self.hass.states.entity_ids()) == 0
 
-    @patch('os.stat', Mock(return_value=FAKE))
     def test_valid_path(self):
         """Test for a valid path."""
+        create_file(TEST_FILE)
+
         config = {
             'sensor': {
                 'platform': 'filesize',
-                CONF_FILE_PATHS: ['/tests/components/sensor/test_filesize.py']}
+                CONF_FILE_PATHS: [TEST_FILE]}
         }
 
-        self.config.whitelist_external_dirs = set(
-            ('/tests/components/sensor/'))
         self.assertTrue(
             setup_component(self.hass, 'sensor', config))
 

--- a/tests/components/sensor/test_filesize.py
+++ b/tests/components/sensor/test_filesize.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 from homeassistant.components.sensor.filesize import CONF_FILE_PATHS
 from homeassistant.setup import setup_component
+import homeassistant.core as ha
 from tests.common import get_test_home_assistant, mock_registry
 
 
@@ -23,6 +24,7 @@ class TestFileSensor(unittest.TestCase):
     def setup_method(self, method):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
+        self.config = ha.Config()
         mock_registry(self.hass)
 
     def teardown_method(self, method):
@@ -48,9 +50,10 @@ class TestFileSensor(unittest.TestCase):
         config = {
             'sensor': {
                 'platform': 'filesize',
-                CONF_FILE_PATHS: ['tests/components/sensor/test_filesize.py']}
+                CONF_FILE_PATHS: ['/tests/components/sensor/test_filesize.py']}
         }
 
+        self.config.whitelist_external_dirs = set(('/tests/components/sensor/'))
         self.assertTrue(
             setup_component(self.hass, 'sensor', config))
 

--- a/tests/components/sensor/test_filesize.py
+++ b/tests/components/sensor/test_filesize.py
@@ -6,8 +6,6 @@ from homeassistant.components.sensor.filesize import CONF_FILE_PATHS
 from homeassistant.setup import setup_component
 from tests.common import get_test_home_assistant, mock_registry
 
-PATH = '/Users/robincole/.homeassistant/home-assistant_v2.db'
-
 
 class FakeObj():
     '''Fake object for testing.'''
@@ -17,11 +15,10 @@ class FakeObj():
         self.st_mode = st_mode
 
 
-FAKE = FakeObj(37990000, 1518126363.5514238, 33188)
-
-
 class TestFileSensor(unittest.TestCase):
     """Test the filesize sensor."""
+
+    FAKE = FakeObj(37990000, 1518126363.5514238, 33188)
 
     def setup_method(self, method):
         """Set up things to be run when tests are started."""
@@ -32,24 +29,24 @@ class TestFileSensor(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    @patch('os.path.isfile', Mock(return_value=True))
-    @patch('os.access', Mock(return_value=True))
     @patch('os.stat', Mock(return_value=FAKE))
     def test_filesize_class(self):
-
+        """Test the filesize class."""
         config = {
             'sensor': {
                 'platform': 'filesize',
-                CONF_FILE_PATHS: [PATH]}
+                CONF_FILE_PATHS: ['mock.file1']}
         }
 
         self.assertTrue(
             setup_component(self.hass, 'sensor', config))
 
-        state = self.hass.states.get('sensor.homeassistant_v2db')
+        assert len(self.hass.states.entity_ids()) == 0
 
-        assert state.state == 37.99
-        assert state.attributes.get('bytes') == 37990000
-        assert state.attributes.get(
-            'last_updated') == '2018-02-08 21:46:03.551424'
-        assert state.attributes.get('path') == PATH
+        #state = self.hass.states.get('sensor.test_api_streamspy')
+
+    #    assert state.state == 37.99
+    #    assert state.attributes.get('bytes') == 37990000
+    #    assert state.attributes.get(
+    #        'last_updated') == '2018-02-08 21:46:03.551424'
+    #    assert state.attributes.get('path') == PATH

--- a/tests/components/sensor/test_filesize.py
+++ b/tests/components/sensor/test_filesize.py
@@ -29,8 +29,7 @@ class TestFileSensor(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    @patch('os.stat', Mock(return_value=FAKE))
-    def test_filesize_class(self):
+    def test_invalid_path(self):
         """Test the filesize class."""
         config = {
             'sensor': {
@@ -42,6 +41,20 @@ class TestFileSensor(unittest.TestCase):
             setup_component(self.hass, 'sensor', config))
 
         assert len(self.hass.states.entity_ids()) == 0
+
+    @patch('os.stat', Mock(return_value=FAKE))
+    def test_valid_path(self):
+        """Test the filesize class."""
+        config = {
+            'sensor': {
+                'platform': 'filesize',
+                CONF_FILE_PATHS: ['/tmp']}
+        }
+
+        self.assertTrue(
+            setup_component(self.hass, 'sensor', config))
+
+        assert len(self.hass.states.entity_ids()) == 1
 
         #state = self.hass.states.get('sensor.test_api_streamspy')
 


### PR DESCRIPTION
## Description:
Component for displaying the size of a file.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/pull/4589) with documentation (if applicable):** home-assistant/home-assistant.github.io#4589

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: filesize
    file_paths:
      - /config/home-assistant_v2.db
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x ] Tests have been added to verify that the new code works.
