### PR TITLE
AirVisual: Entity Registry updates and cleanup

### DIFF
--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -155,7 +155,7 @@ class AirVisualBaseSensor(Entity):
             self._attrs[ATTR_LATITUDE] = self.data.latitude
             self._attrs[ATTR_LONGITUDE] = self.data.longitude
         else:
-            self._attrs['lat'] = self.data.latitude
+            self._attrs['lati'] = self.data.latitude
             self._attrs['long'] = self.data.longitude
 
         return self._attrs

--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -56,11 +56,6 @@ POLLUTANT_MAPPING = {
 }
 
 SENSOR_LOCALES = {'cn': 'Chinese', 'us': 'U.S.'}
-SENSOR_TYPES = [
-    ('AirPollutionLevelSensor', 'Air Pollution Level', 'mdi:scale'),
-    ('AirQualityIndexSensor', 'Air Quality Index', 'mdi:format-list-numbers'),
-    ('MainPollutantSensor', 'Main Pollutant', 'mdi:chemical-weapon'),
-]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
@@ -112,12 +107,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     sensors = []
     for locale in monitored_locales:
         for sensor_class, name, icon in SENSOR_TYPES:
-            sensors.append(globals()[sensor_class](
-                data,
-                name,
-                icon,
-                locale,
-                unique_id))
+            sensors.append(sensor_class(data, name, icon, locale, unique_id))
 
     add_devices(sensors, True)
 
@@ -291,3 +281,10 @@ class AirVisualData(object):
                           self.__dict__)
             _LOGGER.debug(exc_info)
             self.pollution_info = {}
+
+
+SENSOR_TYPES = [
+    (AirPollutionLevelSensor, 'Air Pollution Level', 'mdi:scale'),
+    (AirQualityIndexSensor, 'Air Quality Index', 'mdi:format-list-numbers'),
+    (MainPollutantSensor, 'Main Pollutant', 'mdi:chemical-weapon'),
+]

--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -100,14 +100,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if city and state and country:
         _LOGGER.debug(
             "Using city, state, and country: %s, %s, %s", city, state, country)
-        location = ','.join((city, state, country))
+        location_id = ','.join((city, state, country))
         data = AirVisualData(
             Client(api_key), city=city, state=state, country=country,
             show_on_map=show_on_map)
     else:
         _LOGGER.debug(
             "Using latitude and longitude: %s, %s", latitude, longitude)
-        location = ','.join((str(latitude), str(longitude)))
+        location_id = ','.join((str(latitude), str(longitude)))
         data = AirVisualData(
             Client(api_key), latitude=latitude, longitude=longitude,
             radius=radius, show_on_map=show_on_map)
@@ -122,7 +122,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 name,
                 icon,
                 locale,
-                location
+                location_id
             ))
 
     add_devices(sensors, True)

--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -79,8 +79,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Configure the platform and add the sensors."""
-    from zlib import adler32
-
     from pyairvisual import Client
 
     classes = {
@@ -124,7 +122,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 name,
                 icon,
                 locale,
-                adler32(location.encode('utf-8'))
+                location
             ))
 
     add_devices(sensors, True)

--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -81,7 +81,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Configure the platform and add the sensors."""
     from zlib import adler32
 
-    import pyairvisual as pav
+    from pyairvisual import Client
 
     classes = {
         'AirPollutionLevelSensor': AirPollutionLevelSensor,
@@ -104,14 +104,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             "Using city, state, and country: %s, %s, %s", city, state, country)
         location = ','.join((city, state, country))
         data = AirVisualData(
-            pav.Client(api_key), city=city, state=state, country=country,
+            Client(api_key), city=city, state=state, country=country,
             show_on_map=show_on_map)
     else:
         _LOGGER.debug(
             "Using latitude and longitude: %s, %s", latitude, longitude)
         location = ','.join((str(latitude), str(longitude)))
         data = AirVisualData(
-            pav.Client(api_key), latitude=latitude, longitude=longitude,
+            Client(api_key), latitude=latitude, longitude=longitude,
             radius=radius, show_on_map=show_on_map)
 
     data.update()
@@ -274,7 +274,7 @@ class AirVisualData(object):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update with new AirVisual data."""
-        import pyairvisual.exceptions as exceptions
+        from pyairvisual.exceptions import HTTPError
 
         try:
             if self.city and self.state and self.country:
@@ -294,7 +294,7 @@ class AirVisualData(object):
                 ATTR_REGION: resp.get('state'),
                 ATTR_COUNTRY: resp.get('country')
             }
-        except exceptions.HTTPError as exc_info:
+        except HTTPError as exc_info:
             _LOGGER.error("Unable to retrieve data on this location: %s",
                           self.__dict__)
             _LOGGER.debug(exc_info)

--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -19,7 +19,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
 REQUIREMENTS = ['pyairvisual==1.0.0']
-
 _LOGGER = getLogger(__name__)
 
 ATTR_CITY = 'city'


### PR DESCRIPTION
## Description:

1. Gives AirVisual sensors a unique ID (based on either city/state/country or latitude/longitude) for inclusion in the entity registry.
2. General cleanup.

**Breaking Change:** this is technically a breaking change. If AirVisual had been configured previously, new entries will be placed into the entity registry, causing there to be two of each sensor type defined. To address, simply alter the `entity_registry.yaml` as desired.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: airvisual
  api_key: qePWFp2pHoP37txTx
  monitored_conditions:
    - us
  show_on_map: false
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
