### PR TITLE
Revert #12316

### DIFF
--- a/homeassistant/components/binary_sensor/bloomsky.py
+++ b/homeassistant/components/binary_sensor/bloomsky.py
@@ -31,10 +31,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the available BloomSky weather binary sensors."""
-    # Protect against people having setup the bloomsky platforms
-    if discovery_info is None:
-        return
-
     bloomsky = get_component('bloomsky')
     # Default needed in case of discovery
     sensors = config.get(CONF_MONITORED_CONDITIONS, SENSOR_TYPES)

--- a/homeassistant/components/camera/bloomsky.py
+++ b/homeassistant/components/camera/bloomsky.py
@@ -17,10 +17,6 @@ DEPENDENCIES = ['bloomsky']
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up access to BloomSky cameras."""
-    # Protect against people having setup the bloomsky platforms
-    if discovery_info is None:
-        return
-
     bloomsky = get_component('bloomsky')
     for device in bloomsky.BLOOMSKY.devices.values():
         add_devices([BloomSkyCamera(bloomsky.BLOOMSKY, device)])

--- a/homeassistant/components/sensor/bloomsky.py
+++ b/homeassistant/components/sensor/bloomsky.py
@@ -45,10 +45,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the available BloomSky weather sensors."""
-    # Protect against people having setup the bloomsky platforms
-    if discovery_info is None:
-        return
-
     bloomsky = get_component('bloomsky')
     # Default needed in case of discovery
     sensors = config.get(CONF_MONITORED_CONDITIONS, SENSOR_TYPES)


### PR DESCRIPTION
## Description:
I had the wrong solution (#12316) for the Bloomsky issue that started in 0.63. The real issue is that we did not properly load dependencies for platforms if a component with same name was already loaded.

