### PR TITLE
optional displaying the sensors location on the map

### DIFF
--- a/homeassistant/components/sensor/luftdaten.py
+++ b/homeassistant/components/sensor/luftdaten.py
@@ -119,16 +119,16 @@ class LuftdatenSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
+        onmap = ATTR_LATITUDE, ATTR_LONGITUDE
+        nomap = 'lat', 'long'
+        lat_format, lon_format = onmap if self._show_on_map else nomap
         try:
             attr = {
                 ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
                 ATTR_SENSOR_ID: self._sensor_id,
-                'lat': self.luftdaten.data.meta['latitude'],
-                'long': self.luftdaten.data.meta['longitude'],
+                lat_format: self.luftdaten.data.meta['latitude'],
+                lon_format: self.luftdaten.data.meta['longitude'],
             }
-            if self._show_on_map:
-                attr[ATTR_LATITUDE] = self.luftdaten.data.meta['latitude']
-                attr[ATTR_LONGITUDE] = self.luftdaten.data.meta['longitude']
             return attr
         except KeyError:
             return

--- a/homeassistant/components/sensor/luftdaten.py
+++ b/homeassistant/components/sensor/luftdaten.py
@@ -123,6 +123,8 @@ class LuftdatenSensor(Entity):
             attr = {
                 ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
                 ATTR_SENSOR_ID: self._sensor_id,
+                'lat': self.luftdaten.data.meta['latitude'],
+                'long': self.luftdaten.data.meta['longitude'],
             }
             if self._show_on_map:
                 attr[ATTR_LATITUDE] = self.luftdaten.data.meta['latitude']

--- a/homeassistant/components/sensor/luftdaten.py
+++ b/homeassistant/components/sensor/luftdaten.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_ATTRIBUTION, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_MONITORED_CONDITIONS,
-    CONF_NAME, TEMP_CELSIUS)
+    CONF_NAME, CONF_SHOW_ON_MAP, TEMP_CELSIUS)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -55,6 +55,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_MONITORED_CONDITIONS):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SHOW_ON_MAP, default=False): cv.boolean,
 })
 
 
@@ -64,6 +65,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     from luftdaten import Luftdaten
 
     name = config.get(CONF_NAME)
+    show_on_map = config.get(CONF_SHOW_ON_MAP)
     sensor_id = config.get(CONF_SENSORID)
 
     session = async_get_clientsession(hass)
@@ -80,7 +82,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         if luftdaten.data.values[variable] is None:
             _LOGGER.warning("It might be that sensor %s is not providing "
                             "measurements for %s", sensor_id, variable)
-        devices.append(LuftdatenSensor(luftdaten, name, variable, sensor_id))
+        devices.append(
+            LuftdatenSensor(luftdaten, name, variable, sensor_id, show_on_map))
 
     async_add_devices(devices)
 
@@ -88,7 +91,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class LuftdatenSensor(Entity):
     """Implementation of a Luftdaten sensor."""
 
-    def __init__(self, luftdaten, name, sensor_type, sensor_id):
+    def __init__(self, luftdaten, name, sensor_type, sensor_id, show):
         """Initialize the Luftdaten sensor."""
         self.luftdaten = luftdaten
         self._name = name
@@ -96,6 +99,7 @@ class LuftdatenSensor(Entity):
         self._sensor_id = sensor_id
         self.sensor_type = sensor_type
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        self._show_on_map = show
 
     @property
     def name(self):
@@ -119,9 +123,10 @@ class LuftdatenSensor(Entity):
             attr = {
                 ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
                 ATTR_SENSOR_ID: self._sensor_id,
-                ATTR_LATITUDE: self.luftdaten.data.meta['latitude'],
-                ATTR_LONGITUDE: self.luftdaten.data.meta['longitude'],
             }
+            if self._show_on_map:
+                attr[ATTR_LATITUDE] = self.luftdaten.data.meta['latitude']
+                attr[ATTR_LONGITUDE] = self.luftdaten.data.meta['longitude']
             return attr
         except KeyError:
             return

--- a/homeassistant/components/sensor/luftdaten.py
+++ b/homeassistant/components/sensor/luftdaten.py
@@ -12,7 +12,8 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS, CONF_NAME, TEMP_CELSIUS)
+    ATTR_ATTRIBUTION, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_MONITORED_CONDITIONS,
+    CONF_NAME, TEMP_CELSIUS)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -118,8 +119,8 @@ class LuftdatenSensor(Entity):
             attr = {
                 ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
                 ATTR_SENSOR_ID: self._sensor_id,
-                'lat': self.luftdaten.data.meta['latitude'],
-                'long': self.luftdaten.data.meta['longitude'],
+                ATTR_LATITUDE: self.luftdaten.data.meta['latitude'],
+                ATTR_LONGITUDE: self.luftdaten.data.meta['longitude'],
             }
             return attr
         except KeyError:


### PR DESCRIPTION
## Description:

the sensor is now using the correct attributes (_latitued_ and _longitued_) which enables them to show up on the map. 

![example](https://lh4.googleusercontent.com/HCkyxMOZ0twO8FVi-ee7aGKA3-uqYGiR4JK8a_j5LKbWA6izLbfCHFVODY5YCzsemZJ69lcXAJQEmrdEIO6c=w1280-h944)


## ~Breaking change~

~The sensor attributes for GPS location used to be `lat` and `long`. This has been changed to `latitude` and `longitude` respectively.~

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4680

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54