### PR TITLE
Add unique_id to Xiaomi Aqara

### DIFF
--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -21,6 +21,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
+from homeassistant.util import slugify
 
 REQUIREMENTS = ['PyXiaomiGateway==0.8.0']
 
@@ -213,8 +214,9 @@ class XiaomiDevice(Entity):
         self._name = '{}_{}'.format(name, self._sid)
         self._write_to_hub = xiaomi_hub.write_to_hub
         self._get_from_hub = xiaomi_hub.get_from_hub
+        self._unique_id = "aqara-" + slugify(self._name)
         self._device_state_attributes = {
-            'unique_id': self.unique_id
+            'unique_id': self._unique_id
         }
         self._remove_unavailability_tracker = None
         xiaomi_hub.callbacks[self._sid].append(self._add_push_data_job)
@@ -237,7 +239,7 @@ class XiaomiDevice(Entity):
     @property
     def unique_id(self) -> str:
         """Return an unique ID."""
-        return "aqara-" + self._name
+        return self._unique_id
 
     @property
     def available(self):

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -221,7 +221,7 @@ class XiaomiDevice(Entity):
         self.parse_data(device['data'], device['raw_data'])
         self.parse_voltage(device['data'])
 
-        if hasattr(self, '_data_key'):
+        if hasattr(self, '_data_key') and self._data_key:
             self._unique_id = slugify("{}-{}".format(self._data_key,
                                                      self._sid))
         else:

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -215,7 +215,7 @@ class XiaomiDevice(Entity):
         self._write_to_hub = xiaomi_hub.write_to_hub
         self._get_from_hub = xiaomi_hub.get_from_hub
         self._device_state_attributes = {}
-        self._unique_id = DOMAIN + "_" + slugify(self._name)
+        self._unique_id = slugify(self._name)
         self._remove_unavailability_tracker = None
         xiaomi_hub.callbacks[self._sid].append(self._add_push_data_job)
         self.parse_data(device['data'], device['raw_data'])

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -214,6 +214,7 @@ class XiaomiDevice(Entity):
         self._name = '{}_{}'.format(name, self._sid)
         self._write_to_hub = xiaomi_hub.write_to_hub
         self._get_from_hub = xiaomi_hub.get_from_hub
+        self._device_state_attributes = {}
         self._unique_id = DOMAIN + "_" + slugify(self._name)
         self._remove_unavailability_tracker = None
         xiaomi_hub.callbacks[self._sid].append(self._add_push_data_job)

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -206,20 +206,26 @@ def setup(hass, config):
 class XiaomiDevice(Entity):
     """Representation a base Xiaomi device."""
 
-    def __init__(self, device, name, xiaomi_hub):
+    def __init__(self, device, device_type, xiaomi_hub):
         """Initialize the Xiaomi device."""
         self._state = None
         self._is_available = True
         self._sid = device['sid']
-        self._name = '{}_{}'.format(name, self._sid)
+        self._name = '{}_{}'.format(device_type, self._sid)
+        self._type = device_type
         self._write_to_hub = xiaomi_hub.write_to_hub
         self._get_from_hub = xiaomi_hub.get_from_hub
         self._device_state_attributes = {}
-        self._unique_id = slugify(self._name)
         self._remove_unavailability_tracker = None
         xiaomi_hub.callbacks[self._sid].append(self._add_push_data_job)
         self.parse_data(device['data'], device['raw_data'])
         self.parse_voltage(device['data'])
+
+        if hasattr(self, '_data_key'):
+            self._unique_id = slugify("{}-{}".format(self._data_key,
+                                                     self._sid))
+        else:
+            self._unique_id = slugify("{}-{}".format(self._type, self._sid))
 
     def _add_push_data_job(self, *args):
         self.hass.add_job(self.push_data, *args)

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -221,9 +221,11 @@ class XiaomiDevice(Entity):
         self.parse_data(device['data'], device['raw_data'])
         self.parse_voltage(device['data'])
 
-        if hasattr(self, '_data_key') and self._data_key:
-            self._unique_id = slugify("{}-{}".format(self._data_key,
-                                                     self._sid))
+        if hasattr(self, '_data_key') \
+                and self._data_key:  # pylint: disable=no-member
+            self._unique_id = slugify("{}-{}".format(
+                self._data_key,  # pylint: disable=no-member
+                self._sid))
         else:
             self._unique_id = slugify("{}-{}".format(self._type, self._sid))
 

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -214,7 +214,7 @@ class XiaomiDevice(Entity):
         self._name = '{}_{}'.format(name, self._sid)
         self._write_to_hub = xiaomi_hub.write_to_hub
         self._get_from_hub = xiaomi_hub.get_from_hub
-        self._unique_id = DOMAIN + slugify(self._name)
+        self._unique_id = DOMAIN + "_" + slugify(self._name)
         self._device_state_attributes = {
             'unique_id': self._unique_id
         }

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -213,7 +213,9 @@ class XiaomiDevice(Entity):
         self._name = '{}_{}'.format(name, self._sid)
         self._write_to_hub = xiaomi_hub.write_to_hub
         self._get_from_hub = xiaomi_hub.get_from_hub
-        self._device_state_attributes = {}
+        self._device_state_attributes = {
+            'unique_id': self.unique_id
+        }
         self._remove_unavailability_tracker = None
         xiaomi_hub.callbacks[self._sid].append(self._add_push_data_job)
         self.parse_data(device['data'], device['raw_data'])
@@ -231,6 +233,11 @@ class XiaomiDevice(Entity):
     def name(self):
         """Return the name of the device."""
         return self._name
+
+    @property
+    def unique_id(self) -> str:
+        """Return an unique ID."""
+        return "aqara-" + self._name
 
     @property
     def available(self):

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -214,7 +214,7 @@ class XiaomiDevice(Entity):
         self._name = '{}_{}'.format(name, self._sid)
         self._write_to_hub = xiaomi_hub.write_to_hub
         self._get_from_hub = xiaomi_hub.get_from_hub
-        self._unique_id = "aqara-" + slugify(self._name)
+        self._unique_id = DOMAIN + slugify(self._name)
         self._device_state_attributes = {
             'unique_id': self._unique_id
         }

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -215,9 +215,6 @@ class XiaomiDevice(Entity):
         self._write_to_hub = xiaomi_hub.write_to_hub
         self._get_from_hub = xiaomi_hub.get_from_hub
         self._unique_id = DOMAIN + "_" + slugify(self._name)
-        self._device_state_attributes = {
-            'unique_id': self._unique_id
-        }
         self._remove_unavailability_tracker = None
         xiaomi_hub.callbacks[self._sid].append(self._add_push_data_job)
         self.parse_data(device['data'], device['raw_data'])


### PR DESCRIPTION
## Description:

This adds unique IDs to the Xiaomi Aqara component. The IDs are based on serial numbers, the device type and the component domain.

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
