### PR TITLE
WIP: Filter out publishing to mqtt topics from the eventstream

### DIFF
--- a/homeassistant/components/mqtt_eventstream.py
+++ b/homeassistant/components/mqtt_eventstream.py
@@ -54,12 +54,12 @@ def async_setup(hass, config):
             return
 
         # Filter out the events that were triggered by publishing
-        # to the MQTT topic, or you will end up in an infinite loop.
+        # to any MQTT topic, as this causes hass to publish
+        # the same message to the same mqtt topic
         if event.event_type == EVENT_CALL_SERVICE:
             if (
                     event.data.get('domain') == mqtt.DOMAIN and
-                    event.data.get('service') == mqtt.SERVICE_PUBLISH and
-                    event.data[ATTR_SERVICE_DATA].get('topic') == pub_topic
+                    event.data.get('service') == mqtt.SERVICE_PUBLISH
             ):
                 return
 


### PR DESCRIPTION
## Description:
Since the server is connected to the same mqtt server to get updates from master/slave, services like snips.say which publish tts to mqtt will cause the tts to be executed twice.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [na] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [na] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [na] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [na] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [na] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [na] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [na] Tests have been added to verify that the new code works.