### PR TITLE
Add new component: BMW connected drive

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -29,6 +29,9 @@ omit =
     homeassistant/components/arduino.py
     homeassistant/components/*/arduino.py
 
+    homeassistant/components/bmw_connected_drive.py
+    homeassistant/components/*/bmw_connected_drive.py
+
     homeassistant/components/android_ip_webcam.py
     homeassistant/components/*/android_ip_webcam.py
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,6 +43,7 @@ homeassistant/components/hassio.py @home-assistant/hassio
 
 # Individual components
 homeassistant/components/alarm_control_panel/egardia.py @jeroenterheerdt
+homeassistant/components/bmw_connected_drive.py @ChristianKuehnel
 homeassistant/components/camera/yi.py @bachya
 homeassistant/components/climate/ephember.py @ttroy50
 homeassistant/components/climate/eq3btsmart.py @rytilahti
@@ -70,6 +71,7 @@ homeassistant/components/switch/tplink.py @rytilahti
 homeassistant/components/xiaomi_aqara.py @danielhiversen @syssi
 
 homeassistant/components/*/axis.py @kane610
+homeassistant/components/*/bmw_connected_drive.py @ChristianKuehnel
 homeassistant/components/*/broadlink.py @danielhiversen
 homeassistant/components/hive.py @Rendili @KJonline
 homeassistant/components/*/hive.py @Rendili @KJonline

--- a/homeassistant/components/bmw_connected_drive.py
+++ b/homeassistant/components/bmw_connected_drive.py
@@ -85,7 +85,7 @@ def setup(hass, config):
 class BMWConnectedDriveAccount(object):
     """Representation of a BMW vehicle."""
 
-    def __init__(self,  username: str, password: str, country: str,
+    def __init__(self, username: str, password: str, country: str,
                  name: str) -> None:
         """Constructor."""
         from bimmer_connected import ConnectedDriveAccount

--- a/homeassistant/components/bmw_connected_drive.py
+++ b/homeassistant/components/bmw_connected_drive.py
@@ -59,7 +59,8 @@ def setup(hass, config):
         password = account_config[CONF_PASSWORD]
         country = account_config[CONF_COUNTRY]
         _LOGGER.debug('Adding new account %s', name)
-        bimmer = BMWConnectedDriveEntity(hass, username, password, country, name)
+        bimmer = BMWConnectedDriveEntity(hass, username, password, country,
+                                         name)
         accounts.append(bimmer)
 
         # update every 5 minutes, select second randomly to reduce server

--- a/homeassistant/components/bmw_connected_drive.py
+++ b/homeassistant/components/bmw_connected_drive.py
@@ -24,16 +24,6 @@ DOMAIN = 'bmw_connected_drive'
 CONF_VALUES = 'values'
 CONF_COUNTRY = 'country'
 
-LENGTH_ATTRIBUTES = [
-    'remaining_range_fuel',
-    'mileage',
-    ]
-
-VAILD_ATTRIBUTES = LENGTH_ATTRIBUTES + [
-    'timestamp',
-    'remaining_fuel',
-]
-
 ACCOUNT_SCHEMA = vol.Schema({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
@@ -113,4 +103,3 @@ class BMWConnectedDriveAccount(object):
     def add_update_listener(self, listener):
         """Add a listener for update notifications."""
         self._update_listeners.append(listener)
-        listener()

--- a/homeassistant/components/bmw_connected_drive.py
+++ b/homeassistant/components/bmw_connected_drive.py
@@ -81,4 +81,3 @@ class BMWConnectedDriveVehicle(object):
         from bimmer_connected import BimmerConnected
         self.bimmer = BimmerConnected(vin, username, password, cache=True)
         self.name = name
-

--- a/homeassistant/components/bmw_connected_drive.py
+++ b/homeassistant/components/bmw_connected_drive.py
@@ -56,7 +56,6 @@ BMW_COMPONENTS = ['device_tracker', 'sensor']
 @asyncio.coroutine
 def async_setup(hass, config):
     """Set up the Demo sensors."""
-
     vehicles = []
     for name, vehicle_config in config[DOMAIN].items():
         vin = vehicle_config[CONF_VIN]
@@ -78,6 +77,7 @@ class BMWConnectedDriveVehicle(object):
     """Representation of a BMW vehicle."""
 
     def __init__(self, name: str, vin: str, username: str, password: str):
+        """Constructor."""
         from bimmer_connected import BimmerConnected
         self.bimmer = BimmerConnected(vin, username, password, cache=True)
         self.name = name

--- a/homeassistant/components/bmw_connected_drive.py
+++ b/homeassistant/components/bmw_connected_drive.py
@@ -1,0 +1,84 @@
+"""
+Reads vehicle status from BMW connected drive portal.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/bmw_connected_drive/
+"""
+import logging
+import asyncio
+
+import voluptuous as vol
+from homeassistant.helpers import discovery
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    CONF_USERNAME, CONF_PASSWORD
+)
+
+
+REQUIREMENTS = ['bimmer_connected==0.1.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_VIN = 'vin'
+DOMAIN = 'bmw_connected_drive'
+CONF_VALUES = 'values'
+
+
+LENGTH_ATTRIBUTES = [
+    'remaining_range_fuel',
+    'mileage',
+    ]
+
+VAILD_ATTRIBUTES = LENGTH_ATTRIBUTES + [
+    'timestamp',
+    'remaining_fuel',
+]
+
+VEHICLE_SCHEMA = vol.Schema({
+    vol.Required(CONF_VIN): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_VALUES, default=VAILD_ATTRIBUTES):
+        vol.All(cv.ensure_list, [vol.In(VAILD_ATTRIBUTES)]),
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: {
+        cv.string: VEHICLE_SCHEMA
+    },
+}, extra=vol.ALLOW_EXTRA)
+
+
+BMW_COMPONENTS = ['device_tracker', 'sensor']
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up the Demo sensors."""
+
+    vehicles = []
+    for name, vehicle_config in config[DOMAIN].items():
+        vin = vehicle_config[CONF_VIN]
+        username = vehicle_config[CONF_USERNAME]
+        password = vehicle_config[CONF_PASSWORD]
+        _LOGGER.debug('Adding new vehicle %s as %s', vin, name)
+        bimmer = BMWConnectedDriveVehicle(name, vin, username, password)
+        vehicles.append(bimmer)
+
+    hass.data[DOMAIN] = vehicles
+
+    for component in BMW_COMPONENTS:
+        discovery.load_platform(hass, component, DOMAIN, {}, config)
+
+    return True
+
+
+class BMWConnectedDriveVehicle(object):
+    """Representation of a BMW vehicle."""
+
+    def __init__(self, name: str, vin: str, username: str, password: str):
+        from bimmer_connected import BimmerConnected
+        self.bimmer = BimmerConnected(vin, username, password, cache=True)
+        self.name = name
+

--- a/homeassistant/components/bmw_connected_drive.py
+++ b/homeassistant/components/bmw_connected_drive.py
@@ -6,24 +6,24 @@ https://home-assistant.io/components/bmw_connected_drive/
 """
 import logging
 import asyncio
+from random import randint
 
 import voluptuous as vol
 from homeassistant.helpers import discovery
+from homeassistant.helpers.event import async_track_utc_time_change
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD
 )
 
-
-REQUIREMENTS = ['bimmer_connected==0.1.0']
+REQUIREMENTS = ['bimmer_connected==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_VIN = 'vin'
 DOMAIN = 'bmw_connected_drive'
 CONF_VALUES = 'values'
-
+CONF_COUNTRY = 'country'
 
 LENGTH_ATTRIBUTES = [
     'remaining_range_fuel',
@@ -35,17 +35,15 @@ VAILD_ATTRIBUTES = LENGTH_ATTRIBUTES + [
     'remaining_fuel',
 ]
 
-VEHICLE_SCHEMA = vol.Schema({
-    vol.Required(CONF_VIN): cv.string,
+ACCOUNT_SCHEMA = vol.Schema({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_VALUES, default=VAILD_ATTRIBUTES):
-        vol.All(cv.ensure_list, [vol.In(VAILD_ATTRIBUTES)]),
+    vol.Required(CONF_COUNTRY): cv.string,
 })
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: {
-        cv.string: VEHICLE_SCHEMA
+        cv.string: ACCOUNT_SCHEMA
     },
 }, extra=vol.ALLOW_EXTRA)
 
@@ -53,19 +51,27 @@ CONFIG_SCHEMA = vol.Schema({
 BMW_COMPONENTS = ['device_tracker', 'sensor']
 
 
-@asyncio.coroutine
-def async_setup(hass, config):
-    """Set up the Demo sensors."""
-    vehicles = []
-    for name, vehicle_config in config[DOMAIN].items():
-        vin = vehicle_config[CONF_VIN]
-        username = vehicle_config[CONF_USERNAME]
-        password = vehicle_config[CONF_PASSWORD]
-        _LOGGER.debug('Adding new vehicle %s as %s', vin, name)
-        bimmer = BMWConnectedDriveVehicle(name, vin, username, password)
-        vehicles.append(bimmer)
+def setup(hass, config):
+    """Set up the BMW connected drive components."""
+    accounts = []
+    for name, account_config in config[DOMAIN].items():
+        username = account_config[CONF_USERNAME]
+        password = account_config[CONF_PASSWORD]
+        country = account_config[CONF_COUNTRY]
+        _LOGGER.debug('Adding new account %s', name)
+        bimmer = BMWConnectedDriveEntity(hass, username, password, country, name)
+        accounts.append(bimmer)
 
-    hass.data[DOMAIN] = vehicles
+        # update every 5 minutes, select second randomly to reduce server
+        # load
+        async_track_utc_time_change(
+            hass, bimmer.async_update, minute=range(0, 60, 5),
+            second=randint(0, 59))
+
+    hass.data[DOMAIN] = accounts
+
+    for account in accounts:
+        account.async_update()
 
     for component in BMW_COMPONENTS:
         discovery.load_platform(hass, component, DOMAIN, {}, config)
@@ -73,11 +79,33 @@ def async_setup(hass, config):
     return True
 
 
-class BMWConnectedDriveVehicle(object):
+class BMWConnectedDriveEntity(object):
     """Representation of a BMW vehicle."""
 
-    def __init__(self, name: str, vin: str, username: str, password: str):
+    def __init__(self, hass, username: str, password: str, country: str,
+                 name: str) -> None:
         """Constructor."""
-        from bimmer_connected import BimmerConnected
-        self.bimmer = BimmerConnected(vin, username, password, cache=True)
+        from bimmer_connected import ConnectedDriveAccount
+
+        self._hass = hass
+        self.account = ConnectedDriveAccount(username, password, country)
         self.name = name
+        self._update_listeners = []
+
+    @asyncio.coroutine
+    def async_update(self, *_):
+        """Update the state of all vehicles.
+
+        Notify all listeners about the update.
+        """
+        _LOGGER.debug('Updating vehicle state for account %s, '
+                      'notifying %d listeners',
+                      self.name, len(self._update_listeners))
+        self.account.update_vehicle_states()
+
+        for listener in self._update_listeners:
+            listener()
+
+    def add_update_listener(self, listener):
+        """Add a listener for update notifications."""
+        self._update_listeners.append(listener)

--- a/homeassistant/components/bmw_connected_drive.py
+++ b/homeassistant/components/bmw_connected_drive.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD
 )
 
-REQUIREMENTS = ['bimmer_connected==0.2.0']
+REQUIREMENTS = ['bimmer_connected==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,7 +88,7 @@ class BMWConnectedDriveAccount(object):
     def __init__(self, username: str, password: str, country: str,
                  name: str) -> None:
         """Constructor."""
-        from bimmer_connected import ConnectedDriveAccount
+        from bimmer_connected.account import ConnectedDriveAccount
 
         self.account = ConnectedDriveAccount(username, password, country)
         self.name = name

--- a/homeassistant/components/bmw_connected_drive.py
+++ b/homeassistant/components/bmw_connected_drive.py
@@ -101,10 +101,13 @@ class BMWConnectedDriveEntity(object):
         _LOGGER.debug('Updating vehicle state for account %s, '
                       'notifying %d listeners',
                       self.name, len(self._update_listeners))
-        self.account.update_vehicle_states()
-
-        for listener in self._update_listeners:
-            listener()
+        try:
+            self.account.update_vehicle_states()
+            for listener in self._update_listeners:
+                listener()
+        except IOError as exception:
+            _LOGGER.error('Error updating the vehicle state.')
+            _LOGGER.exception(exception)
 
     def add_update_listener(self, listener):
         """Add a listener for update notifications."""

--- a/homeassistant/components/device_tracker/bmw_connected_drive.py
+++ b/homeassistant/components/device_tracker/bmw_connected_drive.py
@@ -7,7 +7,6 @@ import logging
 
 from homeassistant.components.bmw_connected_drive import DOMAIN \
     as BMW_DOMAIN
-from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
@@ -15,38 +14,38 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['bmw_connected_drive']
 
 
-def setup_scanner(hass, config, see, discovery_info=None):
+def setup_scanner(hass, config, async_see, discovery_info=None):
     """Set up the BMW tracker."""
-    vehicles = hass.data[BMW_DOMAIN]
-    _LOGGER.debug('Found BME vehicles: %s',
-                  ', '.join([v.name for v in vehicles]))
-    for vehicle in vehicles:
-        BMWDeviceTracker(hass, see, vehicle)
+    entities = hass.data[BMW_DOMAIN]
+    _LOGGER.debug('Found BMW accounts: %s',
+                  ', '.join([v.name for v in entities]))
+    for entity in entities:
+        account = entity.account
+        for vehicle in account.vehicles:
+            BMWDeviceTracker(async_see, entity, account, vehicle)
     return True
 
 
 class BMWDeviceTracker(object):
-    """A class representing a BMW device tracker."""
+    """BMW Connected Drive device tracker."""
 
-    def __init__(self, hass, see, vehicle):
+    def __init__(self, async_see, entity, account, vehicle):
         """Initialize the Tracker."""
-        self._see = see
-        self._vehicle = vehicle
-        self._update_info()
+        self._async_see = async_see
+        self.account = account
+        self.vehicle = vehicle
+        entity.add_update_listener(self.update)
 
-        track_utc_time_change(
-            hass, self._update_info, second=range(0, 60, 30))
-
-    def _update_info(self, now=None):
+    def update(self) -> None:
         """Update the device info."""
-        dev_id = slugify(self._vehicle.name)
+        dev_id = slugify(self.vehicle.modelName)
         attrs = {
             'trackr_id': dev_id,
             'id': dev_id,
-            'name': self._vehicle.name
+            'name': self.vehicle.modelName
         }
-        self._see(
-            dev_id=dev_id, host_name=self._vehicle.name,
-            gps=self._vehicle.bimmer.gps_position, attributes=attrs,
+        self._async_see(
+            dev_id=dev_id, host_name=self.vehicle.modelName,
+            gps=self.vehicle.state.gps_position, attributes=attrs,
             icon='mdi:car'
         )

--- a/homeassistant/components/device_tracker/bmw_connected_drive.py
+++ b/homeassistant/components/device_tracker/bmw_connected_drive.py
@@ -1,0 +1,52 @@
+"""Device tracker for BMW Connected Drive vehicles.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.bmw_connected_drive/
+"""
+import logging
+
+from homeassistant.components.bmw_connected_drive import DOMAIN \
+    as BMW_DOMAIN
+from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.util import slugify
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['bmw_connected_drive']
+
+
+def setup_scanner(hass, config, see, discovery_info=None):
+    """Set up the BMW tracker."""
+    vehicles = hass.data[BMW_DOMAIN]
+    _LOGGER.debug('Found BME vehicles: %s',
+                  ', '.join([v.name for v in vehicles]))
+    for vehicle in vehicles:
+        BMWDeviceTracker(hass, see, vehicle)
+    return True
+
+
+class BMWDeviceTracker(object):
+    """A class representing a BMW device tracker."""
+
+    def __init__(self, hass, see, vehicle):
+        """Initialize the Tracker."""
+        self._see = see
+        self._vehicle = vehicle
+        self._update_info()
+
+        track_utc_time_change(
+            hass, self._update_info, second=range(0, 60, 30))
+
+    def _update_info(self, now=None):
+        """Update the device info."""
+        dev_id = slugify(self._vehicle.name)
+        attrs = {
+            'trackr_id': dev_id,
+            'id': dev_id,
+            'name': self._vehicle.name
+        }
+        self._see(
+            dev_id=dev_id, host_name=self._vehicle.name,
+            gps=self._vehicle.bimmer.gps_position, attributes=attrs,
+            icon='mdi:car'
+        )

--- a/homeassistant/components/device_tracker/bmw_connected_drive.py
+++ b/homeassistant/components/device_tracker/bmw_connected_drive.py
@@ -51,5 +51,9 @@ class BMWDeviceTracker(object):
 
     @asyncio.coroutine
     def async_added_to_hass(self):
-        """Add callback after being added to hass."""
+        """Add callback after being added to hass.
+
+        Show latest data after startup.
+        """
         self._account.add_update_listener(self.update)
+        self.update()

--- a/homeassistant/components/device_tracker/bmw_connected_drive.py
+++ b/homeassistant/components/device_tracker/bmw_connected_drive.py
@@ -21,7 +21,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
                   ', '.join([a.name for a in accounts]))
     for account in accounts:
         for vehicle in account.account.vehicles:
-            tracker = BMWDeviceTracker(see, account, vehicle)
+            tracker = BMWDeviceTracker(see, vehicle)
             account.add_update_listener(tracker.update)
             tracker.update()
     return True
@@ -30,11 +30,10 @@ def setup_scanner(hass, config, see, discovery_info=None):
 class BMWDeviceTracker(object):
     """BMW Connected Drive device tracker."""
 
-    def __init__(self, see, account, vehicle):
+    def __init__(self, see, vehicle):
         """Initialize the Tracker."""
         self._see = see
         self.vehicle = vehicle
-        self._account = account
 
     def update(self) -> None:
         """Update the device info."""

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -1,0 +1,87 @@
+"""
+Reads vehicle status from BMW connected drive portal.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.bmw_connected_drive/
+"""
+import logging
+import asyncio
+
+from homeassistant.components.bmw_connected_drive \
+    import BMWConnectedDriveVehicle, DOMAIN as BMW_DOMAIN
+from homeassistant.helpers.entity import Entity
+
+
+_LOGGER = logging.getLogger(__name__)
+
+LENGTH_ATTRIBUTES = [
+    'remaining_range_fuel',
+    'mileage',
+    ]
+
+VAILD_ATTRIBUTES = LENGTH_ATTRIBUTES + [
+    'remaining_fuel',
+]
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the BMW sensors."""
+    vehicles = hass.data[BMW_DOMAIN]
+    _LOGGER.debug('Found BME vehicles: %s',
+                  ', '.join([v.name for v in vehicles]))
+    devices = []
+    for vehicle in vehicles:
+        for sensor in VAILD_ATTRIBUTES:
+            device = BMWConnectedDriveSensor(vehicle, sensor)
+            devices.append(device)
+    return add_devices(devices)
+
+
+class BMWConnectedDriveSensor(Entity):
+    """Representation of a BMW vehicle."""
+
+    def __init__(self, vehicle: BMWConnectedDriveVehicle, attribute: str):
+        """Constructor."""
+        self._vehicle = vehicle
+        self._attribute = attribute
+        self._state = None
+        self._unit_of_measurement = None
+        self._name = '{}_{}'.format(self._vehicle.name, self._attribute)
+
+    @property
+    def should_poll(self) -> bool:
+        """Data needs to be polled from server."""
+        return True
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor.
+
+        The return type of this call depends on the attribute that
+        is configured.
+        """
+        return self._state
+
+    @property
+    def unit_of_measurement(self) -> str:
+        """Get the unit of measurement."""
+        return self._unit_of_measurement
+
+    @asyncio.coroutine
+    def async_update(self) -> None:
+        """Read new state data from the library."""
+        bimmer = self._vehicle.bimmer
+        self._state = getattr(bimmer, self._attribute)
+
+        if self._attribute in LENGTH_ATTRIBUTES:
+            self._unit_of_measurement = bimmer.unit_of_length
+        elif self._attribute == 'remaining_fuel':
+            self._unit_of_measurement = bimmer.unit_of_volume
+        else:
+            self._unit_of_measurement = None

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -6,8 +6,7 @@ https://home-assistant.io/components/sensor.bmw_connected_drive/
 """
 import logging
 
-from homeassistant.components.bmw_connected_drive \
-    import BMWConnectedDriveEntity, DOMAIN as BMW_DOMAIN
+from homeassistant.components.bmw_connected_drive import DOMAIN as BMW_DOMAIN
 from homeassistant.helpers.entity import Entity
 
 
@@ -42,10 +41,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class BMWConnectedDriveSensor(Entity):
     """Representation of a BMW vehicle."""
 
-    def __init__(self, entity: 'BMWConnectedDriveEntity',
-                 account, vehicle, attribute: str):
+    def __init__(self, entity, account, vehicle, attribute: str):
         """Constructor."""
-
         self._vehicle = vehicle
         self._attribute = attribute
         self._state = None

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -35,7 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             for sensor in VALID_ATTRIBUTES:
                 device = BMWConnectedDriveSensor(account, vehicle, sensor)
                 devices.append(device)
-    return add_devices(devices)
+    add_devices(devices)
 
 
 class BMWConnectedDriveSensor(Entity):
@@ -76,6 +76,7 @@ class BMWConnectedDriveSensor(Entity):
 
     def update(self) -> None:
         """Read new state data from the library."""
+        _LOGGER.debug('Updating %s', self.entity_id)
         vehicle_state = self._vehicle.state
         self._state = getattr(vehicle_state, self._attribute)
 

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -96,4 +96,4 @@ class BMWConnectedDriveSensor(Entity):
         Show latest data after startup.
         """
         self._account.add_update_listener(self.update)
-        self.update()
+        yield from self.hass.async_add_job(self.update)

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -90,5 +90,9 @@ class BMWConnectedDriveSensor(Entity):
 
     @asyncio.coroutine
     def async_added_to_hass(self):
-        """Add callback after being added to hass."""
+        """Add callback after being added to hass.
+
+        Show latest data after startup.
+        """
         self._account.add_update_listener(self.update)
+        self.update()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -129,7 +129,7 @@ beautifulsoup4==4.6.0
 bellows==0.5.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.1.0
+bimmer_connected==0.2.0
 
 # homeassistant.components.blink
 blinkpy==0.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -128,6 +128,9 @@ beautifulsoup4==4.6.0
 # homeassistant.components.zha
 bellows==0.5.0
 
+# homeassistant.components.bmw_connected_drive
+bimmer_connected==0.1.0
+
 # homeassistant.components.blink
 blinkpy==0.6.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -129,7 +129,7 @@ beautifulsoup4==4.6.0
 bellows==0.5.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.2.0
+bimmer_connected==0.3.0
 
 # homeassistant.components.blink
 blinkpy==0.6.0


### PR DESCRIPTION
## Description:
This is a basic implementation of a sensor for BMW Connected Drive vehicles. In the current version your're getting:
* device tracker for your vehicle
* current mileage, fuel and remaining range

I could only test this with one BMW model. So there might be changes necessary to make it work with other models...

**Related issue (if applicable):**  N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4617

## Example entry for `configuration.yaml` (if applicable):
```yaml
bmw_connected_drive:
  mycar:
    username: your_name
    password: your_password
    country: country_of_your_connected_drive_account

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
