### PR TITLE
Make WUnderground async

### DIFF
--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -4,21 +4,24 @@ Support for WUnderground weather service.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.wunderground/
 """
+import asyncio
 from datetime import timedelta
 import logging
 
+import aiohttp
+import async_timeout
 import re
-import requests
 import voluptuous as vol
 
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 from homeassistant.components.sensor import PLATFORM_SCHEMA, ENTITY_ID_FORMAT
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE,
     TEMP_FAHRENHEIT, TEMP_CELSIUS, LENGTH_INCHES, LENGTH_KILOMETERS,
     LENGTH_MILES, LENGTH_FEET, STATE_UNKNOWN, ATTR_ATTRIBUTION)
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import Entity, generate_entity_id
+from homeassistant.helpers.entity import Entity, async_generate_entity_id
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
@@ -627,7 +630,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
+                         async_add_devices, discovery_info=None):
     """Set up the WUnderground sensor."""
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
@@ -639,11 +644,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for variable in config[CONF_MONITORED_CONDITIONS]:
         sensors.append(WUndergroundSensor(hass, rest, variable))
 
-    rest.update()
+    yield from rest.async_update()
     if not rest.data:
         raise PlatformNotReady
 
-    add_devices(sensors)
+    async_add_devices(sensors)
 
     return True
 
@@ -663,7 +668,7 @@ class WUndergroundSensor(Entity):
         self._entity_picture = None
         self._unit_of_measurement = self._cfg_expand("unit_of_measurement")
         self.rest.request_feature(SENSOR_TYPES[condition].feature)
-        self.entity_id = generate_entity_id(
+        self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, "pws_" + condition, hass=hass)
 
     def _cfg_expand(self, what, default=None):
@@ -727,9 +732,10 @@ class WUndergroundSensor(Entity):
         """Return the units of measurement."""
         return self._unit_of_measurement
 
-    def update(self):
+    @asyncio.coroutine
+    def async_update(self):
         """Update current conditions."""
-        self.rest.update()
+        yield from self.rest.async_update()
 
         if not self.rest.data:
             # no data, return
@@ -764,7 +770,7 @@ class WUndergroundData(object):
 
     def _build_url(self, baseurl=_RESOURCE):
         url = baseurl.format(
-            self._api_key, "/".join(self._features), self._lang)
+            self._api_key, '/'.join(sorted(self._features)), self._lang)
         if self._pws_id:
             url = url + 'pws:{}'.format(self._pws_id)
         else:
@@ -772,20 +778,23 @@ class WUndergroundData(object):
 
         return url + '.json'
 
+    @asyncio.coroutine
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self):
+    def async_update(self):
         """Get the latest data from WUnderground."""
         try:
-            result = requests.get(self._build_url(), timeout=10).json()
+            websession = async_get_clientsession(self._hass)
+            with async_timeout.timeout(10, loop=self._hass.loop):
+                response = yield from websession.get(self._build_url())
+            result = yield from response.json()
             if "error" in result['response']:
                 raise ValueError(result['response']["error"]
                                  ["description"])
-            else:
-                self.data = result
-                return True
+            self.data = result
+            return True
         except ValueError as err:
             _LOGGER.error("Check WUnderground API %s", err.args)
-            self.data = None
-        except requests.RequestException as err:
+        except (asyncio.TimeoutError, aiohttp.ClientError) as err:
             _LOGGER.error("Error fetching WUnderground data: %s", repr(err))
-            self.data = None
+        self.data = None
+        return False

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -7,10 +7,10 @@ https://home-assistant.io/components/sensor.wunderground/
 import asyncio
 from datetime import timedelta
 import logging
+import re
 
 import aiohttp
 import async_timeout
-import re
 import voluptuous as vol
 
 from homeassistant.helpers.typing import HomeAssistantType, ConfigType

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -648,7 +648,7 @@ def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
     if not rest.data:
         raise PlatformNotReady
 
-    async_add_devices(sensors)
+    async_add_devices(sensors, True)
 
 
 class WUndergroundSensor(Entity):

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -18,7 +18,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA, ENTITY_ID_FORMAT
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE,
     TEMP_FAHRENHEIT, TEMP_CELSIUS, LENGTH_INCHES, LENGTH_KILOMETERS,
-    LENGTH_MILES, LENGTH_FEET, STATE_UNKNOWN, ATTR_ATTRIBUTION)
+    LENGTH_MILES, LENGTH_FEET, ATTR_ATTRIBUTION)
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -739,7 +739,7 @@ class WUndergroundSensor(Entity):
             # no data, return
             return
 
-        self._state = self._cfg_expand("value", STATE_UNKNOWN)
+        self._state = self._cfg_expand("value")
         self._update_attrs()
         self._icon = self._cfg_expand("icon", super().icon)
         url = self._cfg_expand("entity_picture")

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -1,13 +1,13 @@
 """The tests for the WUnderground platform."""
 import asyncio
-
 import aiohttp
+
+from pytest import raises
+
 from homeassistant.core import callback
 from homeassistant.components.sensor import wunderground
 from homeassistant.const import TEMP_CELSIUS, LENGTH_INCHES, STATE_UNKNOWN
 from homeassistant.exceptions import PlatformNotReady
-from pytest import raises
-
 from tests.common import load_fixture
 
 VALID_CONFIG_PWS = {
@@ -93,37 +93,37 @@ def test_sensor(hass, aioclient_mock):
         friendly_name = device.name
 
         if entity_id == 'sensor.pws_weather':
-            assert 'https://icons.wxug.com/i/c/k/clear.gif' == \
-                   device.entity_picture
-            assert 'Clear' == device.state
+            assert device.entity_picture == \
+                'https://icons.wxug.com/i/c/k/clear.gif'
+            assert device.state == 'Clear'
             assert device.unit_of_measurement is None
-            assert "Weather Summary" == friendly_name
+            assert friendly_name == "Weather Summary"
         elif entity_id == 'sensor.pws_alerts':
-            assert 1 == device.state
-            assert 'This is a test alert message' == \
-                   device.device_state_attributes['Message']
-            assert 'mdi:alert-circle-outline' == device.icon
+            assert device.state == 1
+            assert device.device_state_attributes['Message'] == \
+                'This is a test alert message'
+            assert device.icon == 'mdi:alert-circle-outline'
             assert device.entity_picture is None
-            assert 'Alerts' == friendly_name
+            assert friendly_name == 'Alerts'
         elif entity_id == 'sensor.pws_location':
-            assert 'Holly Springs, NC' == device.state
-            assert 'Location' == friendly_name
+            assert device.state == 'Holly Springs, NC'
+            assert friendly_name == 'Location'
         elif entity_id == 'sensor.pws_elevation':
-            assert '413' == device.state
-            assert 'Elevation' == friendly_name
+            assert device.state == '413'
+            assert friendly_name == 'Elevation'
         elif entity_id == 'sensor.pws_feelslike_c':
             assert device.entity_picture is None
-            assert '40' == device.state
-            assert TEMP_CELSIUS == device.unit_of_measurement
-            assert "Feels Like" == friendly_name
+            assert device.state == '40'
+            assert device.unit_of_measurement == TEMP_CELSIUS
+            assert friendly_name == "Feels Like"
         elif entity_id == 'sensor.pws_weather_1d_metric':
-            assert 'Mostly Cloudy. Fog overnight.' == device.state
-            assert 'Tuesday' == friendly_name
+            assert device.state == 'Mostly Cloudy. Fog overnight.'
+            assert friendly_name == 'Tuesday'
         else:
-            assert 'sensor.pws_precip_1d_in' == entity_id
-            assert 0.03 == device.state
-            assert LENGTH_INCHES == device.unit_of_measurement
-            assert 'Precipitation Intensity Today' == friendly_name
+            assert entity_id == 'sensor.pws_precip_1d_in'
+            assert device.state == 0.03
+            assert device.unit_of_measurement == LENGTH_INCHES
+            assert friendly_name == 'Precipitation Intensity Today'
 
 
 @asyncio.coroutine

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -83,9 +83,7 @@ def test_sensor(hass, aioclient_mock):
     """Test the WUnderground sensor class and methods."""
     aioclient_mock.get(URL, text=load_fixture('wunderground-valid.json'))
 
-    with assert_setup_component(1, 'sensor'):
-        yield from async_setup_component(hass, 'sensor',
-                                         {'sensor': VALID_CONFIG})
+    yield from async_setup_component(hass, 'sensor', {'sensor': VALID_CONFIG})
 
     state = hass.states.get('sensor.pws_weather')
     assert state.state == 'Clear'
@@ -140,9 +138,7 @@ def test_invalid_data(hass, aioclient_mock):
     """Test the WUnderground invalid data."""
     aioclient_mock.get(URL, text=load_fixture('wunderground-invalid.json'))
 
-    with assert_setup_component(1, 'sensor'):
-        yield from async_setup_component(hass, 'sensor',
-                                         {'sensor': VALID_CONFIG})
+    yield from async_setup_component(hass, 'sensor', {'sensor': VALID_CONFIG})
 
     for condition in VALID_CONFIG['monitored_conditions']:
         state = hass.states.get('sensor.pws_' + condition)

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -51,7 +51,8 @@ def test_setup(hass, aioclient_mock):
     """Test that the component is loaded if passed in PWS Id."""
     aioclient_mock.get(URL, text=load_fixture('wunderground-valid.json'))
     aioclient_mock.get(PWS_URL, text=load_fixture('wunderground-valid.json'))
-    aioclient_mock.get(INVALID_URL, text=load_fixture('wunderground-error.json'))
+    aioclient_mock.get(INVALID_URL,
+                       text=load_fixture('wunderground-error.json'))
 
     result = yield from wunderground.async_setup_platform(
         hass, VALID_CONFIG_PWS, lambda _: None)
@@ -92,13 +93,15 @@ def test_sensor(hass, aioclient_mock):
         friendly_name = device.name
 
         if entity_id == 'sensor.pws_weather':
-            assert 'https://icons.wxug.com/i/c/k/clear.gif' == device.entity_picture
+            assert 'https://icons.wxug.com/i/c/k/clear.gif' == \
+                   device.entity_picture
             assert 'Clear' == device.state
             assert device.unit_of_measurement is None
             assert "Weather Summary" == friendly_name
         elif entity_id == 'sensor.pws_alerts':
             assert 1 == device.state
-            assert 'This is a test alert message' == device.device_state_attributes['Message']
+            assert 'This is a test alert message' == \
+                   device.device_state_attributes['Message']
             assert 'mdi:alert-circle-outline' == device.icon
             assert device.entity_picture is None
             assert 'Alerts' == friendly_name

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -22,6 +22,7 @@ VALID_CONFIG_PWS = {
 VALID_CONFIG = {
     'platform': 'wunderground',
     'api_key': 'foo',
+    'lang': 'EN',
     'monitored_conditions': [
         'weather', 'feelslike_c', 'alerts', 'elevation', 'location',
         'weather_1d_metric', 'precip_1d_in'
@@ -94,7 +95,7 @@ def test_sensor(hass, aioclient_mock):
         'https://icons.wxug.com/i/c/k/clear.gif'
 
     state = hass.states.get('sensor.pws_alerts')
-    assert state.state == 1
+    assert state.state == '1'
     assert state.name == 'Alerts'
     assert state.attributes['Message'] == \
         "This is a test alert message"
@@ -115,12 +116,12 @@ def test_sensor(hass, aioclient_mock):
     assert 'entity_picture' not in state.attributes
     assert state.attributes['unit_of_measurement'] == TEMP_CELSIUS
 
-    state = hass.states.get('sensor.pws_pws_weather_1d_metric')
+    state = hass.states.get('sensor.pws_weather_1d_metric')
     assert state.state == "Mostly Cloudy. Fog overnight."
     assert state.name == 'Tuesday'
 
     state = hass.states.get('sensor.pws_precip_1d_in')
-    assert state.state == 0.03
+    assert state.state == '0.03'
     assert state.name == "Precipitation Intensity Today"
     assert state.attributes['unit_of_measurement'] == LENGTH_INCHES
 

--- a/tests/fixtures/wunderground-error.json
+++ b/tests/fixtures/wunderground-error.json
@@ -1,0 +1,11 @@
+{
+    "response": {
+        "version": "0.1",
+        "termsofService": "http://www.wunderground.com/weather/api/d/terms.html",
+        "features": {},
+        "error": {
+            "type": "keynotfound",
+            "description": "this key does not exist"
+        }
+    }
+}

--- a/tests/fixtures/wunderground-invalid.json
+++ b/tests/fixtures/wunderground-invalid.json
@@ -1,0 +1,18 @@
+{
+    "response": {
+        "version": "0.1",
+        "termsofService": "http://www.wunderground.com/weather/api/d/terms.html",
+        "features": {
+            "conditions": 1,
+            "alerts": 1,
+            "forecast": 1
+        }
+    },
+    "current_observation": {
+        "image": {
+            "url": "http://icons.wxug.com/graphics/wu2/logo_130x80.png",
+            "title": "Weather Underground",
+            "link": "http://www.wunderground.com"
+        }
+    }
+}

--- a/tests/fixtures/wunderground-valid.json
+++ b/tests/fixtures/wunderground-valid.json
@@ -1,0 +1,90 @@
+{
+    "response": {
+        "version": "0.1",
+        "termsofService": "http://www.wunderground.com/weather/api/d/terms.html",
+        "features": {
+            "conditions": 1,
+            "alerts": 1,
+            "forecast": 1
+        }
+    },
+    "current_observation": {
+        "image": {
+            "url": "http://icons.wxug.com/graphics/wu2/logo_130x80.png",
+            "title": "Weather Underground",
+            "link": "http://www.wunderground.com"
+        },
+        "feelslike_c": "40",
+        "weather": "Clear",
+        "icon_url": "http://icons.wxug.com/i/c/k/clear.gif",
+        "display_location": {
+            "city": "Holly Springs",
+            "country": "US",
+            "full": "Holly Springs, NC"
+        },
+        "observation_location": {
+            "elevation": "413 ft",
+            "full": "Twin Lake, Holly Springs, North Carolina"
+        }
+    },
+    "alerts": [
+        {
+            "type": "FLO",
+            "description": "Areal Flood Warning",
+            "date": "9:36 PM CDT on September 22, 2016",
+            "expires": "10:00 AM CDT on September 23, 2016",
+            "message": "This is a test alert message"
+        }
+    ],
+    "forecast": {
+        "txt_forecast": {
+            "date": "22:35 CEST",
+            "forecastday": [
+                {
+                    "period": 0,
+                    "icon_url": "http://icons.wxug.com/i/c/k/clear.gif",
+                    "title": "Tuesday",
+                    "fcttext": "Mostly Cloudy. Fog overnight.",
+                    "fcttext_metric": "Mostly Cloudy. Fog overnight.",
+                    "pop": "0"
+                }
+            ]
+        },
+        "simpleforecast": {
+            "forecastday": [
+                {
+                    "date": {
+                        "pretty": "19:00 CEST 4. Duben 2017"
+                    },
+                    "period": 1,
+                    "high": {
+                        "fahrenheit": "56",
+                        "celsius": "13"
+                    },
+                    "low": {
+                        "fahrenheit": "43",
+                        "celsius": "6"
+                    },
+                    "conditions": "Mo\u017enost de\u0161t\u011b",
+                    "icon_url": "http://icons.wxug.com/i/c/k/chancerain.gif",
+                    "qpf_allday": {
+                        "in": 0.03,
+                        "mm": 1
+                    },
+                    "maxwind": {
+                        "mph": 0,
+                        "kph": 0,
+                        "dir": "",
+                        "degrees": 0
+                    },
+                    "avewind": {
+                        "mph": 0,
+                        "kph": 0,
+                        "dir": "severn\u00ed",
+                        "degrees": 0
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Description:

Makes [WUnderground](https://home-assistant.io/components/sensor.wunderground/) sensor platform async, using [aiohttp's HTTP client](http://aiohttp.readthedocs.io/en/v0.15.3/client.html).

Previous tests had to be updated quite significantly to use the `aiohttp_mock` fixture. During that process, the JSON payloads were moved to file fixtures. I didn't know how a `unittest.TestCase` class could be transformed to handle async tests, so I had to move the tests to top-level coroutines and change the `self.assert*` calls.

If someone knows how to fix the tests/make them aiohttp-aware without changing the whole `test_wunderground.py` file and making reviewing more difficult, please tell me.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: wunderground
    api_key: !secret wunderground_api_key
    monitored_conditions:
      - weather
      - weather_1d_metric
      - weather_1n_metric
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
