### PR TITLE
Upgrade sphinx-autodoc-typehints to 1.2.5

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
 Sphinx==1.7.0
-sphinx-autodoc-typehints==1.2.4
+sphinx-autodoc-typehints==1.2.5
 sphinx-autodoc-annotation==1.0.post1


### PR DESCRIPTION
## Description:
Changelog: https://github.com/agronholm/sphinx-autodoc-typehints/blob/master/CHANGELOG.rst#125

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
