### PR TITLE
Telegram bot timeout as float

### DIFF
--- a/homeassistant/components/camera/doorbird.py
+++ b/homeassistant/components/camera/doorbird.py
@@ -18,8 +18,10 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 DEPENDENCIES = ['doorbird']
 
 _CAMERA_LAST_VISITOR = "DoorBird Last Ring"
+_CAMERA_LAST_MOTION = "Doorbird Last Motion"
 _CAMERA_LIVE = "DoorBird Live"
 _LAST_VISITOR_INTERVAL = datetime.timedelta(minutes=1)
+_LAST_MOTION_INTERVAL = datetime.timedelta(minutes=1)
 _LIVE_INTERVAL = datetime.timedelta(seconds=1)
 _LOGGER = logging.getLogger(__name__)
 _TIMEOUT = 10  # seconds
@@ -34,6 +36,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         DoorBirdCamera(
             device.history_image_url(1, 'doorbell'), _CAMERA_LAST_VISITOR,
             _LAST_VISITOR_INTERVAL),
+        DoorBirdCamera(
+            device.history_image_url(1, 'motionsensor'), _CAMERA_LAST_MOTION,
+            _LAST_MOTION_INTERVAL),
     ])
 
 

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -96,6 +96,7 @@ BASE_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_DISABLE_WEB_PREV): cv.boolean,
     vol.Optional(ATTR_KEYBOARD): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(ATTR_KEYBOARD_INLINE): cv.ensure_list,
+    vol.Optional(CONF_TIMEOUT): vol.Coerce(float),
 }, extra=vol.ALLOW_EXTRA)
 
 SERVICE_SCHEMA_SEND_MESSAGE = BASE_SERVICE_SCHEMA.extend({


### PR DESCRIPTION
## Description:
Telegram bot accepts timeout as data parameter, but when using it, it fails because it cannot convert string to float. This fix defines timeout in service schema, so it's converted to float.

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
