### PR TITLE
One bug fix and one improvement to the statistics sensor.

### DIFF
--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -111,8 +111,7 @@ class StatisticsSensor(Entity):
         try:
             self.states.append(float(new_state.state))
             if self._max_age is not None:
-                now = dt_util.utcnow()
-                self.ages.append(now)
+                self.ages.append(new_state.last_updated)
             self.count = self.count + 1
         except ValueError:
             self.count = self.count + 1


### PR DESCRIPTION
The bug fix is that the sensor actually uses the age from the recorder
when loading values from the recorder. Previous code used now as the
age of the sample

The improvement is that it exposes the min / max age of the values over
which the statistics is kept. I'm using this to later in a template
sensor calculate rate of change and other derived statistics.

  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**