### PR TITLE
Fix WUnderground names

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -11,14 +11,14 @@ import re
 import requests
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.components.sensor import PLATFORM_SCHEMA, ENTITY_ID_FORMAT
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE,
     TEMP_FAHRENHEIT, TEMP_CELSIUS, LENGTH_INCHES, LENGTH_KILOMETERS,
-    LENGTH_MILES, LENGTH_FEET, STATE_UNKNOWN, ATTR_ATTRIBUTION,
-    ATTR_FRIENDLY_NAME)
+    LENGTH_MILES, LENGTH_FEET, STATE_UNKNOWN, ATTR_ATTRIBUTION)
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
@@ -637,7 +637,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_LANG), latitude, longitude)
     sensors = []
     for variable in config[CONF_MONITORED_CONDITIONS]:
-        sensors.append(WUndergroundSensor(rest, variable))
+        sensors.append(WUndergroundSensor(hass, rest, variable))
 
     rest.update()
     if not rest.data:
@@ -651,7 +651,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class WUndergroundSensor(Entity):
     """Implementing the WUnderground sensor."""
 
-    def __init__(self, rest, condition):
+    def __init__(self, hass: HomeAssistantType, rest, condition):
         """Initialize the sensor."""
         self.rest = rest
         self._condition = condition
@@ -663,6 +663,8 @@ class WUndergroundSensor(Entity):
         self._entity_picture = None
         self._unit_of_measurement = self._cfg_expand("unit_of_measurement")
         self.rest.request_feature(SENSOR_TYPES[condition].feature)
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, "pws_" + condition, hass=hass)
 
     def _cfg_expand(self, what, default=None):
         """Parse and return sensor data."""
@@ -684,9 +686,6 @@ class WUndergroundSensor(Entity):
         """Parse and update device state attributes."""
         attrs = self._cfg_expand("device_state_attributes", {})
 
-        self._attributes[ATTR_FRIENDLY_NAME] = self._cfg_expand(
-            "friendly_name")
-
         for (attr, callback) in attrs.items():
             if callable(callback):
                 try:
@@ -701,7 +700,7 @@ class WUndergroundSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "PWS_" + self._condition
+        return self._cfg_expand("friendly_name")
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT, TEMP_CELSIUS, LENGTH_INCHES, LENGTH_KILOMETERS,
     LENGTH_MILES, LENGTH_FEET, STATE_UNKNOWN, ATTR_ATTRIBUTION)
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import Entity, async_generate_entity_id
+from homeassistant.helpers.entity import Entity, generate_entity_id
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
@@ -663,7 +663,7 @@ class WUndergroundSensor(Entity):
         self._entity_picture = None
         self._unit_of_measurement = self._cfg_expand("unit_of_measurement")
         self.rest.request_feature(SENSOR_TYPES[condition].feature)
-        self.entity_id = async_generate_entity_id(
+        self.entity_id = generate_entity_id(
             ENTITY_ID_FORMAT, "pws_" + condition, hass=hass)
 
     def _cfg_expand(self, what, default=None):

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -249,31 +249,41 @@ class TestWundergroundSetup(unittest.TestCase):
                                     None)
         for device in self.DEVICES:
             device.update()
-            self.assertTrue(str(device.name).startswith('PWS_'))
-            if device.name == 'PWS_weather':
+            entity_id = device.entity_id
+            friendly_name = device.name
+            self.assertTrue(entity_id.startswith('sensor.pws_'))
+            if entity_id == 'sensor.pws_weather':
                 self.assertEqual(HTTPS_ICON_URL, device.entity_picture)
                 self.assertEqual(WEATHER, device.state)
                 self.assertIsNone(device.unit_of_measurement)
-            elif device.name == 'PWS_alerts':
+                self.assertEqual("Weather Summary", friendly_name)
+            elif entity_id == 'sensor.pws_alerts':
                 self.assertEqual(1, device.state)
                 self.assertEqual(ALERT_MESSAGE,
                                  device.device_state_attributes['Message'])
                 self.assertEqual(ALERT_ICON, device.icon)
                 self.assertIsNone(device.entity_picture)
-            elif device.name == 'PWS_location':
+                self.assertEqual('Alerts', friendly_name)
+            elif entity_id == 'sensor.pws_location':
                 self.assertEqual('Holly Springs, NC', device.state)
-            elif device.name == 'PWS_elevation':
+                self.assertEqual('Location', friendly_name)
+            elif entity_id == 'sensor.pws_elevation':
                 self.assertEqual('413', device.state)
-            elif device.name == 'PWS_feelslike_c':
+                self.assertEqual('Elevation', friendly_name)
+            elif entity_id == 'sensor.pws_feelslike_c':
                 self.assertIsNone(device.entity_picture)
                 self.assertEqual(FEELS_LIKE, device.state)
                 self.assertEqual(TEMP_CELSIUS, device.unit_of_measurement)
-            elif device.name == 'PWS_weather_1d_metric':
+                self.assertEqual("Feels Like", friendly_name)
+            elif entity_id == 'sensor.pws_weather_1d_metric':
                 self.assertEqual(FORECAST_TEXT, device.state)
+                self.assertEqual('Tuesday', friendly_name)
             else:
-                self.assertEqual(device.name, 'PWS_precip_1d_in')
+                self.assertEqual(entity_id, 'sensor.pws_precip_1d_in')
                 self.assertEqual(PRECIP_IN, device.state)
                 self.assertEqual(LENGTH_INCHES, device.unit_of_measurement)
+                self.assertEqual('Precipitation Intensity Today',
+                                 friendly_name)
 
     @unittest.mock.patch('requests.get',
                          side_effect=ConnectionError('test exception'))


### PR DESCRIPTION
## Description:

With the changes made for the entity registry, [WUnderground's](https://home-assistant.io/components/sensor.wunderground/) (horrible) way of reporting friendly names to Home Assistant's core broke. Before, each WUnderground sensor would set the **friendly name** by setting the `ATTR_FRIENDLY_NAME` attribute on the sensor and the **entity_id** would be reported through the `name` property. This no longer works with the following code that creates the `entity_id` for each entity and no longer takes into account `attributes[ATTR_FRIENDLY_NAME]`:

https://github.com/home-assistant/home-assistant/blob/034eb9ae1aa33cec829393f409343919c036044c/homeassistant/helpers/entity_platform.py#L230-L233

This PR simply makes WUnderground use the `name` property for the friendly name and the `entity_id` attribute to set the entity_id.

Before:

<img width="485" alt="screen shot 2018-02-12 at 17 42 19" src="https://user-images.githubusercontent.com/6833237/36108068-27f6a580-101c-11e8-97f5-d9af88364f77.png">

After:

<img width="485" alt="screen shot 2018-02-12 at 17 42 12" src="https://user-images.githubusercontent.com/6833237/36108073-2cde9bac-101c-11e8-9289-858465ec20ae.png">


**Related issue (if applicable):** fixes #12282

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: wunderground
    api_key: !secret wunderground_api_key
    monitored_conditions:
      - weather
      - weather_1d_metric
      - weather_1n_metric
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
