### PR TITLE
Changed pyvera version to 0.2.41

### DIFF
--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP, CONF_LIGHTS, CONF_EXCLUDE)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.39']
+REQUIREMENTS = ['pyvera==0.2.41']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -998,7 +998,7 @@ pyunifi==2.13
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.2.39
+pyvera==0.2.41
 
 # homeassistant.components.media_player.vizio
 pyvizio==0.0.2


### PR DESCRIPTION
Changed required pyvera version to 0.2.41 from 0.2.39.
The 0.2.41 supports the VeraSecure built in siren. Siren is treated as switch and can now be turned on and off. Before it was armable but generated error in Vera controller.  This allows for both detecting status of Siren if triggered from within Vera and also outside controll from HA.

## Description:
Adding support to controll the built in siren in the VeraSecure controller.
