### PR TITLE
Fix some rfxtrx devices with multiple sensors

### DIFF
--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -71,14 +71,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         if device_id in rfxtrx.RFX_DEVICES:
             sensors = rfxtrx.RFX_DEVICES[device_id]
-            for key in sensors:
-                sensor = sensors[key]
+            for data_type in sensors:
+                if data_type not in event.values:
+                    continue
+                sensor = sensors[data_type]
                 sensor.event = event
                 # Fire event
-                if sensors[key].should_fire_event:
+                if sensor.should_fire_event:
                     sensor.hass.bus.fire(
                         "signal_received", {
-                            ATTR_ENTITY_ID: sensors[key].entity_id,
+                            ATTR_ENTITY_ID: sensor.entity_id,
                         }
                     )
             return

--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -72,6 +72,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if device_id in rfxtrx.RFX_DEVICES:
             sensors = rfxtrx.RFX_DEVICES[device_id]
             for data_type in sensors:
+                # Some multi-sensor devices send individual messages for each
+                # of their sensors. Update only if event contains the
+                # right data_type for the sensor.
                 if data_type not in event.values:
                     continue
                 sensor = sensors[data_type]


### PR DESCRIPTION
Some combined temperature/humidity sensors send one packet for each of
their sensors. Without this fix one of the home assistant sensors would
always display an unknown value.