### PR TITLE
Unifi tracking filter by SSID

### DIFF
--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -53,7 +53,8 @@ def test_config_valid_verify_ssl(hass, mock_scanner, mock_ctrl):
 
     assert mock_scanner.call_count == 1
     assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
-                                               DEFAULT_DETECTION_TIME)
+                                               DEFAULT_DETECTION_TIME,
+                                               None)
 
 
 def test_config_minimal(hass, mock_scanner, mock_ctrl):
@@ -74,7 +75,8 @@ def test_config_minimal(hass, mock_scanner, mock_ctrl):
 
     assert mock_scanner.call_count == 1
     assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
-                                               DEFAULT_DETECTION_TIME)
+                                               DEFAULT_DETECTION_TIME,
+                                               None)
 
 
 def test_config_full(hass, mock_scanner, mock_ctrl):
@@ -100,7 +102,8 @@ def test_config_full(hass, mock_scanner, mock_ctrl):
 
     assert mock_scanner.call_count == 1
     assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
-                                               DEFAULT_DETECTION_TIME)
+                                               DEFAULT_DETECTION_TIME,
+                                               None)
 
 
 def test_config_error():
@@ -148,11 +151,13 @@ def test_scanner_update():
     """Test the scanner update."""
     ctrl = mock.MagicMock()
     fake_clients = [
-        {'mac': '123', 'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-        {'mac': '234', 'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
+        {'mac': '123', 'essid': 'barnet',
+         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
+        {'mac': '234', 'essid': 'barnet',
+         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
     ctrl.get_clients.return_value = fake_clients
-    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME)
+    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None)
     assert ctrl.get_clients.call_count == 1
     assert ctrl.get_clients.call_args == mock.call()
 
@@ -162,19 +167,41 @@ def test_scanner_update_error():
     ctrl = mock.MagicMock()
     ctrl.get_clients.side_effect = APIError(
         '/', 500, 'foo', {}, None)
-    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME)
+    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None)
 
 
 def test_scan_devices():
     """Test the scanning for devices."""
     ctrl = mock.MagicMock()
     fake_clients = [
-        {'mac': '123', 'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-        {'mac': '234', 'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
+        {'mac': '123', 'essid': 'barnet',
+         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
+        {'mac': '234', 'essid': 'barnet',
+         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME)
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None)
     assert set(scanner.scan_devices()) == set(['123', '234'])
+
+
+def test_scan_devices_filtered():
+    """Test the scanning for devices based on SSID."""
+    ctrl = mock.MagicMock()
+    fake_clients = [
+        {'mac': '123', 'essid': 'foonet',
+         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
+        {'mac': '234', 'essid': 'foonet',
+         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
+        {'mac': '567', 'essid': 'notnet',
+         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
+        {'mac': '890', 'essid': 'barnet',
+         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
+    ]
+
+    ssid_filter = ['foonet', 'barnet']
+    ctrl.get_clients.return_value = fake_clients
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, ssid_filter)
+    assert set(scanner.scan_devices()) == set(['123', '234', '890'])
 
 
 def test_get_device_name():
@@ -183,15 +210,18 @@ def test_get_device_name():
     fake_clients = [
         {'mac': '123',
          'hostname': 'foobar',
+         'essid': 'barnet',
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
         {'mac': '234',
          'name': 'Nice Name',
+         'essid': 'barnet',
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
         {'mac': '456',
+         'essid': 'barnet',
          'last_seen': '1504786810'},
     ]
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME)
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None)
     assert scanner.get_device_name('123') == 'foobar'
     assert scanner.get_device_name('234') == 'Nice Name'
     assert scanner.get_device_name('456') is None


### PR DESCRIPTION
## Description:

Enable unifi device tracker component to track devices only on specific SSIDs.
Example: Only track main network, not a guest network.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4622

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Wifi Tracking
device_tracker:
  - platform: unifi
    host: unifi
    username: username
    password: password
    ssid_filter:
      - 'HomeSSID'
      - 'IoTSSID'
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
