### PR TITLE
Vagrant - sendfile python3.5 debian-stretch

### DIFF
--- a/virtualization/vagrant/Vagrantfile
+++ b/virtualization/vagrant/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "debian/contrib-jessie64"
+  config.vm.box = "debian/contrib-stretch64"
   config.vm.synced_folder "../../", "/home-assistant"
   config.vm.synced_folder "./config", "/root/.homeassistant"
   config.vm.network "forwarded_port", guest: 8123, host: 8123

--- a/virtualization/vagrant/home-assistant@.service
+++ b/virtualization/vagrant/home-assistant@.service
@@ -16,5 +16,8 @@ ExecStart=/usr/bin/hass --runner
 SendSIGKILL=no
 RestartForceExitStatus=100
 
+# on vagrant (vboxfs), disable sendfile https://www.virtualbox.org/ticket/9069
+Environment=AIOHTTP_NOSENDFILE=1
+
 [Install]
 WantedBy=multi-user.target

--- a/virtualization/vagrant/provision.sh
+++ b/virtualization/vagrant/provision.sh
@@ -105,7 +105,7 @@ main() {
                     vagrant up --provision; exit ;;
     esac
     # ...otherwise we assume it's the Vagrant provisioner
-    if [ $(hostname) != "contrib-jessie" ]; then usage; exit; fi
+    if [ $(hostname) != "contrib-jessie" ] && [ $(hostname) != "contrib-stretch" ]; then usage; exit; fi
     if ! [ -f $SETUP_DONE ]; then setup; fi
     if [ -f $RESTART ]; then restart; fi
     if [ -f $RUN_TESTS ]; then run_tests; fi


### PR DESCRIPTION
## Description:

Updates the `Vagrant` box used to `debian-stretch` to get `python3.5` (current is jessie on py3.4)

Also disables `aiohttp:SENDFILE` ussage as that is [problematic on vboxFS](https://www.virtualbox.org/ticket/9069)
 This is especially helpfull if one clones [home-assistant/home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) into it as I did ;-)



## Checklist:
  - [x] The code change is tested and works locally.



[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
