### PR TITLE
have climate fallback to state if no ATTR_OPERATION_MODE (#12272)

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -237,7 +237,10 @@ def query_response_sensor(
 def query_response_climate(
         entity: Entity, config: Config, units: UnitSystem) -> dict:
     """Convert a climate entity to a QUERY response."""
-    mode = entity.attributes.get(climate.ATTR_OPERATION_MODE).lower()
+    mode = entity.attributes.get(climate.ATTR_OPERATION_MODE)
+    if mode is None:
+        mode = entity.state
+    mode = mode.lower()
     if mode not in CLIMATE_SUPPORTED_MODES:
         mode = 'heat'
     attrs = entity.attributes


### PR DESCRIPTION
## Description:

As described in #12272 if a cliate device doesn't support setting operation mode, the google assistant component will not return the state of the device.

This updates google assistant to fallback to using the state if the operation_mode attribute is not available.

**Related issue (if applicable):** fixes #12272 


## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
