### PR TITLE
Reduce the load on met.no servers, yr.no sensor

### DIFF
--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -91,9 +91,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     async_add_devices(dev)
 
     weather = YrData(hass, coordinates, forecast, dev)
-    # Update weather on the hour, spread seconds
     async_track_utc_time_change(hass, weather.updating_devices, minute=31)
-    yield from weather.fetching_data()
+    # wait 1 minute after start up before we fetch data,
+    # to avoid several restarts to fetch new data.
+    async_call_later(hass, 60, weather.fetching_data)
 
 
 class YrSensor(Entity):

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -22,16 +22,17 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_NAME)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import (
-    async_track_point_in_utc_time, async_track_utc_time_change, async_call_later)
+from homeassistant.helpers.event import (async_track_utc_time_change,
+                                         async_call_later)
 from homeassistant.util import dt as dt_util
 
 REQUIREMENTS = ['xmltodict==0.11.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ATTRIBUTION = "Weather forecast from yr.no, delivered by the Norwegian " \
-                   "Meteorological Institute and the NRK."
+CONF_ATTRIBUTION = "Weather forecast from met.no, delivered by the Norwegian " \
+                   "Meteorological Institute."
+# https://api.met.no/license_data.html
 
 SENSOR_TYPES = {
     'symbol': ['Symbol', None],
@@ -171,7 +172,7 @@ class YrData(object):
         def try_again(err: str):
             """Retry in at least 20 minutes."""
             minutes = 15 + randrange(5)
-            _LOGGER.error("Retrying in %i minutes: %s", minutes, err)
+            _LOGGER.warning("Retrying in %i minutes: %s", minutes, err)
             async_call_later(self.hass, minutes*60, self.download_new_data)
         _LOGGER.error('asking for new data')
         _LOGGER.error(self._url)
@@ -200,7 +201,6 @@ class YrData(object):
                                                                           minute=self._random_update_time[0],
                                                                           second=self._random_update_time[1])
         _LOGGER.error(self._random_update_time)
-
         yield from self.async_update()
 
 

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -156,7 +156,7 @@ class YrData(object):
         self.data = {}
         self.hass = hass
         self._unsubscribe_download_new_data = None
-        self._update_time = [randrange(59), randrange(59)]
+        self._update_time = [randrange(60), randrange(60)]
 
     @asyncio.coroutine
     def download_new_data(self, *_):
@@ -168,8 +168,8 @@ class YrData(object):
             self._unsubscribe_download_new_data = None
 
         def try_again(err: str):
-            """Retry in at least 20 minutes."""
-            minutes = 15 + randrange(5)
+            """Retry in 15 to 20 minutes."""
+            minutes = 15 + randrange(6)
             _LOGGER.error("Retrying in %i minutes: %s", minutes, err)
             async_call_later(self.hass, minutes*60, self.download_new_data)
         try:

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -197,8 +197,11 @@ class YrData(object):
             try_again(err)
             return
 
-        nxt = self._nextrun + timedelta(minutes=randrange(59))
+        # Wait at least 3 min after nextrun timestamp
+        nxt = self._nextrun + timedelta(minutes=3+randrange(56))
         async_track_point_in_utc_time(self.hass, self.async_update, nxt)
+        _LOGGER.error(nxt)
+        _LOGGER.error(self._nextrun)
         yield from self.async_update()
 
 

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -198,7 +198,6 @@ class YrData(object):
                                              second=self._update_time[1])
         self._unsubscribe_download_new_data = _unsub
 
-        _LOGGER.error(self._random_update_time)
         yield from self.async_update()
 
     @asyncio.coroutine

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -92,9 +92,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     weather = YrData(hass, coordinates, forecast, dev)
     async_track_utc_time_change(hass, weather.updating_devices, minute=31)
-    # wait 1 minute after start up before we fetch data,
-    # to avoid several restarts to fetch new data.
-    async_call_later(hass, 60, weather.fetching_data)
+    yield from weather.fetching_data()
 
 
 class YrSensor(Entity):

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/sensor.yr/
 import asyncio
 import logging
 
-from datetime import timedelta
 from random import randrange
 from xml.parsers.expat import ExpatError
 
@@ -197,9 +196,13 @@ class YrData(object):
             try_again(err)
             return
 
-        self._unsubscribe_download_new_data = async_track_utc_time_change(self.hass, self.download_new_data,
-                                                                          minute=self._random_update_time[0],
-                                                                          second=self._random_update_time[1])
+        self._unsubscribe_download_new_data = async_track_utc_time_change(self.hass,
+                                                                          self.download_new_data,
+                                                                          minute=
+                                                                          self._random_update_time[0],
+                                                                          second=
+                                                                          self._random_update_time[1])
+
         _LOGGER.error(self._random_update_time)
         yield from self.async_update()
 

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -29,8 +29,8 @@ REQUIREMENTS = ['xmltodict==0.11.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ATTRIBUTION = "Weather forecast from met.no, delivered by the Norwegian " \
-                   "Meteorological Institute."
+CONF_ATTRIBUTION = "Weather forecast from met.no, delivered " \
+                   "by the Norwegian Meteorological Institute."
 # https://api.met.no/license_data.html
 
 SENSOR_TYPES = {
@@ -156,7 +156,7 @@ class YrData(object):
         self.data = {}
         self.hass = hass
         self._unsubscribe_download_new_data = None
-        self._random_update_time = [randrange(59), randrange(59)]
+        self._update_time = [randrange(59), randrange(59)]
 
     @asyncio.coroutine
     def download_new_data(self, *_):
@@ -167,15 +167,11 @@ class YrData(object):
             self._unsubscribe_download_new_data()
             self._unsubscribe_download_new_data = None
 
-        _LOGGER.error('download_new_data')
         def try_again(err: str):
             """Retry in at least 20 minutes."""
             minutes = 15 + randrange(5)
             _LOGGER.error("Retrying in %i minutes: %s", minutes, err)
             async_call_later(self.hass, minutes*60, self.download_new_data)
-        _LOGGER.error('asking for new data')
-        _LOGGER.error(self._url)
-        _LOGGER.error(self._urlparams)
         try:
             websession = async_get_clientsession(self.hass)
             with async_timeout.timeout(10, loop=self.hass.loop):
@@ -196,16 +192,14 @@ class YrData(object):
             try_again(err)
             return
 
-        self._unsubscribe_download_new_data = async_track_utc_time_change(self.hass,
-                                                                          self.download_new_data,
-                                                                          minute=
-                                                                          self._random_update_time[0],
-                                                                          second=
-                                                                          self._random_update_time[1])
+        _unsub = async_track_utc_time_change(self.hass,
+                                             self.download_new_data,
+                                             minute=self._update_time[0],
+                                             second=self._update_time[1])
+        self._unsubscribe_download_new_data = _unsub
 
         _LOGGER.error(self._random_update_time)
         yield from self.async_update()
-
 
     @asyncio.coroutine
     def async_update(self, *_):

--- a/homeassistant/components/sensor/yr.py
+++ b/homeassistant/components/sensor/yr.py
@@ -172,7 +172,7 @@ class YrData(object):
         def try_again(err: str):
             """Retry in at least 20 minutes."""
             minutes = 15 + randrange(5)
-            _LOGGER.warning("Retrying in %i minutes: %s", minutes, err)
+            _LOGGER.error("Retrying in %i minutes: %s", minutes, err)
             async_call_later(self.hass, minutes*60, self.download_new_data)
         _LOGGER.error('asking for new data')
         _LOGGER.error(self._url)


### PR DESCRIPTION
## Description:
Reduce the load on met.no servers, yr.no sensor

Try to spread the load more.
Each user will at initialization of the sensor get a random time (min:sec), and will only ask for new data at that time

**Related issue (if applicable):** fixes #12425

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
 - platform: yr
   monitored_conditions:
     - temperature
```

## Checklist:
  - [x] The code change is tested and works locally.
