### PR TITLE
Allow replacing entities in add_devices

### DIFF
--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -484,6 +484,31 @@ def test_overriding_name_from_registry(hass):
 
 
 @asyncio.coroutine
+def test_replace_entities_with_equal_unique_ids(hass):
+    """Test replacing an entity with an entity of the same unique ID."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    mock_registry(hass, {
+        'test_domain.world': entity_registry.RegistryEntry(
+            entity_id='test_domain.world',
+            unique_id='1234',
+            platform='test_domain',
+        )
+    })
+    old_entity = MockEntity(unique_id='1234', name='old')
+    new_entity = MockEntity(unique_id='1234', name='new')
+
+    yield from component.async_add_entities([old_entity])
+    state = hass.states.get('test_domain.world')
+    assert state is not None
+    assert state.name == 'old'
+
+    yield from component.async_add_entities([new_entity], replace=True)
+    state = hass.states.get('test_domain.world')
+    assert state is not None
+    assert state.name == 'new'
+
+
+@asyncio.coroutine
 def test_registry_respect_entity_namespace(hass):
     """Test that the registry respects entity namespace."""
     mock_registry(hass)


### PR DESCRIPTION
## Description:

This adds an optional boolean `replace` option to the `add_devices` function passed into the `setup_platform` functions. If this boolean if set to `True`, adding an entity with the same entity ID as an already existing entity ID will remove that existing entity and replace it with the new one instead of raising an exception.

A platform should set this to `True` only if its entities have reliable unique IDs. This solves the problem of auto-discovered devices being discovered multiple times, e.g., because they lost the connection in between, changed their IP address, or whatever. If they have a reliable unique ID, the old entity can just be replaced with the new one.

The issue came up in #12395.

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

