### PR TITLE
Removed default sensor configuration

### DIFF
--- a/homeassistant/components/sensor/alpha_vantage.py
+++ b/homeassistant/components/sensor/alpha_vantage.py
@@ -73,8 +73,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     symbols = config.get(CONF_SYMBOLS)
     conversions = config.get(CONF_FOREIGN_EXCHANGE)
 
-    if (symbols is None or len(symbols) == 0) and \
-            (conversions is None or len(conversions) == 0):
+    if not symbols and not conversions:
         msg = 'Warning: No symbols or currencies configured.'
         hass.components.persistent_notification.create(
             msg, 'Sensor alpha_vantage')

--- a/homeassistant/components/sensor/alpha_vantage.py
+++ b/homeassistant/components/sensor/alpha_vantage.py
@@ -37,7 +37,7 @@ ICONS = {
     'GBP': 'mdi:currency-gbp',
     'INR': 'mdi:currency-inr',
     'RUB': 'mdi:currency-rub',
-    'TRY': 'mdi: currency-try',
+    'TRY': 'mdi:currency-try',
     'USD': 'mdi:currency-usd',
 }
 


### PR DESCRIPTION
## Description:
As described in #12165, the sensor alpha vantage by default configures some smybols. This is removed now, instead a persistent_notification is shown if not symbols and no currencies are configured.

**Related issue (if applicable):** fixes #12165

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/4618

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: alpha_vantage
    api_key: <your API key>
    # do not configure anything here to see the new persistent_notification
```

## Checklist:
  - [x] The code change is tested and works locally.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
