### PR TITLE
Set tahoma cover update interval to default (15)

### DIFF
--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.tahoma/
 """
 import logging
-from datetime import timedelta
 
 from homeassistant.components.cover import CoverDevice
 from homeassistant.components.tahoma import (
@@ -14,8 +13,6 @@ from homeassistant.components.tahoma import (
 DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
-
-SCAN_INTERVAL = timedelta(seconds=60)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):


### PR DESCRIPTION
## Description:
I set this as a measure to reduce requests to the API, but it's not a good solution, and it can be set in the config file manually if needed. To fix the amount of requests there needs to be a big change to this component, but it is possible.

reverts 35f35050ff158b423dc437c66bdea5ebcbabc009

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  platform: tahoma
  scan_interval: 60
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**