### PR TITLE
Platform dependencies

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -206,7 +206,7 @@ def async_prepare_setup_platform(hass: core.HomeAssistant, config, domain: str,
         return platform
 
     try:
-        yield from _process_deps_reqs(hass, config, platform_name, platform)
+        yield from _process_deps_reqs(hass, config, platform_path, platform)
     except HomeAssistantError as err:
         log_error(str(err))
         return None


### PR DESCRIPTION
## Description:
I introduced a bug in #12051 where we would not process the dependencies and requirements of platforms if a component was already processed with an identical name. This is very common (ie bloomsky and sensor.bloomsky)

**Related issue (if applicable):** fixes #12288


## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
