### PR TITLE
Add the Xiaomi TV platform.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -462,6 +462,7 @@ omit =
     homeassistant/components/media_player/vizio.py
     homeassistant/components/media_player/vlc.py
     homeassistant/components/media_player/volumio.py
+    homeassistant/components/media_player/xiaomi_tv.py
     homeassistant/components/media_player/yamaha.py
     homeassistant/components/media_player/yamaha_musiccast.py
     homeassistant/components/media_player/ziggo_mediabox_xl.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -55,6 +55,7 @@ homeassistant/components/light/tplink.py @rytilahti
 homeassistant/components/light/yeelight.py @rytilahti
 homeassistant/components/media_player/kodi.py @armills
 homeassistant/components/media_player/monoprice.py @etsinko
+homeassistant/components/media_player/xiaomi_tv.py @fattdev
 homeassistant/components/media_player/yamaha_musiccast.py @jalmeroth
 homeassistant/components/plant.py @ChristianKuehnel
 homeassistant/components/sensor/airvisual.py @bachya

--- a/homeassistant/components/media_player/xiaomi_tv.py
+++ b/homeassistant/components/media_player/xiaomi_tv.py
@@ -15,6 +15,8 @@ from homeassistant.components.media_player import (
 
 REQUIREMENTS = ['pymitv==1.0.0']
 
+DEFAULT_NAME="Xiaomi TV"
+
 _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_XIAOMI_TV = SUPPORT_VOLUME_STEP | SUPPORT_TURN_ON | \
@@ -23,7 +25,7 @@ SUPPORT_XIAOMI_TV = SUPPORT_VOLUME_STEP | SUPPORT_TURN_ON | \
 # No host is needed for configuration, however it can be set.
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
 
@@ -43,11 +45,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             )
         else:
             # Register TV with Home Assistant.
-            if name is not None:
-                add_devices([XiaomiTV(host, name)])
-            else:
-                add_devices([XiaomiTV(host)])
-
+            add_devices([XiaomiTV(host, name)])
     else:
         # Otherwise, discover TVs on network.
         add_devices(XiaomiTV(tv) for tv in Discover().scan())
@@ -56,7 +54,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class XiaomiTV(MediaPlayerDevice):
     """Represent the Xiaomi TV for Home Assistant."""
 
-    def __init__(self, ip, name="Xiaomi TV"):
+    def __init__(self, ip, name=DEFAULT_TV):
         """Receive IP address and name to construct class."""
         # Import pymitv library.
         from pymitv import TV

--- a/homeassistant/components/media_player/xiaomi_tv.py
+++ b/homeassistant/components/media_player/xiaomi_tv.py
@@ -67,13 +67,18 @@ class XiaomiTV(MediaPlayerDevice):
 
     @property
     def name(self):
-        """Return the display name of this light."""
+        """Return the display name of this TV."""
         return self._name
 
     @property
     def state(self):
         """Return _state variable, containing the appropriate constant."""
         return self._state
+
+    @property
+    def assumed_state(self):
+        """Indicate that state is assumed."""
+        return True
 
     @property
     def supported_features(self):

--- a/homeassistant/components/media_player/xiaomi_tv.py
+++ b/homeassistant/components/media_player/xiaomi_tv.py
@@ -1,0 +1,109 @@
+"""
+Add support for the Xiaomi TVs.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/xiaomi_tv/
+"""
+
+import logging
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON)
+from homeassistant.components.media_player import (
+    SUPPORT_TURN_ON, SUPPORT_TURN_OFF, MediaPlayerDevice, PLATFORM_SCHEMA,
+    SUPPORT_VOLUME_STEP)
+
+REQUIREMENTS = ['pymitv==1.0.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORT_XIAOMI_TV = SUPPORT_VOLUME_STEP | SUPPORT_TURN_ON | \
+                    SUPPORT_TURN_OFF
+
+# No host is needed for configuration, however it can be set.
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Xiaomi TV platform."""
+    from pymitv import Discover
+
+    # If a hostname is set. Discovery is skipped.
+    host = config.get(CONF_HOST)
+    name = config.get(CONF_NAME)
+
+    if host is not None:
+        # Check if there's a valid TV at the IP address.
+        if not Discover().checkIp(host):
+            _LOGGER.error(
+                "Could not find Xiaomi TV with specified IP: %s", host
+            )
+        else:
+            # Register TV with Home Assistant.
+            if name is not None:
+                add_devices([XiaomiTV(host, name)])
+            else:
+                add_devices([XiaomiTV(host)])
+
+    else:
+        # Otherwise, discover TVs on network.
+        add_devices(XiaomiTV(tv) for tv in Discover().scan())
+
+
+class XiaomiTV(MediaPlayerDevice):
+    """Represent the Xiaomi TV for Home Assistant."""
+
+    def __init__(self, ip, name="Xiaomi TV"):
+        """Receive IP address and name to construct class."""
+        # Import pymitv library.
+        from pymitv import TV
+
+        # Initialize the Xiaomi TV.
+        self._tv = TV(ip)
+        # Default name value, only to be overridden by user.
+        self._name = name
+        self._state = STATE_OFF
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return _state variable, containing the appropriate constant."""
+        return self._state
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_XIAOMI_TV
+
+    def turn_off(self):
+        """
+        Instruct the TV to turn sleep.
+
+        This is done instead of turning off,
+        because the TV won't accept any input when turned off. Thus, the user
+        would be unable to turn the TV back on, unless it's done manually.
+        """
+        self._tv.sleep()
+
+        self._state = STATE_OFF
+
+    def turn_on(self):
+        """Wake the TV back up from sleep."""
+        self._tv.wake()
+
+        self._state = STATE_ON
+
+    def volume_up(self):
+        """Increase volume by one."""
+        self._tv.volume_up()
+
+    def volume_down(self):
+        """Decrease volume by one."""
+        self._tv.volume_down()

--- a/homeassistant/components/media_player/xiaomi_tv.py
+++ b/homeassistant/components/media_player/xiaomi_tv.py
@@ -15,7 +15,7 @@ from homeassistant.components.media_player import (
 
 REQUIREMENTS = ['pymitv==1.0.0']
 
-DEFAULT_NAME="Xiaomi TV"
+DEFAULT_NAME = "Xiaomi TV"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,13 +48,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             add_devices([XiaomiTV(host, name)])
     else:
         # Otherwise, discover TVs on network.
-        add_devices(XiaomiTV(tv) for tv in Discover().scan())
+        add_devices(XiaomiTV(tv, DEFAULT_NAME) for tv in Discover().scan())
 
 
 class XiaomiTV(MediaPlayerDevice):
     """Represent the Xiaomi TV for Home Assistant."""
 
-    def __init__(self, ip, name=DEFAULT_TV):
+    def __init__(self, ip, name):
         """Receive IP address and name to construct class."""
         # Import pymitv library.
         from pymitv import TV

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -787,6 +787,9 @@ pymailgunner==1.4
 # homeassistant.components.media_player.mediaroom
 pymediaroom==0.5
 
+# homeassistant.components.media_player.xiaomi_tv
+pymitv==1.0.0
+
 # homeassistant.components.mochad
 pymochad==0.2.0
 


### PR DESCRIPTION
## Description:
This pull request adds the platform Xiaomi TV, implementing the pymitv Python library.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4653

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: xiaomi_tv
    host: 192.168.0.41 # Optional
    name: Mi TV 3s # Optional
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
