### PR TITLE
check_config script fix exit code

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -30,6 +30,8 @@ MOCKS = {
                       config_util._log_pkg_error),
     'logger_exception': ("homeassistant.setup._LOGGER.error",
                          setup._LOGGER.error),
+    'logger_exception_bootstrap': ("homeassistant.bootstrap._LOGGER.error",
+                                   bootstrap._LOGGER.error),
 }
 SILENCE = (
     'homeassistant.bootstrap.clear_secret_cache',
@@ -228,6 +230,11 @@ def check(config_path):
         """Log logger.exceptions."""
         res['except'].setdefault(ERROR_STR, []).append(msg % params)
         MOCKS['logger_exception'][1](msg, *params)
+
+    def mock_logger_exception_bootstrap(msg, *params):
+        """Log logger.exceptions."""
+        res['except'].setdefault(ERROR_STR, []).append(msg % params)
+        MOCKS['logger_exception_bootstrap'][1](msg, *params)
 
     # Patches to skip functions
     for sil in SILENCE:

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -212,3 +212,20 @@ class TestCheckConfig(unittest.TestCase):
             assert res['components'] == {}
             assert res['secret_cache'] == {}
             assert res['secrets'] == {}
+
+    def test_bootstrap_error(self): \
+            # pylint: disable=no-self-use,invalid-name
+        """Test a valid platform setup."""
+        files = {
+            'badbootstrap.yaml': BASE_CONFIG + 'automation: !include no.yaml',
+        }
+        with patch_yaml_files(files):
+            res = check_config.check(get_test_config_dir('badbootstrap.yaml'))
+            change_yaml_files(res)
+
+            err = res['except'].pop(check_config.ERROR_STR)
+            assert len(err) == 1
+            assert res['except'] == {}
+            assert res['components'] == {}
+            assert res['secret_cache'] == {}
+            assert res['secrets'] == {}


### PR DESCRIPTION
## Description:
Catch errors raised in bootstrap.py. 

**Related issue (if applicable):** fixes #6200 

## Example entry for `configuration.yaml` (if applicable):
```yaml
autmoation: !include bad.yaml
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
