### PR TITLE
Allow zero purge_interval to disable recorder purge

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -79,7 +79,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_PURGE_KEEP_DAYS):
             vol.All(vol.Coerce(int), vol.Range(min=1)),
         vol.Optional(CONF_PURGE_INTERVAL, default=1):
-            vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.All(vol.Coerce(int), vol.Range(min=0)),
         vol.Optional(CONF_DB_URL): cv.string,
     })
 }, extra=vol.ALLOW_EXTRA)
@@ -122,11 +122,11 @@ def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     keep_days = conf.get(CONF_PURGE_KEEP_DAYS)
     purge_interval = conf.get(CONF_PURGE_INTERVAL)
 
-    if keep_days is None:
+    if keep_days is None and purge_interval != 0:
         _LOGGER.warning(
             "From version 0.64.0 the 'recorder' component will by default "
             "purge data older than 10 days. To keep data longer you must "
-            "configure a 'purge_keep_days' value.")
+            "configure 'purge_keep_days' or 'purge_interval'.")
 
     db_url = conf.get(CONF_DB_URL, None)
     if not db_url:


### PR DESCRIPTION
## Description:

This was suggested in https://github.com/home-assistant/home-assistant/pull/11976#issuecomment-363399502 as an easy way to disable recorder purge, now that purging soon becomes the default.

It turns out that we still have the code to disable purging if `purge_interval` is falsy. It was a leftover from when `purge_interval` could be `None` so maybe I subconsciously anticipated this suggestion :)

So this PR just includes zero in the allowed range.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4591

## Example entry for `configuration.yaml` (if applicable):
```yaml
recorder:
  purge_interval: 0
```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [ ] Tests have been added to verify that the new code works.
