### PR TITLE
Remove print statement in Template Light

### DIFF
--- a/homeassistant/components/light/template.py
+++ b/homeassistant/components/light/template.py
@@ -237,7 +237,6 @@ class LightTemplate(Light):
     @asyncio.coroutine
     def async_update(self):
         """Update the state from the template."""
-        print("ASYNC UPDATE")
         if self._template is not None:
             try:
                 state = self._template.async_render().lower()


### PR DESCRIPTION
## Description:

Removes a debug print statement from Template Light.

**Source:** https://github.com/home-assistant/home-assistant/pull/9924#discussion_r168532178

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
