### PR TITLE
Added support for a new platform: climate.modbus

### DIFF
--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -131,6 +131,7 @@ class ModbusThermostat(ClimateDevice):
             _LOGGER.error(ex)
 
     def read_register(self, register):
+        """Reads holding registers using the modbus hub slave."""
         try:
             result = modbus.HUB.read_holding_registers(self._slave, register,
                                                        self._count)
@@ -143,4 +144,5 @@ class ModbusThermostat(ClimateDevice):
         return register_value
 
     def write_register(self, register, value):
+        """Writes registers using the modbus hub slave."""
         modbus.HUB.write_registers(self._slave, register, [value, 0])

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -50,7 +50,7 @@ _LOGGER = logging.getLogger(__name__)
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
 
 
-def setup_platform(config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Modbus Thermostat Platform."""
     name = config.get(CONF_NAME)
     modbus_slave = config.get(CONF_SLAVE)
@@ -118,8 +118,9 @@ class ModbusThermostat(ClimateDevice):
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
-        if kwargs.get(ATTR_TEMPERATURE) is not None:
-            target_temperature = kwargs.get(ATTR_TEMPERATURE)
+        target_temperature = kwargs.get(ATTR_TEMPERATURE)
+        if target_temperature is None:
+            return
         byte_string = struct.pack(self._structure, target_temperature)
         register_value = struct.unpack('>h', byte_string[0:2])[0]
 

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -119,9 +119,8 @@ class ModbusThermostat(ClimateDevice):
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
         if kwargs.get(ATTR_TEMPERATURE) is not None:
-            self._target_temperature = kwargs.get(ATTR_TEMPERATURE)
-        byte_string = struct.pack(self._structure,
-                                  self._target_temperature)
+            target_temperature = kwargs.get(ATTR_TEMPERATURE)
+        byte_string = struct.pack(self._structure, target_temperature)
         register_value = struct.unpack('>h', byte_string[0:2])[0]
 
         try:

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -130,7 +130,7 @@ class ModbusThermostat(ClimateDevice):
             _LOGGER.error(ex)
 
     def read_register(self, register):
-        """Reads holding registers using the modbus hub slave."""
+        """Read holding register using the modbus hub slave."""
         try:
             result = modbus.HUB.read_holding_registers(self._slave, register,
                                                        self._count)
@@ -143,5 +143,5 @@ class ModbusThermostat(ClimateDevice):
         return register_value
 
     def write_register(self, register, value):
-        """Writes registers using the modbus hub slave."""
+        """Write register using the modbus hub slave."""
         modbus.HUB.write_registers(self._slave, register, [value, 0])

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -142,6 +142,5 @@ class ModbusThermostat(ClimateDevice):
         register_value = format(val, '.{}f'.format(self._precision))
         return register_value
 
-
     def write_register(self, register, value):
         modbus.HUB.write_registers(self._slave, register, [value, 0])

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -88,8 +88,8 @@ class ModbusThermostat(ClimateDevice):
         self.hass = hass
         self._name = name
         self._slave = modbus_slave
-        self._target_temperature_register = int(target_temp_register)
-        self._current_temperature_register = int(current_temp_register)
+        self._target_temperature_register = target_temp_register
+        self._current_temperature_register = current_temp_register
         self._target_temperature = None
         self._current_temperature = None
         self._data_type = data_type
@@ -98,9 +98,9 @@ class ModbusThermostat(ClimateDevice):
         self._structure = '>f'
         self._error = False
 
-        data_types = {DATA_TYPE_INT: {1: 'h', 2: 'i', 4: 'q'}}
-        data_types[DATA_TYPE_UINT] = {1: 'H', 2: 'I', 4: 'Q'}
-        data_types[DATA_TYPE_FLOAT] = {1: 'e', 2: 'f', 4: 'd'}
+        data_types = {DATA_TYPE_INT: {1: 'h', 2: 'i', 4: 'q'},
+                      DATA_TYPE_UINT: {1: 'H', 2: 'I', 4: 'Q'},
+                      DATA_TYPE_FLOAT: {1: 'e', 2: 'f', 4: 'd'}}
 
         self._structure = '>{}'.format(data_types[self._data_type]
                                        [self._count])
@@ -147,8 +147,8 @@ class ModbusThermostat(ClimateDevice):
     def state(self):
         """Return the current state - implied."""
         if self._error:
-            return STATE_OK
-        return STATE_PROBLEM
+            return STATE_PROBLEM
+        return STATE_OK
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -5,21 +5,6 @@ This uses a setpoint and process
 value within the controller, so both the current temperature register and the
 target temperature register need to be configured.
 
-TODO:
- - add support for offsetting register values
- - add support for scaling register values
- - add support for uint and int data types
- - add support for input registers (default is holding registers)
-
-# Example Modbus Thermostat configuration (required & optional attributes):
-climate:
-  - platform: modbus
-    name: Watlow F4T
-    slave: 1
-    target_temp_register: 2782 # Control Loop 1 Setpoint
-    current_temp_register: 27586 # Universal Input 1 Module 1
-    data_type: float
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.modbus/
 """

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -1,0 +1,182 @@
+"""
+Platform for a Generic Modbus Thermostat.
+
+This uses a setpoint and process
+value within the controller, so both the current temperature register and the
+target temperature register need to be configured.
+
+TODO:
+ - add support for offsetting register values
+ - add support for scaling register values
+ - add support for uint and int data types
+ - add support for input registers (default is holding registers)
+
+# Example Modbus Thermostat configuration (required & optional attributes):
+climate:
+  - platform: modbus
+    name: Watlow F4T
+    slave: 1
+    target_temp_register: 2782 # Control Loop 1 Setpoint
+    current_temp_register: 27586 # Universal Input 1 Module 1
+    data_type: float
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/climate.modbus/
+"""
+import logging
+import struct
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_NAME, CONF_SLAVE, ATTR_TEMPERATURE, STATE_OK, STATE_PROBLEM)
+from homeassistant.components.climate import (
+    ClimateDevice, PLATFORM_SCHEMA, SUPPORT_TARGET_TEMPERATURE)
+
+import homeassistant.components.modbus as modbus
+import homeassistant.helpers.config_validation as cv
+
+DEPENDENCIES = ['modbus']
+
+# Parameters not defined by homeassistant.const
+CONF_TARGET_TEMP = 'target_temp_register'
+CONF_CURRENT_TEMP = 'current_temp_register'
+CONF_DATA_TYPE = 'data_type'
+CONF_COUNT = 'data_count'
+CONF_PRECISION = 'precision'
+
+DATA_TYPE_INT = 'int'
+DATA_TYPE_UINT = 'uint'
+DATA_TYPE_FLOAT = 'float'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_SLAVE): cv.positive_int,
+    vol.Required(CONF_TARGET_TEMP): cv.positive_int,
+    vol.Required(CONF_CURRENT_TEMP): cv.positive_int,
+    vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_FLOAT):
+        vol.In([DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT]),
+    vol.Optional(CONF_COUNT, default=2): cv.positive_int,
+    vol.Optional(CONF_PRECISION, default=1): cv.positive_int
+})
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Modbus Thermostat Platform."""
+    name = config.get(CONF_NAME)
+    modbus_slave = config.get(CONF_SLAVE)
+    target_temp_register = config.get(CONF_TARGET_TEMP)
+    current_temp_register = config.get(CONF_CURRENT_TEMP)
+    data_type = config.get(CONF_DATA_TYPE)
+    count = config.get(CONF_COUNT)
+    precision = config.get(CONF_PRECISION)
+
+    add_devices([ModbusThermostat(hass, name, modbus_slave,
+                                  target_temp_register, current_temp_register,
+                                  data_type, count, precision)], True)
+
+
+class ModbusThermostat(ClimateDevice):
+    """Representation of a Modbus Thermostat."""
+
+    def __init__(self, hass, name, modbus_slave, target_temp_register,
+                 current_temp_register, data_type, count, precision):
+        """Initialize the unit."""
+        self.hass = hass
+        self._name = name
+        self._slave = modbus_slave
+        self._target_temperature_register = int(target_temp_register)
+        self._current_temperature_register = int(current_temp_register)
+        self._target_temperature = None
+        self._current_temperature = None
+        self._data_type = data_type
+        self._count = int(count)
+        self._precision = precision
+        self._structure = '>f'
+        self._error = False
+
+        data_types = {DATA_TYPE_INT: {1: 'h', 2: 'i', 4: 'q'}}
+        data_types[DATA_TYPE_UINT] = {1: 'H', 2: 'I', 4: 'Q'}
+        data_types[DATA_TYPE_FLOAT] = {1: 'e', 2: 'f', 4: 'd'}
+
+        self._structure = '>{}'.format(data_types[self._data_type]
+                                       [self._count])
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return SUPPORT_FLAGS
+
+    def update(self):
+        """Update Target & Current Temperature."""
+        try:
+            result = modbus.HUB.read_holding_registers(
+                self._slave, self._target_temperature_register, self._count)
+        except AttributeError as ex:
+            self._error = True
+            _LOGGER.error(ex)
+
+        byte_string = b''.join(
+            [x.to_bytes(2, byteorder='big') for x in result.registers])
+        val = struct.unpack(self._structure, byte_string)[0]
+        formatted_string = format(val, '.{}f'.format(self._precision))
+        self._target_temperature = float(formatted_string)
+
+        try:
+            result = modbus.HUB.read_holding_registers(
+                self._slave, self._current_temperature_register, self._count)
+        except AttributeError as ex:
+            self._error = True
+            _LOGGER.error(ex)
+
+        byte_string = b''.join(
+            [x.to_bytes(2, byteorder='big') for x in result.registers])
+        val = struct.unpack(self._structure, byte_string)[0]
+        formatted_string = format(val, '.{}f'.format(self._precision))
+        self._current_temperature = float(formatted_string)
+
+    @property
+    def name(self):
+        """Return the name of the climate device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the current state - implied."""
+        if self._error:
+            return STATE_OK
+        return STATE_PROBLEM
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return self.hass.config.units.temperature_unit
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self._current_temperature
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._target_temperature
+
+    def set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        if kwargs.get(ATTR_TEMPERATURE) is not None:
+            self._target_temperature = kwargs.get(ATTR_TEMPERATURE)
+        byte_string = struct.pack(self._structure,
+                                  self._target_temperature)
+        register_value = struct.unpack('>h', byte_string[0:2])[0]
+
+        try:
+            modbus.HUB.write_registers(self._slave,
+                                       self._target_temperature_register,
+                                       [register_value, 0])
+        except AttributeError as ex:
+            self._error = True
+            _LOGGER.error(ex)


### PR DESCRIPTION
## Description:
This module is for using modbus registers as a thermostat. It allows for changing the target temperature, and monitoring the current temperature. A pull request has been submitted for home-assistant.github.io as well.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4593

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: modbus
    name: Watlow F4T
    # Modbus TCP
    slave: 1
    # Control Loop 1 Setpoint
    target_temp_register: 2782
    # Universal Input 1 Module 1
    current_temp_register: 27586
    data_type: float
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.