### PR TITLE
Fix Panel_IFrame - FTP URL not allowed in 0.63

### DIFF
--- a/homeassistant/components/panel_iframe.py
+++ b/homeassistant/components/panel_iframe.py
@@ -23,13 +23,14 @@ CONF_RELATIVE_URL_REGEX = r'\A/'
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         cv.slug: {
+            # pylint: disable=no-value-for-parameter
             vol.Optional(CONF_TITLE): cv.string,
             vol.Optional(CONF_ICON): cv.icon,
             vol.Required(CONF_URL): vol.Any(
                 vol.Match(
                     CONF_RELATIVE_URL_REGEX,
                     msg=CONF_RELATIVE_URL_ERROR_MSG),
-                cv.url),
+                vol.Url()),
         }})}, extra=vol.ALLOW_EXTRA)
 
 

--- a/tests/components/test_panel_iframe.py
+++ b/tests/components/test_panel_iframe.py
@@ -55,6 +55,11 @@ class TestPanelIframe(unittest.TestCase):
                         'title': 'Api',
                         'url': '/api',
                     },
+                    'ftp': {
+                        'icon': 'mdi:weather',
+                        'title': 'FTP',
+                        'url': 'ftp://some/ftp',
+                    },
                 },
             })
 
@@ -85,4 +90,13 @@ class TestPanelIframe(unittest.TestCase):
             'title': 'Api',
             'url': '/frontend_es5/panels/ha-panel-iframe-md5md5.html',
             'url_path': 'api',
+        }
+
+        assert panels.get('ftp').to_response(self.hass, None) == {
+            'component_name': 'iframe',
+            'config': {'url': 'ftp://some/ftp'},
+            'icon': 'mdi:weather',
+            'title': 'FTP',
+            'url': '/frontend_es5/panels/ha-panel-iframe-md5md5.html',
+            'url_path': 'ftp',
         }


### PR DESCRIPTION
## Description:
FTP links are not allowed in 0.63. Changed code back to vol.url() test.
Additional test added.

**Related issue (if applicable):** fixes #12286 

## Example entry for `configuration.yaml` (if applicable):
```yaml
panel_iframe:
  router:
    title: 'Router'
    url: 'ftp://192.168.1.1'
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
