### PR TITLE
Input_number: Added display_state option

### DIFF
--- a/homeassistant/components/input_number.py
+++ b/homeassistant/components/input_number.py
@@ -26,6 +26,7 @@ CONF_INITIAL = 'initial'
 CONF_MIN = 'min'
 CONF_MAX = 'max'
 CONF_STEP = 'step'
+CONF_DISPLAY_STATE = 'display_state'
 
 MODE_SLIDER = 'slider'
 MODE_BOX = 'box'
@@ -35,6 +36,7 @@ ATTR_MIN = 'min'
 ATTR_MAX = 'max'
 ATTR_STEP = 'step'
 ATTR_MODE = 'mode'
+ATTR_DISPLAY_STATE = 'display_state'
 
 SERVICE_SET_VALUE = 'set_value'
 SERVICE_INCREMENT = 'increment'
@@ -77,6 +79,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
             vol.Optional(CONF_MODE, default=MODE_SLIDER):
                 vol.In([MODE_BOX, MODE_SLIDER]),
+            vol.Optional(CONF_DISPLAY_STATE): cv.boolean,
         }, _cv_input_number)
     })
 }, required=True, extra=vol.ALLOW_EXTRA)
@@ -136,10 +139,11 @@ def async_setup(hass, config):
         icon = cfg.get(CONF_ICON)
         unit = cfg.get(ATTR_UNIT_OF_MEASUREMENT)
         mode = cfg.get(CONF_MODE)
+        display_state = cfg.get(CONF_DISPLAY_STATE, True)
 
         entities.append(InputNumber(
             object_id, name, initial, minimum, maximum, step, icon, unit,
-            mode))
+            mode, display_state))
 
     if not entities:
         return False
@@ -175,7 +179,7 @@ class InputNumber(Entity):
     """Representation of a slider."""
 
     def __init__(self, object_id, name, initial, minimum, maximum, step, icon,
-                 unit, mode):
+                 unit, mode, display_state):
         """Initialize an input number."""
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)
         self._name = name
@@ -186,6 +190,7 @@ class InputNumber(Entity):
         self._icon = icon
         self._unit = unit
         self._mode = mode
+        self._display_state = display_state
 
     @property
     def should_poll(self):
@@ -220,6 +225,7 @@ class InputNumber(Entity):
             ATTR_MAX: self._maximum,
             ATTR_STEP: self._step,
             ATTR_MODE: self._mode,
+            ATTR_DISPLAY_STATE: self._display_state
         }
 
     @asyncio.coroutine

--- a/tests/components/test_input_number.py
+++ b/tests/components/test_input_number.py
@@ -123,8 +123,8 @@ class TestInputNumber(unittest.TestCase):
         state = self.hass.states.get(entity_id)
         self.assertEqual(49, float(state.state))
 
-    def test_mode(self):
-        """Test mode settings."""
+    def test_mode_and_display_state(self):
+        """Test mode and display_state settings."""
         self.assertTrue(
             setup_component(self.hass, DOMAIN, {DOMAIN: {
                 'test_default_slider': {
@@ -135,25 +135,30 @@ class TestInputNumber(unittest.TestCase):
                     'min': 0,
                     'max': 100,
                     'mode': 'box',
+                    'display_state': 'true',
                 },
                 'test_explicit_slider': {
                     'min': 0,
                     'max': 100,
                     'mode': 'slider',
+                    'display_state': 'false',
                 },
             }}))
 
         state = self.hass.states.get('input_number.test_default_slider')
         assert state
         self.assertEqual('slider', state.attributes['mode'])
+        self.assertTrue(state.attributes['display_state'])
 
         state = self.hass.states.get('input_number.test_explicit_box')
         assert state
         self.assertEqual('box', state.attributes['mode'])
+        self.assertTrue(state.attributes['display_state'])
 
         state = self.hass.states.get('input_number.test_explicit_slider')
         assert state
         self.assertEqual('slider', state.attributes['mode'])
+        self.assertFalse(state.attributes['display_state'])
 
 
 @asyncio.coroutine
@@ -188,6 +193,7 @@ def test_restore_state(hass):
 
 
 @asyncio.coroutine
+# pylint: disable=invalid-name
 def test_initial_state_overrules_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(hass, (
@@ -221,6 +227,7 @@ def test_initial_state_overrules_restore_state(hass):
 
 
 @asyncio.coroutine
+# pylint: disable=invalid-name
 def test_no_initial_state_and_no_restore_state(hass):
     """Ensure that entity is create without initial and restore feature."""
     hass.state = CoreState.starting


### PR DESCRIPTION
## Description:
Added parameter to make changes made by home-assistant/home-assistant-polymer/pull/808 optional.
The default for `display_state` is `true`, so it doesn't change anything until it's set to `false`.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4654
**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) (if applicable):** home-assistant/home-assistant-polymer#886

## Example entry for `configuration.yaml` (if applicable):
```yaml
input_number:
  slider1:
    min: 10
    max: 2
    step: 1
    display_state: false
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
