### PR TITLE
Add light.group platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -404,6 +404,7 @@ omit =
     homeassistant/components/light/decora_wifi.py
     homeassistant/components/light/flux_led.py
     homeassistant/components/light/greenwave.py
+    homeassistant/components/light/group.py
     homeassistant/components/light/hue.py
     homeassistant/components/light/hyperion.py
     homeassistant/components/light/iglo.py

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -162,12 +162,8 @@ def turn_on(hass, entity_id=None, transition=None, brightness=None,
 def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
                   brightness_pct=None, rgb_color=None, xy_color=None,
                   color_temp=None, kelvin=None, white_value=None,
-                  profile=None, flash=None, effect=None, color_name=None,
-                  blocking=False):
-    """Turn all or specified light on.
-
-    This method must be run in the event loop and returns a coroutine.
-    """
+                  profile=None, flash=None, effect=None, color_name=None):
+    """Turn all or specified light on."""
     data = {
         key: value for key, value in [
             (ATTR_ENTITY_ID, entity_id),
@@ -186,8 +182,7 @@ def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
         ] if value is not None
     }
 
-    return hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_TURN_ON, data, blocking=blocking))
+    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_TURN_ON, data))
 
 
 @bind_hass
@@ -198,11 +193,8 @@ def turn_off(hass, entity_id=None, transition=None):
 
 @callback
 @bind_hass
-def async_turn_off(hass, entity_id=None, transition=None, blocking=False):
-    """Turn all or specified light off.
-
-    This method must be run in the event loop and returns a coroutine.
-    """
+def async_turn_off(hass, entity_id=None, transition=None):
+    """Turn all or specified light off."""
     data = {
         key: value for key, value in [
             (ATTR_ENTITY_ID, entity_id),
@@ -210,17 +202,14 @@ def async_turn_off(hass, entity_id=None, transition=None, blocking=False):
         ] if value is not None
     }
 
-    return hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, data, blocking=blocking))
+    hass.async_add_job(hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, data))
 
 
 @callback
 @bind_hass
-def async_toggle(hass, entity_id=None, transition=None, blocking=False):
-    """Toggle all or specified light.
-
-    This method must be run in the event loop and returns a coroutine.
-    """
+def async_toggle(hass, entity_id=None, transition=None):
+    """Toggle all or specified light."""
     data = {
         key: value for key, value in [
             (ATTR_ENTITY_ID, entity_id),
@@ -228,8 +217,8 @@ def async_toggle(hass, entity_id=None, transition=None, blocking=False):
         ] if value is not None
     }
 
-    return hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_TOGGLE, data, blocking=blocking))
+    hass.async_add_job(hass.services.async_call(
+        DOMAIN, SERVICE_TOGGLE, data))
 
 
 @bind_hass

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -206,8 +206,9 @@ def async_turn_off(hass, entity_id=None, transition=None):
         DOMAIN, SERVICE_TURN_OFF, data))
 
 
+@callback
 @bind_hass
-def toggle(hass, entity_id=None, transition=None):
+def async_toggle(hass, entity_id=None, transition=None):
     """Toggle all or specified light."""
     data = {
         key: value for key, value in [
@@ -216,7 +217,14 @@ def toggle(hass, entity_id=None, transition=None):
         ] if value is not None
     }
 
-    hass.services.call(DOMAIN, SERVICE_TOGGLE, data)
+    hass.async_add_job(hass.services.async_call(
+        DOMAIN, SERVICE_TOGGLE, data))
+
+
+@bind_hass
+def toggle(hass, entity_id=None, transition=None):
+    """Toggle all or specified light."""
+    hass.add_job(async_toggle, hass, entity_id, transition)
 
 
 def preprocess_turn_on_alternatives(params):

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -12,7 +12,8 @@ import os
 
 import voluptuous as vol
 
-from homeassistant.components import group
+from homeassistant.components.group import \
+    ENTITY_ID_FORMAT as GROUP_ENTITY_ID_FORMAT
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TOGGLE, SERVICE_TURN_OFF, SERVICE_TURN_ON,
     STATE_ON)
@@ -29,7 +30,7 @@ DEPENDENCIES = ['group']
 SCAN_INTERVAL = timedelta(seconds=30)
 
 GROUP_NAME_ALL_LIGHTS = 'all lights'
-ENTITY_ID_ALL_LIGHTS = group.ENTITY_ID_FORMAT.format('all_lights')
+ENTITY_ID_ALL_LIGHTS = GROUP_ENTITY_ID_FORMAT.format('all_lights')
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -162,8 +162,12 @@ def turn_on(hass, entity_id=None, transition=None, brightness=None,
 def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
                   brightness_pct=None, rgb_color=None, xy_color=None,
                   color_temp=None, kelvin=None, white_value=None,
-                  profile=None, flash=None, effect=None, color_name=None):
-    """Turn all or specified light on."""
+                  profile=None, flash=None, effect=None, color_name=None,
+                  blocking=False):
+    """Turn all or specified light on.
+
+    This method must be run in the event loop and returns a coroutine.
+    """
     data = {
         key: value for key, value in [
             (ATTR_ENTITY_ID, entity_id),
@@ -182,7 +186,8 @@ def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
         ] if value is not None
     }
 
-    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_TURN_ON, data))
+    return hass.async_add_job(hass.services.async_call(
+        DOMAIN, SERVICE_TURN_ON, data, blocking=blocking))
 
 
 @bind_hass
@@ -193,8 +198,11 @@ def turn_off(hass, entity_id=None, transition=None):
 
 @callback
 @bind_hass
-def async_turn_off(hass, entity_id=None, transition=None):
-    """Turn all or specified light off."""
+def async_turn_off(hass, entity_id=None, transition=None, blocking=False):
+    """Turn all or specified light off.
+
+    This method must be run in the event loop and returns a coroutine.
+    """
     data = {
         key: value for key, value in [
             (ATTR_ENTITY_ID, entity_id),
@@ -202,14 +210,17 @@ def async_turn_off(hass, entity_id=None, transition=None):
         ] if value is not None
     }
 
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, data))
+    return hass.async_add_job(hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, data, blocking=blocking))
 
 
 @callback
 @bind_hass
-def async_toggle(hass, entity_id=None, transition=None):
-    """Toggle all or specified light."""
+def async_toggle(hass, entity_id=None, transition=None, blocking=False):
+    """Toggle all or specified light.
+
+    This method must be run in the event loop and returns a coroutine.
+    """
     data = {
         key: value for key, value in [
             (ATTR_ENTITY_ID, entity_id),
@@ -217,8 +228,8 @@ def async_toggle(hass, entity_id=None, transition=None):
         ] if value is not None
     }
 
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_TOGGLE, data))
+    return hass.async_add_job(hass.services.async_call(
+        DOMAIN, SERVICE_TOGGLE, data, blocking=blocking))
 
 
 @bind_hass

--- a/homeassistant/components/light/group.py
+++ b/homeassistant/components/light/group.py
@@ -254,6 +254,8 @@ def _average_tuple(*args):
     return tuple(sum(l) / len(l) for l in zip(*args))
 
 
+# https://github.com/PyCQA/pylint/issues/1831
+# pylint: disable=bad-whitespace
 def _reduce_attribute(states: List[State],
                       key: str,
                       default: Optional[Any] = None,

--- a/homeassistant/components/light/group.py
+++ b/homeassistant/components/light/group.py
@@ -158,17 +158,13 @@ class GroupLight(light.Light):
 
     async def async_turn_on(self, **kwargs):
         """Forward the turn_on command to all lights in the group."""
-        for entity_id in self._entity_ids:
-            payload = dict(kwargs)
-            payload[ATTR_ENTITY_ID] = entity_id
-            light.async_turn_on(self.hass, **payload)
+        kwargs[ATTR_ENTITY_ID] = self._entity_ids
+        await light.async_turn_on(self.hass, blocking=True, **kwargs)
 
     async def async_turn_off(self, **kwargs):
         """Forward the turn_off command to all lights in the group."""
-        for entity_id in self._entity_ids:
-            payload = dict(kwargs)
-            payload[ATTR_ENTITY_ID] = entity_id
-            light.async_turn_off(self.hass, **payload)
+        kwargs[ATTR_ENTITY_ID] = self._entity_ids
+        await light.async_turn_off(self.hass, blocking=True, **kwargs)
 
     async def async_update(self):
         """Query all members and determine the group state."""

--- a/homeassistant/components/light/group.py
+++ b/homeassistant/components/light/group.py
@@ -29,8 +29,6 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = 'group'
-
 DEFAULT_NAME = 'Group Light'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/light/group.py
+++ b/homeassistant/components/light/group.py
@@ -4,7 +4,6 @@ This component allows several lights to be grouped into one light.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.group/
 """
-import asyncio
 import logging
 import itertools
 from typing import List, Tuple, Optional, Iterator, Any, Callable

--- a/homeassistant/components/light/group.py
+++ b/homeassistant/components/light/group.py
@@ -158,13 +158,17 @@ class GroupLight(light.Light):
 
     async def async_turn_on(self, **kwargs):
         """Forward the turn_on command to all lights in the group."""
-        kwargs[ATTR_ENTITY_ID] = self._entity_ids
-        await light.async_turn_on(self.hass, blocking=True, **kwargs)
+        for entity_id in self._entity_ids:
+            payload = dict(kwargs)
+            payload[ATTR_ENTITY_ID] = entity_id
+            light.async_turn_on(self.hass, **payload)
 
     async def async_turn_off(self, **kwargs):
         """Forward the turn_off command to all lights in the group."""
-        kwargs[ATTR_ENTITY_ID] = self._entity_ids
-        await light.async_turn_off(self.hass, blocking=True, **kwargs)
+        for entity_id in self._entity_ids:
+            payload = dict(kwargs)
+            payload[ATTR_ENTITY_ID] = entity_id
+            light.async_turn_off(self.hass, **payload)
 
     async def async_update(self):
         """Query all members and determine the group state."""

--- a/homeassistant/components/light/group.py
+++ b/homeassistant/components/light/group.py
@@ -37,7 +37,7 @@ DEFAULT_NAME = 'Group Light'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Required(CONF_ENTITIES): cv.entity_ids,
+    vol.Required(CONF_ENTITIES): cv.entities_domain('light')
 })
 
 SUPPORT_GROUP_LIGHT = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_EFFECT

--- a/homeassistant/components/light/grouped_light.py
+++ b/homeassistant/components/light/grouped_light.py
@@ -1,0 +1,265 @@
+"""
+This component allows several lights to be grouped into one light.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.grouped_light/
+"""
+import asyncio
+import logging
+import itertools
+from typing import List, Tuple, Optional, TypeVar, Iterator
+import voluptuous as vol
+
+from homeassistant.core import State
+from homeassistant.components import light
+from homeassistant.const import (STATE_OFF, STATE_ON, SERVICE_TURN_ON,
+                                 SERVICE_TURN_OFF, ATTR_ENTITY_ID, CONF_NAME,
+                                 CONF_ENTITIES, STATE_UNAVAILABLE,
+                                 STATE_UNKNOWN)
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.typing import HomeAssistantType, ConfigType
+from homeassistant.components.light import (SUPPORT_BRIGHTNESS,
+                                            SUPPORT_RGB_COLOR,
+                                            SUPPORT_COLOR_TEMP,
+                                            SUPPORT_TRANSITION, SUPPORT_EFFECT,
+                                            SUPPORT_FLASH, SUPPORT_XY_COLOR,
+                                            SUPPORT_WHITE_VALUE,
+                                            PLATFORM_SCHEMA)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'grouped_light'
+
+DEFAULT_NAME = 'Grouped Light'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ENTITIES): cv.entity_ids,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+SUPPORT_GROUP_LIGHT = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP |
+                       SUPPORT_EFFECT | SUPPORT_FLASH | SUPPORT_RGB_COLOR |
+                       SUPPORT_TRANSITION | SUPPORT_XY_COLOR |
+                       SUPPORT_WHITE_VALUE)
+
+
+@asyncio.coroutine
+def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
+                         async_add_devices, discovery_info=None) -> None:
+    """Initialize grouped_light platform."""
+    async_add_devices([GroupedLight(
+        hass,
+        config.get(CONF_NAME),
+        config.get(CONF_ENTITIES)
+    )])
+
+
+T = TypeVar('T')
+
+
+class GroupedLight(light.Light):
+    """Representation of a Grouped Light."""
+
+    def __init__(self, hass: HomeAssistantType, name: str,
+                 entity_ids: List[str]) -> None:
+        """Initialize a Grouped Light."""
+        self.hass = hass  # type: HomeAssistantType
+        self._name = name  # type: str
+        self._entity_ids = entity_ids  # type: List[str]
+        self._state = STATE_OFF  # type: str
+        self._brightness = None  # type: Optional[int]
+        self._xy_color = None  # type: Optional[Tuple[float, float]]
+        self._rgb_color = None  # type: Optional[Tuple[int, int, int]]
+        self._color_temp = None  # type: Optional[int]
+        self._min_mireds = 154  # type: Optional[int]
+        self._max_mireds = 500  # type: Optional[int]
+        self._white_value = None  # type: Optional[int]
+        self._effect_list = None  # type: Optional[List[str]]
+        self._effect = None  # type: Optional[str]
+        self._supported_features = 0  # type: int
+
+    @asyncio.coroutine
+    def async_added_to_hass(self) -> None:
+        """Subscribe to light events."""
+        async_track_state_change(self.hass, self._entity_ids,
+                                 self._async_state_changed_listener)
+
+    @property
+    def name(self) -> str:
+        """Return the name of the entity."""
+        return self._name
+
+    @property
+    def state(self) -> str:
+        """Return the state."""
+        return self._state
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if entity is on."""
+        return self.state == STATE_ON
+
+    @property
+    def brightness(self) -> Optional[int]:
+        """Return the brightness of this light between 0..255."""
+        return self._brightness
+
+    @property
+    def xy_color(self) -> Optional[Tuple[float, float]]:
+        """Return the XY color value [float, float]."""
+        return self._xy_color
+
+    @property
+    def rgb_color(self) -> Optional[Tuple[int, int, int]]:
+        """Return the RGB color value [int, int, int]."""
+        return self._rgb_color
+
+    @property
+    def color_temp(self) -> Optional[int]:
+        """Return the CT color value in mireds."""
+        return self._color_temp
+
+    @property
+    def min_mireds(self) -> Optional[int]:
+        """Return the coldest color_temp that this light supports."""
+        return self._min_mireds
+
+    @property
+    def max_mireds(self) -> Optional[int]:
+        """Return the warmest color_temp that this light supports."""
+        return self._max_mireds
+
+    @property
+    def white_value(self) -> Optional[int]:
+        """Return the white value of this light between 0..255."""
+        return self._white_value
+
+    @property
+    def effect_list(self) -> Optional[List[str]]:
+        """Return the list of supported effects."""
+        return self._effect_list
+
+    @property
+    def effect(self) -> Optional[str]:
+        """Return the current effect."""
+        return self._effect
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return self._supported_features
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed for a Grouped Light."""
+        return False
+
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """Forward the turn_on command to all lights in the group."""
+        for entity_id in self._entity_ids:
+            kwargs[ATTR_ENTITY_ID] = entity_id
+            yield from self.hass.services.async_call('light', SERVICE_TURN_ON,
+                                                     kwargs, blocking=True)
+
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
+        """Forward the turn_off command to all lights in the group."""
+        for entity_id in self._entity_ids:
+            kwargs[ATTR_ENTITY_ID] = entity_id
+            yield from self.hass.services.async_call('light', SERVICE_TURN_OFF,
+                                                     kwargs, blocking=True)
+
+    @asyncio.coroutine
+    def async_update(self):
+        """Query all members and determine the group state."""
+        states = self._child_states()
+
+        self._state = _determine_on_off_state(states)
+        self._brightness = _reduce_attribute(states, 'brightness')
+        self._xy_color = _reduce_attribute(states, 'xy_color')
+        self._rgb_color = _reduce_attribute(states, 'rgb_color')
+        self._color_temp = _reduce_attribute(states, 'color_temp')
+        self._min_mireds = _reduce_attribute(states, 'min_mireds', default=154,
+                                             force_on=False)
+        self._max_mireds = _reduce_attribute(states, 'max_mireds', default=500,
+                                             force_on=False)
+        self._white_value = _reduce_attribute(states, 'white_value')
+
+        all_effect_lists = list(_find_state_attributes(states, 'effect_list',
+                                                       force_on=False))
+        self._effect_list = None
+        if all_effect_lists:
+            # Merge all effects from all effect_lists with a union merge.
+            self._effect_list = list(set().union(*all_effect_lists))
+
+        all_effects = list(_find_state_attributes(states, 'effect'))
+        self._effect = None
+        if all_effects:
+            flat_effects = list(itertools.chain(*all_effect_lists))
+            # Report the most common effect.
+            self._effect = max(set(flat_effects), key=flat_effects.count)
+
+        self._supported_features = 0
+        for support in _find_state_attributes(states, 'supported_features',
+                                              force_on=False):
+            # Merge supported features by emulating support for every feature
+            # we find.
+            self._supported_features |= support
+        # Bitwise-and the supported features with the GroupedLight's features
+        # so that we don't break in the future when a new feature is added.
+        self._supported_features &= SUPPORT_GROUP_LIGHT
+
+    @asyncio.coroutine
+    def _async_state_changed_listener(self, entity_id: str, old_state: State,
+                                      new_state: State):
+        """Respond to a member state changing."""
+        yield from self._update_hass()
+
+    def _child_states(self) -> List[State]:
+        """The states that the group is tracking."""
+        states = [self.hass.states.get(x) for x in self._entity_ids]
+        return list(filter(None, states))
+
+    @asyncio.coroutine
+    def _update_hass(self):
+        """Request new status and push it to hass."""
+        yield from self.async_update()
+        yield from self.async_update_ha_state()
+
+
+def _find_state_attributes(states: List[State], key: str,
+                           force_on: bool = True) -> Iterator[T]:
+    """Find attributes with matching key from states.
+
+    Only returns attributes of enabled lights when force_on is True.
+    """
+    for state in states:
+        assume_on = (not force_on) or state.state == STATE_ON
+        if assume_on and key in state.attributes:
+            yield state.attributes.get(key)
+
+
+def _reduce_attribute(states: List[State], key: str,
+                      default: Optional[T] = None, force_on: bool = True) -> T:
+    """Find the first attribute matching key from states.
+
+    If none are found, returns default.
+    """
+    return next(_find_state_attributes(states, key, force_on), default)
+
+
+def _determine_on_off_state(states: List[State]) -> str:
+    """Helper method to determine the ON/OFF/... state of a light."""
+    s_states = [state.state for state in states]
+
+    if not s_states:
+        return STATE_UNAVAILABLE
+    elif any(state == STATE_ON for state in s_states):
+        return STATE_ON
+    elif all(state == STATE_UNAVAILABLE for state in s_states):
+        return STATE_UNAVAILABLE
+    elif all(state == STATE_UNKNOWN for state in s_states):
+        return STATE_UNKNOWN
+    return STATE_OFF

--- a/homeassistant/components/light/grouped_light.py
+++ b/homeassistant/components/light/grouped_light.py
@@ -229,6 +229,8 @@ class GroupedLight(light.Light):
         yield from self.async_update_ha_state()
 
 
+# https://github.com/PyCQA/pylint/issues/1543
+# pylint: disable=bad-whitespace
 def _find_state_attributes(states: List[State], key: str,
                            force_on: bool = True) -> Iterator[T]:
     """Find attributes with matching key from states.
@@ -241,6 +243,8 @@ def _find_state_attributes(states: List[State], key: str,
             yield state.attributes.get(key)
 
 
+# https://github.com/PyCQA/pylint/issues/1543
+# pylint: disable=bad-whitespace
 def _reduce_attribute(states: List[State], key: str,
                       default: Optional[T] = None, force_on: bool = True) -> T:
     """Find the first attribute matching key from states.

--- a/homeassistant/components/light/grouped_light.py
+++ b/homeassistant/components/light/grouped_light.py
@@ -12,19 +12,15 @@ import voluptuous as vol
 
 from homeassistant.core import State
 from homeassistant.components import light
-from homeassistant.const import (STATE_OFF, STATE_ON, SERVICE_TURN_ON,
-                                 SERVICE_TURN_OFF, ATTR_ENTITY_ID, CONF_NAME,
-                                 CONF_ENTITIES, STATE_UNAVAILABLE,
-                                 STATE_UNKNOWN)
+from homeassistant.const import (
+    STATE_OFF, STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF, ATTR_ENTITY_ID,
+    CONF_NAME, CONF_ENTITIES, STATE_UNAVAILABLE, STATE_UNKNOWN)
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.typing import HomeAssistantType, ConfigType
-from homeassistant.components.light import (SUPPORT_BRIGHTNESS,
-                                            SUPPORT_RGB_COLOR,
-                                            SUPPORT_COLOR_TEMP,
-                                            SUPPORT_TRANSITION, SUPPORT_EFFECT,
-                                            SUPPORT_FLASH, SUPPORT_XY_COLOR,
-                                            SUPPORT_WHITE_VALUE,
-                                            PLATFORM_SCHEMA)
+from homeassistant.components.light import (
+    SUPPORT_BRIGHTNESS, SUPPORT_RGB_COLOR, SUPPORT_COLOR_TEMP,
+    SUPPORT_TRANSITION, SUPPORT_EFFECT, SUPPORT_FLASH, SUPPORT_XY_COLOR,
+    SUPPORT_WHITE_VALUE, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,15 +34,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-SUPPORT_GROUP_LIGHT = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP |
-                       SUPPORT_EFFECT | SUPPORT_FLASH | SUPPORT_RGB_COLOR |
-                       SUPPORT_TRANSITION | SUPPORT_XY_COLOR |
-                       SUPPORT_WHITE_VALUE)
+SUPPORT_GROUP_LIGHT = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_EFFECT
+                       | SUPPORT_FLASH | SUPPORT_RGB_COLOR | SUPPORT_TRANSITION
+                       | SUPPORT_XY_COLOR | SUPPORT_WHITE_VALUE)
 
 
 @asyncio.coroutine
-def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
-                         async_add_devices, discovery_info=None) -> None:
+def async_setup_platform(hass: HomeAssistantType,
+                         config: ConfigType,
+                         async_add_devices,
+                         discovery_info=None) -> None:
     """Initialize grouped_light platform."""
     async_add_devices([GroupedLight(
         hass,
@@ -160,16 +157,16 @@ class GroupedLight(light.Light):
         """Forward the turn_on command to all lights in the group."""
         for entity_id in self._entity_ids:
             kwargs[ATTR_ENTITY_ID] = entity_id
-            yield from self.hass.services.async_call('light', SERVICE_TURN_ON,
-                                                     kwargs, blocking=True)
+            yield from self.hass.services.async_call(
+                'light', SERVICE_TURN_ON, kwargs, blocking=True)
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Forward the turn_off command to all lights in the group."""
         for entity_id in self._entity_ids:
             kwargs[ATTR_ENTITY_ID] = entity_id
-            yield from self.hass.services.async_call('light', SERVICE_TURN_OFF,
-                                                     kwargs, blocking=True)
+            yield from self.hass.services.async_call(
+                'light', SERVICE_TURN_OFF, kwargs, blocking=True)
 
     @asyncio.coroutine
     def async_update(self):
@@ -181,14 +178,14 @@ class GroupedLight(light.Light):
         self._xy_color = _reduce_attribute(states, 'xy_color')
         self._rgb_color = _reduce_attribute(states, 'rgb_color')
         self._color_temp = _reduce_attribute(states, 'color_temp')
-        self._min_mireds = _reduce_attribute(states, 'min_mireds', default=154,
-                                             force_on=False)
-        self._max_mireds = _reduce_attribute(states, 'max_mireds', default=500,
-                                             force_on=False)
+        self._min_mireds = _reduce_attribute(
+            states, 'min_mireds', default=154, force_on=False)
+        self._max_mireds = _reduce_attribute(
+            states, 'max_mireds', default=500, force_on=False)
         self._white_value = _reduce_attribute(states, 'white_value')
 
-        all_effect_lists = list(_find_state_attributes(states, 'effect_list',
-                                                       force_on=False))
+        all_effect_lists = list(
+            _find_state_attributes(states, 'effect_list', force_on=False))
         self._effect_list = None
         if all_effect_lists:
             # Merge all effects from all effect_lists with a union merge.
@@ -202,8 +199,8 @@ class GroupedLight(light.Light):
             self._effect = max(set(flat_effects), key=flat_effects.count)
 
         self._supported_features = 0
-        for support in _find_state_attributes(states, 'supported_features',
-                                              force_on=False):
+        for support in _find_state_attributes(
+                states, 'supported_features', force_on=False):
             # Merge supported features by emulating support for every feature
             # we find.
             self._supported_features |= support
@@ -231,7 +228,8 @@ class GroupedLight(light.Light):
 
 # https://github.com/PyCQA/pylint/issues/1543
 # pylint: disable=bad-whitespace
-def _find_state_attributes(states: List[State], key: str,
+def _find_state_attributes(states: List[State],
+                           key: str,
                            force_on: bool = True) -> Iterator[T]:
     """Find attributes with matching key from states.
 
@@ -245,8 +243,10 @@ def _find_state_attributes(states: List[State], key: str,
 
 # https://github.com/PyCQA/pylint/issues/1543
 # pylint: disable=bad-whitespace
-def _reduce_attribute(states: List[State], key: str,
-                      default: Optional[T] = None, force_on: bool = True) -> T:
+def _reduce_attribute(states: List[State],
+                      key: str,
+                      default: Optional[T] = None,
+                      force_on: bool = True) -> T:
     """Find the first attribute matching key from states.
 
     If none are found, returns default.

--- a/tests/components/light/test_group.py
+++ b/tests/components/light/test_group.py
@@ -44,11 +44,6 @@ async def test_state_reporting(hass):
     await hass.async_block_till_done()
     assert hass.states.get('light.group_light').state == 'off'
 
-    hass.states.async_set('light.test1', 'unknown')
-    hass.states.async_set('light.test2', 'unknown')
-    await hass.async_block_till_done()
-    assert hass.states.get('light.group_light').state == 'unknown'
-
     hass.states.async_set('light.test1', 'unavailable')
     hass.states.async_set('light.test2', 'unavailable')
     await hass.async_block_till_done()

--- a/tests/components/light/test_group.py
+++ b/tests/components/light/test_group.py
@@ -1,0 +1,371 @@
+"""The tests for the Group Light platform."""
+from homeassistant.components import light
+from homeassistant.setup import async_setup_component
+
+
+async def test_default_state(hass):
+    """Test light group default state."""
+    await async_setup_component(hass, 'light', {'light': {
+        'platform': 'group', 'entities': [], 'name': 'Bedroom Group'
+    }})
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.bedroom_group')
+    assert state is not None
+    assert state.state == 'unavailable'
+    assert state.attributes['supported_features'] == 0
+    assert state.attributes.get('brightness') is None
+    assert state.attributes.get('rgb_color') is None
+    assert state.attributes.get('xy_color') is None
+    assert state.attributes.get('color_temp') is None
+    assert state.attributes.get('white_value') is None
+    assert state.attributes.get('effect_list') is None
+    assert state.attributes.get('effect') is None
+
+
+async def test_state_reporting(hass):
+    """Test the state reporting."""
+    await async_setup_component(hass, 'light', {'light': {
+        'platform': 'group', 'entities': ['light.test1', 'light.test2']
+    }})
+
+    hass.states.async_set('light.test1', 'on')
+    hass.states.async_set('light.test2', 'unavailable')
+    await hass.async_block_till_done()
+    assert hass.states.get('light.group_light').state == 'on'
+
+    hass.states.async_set('light.test1', 'on')
+    hass.states.async_set('light.test2', 'off')
+    await hass.async_block_till_done()
+    assert hass.states.get('light.group_light').state == 'on'
+
+    hass.states.async_set('light.test1', 'off')
+    hass.states.async_set('light.test2', 'off')
+    await hass.async_block_till_done()
+    assert hass.states.get('light.group_light').state == 'off'
+
+    hass.states.async_set('light.test1', 'unknown')
+    hass.states.async_set('light.test2', 'unknown')
+    await hass.async_block_till_done()
+    assert hass.states.get('light.group_light').state == 'unknown'
+
+    hass.states.async_set('light.test1', 'unavailable')
+    hass.states.async_set('light.test2', 'unavailable')
+    await hass.async_block_till_done()
+    assert hass.states.get('light.group_light').state == 'unavailable'
+
+
+async def test_brightness(hass):
+    """Test brightness reporting."""
+    await async_setup_component(hass, 'light', {'light': {
+        'platform': 'group', 'entities': ['light.test1', 'light.test2']
+    }})
+
+    hass.states.async_set('light.test1', 'on',
+                          {'brightness': 255, 'supported_features': 1})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.state == 'on'
+    assert state.attributes['supported_features'] == 1
+    assert state.attributes['brightness'] == 255
+
+    hass.states.async_set('light.test2', 'on',
+                          {'brightness': 100, 'supported_features': 1})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.state == 'on'
+    assert state.attributes['brightness'] == 177
+
+    hass.states.async_set('light.test1', 'off',
+                          {'brightness': 255, 'supported_features': 1})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.state == 'on'
+    assert state.attributes['supported_features'] == 1
+    assert state.attributes['brightness'] == 100
+
+
+async def test_xy_color(hass):
+    """Test XY reporting."""
+    await async_setup_component(hass, 'light', {'light': {
+        'platform': 'group', 'entities': ['light.test1', 'light.test2']
+    }})
+
+    hass.states.async_set('light.test1', 'on',
+                          {'xy_color': (1.0, 1.0), 'supported_features': 64})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.state == 'on'
+    assert state.attributes['supported_features'] == 64
+    assert state.attributes['xy_color'] == (1.0, 1.0)
+
+    hass.states.async_set('light.test2', 'on',
+                          {'xy_color': (0.5, 0.5), 'supported_features': 64})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.state == 'on'
+    assert state.attributes['xy_color'] == (0.75, 0.75)
+
+    hass.states.async_set('light.test1', 'off',
+                          {'xy_color': (1.0, 1.0), 'supported_features': 64})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.state == 'on'
+    assert state.attributes['xy_color'] == (0.5, 0.5)
+
+
+async def test_rgb_color(hass):
+    """Test RGB reporting."""
+    await async_setup_component(hass, 'light', {'light': {
+        'platform': 'group', 'entities': ['light.test1', 'light.test2']
+    }})
+
+    hass.states.async_set('light.test1', 'on',
+                          {'rgb_color': (255, 0, 0), 'supported_features': 16})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.state == 'on'
+    assert state.attributes['supported_features'] == 16
+    assert state.attributes['rgb_color'] == (255, 0, 0)
+
+    hass.states.async_set('light.test2', 'on',
+                          {'rgb_color': (255, 255, 255),
+                           'supported_features': 16})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['rgb_color'] == (255, 127, 127)
+
+    hass.states.async_set('light.test1', 'off',
+                          {'rgb_color': (255, 0, 0), 'supported_features': 16})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['rgb_color'] == (255, 255, 255)
+
+
+async def test_white_value(hass):
+    """Test white value reporting."""
+    await async_setup_component(hass, 'light', {'light': {
+        'platform': 'group', 'entities': ['light.test1', 'light.test2']
+    }})
+
+    hass.states.async_set('light.test1', 'on',
+                          {'white_value': 255, 'supported_features': 128})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['white_value'] == 255
+
+    hass.states.async_set('light.test2', 'on',
+                          {'white_value': 100, 'supported_features': 128})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['white_value'] == 177
+
+    hass.states.async_set('light.test1', 'off',
+                          {'white_value': 255, 'supported_features': 128})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['white_value'] == 100
+
+
+async def test_color_temp(hass):
+    """Test color temp reporting."""
+    await async_setup_component(hass, 'light', {'light': {
+        'platform': 'group', 'entities': ['light.test1', 'light.test2']
+    }})
+
+    hass.states.async_set('light.test1', 'on',
+                          {'color_temp': 2, 'supported_features': 2})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['color_temp'] == 2
+
+    hass.states.async_set('light.test2', 'on',
+                          {'color_temp': 1000, 'supported_features': 2})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['color_temp'] == 501
+
+    hass.states.async_set('light.test1', 'off',
+                          {'color_temp': 2, 'supported_features': 2})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['color_temp'] == 1000
+
+
+async def test_min_max_mireds(hass):
+    """Test min/max mireds reporting."""
+    await async_setup_component(hass, 'light', {'light': {
+        'platform': 'group', 'entities': ['light.test1', 'light.test2']
+    }})
+
+    hass.states.async_set('light.test1', 'on',
+                          {'min_mireds': 2, 'max_mireds': 5,
+                           'supported_features': 2})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['min_mireds'] == 2
+    assert state.attributes['max_mireds'] == 5
+
+    hass.states.async_set('light.test2', 'on',
+                          {'min_mireds': 7, 'max_mireds': 1234567890,
+                           'supported_features': 2})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['min_mireds'] == 2
+    assert state.attributes['max_mireds'] == 1234567890
+
+    hass.states.async_set('light.test1', 'off',
+                          {'min_mireds': 1, 'max_mireds': 2,
+                           'supported_features': 2})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['min_mireds'] == 1
+    assert state.attributes['max_mireds'] == 1234567890
+
+
+async def test_effect_list(hass):
+    """Test effect_list reporting."""
+    await async_setup_component(hass, 'light', {'light': {
+        'platform': 'group', 'entities': ['light.test1', 'light.test2']
+    }})
+
+    hass.states.async_set('light.test1', 'on',
+                          {'effect_list': ['None', 'Random', 'Colorloop']})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert set(state.attributes['effect_list']) == {
+        'None', 'Random', 'Colorloop'}
+
+    hass.states.async_set('light.test2', 'on',
+                          {'effect_list': ['None', 'Random', 'Rainbow']})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert set(state.attributes['effect_list']) == {
+        'None', 'Random', 'Colorloop', 'Rainbow'}
+
+    hass.states.async_set('light.test1', 'off',
+                          {'effect_list': ['None', 'Colorloop', 'Seven']})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert set(state.attributes['effect_list']) == {
+        'None', 'Random', 'Colorloop', 'Seven', 'Rainbow'}
+
+
+async def test_effect(hass):
+    """Test effect reporting."""
+    await async_setup_component(hass, 'light', {'light': {
+        'platform': 'group', 'entities': ['light.test1', 'light.test2',
+                                          'light.test3']
+    }})
+
+    hass.states.async_set('light.test1', 'on',
+                          {'effect': 'None', 'supported_features': 2})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['effect'] == 'None'
+
+    hass.states.async_set('light.test2', 'on',
+                          {'effect': 'None', 'supported_features': 2})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['effect'] == 'None'
+
+    hass.states.async_set('light.test3', 'on',
+                          {'effect': 'Random', 'supported_features': 2})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['effect'] == 'None'
+
+    hass.states.async_set('light.test1', 'off',
+                          {'effect': 'None', 'supported_features': 2})
+    hass.states.async_set('light.test2', 'off',
+                          {'effect': 'None', 'supported_features': 2})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['effect'] == 'Random'
+
+
+async def test_supported_features(hass):
+    """Test supported features reporting."""
+    await async_setup_component(hass, 'light', {'light': {
+        'platform': 'group', 'entities': ['light.test1', 'light.test2']
+    }})
+
+    hass.states.async_set('light.test1', 'on',
+                          {'supported_features': 0})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['supported_features'] == 0
+
+    hass.states.async_set('light.test2', 'on',
+                          {'supported_features': 2})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['supported_features'] == 2
+
+    hass.states.async_set('light.test1', 'off',
+                          {'supported_features': 41})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['supported_features'] == 43
+
+    hass.states.async_set('light.test2', 'off',
+                          {'supported_features': 256})
+    await hass.async_block_till_done()
+    state = hass.states.get('light.group_light')
+    assert state.attributes['supported_features'] == 41
+
+
+async def test_service_calls(hass):
+    """Test service calls."""
+    await async_setup_component(hass, 'light', {'light': [
+        {'platform': 'demo'},
+        {'platform': 'group', 'entities': ['light.bed_light',
+                                           'light.ceiling_lights',
+                                           'light.kitchen_lights']}
+    ]})
+    await hass.async_block_till_done()
+
+    assert hass.states.get('light.group_light').state == 'on'
+    light.async_toggle(hass, 'light.group_light')
+    await hass.async_block_till_done()
+
+    assert hass.states.get('light.bed_light').state == 'off'
+    assert hass.states.get('light.ceiling_lights').state == 'off'
+    assert hass.states.get('light.kitchen_lights').state == 'off'
+
+    light.async_turn_on(hass, 'light.group_light')
+    await hass.async_block_till_done()
+
+    assert hass.states.get('light.bed_light').state == 'on'
+    assert hass.states.get('light.ceiling_lights').state == 'on'
+    assert hass.states.get('light.kitchen_lights').state == 'on'
+
+    light.async_turn_off(hass, 'light.group_light')
+    await hass.async_block_till_done()
+
+    assert hass.states.get('light.bed_light').state == 'off'
+    assert hass.states.get('light.ceiling_lights').state == 'off'
+    assert hass.states.get('light.kitchen_lights').state == 'off'
+
+    light.async_turn_on(hass, 'light.group_light', brightness=128,
+                        effect='Random', rgb_color=(42, 255, 255))
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.bed_light')
+    assert state.state == 'on'
+    assert state.attributes['brightness'] == 128
+    assert state.attributes['effect'] == 'Random'
+    assert state.attributes['rgb_color'] == (42, 255, 255)
+
+    state = hass.states.get('light.ceiling_lights')
+    assert state.state == 'on'
+    assert state.attributes['brightness'] == 128
+    assert state.attributes['effect'] == 'Random'
+    assert state.attributes['rgb_color'] == (42, 255, 255)
+
+    state = hass.states.get('light.kitchen_lights')
+    assert state.state == 'on'
+    assert state.attributes['brightness'] == 128
+    assert state.attributes['effect'] == 'Random'
+    assert state.attributes['rgb_color'] == (42, 255, 255)


### PR DESCRIPTION
## Description:

Adds supports for grouping several lights into one combined light.

<img width="325" alt="screen shot 2018-02-19 at 22 19 51" src="https://user-images.githubusercontent.com/6833237/36397432-0c693a92-15c3-11e8-86cf-8b573b5cd7fc.png">

For example, in my home, I have 4 RGBW light strips along the upper circumference of the living room and they each appear as their own component in Home Assistant. However, I would like them to appear as the same light in the front end so that I don't have to manually control each of them, or use scripts/template lights with `light.turn_on` and a group. Most platforms, like Philips Hue, can already do this on their own through their own Apps, but for other platforms such as MQTT or if you're mixing platforms this is currently not possible.

In a (pretty old) [discussion in the community forums](https://community.home-assistant.io/t/grouped-light-control/1034/56), @balloob pointed out that this could also be done in the front end. In a nutshell, if the front end encounters a group consisting only of lights, it would display the group as a light. But I would argue that this is not ideal, especially if you're using something like AppDaemon, which would then have to support that too. Additionally, this would also fix some of the issues #11548 tries to fix.

As for the `GroupedLight` component/platform itself - it only really tracks the child entities for state changes and (in most cases) reports the state of the first active light encountered. And when a `turn_on`/`turn_off` is received, the command is basically just forwarded to all children.

As said, there are several ways to approach solving this issue, and this is only one of the possible ones. This PR is far from complete (tests, documentation). Please feel free to comment on whether this is the right approach to fix this issue.

(Based off of https://gist.github.com/jjensn/83dd60d96330bbf66e58dfae336187bf)

**Related issue/PR/discussion (if applicable):** andrey-git/home-assistant-custom-ui#5 | https://community.home-assistant.io/t/grouped-light-control/1034/56 | #11548, fixes #12130

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4739

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: group
    name: Cool Light Group
    entities:
      - light.amazing_light
      - light.foobar
      - light.sun
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
