### PR TITLE
Entity Registry: disable entities

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -216,6 +216,14 @@ class EntityPlatform(object):
             entry = registry.async_get_or_create(
                 self.domain, self.platform_name, entity.unique_id,
                 suggested_object_id=suggested_object_id)
+
+            if entry.disabled:
+                self.logger.info(
+                    "Not adding entity %s because it's disabled",
+                    entry.name or entity.name or
+                    '"{} {}"'.format(self.platform_name, entity.unique_id))
+                return
+
             entity.entity_id = entry.entity_id
             entity.registry_name = entry.name
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -19,16 +19,17 @@ from tests.common import (
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "test_domain"
+PLATFORM = 'test_platform'
 
 
 class MockEntityPlatform(entity_platform.EntityPlatform):
     """Mock class with some mock defaults."""
 
     def __init__(
-        self, *, hass,
+        self, hass,
         logger=None,
-        domain='test',
-        platform_name='test_platform',
+        domain=DOMAIN,
+        platform_name=PLATFORM,
         scan_interval=timedelta(seconds=15),
         parallel_updates=0,
         entity_namespace=None,
@@ -486,7 +487,26 @@ def test_overriding_name_from_registry(hass):
 def test_registry_respect_entity_namespace(hass):
     """Test that the registry respects entity namespace."""
     mock_registry(hass)
-    platform = MockEntityPlatform(hass=hass, entity_namespace='ns')
+    platform = MockEntityPlatform(hass, entity_namespace='ns')
     entity = MockEntity(unique_id='1234', name='Device Name')
     yield from platform.async_add_entities([entity])
-    assert entity.entity_id == 'test.ns_device_name'
+    assert entity.entity_id == 'test_domain.ns_device_name'
+
+
+@asyncio.coroutine
+def test_registry_respect_entity_disabled(hass):
+    """Test that the registry respects entity disabled."""
+    mock_registry(hass, {
+        'test_domain.world': entity_registry.RegistryEntry(
+            entity_id='test_domain.world',
+            unique_id='1234',
+            # Using component.async_add_entities is equal to platform "domain"
+            platform='test_platform',
+            disabled_by=entity_registry.DISABLED_USER
+        )
+    })
+    platform = MockEntityPlatform(hass)
+    entity = MockEntity(unique_id='1234')
+    yield from platform.async_add_entities([entity])
+    assert entity.entity_id is None
+    assert hass.states.async_entity_ids() == []

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -148,6 +148,14 @@ test.named:
 test.no_name:
   platform: super_platform
   unique_id: without-name
+test.disabled_user:
+  platform: super_platform
+  unique_id: disabled-user
+  disabled_by: user
+test.disabled_hass:
+  platform: super_platform
+  unique_id: disabled-hass
+  disabled_by: hass
 """
 
     registry = entity_registry.EntityRegistry(hass)
@@ -162,3 +170,13 @@ test.no_name:
         'test', 'super_platform', 'without-name')
     assert entry_with_name.name == 'registry override'
     assert entry_without_name.name is None
+    assert not entry_with_name.disabled
+
+    entry_disabled_hass = registry.async_get_or_create(
+        'test', 'super_platform', 'disabled-hass')
+    entry_disabled_user = registry.async_get_or_create(
+        'test', 'super_platform', 'disabled-user')
+    assert entry_disabled_hass.disabled
+    assert entry_disabled_hass.disabled_by == entity_registry.DISABLED_HASS
+    assert entry_disabled_user.disabled
+    assert entry_disabled_user.disabled_by == entity_registry.DISABLED_USER


### PR DESCRIPTION
## Description:
Add ability to disable entities from the entity registry. When a disabled entity is passed to `async_add_entities`, it will be ignored.

To disable an entity, add the key `disabled_by: user` to an entity. We might in the future also get `disabled_by: hass` if an entity is doing I/O in the event loop or misbehaving in any other way 👍 

For integrations to make sure that they don't do any extra work, they should make sure to only listen for updates to their entities when `async_added_to_hass` is called.

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
