### PR TITLE
Fix test fixture encoding

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -246,7 +246,7 @@ def fire_service_discovered(hass, service, info):
 def load_fixture(filename):
     """Load a fixture."""
     path = os.path.join(os.path.dirname(__file__), 'fixtures', filename)
-    with open(path) as fptr:
+    with open(path, encoding='utf-8') as fptr:
         return fptr.read()
 
 


### PR DESCRIPTION
## Description:

For the past week, I've constantly been getting errors when running the py.test tests from within PyCharm and ignored them since they had nothing to do with my code. Example:

```
tests/components/weather/test_darksky.py:29 (TestDarkSky.test_setup)
self = <tests.components.weather.test_darksky.TestDarkSky testMethod=test_setup>
mock_req = <requests_mock.mocker.Mocker object at 0x1032a5dd8>
mock_get_forecast = <MagicMock name='get_forecast' id='4348075424'>

    @requests_mock.Mocker()
    @patch('forecastio.api.get_forecast', wraps=forecastio.api.get_forecast)
    def test_setup(self, mock_req, mock_get_forecast):
        """Test for successfully setting up the forecast.io platform."""
        uri = (r'https://api.(darksky.net|forecast.io)\/forecast\/(\w+)\/'
               r'(-?\d+\.?\d*),(-?\d+\.?\d*)')
        mock_req.get(re.compile(uri),
>                    text=load_fixture('darksky.json'))

test_darksky.py:37: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../common.py:250: in load_fixture
    return fptr.read()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <encodings.ascii.IncrementalDecoder object at 0x1032a3828>
input = b'{\n    "alerts": [\n        {\n            "description": "...BEACH HAZARDS STATEMENT REMAINS IN EFFECT UNTIL 9 PM P...day",\n        "summary": "Clear for the hour."\n    },\n    "offset": -7,\n    "timezone": "America/Los_Angeles"\n}\n'
final = True

    def decode(self, input, final=False):
>       return codecs.ascii_decode(input, self.errors)[0]
E       UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 10233: ordinal not in range(128)

[...]/lib/python3.6/encodings/ascii.py:26: UnicodeDecodeError
```

Now I finally took some time to dig into this and manually setting the encoding in `load_fixture` seems to fix the problem. This shouldn't cause any issues on other systems since all fixtures are encoded with `utf-8` anyway.

Side note: Is there any reason we're not using [pathlib](https://docs.python.org/3/library/pathlib.html)? I've used it in my own scripts for months now and it's so much easier to use (and probably safer) than doing `os.path.join`.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
