### PR TITLE
Add Service Schema to Broadlink Switch

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -144,7 +144,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         hass.services.register(DOMAIN, SERVICE_LEARN + '_' +
                                ip_addr.replace('.', '_'), _learn_command)
         hass.services.register(DOMAIN, SERVICE_SEND + '_' +
-                               ip_addr.replace('.', '_'), _send_packet)
+                               ip_addr.replace('.', '_'), _send_packet,
+					           vol.Schema({ 'packet': cv.ensure_list }))
         switches = []
         for object_id, device_config in devices.items():
             switches.append(

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -145,7 +145,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                ip_addr.replace('.', '_'), _learn_command)
         hass.services.register(DOMAIN, SERVICE_SEND + '_' +
                                ip_addr.replace('.', '_'), _send_packet,
-					           vol.Schema({ 'packet': cv.ensure_list }))
+                               vol.Schema({'packet': cv.ensure_list}))
         switches = []
         for object_id, device_config in devices.items():
             switches.append(


### PR DESCRIPTION
## Description:

This adds a service schema for the broadlink switch to ensure its inputs are always wrapped in a list.

This is especially helpful in that it lets you use a `data_template` when using the `broadlink_send_packet` service, which requires a list. You can just return a string, and it will get wrapped into a list by the component.

Co-Authored-By: @balloob 
