### PR TITLE
0.63.2

### DIFF
--- a/homeassistant/components/binary_sensor/mercedesme.py
+++ b/homeassistant/components/binary_sensor/mercedesme.py
@@ -9,7 +9,7 @@ import datetime
 
 from homeassistant.components.binary_sensor import (BinarySensorDevice)
 from homeassistant.components.mercedesme import (
-    DATA_MME, MercedesMeEntity, BINARY_SENSORS)
+    DATA_MME, FEATURE_NOT_AVAILABLE, MercedesMeEntity, BINARY_SENSORS)
 
 DEPENDENCIES = ['mercedesme']
 
@@ -27,8 +27,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     devices = []
     for car in data.cars:
         for key, value in sorted(BINARY_SENSORS.items()):
-            devices.append(MercedesMEBinarySensor(
-                data, key, value[0], car["vin"], None))
+            if car['availabilities'].get(key, 'INVALID') == 'VALID':
+                devices.append(MercedesMEBinarySensor(
+                    data, key, value[0], car["vin"], None))
+            else:
+                _LOGGER.warning(FEATURE_NOT_AVAILABLE, key, car["license"])
 
     add_devices(devices, True)
 

--- a/homeassistant/components/device_tracker/mercedesme.py
+++ b/homeassistant/components/device_tracker/mercedesme.py
@@ -49,10 +49,13 @@ class MercedesMEDeviceTracker(object):
     def update_info(self, now=None):
         """Update the device info."""
         for device in self.data.cars:
-            _LOGGER.debug("Updating %s", device["vin"])
+            if not device['services'].get('VEHICLE_FINDER', False):
+                continue
+
             location = self.data.get_location(device["vin"])
             if location is None:
-                return False
+                continue
+
             dev_id = device["vin"]
             name = device["license"]
 

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -16,7 +16,7 @@ from homeassistant.components.light import (
     SUPPORT_RGB_COLOR, SUPPORT_TRANSITION, Light, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['limitlessled==1.0.9']
+REQUIREMENTS = ['limitlessled==1.0.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/yamaha.py
+++ b/homeassistant/components/media_player/yamaha.py
@@ -60,7 +60,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import rxv
     # Keep track of configured receivers so that we don't end up
     # discovering a receiver dynamically that we have static config
-    # for. Map each device from its unique_id to an instance since
+    # for. Map each device from its zone_id to an instance since
     # YamahaDevice is not hashable (thus not possible to add to a set).
     if hass.data.get(DATA_YAMAHA) is None:
         hass.data[DATA_YAMAHA] = {}
@@ -100,8 +100,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                               source_names, zone_names)
 
         # Only add device if it's not already added
-        if device.unique_id not in hass.data[DATA_YAMAHA]:
-            hass.data[DATA_YAMAHA][device.unique_id] = device
+        if device.zone_id not in hass.data[DATA_YAMAHA]:
+            hass.data[DATA_YAMAHA][device.zone_id] = device
             devices.append(device)
         else:
             _LOGGER.debug('Ignoring duplicate receiver %s', name)
@@ -219,6 +219,11 @@ class YamahaDevice(MediaPlayerDevice):
     def source_list(self):
         """List of available input sources."""
         return self._source_list
+
+    @property
+    def zone_id(self):
+        """Return an zone_id to ensure 1 media player per zone."""
+        return '{0}:{1}'.format(self.receiver.ctrl_url, self._zone)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/mercedesme.py
+++ b/homeassistant/components/mercedesme.py
@@ -41,6 +41,8 @@ SENSORS = {
 DATA_MME = 'mercedesme'
 DOMAIN = 'mercedesme'
 
+FEATURE_NOT_AVAILABLE = "The feature %s is not available for your car %s"
+
 NOTIFICATION_ID = 'mercedesme_integration_notification'
 NOTIFICATION_TITLE = 'Mercedes me integration setup'
 

--- a/homeassistant/components/sensor/eddystone_temperature.py
+++ b/homeassistant/components/sensor/eddystone_temperature.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_NAME, TEMP_CELSIUS, STATE_UNKNOWN, EVENT_HOMEASSISTANT_STOP,
     EVENT_HOMEASSISTANT_START)
 
-REQUIREMENTS = ['beacontools[scan]==1.0.1']
+REQUIREMENTS = ['beacontools[scan]==1.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/mercedesme.py
+++ b/homeassistant/components/sensor/mercedesme.py
@@ -8,7 +8,7 @@ import logging
 import datetime
 
 from homeassistant.components.mercedesme import (
-    DATA_MME, MercedesMeEntity, SENSORS)
+    DATA_MME, FEATURE_NOT_AVAILABLE, MercedesMeEntity, SENSORS)
 
 
 DEPENDENCIES = ['mercedesme']
@@ -29,8 +29,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     devices = []
     for car in data.cars:
         for key, value in sorted(SENSORS.items()):
-            devices.append(
-                MercedesMESensor(data, key, value[0], car["vin"], value[1]))
+            if car['availabilities'].get(key, 'INVALID') == 'VALID':
+                devices.append(
+                    MercedesMESensor(
+                        data, key, value[0], car["vin"], value[1]))
+            else:
+                _LOGGER.warning(FEATURE_NOT_AVAILABLE, key, car["license"])
 
     add_devices(devices, True)
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 63
-PATCH_VERSION = '1'
+PATCH_VERSION = '2'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 4, 2)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -454,7 +454,7 @@ liffylights==0.9.4
 lightify==1.0.6.1
 
 # homeassistant.components.light.limitlessled
-limitlessled==1.0.9
+limitlessled==1.0.8
 
 # homeassistant.components.linode
 linode-api==4.1.4b2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -118,7 +118,7 @@ basicmodem==0.7
 batinfo==0.4.2
 
 # homeassistant.components.sensor.eddystone_temperature
-# beacontools[scan]==1.0.1
+# beacontools[scan]==1.2.1
 
 # homeassistant.components.device_tracker.linksys_ap
 # homeassistant.components.sensor.geizhals

--- a/tests/components/sensor/test_wunderground.py
+++ b/tests/components/sensor/test_wunderground.py
@@ -249,31 +249,41 @@ class TestWundergroundSetup(unittest.TestCase):
                                     None)
         for device in self.DEVICES:
             device.update()
-            self.assertTrue(str(device.name).startswith('PWS_'))
-            if device.name == 'PWS_weather':
+            entity_id = device.entity_id
+            friendly_name = device.name
+            self.assertTrue(entity_id.startswith('sensor.pws_'))
+            if entity_id == 'sensor.pws_weather':
                 self.assertEqual(HTTPS_ICON_URL, device.entity_picture)
                 self.assertEqual(WEATHER, device.state)
                 self.assertIsNone(device.unit_of_measurement)
-            elif device.name == 'PWS_alerts':
+                self.assertEqual("Weather Summary", friendly_name)
+            elif entity_id == 'sensor.pws_alerts':
                 self.assertEqual(1, device.state)
                 self.assertEqual(ALERT_MESSAGE,
                                  device.device_state_attributes['Message'])
                 self.assertEqual(ALERT_ICON, device.icon)
                 self.assertIsNone(device.entity_picture)
-            elif device.name == 'PWS_location':
+                self.assertEqual('Alerts', friendly_name)
+            elif entity_id == 'sensor.pws_location':
                 self.assertEqual('Holly Springs, NC', device.state)
-            elif device.name == 'PWS_elevation':
+                self.assertEqual('Location', friendly_name)
+            elif entity_id == 'sensor.pws_elevation':
                 self.assertEqual('413', device.state)
-            elif device.name == 'PWS_feelslike_c':
+                self.assertEqual('Elevation', friendly_name)
+            elif entity_id == 'sensor.pws_feelslike_c':
                 self.assertIsNone(device.entity_picture)
                 self.assertEqual(FEELS_LIKE, device.state)
                 self.assertEqual(TEMP_CELSIUS, device.unit_of_measurement)
-            elif device.name == 'PWS_weather_1d_metric':
+                self.assertEqual("Feels Like", friendly_name)
+            elif entity_id == 'sensor.pws_weather_1d_metric':
                 self.assertEqual(FORECAST_TEXT, device.state)
+                self.assertEqual('Tuesday', friendly_name)
             else:
-                self.assertEqual(device.name, 'PWS_precip_1d_in')
+                self.assertEqual(entity_id, 'sensor.pws_precip_1d_in')
                 self.assertEqual(PRECIP_IN, device.state)
                 self.assertEqual(LENGTH_INCHES, device.unit_of_measurement)
+                self.assertEqual('Precipitation Intensity Today',
+                                 friendly_name)
 
     @unittest.mock.patch('requests.get',
                          side_effect=ConnectionError('test exception'))


### PR DESCRIPTION
- Fix MercedesMe - add check for unsupported features ([@ReneNulschDE] - [#12342]) ([mercedesme docs]) ([binary_sensor.mercedesme docs]) ([device_tracker.mercedesme docs]) ([sensor.mercedesme docs])
- Fix WUnderground names ([@OttoWinter] - [#12346]) ([sensor.wunderground docs])
- Updated beacontools ([@citruz] - [#12368]) ([sensor.eddystone_temperature docs])
- Introduce zone_id to identify player+zone ([@sdague] - [#12382]) ([media_player.yamaha docs])
- Downgrade limitlessled to 1.0.8 ([@amelchio] - [#12403]) ([light.limitlessled docs])

[#12342]: https://github.com/home-assistant/home-assistant/pull/12342
[#12346]: https://github.com/home-assistant/home-assistant/pull/12346
[#12368]: https://github.com/home-assistant/home-assistant/pull/12368
[#12382]: https://github.com/home-assistant/home-assistant/pull/12382
[#12403]: https://github.com/home-assistant/home-assistant/pull/12403
[@OttoWinter]: https://github.com/OttoWinter
[@ReneNulschDE]: https://github.com/ReneNulschDE
[@amelchio]: https://github.com/amelchio
[@citruz]: https://github.com/citruz
[@sdague]: https://github.com/sdague
[binary_sensor.mercedesme docs]: https://home-assistant.io/components/binary_sensor.mercedesme/
[device_tracker.mercedesme docs]: https://home-assistant.io/components/device_tracker.mercedesme/
[light.limitlessled docs]: https://home-assistant.io/components/light.limitlessled/
[media_player.yamaha docs]: https://home-assistant.io/components/media_player.yamaha/
[mercedesme docs]: https://home-assistant.io/components/mercedesme/
[sensor.eddystone_temperature docs]: https://home-assistant.io/components/sensor.eddystone_temperature/
[sensor.mercedesme docs]: https://home-assistant.io/components/sensor.mercedesme/
[sensor.wunderground docs]: https://home-assistant.io/components/sensor.wunderground/
