### PR TITLE
Purge recorder data by default

### DIFF
--- a/homeassistant/components/recorder/services.yaml
+++ b/homeassistant/components/recorder/services.yaml
@@ -6,3 +6,6 @@ purge:
     keep_days:
       description: Number of history days to keep in database after purge. Value >= 0.
       example: 2
+    repack:
+      description: Attempt to save disk space by rewriting the entire database file.
+      example: true

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -95,10 +95,6 @@ conversation:
 # Enables support for tracking state changes over time
 history:
 
-# Tracked history is kept for 10 days
-recorder:
-  purge_keep_days: 10
-
 # View all events in a logbook
 logbook:
 


### PR DESCRIPTION
## Breaking change note:

Home Assistant now defaults to purge recorded history that is older than 10 days. If you want to keep your recorded data for longer than that, you must configure the number of days to retain _before starting 0.64 for the first time_, for example:
```yaml
recorder:
  purge_keep_days: 30
```

If you want to keep the previous default of never deleting history, use this configuration:
```yaml
recorder:
  purge_interval: 0
```

## Description:

This is step 2 of the [plan to purge recorder data by default](https://github.com/home-assistant/home-assistant/pull/11903#issuecomment-360892485). Step 1 was merged in #11976 with tweaks in #12220 and #12246.

The PR enables purge every ten days by default. This means that we can remove the explicit configuration from generated config that was introduced in 0.63.

The pre-0.64 behavior can be restored with this configuration:
```yaml
recorder:
  purge_interval: 0
```

This can also be used to run the purging at predictable times, like at night:
```yaml
recorder:
  purge_interval: 0

automation:
  - alias: "Purge database"
    trigger:
      platform: time
      at: '04:00:00'
    action:
      - service: recorder.purge
```

We always have a `purge_keep_days` value now so `recorder.purge` will default to using that.

Also, the `recorder.purge` service now supports an optional `repack` parameter that will do a vacuum for SQLite. I picked "repack" rather than "vacuum" or "optimize" (as it is called in MySQL) to get a generic word that does not sound too positive (because repacking can be pointless or even bad).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4643

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [X] Tests have been added to verify that the new code works.
