### PR TITLE
Fix Weblinks - FTP URL not allowed in 0.63

### DIFF
--- a/homeassistant/components/weblink.py
+++ b/homeassistant/components/weblink.py
@@ -22,9 +22,10 @@ CONF_RELATIVE_URL_REGEX = r'\A/'
 DOMAIN = 'weblink'
 
 ENTITIES_SCHEMA = vol.Schema({
+    # pylint: disable=no-value-for-parameter
     vol.Required(CONF_URL): vol.Any(
         vol.Match(CONF_RELATIVE_URL_REGEX, msg=CONF_RELATIVE_URL_ERROR_MSG),
-        cv.url),
+        vol.Url()),
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_ICON): cv.icon,
 })

--- a/tests/components/test_weblink.py
+++ b/tests/components/test_weblink.py
@@ -91,6 +91,19 @@ class TestComponentWeblink(unittest.TestCase):
             }
         }))
 
+    def test_good_config_ftp_link(self):
+        """Test if new entity is created."""
+        self.assertTrue(setup_component(self.hass, 'weblink', {
+            'weblink': {
+                'entities': [
+                    {
+                        weblink.CONF_NAME: 'My FTP URL',
+                        weblink.CONF_URL: 'ftp://somehost/'
+                    },
+                ],
+            }
+        }))
+
     def test_entities_get_created(self):
         """Test if new entity is created."""
         self.assertTrue(setup_component(self.hass, weblink.DOMAIN, {


### PR DESCRIPTION
## Description:
FTP links are not allowed in 0.63. Changed code back to vol.url() test. 
Additional test added. 

**Related issue (if applicable):** fixes #12286 

## Example entry for `configuration.yaml` (if applicable):
```yaml
weblink:
  entities:
    - name: IP Cam Files
      url: ftp://some/url
      icon: mdi:webcam
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
