### PR TITLE
Pollen.com: Entity Registry updates and cleanup

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -116,6 +116,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Configure the platform and add the sensors."""
     from zlib import adler32
+
     from pypollencom import Client
 
     _LOGGER.debug('Configuration data: %s', config)

--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -115,8 +115,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Configure the platform and add the sensors."""
-    from zlib import adler32
-
     from pypollencom import Client
 
     _LOGGER.debug('Configuration data: %s', config)
@@ -143,7 +141,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             params,
             name,
             icon,
-            adler32(str(config[CONF_ZIP_CODE]).encode('utf-8'))
+            config[CONF_ZIP_CODE]
         ))
 
     add_devices(sensors, True)
@@ -161,7 +159,7 @@ def calculate_trend(list_of_nums):
 class BaseSensor(Entity):
     """Define a base class for all of our sensors."""
 
-    def __init__(self, data, data_params, name, icon, entity_id):
+    def __init__(self, data, data_params, name, icon, unique_id):
         """Initialize the sensor."""
         self._attrs = {}
         self._icon = icon
@@ -169,7 +167,7 @@ class BaseSensor(Entity):
         self._data_params = data_params
         self._state = None
         self._unit = None
-        self._entity_id = entity_id
+        self._unique_id = unique_id
         self.data = data
 
     @property
@@ -196,7 +194,7 @@ class BaseSensor(Entity):
     @property
     def unique_id(self):
         """Return a unique, HASS-friendly identifier for this entity."""
-        return '{0}_{1}'.format(self._entity_id, slugify(self._name))
+        return '{0}_{1}'.format(self._unique_id, slugify(self._name))
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -136,7 +136,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             datas[data_key],
             params,
             name,
-            icon
+            icon,
+            config[CONF_ZIP_CODE]
         ))
 
     add_devices(sensors, True)
@@ -154,7 +155,7 @@ def calculate_trend(list_of_nums):
 class BaseSensor(Entity):
     """Define a base class for all of our sensors."""
 
-    def __init__(self, data, data_params, name, icon):
+    def __init__(self, data, data_params, name, icon, zip_code):
         """Initialize the sensor."""
         self._attrs = {}
         self._icon = icon
@@ -162,6 +163,7 @@ class BaseSensor(Entity):
         self._data_params = data_params
         self._state = None
         self._unit = None
+        self._zip_code = zip_code
         self.data = data
 
     @property
@@ -193,6 +195,11 @@ class BaseSensor(Entity):
 
 class AllergyAverageSensor(BaseSensor):
     """Define a sensor to show allergy average information."""
+
+    @property
+    def unique_id(self):
+        """Return a unique, HASS-friendly identifier for this entity."""
+        return '{0}_pollution_level'.format(self._unique_id)
 
     def update(self):
         """Update the status of the sensor."""


### PR DESCRIPTION
## Description:

1. Gives Pollen.com sensors a unique ID (based on ZIP code) for inclusion in the entity registry.
2. General cleanup.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: pollen
  zip_code: 12345
  monitored_conditions:
    - allergy_average_forecasted
    - allergy_average_historical
    - allergy_index_today
    - allergy_index_tomorrow
    - allergy_index_yesterday
    - disease_average_forecasted
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54