### PR TITLE
Fix MQTT payload decode returning prematurely

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -607,7 +607,7 @@ class MQTT(object):
                                     "with encoding %s",
                                     msg.payload, msg.topic,
                                     subscription.encoding)
-                    return
+                    continue
 
             self.hass.async_run_job(subscription.callback,
                                     msg.topic, payload, msg.qos)

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -172,6 +172,17 @@ class TestMQTTCallbacks(unittest.TestCase):
                 "b'\\x9a' on test-topic with encoding utf-8",
                 test_handle.output[0])
 
+    def test_all_subscriptions_run_when_decode_fails(self):
+        """Test all other subscriptions still run when decode fails for one."""
+        mqtt.subscribe(self.hass, 'test-topic', self.record_calls,
+                       encoding='ascii')
+        mqtt.subscribe(self.hass, 'test-topic', self.record_calls)
+
+        fire_mqtt_message(self.hass, 'test-topic', '°C')
+
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
     def test_subscribe_topic(self):
         """Test the subscription of a topic."""
         unsub = mqtt.subscribe(self.hass, 'test-topic', self.record_calls)


### PR DESCRIPTION
## Description:

Follow-up on #12004 - the code there had a bug that could potentially prevent subscription callbacks from being run.

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt:
  broker: the.broker.com
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
