### PR TITLE
allow wildcards in subscription

### DIFF
--- a/homeassistant/components/device_tracker/mqtt.py
+++ b/homeassistant/components/device_tracker/mqtt.py
@@ -37,7 +37,7 @@ def async_setup_scanner(hass, config, async_see, discovery_info=None):
     def async_tracker_message_received(topic, payload, qos):
         """Handle received MQTT message."""
         for subscription in dev_id_lookup:
-            if mqtt._match_topic(subscription, topic):
+            if mqtt.match_topic(subscription, topic):
                 hass.async_add_job(async_see(
                     dev_id=dev_id_lookup[subscription],
                     location_name=payload))

--- a/homeassistant/components/device_tracker/mqtt.py
+++ b/homeassistant/components/device_tracker/mqtt.py
@@ -37,10 +37,10 @@ def async_setup_scanner(hass, config, async_see, discovery_info=None):
     def async_tracker_message_received(topic, payload, qos):
         """Handle received MQTT message."""
         for subscription in dev_id_lookup:
-            if mqtt._match_topic(subscription, topic):                                                          
-                hass.async_add_job(async_see(         
+            if mqtt._match_topic(subscription, topic):
+                hass.async_add_job(async_see(
                     dev_id=dev_id_lookup[subscription],
-                    location_name=payload)) 
+                    location_name=payload))
 
     for dev_id, topic in devices.items():
         dev_id_lookup[topic] = dev_id

--- a/homeassistant/components/device_tracker/mqtt.py
+++ b/homeassistant/components/device_tracker/mqtt.py
@@ -31,20 +31,14 @@ def async_setup_scanner(hass, config, async_see, discovery_info=None):
     devices = config[CONF_DEVICES]
     qos = config[CONF_QOS]
 
-    dev_id_lookup = {}
-
-    @callback
-    def async_tracker_message_received(topic, payload, qos):
-        """Handle received MQTT message."""
-        for subscription in dev_id_lookup:
-            if mqtt.match_topic(subscription, topic):
-                hass.async_add_job(async_see(
-                    dev_id=dev_id_lookup[subscription],
-                    location_name=payload))
-
     for dev_id, topic in devices.items():
-        dev_id_lookup[topic] = dev_id
+        @callback
+        def async_message_received(topic, payload, qos, dev_id=dev_id):
+            """Handle received MQTT message."""
+            hass.async_add_job(
+                async_see(dev_id=dev_id, location_name=payload))
+
         yield from mqtt.async_subscribe(
-            hass, topic, async_tracker_message_received, qos)
+            hass, topic, async_message_received, qos)
 
     return True

--- a/homeassistant/components/device_tracker/mqtt.py
+++ b/homeassistant/components/device_tracker/mqtt.py
@@ -36,8 +36,11 @@ def async_setup_scanner(hass, config, async_see, discovery_info=None):
     @callback
     def async_tracker_message_received(topic, payload, qos):
         """Handle received MQTT message."""
-        hass.async_add_job(
-            async_see(dev_id=dev_id_lookup[topic], location_name=payload))
+        for subscription in dev_id_lookup:
+            if mqtt._match_topic(subscription, topic):                                                          
+                hass.async_add_job(async_see(         
+                    dev_id=dev_id_lookup[subscription],
+                    location_name=payload)) 
 
     for dev_id, topic in devices.items():
         dev_id_lookup[topic] = dev_id

--- a/homeassistant/components/device_tracker/mqtt_json.py
+++ b/homeassistant/components/device_tracker/mqtt_json.py
@@ -41,32 +41,26 @@ def async_setup_scanner(hass, config, async_see, discovery_info=None):
     devices = config[CONF_DEVICES]
     qos = config[CONF_QOS]
 
-    dev_id_lookup = {}
-
-    @callback
-    def async_tracker_message_received(topic, payload, qos):
-        """Handle received MQTT message."""
-        try:
-            data = GPS_JSON_PAYLOAD_SCHEMA(json.loads(payload))
-        except vol.MultipleInvalid:
-            _LOGGER.error("Skipping update for following data "
-                          "because of missing or malformatted data: %s",
-                          payload)
-            return
-        except ValueError:
-            _LOGGER.error("Error parsing JSON payload: %s", payload)
-            return
-
-        for subscription in dev_id_lookup:
-            if mqtt.match_topic(subscription, topic):
-                kwargs = _parse_see_args(dev_id_lookup[subscription], data)
-                hass.async_add_job(
-                    async_see(**kwargs))
-
     for dev_id, topic in devices.items():
-        dev_id_lookup[topic] = dev_id
+        @callback
+        def async_message_received(topic, payload, qos, dev_id=dev_id):
+            """Handle received MQTT message."""
+            try:
+                data = GPS_JSON_PAYLOAD_SCHEMA(json.loads(payload))
+            except vol.MultipleInvalid:
+                _LOGGER.error("Skipping update for following data "
+                              "because of missing or malformatted data: %s",
+                              payload)
+                return
+            except ValueError:
+                _LOGGER.error("Error parsing JSON payload: %s", payload)
+                return
+
+            kwargs = _parse_see_args(dev_id, data)
+            hass.async_add_job(async_see(**kwargs))
+
         yield from mqtt.async_subscribe(
-            hass, topic, async_tracker_message_received, qos)
+            hass, topic, async_message_received, qos)
 
     return True
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -105,6 +105,27 @@ def valid_discovery_topic(value):
     return valid_subscribe_topic(value, invalid_chars='#+\0/')
 
 
+def match_topic(subscription, topic):
+    """Test if topic matches subscription."""
+    reg_ex_parts = []
+    suffix = ""
+    if subscription.endswith('#'):
+        subscription = subscription[:-2]
+        suffix = "(.*)"
+    sub_parts = subscription.split('/')
+    for sub_part in sub_parts:
+        if sub_part == "+":
+            reg_ex_parts.append(r"([^\/]+)")
+        else:
+            reg_ex_parts.append(re.escape(sub_part))
+
+    reg_ex = "^" + (r'\/'.join(reg_ex_parts)) + suffix + "$"
+
+    reg = re.compile(reg_ex)
+
+    return reg.match(topic) is not None
+
+
 _VALID_QOS_SCHEMA = vol.All(vol.Coerce(int), vol.In([0, 1, 2]))
 
 CLIENT_KEY_AUTH_MSG = 'client_key and client_cert must both be present in ' \
@@ -225,7 +246,7 @@ def async_subscribe(hass, topic, msg_callback, qos=DEFAULT_QOS,
     @callback
     def async_mqtt_topic_subscriber(dp_topic, dp_payload, dp_qos):
         """Match subscribed MQTT topic."""
-        if not _match_topic(topic, dp_topic):
+        if not match_topic(topic, dp_topic):
             return
 
         if encoding is not None:
@@ -640,27 +661,6 @@ def _raise_on_error(result):
 
         raise HomeAssistantError(
             'Error talking to MQTT: {}'.format(mqtt.error_string(result)))
-
-
-def _match_topic(subscription, topic):
-    """Test if topic matches subscription."""
-    reg_ex_parts = []
-    suffix = ""
-    if subscription.endswith('#'):
-        subscription = subscription[:-2]
-        suffix = "(.*)"
-    sub_parts = subscription.split('/')
-    for sub_part in sub_parts:
-        if sub_part == "+":
-            reg_ex_parts.append(r"([^\/]+)")
-        else:
-            reg_ex_parts.append(re.escape(sub_part))
-
-    reg_ex = "^" + (r'\/'.join(reg_ex_parts)) + suffix + "$"
-
-    reg = re.compile(reg_ex)
-
-    return reg.match(topic) is not None
 
 
 class MqttAvailability(Entity):

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -126,7 +126,7 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
         })
         fire_mqtt_message(self.hass, topic, location)
         self.hass.block_till_done()
-        self.assertNotEqual(location, self.hass.states.get(entity_id).state)
+        self.assertIsNone(self.hass.states.get(entity_id))
 
     def test_multi_level_wildcard_topic_not_matching(self):
         """Test not matching multi level wildcard topic."""
@@ -145,4 +145,4 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
         })
         fire_mqtt_message(self.hass, topic, location)
         self.hass.block_till_done()
-        self.assertNotEqual(location, self.hass.states.get(entity_id).state)
+        self.assertIsNone(self.hass.states.get(entity_id))

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -108,3 +108,41 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
         fire_mqtt_message(self.hass, topic, location)
         self.hass.block_till_done()
         self.assertEqual(location, self.hass.states.get(entity_id).state)
+
+    def test_single_level_wildcard_topic_not_matching(self):
+        """Test not matching single level wildcard topic."""
+        dev_id = 'paulus'
+        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
+        subscription = '/location/+/paulus'
+        topic = '/location/paulus'
+        location = 'work'
+
+        self.hass.config.components = set(['mqtt', 'zone'])
+        assert setup_component(self.hass, device_tracker.DOMAIN, {
+            device_tracker.DOMAIN: {
+                CONF_PLATFORM: 'mqtt',
+                'devices': {dev_id: subscription}
+            }
+        })
+        fire_mqtt_message(self.hass, topic, location)
+        self.hass.block_till_done()
+        self.assertNotEqual(location, self.hass.states.get(entity_id).state)
+
+    def test_multi_level_wildcard_topic_not_matching(self):
+        """Test not matching multi level wildcard topic."""
+        dev_id = 'paulus'
+        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
+        subscription = '/location/#'
+        topic = '/somewhere/room/paulus'
+        location = 'work'
+
+        self.hass.config.components = set(['mqtt', 'zone'])
+        assert setup_component(self.hass, device_tracker.DOMAIN, {
+            device_tracker.DOMAIN: {
+                CONF_PLATFORM: 'mqtt',
+                'devices': {dev_id: subscription}
+            }
+        })
+        fire_mqtt_message(self.hass, topic, location)
+        self.hass.block_till_done()
+        self.assertNotEqual(location, self.hass.states.get(entity_id).state)

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -70,3 +70,41 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
         fire_mqtt_message(self.hass, topic, location)
         self.hass.block_till_done()
         self.assertEqual(location, self.hass.states.get(entity_id).state)
+
+    def test_single_level_wildcard_topic(self):
+        """Test single level wildcard topic."""
+        dev_id = 'paulus'
+        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
+        subscription = '/location/+/paulus'
+        topic = '/location/room/paulus'
+        location = 'work'
+
+        self.hass.config.components = set(['mqtt', 'zone'])
+        assert setup_component(self.hass, device_tracker.DOMAIN, {
+            device_tracker.DOMAIN: {
+                CONF_PLATFORM: 'mqtt',
+                'devices': {dev_id: subscription}
+            }
+        })
+        fire_mqtt_message(self.hass, topic, location)
+        self.hass.block_till_done()
+        self.assertEqual(location, self.hass.states.get(entity_id).state)
+
+    def test_multi_level_wildcard_topic(self):
+        """Test multi level wildcard topic."""
+        dev_id = 'paulus'
+        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
+        subscription = '/location/#'
+        topic = '/location/room/paulus'
+        location = 'work'
+
+        self.hass.config.components = set(['mqtt', 'zone'])
+        assert setup_component(self.hass, device_tracker.DOMAIN, {
+            device_tracker.DOMAIN: {
+                CONF_PLATFORM: 'mqtt',
+                'devices': {dev_id: subscription}
+            }
+        })
+        fire_mqtt_message(self.hass, topic, location)
+        self.hass.block_till_done()
+        self.assertEqual(location, self.hass.states.get(entity_id).state)

--- a/tests/components/device_tracker/test_mqtt_json.py
+++ b/tests/components/device_tracker/test_mqtt_json.py
@@ -123,3 +123,41 @@ class TestComponentsDeviceTrackerJSONMQTT(unittest.TestCase):
                 "Skipping update for following data because of missing "
                 "or malformatted data: {\"longitude\": 2.0}",
                 test_handle.output[0])
+
+    def test_single_level_wildcard_topic(self):
+        """Test single level wildcard topic."""
+        dev_id = 'zanzito'
+        subscription = 'location/+/zanzito'
+        topic = 'location/room/zanzito'
+        location = json.dumps(LOCATION_MESSAGE)
+
+        assert setup_component(self.hass, device_tracker.DOMAIN, {
+            device_tracker.DOMAIN: {
+                CONF_PLATFORM: 'mqtt_json',
+                'devices': {dev_id: subscription}
+            }
+        })
+        fire_mqtt_message(self.hass, topic, location)
+        self.hass.block_till_done()
+        state = self.hass.states.get('device_tracker.zanzito')
+        self.assertEqual(state.attributes.get('latitude'), 2.0)
+        self.assertEqual(state.attributes.get('longitude'), 1.0)
+
+    def test_multi_level_wildcard_topic(self):
+        """Test multi level wildcard topic."""
+        dev_id = 'zanzito'
+        subscription = 'location/#'
+        topic = 'location/zanzito'
+        location = json.dumps(LOCATION_MESSAGE)
+
+        assert setup_component(self.hass, device_tracker.DOMAIN, {
+            device_tracker.DOMAIN: {
+                CONF_PLATFORM: 'mqtt_json',
+                'devices': {dev_id: subscription}
+            }
+        })
+        fire_mqtt_message(self.hass, topic, location)
+        self.hass.block_till_done()
+        state = self.hass.states.get('device_tracker.zanzito')
+        self.assertEqual(state.attributes.get('latitude'), 2.0)
+        self.assertEqual(state.attributes.get('longitude'), 1.0)

--- a/tests/components/device_tracker/test_mqtt_json.py
+++ b/tests/components/device_tracker/test_mqtt_json.py
@@ -165,6 +165,7 @@ class TestComponentsDeviceTrackerJSONMQTT(unittest.TestCase):
     def test_single_level_wildcard_topic_not_matching(self):
         """Test not matching single level wildcard topic."""
         dev_id = 'zanzito'
+        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
         subscription = 'location/+/zanzito'
         topic = 'location/zanzito'
         location = json.dumps(LOCATION_MESSAGE)
@@ -177,13 +178,12 @@ class TestComponentsDeviceTrackerJSONMQTT(unittest.TestCase):
         })
         fire_mqtt_message(self.hass, topic, location)
         self.hass.block_till_done()
-        state = self.hass.states.get('device_tracker.zanzito')
-        self.assertNotEqual(state.attributes.get('latitude'), 2.0)
-        self.assertNotEqual(state.attributes.get('longitude'), 1.0)
+        self.assertIsNone(self.hass.states.get(entity_id))
 
     def test_multi_level_wildcard_topic_not_matching(self):
         """Test not matching multi level wildcard topic."""
         dev_id = 'zanzito'
+        entity_id = device_tracker.ENTITY_ID_FORMAT.format(dev_id)
         subscription = 'location/#'
         topic = 'somewhere/zanzito'
         location = json.dumps(LOCATION_MESSAGE)
@@ -196,6 +196,4 @@ class TestComponentsDeviceTrackerJSONMQTT(unittest.TestCase):
         })
         fire_mqtt_message(self.hass, topic, location)
         self.hass.block_till_done()
-        state = self.hass.states.get('device_tracker.zanzito')
-        self.assertNotEqual(state.attributes.get('latitude'), 2.0)
-        self.assertNotEqual(state.attributes.get('longitude'), 1.0)
+        self.assertIsNone(self.hass.states.get(entity_id))

--- a/tests/components/device_tracker/test_mqtt_json.py
+++ b/tests/components/device_tracker/test_mqtt_json.py
@@ -161,3 +161,41 @@ class TestComponentsDeviceTrackerJSONMQTT(unittest.TestCase):
         state = self.hass.states.get('device_tracker.zanzito')
         self.assertEqual(state.attributes.get('latitude'), 2.0)
         self.assertEqual(state.attributes.get('longitude'), 1.0)
+
+    def test_single_level_wildcard_topic_not_matching(self):
+        """Test not matching single level wildcard topic."""
+        dev_id = 'zanzito'
+        subscription = 'location/+/zanzito'
+        topic = 'location/zanzito'
+        location = json.dumps(LOCATION_MESSAGE)
+
+        assert setup_component(self.hass, device_tracker.DOMAIN, {
+            device_tracker.DOMAIN: {
+                CONF_PLATFORM: 'mqtt_json',
+                'devices': {dev_id: subscription}
+            }
+        })
+        fire_mqtt_message(self.hass, topic, location)
+        self.hass.block_till_done()
+        state = self.hass.states.get('device_tracker.zanzito')
+        self.assertNotEqual(state.attributes.get('latitude'), 2.0)
+        self.assertNotEqual(state.attributes.get('longitude'), 1.0)
+
+    def test_multi_level_wildcard_topic_not_matching(self):
+        """Test not matching multi level wildcard topic."""
+        dev_id = 'zanzito'
+        subscription = 'location/#'
+        topic = 'somewhere/zanzito'
+        location = json.dumps(LOCATION_MESSAGE)
+
+        assert setup_component(self.hass, device_tracker.DOMAIN, {
+            device_tracker.DOMAIN: {
+                CONF_PLATFORM: 'mqtt_json',
+                'devices': {dev_id: subscription}
+            }
+        })
+        fire_mqtt_message(self.hass, topic, location)
+        self.hass.block_till_done()
+        state = self.hass.states.get('device_tracker.zanzito')
+        self.assertNotEqual(state.attributes.get('latitude'), 2.0)
+        self.assertNotEqual(state.attributes.get('longitude'), 1.0)


### PR DESCRIPTION
## Description:
Currently it's possible to use a subscription topic with wildcards but an error is thrown when received because it's not equals the received topic. This PR adds the missing match to the subscription topic.

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: mqtt
    devices:
      device1: 'home/+/BLE_11:22:33:44:55:66'
      device2: 'home/+/BLE_22:33:44:55:66:77'
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54