### PR TITLE
Fail gracefully with unreachable LaMetric

### DIFF
--- a/homeassistant/components/notify/lametric.py
+++ b/homeassistant/components/notify/lametric.py
@@ -93,6 +93,11 @@ class LaMetricNotificationService(BaseNotificationService):
             devices = lmn.get_devices()
         for dev in devices:
             if targets is None or dev["name"] in targets:
-                lmn.set_device(dev)
-                lmn.send_notification(model, lifetime=self._lifetime)
-                _LOGGER.debug("Sent notification to LaMetric %s", dev["name"])
+                try:
+                    lmn.set_device(dev)
+                    lmn.send_notification(model, lifetime=self._lifetime)
+                    _LOGGER.debug("Sent notification to LaMetric %s",
+                                  dev["name"])
+                except OSError:
+                    _LOGGER.warning("Cannot connect to LaMetric %s",
+                                    dev["name"])


### PR DESCRIPTION
## Description:
Accounts with multiple LaMetric devices at unreachable IPs (for example at a different location, on a different/unroutable subnet, etc.) may cause the `notify.lametric` service to fail. This update wraps the message sending routine in a try/except clause and outputs log messages indicating the problem.


**Related issue (if applicable):**
Fixes #12450

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
