### PR TITLE
Xiaomi MiIO Light: Flag the device as unavailable if not reachable

### DIFF
--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -169,3 +169,13 @@ xiaomi_miio_set_scene:
     scene:
       description: Number of the fixed scene, between 1 and 4.
       example: 1
+
+xiaomi_miio_set_delayed_turn_off:
+  description: Delayed turn off.
+  fields:
+    entity_id:
+      description: Name of the light entity.
+      example: 'light.xiaomi_miio'
+    scene:
+      description: Turn off delay in seconds.
+      example: 120

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -176,6 +176,6 @@ xiaomi_miio_set_delayed_turn_off:
     entity_id:
       description: Name of the light entity.
       example: 'light.xiaomi_miio'
-    seconds:
-      description: Turn off delay in seconds.
-      example: 120
+    time_period:
+      description: Time period for the delayed turn off.
+      example: 5, '0:05', {'minutes': 5}

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -176,6 +176,6 @@ xiaomi_miio_set_delayed_turn_off:
     entity_id:
       description: Name of the light entity.
       example: 'light.xiaomi_miio'
-    scene:
+    seconds:
       description: Turn off delay in seconds.
       example: 120

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -261,8 +261,8 @@ class XiaomiPhilipsGenericLight(Light):
             self._brightness = ceil((255 / 100.0) * state.brightness)
 
             if state.delay_off_countdown > 0:
-                delayed_turn_off = dt.utcnow() + timedelta(
-                    seconds=state.delay_off_countdown)
+                delayed_turn_off = dt.utcnow().replace(microsecond=0) + \
+                    timedelta(seconds=state.delay_off_countdown)
             else:
                 delayed_turn_off = None
 
@@ -399,8 +399,8 @@ class XiaomiPhilipsLightBall(XiaomiPhilipsGenericLight, Light):
                 self.max_mireds, self.min_mireds)
 
             if state.delay_off_countdown > 0:
-                delayed_turn_off = dt.utcnow() + timedelta(
-                    seconds=state.delay_off_countdown)
+                delayed_turn_off = dt.utcnow().replace(microsecond=0) + \
+                    timedelta(seconds=state.delay_off_countdown)
             else:
                 delayed_turn_off = None
 

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -284,7 +284,7 @@ class XiaomiPhilipsGenericLight(Light):
 
     @asyncio.coroutine
     def async_set_delayed_turn_off(self, delayed_turn_off: int):
-        """Set delay off. The unit is different per device"""
+        """Set delay off. The unit is different per device."""
         yield from self._try_command(
             "Setting the delay off failed.",
             self._light.delay_off, delayed_turn_off)

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -261,7 +261,7 @@ class XiaomiPhilipsGenericLight(Light):
             self._brightness = ceil((255 / 100.0) * state.brightness)
 
             if state.delay_off_countdown > 0:
-                delayed_turn_off = dt.utcnow() - timedelta(
+                delayed_turn_off = dt.utcnow() + timedelta(
                     seconds=state.delay_off_countdown)
             else:
                 delayed_turn_off = None
@@ -399,7 +399,7 @@ class XiaomiPhilipsLightBall(XiaomiPhilipsGenericLight, Light):
                 self.max_mireds, self.min_mireds)
 
             if state.delay_off_countdown > 0:
-                delayed_turn_off = dt.utcnow() - timedelta(
+                delayed_turn_off = dt.utcnow() + timedelta(
                     seconds=state.delay_off_countdown)
             else:
                 delayed_turn_off = None

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -51,6 +51,7 @@ SUCCESS = ['ok']
 ATTR_MODEL = 'model'
 ATTR_SCENE = 'scene'
 ATTR_DELAYED_TURN_OFF = 'delayed_turn_off'
+ATTR_SECONDS = 'seconds'
 
 SERVICE_SET_SCENE = 'xiaomi_miio_set_scene'
 SERVICE_SET_DELAYED_TURN_OFF = 'xiaomi_miio_set_delayed_turn_off'
@@ -65,7 +66,7 @@ SERVICE_SCHEMA_SET_SCENE = XIAOMI_MIIO_SERVICE_SCHEMA.extend({
 })
 
 SERVICE_SCHEMA_SET_DELAYED_TURN_OFF = XIAOMI_MIIO_SERVICE_SCHEMA.extend({
-    vol.Required(ATTR_DELAYED_TURN_OFF):
+    vol.Required(ATTR_SECONDS):
         vol.All(vol.Coerce(int), vol.Range(min=0))
 })
 
@@ -285,11 +286,11 @@ class XiaomiPhilipsGenericLight(Light):
             self._light.set_scene, scene)
 
     @asyncio.coroutine
-    def async_set_delayed_turn_off(self, delayed_turn_off: int):
+    def async_set_delayed_turn_off(self, seconds: int):
         """Set delay off. The unit is different per device."""
         yield from self._try_command(
             "Setting the delay off failed.",
-            self._light.delay_off, delayed_turn_off)
+            self._light.delay_off, seconds)
 
     @staticmethod
     def translate(value, left_min, left_max, right_min, right_max):

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -265,7 +265,7 @@ class XiaomiPhilipsGenericLight(Light):
 
             delayed_turn_off = self.delayed_turn_off_timestamp(
                 state.delay_off_countdown,
-                self._state.attrs[ATTR_DELAYED_TURN_OFF])
+                self._state_attrs[ATTR_DELAYED_TURN_OFF])
 
             self._state_attrs.update({
                 ATTR_SCENE: state.scene,
@@ -420,7 +420,7 @@ class XiaomiPhilipsLightBall(XiaomiPhilipsGenericLight, Light):
 
             delayed_turn_off = self.delayed_turn_off_timestamp(
                 state.delay_off_countdown,
-                self._state.attrs[ATTR_DELAYED_TURN_OFF])
+                self._state_attrs[ATTR_DELAYED_TURN_OFF])
 
             self._state_attrs.update({
                 ATTR_SCENE: state.scene,

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -96,8 +96,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     if model is None:
         try:
-            light = Device(host, token)
-            device_info = light.info()
+            miio_device = Device(host, token)
+            device_info = miio_device.info()
             model = device_info.model
             _LOGGER.info("%s %s %s detected",
                          model,

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -25,7 +25,7 @@ from homeassistant.util import dt
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Xiaomi Philips Light'
-PLATFORM = 'xiaomi_miio'
+DATA_KEY = 'light.xiaomi_miio'
 
 CONF_MODEL = 'model'
 
@@ -86,8 +86,8 @@ SERVICE_TO_METHOD = {
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the light from config."""
     from miio import Device, DeviceException
-    if PLATFORM not in hass.data:
-        hass.data[PLATFORM] = {}
+    if DATA_KEY not in hass.data:
+        hass.data[DATA_KEY] = {}
 
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
@@ -127,7 +127,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             'and provide the following data: %s', model)
         return False
 
-    hass.data[PLATFORM][host] = device
+    hass.data[DATA_KEY][host] = device
     async_add_devices([device], update_before_add=True)
 
     @asyncio.coroutine
@@ -138,10 +138,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                   if key != ATTR_ENTITY_ID}
         entity_ids = service.data.get(ATTR_ENTITY_ID)
         if entity_ids:
-            target_devices = [dev for dev in hass.data[PLATFORM].values()
+            target_devices = [dev for dev in hass.data[DATA_KEY].values()
                               if dev.entity_id in entity_ids]
         else:
-            target_devices = hass.data[PLATFORM].values()
+            target_devices = hass.data[DATA_KEY].values()
 
         update_tasks = []
         for target_device in target_devices:

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -9,6 +9,7 @@ from functools import partial
 import logging
 from math import ceil
 from datetime import timedelta
+import datetime
 
 import voluptuous as vol
 
@@ -298,7 +299,7 @@ class XiaomiPhilipsGenericLight(Light):
         return int(right_min + (value_scaled * right_span))
 
     def delayed_turn_off_timestamp(self, countdown: int,
-                                   previous_timestamp: dt.datetime):
+                                   previous_timestamp: datetime):
         if countdown > 0:
             turn_off_timestamp = dt.utcnow().replace(microsecond=0) + \
                                  timedelta(seconds=countdown)

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -33,11 +33,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_TOKEN): vol.All(cv.string, vol.Length(min=32, max=32)),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_MODEL, default=None): vol.In(
+    vol.Optional(CONF_MODEL): vol.In(
         ['philips.light.sread1',
          'philips.light.ceiling',
          'philips.light.zyceiling',
-         'philips.light.bulb', None]),
+         'philips.light.bulb']),
 })
 
 REQUIREMENTS = ['python-miio==0.3.6']
@@ -52,7 +52,7 @@ SUCCESS = ['ok']
 ATTR_MODEL = 'model'
 ATTR_SCENE = 'scene'
 ATTR_DELAYED_TURN_OFF = 'delayed_turn_off'
-ATTR_SECONDS = 'seconds'
+ATTR_TIME_PERIOD = 'time_period'
 
 SERVICE_SET_SCENE = 'xiaomi_miio_set_scene'
 SERVICE_SET_DELAYED_TURN_OFF = 'xiaomi_miio_set_delayed_turn_off'
@@ -67,8 +67,8 @@ SERVICE_SCHEMA_SET_SCENE = XIAOMI_MIIO_SERVICE_SCHEMA.extend({
 })
 
 SERVICE_SCHEMA_SET_DELAYED_TURN_OFF = XIAOMI_MIIO_SERVICE_SCHEMA.extend({
-    vol.Required(ATTR_SECONDS):
-        vol.All(vol.Coerce(int), vol.Range(min=0))
+    vol.Required(ATTR_TIME_PERIOD):
+        vol.All(cv.time_period, cv.positive_timedelta)
 })
 
 SERVICE_TO_METHOD = {
@@ -287,11 +287,11 @@ class XiaomiPhilipsGenericLight(Light):
             self._light.set_scene, scene)
 
     @asyncio.coroutine
-    def async_set_delayed_turn_off(self, seconds: int):
+    def async_set_delayed_turn_off(self, time_period: timedelta):
         """Set delay off. The unit is different per device."""
         yield from self._try_command(
             "Setting the delay off failed.",
-            self._light.delay_off, seconds)
+            self._light.delay_off, time_period.total_seconds())
 
     @staticmethod
     def translate(value, left_min, left_max, right_min, right_max):

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -35,7 +35,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MODEL, default=None): vol.In(
         ['philips.light.sread1',
          'philips.light.ceiling',
-         'philips.light.bulb']),
+         'philips.light.bulb', None]),
 })
 
 REQUIREMENTS = ['python-miio==0.3.6']

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -36,6 +36,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MODEL, default=None): vol.In(
         ['philips.light.sread1',
          'philips.light.ceiling',
+         'philips.light.zyceiling',
          'philips.light.bulb', None]),
 })
 
@@ -111,7 +112,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         from miio import PhilipsEyecare
         light = PhilipsEyecare(host, token)
         device = XiaomiPhilipsEyecareLamp(name, light, model)
-    elif model == 'philips.light.ceiling':
+    elif model in ['philips.light.ceiling', 'philips.light.zyceiling']:
         from miio import Ceil
         light = Ceil(host, token)
         device = XiaomiPhilipsCeilingLamp(name, light, model)
@@ -307,7 +308,7 @@ class XiaomiPhilipsGenericLight(Light):
         """Update the turn off timestamp only if necessary."""
         if countdown > 0:
             new = current.replace(microsecond=0) + \
-                                 timedelta(seconds=countdown)
+                  timedelta(seconds=countdown)
 
             if previous is None:
                 return new


### PR DESCRIPTION
## Description

A new configuration key "model" can be used to define the device type. The key is optional but required to bypass the device model detection f.e. if the device isn't available at the startup of homeassistant.

- New attribute "scene" and "delay_off_countdown" added.
- New service xiaomi_miio_set_delay_off introduced.
- New ceiling lamp model (philips.light.zyceiling) added.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** https://github.com/home-assistant/home-assistant.github.io/pull/4699

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: xiaomi_miio
    name: Xiaomi Philips Smart LED Ball
    host: 192.168.130.67
    token: da548d86f55996413d82eea94279d2ff
    # Bypass of the device model detection.
    # Optional but required to add an unavailable device
    model: philips.light.bulb

```