### PR TITLE
Always return lockState == LOCKED when handling Alexa.LockController

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -1064,7 +1064,16 @@ def async_api_lock(hass, config, request, entity):
         ATTR_ENTITY_ID: entity.entity_id
     }, blocking=False)
 
-    return api_message(request)
+    # Alexa expects a lockState in the response, we don't know the actual
+    # lockState at this point but assume it is locked. It is reported
+    # correctly later when ReportState is called. The alt. to this approach
+    # is to implement DeferredResponse
+    properties = [{
+        'name': 'lockState',
+        'namespace': 'Alexa.LockController',
+        'value': 'LOCKED'
+    }]
+    return api_message(request, context={'properties': properties})
 
 
 # Not supported by Alexa yet

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -401,10 +401,16 @@ def test_lock(hass):
     assert appliance['friendlyName'] == "Test lock"
     assert_endpoint_capabilities(appliance, 'Alexa.LockController')
 
-    yield from assert_request_calls_service(
+    _, msg = yield from assert_request_calls_service(
         'Alexa.LockController', 'Lock', 'lock#test',
         'lock.lock',
         hass)
+
+    # always return LOCKED for now
+    properties = msg['context']['properties'][0]
+    assert properties['name'] == 'lockState'
+    assert properties['namespace'] == 'Alexa.LockController'
+    assert properties['value'] == 'LOCKED'
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

Alexa expects a `lockState` in the response, we don't know the actual `lockState` at this point but assume it is locked. This is fairly safe as this only returned on a lock directive and unless the lock failed the device should be locked. Either way it doesn't matter if the `lockState`is reported correctly at this point because ReportState will return the correct value if the state is queried via voice or the Alexa App. 

The alternative to this approach is to implement [DeferredResponse](https://developer.amazon.com/docs/device-apis/alexa-lockcontroller.html#deferredresponse)

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54