### PR TITLE
nmap_tracker: don't scan on setup

### DIFF
--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -43,7 +43,7 @@ def get_scanner(hass, config):
     """Validate the configuration and return a Nmap scanner."""
     scanner = NmapDeviceScanner(config[DOMAIN])
 
-    return scanner if scanner.success_init else None
+    return scanner
 
 
 Device = namedtuple('Device', ['mac', 'name', 'ip', 'last_update'])
@@ -76,7 +76,6 @@ class NmapDeviceScanner(DeviceScanner):
         self._options = config[CONF_OPTIONS]
         self.home_interval = timedelta(minutes=minutes)
 
-        self.success_init = self._update_info()
         _LOGGER.info("Scanner initialized")
 
     def scan_devices(self):

--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -41,9 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def get_scanner(hass, config):
     """Validate the configuration and return a Nmap scanner."""
-    scanner = NmapDeviceScanner(config[DOMAIN])
-
-    return scanner
+    return NmapDeviceScanner(config[DOMAIN])
 
 
 Device = namedtuple('Device', ['mac', 'name', 'ip', 'last_update'])


### PR DESCRIPTION
## Description:
A scan takes about 6 seconds so it delays HA from booting. Since another scan is done by the device_tracker base component during setup, there is no need to do two scans on boot (taking 12 seconds).

## Checklist:
  - [x] The code change is tested and works locally.