### PR TITLE
Add explicit first-time config for new purge_keep_days default

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -95,6 +95,10 @@ conversation:
 # Enables support for tracking state changes over time
 history:
 
+# Tracked history is kept for 10 days
+recorder:
+  purge_keep_days: 10
+
 # View all events in a logbook
 logbook:
 


### PR DESCRIPTION
## Description:

Add explicit `recorder` configuration to auto-generated configs, avoiding a warning that the default is about to change.

**Related issue (if applicable):** fixes #12238

## Checklist:
  - [X] The code change is tested and works locally.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [ ] Tests have been added to verify that the new code works.
