### PR TITLE
Introduce zone_id to identify player+zone

### DIFF
--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -60,7 +60,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import rxv
     # Keep track of configured receivers so that we don't end up
     # discovering a receiver dynamically that we have static config
-    # for. Map each device from its unique_id to an instance since
+    # for. Map each device from its zone_id to an instance since
     # YamahaDevice is not hashable (thus not possible to add to a set).
     if hass.data.get(DATA_YAMAHA) is None:
         hass.data[DATA_YAMAHA] = {}
@@ -100,8 +100,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                               source_names, zone_names)
 
         # Only add device if it's not already added
-        if device.unique_id not in hass.data[DATA_YAMAHA]:
-            hass.data[DATA_YAMAHA][device.unique_id] = device
+        if device.zone_id not in hass.data[DATA_YAMAHA]:
+            hass.data[DATA_YAMAHA][device.zone_id] = device
             devices.append(device)
         else:
             _LOGGER.debug('Ignoring duplicate receiver %s', name)
@@ -219,6 +219,11 @@ class YamahaDevice(MediaPlayerDevice):
     def source_list(self):
         """List of available input sources."""
         return self._source_list
+
+    @property
+    def zone_id(self):
+        """Return an zone_id to ensure 1 media player per zone."""
+        return '{0}:{1}'.format(self.receiver.ctrl_url, self._zone)
 
     @property
     def supported_features(self):


### PR DESCRIPTION
The yamaha component previously used a property named unique_id to
ensure that exactly 1 media_player was discovered per zone per
control_url. This was introduced so that hard coded devices wouldn't
be duplicated by automatically discovered devices.

In HA 0.63 unique_id became a reserved concept as part of the new
device registry, and the property was removed from the component. But
the default returns None, which had the side effect of only ever
registering a single unit + zone, the first one discovered. This was
typically the Main_Zone of the unit, but there is actually no
guaruntee of that.

This fix brings back the logic under a different property called
zone_id. This is not guarunteed to be globally stable like unique_id
is supposed to be, but it is suitable for the deduplication for yamaha
media players.

Fixes #12373