### PR TITLE
Fix Alexa Step Speaker Volume

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -1168,7 +1168,7 @@ def async_api_adjust_volume(hass, config, request, entity):
 @asyncio.coroutine
 def async_api_adjust_volume_step(hass, config, request, entity):
     """Process an adjust volume step request."""
-    volume_step = round(float(request[API_PAYLOAD]['volume'] / 100), 2)
+    volume_step = round(float(request[API_PAYLOAD]['volumeSteps'] / 100), 2)
 
     current_level = entity.attributes.get(media_player.ATTR_MEDIA_VOLUME_LEVEL)
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -511,14 +511,14 @@ def test_media_player(hass):
         'Alexa.StepSpeaker', 'AdjustVolume', 'media_player#test',
         'media_player.volume_set',
         hass,
-        payload={'volume': 20})
+        payload={'volumeSteps': 20})
     assert call.data['volume_level'] == 0.95
 
     call, _ = yield from assert_request_calls_service(
         'Alexa.StepSpeaker', 'AdjustVolume', 'media_player#test',
         'media_player.volume_set',
         hass,
-        payload={'volume': -20})
+        payload={'volumeSteps': -20})
     assert call.data['volume_level'] == 0.55
 
 


### PR DESCRIPTION
## Description:

The Alexa.StepSpeaker Interface returns `volumeSteps` not `volume` in the payload.

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54