### PR TITLE
Stop mapping zigbee switches to lights & switches.

### DIFF
--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -15,15 +15,11 @@ def populate_data():
     from zigpy.profiles import PROFILES, zha, zll
 
     DEVICE_CLASS[zha.PROFILE_ID] = {
-        zha.DeviceType.ON_OFF_SWITCH: 'switch',
         zha.DeviceType.SMART_PLUG: 'switch',
 
         zha.DeviceType.ON_OFF_LIGHT: 'light',
         zha.DeviceType.DIMMABLE_LIGHT: 'light',
         zha.DeviceType.COLOR_DIMMABLE_LIGHT: 'light',
-        zha.DeviceType.ON_OFF_LIGHT_SWITCH: 'light',
-        zha.DeviceType.DIMMER_SWITCH: 'light',
-        zha.DeviceType.COLOR_DIMMER_SWITCH: 'light',
     }
     DEVICE_CLASS[zll.PROFILE_ID] = {
         zll.DeviceType.ON_OFF_LIGHT: 'light',


### PR DESCRIPTION
## Description:
Zigbee switches only contain client clusters that are meant to control server clusters on a different device/endpoint.
This device type -> cluster mapping can be found in https://www.nxp.com/docs/en/user-guide/JN-UG-3076.pdf.
The intended usage is of connecting client clusters to server clusters is described in https://products.currentbyge.com/sites/products.currentbyge.com/files/document_file/DT200-GE-Zigbee-Primer-Whitepaper.pdf

The lack of server clusters on switches has been verified using a GE ZigBee Lighting Switch 45856GE and a 45857GE dimmer.

Output from a 45856GE:
```
Device:
  NWK: 0x0cd8
  IEEE: 00:22:a3:00:00:1f:37:68
  Endpoints:
    1: profile=0x104, device_type=DeviceType.ON_OFF_LIGHT
      Input Clusters:
        Basic (0)
        Identify (3)
        Groups (4)
        Scenes (5)
        On/Off (6)
        Metering (1794)
        Diagnostic (2821)
      Output Clusters:
        Time (10)
        Ota (25)
    2: profile=0x104, device_type=DeviceType.ON_OFF_LIGHT_SWITCH
      Input Clusters:
        Basic (0)
        Identify (3)
        Diagnostic (2821)
      Output Clusters:
        Identify (3)
        On/Off (6)
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
fixes #11847

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [N/A] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [N/A] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [N/A] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [N/A] Tests have been added to verify that the new code works.