### PR TITLE
Return of entity_id in template platforms

### DIFF
--- a/homeassistant/components/binary_sensor/template.py
+++ b/homeassistant/components/binary_sensor/template.py
@@ -41,11 +41,6 @@ SENSOR_SCHEMA = vol.Schema({
         vol.All(cv.time_period, cv.positive_timedelta),
 })
 
-SENSOR_SCHEMA = vol.All(
-    cv.deprecated(ATTR_ENTITY_ID),
-    SENSOR_SCHEMA,
-)
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SENSORS): vol.Schema({cv.slug: SENSOR_SCHEMA}),
 })

--- a/homeassistant/components/cover/template.py
+++ b/homeassistant/components/cover/template.py
@@ -67,11 +67,6 @@ COVER_SCHEMA = vol.Schema({
     vol.Optional(CONF_ENTITY_ID): cv.entity_ids
 })
 
-COVER_SCHEMA = vol.All(
-    cv.deprecated(CONF_ENTITY_ID),
-    COVER_SCHEMA,
-)
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COVERS): vol.Schema({cv.slug: COVER_SCHEMA}),
 })

--- a/homeassistant/components/light/template.py
+++ b/homeassistant/components/light/template.py
@@ -44,11 +44,6 @@ LIGHT_SCHEMA = vol.Schema({
     vol.Optional(CONF_ENTITY_ID): cv.entity_ids
 })
 
-LIGHT_SCHEMA = vol.All(
-    cv.deprecated(CONF_ENTITY_ID),
-    LIGHT_SCHEMA,
-)
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_LIGHTS): vol.Schema({cv.slug: LIGHT_SCHEMA}),
 })

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -31,11 +31,6 @@ SENSOR_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
 })
 
-SENSOR_SCHEMA = vol.All(
-    cv.deprecated(ATTR_ENTITY_ID),
-    SENSOR_SCHEMA,
-)
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SENSORS): vol.Schema({cv.slug: SENSOR_SCHEMA}),
 })

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -38,11 +38,6 @@ SWITCH_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
 })
 
-SWITCH_SCHEMA = vol.All(
-    cv.deprecated(ATTR_ENTITY_ID),
-    SWITCH_SCHEMA,
-)
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SWITCHES): vol.Schema({cv.slug: SWITCH_SCHEMA}),
 })


### PR DESCRIPTION
## Description:

This reverts #11123 because there are too many situations where the automatic entity extraction does not work.

**Related issue (if applicable):** fixes #11863

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4600

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [ ] Tests have been added to verify that the new code works.
