### PR TITLE
[WIP] Add a unique ID to cast entities

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -118,7 +118,10 @@ class CastDevice(MediaPlayerDevice):
         self.cast_status = self.cast.status
         self.media_status = self.cast.media_controller.status
         self.media_status_received = None
-        self._unique_id = "cast_" + str(self.cast.device.uuid)
+        if self.cast.device.uuid:
+            self._unique_id = str(self.cast.device.uuid)
+        else:
+            self._unique_id = None
 
     @property
     def should_poll(self):

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -118,11 +118,17 @@ class CastDevice(MediaPlayerDevice):
         self.cast_status = self.cast.status
         self.media_status = self.cast.media_controller.status
         self.media_status_received = None
+        self._unique_id = "cast_" + str(self.cast.device.uuid)
 
     @property
     def should_poll(self):
         """No polling needed."""
         return False
+
+    @property
+    def unique_id(self):
+        """Return a unique id."""
+        return self._unique_id
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:

Adds a unique ID to chromecast entities, based on the UUID which is computed (if I got this correctly) from some device identifier.

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
