### PR TITLE
WIP: Wildcard support for entity_id lists

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -48,6 +48,8 @@ SERVICE_CALL_LIMIT = 10  # seconds
 
 # Pattern for validating entity IDs (format: <domain>.<entity>)
 ENTITY_ID_PATTERN = re.compile(r"^(\w+)\.(\w+)$")
+# Pattern for validating entity ID patterns using fnmatch
+ENTITY_ID_FNMATCH_PATTERN = re.compile(r"^(\S*(\*|\?|\[\S*\])\S*)$")
 
 # How long to wait till things that run on startup have to finish.
 TIMEOUT_EVENT_START = 15
@@ -63,6 +65,11 @@ def split_entity_id(entity_id: str) -> List[str]:
 def valid_entity_id(entity_id: str) -> bool:
     """Test if an entity ID is a valid format."""
     return ENTITY_ID_PATTERN.match(entity_id) is not None
+
+
+def valid_entity_id_fnmatch_pattern(entity_id: str) -> bool:
+    """Test if an entity ID pattern is a valid format."""
+    return ENTITY_ID_FNMATCH_PATTERN.match(entity_id) is not None
 
 
 def valid_state(state: str) -> bool:

--- a/homeassistant/helpers/entity_pattern_matching.py
+++ b/homeassistant/helpers/entity_pattern_matching.py
@@ -1,0 +1,65 @@
+"""A Class to handle matching entity_ids through patterns."""
+import fnmatch
+import re
+
+from homeassistant.core import callback
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.components.zwave.const import EVENT_NETWORK_READY
+
+
+class EntityPatternMatching(object):
+    """Class to generate patterns and match entity_ids."""
+
+    def __init__(self, hass, action, entity_list):
+        """Initialize and EntityPatternMatching (EPM) object."""
+        self.hass = hass
+        self.action = action
+        self.entity_list = entity_list
+        self.pattern = set()
+        self.entity_ids = set()
+        self.entity_ids_matched = set()
+        self.start_matching()
+
+    def start_matching(self):
+        """Start the matching process."""
+        self.filter_entity_ids()
+        self.report_entity_ids()
+        self.hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_START, self.report_matched_entity_ids)
+        self.hass.bus.async_listen_once(
+            EVENT_NETWORK_READY, self.report_matched_entity_ids)
+
+    def filter_entity_ids(self):
+        """Filter patterns from the entity_list."""
+        for entity in self.entity_list:
+            if entity.find('*') != -1 or entity.find('?') != -1 or \
+               entity.find('[') != -1:
+                self.pattern.add(re.compile(fnmatch.translate(entity)))
+            else:
+                self.entity_ids.add(entity)
+
+    def match_entity_ids(self):
+        """Match entity_ids through saved patterns."""
+        all_ids = self.hass.states.async_entity_ids()
+        for entity in self.entity_ids_matched:
+            if entity in all_ids:
+                all_ids.remove(entity)
+
+        for pattern in self.pattern:
+            for entity in all_ids[:]:
+                if pattern.match(entity):
+                    all_ids.remove(entity)
+                    self.entity_ids.add(entity)
+                    self.entity_ids_matched.add(entity)
+
+    def report_entity_ids(self):
+        """Report all entity_ids after filtering."""
+        self.hass.async_run_job(self.action, self.entity_ids)
+        self.entity_ids.clear()
+
+    @callback
+    def report_matched_entity_ids(self, event):
+        """Report all matched entity_ids."""
+        self.match_entity_ids()
+        self.hass.async_run_job(self.action, self.entity_ids)
+        self.entity_ids.clear()

--- a/homeassistant/helpers/entity_pattern_matching.py
+++ b/homeassistant/helpers/entity_pattern_matching.py
@@ -10,33 +10,19 @@ from homeassistant.components.zwave.const import EVENT_NETWORK_READY
 class EntityPatternMatching(object):
     """Class to generate patterns and match entity_ids."""
 
-    def __init__(self, hass, action, entity_list):
+    def __init__(self, hass, action, entities_patterns):
         """Initialize and EntityPatternMatching (EPM) object."""
         self.hass = hass
         self.action = action
-        self.entity_list = entity_list
-        self.pattern = set()
         self.entity_ids = set()
-        self.entity_ids_matched = set()
-        self.start_matching()
+        self.entity_ids_matched = entities_patterns[0]
+        self.patterns = [re.compile(fnmatch.translate(pattern))
+                         for pattern in entities_patterns[1]]
 
-    def start_matching(self):
-        """Start the matching process."""
-        self.filter_entity_ids()
-        self.report_entity_ids()
         self.hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_START, self.report_matched_entity_ids)
         self.hass.bus.async_listen_once(
             EVENT_NETWORK_READY, self.report_matched_entity_ids)
-
-    def filter_entity_ids(self):
-        """Filter patterns from the entity_list."""
-        for entity in self.entity_list:
-            if entity.find('*') != -1 or entity.find('?') != -1 or \
-               entity.find('[') != -1:
-                self.pattern.add(re.compile(fnmatch.translate(entity)))
-            else:
-                self.entity_ids.add(entity)
 
     def match_entity_ids(self):
         """Match entity_ids through saved patterns."""
@@ -45,17 +31,12 @@ class EntityPatternMatching(object):
             if entity in all_ids:
                 all_ids.remove(entity)
 
-        for pattern in self.pattern:
+        for pattern in self.patterns:
             for entity in all_ids[:]:
                 if pattern.match(entity):
                     all_ids.remove(entity)
                     self.entity_ids.add(entity)
                     self.entity_ids_matched.add(entity)
-
-    def report_entity_ids(self):
-        """Report all entity_ids after filtering."""
-        self.hass.async_run_job(self.action, self.entity_ids)
-        self.entity_ids.clear()
 
     @callback
     def report_matched_entity_ids(self, event):

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -164,6 +164,23 @@ def test_entity_ids():
     ]
 
 
+def test_entity_id_pattern_list():
+    """Test entity_id_pattern_list."""
+    schema = vol.Schema(cv.entity_id_pattern_list)
+    with pytest.raises(vol.MultipleInvalid):
+        schema('a sensor.*')
+        schema('sensor?light f')
+        schema('sensor[a.light')
+    assert ([], []) == schema(None)
+    assert ({'sensor.light'}, set()) == schema('sensor.LIGHT ')
+    assert ({'sensor.light'}, {'sensor.*'}) == \
+        schema(['sensor.light', 'sensor.*'])
+    assert (set(), {'sen?or.light', 'sensor.*', 'sen[s]or.light'}) == \
+        schema(['sen?or.light', 'sensor.*', 'sen[s]or.light'])
+    assert ({'sensor.light'}, set()) == \
+        schema(['sensor.light', 'sensor.light'])
+
+
 def test_ensure_list_csv():
     """Test ensure_list_csv."""
     schema = vol.Schema(cv.ensure_list_csv)
@@ -453,7 +470,7 @@ def test_deprecated(caplog):
     )
 
     deprecated_schema({'venus': True})
-    assert len(caplog.records) == 0
+    assert caplog.records == []
 
     deprecated_schema({'mars': True})
     assert len(caplog.records) == 1

--- a/tests/helpers/test_entity_pattern_matching.py
+++ b/tests/helpers/test_entity_pattern_matching.py
@@ -25,8 +25,8 @@ class TestEntityPatternMatching(unittest.TestCase):
         """Test if entity pattern matching works correctly."""
         entity_ids = set()
         update_runs = []
-        entity_list = ['light.demo', 'light.b*', 'lig[h]t.demo2',
-                       'light?demo3']
+        entities_patterns = ({'light.demo'}, {'light.d*', 'light.b*',
+                                              'lig[h]t.demo2', 'light?demo3'})
 
         @callback
         def update_entity_ids(new_entity_ids):
@@ -36,17 +36,16 @@ class TestEntityPatternMatching(unittest.TestCase):
                 self.assertFalse(entity in entity_ids)
             entity_ids.update(new_entity_ids)
 
-        EPM(self.hass, update_entity_ids, entity_list)
+        EPM(self.hass, update_entity_ids, entities_patterns)
 
-        self.assertEqual(1, len(update_runs))
-        self.assertEqual(update_runs[0], {'light.demo'})
+        self.assertEqual(0, len(update_runs))
 
         self.hass.states.set('light.Bowl', 'on')
         self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
         self.hass.block_till_done()
 
-        self.assertEqual(2, len(update_runs))
-        self.assertEqual(update_runs[1], {'light.bowl'})
+        self.assertEqual(1, len(update_runs))
+        self.assertEqual(update_runs[0], {'light.bowl'})
 
         self.hass.states.set('light.demo2', 'off')
         self.hass.states.set('light.demo3', 'off')
@@ -54,5 +53,5 @@ class TestEntityPatternMatching(unittest.TestCase):
         self.hass.bus.fire(EVENT_NETWORK_READY)
         self.hass.block_till_done()
 
-        self.assertEqual(3, len(update_runs))
-        self.assertEqual(update_runs[2], {'light.demo2', 'light.demo3'})
+        self.assertEqual(2, len(update_runs))
+        self.assertEqual(update_runs[1], {'light.demo2', 'light.demo3'})

--- a/tests/helpers/test_entity_pattern_matching.py
+++ b/tests/helpers/test_entity_pattern_matching.py
@@ -1,0 +1,58 @@
+"""The tests for the entity_patter_matching helper class."""
+import unittest
+
+from homeassistant.core import callback
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.components.zwave.const import EVENT_NETWORK_READY
+from homeassistant.helpers.entity_pattern_matching \
+    import EntityPatternMatching as EPM
+
+from tests.common import get_test_home_assistant
+
+
+class TestEntityPatternMatching(unittest.TestCase):
+    """Test the EntityPatterMatching helper class."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop down everthing that was started."""
+        self.hass.stop()
+
+    def test_entity_pattern_matching(self):
+        """Test if entity pattern matching works correctly."""
+        entity_ids = set()
+        update_runs = []
+        entity_list = ['light.demo', 'light.b*', 'lig[h]t.demo2',
+                       'light?demo3']
+
+        @callback
+        def update_entity_ids(new_entity_ids):
+            """Method called from EPM to report new entity ids."""
+            update_runs.append(new_entity_ids.copy())
+            for entity in new_entity_ids:
+                self.assertFalse(entity in entity_ids)
+            entity_ids.update(new_entity_ids)
+
+        EPM(self.hass, update_entity_ids, entity_list)
+
+        self.assertEqual(1, len(update_runs))
+        self.assertEqual(update_runs[0], {'light.demo'})
+
+        self.hass.states.set('light.Bowl', 'on')
+        self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
+        self.hass.block_till_done()
+
+        self.assertEqual(2, len(update_runs))
+        self.assertEqual(update_runs[1], {'light.bowl'})
+
+        self.hass.states.set('light.demo2', 'off')
+        self.hass.states.set('light.demo3', 'off')
+        self.hass.states.set('cover.living_room', 'open')
+        self.hass.bus.fire(EVENT_NETWORK_READY)
+        self.hass.block_till_done()
+
+        self.assertEqual(3, len(update_runs))
+        self.assertEqual(update_runs[2], {'light.demo2', 'light.demo3'})


### PR DESCRIPTION
## Description:
Adding wildcard support through `fnmatch` pattern for `entity_id` lists. This could be quite useful for a number of components:
* Groups
* Recorder
* History
* Logbook
* ..

To enable this, the component has to be updated. As an example I included an updated version for the `min_max sensor`. It probably isn't the most elegant way to do it, but a start. Currently this is a Work in Progress.

https://community.home-assistant.io/t/wildcard-operators-for-groups/4643
https://community.home-assistant.io/t/allow-wildcard-for-entity-selection-in-config-files/9029
https://community.home-assistant.io/t/wildcard-entities-in-groups/10021

**Related:**  #5215

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: min_max
    entity_ids:
      - input_number.slider*

input_number:
  slider1:
    name: Slider
    initial: 30
    min: -20
    max: 50
    step: 2
  slider2:
    name: Slider2
    initial: 10
    min: -50
    max: 20
    step: 2
```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
