### PR TITLE
Respect entity namespace for entity registry

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -209,6 +209,10 @@ class EntityPlatform(object):
             else:
                 suggested_object_id = entity.name
 
+            if self.entity_namespace is not None:
+                suggested_object_id = '{} {}'.format(
+                    self.entity_namespace, suggested_object_id)
+
             entry = registry.async_get_or_create(
                 self.domain, self.platform_name, entity.unique_id,
                 suggested_object_id=suggested_object_id)

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -46,6 +46,7 @@ class MockEntityPlatform(entity_platform.EntityPlatform):
             async_entities_added_callback=async_entities_added_callback,
         )
 
+
 class TestHelpersEntityPlatform(unittest.TestCase):
     """Test homeassistant.helpers.entity_component module."""
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -21,6 +21,31 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "test_domain"
 
 
+class MockEntityPlatform(entity_platform.EntityPlatform):
+    """Mock class with some mock defaults."""
+
+    def __init__(
+        self, *, hass,
+        logger=None,
+        domain='test',
+        platform_name='test_platform',
+        scan_interval=timedelta(seconds=15),
+        parallel_updates=0,
+        entity_namespace=None,
+        async_entities_added_callback=lambda: None
+    ):
+        """Initialize a mock entity platform."""
+        super().__init__(
+            hass=hass,
+            logger=logger,
+            domain=domain,
+            platform_name=platform_name,
+            scan_interval=scan_interval,
+            parallel_updates=parallel_updates,
+            entity_namespace=entity_namespace,
+            async_entities_added_callback=async_entities_added_callback,
+        )
+
 class TestHelpersEntityPlatform(unittest.TestCase):
     """Test homeassistant.helpers.entity_component module."""
 
@@ -454,3 +479,13 @@ def test_overriding_name_from_registry(hass):
     state = hass.states.get('test_domain.world')
     assert state is not None
     assert state.name == 'Overridden'
+
+
+@asyncio.coroutine
+def test_registry_respect_entity_namespace(hass):
+    """Test that the registry respects entity namespace."""
+    mock_registry(hass)
+    platform = MockEntityPlatform(hass=hass, entity_namespace='ns')
+    entity = MockEntity(unique_id='1234', name='Device Name')
+    yield from platform.async_add_entities([entity])
+    assert entity.entity_id == 'test.ns_device_name'


### PR DESCRIPTION
## Description:
Fix entity registry not taking entity namespace into consideration when generating initial entity id.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>


## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  platform: something
  entity_namespace: bla
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
