### PR TITLE
Fixed 3 small issues in isy994 component

### DIFF
--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -83,9 +83,9 @@ NODE_FILTERS = {
     },
     'fan': {
         'uom': [],
-        'states': ['on', 'off', 'low', 'medium', 'high'],
+        'states': ['off', 'low', 'medium', 'high'],
         'node_def_id': ['FanLincMotor'],
-        'insteon_type': ['1.46.']
+        'insteon_type': []
     },
     'cover': {
         'uom': ['97'],
@@ -99,7 +99,7 @@ NODE_FILTERS = {
         'node_def_id': ['DimmerLampSwitch', 'DimmerLampSwitch_ADV',
                         'DimmerSwitchOnly', 'DimmerSwitchOnly_ADV',
                         'DimmerLampOnly', 'BallastRelayLampSwitch',
-                        'BallastRelayLampSwitch_ADV', 'RelayLampSwitch',
+                        'BallastRelayLampSwitch_ADV',
                         'RemoteLinc2', 'RemoteLinc2_ADV'],
         'insteon_type': ['1.']
     },
@@ -433,7 +433,10 @@ class ISYDevice(Entity):
     def unique_id(self) -> str:
         """Get the unique identifier of the device."""
         # pylint: disable=protected-access
-        return self._node._id
+        if hasattr(self._node, '_id'):
+            return self._node._id
+
+        return None
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
## Description:
Three tiny fixes that were still lingering from my big cleanup in #11243

1. FanLincs have two nodes: one light and one fan motor. In order for each node to get detected as different Hass entity types, I removed the device-type check for FanLinc. The logic will now fall back on the uom checks which should work just fine. (An alternative approach here would be to special case FanLincs and handle them directly - but seeing as the newer 5.x ISY firmware already handles this much better using NodeDefs, I think this quick and dirty approach is fine for the older firmware.) Fixes #12030

2. Some non-dimming switches were appearing as `light`s in Hass due to an duplicate NodeDef being in the light domain filter. Removed! Fixes #12340

3. The `unqiue_id` property was throwing an error for certain entity types that don't have an `_id` property from the ISY. This issue has always been present, but was exposed by the entity registry which seems to be the first thing to actually try reading the `unique_id` property from the isy994 component.

## Breaking Change Notes
Some non-dimming switches were getting detected as `light` entities rather than `switch` entities for users on ISY 5.x firmware. The issue has been fixed, which means that some `light` entities will go back to being `switch`es, as they always should have been.

**Related issue (if applicable):** fixes #12030 and #12340

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** No documentation update

## Checklist:
  - [x] The code change is tested and works locally.
