### PR TITLE
Fix Report State for Alexa Brightness Controller

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -328,8 +328,10 @@ class _AlexaBrightnessController(_AlexaInterface):
     def get_property(self, name):
         if name != 'brightness':
             raise _UnsupportedProperty(name)
-
-        return round(self.entity.attributes['brightness'] / 255.0 * 100)
+        if 'brightness' in self.entity.attributes:
+            return round(self.entity.attributes['brightness'] / 255.0 * 100)
+        else:
+            return 0
 
 
 class _AlexaColorController(_AlexaInterface):

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -330,8 +330,7 @@ class _AlexaBrightnessController(_AlexaInterface):
             raise _UnsupportedProperty(name)
         if 'brightness' in self.entity.attributes:
             return round(self.entity.attributes['brightness'] / 255.0 * 100)
-        else:
-            return 0
+        return 0
 
 
 class _AlexaColorController(_AlexaInterface):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1096,6 +1096,23 @@ def test_report_lock_state(hass):
 
 
 @asyncio.coroutine
+def test_report_dimmable_light_state(hass):
+    """Test BrightnessController reports brightness correctly."""
+    hass.states.async_set(
+        'light.test_on', 'on', {'friendly_name': "Test light On",
+                                'brightness': 128, 'supported_features': 1})
+    hass.states.async_set(
+        'light.test_off', 'off', {'friendly_name': "Test light Off",
+                                  'supported_features': 1})
+
+    properties = yield from reported_properties(hass, 'light.test_on')
+    properties.assert_equal('Alexa.BrightnessController', 'brightness', 50)
+
+    properties = yield from reported_properties(hass, 'light.test_off')
+    properties.assert_equal('Alexa.BrightnessController', 'brightness', 0)
+
+
+@asyncio.coroutine
 def reported_properties(hass, endpoint):
     """Use ReportState to get properties and return them.
 
@@ -1118,7 +1135,7 @@ class _ReportedProperties(object):
         for prop in self.properties:
             if prop['namespace'] == namespace and prop['name'] == name:
                 assert prop['value'] == value
-            return prop
+                return prop
 
         assert False, 'property %s:%s not in %r' % (
             namespace,


### PR DESCRIPTION
## Description:

The Report State for Alexa.BrightnessController fails because it assumes `brightness` is included in the entities properties at all times. This is not the case, `brightness` is only included when the light is on.

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
