### PR TITLE
Extract data validator to own file and add tests

### DIFF
--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -6,8 +6,9 @@ import logging
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.components.http import (
-    HomeAssistantView, RequestDataValidator)
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.http.data_validator import (
+    RequestDataValidator)
 
 from . import auth_api
 from .const import DOMAIN, REQUEST_TIMEOUT

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -12,6 +12,8 @@ import voluptuous as vol
 
 from homeassistant import core
 from homeassistant.components import http
+from homeassistant.components.http.data_validator import (
+    RequestDataValidator)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import intent
 
@@ -148,7 +150,7 @@ class ConversationProcessView(http.HomeAssistantView):
     url = '/api/conversation/process'
     name = "api:conversation:process"
 
-    @http.RequestDataValidator(vol.Schema({
+    @RequestDataValidator(vol.Schema({
         vol.Required('text'): str,
     }))
     @asyncio.coroutine

--- a/homeassistant/components/http/data_validator.py
+++ b/homeassistant/components/http/data_validator.py
@@ -1,0 +1,51 @@
+"""Decorator for view methods to help with data validation."""
+import asyncio
+from functools import wraps
+import logging
+
+import voluptuous as vol
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RequestDataValidator:
+    """Decorator that will validate the incoming data.
+
+    Takes in a voluptuous schema and adds 'post_data' as
+    keyword argument to the function call.
+
+    Will return a 400 if no JSON provided or doesn't match schema.
+    """
+
+    def __init__(self, schema, allow_empty=False):
+        """Initialize the decorator."""
+        self._schema = schema
+        self._allow_empty = allow_empty
+
+    def __call__(self, method):
+        """Decorate a function."""
+        @asyncio.coroutine
+        @wraps(method)
+        def wrapper(view, request, *args, **kwargs):
+            """Wrap a request handler with data validation."""
+            data = None
+            try:
+                data = yield from request.json()
+            except ValueError:
+                if not self._allow_empty or \
+                   (yield from request.content.read()) != b'':
+                    _LOGGER.error('Invalid JSON received.')
+                    return view.json_message('Invalid JSON.', 400)
+                data = {}
+
+            try:
+                kwargs['data'] = self._schema(data)
+            except vol.Invalid as err:
+                _LOGGER.error('Data does not match schema: %s', err)
+                return view.json_message(
+                    'Message format incorrect: {}'.format(err), 400)
+
+            result = yield from method(view, request, *args, **kwargs)
+            return result
+
+        return wrapper

--- a/homeassistant/components/http/util.py
+++ b/homeassistant/components/http/util.py
@@ -10,7 +10,7 @@ def get_real_ip(request):
     if KEY_REAL_IP in request:
         return request[KEY_REAL_IP]
 
-    if (request.app[KEY_USE_X_FORWARDED_FOR] and
+    if (request.app.get(KEY_USE_X_FORWARDED_FOR) and
             HTTP_HEADER_X_FORWARDED_FOR in request.headers):
         request[KEY_REAL_IP] = ip_address(
             request.headers.get(HTTP_HEADER_X_FORWARDED_FOR).split(',')[0])

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -10,6 +10,8 @@ import voluptuous as vol
 from homeassistant.const import HTTP_NOT_FOUND, HTTP_BAD_REQUEST
 from homeassistant.core import callback
 from homeassistant.components import http
+from homeassistant.components.http.data_validator import (
+    RequestDataValidator)
 from homeassistant.helpers import intent
 import homeassistant.helpers.config_validation as cv
 
@@ -199,7 +201,7 @@ class CreateShoppingListItemView(http.HomeAssistantView):
     url = '/api/shopping_list/item'
     name = "api:shopping_list:item"
 
-    @http.RequestDataValidator(vol.Schema({
+    @RequestDataValidator(vol.Schema({
         vol.Required('name'): str,
     }))
     @asyncio.coroutine

--- a/tests/components/http/test_data_validator.py
+++ b/tests/components/http/test_data_validator.py
@@ -1,0 +1,77 @@
+"""Test data validator decorator."""
+import asyncio
+from unittest.mock import Mock
+
+from aiohttp import web
+import voluptuous as vol
+
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.http.data_validator import RequestDataValidator
+
+
+@asyncio.coroutine
+def get_client(test_client, validator):
+    """Generate a client that hits a view decorated with validator."""
+    app = web.Application()
+    app['hass'] = Mock(is_running=True)
+
+    class TestView(HomeAssistantView):
+        url = '/'
+        name = 'test'
+        requires_auth = False
+
+        @asyncio.coroutine
+        @validator
+        def post(self, request, data):
+            """Test method."""
+            return b''
+
+    TestView().register(app.router)
+    client = yield from test_client(app)
+    return client
+
+
+@asyncio.coroutine
+def test_validator(test_client):
+    """Test the validator."""
+    client = yield from get_client(
+        test_client, RequestDataValidator(vol.Schema({
+            vol.Required('test'): str
+        })))
+
+    resp = yield from client.post('/', json={
+        'test': 'bla'
+    })
+    assert resp.status == 200
+
+    resp = yield from client.post('/', json={
+        'test': 100
+    })
+    assert resp.status == 400
+
+    resp = yield from client.post('/')
+    assert resp.status == 400
+
+
+@asyncio.coroutine
+def test_validator_allow_empty(test_client):
+    """Test the validator with empty data."""
+    client = yield from get_client(
+        test_client, RequestDataValidator(vol.Schema({
+            # Although we allow empty, our schema should still be able
+            # to validate an empty dict.
+            vol.Optional('test'): str
+        }), allow_empty=True))
+
+    resp = yield from client.post('/', json={
+        'test': 'bla'
+    })
+    assert resp.status == 200
+
+    resp = yield from client.post('/', json={
+        'test': 100
+    })
+    assert resp.status == 400
+
+    resp = yield from client.post('/')
+    assert resp.status == 200


### PR DESCRIPTION
## Description:
Extract the data validator decorator from `http.__init__` into its own file and add tests.

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
