### PR TITLE
Script/lint: Print every changed file on new line

### DIFF
--- a/script/lint
+++ b/script/lint
@@ -8,7 +8,7 @@ if [ "$1" = "--changed" ]; then
   echo "================================================="
   echo "FILES CHANGED (git diff upstream/dev --name-only)"
   echo "================================================="
-  echo  $files
+  printf "%s\n" $files
   echo "================"
   echo "LINT with flake8"
   echo "================"


### PR DESCRIPTION
## Description:
`echo $files` outputs all changed files separated by spaces. To improve readability `printf "%s\n" $files` outputs each filename on a new line.