### PR TITLE
device_tracker.asuswrt: Clean up unused connection param

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -118,11 +118,10 @@ class AsusWrtDeviceScanner(DeviceScanner):
         if self.protocol == 'ssh':
             self.connection = SshConnection(
                 self.host, self.port, self.username, self.password,
-                self.ssh_key, self.mode == 'ap')
+                self.ssh_key)
         else:
             self.connection = TelnetConnection(
-                self.host, self.port, self.username, self.password,
-                self.mode == 'ap')
+                self.host, self.port, self.username, self.password)
 
         self.last_results = {}
 
@@ -253,7 +252,7 @@ class _Connection:
 class SshConnection(_Connection):
     """Maintains an SSH connection to an ASUS-WRT router."""
 
-    def __init__(self, host, port, username, password, ssh_key, ap):
+    def __init__(self, host, port, username, password, ssh_key):
         """Initialize the SSH connection properties."""
         super().__init__()
 
@@ -263,7 +262,6 @@ class SshConnection(_Connection):
         self._username = username
         self._password = password
         self._ssh_key = ssh_key
-        self._ap = ap
 
     def run_command(self, command):
         """Run commands through an SSH connection.
@@ -323,7 +321,7 @@ class SshConnection(_Connection):
 class TelnetConnection(_Connection):
     """Maintains a Telnet connection to an ASUS-WRT router."""
 
-    def __init__(self, host, port, username, password, ap):
+    def __init__(self, host, port, username, password):
         """Initialize the Telnet connection properties."""
         super().__init__()
 
@@ -332,7 +330,6 @@ class TelnetConnection(_Connection):
         self._port = port
         self._username = username
         self._password = password
-        self._ap = ap
         self._prompt_string = None
 
     def run_command(self, command):

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -473,7 +473,7 @@ class TestSshConnection(unittest.TestCase):
     def setUp(self):
         """Setup test env."""
         self.connection = SshConnection(
-            'fake', 'fake', 'fake', 'fake', 'fake', 'fake')
+            'fake', 'fake', 'fake', 'fake', 'fake')
         self.connection._connected = True
 
     def test_run_command_exception_eof(self):
@@ -513,7 +513,7 @@ class TestTelnetConnection(unittest.TestCase):
     def setUp(self):
         """Setup test env."""
         self.connection = TelnetConnection(
-            'fake', 'fake', 'fake', 'fake', 'fake')
+            'fake', 'fake', 'fake', 'fake')
         self.connection._connected = True
 
     def test_run_command_exception_eof(self):


### PR DESCRIPTION
## Description:
This removes the `ap` parameter for the SshConnection and TelnetConnection class methods. This parameter is used to assign the `_ap` attribute as a boolean, which is never used. (The `ap` configuration parameter check uses the `mode` attribute of AsusWrtDeviceScanner).

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**