### PR TITLE
Added support for colored KNX lights

### DIFF
--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.script import Script
 
-REQUIREMENTS = ['xknx==0.7.18']
+REQUIREMENTS = ['xknx==0.8.3']
 
 DOMAIN = "knx"
 DATA_KNX = "data_knx"
@@ -216,7 +216,7 @@ class KNXModule(object):
     @asyncio.coroutine
     def service_send_to_knx_bus(self, call):
         """Service for sending an arbitrary KNX message to the KNX bus."""
-        from xknx.knx import Telegram, Address, DPTBinary, DPTArray
+        from xknx.knx import Telegram, GroupAddress, DPTBinary, DPTArray
         attr_payload = call.data.get(SERVICE_KNX_ATTR_PAYLOAD)
         attr_address = call.data.get(SERVICE_KNX_ATTR_ADDRESS)
 
@@ -226,7 +226,7 @@ class KNXModule(object):
                 return DPTBinary(attr_payload)
             return DPTArray(attr_payload)
         payload = calculate_payload(attr_payload)
-        address = Address(attr_address)
+        address = GroupAddress(attr_address)
 
         telegram = Telegram()
         telegram.payload = payload

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -10,7 +10,8 @@ import voluptuous as vol
 
 from homeassistant.components.knx import ATTR_DISCOVER_DEVICES, DATA_KNX
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, Light)
+    ATTR_BRIGHTNESS, ATTR_RGB_COLOR, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS,
+    SUPPORT_RGB_COLOR, Light)
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -19,6 +20,8 @@ CONF_ADDRESS = 'address'
 CONF_STATE_ADDRESS = 'state_address'
 CONF_BRIGHTNESS_ADDRESS = 'brightness_address'
 CONF_BRIGHTNESS_STATE_ADDRESS = 'brightness_state_address'
+CONF_COLOR_ADDRESS = 'color_address'
+CONF_COLOR_STATE_ADDRESS = 'color_state_address'
 
 DEFAULT_NAME = 'KNX Light'
 DEPENDENCIES = ['knx']
@@ -29,6 +32,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_BRIGHTNESS_ADDRESS): cv.string,
     vol.Optional(CONF_BRIGHTNESS_STATE_ADDRESS): cv.string,
+    vol.Optional(CONF_COLOR_ADDRESS): cv.string,
+    vol.Optional(CONF_COLOR_STATE_ADDRESS): cv.string,
 })
 
 
@@ -66,7 +71,9 @@ def async_add_devices_config(hass, config, async_add_devices):
         group_address_switch_state=config.get(CONF_STATE_ADDRESS),
         group_address_brightness=config.get(CONF_BRIGHTNESS_ADDRESS),
         group_address_brightness_state=config.get(
-            CONF_BRIGHTNESS_STATE_ADDRESS))
+            CONF_BRIGHTNESS_STATE_ADDRESS),
+        group_address_color=config.get(CONF_COLOR_ADDRESS),
+        group_address_color_state=config.get(CONF_COLOR_STATE_ADDRESS))
     hass.data[DATA_KNX].xknx.devices.add(light)
     async_add_devices([KNXLight(hass, light)])
 
@@ -120,6 +127,8 @@ class KNXLight(Light):
     @property
     def rgb_color(self):
         """Return the RBG color value."""
+        if self.device.supports_color:
+            return self.device.current_color()
         return None
 
     @property
@@ -153,6 +162,8 @@ class KNXLight(Light):
         flags = 0
         if self.device.supports_dimming:
             flags |= SUPPORT_BRIGHTNESS
+        if self.device.supports_color:
+            flags |= SUPPORT_RGB_COLOR
         return flags
 
     @asyncio.coroutine
@@ -160,6 +171,8 @@ class KNXLight(Light):
         """Turn the light on."""
         if ATTR_BRIGHTNESS in kwargs and self.device.supports_dimming:
             yield from self.device.set_brightness(int(kwargs[ATTR_BRIGHTNESS]))
+        elif ATTR_RGB_COLOR in kwargs:
+            yield from self.device.set_color(kwargs[ATTR_RGB_COLOR])
         else:
             yield from self.device.set_on()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1239,7 +1239,7 @@ xbee-helper==0.0.7
 xboxapi==0.1.1
 
 # homeassistant.components.knx
-xknx==0.7.18
+xknx==0.8.3
 
 # homeassistant.components.media_player.bluesound
 # homeassistant.components.sensor.startca


### PR DESCRIPTION
## Description:

Added support for colored KNX lights



## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: knx
    name: Kitchen
    address: '1/0/9'
    color_address: '1/0/11'
```

## Checklist:
  - [x ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
