### PR TITLE
Upgrade pylint to 1.8.2

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -35,13 +35,13 @@ FIRST_INIT_COMPONENT = set((
 
 
 def from_config_dict(config: Dict[str, Any],
-                     hass: Optional[core.HomeAssistant]=None,
-                     config_dir: Optional[str]=None,
-                     enable_log: bool=True,
-                     verbose: bool=False,
-                     skip_pip: bool=False,
-                     log_rotate_days: Any=None,
-                     log_file: Any=None) \
+                     hass: Optional[core.HomeAssistant] = None,
+                     config_dir: Optional[str] = None,
+                     enable_log: bool = True,
+                     verbose: bool = False,
+                     skip_pip: bool = False,
+                     log_rotate_days: Any = None,
+                     log_file: Any = None) \
                      -> Optional[core.HomeAssistant]:
     """Try to configure Home Assistant from a configuration dictionary.
 
@@ -68,12 +68,12 @@ def from_config_dict(config: Dict[str, Any],
 @asyncio.coroutine
 def async_from_config_dict(config: Dict[str, Any],
                            hass: core.HomeAssistant,
-                           config_dir: Optional[str]=None,
-                           enable_log: bool=True,
-                           verbose: bool=False,
-                           skip_pip: bool=False,
-                           log_rotate_days: Any=None,
-                           log_file: Any=None) \
+                           config_dir: Optional[str] = None,
+                           enable_log: bool = True,
+                           verbose: bool = False,
+                           skip_pip: bool = False,
+                           log_rotate_days: Any = None,
+                           log_file: Any = None) \
                            -> Optional[core.HomeAssistant]:
     """Try to configure Home Assistant from a configuration dictionary.
 
@@ -163,11 +163,11 @@ def async_from_config_dict(config: Dict[str, Any],
 
 
 def from_config_file(config_path: str,
-                     hass: Optional[core.HomeAssistant]=None,
-                     verbose: bool=False,
-                     skip_pip: bool=True,
-                     log_rotate_days: Any=None,
-                     log_file: Any=None):
+                     hass: Optional[core.HomeAssistant] = None,
+                     verbose: bool = False,
+                     skip_pip: bool = True,
+                     log_rotate_days: Any = None,
+                     log_file: Any = None):
     """Read the configuration file and try to start all the functionality.
 
     Will add functionality to 'hass' parameter if given,
@@ -188,10 +188,10 @@ def from_config_file(config_path: str,
 @asyncio.coroutine
 def async_from_config_file(config_path: str,
                            hass: core.HomeAssistant,
-                           verbose: bool=False,
-                           skip_pip: bool=True,
-                           log_rotate_days: Any=None,
-                           log_file: Any=None):
+                           verbose: bool = False,
+                           skip_pip: bool = True,
+                           log_rotate_days: Any = None,
+                           log_file: Any = None):
     """Read the configuration file and try to start all the functionality.
 
     Will add functionality to 'hass' parameter.
@@ -219,7 +219,7 @@ def async_from_config_file(config_path: str,
 
 
 @core.callback
-def async_enable_logging(hass: core.HomeAssistant, verbose: bool=False,
+def async_enable_logging(hass: core.HomeAssistant, verbose: bool = False,
                          log_rotate_days=None, log_file=None) -> None:
     """Set up the logging.
 

--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/abode/
 import asyncio
 import logging
 from functools import partial
+from requests.exceptions import HTTPError, ConnectTimeout
 
 import voluptuous as vol
 
@@ -17,7 +18,6 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
-from requests.exceptions import HTTPError, ConnectTimeout
 
 REQUIREMENTS = ['abodepy==0.12.2']
 

--- a/homeassistant/components/alarm_control_panel/canary.py
+++ b/homeassistant/components/alarm_control_panel/canary.py
@@ -59,8 +59,7 @@ class CanaryAlarm(AlarmControlPanel):
             return STATE_ALARM_ARMED_HOME
         elif mode.name == LOCATION_MODE_NIGHT:
             return STATE_ALARM_ARMED_NIGHT
-        else:
-            return None
+        return None
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -172,9 +172,8 @@ class ManualAlarm(alarm.AlarmControlPanel):
                     trigger_time) < dt_util.utcnow():
                 if self._disarm_after_trigger:
                     return STATE_ALARM_DISARMED
-                else:
-                    self._state = self._previous_state
-                    return self._state
+                self._state = self._previous_state
+                return self._state
 
         if self._state in SUPPORTED_PENDING_STATES and \
                 self._within_pending_time(self._state):
@@ -187,8 +186,7 @@ class ManualAlarm(alarm.AlarmControlPanel):
         """Get the current state."""
         if self.state == STATE_ALARM_PENDING:
             return self._previous_state
-        else:
-            return self._state
+        return self._state
 
     def _pending_time(self, state):
         """Get the pending time."""

--- a/homeassistant/components/alarm_control_panel/manual_mqtt.py
+++ b/homeassistant/components/alarm_control_panel/manual_mqtt.py
@@ -208,9 +208,8 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
                     trigger_time) < dt_util.utcnow():
                 if self._disarm_after_trigger:
                     return STATE_ALARM_DISARMED
-                else:
-                    self._state = self._previous_state
-                    return self._state
+                self._state = self._previous_state
+                return self._state
 
         if self._state in SUPPORTED_PENDING_STATES and \
                 self._within_pending_time(self._state):
@@ -223,8 +222,7 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
         """Get the current state."""
         if self.state == STATE_ALARM_PENDING:
             return self._previous_state
-        else:
-            return self._state
+        return self._state
 
     def _pending_time(self, state):
         """Get the pending time."""

--- a/homeassistant/components/binary_sensor/envisalink.py
+++ b/homeassistant/components/binary_sensor/envisalink.py
@@ -50,7 +50,7 @@ class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorDevice):
         self._zone_type = zone_type
         self._zone_number = zone_number
 
-        _LOGGER.debug('Setting up zone: ' + zone_name)
+        _LOGGER.debug('Setting up zone: %s', zone_name)
         super().__init__(zone_name, info, controller)
 
     @asyncio.coroutine

--- a/homeassistant/components/binary_sensor/ihc.py
+++ b/homeassistant/components/binary_sensor/ihc.py
@@ -70,7 +70,7 @@ class IHCBinarySensor(IHCDevice, BinarySensorDevice):
 
     def __init__(self, ihc_controller, name, ihc_id: int, info: bool,
                  sensor_type: str, inverting: bool,
-                 product: Element=None) -> None:
+                 product: Element = None) -> None:
         """Initialize the IHC binary sensor."""
         super().__init__(ihc_controller, name, ihc_id, info, product)
         self._state = None

--- a/homeassistant/components/calendar/todoist.py
+++ b/homeassistant/components/calendar/todoist.py
@@ -498,7 +498,7 @@ class TodoistProjectData(object):
 
         # Organize the best tasks (so users can see all the tasks
         # they have, organized)
-        while len(project_tasks) > 0:
+        while project_tasks:
             best_task = self.select_best_task(project_tasks)
             _LOGGER.debug("Found Todoist Task: %s", best_task[SUMMARY])
             project_tasks.remove(best_task)

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -119,6 +119,8 @@ class MjpegCamera(Camera):
         else:
             req = requests.get(self._mjpeg_url, stream=True, timeout=10)
 
+        # https://github.com/PyCQA/pylint/issues/1437
+        # pylint: disable=no-member
         with closing(req) as response:
             return extract_image_from_mjpeg(response.iter_content(102400))
 

--- a/homeassistant/components/camera/uvc.py
+++ b/homeassistant/components/camera/uvc.py
@@ -188,7 +188,7 @@ class UnifiVideoCamera(Camera):
             self._nvr.set_recordmode(self._uuid, set_mode)
             self._motion_status = mode
         except NvrError as err:
-            _LOGGER.error("Unable to set recordmode to " + set_mode)
+            _LOGGER.error("Unable to set recordmode to %s", set_mode)
             _LOGGER.debug(err)
 
     def enable_motion_detection(self):

--- a/homeassistant/components/camera/xeoma.py
+++ b/homeassistant/components/camera/xeoma.py
@@ -42,7 +42,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 @asyncio.coroutine
-# pylint: disable=unused-argument
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Discover and setup Xeoma Cameras."""
     from pyxeoma.xeoma import Xeoma, XeomaError
@@ -69,6 +68,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         ]
 
         for cam in config[CONF_CAMERAS]:
+            # https://github.com/PyCQA/pylint/issues/1830
+            # pylint: disable=stop-iteration-return
             camera = next(
                 (dc for dc in discovered_cameras
                  if dc[CONF_IMAGE_NAME] == cam[CONF_IMAGE_NAME]), None)

--- a/homeassistant/components/camera/xeoma.py
+++ b/homeassistant/components/camera/xeoma.py
@@ -69,7 +69,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
         for cam in config[CONF_CAMERAS]:
             # https://github.com/PyCQA/pylint/issues/1830
-            # pylint: disable=bad-option-value,stop-iteration-return
+            # pylint: disable=stop-iteration-return
             camera = next(
                 (dc for dc in discovered_cameras
                  if dc[CONF_IMAGE_NAME] == cam[CONF_IMAGE_NAME]), None)

--- a/homeassistant/components/camera/xeoma.py
+++ b/homeassistant/components/camera/xeoma.py
@@ -69,7 +69,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
         for cam in config[CONF_CAMERAS]:
             # https://github.com/PyCQA/pylint/issues/1830
-            # pylint: disable=stop-iteration-return
+            # pylint: disable=bad-option-value,stop-iteration-return
             camera = next(
                 (dc for dc in discovered_cameras
                  if dc[CONF_IMAGE_NAME] == cam[CONF_IMAGE_NAME]), None)

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -669,16 +669,16 @@ class ClimateDevice(Entity):
         """
         return self.hass.async_add_job(self.set_humidity, humidity)
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
         raise NotImplementedError()
 
-    def async_set_fan_mode(self, fan):
+    def async_set_fan_mode(self, fan_mode):
         """Set new target fan mode.
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.async_add_job(self.set_fan_mode, fan)
+        return self.hass.async_add_job(self.set_fan_mode, fan_mode)
 
     def set_operation_mode(self, operation_mode):
         """Set new target operation mode."""

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -236,9 +236,9 @@ class DaikinClimate(ClimateDevice):
         """Return the fan setting."""
         return self.get(ATTR_FAN_MODE)
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """Set fan mode."""
-        self.set({ATTR_FAN_MODE: fan})
+        self.set({ATTR_FAN_MODE: fan_mode})
 
     @property
     def fan_list(self):

--- a/homeassistant/components/climate/demo.py
+++ b/homeassistant/components/climate/demo.py
@@ -195,9 +195,9 @@ class DemoClimate(ClimateDevice):
         self._current_swing_mode = swing_mode
         self.schedule_update_ha_state()
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """Set new target temperature."""
-        self._current_fan_mode = fan
+        self._current_fan_mode = fan_mode
         self.schedule_update_ha_state()
 
     def set_operation_mode(self, operation_mode):
@@ -225,9 +225,9 @@ class DemoClimate(ClimateDevice):
         self._away = False
         self.schedule_update_ha_state()
 
-    def set_hold_mode(self, hold):
-        """Update hold mode on."""
-        self._hold = hold
+    def set_hold_mode(self, hold_mode):
+        """Update hold_mode on."""
+        self._hold = hold_mode
         self.schedule_update_ha_state()
 
     def turn_aux_heat_on(self):

--- a/homeassistant/components/climate/ephember.py
+++ b/homeassistant/components/climate/ephember.py
@@ -98,8 +98,7 @@ class EphEmberThermostat(ClimateDevice):
         """Return current operation ie. heat, cool, idle."""
         if self._zone['isCurrentlyActive']:
             return STATE_HEAT
-        else:
-            return STATE_IDLE
+        return STATE_IDLE
 
     @property
     def is_aux_heat_on(self):

--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -53,7 +53,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(devices)
 
 
-# pylint: disable=import-error
+# pylint: disable=import-error, no-name-in-module
 class EQ3BTSmartThermostat(ClimateDevice):
     """Representation of an eQ-3 Bluetooth Smart thermostat."""
 

--- a/homeassistant/components/climate/flexit.py
+++ b/homeassistant/components/climate/flexit.py
@@ -152,6 +152,6 @@ class Flexit(ClimateDevice):
             self._target_temperature = kwargs.get(ATTR_TEMPERATURE)
         self.unit.set_temp(self._target_temperature)
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """Set new fan mode."""
-        self.unit.set_fan_speed(self._fan_list.index(fan))
+        self.unit.set_fan_speed(self._fan_list.index(fan_mode))

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -190,11 +190,9 @@ class GenericThermostat(ClimateDevice):
         """Return the current state."""
         if self._is_device_active:
             return self.current_operation
-        else:
-            if self._enabled:
-                return STATE_IDLE
-            else:
-                return STATE_OFF
+        if self._enabled:
+            return STATE_IDLE
+        return STATE_OFF
 
     @property
     def should_poll(self):

--- a/homeassistant/components/climate/melissa.py
+++ b/homeassistant/components/climate/melissa.py
@@ -174,8 +174,7 @@ class MelissaClimate(ClimateDevice):
         if not self._api.send(self._serial_number, self._cur_settings):
             self._cur_settings = old_value
             return False
-        else:
-            return True
+        return True
 
     def update(self):
         """Get latest data from Melissa."""
@@ -196,8 +195,7 @@ class MelissaClimate(ClimateDevice):
             return STATE_OFF
         elif state == self._api.STATE_IDLE:
             return STATE_IDLE
-        else:
-            return None
+        return None
 
     def melissa_op_to_hass(self, mode):
         """Translate Melissa modes to hass states."""
@@ -211,10 +209,9 @@ class MelissaClimate(ClimateDevice):
             return STATE_DRY
         elif mode == self._api.MODE_FAN:
             return STATE_FAN_ONLY
-        else:
-            _LOGGER.warning(
-                "Operation mode %s could not be mapped to hass", mode)
-            return None
+        _LOGGER.warning(
+            "Operation mode %s could not be mapped to hass", mode)
+        return None
 
     def melissa_fan_to_hass(self, fan):
         """Translate Melissa fan modes to hass modes."""
@@ -226,9 +223,8 @@ class MelissaClimate(ClimateDevice):
             return SPEED_MEDIUM
         elif fan == self._api.FAN_HIGH:
             return SPEED_HIGH
-        else:
-            _LOGGER.warning("Fan mode %s could not be mapped to hass", fan)
-            return None
+        _LOGGER.warning("Fan mode %s could not be mapped to hass", fan)
+        return None
 
     def hass_mode_to_melissa(self, mode):
         """Translate hass states to melissa modes."""

--- a/homeassistant/components/climate/melissa.py
+++ b/homeassistant/components/climate/melissa.py
@@ -146,10 +146,10 @@ class MelissaClimate(ClimateDevice):
         temp = kwargs.get(ATTR_TEMPERATURE)
         self.send({self._api.TEMP: temp})
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """Set fan mode."""
-        fan_mode = self.hass_fan_to_melissa(fan)
-        self.send({self._api.FAN: fan_mode})
+        melissa_fan_mode = self.hass_fan_to_melissa(fan_mode)
+        self.send({self._api.FAN: melissa_fan_mode})
 
     def set_operation_mode(self, operation_mode):
         """Set operation mode."""

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -490,7 +490,7 @@ class MqttClimate(MqttAvailability, ClimateDevice):
                 fan_mode, self._qos, self._retain)
 
         if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None:
-            self._current_fan_mode = fan
+            self._current_fan_mode = fan_mode
             self.async_schedule_update_ha_state()
 
     @asyncio.coroutine
@@ -553,7 +553,7 @@ class MqttClimate(MqttAvailability, ClimateDevice):
 
     @asyncio.coroutine
     def async_set_hold_mode(self, hold_mode):
-        """Update hold_mode on."""
+        """Update hold mode on."""
         if self._topic[CONF_HOLD_COMMAND_TOPIC] is not None:
             mqtt.async_publish(self.hass,
                                self._topic[CONF_HOLD_COMMAND_TOPIC],

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -482,12 +482,12 @@ class MqttClimate(MqttAvailability, ClimateDevice):
             self.async_schedule_update_ha_state()
 
     @asyncio.coroutine
-    def async_set_fan_mode(self, fan):
+    def async_set_fan_mode(self, fan_mode):
         """Set new target temperature."""
         if self._send_if_off or self._current_operation != STATE_OFF:
             mqtt.async_publish(
                 self.hass, self._topic[CONF_FAN_MODE_COMMAND_TOPIC],
-                fan, self._qos, self._retain)
+                fan_mode, self._qos, self._retain)
 
         if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None:
             self._current_fan_mode = fan
@@ -552,15 +552,15 @@ class MqttClimate(MqttAvailability, ClimateDevice):
             self.async_schedule_update_ha_state()
 
     @asyncio.coroutine
-    def async_set_hold_mode(self, hold):
-        """Update hold mode on."""
+    def async_set_hold_mode(self, hold_mode):
+        """Update hold_mode on."""
         if self._topic[CONF_HOLD_COMMAND_TOPIC] is not None:
             mqtt.async_publish(self.hass,
                                self._topic[CONF_HOLD_COMMAND_TOPIC],
-                               hold, self._qos, self._retain)
+                               hold_mode, self._qos, self._retain)
 
         if self._topic[CONF_HOLD_STATE_TOPIC] is None:
-            self._hold = hold
+            self._hold = hold_mode
             self.async_schedule_update_ha_state()
 
     @asyncio.coroutine

--- a/homeassistant/components/climate/mysensors.py
+++ b/homeassistant/components/climate/mysensors.py
@@ -143,14 +143,14 @@ class MySensorsHVAC(mysensors.MySensorsEntity, ClimateDevice):
                 self._values[value_type] = value
                 self.schedule_update_ha_state()
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """Set new target temperature."""
         set_req = self.gateway.const.SetReq
         self.gateway.set_child_value(
-            self.node_id, self.child_id, set_req.V_HVAC_SPEED, fan)
+            self.node_id, self.child_id, set_req.V_HVAC_SPEED, fan_mode)
         if self.gateway.optimistic:
             # Optimistically assume that device has changed state
-            self._values[set_req.V_HVAC_SPEED] = fan
+            self._values[set_req.V_HVAC_SPEED] = fan_mode
             self.schedule_update_ha_state()
 
     def set_operation_mode(self, operation_mode):

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -225,7 +225,7 @@ class NestThermostat(ClimateDevice):
         """Cache value from Python-nest."""
         self._location = self.device.where
         self._name = self.device.name
-        self._humidity = self.device.humidity,
+        self._humidity = self.device.humidity
         self._temperature = self.device.temperature
         self._mode = self.device.mode
         self._target_temperature = self.device.target

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -207,9 +207,9 @@ class NestThermostat(ClimateDevice):
         """List of available fan modes."""
         return self._fan_list
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """Turn fan on/off."""
-        self.device.fan = fan.lower()
+        self.device.fan = fan_mode.lower()
 
     @property
     def min_temp(self):

--- a/homeassistant/components/climate/nuheat.py
+++ b/homeassistant/components/climate/nuheat.py
@@ -185,7 +185,7 @@ class NuHeatThermostat(ClimateDevice):
         self._thermostat.resume_schedule()
         self._force_update = True
 
-    def set_hold_mode(self, hold_mode, **kwargs):
+    def set_hold_mode(self, hold_mode):
         """Update the hold mode of the thermostat."""
         if hold_mode == MODE_AUTO:
             schedule_mode = SCHEDULE_RUN

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -183,8 +183,7 @@ class RadioThermostat(ClimateDevice):
         """List of available fan modes."""
         if self._is_model_ct80:
             return CT80_FAN_OPERATION_LIST
-        else:
-            return CT30_FAN_OPERATION_LIST
+        return CT30_FAN_OPERATION_LIST
 
     @property
     def current_fan_mode(self):

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -190,9 +190,9 @@ class RadioThermostat(ClimateDevice):
         """Return whether the fan is on."""
         return self._fmode
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """Turn fan on/off."""
-        code = FAN_MODE_TO_CODE.get(fan, None)
+        code = FAN_MODE_TO_CODE.get(fan_mode, None)
         if code is not None:
             self.device.fmode = code
 

--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -273,11 +273,11 @@ class SensiboClimate(ClimateDevice):
                 self._id, 'targetTemperature', temperature, self._ac_states)
 
     @asyncio.coroutine
-    def async_set_fan_mode(self, fan):
+    def async_set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
         with async_timeout.timeout(TIMEOUT):
             yield from self._client.async_set_ac_state_property(
-                self._id, 'fanLevel', fan, self._ac_states)
+                self._id, 'fanLevel', fan_mode, self._ac_states)
 
     @asyncio.coroutine
     def async_set_operation_mode(self, operation_mode):

--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -240,13 +240,13 @@ class SensiboClimate(ClimateDevice):
     def min_temp(self):
         """Return the minimum temperature."""
         return self._temperatures_list[0] \
-            if len(self._temperatures_list) else super().min_temp()
+            if self._temperatures_list else super().min_temp()
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
         return self._temperatures_list[-1] \
-            if len(self._temperatures_list) else super().max_temp()
+            if self._temperatures_list else super().max_temp()
 
     @asyncio.coroutine
     def async_set_temperature(self, **kwargs):

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -213,6 +213,7 @@ class TadoClimate(ClimateDevice):
         self._target_temp = temperature
         self._control_heating()
 
+    # pylint: disable=arguments-differ
     def set_operation_mode(self, readable_operation_mode):
         """Set new operation mode."""
         operation_mode = CONST_MODE_SMART_SCHEDULE

--- a/homeassistant/components/climate/tesla.py
+++ b/homeassistant/components/climate/tesla.py
@@ -51,8 +51,7 @@ class TeslaThermostat(TeslaDevice, ClimateDevice):
         mode = self.tesla_device.is_hvac_enabled()
         if mode:
             return OPERATION_LIST[0]  # On
-        else:
-            return OPERATION_LIST[1]  # Off
+        return OPERATION_LIST[1]  # Off
 
     @property
     def operation_list(self):

--- a/homeassistant/components/climate/venstar.py
+++ b/homeassistant/components/climate/venstar.py
@@ -111,8 +111,7 @@ class VenstarThermostat(ClimateDevice):
         """Return the unit of measurement, as defined by the API."""
         if self._client.tempunits == self._client.TEMPUNITS_F:
             return TEMP_FAHRENHEIT
-        else:
-            return TEMP_CELSIUS
+        return TEMP_CELSIUS
 
     @property
     def fan_list(self):
@@ -143,16 +142,14 @@ class VenstarThermostat(ClimateDevice):
             return STATE_COOL
         elif self._client.mode == self._client.MODE_AUTO:
             return STATE_AUTO
-        else:
-            return STATE_OFF
+        return STATE_OFF
 
     @property
     def current_fan_mode(self):
         """Return the fan setting."""
         if self._client.fan == self._client.FAN_AUTO:
             return STATE_AUTO
-        else:
-            return STATE_ON
+        return STATE_ON
 
     @property
     def device_state_attributes(self):
@@ -169,24 +166,21 @@ class VenstarThermostat(ClimateDevice):
             return self._client.heattemp
         elif self._client.mode == self._client.MODE_COOL:
             return self._client.cooltemp
-        else:
-            return None
+        return None
 
     @property
     def target_temperature_low(self):
         """Return the lower bound temp if auto mode is on."""
         if self._client.mode == self._client.MODE_AUTO:
             return self._client.heattemp
-        else:
-            return None
+        return None
 
     @property
     def target_temperature_high(self):
         """Return the upper bound temp if auto mode is on."""
         if self._client.mode == self._client.MODE_AUTO:
             return self._client.cooltemp
-        else:
-            return None
+        return None
 
     @property
     def target_humidity(self):

--- a/homeassistant/components/climate/venstar.py
+++ b/homeassistant/components/climate/venstar.py
@@ -239,9 +239,9 @@ class VenstarThermostat(ClimateDevice):
             if not success:
                 _LOGGER.error("Failed to change the temperature")
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
-        if fan == STATE_ON:
+        if fan_mode == STATE_ON:
             success = self._client.set_fan(self._client.FAN_ON)
         else:
             success = self._client.set_fan(self._client.FAN_AUTO)

--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -85,13 +85,13 @@ class VeraThermostat(VeraDevice, ClimateDevice):
         """Return a list of available fan modes."""
         return FAN_OPERATION_LIST
 
-    def set_fan_mode(self, mode):
+    def set_fan_mode(self, fan_mode):
         """Set new target temperature."""
-        if mode == FAN_OPERATION_LIST[0]:
+        if fan_mode == FAN_OPERATION_LIST[0]:
             self.vera_device.fan_on()
-        elif mode == FAN_OPERATION_LIST[1]:
+        elif fan_mode == FAN_OPERATION_LIST[1]:
             self.vera_device.fan_auto()
-        elif mode == FAN_OPERATION_LIST[2]:
+        elif fan_mode == FAN_OPERATION_LIST[2]:
             return self.vera_device.fan_cycle()
 
     @property

--- a/homeassistant/components/climate/wink.py
+++ b/homeassistant/components/climate/wink.py
@@ -486,8 +486,7 @@ class WinkAC(WinkDevice, ClimateDevice):
             return SPEED_LOW
         elif speed <= 0.66:
             return SPEED_MEDIUM
-        else:
-            return SPEED_HIGH
+        return SPEED_HIGH
 
     @property
     def fan_list(self):

--- a/homeassistant/components/climate/wink.py
+++ b/homeassistant/components/climate/wink.py
@@ -324,9 +324,9 @@ class WinkThermostat(WinkDevice, ClimateDevice):
             return self.wink.fan_modes()
         return None
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """Turn fan on/off."""
-        self.wink.set_fan_mode(fan.lower())
+        self.wink.set_fan_mode(fan_mode.lower())
 
     def turn_aux_heat_on(self):
         """Turn auxiliary heater on."""
@@ -493,18 +493,18 @@ class WinkAC(WinkDevice, ClimateDevice):
         """Return a list of available fan modes."""
         return [SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """
         Set fan speed.
 
         The official Wink app only supports 3 modes [low, medium, high]
         which are equal to [0.33, 0.66, 1.0] respectively.
         """
-        if fan == SPEED_LOW:
+        if fan_mode == SPEED_LOW:
             speed = 0.33
-        elif fan == SPEED_MEDIUM:
+        elif fan_mode == SPEED_MEDIUM:
             speed = 0.66
-        elif fan == SPEED_HIGH:
+        elif fan_mode == SPEED_HIGH:
             speed = 1.0
         self.wink.set_ac_fan_speed(speed)
 

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -198,10 +198,10 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
 
         self.values.primary.data = temperature
 
-    def set_fan_mode(self, fan):
+    def set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
         if self.values.fan_mode:
-            self.values.fan_mode.data = fan
+            self.values.fan_mode.data = fan_mode
 
     def set_operation_mode(self, operation_mode):
         """Set new target operation mode."""

--- a/homeassistant/components/cloud/auth_api.py
+++ b/homeassistant/components/cloud/auth_api.py
@@ -31,6 +31,8 @@ class InvalidCode(CloudError):
 class PasswordChangeRequired(CloudError):
     """Raised when a password change is required."""
 
+    # https://github.com/PyCQA/pylint/issues/1085
+    # pylint: disable=useless-super-delegation
     def __init__(self, message='Password change required.'):
         """Initialize a password change required error."""
         super().__init__(message)

--- a/homeassistant/components/cloud/auth_api.py
+++ b/homeassistant/components/cloud/auth_api.py
@@ -32,7 +32,7 @@ class PasswordChangeRequired(CloudError):
     """Raised when a password change is required."""
 
     # https://github.com/PyCQA/pylint/issues/1085
-    # pylint: disable=useless-super-delegation
+    # pylint: disable=bad-option-value,useless-super-delegation
     def __init__(self, message='Password change required.'):
         """Initialize a password change required error."""
         super().__init__(message)

--- a/homeassistant/components/cloud/auth_api.py
+++ b/homeassistant/components/cloud/auth_api.py
@@ -32,7 +32,7 @@ class PasswordChangeRequired(CloudError):
     """Raised when a password change is required."""
 
     # https://github.com/PyCQA/pylint/issues/1085
-    # pylint: disable=bad-option-value,useless-super-delegation
+    # pylint: disable=useless-super-delegation
     def __init__(self, message='Password change required.'):
         """Initialize a password change required error."""
         super().__init__(message)

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -289,7 +289,7 @@ class CoverDevice(Entity):
         """
         return self.hass.async_add_job(ft.partial(self.close_cover, **kwargs))
 
-    def set_cover_position(self, position: int, **kwargs):
+    def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         pass
 
@@ -336,11 +336,11 @@ class CoverDevice(Entity):
         return self.hass.async_add_job(
             ft.partial(self.close_cover_tilt, **kwargs))
 
-    def set_cover_tilt_position(self, tilt_position: int, **kwargs):
+    def set_cover_tilt_position(self, **kwargs):
         """Move the cover tilt to a specific position."""
         pass
 
-    def async_set_cover_tilt_position(self, tilt_position: int, **kwargs):
+    def async_set_cover_tilt_position(self, **kwargs):
         """Move the cover tilt to a specific position.
 
         This method must be run in the event loop and returns a coroutine.

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -289,7 +289,7 @@ class CoverDevice(Entity):
         """
         return self.hass.async_add_job(ft.partial(self.close_cover, **kwargs))
 
-    def set_cover_position(self, **kwargs):
+    def set_cover_position(self, position: int, **kwargs):
         """Move the cover to a specific position."""
         pass
 
@@ -336,11 +336,11 @@ class CoverDevice(Entity):
         return self.hass.async_add_job(
             ft.partial(self.close_cover_tilt, **kwargs))
 
-    def set_cover_tilt_position(self, **kwargs):
+    def set_cover_tilt_position(self, tilt_position: int, **kwargs):
         """Move the cover tilt to a specific position."""
         pass
 
-    def async_set_cover_tilt_position(self, **kwargs):
+    def async_set_cover_tilt_position(self, tilt_position: int, **kwargs):
         """Move the cover tilt to a specific position.
 
         This method must be run in the event loop and returns a coroutine.

--- a/homeassistant/components/cover/demo.py
+++ b/homeassistant/components/cover/demo.py
@@ -5,7 +5,8 @@ For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/demo/
 """
 from homeassistant.components.cover import (
-    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE)
+    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE, ATTR_POSITION,
+    ATTR_TILT_POSITION)
 from homeassistant.helpers.event import track_utc_time_change
 
 
@@ -137,8 +138,9 @@ class DemoCover(CoverDevice):
         self._listen_cover_tilt()
         self._requested_closing_tilt = False
 
-    def set_cover_position(self, position: int, **kwargs):
+    def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
+        position = kwargs.get(ATTR_POSITION)
         self._set_position = round(position, -1)
         if self._position == position:
             return
@@ -146,8 +148,9 @@ class DemoCover(CoverDevice):
         self._listen_cover()
         self._requested_closing = position < self._position
 
-    def set_cover_tilt_position(self, tilt_position: int, **kwargs):
+    def set_cover_tilt_position(self, **kwargs):
         """Move the cover til to a specific position."""
+        tilt_position = kwargs.get(ATTR_TILT_POSITION)
         self._set_tilt_position = round(tilt_position, -1)
         if self._tilt_position == tilt_position:
             return

--- a/homeassistant/components/cover/demo.py
+++ b/homeassistant/components/cover/demo.py
@@ -137,7 +137,7 @@ class DemoCover(CoverDevice):
         self._listen_cover_tilt()
         self._requested_closing_tilt = False
 
-    def set_cover_position(self, position, **kwargs):
+    def set_cover_position(self, position: int, **kwargs):
         """Move the cover to a specific position."""
         self._set_position = round(position, -1)
         if self._position == position:
@@ -146,7 +146,7 @@ class DemoCover(CoverDevice):
         self._listen_cover()
         self._requested_closing = position < self._position
 
-    def set_cover_tilt_position(self, tilt_position, **kwargs):
+    def set_cover_tilt_position(self, tilt_position: int, **kwargs):
         """Move the cover til to a specific position."""
         self._set_tilt_position = round(tilt_position, -1)
         if self._tilt_position == tilt_position:

--- a/homeassistant/components/cover/garadget.py
+++ b/homeassistant/components/cover/garadget.py
@@ -201,21 +201,21 @@ class GaradgetCover(CoverDevice):
         """Check the state of the service during an operation."""
         self.schedule_update_ha_state(True)
 
-    def close_cover(self):
+    def close_cover(self, **kwargs):
         """Close the cover."""
         if self._state not in ['close', 'closing']:
             ret = self._put_command('setState', 'close')
             self._start_watcher('close')
             return ret.get('return_value') == 1
 
-    def open_cover(self):
+    def open_cover(self, **kwargs):
         """Open the cover."""
         if self._state not in ['open', 'opening']:
             ret = self._put_command('setState', 'open')
             self._start_watcher('open')
             return ret.get('return_value') == 1
 
-    def stop_cover(self):
+    def stop_cover(self, **kwargs):
         """Stop the door where it is."""
         if self._state not in ['stopped']:
             ret = self._put_command('setState', 'stop')

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -61,8 +61,7 @@ class ISYCoverDevice(ISYDevice, CoverDevice):
         """Get the state of the ISY994 cover device."""
         if self.is_unknown():
             return None
-        else:
-            return VALUE_TO_STATE.get(self.value, STATE_OPEN)
+        return VALUE_TO_STATE.get(self.value, STATE_OPEN)
 
     def open_cover(self, **kwargs) -> None:
         """Send the open cover command to the ISY994 cover device."""

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -42,10 +42,6 @@ def setup_platform(hass, config: ConfigType,
 class ISYCoverDevice(ISYDevice, CoverDevice):
     """Representation of an ISY994 cover device."""
 
-    def __init__(self, node: object) -> None:
-        """Initialize the ISY994 cover device."""
-        super().__init__(node)
-
     @property
     def current_cover_position(self) -> int:
         """Return the current cover position."""

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -84,11 +84,11 @@ class MyQDevice(CoverDevice):
         """Return true if cover is closed, else False."""
         return self._status == STATE_CLOSED
 
-    def close_cover(self):
+    def close_cover(self, **kwargs):
         """Issue close command to cover."""
         self.myq.close_device(self.device_id)
 
-    def open_cover(self):
+    def open_cover(self, **kwargs):
         """Issue open command to cover."""
         self.myq.open_device(self.device_id)
 

--- a/homeassistant/components/cover/opengarage.py
+++ b/homeassistant/components/cover/opengarage.py
@@ -119,14 +119,14 @@ class OpenGarageCover(CoverDevice):
             return None
         return self._state in [STATE_CLOSED, STATE_OPENING]
 
-    def close_cover(self):
+    def close_cover(self, **kwargs):
         """Close the cover."""
         if self._state not in [STATE_CLOSED, STATE_CLOSING]:
             self._state_before_move = self._state
             self._state = STATE_CLOSING
             self._push_button()
 
-    def open_cover(self):
+    def open_cover(self, **kwargs):
         """Open the cover."""
         if self._state not in [STATE_OPEN, STATE_OPENING]:
             self._state_before_move = self._state

--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -109,12 +109,12 @@ class RPiGPIOCover(CoverDevice):
         sleep(self._relay_time)
         rpi_gpio.write_output(self._relay_pin, not self._invert_relay)
 
-    def close_cover(self):
+    def close_cover(self, **kwargs):
         """Close the cover."""
         if not self.is_closed:
             self._trigger()
 
-    def open_cover(self):
+    def open_cover(self, **kwargs):
         """Open the cover."""
         if self.is_closed:
             self._trigger()

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -64,8 +64,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
         """Return the class of the device."""
         if self.tahoma_device.type == 'io:WindowOpenerVeluxIOComponent':
             return 'window'
-        else:
-            return None
+        return None
 
     def open_cover(self, **kwargs):
         """Open the cover."""

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/cover.tahoma/
 """
 import logging
 
-from homeassistant.components.cover import CoverDevice
+from homeassistant.components.cover import CoverDevice, ATTR_POSITION
 from homeassistant.components.tahoma import (
     DOMAIN as TAHOMA_DOMAIN, TahomaDevice)
 
@@ -49,9 +49,9 @@ class TahomaCover(TahomaDevice, CoverDevice):
         except KeyError:
             return None
 
-    def set_cover_position(self, position, **kwargs):
+    def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        self.apply_action('setPosition', 100 - position)
+        self.apply_action('setPosition', 100 - kwargs.get(ATTR_POSITION))
 
     @property
     def is_closed(self):

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -44,7 +44,7 @@ class VeraCover(VeraDevice, CoverDevice):
             return 100
         return position
 
-    def set_cover_position(self, position, **kwargs):
+    def set_cover_position(self, position: int, **kwargs):
         """Move the cover to a specific position."""
         self.vera_device.set_level(position)
         self.schedule_update_ha_state()

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -6,7 +6,8 @@ https://home-assistant.io/components/cover.vera/
 """
 import logging
 
-from homeassistant.components.cover import CoverDevice, ENTITY_ID_FORMAT
+from homeassistant.components.cover import CoverDevice, ENTITY_ID_FORMAT, \
+    ATTR_POSITION
 from homeassistant.components.vera import (
     VERA_CONTROLLER, VERA_DEVICES, VeraDevice)
 
@@ -44,9 +45,9 @@ class VeraCover(VeraDevice, CoverDevice):
             return 100
         return position
 
-    def set_cover_position(self, position: int, **kwargs):
+    def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        self.vera_device.set_level(position)
+        self.vera_device.set_level(kwargs.get(ATTR_POSITION))
         self.schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/cover/wink.py
+++ b/homeassistant/components/cover/wink.py
@@ -6,7 +6,8 @@ https://home-assistant.io/components/cover.wink/
 """
 import asyncio
 
-from homeassistant.components.cover import CoverDevice, STATE_UNKNOWN
+from homeassistant.components.cover import CoverDevice, STATE_UNKNOWN, \
+    ATTR_POSITION
 from homeassistant.components.wink import WinkDevice, DOMAIN
 
 DEPENDENCIES = ['wink']
@@ -42,9 +43,10 @@ class WinkCoverDevice(WinkDevice, CoverDevice):
         """Open the cover."""
         self.wink.set_state(1)
 
-    def set_cover_position(self, position, **kwargs):
+    def set_cover_position(self, **kwargs):
         """Move the cover shutter to a specific position."""
-        self.wink.set_state(float(position)/100)
+        position = kwargs.get(ATTR_POSITION)
+        self.wink.set_state(position/100)
 
     @property
     def current_cover_position(self):

--- a/homeassistant/components/cover/wink.py
+++ b/homeassistant/components/cover/wink.py
@@ -51,8 +51,7 @@ class WinkCoverDevice(WinkDevice, CoverDevice):
         """Return the current position of cover shutter."""
         if self.wink.state() is not None:
             return int(self.wink.state()*100)
-        else:
-            return STATE_UNKNOWN
+        return STATE_UNKNOWN
 
     @property
     def is_closed(self):

--- a/homeassistant/components/cover/xiaomi_aqara.py
+++ b/homeassistant/components/cover/xiaomi_aqara.py
@@ -1,7 +1,7 @@
 """Support for Xiaomi curtain."""
 import logging
 
-from homeassistant.components.cover import CoverDevice
+from homeassistant.components.cover import CoverDevice, ATTR_POSITION
 from homeassistant.components.xiaomi_aqara import (PY_XIAOMI_GATEWAY,
                                                    XiaomiDevice)
 
@@ -55,8 +55,9 @@ class XiaomiGenericCover(XiaomiDevice, CoverDevice):
         """Stop the cover."""
         self._write_to_hub(self._sid, **{self._data_key['status']: 'stop'})
 
-    def set_cover_position(self, position: int, **kwargs):
+    def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
+        position = kwargs.get(ATTR_POSITION)
         self._write_to_hub(self._sid, **{self._data_key['pos']: str(position)})
 
     def parse_data(self, data, raw_data):

--- a/homeassistant/components/cover/xiaomi_aqara.py
+++ b/homeassistant/components/cover/xiaomi_aqara.py
@@ -55,7 +55,7 @@ class XiaomiGenericCover(XiaomiDevice, CoverDevice):
         """Stop the cover."""
         self._write_to_hub(self._sid, **{self._data_key['status']: 'stop'})
 
-    def set_cover_position(self, position, **kwargs):
+    def set_cover_position(self, position: int, **kwargs):
         """Move the cover to a specific position."""
         self._write_to_hub(self._sid, **{self._data_key['pos']: str(position)})
 

--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -8,7 +8,7 @@ https://home-assistant.io/components/cover.zwave/
 # pylint: disable=import-error
 import logging
 from homeassistant.components.cover import (
-    DOMAIN, SUPPORT_OPEN, SUPPORT_CLOSE)
+    DOMAIN, SUPPORT_OPEN, SUPPORT_CLOSE, ATTR_POSITION)
 from homeassistant.components.zwave import ZWaveDeviceEntity
 from homeassistant.components import zwave
 from homeassistant.components.zwave import async_setup_platform  # noqa # pylint: disable=unused-import
@@ -97,9 +97,10 @@ class ZwaveRollershutter(zwave.ZWaveDeviceEntity, CoverDevice):
         """Move the roller shutter down."""
         self._network.manager.pressButton(self._close_id)
 
-    def set_cover_position(self, position: int, **kwargs):
+    def set_cover_position(self, **kwargs):
         """Move the roller shutter to a specific position."""
-        self.node.set_dimmer(self.values.primary.value_id, position)
+        self.node.set_dimmer(self.values.primary.value_id,
+                             kwargs.get(ATTR_POSITION))
 
     def stop_cover(self, **kwargs):
         """Stop the roller shutter."""

--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -97,7 +97,7 @@ class ZwaveRollershutter(zwave.ZWaveDeviceEntity, CoverDevice):
         """Move the roller shutter down."""
         self._network.manager.pressButton(self._close_id)
 
-    def set_cover_position(self, position, **kwargs):
+    def set_cover_position(self, position: int, **kwargs):
         """Move the roller shutter to a specific position."""
         self.node.set_dimmer(self.values.primary.value_id, position)
 
@@ -139,11 +139,11 @@ class ZwaveGarageDoorSwitch(ZwaveGarageDoorBase):
         """Return the current position of Zwave garage door."""
         return not self._state
 
-    def close_cover(self):
+    def close_cover(self, **kwargs):
         """Close the garage door."""
         self.values.primary.data = False
 
-    def open_cover(self):
+    def open_cover(self, **kwargs):
         """Open the garage door."""
         self.values.primary.data = True
 
@@ -166,10 +166,10 @@ class ZwaveGarageDoorBarrier(ZwaveGarageDoorBase):
         """Return the current position of Zwave garage door."""
         return self._state == "Closed"
 
-    def close_cover(self):
+    def close_cover(self, **kwargs):
         """Close the garage door."""
         self.values.primary.data = "Closed"
 
-    def open_cover(self):
+    def open_cover(self, **kwargs):
         """Open the garage door."""
         self.values.primary.data = "Opened"

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -622,16 +622,16 @@ class DeviceScanner(object):
         """
         return self.hass.async_add_job(self.scan_devices)
 
-    def get_device_name(self, mac: str) -> str:
-        """Get device name from mac."""
+    def get_device_name(self, device: str) -> str:
+        """Get the name of a device."""
         raise NotImplementedError()
 
-    def async_get_device_name(self, mac: str) -> Any:
-        """Get device name from mac.
+    def async_get_device_name(self, device: str) -> Any:
+        """Get the name of a device.
 
         This method must be run in the event loop and returns a coroutine.
         """
-        return self.hass.async_add_job(self.get_device_name, mac)
+        return self.hass.async_add_job(self.get_device_name, device)
 
 
 def load_config(path: str, hass: HomeAssistantType, consider_home: timedelta):

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -99,17 +99,17 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
 
 
 @bind_hass
-def is_on(hass: HomeAssistantType, entity_id: str=None):
+def is_on(hass: HomeAssistantType, entity_id: str = None):
     """Return the state if any or a specified device is home."""
     entity = entity_id or ENTITY_ID_ALL_DEVICES
 
     return hass.states.is_state(entity, STATE_HOME)
 
 
-def see(hass: HomeAssistantType, mac: str=None, dev_id: str=None,
-        host_name: str=None, location_name: str=None,
-        gps: GPSType=None, gps_accuracy=None,
-        battery=None, attributes: dict=None):
+def see(hass: HomeAssistantType, mac: str = None, dev_id: str = None,
+        host_name: str = None, location_name: str = None,
+        gps: GPSType = None, gps_accuracy=None,
+        battery=None, attributes: dict = None):
     """Call service to notify you see device."""
     data = {key: value for key, value in
             ((ATTR_MAC, mac),
@@ -239,11 +239,11 @@ class DeviceTracker(object):
                 _LOGGER.warning('Duplicate device MAC addresses detected %s',
                                 dev.mac)
 
-    def see(self, mac: str=None, dev_id: str=None, host_name: str=None,
-            location_name: str=None, gps: GPSType=None, gps_accuracy=None,
-            battery: str=None, attributes: dict=None,
-            source_type: str=SOURCE_TYPE_GPS, picture: str=None,
-            icon: str=None):
+    def see(self, mac: str = None, dev_id: str = None, host_name: str = None,
+            location_name: str = None, gps: GPSType = None, gps_accuracy=None,
+            battery: str = None, attributes: dict = None,
+            source_type: str = SOURCE_TYPE_GPS, picture: str = None,
+            icon: str = None):
         """Notify the device tracker that you see a device."""
         self.hass.add_job(
             self.async_see(mac, dev_id, host_name, location_name, gps,
@@ -252,11 +252,11 @@ class DeviceTracker(object):
         )
 
     @asyncio.coroutine
-    def async_see(self, mac: str=None, dev_id: str=None, host_name: str=None,
-                  location_name: str=None, gps: GPSType=None,
-                  gps_accuracy=None, battery: str=None, attributes: dict=None,
-                  source_type: str=SOURCE_TYPE_GPS, picture: str=None,
-                  icon: str=None):
+    def async_see(self, mac: str = None, dev_id: str = None,
+                  host_name: str = None, location_name: str = None,
+                  gps: GPSType = None, gps_accuracy=None, battery: str = None,
+                  attributes: dict = None, source_type: str = SOURCE_TYPE_GPS,
+                  picture: str = None, icon: str = None):
         """Notify the device tracker that you see a device.
 
         This method is a coroutine.
@@ -396,9 +396,9 @@ class Device(Entity):
     _state = STATE_NOT_HOME
 
     def __init__(self, hass: HomeAssistantType, consider_home: timedelta,
-                 track: bool, dev_id: str, mac: str, name: str=None,
-                 picture: str=None, gravatar: str=None, icon: str=None,
-                 hide_if_away: bool=False, vendor: str=None) -> None:
+                 track: bool, dev_id: str, mac: str, name: str = None,
+                 picture: str = None, gravatar: str = None, icon: str = None,
+                 hide_if_away: bool = False, vendor: str = None) -> None:
         """Initialize a device."""
         self.hass = hass
         self.entity_id = ENTITY_ID_FORMAT.format(dev_id)
@@ -475,9 +475,10 @@ class Device(Entity):
         return self.away_hide and self.state != STATE_HOME
 
     @asyncio.coroutine
-    def async_seen(self, host_name: str=None, location_name: str=None,
-                   gps: GPSType=None, gps_accuracy=0, battery: str=None,
-                   attributes: dict=None, source_type: str=SOURCE_TYPE_GPS):
+    def async_seen(self, host_name: str = None, location_name: str = None,
+                   gps: GPSType = None, gps_accuracy=0, battery: str = None,
+                   attributes: dict = None,
+                   source_type: str = SOURCE_TYPE_GPS):
         """Mark the device as seen."""
         self.source_type = source_type
         self.last_seen = dt_util.utcnow()
@@ -504,7 +505,7 @@ class Device(Entity):
         # pylint: disable=not-an-iterable
         yield from self.async_update()
 
-    def stale(self, now: dt_util.dt.datetime=None):
+    def stale(self, now: dt_util.dt.datetime = None):
         """Return if device state is stale.
 
         Async friendly.

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -177,10 +177,9 @@ class AutomaticAuthCallbackView(HomeAssistantView):
                 _LOGGER.error(
                     "Error authorizing Automatic: %s", params['error'])
                 return response
-            else:
-                _LOGGER.error(
-                    "Error authorizing Automatic. Invalid response returned")
-                return response
+            _LOGGER.error(
+                "Error authorizing Automatic. Invalid response returned")
+            return response
 
         if DATA_CONFIGURING not in hass.data or \
                 params['state'] not in hass.data[DATA_CONFIGURING]:

--- a/homeassistant/components/device_tracker/bbox.py
+++ b/homeassistant/components/device_tracker/bbox.py
@@ -45,10 +45,10 @@ class BboxDeviceScanner(DeviceScanner):
 
         return [device.mac for device in self.last_results]
 
-    def get_device_name(self, mac):
+    def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
-        filter_named = [device.name for device in self.last_results if
-                        device.mac == mac]
+        filter_named = [result.name for result in self.last_results if
+                        result.mac == device]
 
         if filter_named:
             return filter_named[0]

--- a/homeassistant/components/device_tracker/bluetooth_le_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_le_tracker.py
@@ -102,7 +102,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
         """Lookup Bluetooth LE devices and update status."""
         devs = discover_ble_devices()
         for mac in devs_to_track:
-            _LOGGER.debug("Checking " + mac)
+            _LOGGER.debug("Checking %s", mac)
             result = mac in devs
             if not result:
                 # Could not lookup device name

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -41,7 +41,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
         result = bluetooth.discover_devices(
             duration=8, lookup_names=True, flush_cache=True,
             lookup_class=False)
-        _LOGGER.debug("Bluetooth devices discovered = " + str(len(result)))
+        _LOGGER.debug("Bluetooth devices discovered = %d", len(result))
         return result
 
     yaml_path = hass.config.path(YAML_DEVICES)

--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -75,9 +75,9 @@ class FritzBoxScanner(DeviceScanner):
                 active_hosts.append(known_host['mac'])
         return active_hosts
 
-    def get_device_name(self, mac):
+    def get_device_name(self, device):
         """Return the name of the given device or None if is not known."""
-        ret = self.fritz_box.get_specific_host_entry(mac).get(
+        ret = self.fritz_box.get_specific_host_entry(device).get(
             'NewHostName'
         )
         if ret == {}:

--- a/homeassistant/components/device_tracker/geofency.py
+++ b/homeassistant/components/device_tracker/geofency.py
@@ -120,8 +120,7 @@ class GeofencyView(HomeAssistantView):
         """Return name of device tracker."""
         if 'beaconUUID' in data:
             return "{}_{}".format(BEACON_DEV_PREFIX, data['name'])
-        else:
-            return data['device']
+        return data['device']
 
     @asyncio.coroutine
     def _set_location(self, hass, data, location_name):

--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -60,11 +60,11 @@ class HitronCODADeviceScanner(DeviceScanner):
 
         return [device.mac for device in self.last_results]
 
-    def get_device_name(self, mac):
+    def get_device_name(self, device):
         """Return the name of the device with the given MAC address."""
         name = next((
-            device.name for device in self.last_results
-            if device.mac == mac), None)
+            result.name for result in self.last_results
+            if result.mac == device), None)
         return name
 
     def _login(self):

--- a/homeassistant/components/device_tracker/huawei_router.py
+++ b/homeassistant/components/device_tracker/huawei_router.py
@@ -86,6 +86,7 @@ class HuaweiDeviceScanner(DeviceScanner):
         active_clients = [client for client in data if client.state]
         self.last_results = active_clients
 
+        # pylint: disable=logging-not-lazy
         _LOGGER.debug("Active clients: " + "\n"
                       .join((client.mac + " " + client.name)
                             for client in active_clients))

--- a/homeassistant/components/device_tracker/keenetic_ndms2.py
+++ b/homeassistant/components/device_tracker/keenetic_ndms2.py
@@ -67,10 +67,10 @@ class KeeneticNDMS2DeviceScanner(DeviceScanner):
 
         return [device.mac for device in self.last_results]
 
-    def get_device_name(self, mac):
+    def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
-        filter_named = [device.name for device in self.last_results
-                        if device.mac == mac]
+        filter_named = [result.name for result in self.last_results
+                        if result.mac == device]
 
         if filter_named:
             return filter_named[0]

--- a/homeassistant/components/device_tracker/linksys_ap.py
+++ b/homeassistant/components/device_tracker/linksys_ap.py
@@ -62,7 +62,7 @@ class LinksysAPDeviceScanner(DeviceScanner):
         return self.last_results
 
     # pylint: disable=no-self-use
-    def get_device_name(self, mac):
+    def get_device_name(self, device):
         """
         Return the name (if known) of the device.
 

--- a/homeassistant/components/device_tracker/linksys_smart.py
+++ b/homeassistant/components/device_tracker/linksys_smart.py
@@ -45,9 +45,9 @@ class LinksysSmartWifiDeviceScanner(DeviceScanner):
 
         return self.last_results.keys()
 
-    def get_device_name(self, mac):
+    def get_device_name(self, device):
         """Return the name (if known) of the device."""
-        return self.last_results.get(mac)
+        return self.last_results.get(device)
 
     def _update_info(self):
         """Check for connected devices."""

--- a/homeassistant/components/device_tracker/meraki.py
+++ b/homeassistant/components/device_tracker/meraki.py
@@ -107,8 +107,7 @@ class MerakiView(HomeAssistantView):
 
             if lat == "NaN" or lng == "NaN":
                 _LOGGER.debug(
-                    "No coordinates received, skipping location for: " + mac
-                )
+                    "No coordinates received, skipping location for: %s", mac)
                 gps_location = None
                 accuracy = None
             else:

--- a/homeassistant/components/device_tracker/meraki.py
+++ b/homeassistant/components/device_tracker/meraki.py
@@ -85,7 +85,7 @@ class MerakiView(HomeAssistantView):
                 return self.json_message('Invalid device type',
                                          HTTP_UNPROCESSABLE_ENTITY)
             _LOGGER.debug("Processing %s", data['type'])
-        if len(data["data"]["observations"]) == 0:
+        if not data["data"]["observations"]:
             _LOGGER.debug("No observations found")
             return
         self._handle(request.app['hass'], data)

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -137,9 +137,9 @@ class MikrotikScanner(DeviceScanner):
         self._update_info()
         return [device for device in self.last_results]
 
-    def get_device_name(self, mac):
+    def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
-        return self.last_results.get(mac)
+        return self.last_results.get(device)
 
     def _update_info(self):
         """Retrieve latest information from the Mikrotik box."""

--- a/homeassistant/components/device_tracker/netgear.py
+++ b/homeassistant/components/device_tracker/netgear.py
@@ -70,11 +70,11 @@ class NetgearDeviceScanner(DeviceScanner):
 
         return (device.mac for device in self.last_results)
 
-    def get_device_name(self, mac):
+    def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
         try:
-            return next(device.name for device in self.last_results
-                        if device.mac == mac)
+            return next(result.name for result in self.last_results
+                        if result.mac == device)
         except StopIteration:
             return None
 

--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -85,10 +85,10 @@ class NmapDeviceScanner(DeviceScanner):
 
         return [device.mac for device in self.last_results]
 
-    def get_device_name(self, mac):
+    def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
-        filter_named = [device.name for device in self.last_results
-                        if device.mac == mac]
+        filter_named = [result.name for result in self.last_results
+                        if result.mac == device]
 
         if filter_named:
             return filter_named[0]

--- a/homeassistant/components/device_tracker/tado.py
+++ b/homeassistant/components/device_tracker/tado.py
@@ -83,10 +83,10 @@ class TadoDeviceScanner(DeviceScanner):
         return [device.mac for device in self.last_results]
 
     @asyncio.coroutine
-    def async_get_device_name(self, mac):
+    def async_get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
-        filter_named = [device.name for device in self.last_results
-                        if device.mac == mac]
+        filter_named = [result.name for result in self.last_results
+                        if result.mac == device]
 
         if filter_named:
             return filter_named[0]

--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -96,11 +96,11 @@ class UbusDeviceScanner(DeviceScanner):
         raise NotImplementedError
 
     @_refresh_on_access_denied
-    def get_device_name(self, mac):
+    def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
         if self.mac2name is None:
             self._generate_mac2name()
-        name = self.mac2name.get(mac.upper(), None)
+        name = self.mac2name.get(device.upper(), None)
         return name
 
     @_refresh_on_access_denied

--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -101,13 +101,13 @@ class UnifiScanner(DeviceScanner):
         self._update()
         return self._clients.keys()
 
-    def get_device_name(self, mac):
+    def get_device_name(self, device):
         """Return the name (if known) of the device.
 
         If a name has been set in Unifi, then return that, else
         return the hostname if it has been detected.
         """
-        client = self._clients.get(mac, {})
+        client = self._clients.get(device, {})
         name = client.get('name') or client.get('hostname')
-        _LOGGER.debug("Device mac %s name %s", mac, name)
+        _LOGGER.debug("Device mac %s name %s", device, name)
         return name

--- a/homeassistant/components/dominos.py
+++ b/homeassistant/components/dominos.py
@@ -140,21 +140,20 @@ class Dominos():
         if self.closest_store is None:
             _LOGGER.warning('Cannot get menu. Store may be closed')
             return []
-        else:
-            menu = self.closest_store.get_menu()
-            product_entries = []
+        menu = self.closest_store.get_menu()
+        product_entries = []
 
-            for product in menu.products:
-                item = {}
-                if isinstance(product.menu_data['Variants'], list):
-                    variants = ', '.join(product.menu_data['Variants'])
-                else:
-                    variants = product.menu_data['Variants']
-                item['name'] = product.name
-                item['variants'] = variants
-                product_entries.append(item)
+        for product in menu.products:
+            item = {}
+            if isinstance(product.menu_data['Variants'], list):
+                variants = ', '.join(product.menu_data['Variants'])
+            else:
+                variants = product.menu_data['Variants']
+            item['name'] = product.name
+            item['variants'] = variants
+            product_entries.append(item)
 
-            return product_entries
+        return product_entries
 
 
 class DominosProductListView(http.HomeAssistantView):
@@ -203,8 +202,7 @@ class DominosOrder(Entity):
         """Return the state either closed, orderable or unorderable."""
         if self.dominos.closest_store is None:
             return 'closed'
-        else:
-            return 'orderable' if self._orderable else 'unorderable'
+        return 'orderable' if self._orderable else 'unorderable'
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -118,7 +118,7 @@ SERVICE_TO_METHOD = {
 
 
 @bind_hass
-def is_on(hass, entity_id: str=None) -> bool:
+def is_on(hass, entity_id: str = None) -> bool:
     """Return if the fans are on based on the statemachine."""
     entity_id = entity_id or ENTITY_ID_ALL_FANS
     state = hass.states.get(entity_id)
@@ -126,7 +126,7 @@ def is_on(hass, entity_id: str=None) -> bool:
 
 
 @bind_hass
-def turn_on(hass, entity_id: str=None, speed: str=None) -> None:
+def turn_on(hass, entity_id: str = None, speed: str = None) -> None:
     """Turn all or specified fan on."""
     data = {
         key: value for key, value in [
@@ -139,7 +139,7 @@ def turn_on(hass, entity_id: str=None, speed: str=None) -> None:
 
 
 @bind_hass
-def turn_off(hass, entity_id: str=None) -> None:
+def turn_off(hass, entity_id: str = None) -> None:
     """Turn all or specified fan off."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
 
@@ -147,7 +147,7 @@ def turn_off(hass, entity_id: str=None) -> None:
 
 
 @bind_hass
-def toggle(hass, entity_id: str=None) -> None:
+def toggle(hass, entity_id: str = None) -> None:
     """Toggle all or specified fans."""
     data = {
         ATTR_ENTITY_ID: entity_id
@@ -157,7 +157,8 @@ def toggle(hass, entity_id: str=None) -> None:
 
 
 @bind_hass
-def oscillate(hass, entity_id: str=None, should_oscillate: bool=True) -> None:
+def oscillate(hass, entity_id: str = None,
+              should_oscillate: bool = True) -> None:
     """Set oscillation on all or specified fan."""
     data = {
         key: value for key, value in [
@@ -170,7 +171,7 @@ def oscillate(hass, entity_id: str=None, should_oscillate: bool=True) -> None:
 
 
 @bind_hass
-def set_speed(hass, entity_id: str=None, speed: str=None) -> None:
+def set_speed(hass, entity_id: str = None, speed: str = None) -> None:
     """Set speed for all or specified fan."""
     data = {
         key: value for key, value in [
@@ -183,7 +184,7 @@ def set_speed(hass, entity_id: str=None, speed: str=None) -> None:
 
 
 @bind_hass
-def set_direction(hass, entity_id: str=None, direction: str=None) -> None:
+def set_direction(hass, entity_id: str = None, direction: str = None) -> None:
     """Set direction for all or specified fan."""
     data = {
         key: value for key, value in [
@@ -258,11 +259,11 @@ class FanEntity(ToggleEntity):
         """
         return self.hass.async_add_job(self.set_direction, direction)
 
-    def turn_on(self: ToggleEntity, speed: str=None, **kwargs) -> None:
+    def turn_on(self: ToggleEntity, speed: str = None, **kwargs) -> None:
         """Turn on the fan."""
         raise NotImplementedError()
 
-    def async_turn_on(self: ToggleEntity, speed: str=None, **kwargs):
+    def async_turn_on(self: ToggleEntity, speed: str = None, **kwargs):
         """Turn on the fan.
 
         This method must be run in the event loop and returns a coroutine.

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -259,10 +259,12 @@ class FanEntity(ToggleEntity):
         """
         return self.hass.async_add_job(self.set_direction, direction)
 
+    # pylint: disable=arguments-differ
     def turn_on(self: ToggleEntity, speed: str = None, **kwargs) -> None:
         """Turn on the fan."""
         raise NotImplementedError()
 
+    # pylint: disable=arguments-differ
     def async_turn_on(self: ToggleEntity, speed: str = None, **kwargs):
         """Turn on the fan.
 

--- a/homeassistant/components/fan/comfoconnect.py
+++ b/homeassistant/components/fan/comfoconnect.py
@@ -97,21 +97,21 @@ class ComfoConnectFan(FanEntity):
         """Turn off the fan (to away)."""
         self.set_speed(SPEED_OFF)
 
-    def set_speed(self, mode):
+    def set_speed(self, speed: str):
         """Set fan speed."""
-        _LOGGER.debug('Changing fan mode to %s.', mode)
+        _LOGGER.debug('Changing fan speed to %s.', speed)
 
         from pycomfoconnect import (
             CMD_FAN_MODE_AWAY, CMD_FAN_MODE_LOW, CMD_FAN_MODE_MEDIUM,
             CMD_FAN_MODE_HIGH)
 
-        if mode == SPEED_OFF:
+        if speed == SPEED_OFF:
             self._ccb.comfoconnect.cmd_rmi_request(CMD_FAN_MODE_AWAY)
-        elif mode == SPEED_LOW:
+        elif speed == SPEED_LOW:
             self._ccb.comfoconnect.cmd_rmi_request(CMD_FAN_MODE_LOW)
-        elif mode == SPEED_MEDIUM:
+        elif speed == SPEED_MEDIUM:
             self._ccb.comfoconnect.cmd_rmi_request(CMD_FAN_MODE_MEDIUM)
-        elif mode == SPEED_HIGH:
+        elif speed == SPEED_HIGH:
             self._ccb.comfoconnect.cmd_rmi_request(CMD_FAN_MODE_HIGH)
 
         # Update current mode

--- a/homeassistant/components/fan/comfoconnect.py
+++ b/homeassistant/components/fan/comfoconnect.py
@@ -87,7 +87,7 @@ class ComfoConnectFan(FanEntity):
         """List of available fan modes."""
         return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
-    def turn_on(self, speed: str=None, **kwargs) -> None:
+    def turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn on the fan."""
         if speed is None:
             speed = SPEED_LOW

--- a/homeassistant/components/fan/demo.py
+++ b/homeassistant/components/fan/demo.py
@@ -59,7 +59,7 @@ class DemoFan(FanEntity):
         """Get the list of available speeds."""
         return [STATE_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
-    def turn_on(self, speed: str=None) -> None:
+    def turn_on(self, speed: str = None) -> None:
         """Turn on the entity."""
         if speed is None:
             speed = SPEED_MEDIUM

--- a/homeassistant/components/fan/demo.py
+++ b/homeassistant/components/fan/demo.py
@@ -59,13 +59,13 @@ class DemoFan(FanEntity):
         """Get the list of available speeds."""
         return [STATE_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
-    def turn_on(self, speed: str = None) -> None:
+    def turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn on the entity."""
         if speed is None:
             speed = SPEED_MEDIUM
         self.set_speed(speed)
 
-    def turn_off(self) -> None:
+    def turn_off(self, **kwargs) -> None:
         """Turn off the entity."""
         self.oscillate(False)
         self.set_speed(STATE_OFF)

--- a/homeassistant/components/fan/dyson.py
+++ b/homeassistant/components/fan/dyson.py
@@ -113,7 +113,7 @@ class DysonPureCoolLinkDevice(FanEntity):
             self._device.set_configuration(
                 fan_mode=FanMode.FAN, fan_speed=fan_speed)
 
-    def turn_on(self: ToggleEntity, speed: str=None, **kwargs) -> None:
+    def turn_on(self: ToggleEntity, speed: str = None, **kwargs) -> None:
         """Turn on the fan."""
         from libpurecoollink.const import FanSpeed, FanMode
 

--- a/homeassistant/components/fan/insteon_local.py
+++ b/homeassistant/components/fan/insteon_local.py
@@ -91,7 +91,7 @@ class InsteonLocalFanDevice(FanEntity):
         """Flag supported features."""
         return SUPPORT_INSTEON_LOCAL
 
-    def turn_on(self: ToggleEntity, speed: str=None, **kwargs) -> None:
+    def turn_on(self: ToggleEntity, speed: str = None, **kwargs) -> None:
         """Turn device on."""
         if speed is None:
             if ATTR_SPEED in kwargs:

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -48,10 +48,6 @@ def setup_platform(hass, config: ConfigType,
 class ISYFanDevice(ISYDevice, FanEntity):
     """Representation of an ISY994 fan device."""
 
-    def __init__(self, node) -> None:
-        """Initialize the ISY994 fan device."""
-        super().__init__(node)
-
     @property
     def speed(self) -> str:
         """Return the current speed."""

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -95,7 +95,7 @@ class ISYFanProgram(ISYFanDevice):
         if not self._actions.runThen():
             _LOGGER.error("Unable to turn off the fan")
 
-    def turn_on(self, **kwargs) -> None:
+    def turn_on(self, speed: str = None, **kwargs) -> None:
         """Send the turn off command to ISY994 fan program."""
         if not self._actions.runElse():
             _LOGGER.error("Unable to turn on the fan")

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -66,7 +66,7 @@ class ISYFanDevice(ISYDevice, FanEntity):
         """Send the set speed command to the ISY994 fan device."""
         self._node.on(val=STATE_TO_VALUE.get(speed, 255))
 
-    def turn_on(self, speed: str=None, **kwargs) -> None:
+    def turn_on(self, speed: str = None, **kwargs) -> None:
         """Send the turn on command to the ISY994 fan device."""
         self.set_speed(speed)
 

--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -252,7 +252,7 @@ class MqttFan(MqttAvailability, FanEntity):
         return self._oscillation
 
     @asyncio.coroutine
-    def async_turn_on(self, speed: str=None) -> None:
+    def async_turn_on(self, speed: str = None) -> None:
         """Turn on the entity.
 
         This method is a coroutine.

--- a/homeassistant/components/fan/mqtt.py
+++ b/homeassistant/components/fan/mqtt.py
@@ -252,7 +252,7 @@ class MqttFan(MqttAvailability, FanEntity):
         return self._oscillation
 
     @asyncio.coroutine
-    def async_turn_on(self, speed: str = None) -> None:
+    def async_turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn on the entity.
 
         This method is a coroutine.
@@ -264,7 +264,7 @@ class MqttFan(MqttAvailability, FanEntity):
             yield from self.async_set_speed(speed)
 
     @asyncio.coroutine
-    def async_turn_off(self) -> None:
+    def async_turn_off(self, **kwargs) -> None:
         """Turn off the entity.
 
         This method is a coroutine.

--- a/homeassistant/components/fan/velbus.py
+++ b/homeassistant/components/fan/velbus.py
@@ -128,7 +128,7 @@ class VelbusFan(FanEntity):
         """Get the list of available speeds."""
         return [STATE_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
-    def turn_on(self, speed, **kwargs):
+    def turn_on(self, speed=None, **kwargs):
         """Turn on the entity."""
         if speed is None:
             speed = SPEED_MEDIUM

--- a/homeassistant/components/fan/velbus.py
+++ b/homeassistant/components/fan/velbus.py
@@ -134,7 +134,7 @@ class VelbusFan(FanEntity):
             speed = SPEED_MEDIUM
         self.set_speed(speed)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn off the entity."""
         self.set_speed(STATE_OFF)
 

--- a/homeassistant/components/fan/wink.py
+++ b/homeassistant/components/fan/wink.py
@@ -47,7 +47,7 @@ class WinkFanDevice(WinkDevice, FanEntity):
         """Set the speed of the fan."""
         self.wink.set_state(True, speed)
 
-    def turn_on(self: ToggleEntity, speed: str=None, **kwargs) -> None:
+    def turn_on(self: ToggleEntity, speed: str = None, **kwargs) -> None:
         """Turn on the fan."""
         self.wink.set_state(True, speed)
 

--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -283,7 +283,7 @@ class XiaomiAirPurifier(FanEntity):
     @asyncio.coroutine
     def async_set_speed(self: ToggleEntity, speed: str) -> None:
         """Set the speed of the fan."""
-        _LOGGER.debug("Setting the operation mode to: " + speed)
+        _LOGGER.debug("Setting the operation mode to: %s", speed)
         from miio.airpurifier import OperationMode
 
         yield from self._try_command(

--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -214,7 +214,7 @@ class XiaomiAirPurifier(FanEntity):
             return False
 
     @asyncio.coroutine
-    def async_turn_on(self: ToggleEntity, speed: str=None, **kwargs) -> None:
+    def async_turn_on(self: ToggleEntity, speed: str = None, **kwargs) -> None:
         """Turn the fan on."""
         if speed:
             # If operation mode was set the device must not be turned on.
@@ -333,7 +333,7 @@ class XiaomiAirPurifier(FanEntity):
             self._air_purifier.set_child_lock, False)
 
     @asyncio.coroutine
-    def async_set_led_brightness(self, brightness: int=2):
+    def async_set_led_brightness(self, brightness: int = 2):
         """Set the led brightness."""
         from miio.airpurifier import LedBrightness
 
@@ -342,7 +342,7 @@ class XiaomiAirPurifier(FanEntity):
             self._air_purifier.set_led_brightness, LedBrightness(brightness))
 
     @asyncio.coroutine
-    def async_set_favorite_level(self, level: int=1):
+    def async_set_favorite_level(self, level: int = 1):
         """Set the favorite level."""
         yield from self._try_command(
             "Setting the favorite level of the air purifier failed.",

--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -103,7 +103,7 @@ def process_wrong_login(request):
 class IpBan(object):
     """Represents banned IP address."""
 
-    def __init__(self, ip_ban: str, banned_at: datetime=None) -> None:
+    def __init__(self, ip_ban: str, banned_at: datetime = None) -> None:
         """Initialize IP Ban object."""
         self.ip_address = ip_address(ip_ban)
         self.banned_at = banned_at or datetime.utcnow()

--- a/homeassistant/components/ihc/ihcdevice.py
+++ b/homeassistant/components/ihc/ihcdevice.py
@@ -14,7 +14,7 @@ class IHCDevice(Entity):
     """
 
     def __init__(self, ihc_controller, name, ihc_id: int, info: bool,
-                 product: Element=None) -> None:
+                 product: Element = None) -> None:
         """Initialize IHC attributes."""
         self.ihc_controller = ihc_controller
         self._name = name

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -135,7 +135,7 @@ WeatherNode = namedtuple('WeatherNode', ('status', 'name', 'uom'))
 
 
 def _check_for_node_def(hass: HomeAssistant, node,
-                        single_domain: str=None) -> bool:
+                        single_domain: str = None) -> bool:
     """Check if the node matches the node_def_id for any domains.
 
     This is only present on the 5.0 ISY firmware, and is the most reliable
@@ -157,7 +157,7 @@ def _check_for_node_def(hass: HomeAssistant, node,
 
 
 def _check_for_insteon_type(hass: HomeAssistant, node,
-                            single_domain: str=None) -> bool:
+                            single_domain: str = None) -> bool:
     """Check if the node matches the Insteon type for any domains.
 
     This is for (presumably) every version of the ISY firmware, but only
@@ -180,7 +180,7 @@ def _check_for_insteon_type(hass: HomeAssistant, node,
 
 
 def _check_for_uom_id(hass: HomeAssistant, node,
-                      single_domain: str=None, uom_list: list=None) -> bool:
+                      single_domain: str = None, uom_list: list = None) -> bool:
     """Check if a node's uom matches any of the domains uom filter.
 
     This is used for versions of the ISY firmware that report uoms as a single
@@ -207,8 +207,8 @@ def _check_for_uom_id(hass: HomeAssistant, node,
 
 
 def _check_for_states_in_uom(hass: HomeAssistant, node,
-                             single_domain: str=None,
-                             states_list: list=None) -> bool:
+                             single_domain: str = None,
+                             states_list: list = None) -> bool:
     """Check if a list of uoms matches two possible filters.
 
     This is for versions of the ISY firmware that report uoms as a list of all

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -461,8 +461,7 @@ class ISYDevice(Entity):
         """Return the state of the ISY device."""
         if self.is_unknown():
             return None
-        else:
-            return super().state
+        return super().state
 
     @property
     def device_state_attributes(self) -> Dict:

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -302,24 +302,25 @@ def _categorize_programs(hass: HomeAssistant, programs: dict) -> None:
             pass
         else:
             for dtype, _, node_id in folder.children:
-                if dtype == KEY_FOLDER:
-                    entity_folder = folder[node_id]
-                    try:
-                        status = entity_folder[KEY_STATUS]
-                        assert status.dtype == 'program', 'Not a program'
-                        if domain != 'binary_sensor':
-                            actions = entity_folder[KEY_ACTIONS]
-                            assert actions.dtype == 'program', 'Not a program'
-                        else:
-                            actions = None
-                    except (AttributeError, KeyError, AssertionError):
-                        _LOGGER.warning("Program entity '%s' not loaded due "
-                                        "to invalid folder structure.",
-                                        entity_folder.name)
-                        continue
+                if dtype != KEY_FOLDER:
+                    continue
+                entity_folder = folder[node_id]
+                try:
+                    status = entity_folder[KEY_STATUS]
+                    assert status.dtype == 'program', 'Not a program'
+                    if domain != 'binary_sensor':
+                        actions = entity_folder[KEY_ACTIONS]
+                        assert actions.dtype == 'program', 'Not a program'
+                    else:
+                        actions = None
+                except (AttributeError, KeyError, AssertionError):
+                    _LOGGER.warning("Program entity '%s' not loaded due "
+                                    "to invalid folder structure.",
+                                    entity_folder.name)
+                    continue
 
-                    entity = (entity_folder.name, status, actions)
-                    hass.data[ISY994_PROGRAMS][domain].append(entity)
+                entity = (entity_folder.name, status, actions)
+                hass.data[ISY994_PROGRAMS][domain].append(entity)
 
 
 def _categorize_weather(hass: HomeAssistant, climate) -> None:

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -180,7 +180,8 @@ def _check_for_insteon_type(hass: HomeAssistant, node,
 
 
 def _check_for_uom_id(hass: HomeAssistant, node,
-                      single_domain: str = None, uom_list: list = None) -> bool:
+                      single_domain: str = None,
+                      uom_list: list = None) -> bool:
     """Check if a node's uom matches any of the domains uom filter.
 
     This is used for versions of the ISY firmware that report uoms as a single

--- a/homeassistant/components/light/avion.py
+++ b/homeassistant/components/light/avion.py
@@ -37,7 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up an Avion switch."""
-    # pylint: disable=import-error
+    # pylint: disable=import-error, no-member
     import avion
 
     lights = []
@@ -70,7 +70,7 @@ class AvionLight(Light):
 
     def __init__(self, device):
         """Initialize the light."""
-        # pylint: disable=import-error
+        # pylint: disable=import-error, no-member
         import avion
 
         self._name = device['name']
@@ -117,7 +117,7 @@ class AvionLight(Light):
 
     def set_state(self, brightness):
         """Set the state of this lamp to the provided brightness."""
-        # pylint: disable=import-error
+        # pylint: disable=import-error, no-member
         import avion
 
         # Bluetooth LE is unreliable, and the connection may drop at any

--- a/homeassistant/components/light/blinkt.py
+++ b/homeassistant/components/light/blinkt.py
@@ -29,7 +29,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Blinkt Light platform."""
-    # pylint: disable=import-error
+    # pylint: disable=import-error, no-member
     import blinkt
 
     # ensure that the lights are off when exiting

--- a/homeassistant/components/light/decora.py
+++ b/homeassistant/components/light/decora.py
@@ -37,7 +37,7 @@ def retry(method):
     @wraps(method)
     def wrapper_retry(device, *args, **kwargs):
         """Try send command and retry on error."""
-        # pylint: disable=import-error
+        # pylint: disable=import-error, no-member
         import decora
         import bluepy
 
@@ -75,7 +75,7 @@ class DecoraLight(Light):
 
     def __init__(self, device):
         """Initialize the light."""
-        # pylint: disable=import-error
+        # pylint: disable=import-error, no-member
         import decora
 
         self._name = device['name']

--- a/homeassistant/components/light/decora_wifi.py
+++ b/homeassistant/components/light/decora_wifi.py
@@ -36,7 +36,7 @@ NOTIFICATION_TITLE = 'myLeviton Decora Setup'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Decora WiFi platform."""
-    # pylint: disable=import-error
+    # pylint: disable=import-error, no-member, no-name-in-module
     from decora_wifi import DecoraWiFiSession
     from decora_wifi.models.person import Person
     from decora_wifi.models.residential_account import ResidentialAccount

--- a/homeassistant/components/light/decora_wifi.py
+++ b/homeassistant/components/light/decora_wifi.py
@@ -93,8 +93,7 @@ class DecoraWifiLight(Light):
         """Return supported features."""
         if self._switch.canSetLevel:
             return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
-        else:
-            return 0
+        return 0
 
     @property
     def name(self):

--- a/homeassistant/components/light/hive.py
+++ b/homeassistant/components/light/hive.py
@@ -116,7 +116,7 @@ class HiveDeviceLight(Light):
         for entity in self.session.entities:
             entity.handle_update(self.data_updatesource)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Instruct the light to turn off."""
         self.session.light.turn_off(self.node_id)
         for entity in self.session.entities:

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -91,7 +91,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if discovery_info is None or 'bridge_id' not in discovery_info:
         return
 
-    if config is not None and len(config) > 0:
+    if config is not None and config:
         # Legacy configuration, will be removed in 0.60
         config_str = yaml.dump([config])
         # Indent so it renders in a fixed-width font

--- a/homeassistant/components/light/ihc.py
+++ b/homeassistant/components/light/ihc.py
@@ -64,7 +64,7 @@ class IhcLight(IHCDevice, Light):
     """
 
     def __init__(self, ihc_controller, name, ihc_id: int, info: bool,
-                 dimmable=False, product: Element=None) -> None:
+                 dimmable=False, product: Element = None) -> None:
         """Initialize the light."""
         super().__init__(ihc_controller, name, ihc_id, info, product)
         self._brightness = 0

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -29,10 +29,6 @@ def setup_platform(hass, config: ConfigType,
 class ISYLightDevice(ISYDevice, Light):
     """Representation of an ISY994 light device."""
 
-    def __init__(self, node: object) -> None:
-        """Initialize the ISY994 light device."""
-        super().__init__(node)
-
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 light is on."""

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -44,6 +44,7 @@ class ISYLightDevice(ISYDevice, Light):
         if not self._node.off():
             _LOGGER.debug("Unable to turn off light")
 
+    # pylint: disable=arguments-differ
     def turn_on(self, brightness=None, **kwargs) -> None:
         """Send the turn on command to the ISY994 light device."""
         if not self._node.on(val=brightness):

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -198,6 +198,7 @@ class LimitlessLEDGroup(Light):
         """Return the brightness property."""
         return self._brightness
 
+    # pylint: disable=arguments-differ
     @state(False)
     def turn_off(self, transition_time, pipeline, **kwargs):
         """Turn off a group."""
@@ -231,6 +232,7 @@ class LimitlessLEDWhiteGroup(LimitlessLEDGroup):
         """Flag supported features."""
         return SUPPORT_LIMITLESSLED_WHITE
 
+    # pylint: disable=arguments-differ
     @state(True)
     def turn_on(self, transition_time, pipeline, **kwargs):
         """Turn on (or adjust property of) a group."""
@@ -271,6 +273,7 @@ class LimitlessLEDRGBWGroup(LimitlessLEDGroup):
         """Flag supported features."""
         return SUPPORT_LIMITLESSLED_RGB
 
+    # pylint: disable=arguments-differ
     @state(True)
     def turn_on(self, transition_time, pipeline, **kwargs):
         """Turn on (or adjust property of) a group."""
@@ -337,6 +340,7 @@ class LimitlessLEDRGBWWGroup(LimitlessLEDGroup):
         """Flag supported features."""
         return SUPPORT_LIMITLESSLED_RGBWW
 
+    # pylint: disable=arguments-differ
     @state(True)
     def turn_on(self, transition_time, pipeline, **kwargs):
         """Turn on (or adjust property of) a group."""

--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -130,7 +130,7 @@ class MySensorsLight(mysensors.MySensorsEntity, Light):
             self._white = white
             self._values[self.value_type] = hex_color
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the device off."""
         value_type = self.gateway.const.SetReq.V_LIGHT
         self.gateway.set_child_value(

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -118,7 +118,7 @@ class TPLinkSmartBulb(Light):
             rgb = kwargs.get(ATTR_RGB_COLOR)
             self.smartbulb.hsv = rgb_to_hsv(rgb)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the light off."""
         self.smartbulb.state = self.smartbulb.BULB_STATE_OFF
 

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -118,6 +118,6 @@ class WinkLight(WinkDevice, Light):
 
         self.wink.set_state(True, **state_kwargs)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the switch off."""
         self.wink.set_state(False)

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -260,10 +260,6 @@ class XiaomiPhilipsGenericLight(Light):
 class XiaomiPhilipsLightBall(XiaomiPhilipsGenericLight, Light):
     """Representation of a Xiaomi Philips Light Ball."""
 
-    def __init__(self, name, light, device_info):
-        """Initialize the light device."""
-        super().__init__(name, light, device_info)
-
     @property
     def color_temp(self):
         """Return the color temperature."""
@@ -345,10 +341,6 @@ class XiaomiPhilipsLightBall(XiaomiPhilipsGenericLight, Light):
 class XiaomiPhilipsCeilingLamp(XiaomiPhilipsLightBall, Light):
     """Representation of a Xiaomi Philips Ceiling Lamp."""
 
-    def __init__(self, name, light, device_info):
-        """Initialize the light device."""
-        super().__init__(name, light, device_info)
-
     @property
     def min_mireds(self):
         """Return the coldest color_temp that this light supports."""
@@ -362,7 +354,4 @@ class XiaomiPhilipsCeilingLamp(XiaomiPhilipsLightBall, Light):
 
 class XiaomiPhilipsEyecareLamp(XiaomiPhilipsGenericLight, Light):
     """Representation of a Xiaomi Philips Eyecare Lamp 2."""
-
-    def __init__(self, name, light, device_info):
-        """Initialize the light device."""
-        super().__init__(name, light, device_info)
+    pass

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -354,4 +354,5 @@ class XiaomiPhilipsCeilingLamp(XiaomiPhilipsLightBall, Light):
 
 class XiaomiPhilipsEyecareLamp(XiaomiPhilipsGenericLight, Light):
     """Representation of a Xiaomi Philips Eyecare Lamp 2."""
+
     pass

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -242,7 +242,7 @@ class XiaomiPhilipsGenericLight(Light):
             _LOGGER.error("Got exception while fetching the state: %s", ex)
 
     @asyncio.coroutine
-    def async_set_scene(self, scene: int=1):
+    def async_set_scene(self, scene: int = 1):
         """Set the fixed scene."""
         yield from self._try_command(
             "Setting a fixed scene failed.",

--- a/homeassistant/components/lirc.py
+++ b/homeassistant/components/lirc.py
@@ -4,7 +4,7 @@ LIRC interface to receive signals from an infrared remote control.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/lirc/
 """
-# pylint: disable=import-error
+# pylint: disable=import-error,no-member
 import threading
 import time
 import logging

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -53,8 +53,7 @@ class ISYLockDevice(ISYDevice, LockDevice):
         """Get the state of the lock."""
         if self.is_unknown():
             return None
-        else:
-            return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
+        return VALUE_TO_STATE.get(self.value, STATE_UNKNOWN)
 
     def lock(self, **kwargs) -> None:
         """Send the lock command to the ISY994 device."""

--- a/homeassistant/components/media_extractor.py
+++ b/homeassistant/components/media_extractor.py
@@ -85,7 +85,7 @@ class MediaExtractor(object):
         else:
             entities = self.get_entities()
 
-            if len(entities) == 0:
+            if not entities:
                 self.call_media_player_service(stream_selector, None)
 
             for entity_id in entities:
@@ -108,7 +108,7 @@ class MediaExtractor(object):
             _LOGGER.warning(
                 "Playlists are not supported, looking for the first video")
             entries = list(all_media['entries'])
-            if len(entries) > 0:
+            if entries:
                 selected_media = entries[0]
             else:
                 _LOGGER.error("Playlist is empty")

--- a/homeassistant/components/media_player/aquostv.py
+++ b/homeassistant/components/media_player/aquostv.py
@@ -201,9 +201,9 @@ class SharpAquosTVDevice(MediaPlayerDevice):
         self._remote.volume(int(self._volume * 60) - 2)
 
     @_retry
-    def set_volume_level(self, level):
+    def set_volume_level(self, volume):
         """Set Volume media player."""
-        self._remote.volume(int(level * 60))
+        self._remote.volume(int(volume * 60))
 
     @_retry
     def mute_volume(self, mute):

--- a/homeassistant/components/media_player/bluesound.py
+++ b/homeassistant/components/media_player/bluesound.py
@@ -440,8 +440,7 @@ class BluesoundPlayer(MediaPlayerDevice):
             return STATE_PAUSED
         elif status == 'stream' or status == 'play':
             return STATE_PLAYING
-        else:
-            return STATE_IDLE
+        return STATE_IDLE
 
     @property
     def media_title(self):

--- a/homeassistant/components/media_player/bluesound.py
+++ b/homeassistant/components/media_player/bluesound.py
@@ -594,7 +594,7 @@ class BluesoundPlayer(MediaPlayerDevice):
             # But it works with radio service_items will catch playlists.
             items = [x for x in self._preset_items if 'url2' in x and
                      parse.unquote(x['url2']) == stream_url]
-            if len(items) > 0:
+            if items:
                 return items[0]['title']
 
         # This could be a bit difficult to detect. Bluetooth could be named
@@ -605,11 +605,11 @@ class BluesoundPlayer(MediaPlayerDevice):
         if title == 'bluetooth' or stream_url == 'Capture:hw:2,0/44100/16/2':
             items = [x for x in self._capture_items
                      if x['url'] == "Capture%3Abluez%3Abluetooth"]
-            if len(items) > 0:
+            if items:
                 return items[0]['title']
 
         items = [x for x in self._capture_items if x['url'] == stream_url]
-        if len(items) > 0:
+        if items:
             return items[0]['title']
 
         if stream_url[:8] == 'Capture:':
@@ -630,12 +630,12 @@ class BluesoundPlayer(MediaPlayerDevice):
 
         items = [x for x in self._capture_items
                  if x['name'] == current_service]
-        if len(items) > 0:
+        if items:
             return items[0]['title']
 
         items = [x for x in self._services_items
                  if x['name'] == current_service]
-        if len(items) > 0:
+        if items:
             return items[0]['title']
 
         if self._status.get('streamUrl', '') != '':

--- a/homeassistant/components/media_player/hdmi_cec.py
+++ b/homeassistant/components/media_player/hdmi_cec.py
@@ -87,7 +87,7 @@ class CecPlayerDevice(CecDevice, MediaPlayerDevice):
         self.send_keypress(KEY_STOP)
         self._state = STATE_IDLE
 
-    def play_media(self, media_type, media_id):
+    def play_media(self, media_type, media_id, **kwargs):
         """Not supported."""
         raise NotImplementedError()
 

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -182,8 +182,7 @@ class MpdDevice(MediaPlayerDevice):
         if name is None and title is None:
             if file_name is None:
                 return "None"
-            else:
-                return os.path.basename(file_name)
+            return os.path.basename(file_name)
         elif name is None:
             return title
         elif title is None:

--- a/homeassistant/components/media_player/soundtouch.py
+++ b/homeassistant/components/media_player/soundtouch.py
@@ -296,7 +296,7 @@ class SoundTouchDevice(MediaPlayerDevice):
 
     def play_media(self, media_type, media_id, **kwargs):
         """Play a piece of media."""
-        _LOGGER.debug("Starting media with media_id: " + str(media_id))
+        _LOGGER.debug("Starting media with media_id: %s", media_id)
         if re.match(r'http://', str(media_id)):
             # URL
             _LOGGER.debug("Playing URL %s", str(media_id))
@@ -307,11 +307,10 @@ class SoundTouchDevice(MediaPlayerDevice):
             preset = next([preset for preset in presets if
                            preset.preset_id == str(media_id)].__iter__(), None)
             if preset is not None:
-                _LOGGER.debug("Playing preset: " + preset.name)
+                _LOGGER.debug("Playing preset: %s", preset.name)
                 self._device.select_preset(preset)
             else:
-                _LOGGER.warning(
-                    "Unable to find preset with id " + str(media_id))
+                _LOGGER.warning("Unable to find preset with id %s", media_id)
 
     def create_zone(self, slaves):
         """
@@ -323,8 +322,8 @@ class SoundTouchDevice(MediaPlayerDevice):
         if not slaves:
             _LOGGER.warning("Unable to create zone without slaves")
         else:
-            _LOGGER.info(
-                "Creating zone with master " + str(self.device.config.name))
+            _LOGGER.info("Creating zone with master %s",
+                         self.device.config.name)
             self.device.create_zone([slave.device for slave in slaves])
 
     def remove_zone_slave(self, slaves):
@@ -341,8 +340,8 @@ class SoundTouchDevice(MediaPlayerDevice):
         if not slaves:
             _LOGGER.warning("Unable to find slaves to remove")
         else:
-            _LOGGER.info("Removing slaves from zone with master " +
-                         str(self.device.config.name))
+            _LOGGER.info("Removing slaves from zone with master %s",
+                         self.device.config.name)
             self.device.remove_zone_slave([slave.device for slave in slaves])
 
     def add_zone_slave(self, slaves):
@@ -357,7 +356,6 @@ class SoundTouchDevice(MediaPlayerDevice):
         if not slaves:
             _LOGGER.warning("Unable to find slaves to add")
         else:
-            _LOGGER.info(
-                "Adding slaves to zone with master " + str(
-                    self.device.config.name))
+            _LOGGER.info("Adding slaves to zone with master %s",
+                         self.device.config.name)
             self.device.add_zone_slave([slave.device for slave in slaves])

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -270,8 +270,7 @@ class LgWebOSDevice(MediaPlayerDevice):
         """Title of current playing media."""
         if (self._channel is not None) and ('channelName' in self._channel):
             return self._channel['channelName']
-        else:
-            return None
+        return None
 
     @property
     def media_image_url(self):

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -136,7 +136,7 @@ def _load_config(filename):
 class JSONBytesDecoder(json.JSONEncoder):
     """JSONEncoder to decode bytes objects to unicode."""
 
-    # pylint: disable=method-hidden
+    # pylint: disable=method-hidden, arguments-differ
     def default(self, obj):
         """Decode object if it's a bytes object, else defer to base class."""
         if isinstance(obj, bytes):

--- a/homeassistant/components/notify/llamalab_automate.py
+++ b/homeassistant/components/notify/llamalab_automate.py
@@ -56,4 +56,4 @@ class AutomateNotificationService(BaseNotificationService):
 
         response = requests.post(_RESOURCE, json=data)
         if response.status_code != 200:
-            _LOGGER.error("Error sending message: " + str(response))
+            _LOGGER.error("Error sending message: %s", response)

--- a/homeassistant/components/plant.py
+++ b/homeassistant/components/plant.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from collections import deque
 import voluptuous as vol
 
-from exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.const import (
     STATE_OK, STATE_PROBLEM, STATE_UNKNOWN, TEMP_CELSIUS, ATTR_TEMPERATURE,
     CONF_SENSORS, ATTR_UNIT_OF_MEASUREMENT)

--- a/homeassistant/components/plant.py
+++ b/homeassistant/components/plant.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from collections import deque
 import voluptuous as vol
 
+from exceptions import HomeAssistantError
 from homeassistant.const import (
     STATE_OK, STATE_PROBLEM, STATE_UNKNOWN, TEMP_CELSIUS, ATTR_TEMPERATURE,
     CONF_SENSORS, ATTR_UNIT_OF_MEASUREMENT)
@@ -198,8 +199,8 @@ class Plant(Entity):
             self._brightness_history.add_measurement(self._brightness,
                                                      new_state.last_updated)
         else:
-            raise _LOGGER.error("Unknown reading from sensor %s: %s",
-                                entity_id, value)
+            raise HomeAssistantError(
+                "Unknown reading from sensor {}: {}".format(entity_id, value))
         if ATTR_UNIT_OF_MEASUREMENT in new_state.attributes:
             self._unit_of_measurement[reading] = \
                 new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)

--- a/homeassistant/components/python_script.py
+++ b/homeassistant/components/python_script.py
@@ -208,5 +208,4 @@ class TimeWrapper:
                 """Wrap to return callable method if callable."""
                 return attribute(*args, **kw)
             return wrapper
-        else:
-            return attribute
+        return attribute

--- a/homeassistant/components/raspihats.py
+++ b/homeassistant/components/raspihats.py
@@ -4,6 +4,7 @@ Support for controlling raspihats boards.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/raspihats/
 """
+# pylint: disable=import-error,no-name-in-module
 import logging
 import threading
 import time
@@ -143,7 +144,6 @@ class I2CHatsManager(threading.Thread):
 
     def run(self):
         """Keep alive for I2C-HATs."""
-        # pylint: disable=import-error
         from raspihats.i2c_hats import ResponseException
 
         _LOGGER.info(log_message(self, "starting"))
@@ -206,7 +206,6 @@ class I2CHatsManager(threading.Thread):
 
     def read_di(self, address, channel):
         """Read a value from a I2C-HAT digital input."""
-        # pylint: disable=import-error
         from raspihats.i2c_hats import ResponseException
 
         with self._lock:
@@ -219,7 +218,6 @@ class I2CHatsManager(threading.Thread):
 
     def write_dq(self, address, channel, value):
         """Write a value to a I2C-HAT digital output."""
-        # pylint: disable=import-error
         from raspihats.i2c_hats import ResponseException
 
         with self._lock:
@@ -231,7 +229,6 @@ class I2CHatsManager(threading.Thread):
 
     def read_dq(self, address, channel):
         """Read a value from a I2C-HAT digital output."""
-        # pylint: disable=import-error
         from raspihats.i2c_hats import ResponseException
 
         with self._lock:

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -94,7 +94,7 @@ def wait_connection_ready(hass):
     return hass.data[DATA_INSTANCE].async_db_ready
 
 
-def run_information(hass, point_in_time: Optional[datetime]=None):
+def run_information(hass, point_in_time: Optional[datetime] = None):
     """Return information about current run.
 
     There is also the run that covers point_in_time.

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -207,6 +207,7 @@ class HarmonyRemote(remote.RemoteDevice):
         """Start the PowerOff activity."""
         self._client.power_off()
 
+    # pylint: disable=arguments-differ
     def send_command(self, commands, **kwargs):
         """Send a list of commands to one device."""
         device = kwargs.get(ATTR_DEVICE)

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -210,8 +210,7 @@ class XiaomiMiioRemote(RemoteDevice):
         """Hide remote by default."""
         if self._is_hidden:
             return {'hidden': 'true'}
-        else:
-            return
+        return
 
     # pylint: disable=R0201
     @asyncio.coroutine

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -8,8 +8,9 @@ import asyncio
 from collections import defaultdict
 import functools as ft
 import logging
-
 import async_timeout
+
+import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_COMMAND, CONF_HOST, CONF_PORT,
@@ -19,7 +20,6 @@ from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.deprecation import get_deprecated
 from homeassistant.helpers.entity import Entity
-import voluptuous as vol
 
 
 REQUIREMENTS = ['rflink==0.0.34']

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -188,8 +188,8 @@ def find_possible_pt2262_device(device_id):
     for dev_id, device in RFX_DEVICES.items():
         if hasattr(device, 'is_lighting4') and len(dev_id) == len(device_id):
             size = None
-            for i in range(0, len(dev_id)):
-                if dev_id[i] != device_id[i]:
+            for i, (char1, char2) in enumerate(zip(dev_id, device_id)):
+                if char1 != char2:
                     break
                 size = i
 

--- a/homeassistant/components/ring.py
+++ b/homeassistant/components/ring.py
@@ -5,12 +5,12 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/ring/
 """
 import logging
-import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
-
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
-
 from requests.exceptions import HTTPError, ConnectTimeout
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
 REQUIREMENTS = ['ring_doorbell==0.1.8']
 

--- a/homeassistant/components/scene/deconz.py
+++ b/homeassistant/components/scene/deconz.py
@@ -34,7 +34,7 @@ class DeconzScene(Scene):
         self._scene = scene
 
     @asyncio.coroutine
-    def async_activate(self, **kwargs):
+    def async_activate(self):
         """Activate the scene."""
         yield from self._scene.async_set_state({})
 

--- a/homeassistant/components/scene/litejet.py
+++ b/homeassistant/components/scene/litejet.py
@@ -54,6 +54,6 @@ class LiteJetScene(Scene):
             ATTR_NUMBER: self._index
         }
 
-    def activate(self, **kwargs):
+    def activate(self):
         """Activate the scene."""
         self._lj.activate_scene(self._index)

--- a/homeassistant/components/scene/lutron_caseta.py
+++ b/homeassistant/components/scene/lutron_caseta.py
@@ -53,6 +53,6 @@ class LutronCasetaScene(Scene):
         return False
 
     @asyncio.coroutine
-    def async_activate(self, **kwargs):
+    def async_activate(self):
         """Activate the scene."""
         self._bridge.activate_scene(self._scene_id)

--- a/homeassistant/components/scene/velux.py
+++ b/homeassistant/components/scene/velux.py
@@ -48,6 +48,6 @@ class VeluxScene(Scene):
         """There is no way of detecting if a scene is active (yet)."""
         return False
 
-    def activate(self, **kwargs):
+    def activate(self):
         """Activate the scene."""
         self.hass.async_add_job(self.scene.run())

--- a/homeassistant/components/scene/vera.py
+++ b/homeassistant/components/scene/vera.py
@@ -40,7 +40,7 @@ class VeraScene(Scene):
         """Update the scene status."""
         self.vera_scene.refresh()
 
-    def activate(self, **kwargs):
+    def activate(self):
         """Activate the scene."""
         self.vera_scene.activate()
 

--- a/homeassistant/components/scene/wink.py
+++ b/homeassistant/components/scene/wink.py
@@ -43,6 +43,6 @@ class WinkScene(WinkDevice, Scene):
         """Python-wink will always return False."""
         return self.wink.state()
 
-    def activate(self, **kwargs):
+    def activate(self):
         """Activate the scene."""
         self.wink.activate()

--- a/homeassistant/components/sensor/bme680.py
+++ b/homeassistant/components/sensor/bme680.py
@@ -116,7 +116,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     return
 
 
-# pylint: disable=import-error
+# pylint: disable=import-error, no-member
 def _setup_bme680(config):
     """Set up and configure the BME680 sensor."""
     from smbus import SMBus

--- a/homeassistant/components/sensor/cups.py
+++ b/homeassistant/components/sensor/cups.py
@@ -138,6 +138,7 @@ class CupsData(object):
         self._port = port
         self.printers = None
 
+    # pylint: disable=no-name-in-module
     def update(self):
         """Get the latest data from CUPS."""
         from cups import Connection

--- a/homeassistant/components/sensor/cups.py
+++ b/homeassistant/components/sensor/cups.py
@@ -128,7 +128,7 @@ class CupsSensor(Entity):
         self._printer = self.data.printers.get(self._name)
 
 
-# pylint: disable=import-error
+# pylint: disable=import-error, no-name-in-module
 class CupsData(object):
     """Get the latest data from CUPS and update the state."""
 
@@ -138,7 +138,6 @@ class CupsData(object):
         self._port = port
         self.printers = None
 
-    # pylint: disable=no-name-in-module
     def update(self):
         """Get the latest data from CUPS."""
         from cups import Connection

--- a/homeassistant/components/sensor/dovado.py
+++ b/homeassistant/components/sensor/dovado.py
@@ -79,7 +79,7 @@ class Dovado:
 
         def send_sms(service):
             """Send SMS through the router."""
-            number = service.data.get('number'),
+            number = service.data.get('number')
             message = service.data.get('message')
             _LOGGER.debug("message for %s: %s", number, message)
             self._dovado.send_sms(number, message)

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -9,13 +9,14 @@ from datetime import timedelta
 from functools import partial
 import logging
 
+import voluptuous as vol
+
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP, STATE_UNKNOWN)
 from homeassistant.core import CoreState
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-import voluptuous as vol
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/dwd_weather_warnings.py
+++ b/homeassistant/components/sensor/dwd_weather_warnings.py
@@ -137,11 +137,11 @@ class DwdWeatherWarningsSensor(Entity):
             data['warning_{}_name'.format(i)] = event['event']
             data['warning_{}_level'.format(i)] = event['level']
             data['warning_{}_type'.format(i)] = event['type']
-            if len(event['headline']) > 0:
+            if event['headline']:
                 data['warning_{}_headline'.format(i)] = event['headline']
-            if len(event['description']) > 0:
+            if event['description']:
                 data['warning_{}_description'.format(i)] = event['description']
-            if len(event['instruction']) > 0:
+            if event['instruction']:
                 data['warning_{}_instruction'.format(i)] = event['instruction']
 
             if event['start'] is not None:

--- a/homeassistant/components/sensor/fritzbox_netmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_netmonitor.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/sensor.fritzbox_netmonitor/
 """
 import logging
 from datetime import timedelta
+from requests.exceptions import RequestException
 
 import voluptuous as vol
 
@@ -14,8 +15,6 @@ from homeassistant.const import (CONF_HOST, STATE_UNAVAILABLE)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
-
-from requests.exceptions import RequestException
 
 REQUIREMENTS = ['fritzconnection==0.6.5']
 

--- a/homeassistant/components/sensor/hp_ilo.py
+++ b/homeassistant/components/sensor/hp_ilo.py
@@ -172,4 +172,4 @@ class HpIloData(object):
                 password=self._password, port=self._port)
         except (hpilo.IloError, hpilo.IloCommunicationError,
                 hpilo.IloLoginFailed) as error:
-            raise ValueError("Unable to init HP ILO, %s", error)
+            raise ValueError("Unable to init HP ILO, {}".format(error))

--- a/homeassistant/components/sensor/ihc.py
+++ b/homeassistant/components/sensor/ihc.py
@@ -62,7 +62,7 @@ class IHCSensor(IHCDevice, Entity):
     """Implementation of the IHC sensor."""
 
     def __init__(self, ihc_controller, name, ihc_id: int, info: bool,
-                 unit, product: Element=None) -> None:
+                 unit, product: Element = None) -> None:
         """Initialize the IHC sensor."""
         super().__init__(ihc_controller, name, ihc_id, info, product)
         self._state = None

--- a/homeassistant/components/sensor/irish_rail_transport.py
+++ b/homeassistant/components/sensor/irish_rail_transport.py
@@ -92,7 +92,7 @@ class IrishRailTransportSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        if len(self._times) > 0:
+        if self._times:
             next_up = "None"
             if len(self._times) > 1:
                 next_up = self._times[1][ATTR_ORIGIN] + " to "
@@ -126,7 +126,7 @@ class IrishRailTransportSensor(Entity):
         """Get the latest data and update the states."""
         self.data.update()
         self._times = self.data.info
-        if len(self._times) > 0:
+        if self._times:
             self._state = self._times[0][ATTR_DUE_IN]
         else:
             self._state = None
@@ -164,7 +164,7 @@ class IrishRailTransportData(object):
                           ATTR_TRAIN_TYPE: train.get('type')}
             self.info.append(train_data)
 
-        if not self.info or len(self.info) == 0:
+        if not self.info or not self.info:
             self.info = self._empty_train_data()
 
     def _empty_train_data(self):

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -254,10 +254,6 @@ def setup_platform(hass, config: ConfigType,
 class ISYSensorDevice(ISYDevice):
     """Representation of an ISY994 sensor device."""
 
-    def __init__(self, node) -> None:
-        """Initialize the ISY994 sensor device."""
-        super().__init__(node)
-
     @property
     def raw_unit_of_measurement(self) -> str:
         """Get the raw unit of measurement for the ISY994 sensor device."""
@@ -312,10 +308,6 @@ class ISYSensorDevice(ISYDevice):
 
 class ISYWeatherDevice(ISYDevice):
     """Representation of an ISY994 weather device."""
-
-    def __init__(self, node) -> None:
-        """Initialize the ISY994 weather device."""
-        super().__init__(node)
 
     @property
     def raw_units(self) -> str:

--- a/homeassistant/components/sensor/lacrosse.py
+++ b/homeassistant/components/sensor/lacrosse.py
@@ -133,10 +133,6 @@ class LaCrosseSensor(Entity):
         """Return the name of the sensor."""
         return self._name
 
-    def update(self, *args):
-        """Get the latest data."""
-        pass
-
     @property
     def device_state_attributes(self):
         """Return the state attributes."""

--- a/homeassistant/components/sensor/linux_battery.py
+++ b/homeassistant/components/sensor/linux_battery.py
@@ -119,24 +119,23 @@ class LinuxBatterySensor(Entity):
                 ATTR_HEALTH: self._battery_stat.health,
                 ATTR_STATUS: self._battery_stat.status,
             }
-        else:
-            return {
-                ATTR_NAME: self._battery_stat.name,
-                ATTR_PATH: self._battery_stat.path,
-                ATTR_ALARM: self._battery_stat.alarm,
-                ATTR_CAPACITY_LEVEL: self._battery_stat.capacity_level,
-                ATTR_CYCLE_COUNT: self._battery_stat.cycle_count,
-                ATTR_ENERGY_FULL: self._battery_stat.energy_full,
-                ATTR_ENERGY_FULL_DESIGN: self._battery_stat.energy_full_design,
-                ATTR_ENERGY_NOW: self._battery_stat.energy_now,
-                ATTR_MANUFACTURER: self._battery_stat.manufacturer,
-                ATTR_MODEL_NAME: self._battery_stat.model_name,
-                ATTR_POWER_NOW: self._battery_stat.power_now,
-                ATTR_SERIAL_NUMBER: self._battery_stat.serial_number,
-                ATTR_STATUS: self._battery_stat.status,
-                ATTR_VOLTAGE_MIN_DESIGN: self._battery_stat.voltage_min_design,
-                ATTR_VOLTAGE_NOW: self._battery_stat.voltage_now,
-            }
+        return {
+            ATTR_NAME: self._battery_stat.name,
+            ATTR_PATH: self._battery_stat.path,
+            ATTR_ALARM: self._battery_stat.alarm,
+            ATTR_CAPACITY_LEVEL: self._battery_stat.capacity_level,
+            ATTR_CYCLE_COUNT: self._battery_stat.cycle_count,
+            ATTR_ENERGY_FULL: self._battery_stat.energy_full,
+            ATTR_ENERGY_FULL_DESIGN: self._battery_stat.energy_full_design,
+            ATTR_ENERGY_NOW: self._battery_stat.energy_now,
+            ATTR_MANUFACTURER: self._battery_stat.manufacturer,
+            ATTR_MODEL_NAME: self._battery_stat.model_name,
+            ATTR_POWER_NOW: self._battery_stat.power_now,
+            ATTR_SERIAL_NUMBER: self._battery_stat.serial_number,
+            ATTR_STATUS: self._battery_stat.status,
+            ATTR_VOLTAGE_MIN_DESIGN: self._battery_stat.voltage_min_design,
+            ATTR_VOLTAGE_NOW: self._battery_stat.voltage_now,
+        }
 
     def update(self):
         """Get the latest data and updates the states."""

--- a/homeassistant/components/sensor/mold_indicator.py
+++ b/homeassistant/components/sensor/mold_indicator.py
@@ -174,7 +174,7 @@ class MoldIndicator(Entity):
             self._dewpoint = \
                 MAGNUS_K3 * (alpha + math.log(self._indoor_hum / 100.0)) / \
                 (beta - math.log(self._indoor_hum / 100.0))
-        _LOGGER.debug("Dewpoint: %f " + TEMP_CELSIUS, self._dewpoint)
+        _LOGGER.debug("Dewpoint: %f %s", self._dewpoint, TEMP_CELSIUS)
 
     def _calc_moldindicator(self):
         """Calculate the humidity at the (cold) calibration point."""
@@ -192,8 +192,8 @@ class MoldIndicator(Entity):
             self._outdoor_temp + (self._indoor_temp - self._outdoor_temp) / \
             self._calib_factor
 
-        _LOGGER.debug("Estimated Critical Temperature: %f " +
-                      TEMP_CELSIUS, self._crit_temp)
+        _LOGGER.debug("Estimated Critical Temperature: %f %s",
+                      self._crit_temp, TEMP_CELSIUS)
 
         # Then calculate the humidity at this point
         alpha = MAGNUS_K2 * self._crit_temp / (MAGNUS_K3 + self._crit_temp)

--- a/homeassistant/components/sensor/nederlandse_spoorwegen.py
+++ b/homeassistant/components/sensor/nederlandse_spoorwegen.py
@@ -71,7 +71,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             NSDepartureSensor(
                 nsapi, departure.get(CONF_NAME), departure.get(CONF_FROM),
                 departure.get(CONF_TO), departure.get(CONF_VIA)))
-    if len(sensors):
+    if sensors:
         add_devices(sensors, True)
 
 

--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -7,6 +7,8 @@ https://home-assistant.io/components/sensor.qnap/
 import logging
 from datetime import timedelta
 
+import voluptuous as vol
+
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
@@ -14,8 +16,6 @@ from homeassistant.const import (
     CONF_VERIFY_SSL, CONF_TIMEOUT, CONF_MONITORED_CONDITIONS, TEMP_CELSIUS)
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
-
-import voluptuous as vol
 
 REQUIREMENTS = ['qnapstats==0.2.4']
 

--- a/homeassistant/components/sensor/skybeacon.py
+++ b/homeassistant/components/sensor/skybeacon.py
@@ -140,7 +140,7 @@ class Monitor(threading.Thread):
 
     def run(self):
         """Thread that keeps connection alive."""
-        # pylint: disable=import-error
+        # pylint: disable=import-error, no-name-in-module, no-member
         import pygatt
         from pygatt.backends import Characteristic
         from pygatt.exceptions import (

--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -173,7 +173,7 @@ class StatisticsSensor(Entity):
         """Remove states which are older than self._max_age."""
         now = dt_util.utcnow()
 
-        while (len(self.ages) > 0) and (now - self.ages[0]) > self._max_age:
+        while self.ages and (now - self.ages[0]) > self._max_age:
             self.ages.popleft()
             self.states.popleft()
 

--- a/homeassistant/components/sensor/teksavvy.py
+++ b/homeassistant/components/sensor/teksavvy.py
@@ -142,18 +142,17 @@ class TekSavvyData(object):
         if req.status != 200:
             _LOGGER.error("Request failed with status: %u", req.status)
             return False
-        else:
-            data = yield from req.json()
-            for (api, ha_name) in API_HA_MAP:
-                self.data[ha_name] = float(data["value"][0][api])
-            on_peak_download = self.data["onpeak_download"]
-            on_peak_upload = self.data["onpeak_upload"]
-            off_peak_download = self.data["offpeak_download"]
-            off_peak_upload = self.data["offpeak_upload"]
-            limit = self.data["limit"]
-            self.data["usage"] = 100*on_peak_download/self.bandwidth_cap
-            self.data["usage_gb"] = on_peak_download
-            self.data["onpeak_total"] = on_peak_download + on_peak_upload
-            self.data["offpeak_total"] = off_peak_download + off_peak_upload
-            self.data["onpeak_remaining"] = limit - on_peak_download
-            return True
+        data = yield from req.json()
+        for (api, ha_name) in API_HA_MAP:
+            self.data[ha_name] = float(data["value"][0][api])
+        on_peak_download = self.data["onpeak_download"]
+        on_peak_upload = self.data["onpeak_upload"]
+        off_peak_download = self.data["offpeak_download"]
+        off_peak_upload = self.data["offpeak_upload"]
+        limit = self.data["limit"]
+        self.data["usage"] = 100*on_peak_download/self.bandwidth_cap
+        self.data["usage_gb"] = on_peak_download
+        self.data["onpeak_total"] = on_peak_download + on_peak_upload
+        self.data["offpeak_total"] = off_peak_download + off_peak_upload
+        self.data["onpeak_remaining"] = limit - on_peak_download
+        return True

--- a/homeassistant/components/sensor/teksavvy.py
+++ b/homeassistant/components/sensor/teksavvy.py
@@ -6,9 +6,11 @@ https://home-assistant.io/components/sensor.teksavvy/
 """
 from datetime import timedelta
 import logging
-
 import asyncio
 import async_timeout
+
+import voluptuous as vol
+
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_API_KEY, CONF_MONITORED_VARIABLES, CONF_NAME)
@@ -16,7 +18,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-import voluptuous as vol
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/viaggiatreno.py
+++ b/homeassistant/components/sensor/viaggiatreno.py
@@ -76,9 +76,8 @@ def async_http_request(hass, uri):
             req = yield from session.get(uri)
         if req.status != 200:
             return {'error': req.status}
-        else:
-            json_response = yield from req.json()
-            return json_response
+        json_response = yield from req.json()
+        return json_response
     except (asyncio.TimeoutError, aiohttp.ClientError) as exc:
         _LOGGER.error("Cannot connect to ViaggiaTreno API endpoint: %s", exc)
     except ValueError:

--- a/homeassistant/components/sensor/volvooncall.py
+++ b/homeassistant/components/sensor/volvooncall.py
@@ -42,12 +42,10 @@ class VolvoSensor(VolvoEntity):
             val /= 10  # L/1000km -> L/100km
             if 'mil' in self.unit_of_measurement:
                 return round(val, 2)
-            else:
-                return round(val, 1)
+            return round(val, 1)
         elif self._attribute == 'distance_to_empty':
             return int(floor(val))
-        else:
-            return int(round(val))
+        return int(round(val))
 
     @property
     def unit_of_measurement(self):
@@ -56,8 +54,7 @@ class VolvoSensor(VolvoEntity):
         if self._state.config[CONF_SCANDINAVIAN_MILES] and 'km' in unit:
             if self._attribute == 'average_fuel_consumption':
                 return 'L/mil'
-            else:
-                return unit.replace('km', 'mil')
+            return unit.replace('km', 'mil')
         return unit
 
     @property

--- a/homeassistant/components/sensor/worldtidesinfo.py
+++ b/homeassistant/components/sensor/worldtidesinfo.py
@@ -90,10 +90,8 @@ class WorldTidesInfoSensor(Entity):
                 tidetime = time.strftime('%I:%M %p', time.localtime(
                     self.data['extremes'][0]['dt']))
                 return "Low tide at %s" % (tidetime)
-            else:
-                return STATE_UNKNOWN
-        else:
             return STATE_UNKNOWN
+        return STATE_UNKNOWN
 
     def update(self):
         """Get the latest data from WorldTidesInfo API."""

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -226,7 +226,7 @@ class YrData(object):
 
         # Update all devices
         tasks = []
-        if len(ordered_entries) > 0:
+        if ordered_entries:
             for dev in self.devices:
                 new_state = None
 
@@ -258,5 +258,5 @@ class YrData(object):
                     dev._state = new_state
                     tasks.append(dev.async_update_ha_state())
 
-        if len(tasks) > 0:
+        if tasks:
             yield from asyncio.wait(tasks, loop=self.hass.loop)

--- a/homeassistant/components/sensor/zigbee.py
+++ b/homeassistant/components/sensor/zigbee.py
@@ -70,7 +70,7 @@ class ZigBeeTemperatureSensor(Entity):
         """Return the unit of measurement the value is expressed in."""
         return TEMP_CELSIUS
 
-    def update(self, *args):
+    def update(self):
         """Get the latest data."""
         try:
             self._temp = zigbee.DEVICE.get_temperature(self._config.address)

--- a/homeassistant/components/sleepiq.py
+++ b/homeassistant/components/sleepiq.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/sleepiq/
 """
 import logging
 from datetime import timedelta
+from requests.exceptions import HTTPError
 
 import voluptuous as vol
 
@@ -14,7 +15,6 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.util import Throttle
-from requests.exceptions import HTTPError
 
 DOMAIN = 'sleepiq'
 

--- a/homeassistant/components/switch/acer_projector.py
+++ b/homeassistant/components/switch/acer_projector.py
@@ -155,13 +155,13 @@ class AcerSwitch(SwitchDevice):
                 awns = self._write_read_format(msg)
                 self._attributes[key] = awns
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the projector on."""
         msg = CMD_DICT[STATE_ON]
         self._write_read(msg)
         self._state = STATE_ON
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the projector off."""
         msg = CMD_DICT[STATE_OFF]
         self._write_read(msg)

--- a/homeassistant/components/switch/anel_pwrctrl.py
+++ b/homeassistant/components/switch/anel_pwrctrl.py
@@ -101,11 +101,11 @@ class PwrCtrlSwitch(SwitchDevice):
         """Trigger update for all switches on the parent device."""
         self._parent_device.update()
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the switch on."""
         self._port.on()
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the switch off."""
         self._port.off()
 

--- a/homeassistant/components/switch/arduino.py
+++ b/homeassistant/components/switch/arduino.py
@@ -83,12 +83,12 @@ class ArduinoSwitch(SwitchDevice):
         """Return true if pin is high/on."""
         return self._state
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the pin to high/on."""
         self._state = True
         self.turn_on_handler(self._pin)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the pin to low/off."""
         self._state = False
         self.turn_off_handler(self._pin)

--- a/homeassistant/components/switch/dlink.py
+++ b/homeassistant/components/switch/dlink.py
@@ -117,7 +117,7 @@ class SmartPlugSwitch(SwitchDevice):
         """Turn the switch on."""
         self.data.smartplug.state = 'ON'
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the switch off."""
         self.data.smartplug.state = 'OFF'
 

--- a/homeassistant/components/switch/edimax.py
+++ b/homeassistant/components/switch/edimax.py
@@ -77,7 +77,7 @@ class SmartPlugSwitch(SwitchDevice):
         """Turn the switch on."""
         self.smartplug.state = 'ON'
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the switch off."""
         self.smartplug.state = 'OFF'
 

--- a/homeassistant/components/switch/fritzdect.py
+++ b/homeassistant/components/switch/fritzdect.py
@@ -130,7 +130,7 @@ class FritzDectSwitch(SwitchDevice):
             _LOGGER.error("Fritz!Box query failed, triggering relogin")
             self.data.is_online = False
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the switch off."""
         if not self.data.is_online:
             _LOGGER.error("turn_off: Not online skipping request")

--- a/homeassistant/components/switch/gc100.py
+++ b/homeassistant/components/switch/gc100.py
@@ -56,11 +56,11 @@ class GC100Switch(ToggleEntity):
         """Return the state of the entity."""
         return self._state
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the device on."""
         self._gc100.write_switch(self._port_addr, 1, self.set_state)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the device off."""
         self._gc100.write_switch(self._port_addr, 0, self.set_state)
 

--- a/homeassistant/components/switch/hdmi_cec.py
+++ b/homeassistant/components/switch/hdmi_cec.py
@@ -47,7 +47,7 @@ class CecSwitchDevice(CecDevice, SwitchDevice):
         self._device.turn_off()
         self._state = STATE_ON
 
-    def toggle(self):
+    def toggle(self, **kwargs):
         """Toggle the entity."""
         self._device.toggle()
         if self._state == STATE_ON:

--- a/homeassistant/components/switch/ihc.py
+++ b/homeassistant/components/switch/ihc.py
@@ -53,7 +53,7 @@ class IHCSwitch(IHCDevice, SwitchDevice):
     """IHC Switch."""
 
     def __init__(self, ihc_controller, name: str, ihc_id: int,
-                 info: bool, product: Element=None) -> None:
+                 info: bool, product: Element = None) -> None:
         """Initialize the IHC switch."""
         super().__init__(ihc_controller, name, ihc_id, product)
         self._state = False

--- a/homeassistant/components/switch/isy994.py
+++ b/homeassistant/components/switch/isy994.py
@@ -33,10 +33,6 @@ def setup_platform(hass, config: ConfigType,
 class ISYSwitchDevice(ISYDevice, SwitchDevice):
     """Representation of an ISY994 switch device."""
 
-    def __init__(self, node) -> None:
-        """Initialize the ISY994 switch device."""
-        super().__init__(node)
-
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 device is in the on state."""

--- a/homeassistant/components/switch/netio.py
+++ b/homeassistant/components/switch/netio.py
@@ -141,11 +141,11 @@ class NetioSwitch(SwitchDevice):
         """Return true if entity is available."""
         return not hasattr(self, 'telnet')
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn switch on."""
         self._set(True)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn switch off."""
         self._set(False)
 

--- a/homeassistant/components/switch/pilight.py
+++ b/homeassistant/components/switch/pilight.py
@@ -188,10 +188,10 @@ class PilightSwitch(SwitchDevice):
         self._state = turn_on
         self.schedule_update_ha_state()
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the switch on by calling pilight.send service with on code."""
         self.set_state(turn_on=True)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the switch on by calling pilight.send service with off code."""
         self.set_state(turn_on=False)

--- a/homeassistant/components/switch/rachio.py
+++ b/homeassistant/components/switch/rachio.py
@@ -216,7 +216,7 @@ class RachioZone(SwitchDevice):
 
         _LOGGER.debug("Updated %s", str(self))
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Start the zone."""
         # Stop other zones first
         self.turn_off()
@@ -224,7 +224,7 @@ class RachioZone(SwitchDevice):
         _LOGGER.info("Watering %s for %d s", self.name, self._manual_run_secs)
         self.rachio.zone.start(self.zone_id, self._manual_run_secs)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Stop all zones."""
         _LOGGER.info("Stopping watering of all zones")
         self.rachio.device.stopWater(self._device.device_id)

--- a/homeassistant/components/switch/raincloud.py
+++ b/homeassistant/components/switch/raincloud.py
@@ -59,7 +59,7 @@ class RainCloudSwitch(RainCloudEntity, SwitchDevice):
         """Return true if device is on."""
         return self._state
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the device on."""
         if self._sensor_type == 'manual_watering':
             self.data.watering_time = self._default_watering_timer
@@ -67,7 +67,7 @@ class RainCloudSwitch(RainCloudEntity, SwitchDevice):
             self.data.auto_watering = True
         self._state = True
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the device off."""
         if self._sensor_type == 'manual_watering':
             self.data.watering_time = 'off'

--- a/homeassistant/components/switch/raspihats.py
+++ b/homeassistant/components/switch/raspihats.py
@@ -121,7 +121,7 @@ class I2CHatSwitch(ToggleEntity):
             _LOGGER.error(self._log_message("Is ON check failed, " + str(ex)))
             return False
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the device on."""
         try:
             state = True if self._invert_logic is False else False
@@ -130,7 +130,7 @@ class I2CHatSwitch(ToggleEntity):
         except I2CHatsException as ex:
             _LOGGER.error(self._log_message("Turn ON failed, " + str(ex)))
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the device off."""
         try:
             state = False if self._invert_logic is False else True

--- a/homeassistant/components/switch/rpi_pfio.py
+++ b/homeassistant/components/switch/rpi_pfio.py
@@ -75,13 +75,13 @@ class RPiPFIOSwitch(ToggleEntity):
         """Return true if device is on."""
         return self._state
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the device on."""
         rpi_pfio.write_output(self._port, 0 if self._invert_logic else 1)
         self._state = True
         self.schedule_update_ha_state()
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the device off."""
         rpi_pfio.write_output(self._port, 1 if self._invert_logic else 0)
         self._state = False

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -117,13 +117,13 @@ class RPiRFSwitch(SwitchDevice):
                 self._rfdevice.tx_code(code, protocol, pulselength)
         return True
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the switch on."""
         if self._send_code(self._code_on, self._protocol, self._pulselength):
             self._state = True
             self.schedule_update_ha_state()
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the switch off."""
         if self._send_code(self._code_off, self._protocol, self._pulselength):
             self._state = False

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -44,7 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument, import-error
+# pylint: disable=unused-argument, import-error, no-member
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return switches controlled by a generic RF device via GPIO."""
     import rpi_rf

--- a/homeassistant/components/switch/snmp.py
+++ b/homeassistant/components/switch/snmp.py
@@ -95,13 +95,13 @@ class SnmpSwitch(SwitchDevice):
         self._payload_on = payload_on
         self._payload_off = payload_off
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn on the switch."""
         from pyasn1.type.univ import (Integer)
 
         self._set(Integer(self._command_payload_on))
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn off the switch."""
         from pyasn1.type.univ import (Integer)
 

--- a/homeassistant/components/switch/toon.py
+++ b/homeassistant/components/switch/toon.py
@@ -64,7 +64,7 @@ class EnecoSmartPlug(SwitchDevice):
         """Turn the switch on."""
         return self.smartplug.turn_on()
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the switch off."""
         return self.smartplug.turn_off()
 

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -75,7 +75,7 @@ class SmartPlugSwitch(SwitchDevice):
         """Turn the switch on."""
         self.smartplug.turn_on()
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the switch off."""
         self.smartplug.turn_off()
 

--- a/homeassistant/components/switch/verisure.py
+++ b/homeassistant/components/switch/verisure.py
@@ -60,13 +60,13 @@ class VerisureSmartplug(SwitchDevice):
             "$.smartPlugs[?(@.deviceLabel == '%s')]",
             self._device_label) is not None
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Set smartplug status on."""
         hub.session.set_smartplug_state(self._device_label, True)
         self._state = True
         self._change_timestamp = time()
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Set smartplug status off."""
         hub.session.set_smartplug_state(self._device_label, False)
         self._state = False

--- a/homeassistant/components/switch/vultr.py
+++ b/homeassistant/components/switch/vultr.py
@@ -90,12 +90,12 @@ class VultrSwitch(SwitchDevice):
             ATTR_VCPUS: self.data.get('vcpu_count'),
         }
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Boot-up the subscription."""
         if self.data['power_status'] != 'running':
             self._vultr.start(self.subscription)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Halt the subscription."""
         if self.data['power_status'] == 'running':
             self._vultr.halt(self.subscription)

--- a/homeassistant/components/switch/wake_on_lan.py
+++ b/homeassistant/components/switch/wake_on_lan.py
@@ -78,7 +78,7 @@ class WOLSwitch(SwitchDevice):
         """Return the name of the switch."""
         return self._name
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the device on."""
         if self._broadcast_address:
             self._wol.send_magic_packet(
@@ -86,7 +86,7 @@ class WOLSwitch(SwitchDevice):
         else:
             self._wol.send_magic_packet(self._mac_address)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the device off if an off action is present."""
         if self._off_script is not None:
             self._off_script.run()

--- a/homeassistant/components/switch/wink.py
+++ b/homeassistant/components/switch/wink.py
@@ -54,7 +54,7 @@ class WinkToggleDevice(WinkDevice, ToggleEntity):
         """Turn the device on."""
         self.wink.set_state(True)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the device off."""
         self.wink.set_state(False)
 

--- a/homeassistant/components/switch/xiaomi_aqara.py
+++ b/homeassistant/components/switch/xiaomi_aqara.py
@@ -101,7 +101,7 @@ class XiaomiGenericSwitch(XiaomiDevice, SwitchDevice):
             self._state = True
             self.schedule_update_ha_state()
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the switch off."""
         if self._write_to_hub(self._sid, **{self._data_key: 'off'}):
             self._state = False

--- a/homeassistant/components/switch/zoneminder.py
+++ b/homeassistant/components/switch/zoneminder.py
@@ -75,14 +75,14 @@ class ZMSwitchMonitors(SwitchDevice):
         """Return True if entity is on."""
         return self._state
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the entity on."""
         zoneminder.change_state(
             'api/monitors/%i.json' % self._monitor_id,
             {'Monitor[Function]': self._on_state}
         )
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the entity off."""
         zoneminder.change_state(
             'api/monitors/%i.json' % self._monitor_id,

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -93,7 +93,7 @@ class TelegramPoll(BaseTelegramBotEntity):
                 _json = yield from resp.json()
                 return _json
             else:
-                raise WrongHttpStatus('wrong status %s', resp.status)
+                raise WrongHttpStatus('wrong status {}'.format(resp.status))
         finally:
             if resp is not None:
                 yield from resp.release()

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -7,6 +7,8 @@ https://home-assistant.io/components/tellduslive/
 from datetime import datetime, timedelta
 import logging
 
+import voluptuous as vol
+
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL, DEVICE_DEFAULT_NAME,
     CONF_TOKEN, CONF_HOST,
@@ -18,7 +20,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant.util.dt import utcnow
 from homeassistant.util.json import load_json, save_json
-import voluptuous as vol
 
 APPLICATION_NAME = 'Home Assistant'
 

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -352,8 +352,7 @@ class TelldusLiveEntity(Entity):
             return None
         elif self.device.battery == BATTERY_OK:
             return 100
-        else:
-            return self.device.battery  # Percentage
+        return self.device.battery  # Percentage
 
     @property
     def _last_updated(self):

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -411,7 +411,7 @@ class SpeechManager(object):
 
         if key not in self.mem_cache:
             if key not in self.file_cache:
-                raise HomeAssistantError("%s not in cache!", key)
+                raise HomeAssistantError("{} not in cache!".format(key))
             yield from self.async_file_to_mem(key)
 
         content, _ = mimetypes.guess_type(filename)

--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -51,7 +51,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=import-error, no-member, broad-except
+# pylint: disable=import-error, no-member, broad-except, c-extension-no-member
 def setup(hass, config):
     """Register a port mapping for Home Assistant via UPnP."""
     config = config[DOMAIN]

--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -51,6 +51,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
+# pylint: disable=bad-option-value
 # pylint: disable=import-error, no-member, broad-except, c-extension-no-member
 def setup(hass, config):
     """Register a port mapping for Home Assistant via UPnP."""

--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -51,7 +51,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=bad-option-value
 # pylint: disable=import-error, no-member, broad-except, c-extension-no-member
 def setup(hass, config):
     """Register a port mapping for Home Assistant via UPnP."""

--- a/homeassistant/components/vacuum/roomba.py
+++ b/homeassistant/components/vacuum/roomba.py
@@ -242,7 +242,7 @@ class RoombaVacuum(VacuumDevice):
             self.vacuum.set_preference, 'vacHigh', str(high_perf))
 
     @asyncio.coroutine
-    def async_send_command(self, command, params, **kwargs):
+    def async_send_command(self, command, params=None, **kwargs):
         """Send raw command."""
         _LOGGER.debug("async_send_command %s (%s), %s",
                       command, params, kwargs)

--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -341,9 +341,9 @@ class MiroboVacuum(VacuumDevice):
 
     @asyncio.coroutine
     def async_remote_control_move(self,
-                                  rotation: int=0,
-                                  velocity: float=0.3,
-                                  duration: int=1500):
+                                  rotation: int = 0,
+                                  velocity: float = 0.3,
+                                  duration: int = 1500):
         """Move vacuum with remote control mode."""
         yield from self._try_command(
             "Unable to move with remote control the vacuum: %s",
@@ -352,9 +352,9 @@ class MiroboVacuum(VacuumDevice):
 
     @asyncio.coroutine
     def async_remote_control_move_step(self,
-                                       rotation: int=0,
-                                       velocity: float=0.2,
-                                       duration: int=1500):
+                                       rotation: int = 0,
+                                       velocity: float = 0.2,
+                                       duration: int = 1500):
         """Move vacuum one step with remote control mode."""
         yield from self._try_command(
             "Unable to remote control the vacuum: %s",

--- a/homeassistant/components/volvooncall.py
+++ b/homeassistant/components/volvooncall.py
@@ -143,8 +143,7 @@ class VolvoData:
             return vehicle.registration_number
         elif vehicle.vin:
             return vehicle.vin
-        else:
-            return ''
+        return ''
 
 
 class VolvoEntity(Entity):

--- a/homeassistant/components/volvooncall.py
+++ b/homeassistant/components/volvooncall.py
@@ -4,9 +4,10 @@ Support for Volvo On Call.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/volvooncall/
 """
-
 from datetime import timedelta
 import logging
+
+import voluptuous as vol
 
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
                                  CONF_NAME, CONF_RESOURCES)
@@ -16,7 +17,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.util.dt import utcnow
-import voluptuous as vol
 
 DOMAIN = 'volvooncall'
 

--- a/homeassistant/components/weather/buienradar.py
+++ b/homeassistant/components/weather/buienradar.py
@@ -6,6 +6,9 @@ https://home-assistant.io/components/weather.buienradar/
 """
 import logging
 import asyncio
+
+import voluptuous as vol
+
 from homeassistant.components.weather import (
     WeatherEntity, PLATFORM_SCHEMA, ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME)
 from homeassistant.const import \
@@ -14,7 +17,6 @@ from homeassistant.helpers import config_validation as cv
 # Reuse data and API logic from the sensor implementation
 from homeassistant.components.sensor.buienradar import (
     BrData)
-import voluptuous as vol
 
 REQUIREMENTS = ['buienradar==0.9']
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -677,7 +677,7 @@ def async_check_ha_config_file(hass):
 
 
 @callback
-def async_notify_setup_error(hass, component, link=False):
+def async_notify_setup_error(hass, component, display_link=False):
     """Print a persistent notification.
 
     This method must be run in the event loop.
@@ -689,7 +689,7 @@ def async_notify_setup_error(hass, component, link=False):
     if errors is None:
         errors = hass.data[DATA_PERSISTENT_ERRORS] = {}
 
-    errors[component] = errors.get(component) or link
+    errors[component] = errors.get(component) or display_link
 
     message = 'The following components and platforms could not be set up:\n\n'
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -166,7 +166,7 @@ def get_default_config_dir() -> str:
     return os.path.join(data_dir, CONFIG_DIR_NAME)
 
 
-def ensure_config_exists(config_dir: str, detect_location: bool=True) -> str:
+def ensure_config_exists(config_dir: str, detect_location: bool = True) -> str:
     """Ensure a configuration file exists in given configuration directory.
 
     Creating a default one if needed.

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -47,7 +47,7 @@ def _threaded_factory(async_factory):
     return factory
 
 
-def async_from_config(config: ConfigType, config_validation: bool=True):
+def async_from_config(config: ConfigType, config_validation: bool = True):
     """Turn a condition configuration into a method.
 
     Should be run on the event loop.
@@ -70,7 +70,7 @@ def async_from_config(config: ConfigType, config_validation: bool=True):
 from_config = _threaded_factory(async_from_config)
 
 
-def async_and_from_config(config: ConfigType, config_validation: bool=True):
+def async_and_from_config(config: ConfigType, config_validation: bool = True):
     """Create multi condition matcher using 'AND'."""
     if config_validation:
         config = cv.AND_CONDITION_SCHEMA(config)
@@ -101,7 +101,7 @@ def async_and_from_config(config: ConfigType, config_validation: bool=True):
 and_from_config = _threaded_factory(async_and_from_config)
 
 
-def async_or_from_config(config: ConfigType, config_validation: bool=True):
+def async_or_from_config(config: ConfigType, config_validation: bool = True):
     """Create multi condition matcher using 'OR'."""
     if config_validation:
         config = cv.OR_CONDITION_SCHEMA(config)

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -22,8 +22,8 @@ SLOW_UPDATE_WARNING = 10
 
 
 def generate_entity_id(entity_id_format: str, name: Optional[str],
-                       current_ids: Optional[List[str]]=None,
-                       hass: Optional[HomeAssistant]=None) -> str:
+                       current_ids: Optional[List[str]] = None,
+                       hass: Optional[HomeAssistant] = None) -> str:
     """Generate a unique entity ID based on given entity IDs or used IDs."""
     if current_ids is None:
         if hass is None:
@@ -42,8 +42,8 @@ def generate_entity_id(entity_id_format: str, name: Optional[str],
 
 @callback
 def async_generate_entity_id(entity_id_format: str, name: Optional[str],
-                             current_ids: Optional[List[str]]=None,
-                             hass: Optional[HomeAssistant]=None) -> str:
+                             current_ids: Optional[List[str]] = None,
+                             hass: Optional[HomeAssistant] = None) -> str:
     """Generate a unique entity ID based on given entity IDs or used IDs."""
     if current_ids is None:
         if hass is None:

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -74,8 +74,7 @@ def generate_filter(include_domains, include_entities,
             domain = split_entity_id(entity_id)[0]
             if domain in include_d:
                 return entity_id not in exclude_e
-            else:
-                return entity_id in include_e
+            return entity_id in include_e
 
         return entity_filter_4a
 
@@ -88,8 +87,7 @@ def generate_filter(include_domains, include_entities,
             domain = split_entity_id(entity_id)[0]
             if domain in exclude_d:
                 return entity_id in include_e
-            else:
-                return entity_id not in exclude_e
+            return entity_id not in exclude_e
 
         return entity_filter_4b
 

--- a/homeassistant/helpers/icon.py
+++ b/homeassistant/helpers/icon.py
@@ -2,8 +2,8 @@
 from typing import Optional
 
 
-def icon_for_battery_level(battery_level: Optional[int]=None,
-                           charging: bool=False) -> str:
+def icon_for_battery_level(battery_level: Optional[int] = None,
+                           charging: bool = False) -> str:
     """Return a battery icon valid identifier."""
     icon = 'mdi:battery'
     if battery_level is None:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -33,7 +33,7 @@ CONF_WAIT_TEMPLATE = 'wait_template'
 
 
 def call_from_config(hass: HomeAssistant, config: ConfigType,
-                     variables: Optional[Sequence]=None) -> None:
+                     variables: Optional[Sequence] = None) -> None:
     """Call a script based on a config entry."""
     Script(hass, cv.SCRIPT_SCHEMA(config)).run(variables)
 
@@ -41,7 +41,7 @@ def call_from_config(hass: HomeAssistant, config: ConfigType,
 class Script():
     """Representation of a script."""
 
-    def __init__(self, hass: HomeAssistant, sequence, name: str=None,
+    def __init__(self, hass: HomeAssistant, sequence, name: str = None,
                  change_listener=None) -> None:
         """Initialize the script."""
         self.hass = hass
@@ -69,7 +69,7 @@ class Script():
             self.async_run(variables), self.hass.loop).result()
 
     @asyncio.coroutine
-    def async_run(self, variables: Optional[Sequence]=None) -> None:
+    def async_run(self, variables: Optional[Sequence] = None) -> None:
         """Run script.
 
         This method is a coroutine.

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -271,8 +271,7 @@ class TemplateState(State):
         """Return an attribute of the state."""
         if name in TemplateState.__dict__:
             return object.__getattribute__(self, name)
-        else:
-            return getattr(object.__getattribute__(self, '_state'), name)
+        return getattr(object.__getattribute__(self, '_state'), name)
 
     def __repr__(self):
         """Representation of Template State."""

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -45,8 +45,9 @@ class APIStatus(enum.Enum):
 class API(object):
     """Object to pass around Home Assistant API location and credentials."""
 
-    def __init__(self, host: str, api_password: Optional[str]=None,
-                 port: Optional[int]=SERVER_PORT, use_ssl: bool=False) -> None:
+    def __init__(self, host: str, api_password: Optional[str] = None,
+                 port: Optional[int] = SERVER_PORT,
+                 use_ssl: bool = False) -> None:
         """Init the API."""
         self.host = host
         self.port = port
@@ -68,7 +69,7 @@ class API(object):
         if api_password is not None:
             self._headers[HTTP_HEADER_HA_AUTH] = api_password
 
-    def validate_api(self, force_validate: bool=False) -> bool:
+    def validate_api(self, force_validate: bool = False) -> bool:
         """Test if we can communicate with the API."""
         if self.status is None or force_validate:
             self.status = validate_api(self)

--- a/homeassistant/scripts/credstash.py
+++ b/homeassistant/scripts/credstash.py
@@ -24,7 +24,7 @@ def run(args):
         'value', help="The value to save when putting a secret",
         nargs='?', default=None)
 
-    # pylint: disable=import-error
+    # pylint: disable=import-error, no-member
     import credstash
     import botocore
 

--- a/homeassistant/scripts/db_migrator.py
+++ b/homeassistant/scripts/db_migrator.py
@@ -23,8 +23,9 @@ def ts_to_dt(timestamp: Optional[float]) -> Optional[datetime]:
 
 # Based on code at
 # http://stackoverflow.com/questions/3173320/text-progress-bar-in-the-console
-def print_progress(iteration: int, total: int, prefix: str='', suffix: str='',
-                   decimals: int=2, bar_length: int=68) -> None:
+def print_progress(iteration: int, total: int, prefix: str = '',
+                   suffix: str = '', decimals: int = 2,
+                   bar_length: int = 68) -> None:
     """Print progress bar.
 
     Call in a loop to create terminal progress bar

--- a/homeassistant/scripts/influxdb_import.py
+++ b/homeassistant/scripts/influxdb_import.py
@@ -257,8 +257,9 @@ def run(script_args: List) -> int:
 
 # Based on code at
 # http://stackoverflow.com/questions/3173320/text-progress-bar-in-the-console
-def print_progress(iteration: int, total: int, prefix: str='', suffix: str='',
-                   decimals: int=2, bar_length: int=68) -> None:
+def print_progress(iteration: int, total: int, prefix: str = '',
+                   suffix: str = '', decimals: int = 2,
+                   bar_length: int = 68) -> None:
     """Print progress bar.
 
     Call in a loop to create terminal progress bar

--- a/homeassistant/scripts/influxdb_migrator.py
+++ b/homeassistant/scripts/influxdb_migrator.py
@@ -8,8 +8,9 @@ from typing import List
 
 # Based on code at
 # http://stackoverflow.com/questions/3173320/text-progress-bar-in-the-console
-def print_progress(iteration: int, total: int, prefix: str='', suffix: str='',
-                   decimals: int=2, bar_length: int=68) -> None:
+def print_progress(iteration: int, total: int, prefix: str = '',
+                   suffix: str = '', decimals: int = 2,
+                   bar_length: int = 68) -> None:
     """Print progress bar.
 
     Call in a loop to create terminal progress bar

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -24,7 +24,7 @@ SLOW_SETUP_WARNING = 10
 
 
 def setup_component(hass: core.HomeAssistant, domain: str,
-                    config: Optional[Dict]=None) -> bool:
+                    config: Optional[Dict] = None) -> bool:
     """Set up a component and all its dependencies."""
     return run_coroutine_threadsafe(
         async_setup_component(hass, domain, config), loop=hass.loop).result()
@@ -32,7 +32,7 @@ def setup_component(hass: core.HomeAssistant, domain: str,
 
 @asyncio.coroutine
 def async_setup_component(hass: core.HomeAssistant, domain: str,
-                          config: Optional[Dict]=None) -> bool:
+                          config: Optional[Dict] = None) -> bool:
     """Set up a component and all its dependencies.
 
     This method is a coroutine.

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -164,6 +164,7 @@ class OrderedSet(MutableSet):
         """Check if key is in set."""
         return key in self.map
 
+    # pylint: disable=arguments-differ
     def add(self, key):
         """Add an element to the end of the set."""
         if key not in self.map:
@@ -180,6 +181,7 @@ class OrderedSet(MutableSet):
         curr = begin[1]
         curr[2] = begin[1] = self.map[key] = [key, curr, begin]
 
+    # pylint: disable=arguments-differ
     def discard(self, key):
         """Discard an element from the set."""
         if key in self.map:

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -61,7 +61,7 @@ def repr_helper(inp: Any) -> str:
 
 
 def convert(value: T, to_type: Callable[[T], U],
-            default: Optional[U]=None) -> Optional[U]:
+            default: Optional[U] = None) -> Optional[U]:
     """Convert value to to_type, returns default if fails."""
     try:
         return default if value is None else to_type(value)

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -392,8 +392,8 @@ def color_temperature_to_rgb(color_temperature_kelvin):
     return (red, green, blue)
 
 
-def _bound(color_component: float, minimum: float=0,
-           maximum: float=255) -> float:
+def _bound(color_component: float, minimum: float = 0,
+           maximum: float = 255) -> float:
     """
     Bound the given color component value between the given min and max values.
 

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -51,7 +51,7 @@ def utcnow() -> dt.datetime:
     return dt.datetime.now(UTC)
 
 
-def now(time_zone: dt.tzinfo=None) -> dt.datetime:
+def now(time_zone: dt.tzinfo = None) -> dt.datetime:
     """Get now in specified time zone."""
     return dt.datetime.now(time_zone or DEFAULT_TIME_ZONE)
 

--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -84,7 +84,7 @@ def elevation(latitude, longitude):
 # License: https://github.com/maurycyp/vincenty/blob/master/LICENSE
 # pylint: disable=invalid-name, unused-variable, invalid-sequence-index
 def vincenty(point1: Tuple[float, float], point2: Tuple[float, float],
-             miles: bool=False) -> Optional[float]:
+             miles: bool = False) -> Optional[float]:
     """
     Vincenty formula (inverse method) to calculate the distance.
 

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -17,9 +17,9 @@ _LOGGER = logging.getLogger(__name__)
 INSTALL_LOCK = threading.Lock()
 
 
-def install_package(package: str, upgrade: bool=True,
-                    target: Optional[str]=None,
-                    constraints: Optional[str]=None) -> bool:
+def install_package(package: str, upgrade: bool = True,
+                    target: Optional[str] = None,
+                    constraints: Optional[str] = None) -> bool:
     """Install a package on PyPi. Accepts pip compatible package strings.
 
     Return boolean if install successful.

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -13,7 +13,7 @@ except ImportError:
     keyring = None
 
 try:
-    import credstash  # pylint: disable=import-error
+    import credstash  # pylint: disable=import-error, no-member
 except ImportError:
     credstash = None
 
@@ -276,6 +276,7 @@ def _secret_yaml(loader: SafeLineLoader,
     global credstash  # pylint: disable=invalid-name
 
     if credstash:
+        # pylint: disable=no-member
         try:
             pwd = credstash.getSecret(node.value, table=_SECRET_NAMESPACE)
             if pwd:

--- a/pylintrc
+++ b/pylintrc
@@ -13,7 +13,7 @@ reports=no
 # too-many-* - are not enforced for the sake of readability
 # too-few-* - same as too-many-*
 # abstract-method - with intro of async there are always methods missing
-# arguments-differ - for explicit kwargs when overriding methods
+# inconsistent-return-statements - doesn't handle raise
 
 generated-members=botocore.errorfactory
 
@@ -21,10 +21,10 @@ disable=
   abstract-class-little-used,
   abstract-class-not-used,
   abstract-method,
-  arguments-differ,
   cyclic-import,
   duplicate-code,
   global-statement,
+  inconsistent-return-statements,
   locally-disabled,
   not-context-manager,
   redefined-variable-type,

--- a/pylintrc
+++ b/pylintrc
@@ -13,6 +13,7 @@ reports=no
 # too-many-* - are not enforced for the sake of readability
 # too-few-* - same as too-many-*
 # abstract-method - with intro of async there are always methods missing
+# arguments-differ - for explicit kwargs when overriding methods
 
 generated-members=botocore.errorfactory
 
@@ -20,6 +21,7 @@ disable=
   abstract-class-little-used,
   abstract-class-not-used,
   abstract-method,
+  arguments-differ,
   cyclic-import,
   duplicate-code,
   global-statement,

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 # make new things fail. Manually update these pins when pulling in a
 # new version
 flake8==3.5
-pylint==1.6.5
+pylint==1.8.2
 mypy==0.560
 pydocstyle==1.1.1
 coveralls==1.2.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 # make new things fail. Manually update these pins when pulling in a
 # new version
 flake8==3.5
-pylint==1.6.5
+pylint==1.8.1
 mypy==0.560
 pydocstyle==1.1.1
 coveralls==1.2.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 # make new things fail. Manually update these pins when pulling in a
 # new version
 flake8==3.5
-pylint==1.8.1
+pylint==1.6.5
 mypy==0.560
 pydocstyle==1.1.1
 coveralls==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -3,7 +3,7 @@
 # make new things fail. Manually update these pins when pulling in a
 # new version
 flake8==3.5
-pylint==1.6.5
+pylint==1.8.2
 mypy==0.560
 pydocstyle==1.1.1
 coveralls==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -3,7 +3,7 @@
 # make new things fail. Manually update these pins when pulling in a
 # new version
 flake8==3.5
-pylint==1.8.1
+pylint==1.6.5
 mypy==0.560
 pydocstyle==1.1.1
 coveralls==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -3,7 +3,7 @@
 # make new things fail. Manually update these pins when pulling in a
 # new version
 flake8==3.5
-pylint==1.6.5
+pylint==1.8.1
 mypy==0.560
 pydocstyle==1.1.1
 coveralls==1.2.0

--- a/tests/components/cover/test_zwave.py
+++ b/tests/components/cover/test_zwave.py
@@ -118,7 +118,7 @@ def test_roller_commands(hass, mock_openzwave):
     device = zwave.get_device(hass=hass, node=node, values=values,
                               node_config={})
 
-    device.set_cover_position(25)
+    device.set_cover_position(position=25)
     assert node.set_dimmer.called
     value_id, brightness = node.set_dimmer.mock_calls[0][1]
     assert value_id == value.value_id


### PR DESCRIPTION
## Description:

This PR upgrades pylint to 1.8.2 and fixes all resulting error checks.

**Related issue (if applicable):** #7108

### bad-whitespace

[PEP8](https://www.python.org/dev/peps/pep-0008/#other-recommendations) now recommends whitespace between an argument annotation and a default value around the = sign (see PyCQA/pylint#238)

> When combining an argument annotation with a default value, use spaces around the = sign (but only for those arguments that have both an annotation and a default).
> **Yes:**
> ```python
> def munge(sep: AnyStr = None): ...
> def munge(input: AnyStr, sep: AnyStr = None, limit=1000): ...
> ```
> **No:**
> ```python
> def munge(input: AnyStr=None): ...
> def munge(input: AnyStr, limit = 1000): ...
> ```

The code update however causes pylint 1.6.5 to complain about the version **with** the whitespace (i.e. the correct version) - so either the commit has to be reverted (and `bad-whitespace` needs to be disabled for 1.8.2) or `bad-whitespace` is disabled for pylint 1.6.5, which could potentially be a bad idea.

### arguments-differ

Makes sure that the arguments for a overridden method match the super class. Also checks whether the **names** of the arguments match, which seems a bit verbose to me... Anyway, there's one problem though: `DeviceScanner::get_device_name(self, mac: str) -> str` should, as far as I understand, return the device name given a mac. Many implementations of this however don't use MAC-Addresses and call this argument `device`, thus triggering the pylint warning. I don't know what to do about this.

### inconsistent-return-statements

Makes sure all `return` statements in a function either return something (e.g. `None`) or nothing. For example:

```python
def foo():
    if bar():
        return 42
    else:
        return
```

would trigger this check. However, as described in PyCQA/pylint#1782, this currently doesn't handle `raise` - and this erroneous flag is quite common in Home Assistant. Next, I believe correcting this would best be done together with static type checking updates.

### All Changes

 - [x] `len-as-condition`
 - [x] `no-else-return`
 - [x] `bad-whitespace` (see [comment](#bad-whitespace))
 - [x] `too-many-nested-blocks`
 - [x] `logging-not-lazy`
 - [x] `stop-iteration-return` (locally disabled due to bug)
 - [x] `useless-super-delegation`
 - [x] `trailing-comma-tuple` (see commit message)
 - [x] `redefine-argument-from-local`
 - [x] `consider-using-enumerate` (see the one case, the length is already checked before, so that works)
 - [x] `wrong-import-order` (tried to be as consistent as possible)
 - [x] `arguments-differ` ([device_tracker](#arguments-differ))
 - [x] `no-member`
 - [x] `signatures-differ`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
