### PR TITLE
Force LF line endings for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 # Ensure Docker script files uses LF to support Docker for Windows.
-setup_docker_prereqs    eol=lf
-/virtualization/Docker/scripts/*    eol=lf
+# Ensure "git config --global core.autocrlf input" before you clone
+setup_docker_prereqs                text eol=lf
+/virtualization/Docker/scripts/*    text eol=lf
+/script/*                           text eol=lf
+*.sh                                text eol=lf
+*.py                                text eol=lf whitespace=error

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,9 @@
 # Ensure Docker script files uses LF to support Docker for Windows.
 # Ensure "git config --global core.autocrlf input" before you clone
-setup_docker_prereqs                text eol=lf
-/virtualization/Docker/scripts/*    text eol=lf
-/script/*                           text eol=lf
-*.sh                                text eol=lf
-*.py                                text eol=lf whitespace=error
+*     text eol=lf
+*.py  whitespace=error
+
+*.ico binary
+*.jpg binary
+*.png binary
+*.zip binary


### PR DESCRIPTION
## Description:
Closer to a working Docker dev environment on Windows... Ensure no CRLFs in the scripts & force LF on most files

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
