### PR TITLE
Update voluputous

### DIFF
--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -34,7 +34,7 @@ DEFAULT_SKIP_FIRST = False
 
 ALERT_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
-    vol.Optional.get(CONF_DONE_MESSAGE): cv.string,
+    vol.Optional(CONF_DONE_MESSAGE): cv.string,
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Required(CONF_STATE, default=STATE_ON): cv.string,
     vol.Required(CONF_REPEAT): vol.All(cv.ensure_list, [vol.Coerce(float)]),

--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -34,7 +34,7 @@ DEFAULT_SKIP_FIRST = False
 
 ALERT_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
-    vol.Optional(CONF_DONE_MESSAGE, default=None): cv.string,
+    vol.Optional.get(CONF_DONE_MESSAGE): cv.string,
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Required(CONF_STATE, default=STATE_ON): cv.string,
     vol.Required(CONF_REPEAT): vol.All(cv.ensure_list, [vol.Coerce(float)]),
@@ -121,7 +121,7 @@ def async_setup(hass, config):
     # Setup alerts
     for entity_id, alert in alerts.items():
         entity = Alert(hass, entity_id,
-                       alert[CONF_NAME], alert[CONF_DONE_MESSAGE],
+                       alert[CONF_NAME], alert.get(CONF_DONE_MESSAGE),
                        alert[CONF_ENTITY_ID], alert[CONF_STATE],
                        alert[CONF_REPEAT], alert[CONF_SKIP_FIRST],
                        alert[CONF_NOTIFIERS], alert[CONF_CAN_ACK])

--- a/homeassistant/components/alexa/__init__.py
+++ b/homeassistant/components/alexa/__init__.py
@@ -31,10 +31,7 @@ ALEXA_ENTITY_SCHEMA = vol.Schema({
 })
 
 SMART_HOME_SCHEMA = vol.Schema({
-    vol.Optional(
-        CONF_FILTER,
-        default=lambda: entityfilter.generate_filter([], [], [], [])
-    ): entityfilter.FILTER_SCHEMA,
+    vol.Optional(CONF_FILTER, default={}): entityfilter.FILTER_SCHEMA,
     vol.Optional(CONF_ENTITY_CONFIG): {cv.entity_id: ALEXA_ENTITY_SCHEMA}
 })
 

--- a/homeassistant/components/amcrest.py
+++ b/homeassistant/components/amcrest.py
@@ -79,7 +79,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_FFMPEG_ARGUMENTS): cv.string,
         vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL):
             cv.time_period,
-        vol.Optional(CONF_SENSORS, default=None):
+        vol.Optional(CONF_SENSORS):
             vol.All(cv.ensure_list, [vol.In(SENSORS)]),
     })])
 }, extra=vol.ALLOW_EXTRA)

--- a/homeassistant/components/android_ip_webcam.py
+++ b/homeassistant/components/android_ip_webcam.py
@@ -140,11 +140,11 @@ CONFIG_SCHEMA = vol.Schema({
             cv.time_period,
         vol.Inclusive(CONF_USERNAME, 'authentication'): cv.string,
         vol.Inclusive(CONF_PASSWORD, 'authentication'): cv.string,
-        vol.Optional(CONF_SWITCHES, default=None):
+        vol.Optional(CONF_SWITCHES):
             vol.All(cv.ensure_list, [vol.In(SWITCHES)]),
-        vol.Optional(CONF_SENSORS, default=None):
+        vol.Optional(CONF_SENSORS):
             vol.All(cv.ensure_list, [vol.In(SENSORS)]),
-        vol.Optional(CONF_MOTION_SENSOR, default=None): cv.boolean,
+        vol.Optional(CONF_MOTION_SENSOR): cv.boolean,
     })])
 }, extra=vol.ALLOW_EXTRA)
 
@@ -165,9 +165,9 @@ def async_setup(hass, config):
         password = cam_config.get(CONF_PASSWORD)
         name = cam_config[CONF_NAME]
         interval = cam_config[CONF_SCAN_INTERVAL]
-        switches = cam_config[CONF_SWITCHES]
-        sensors = cam_config[CONF_SENSORS]
-        motion = cam_config[CONF_MOTION_SENSOR]
+        switches = cam_config.get(CONF_SWITCHES)
+        sensors = cam_config.get(CONF_SENSORS)
+        motion = cam_config.get(CONF_MOTION_SENSOR)
 
         # Init ip webcam
         cam = PyDroidIPCam(

--- a/homeassistant/components/apple_tv.py
+++ b/homeassistant/components/apple_tv.py
@@ -60,7 +60,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.All(ensure_list, [vol.Schema({
         vol.Required(CONF_HOST): cv.string,
         vol.Required(CONF_LOGIN_ID): cv.string,
-        vol.Optional(CONF_CREDENTIALS, default=None): cv.string,
+        vol.Optional(CONF_CREDENTIALS): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_START_OFF, default=False): cv.boolean,
     })])

--- a/homeassistant/components/binary_sensor/bloomsky.py
+++ b/homeassistant/components/binary_sensor/bloomsky.py
@@ -24,7 +24,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_TYPES):
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 

--- a/homeassistant/components/binary_sensor/hikvision.py
+++ b/homeassistant/components/binary_sensor/hikvision.py
@@ -56,7 +56,7 @@ CUSTOMIZE_SCHEMA = vol.Schema({
     })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_NAME, default=None): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_SSL, default=False): cv.boolean,

--- a/homeassistant/components/binary_sensor/ihc.py
+++ b/homeassistant/components/binary_sensor/ihc.py
@@ -43,7 +43,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             product_cfg = device['product_cfg']
             product = device['product']
             sensor = IHCBinarySensor(ihc_controller, name, ihc_id, info,
-                                     product_cfg[CONF_TYPE],
+                                     product_cfg.get(CONF_TYPE),
                                      product_cfg[CONF_INVERTING],
                                      product)
             devices.append(sensor)

--- a/homeassistant/components/binary_sensor/ihc.py
+++ b/homeassistant/components/binary_sensor/ihc.py
@@ -25,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
             vol.All({
                 vol.Required(CONF_ID): cv.positive_int,
                 vol.Optional(CONF_NAME): cv.string,
-                vol.Optional(CONF_TYPE, default=None): DEVICE_CLASSES_SCHEMA,
+                vol.Optional(CONF_TYPE): DEVICE_CLASSES_SCHEMA,
                 vol.Optional(CONF_INVERTING, default=False): cv.boolean,
             }, validate_name)
         ])
@@ -52,7 +52,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         for sensor_cfg in binary_sensors:
             ihc_id = sensor_cfg[CONF_ID]
             name = sensor_cfg[CONF_NAME]
-            sensor_type = sensor_cfg[CONF_TYPE]
+            sensor_type = sensor_cfg.get(CONF_TYPE)
             inverting = sensor_cfg[CONF_INVERTING]
             sensor = IHCBinarySensor(ihc_controller, name, ihc_id, info,
                                      sensor_type, inverting)

--- a/homeassistant/components/binary_sensor/knx.py
+++ b/homeassistant/components/binary_sensor/knx.py
@@ -49,7 +49,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DEVICE_CLASS): cv.string,
     vol.Optional(CONF_SIGNIFICANT_BIT, default=CONF_DEFAULT_SIGNIFICANT_BIT):
         cv.positive_int,
-    vol.Optional(CONF_AUTOMATION, default=None): AUTOMATIONS_SCHEMA,
+    vol.Optional(CONF_AUTOMATION): AUTOMATIONS_SCHEMA,
 })
 
 

--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -50,10 +50,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_CAMERAS, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_HOME): cv.string,
-    vol.Optional(CONF_PRESENCE_SENSORS, default=PRESENCE_SENSOR_TYPES):
+    vol.Optional(CONF_PRESENCE_SENSORS, default=list(PRESENCE_SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(PRESENCE_SENSOR_TYPES)]),
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-    vol.Optional(CONF_WELCOME_SENSORS, default=WELCOME_SENSOR_TYPES):
+    vol.Optional(CONF_WELCOME_SENSORS, default=list(WELCOME_SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(WELCOME_SENSOR_TYPES)]),
 })
 

--- a/homeassistant/components/binary_sensor/octoprint.py
+++ b/homeassistant/components/binary_sensor/octoprint.py
@@ -27,7 +27,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_TYPES):
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })

--- a/homeassistant/components/binary_sensor/rfxtrx.py
+++ b/homeassistant/components/binary_sensor/rfxtrx.py
@@ -28,15 +28,15 @@ DEPENDENCIES = ['rfxtrx']
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DEVICES, default={}): {
         cv.string: vol.Schema({
-            vol.Optional(CONF_NAME, default=None): cv.string,
-            vol.Optional(CONF_DEVICE_CLASS, default=None):
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_DEVICE_CLASS):
                 DEVICE_CLASSES_SCHEMA,
             vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
-            vol.Optional(CONF_OFF_DELAY, default=None):
+            vol.Optional(CONF_OFF_DELAY):
             vol.Any(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_DATA_BITS, default=None): cv.positive_int,
-            vol.Optional(CONF_COMMAND_ON, default=None): cv.byte,
-            vol.Optional(CONF_COMMAND_OFF, default=None): cv.byte
+            vol.Optional(CONF_DATA_BITS): cv.positive_int,
+            vol.Optional(CONF_COMMAND_ON): cv.byte,
+            vol.Optional(CONF_COMMAND_OFF): cv.byte
         })
     },
     vol.Optional(CONF_AUTOMATIC_ADD, default=False):  cv.boolean,
@@ -48,7 +48,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import RFXtrx as rfxtrxmod
     sensors = []
 
-    for packet_id, entity in config['devices'].items():
+    for packet_id, entity in config[CONF_DEVICES].items():
         event = rfxtrx.get_rfx_object(packet_id)
         device_id = slugify(event.device.id_string.lower())
 
@@ -64,10 +64,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                       entity[ATTR_NAME], entity[CONF_DEVICE_CLASS])
 
         device = RfxtrxBinarySensor(
-            event, entity[ATTR_NAME], entity[CONF_DEVICE_CLASS],
-            entity[CONF_FIRE_EVENT], entity[CONF_OFF_DELAY],
-            entity[CONF_DATA_BITS], entity[CONF_COMMAND_ON],
-            entity[CONF_COMMAND_OFF])
+            event, entity.get(CONF_NAME), entity.get(CONF_DEVICE_CLASS),
+            entity[CONF_FIRE_EVENT], entity.get(CONF_OFF_DELAY),
+            entity.get(CONF_DATA_BITS), entity.get(CONF_COMMAND_ON),
+            entity.get(CONF_COMMAND_OFF))
         device.hass = hass
         sensors.append(device)
         rfxtrx.RFX_DEVICES[device_id] = device

--- a/homeassistant/components/binary_sensor/rpi_pfio.py
+++ b/homeassistant/components/binary_sensor/rpi_pfio.py
@@ -26,7 +26,7 @@ DEFAULT_SETTLE_TIME = 20
 DEPENDENCIES = ['rpi_pfio']
 
 PORT_SCHEMA = vol.Schema({
-    vol.Optional(CONF_NAME, default=None): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_SETTLE_TIME, default=DEFAULT_SETTLE_TIME):
         cv.positive_int,
     vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
@@ -44,7 +44,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     binary_sensors = []
     ports = config.get(CONF_PORTS)
     for port, port_entity in ports.items():
-        name = port_entity[CONF_NAME]
+        name = port_entity.get(CONF_NAME)
         settle_time = port_entity[CONF_SETTLE_TIME] / 1000
         invert_logic = port_entity[CONF_INVERT_LOGIC]
 

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -47,7 +47,7 @@ DEFAULT_OFFSET = 0
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COUNTRY): vol.In(ALL_COUNTRIES),
-    vol.Optional(CONF_PROVINCE, default=None): cv.string,
+    vol.Optional(CONF_PROVINCE): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_OFFSET, default=DEFAULT_OFFSET): vol.Coerce(int),
     vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):

--- a/homeassistant/components/camera/xeoma.py
+++ b/homeassistant/components/camera/xeoma.py
@@ -33,7 +33,7 @@ CAMERAS_SCHEMA = vol.Schema({
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_CAMERAS, default={}):
+    vol.Optional(CONF_CAMERAS):
         vol.Schema(vol.All(cv.ensure_list, [CAMERAS_SCHEMA])),
     vol.Optional(CONF_NEW_VERSION, default=True): cv.boolean,
     vol.Optional(CONF_PASSWORD): cv.string,
@@ -67,7 +67,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             for image_name, username, pw in discovered_image_names
         ]
 
-        for cam in config[CONF_CAMERAS]:
+        for cam in config.get(CONF_CAMERAS, []):
             # https://github.com/PyCQA/pylint/issues/1830
             # pylint: disable=stop-iteration-return
             camera = next(

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_NAME, default=None): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
 })
 
 HA_STATE_TO_DAIKIN = {

--- a/homeassistant/components/climate/knx.py
+++ b/homeassistant/components/climate/knx.py
@@ -47,9 +47,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SETPOINT_SHIFT_STEP,
                  default=DEFAULT_SETPOINT_SHIFT_STEP): vol.All(
                      float, vol.Range(min=0, max=2)),
-    vol.Optional(CONF_SETPOINT_SHIFT_MAX, default=DEFAULT_SETPOINT_SHIFT_MAX):
+    vol.Optional(CONF_SETPOINT_SHIFT_MAX):
         vol.All(int, vol.Range(min=-32, max=0)),
-    vol.Optional(CONF_SETPOINT_SHIFT_MIN, default=DEFAULT_SETPOINT_SHIFT_MIN):
+    vol.Optional(CONF_SETPOINT_SHIFT_MIN):
         vol.All(int, vol.Range(min=0, max=32)),
     vol.Optional(CONF_OPERATION_MODE_ADDRESS): cv.string,
     vol.Optional(CONF_OPERATION_MODE_STATE_ADDRESS): cv.string,
@@ -95,8 +95,10 @@ def async_add_devices_config(hass, config, async_add_devices):
         group_address_setpoint_shift_state=config.get(
             CONF_SETPOINT_SHIFT_STATE_ADDRESS),
         setpoint_shift_step=config.get(CONF_SETPOINT_SHIFT_STEP),
-        setpoint_shift_max=config.get(CONF_SETPOINT_SHIFT_MAX),
-        setpoint_shift_min=config.get(CONF_SETPOINT_SHIFT_MIN),
+        setpoint_shift_max=config.get(CONF_SETPOINT_SHIFT_MAX,
+                                      DEFAULT_SETPOINT_SHIFT_MAX),
+        setpoint_shift_min=config.get(CONF_SETPOINT_SHIFT_MIN,
+                                      DEFAULT_SETPOINT_SHIFT_MIN),
         group_address_operation_mode=config.get(CONF_OPERATION_MODE_ADDRESS),
         group_address_operation_mode_state=config.get(
             CONF_OPERATION_MODE_STATE_ADDRESS),

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -56,10 +56,7 @@ GOOGLE_ENTITY_SCHEMA = vol.Schema({
 })
 
 ASSISTANT_SCHEMA = vol.Schema({
-    vol.Optional(
-        CONF_FILTER,
-        default=lambda: entityfilter.generate_filter([], [], [], [])
-    ): entityfilter.FILTER_SCHEMA,
+    vol.Optional(CONF_FILTER, default={}): entityfilter.FILTER_SCHEMA,
 })
 
 ALEXA_SCHEMA = ASSISTANT_SCHEMA.extend({

--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -65,9 +65,9 @@ TILT_FEATURES = (SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT | SUPPORT_STOP_TILT |
                  SUPPORT_SET_TILT_POSITION)
 
 PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_COMMAND_TOPIC, default=None): valid_publish_topic,
-    vol.Optional(CONF_POSITION_TOPIC, default=None): valid_publish_topic,
-    vol.Optional(CONF_SET_POSITION_TEMPLATE, default=None): cv.template,
+    vol.Optional(CONF_COMMAND_TOPIC): valid_publish_topic,
+    vol.Optional(CONF_POSITION_TOPIC): valid_publish_topic,
+    vol.Optional(CONF_SET_POSITION_TEMPLATE): cv.template,
     vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
     vol.Optional(CONF_STATE_TOPIC): valid_subscribe_topic,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
@@ -78,8 +78,8 @@ PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_STATE_OPEN, default=STATE_OPEN): cv.string,
     vol.Optional(CONF_STATE_CLOSED, default=STATE_CLOSED): cv.string,
     vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
-    vol.Optional(CONF_TILT_COMMAND_TOPIC, default=None): valid_publish_topic,
-    vol.Optional(CONF_TILT_STATUS_TOPIC, default=None): valid_subscribe_topic,
+    vol.Optional(CONF_TILT_COMMAND_TOPIC): valid_publish_topic,
+    vol.Optional(CONF_TILT_STATUS_TOPIC): valid_subscribe_topic,
     vol.Optional(CONF_TILT_CLOSED_POSITION,
                  default=DEFAULT_TILT_CLOSED_POSITION): int,
     vol.Optional(CONF_TILT_OPEN_POSITION,

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -649,8 +649,7 @@ def async_load_config(path: str, hass: HomeAssistantType,
     """
     dev_schema = vol.Schema({
         vol.Required(CONF_NAME): cv.string,
-        vol.Optional(CONF_ICON, default=False):
-            vol.Any(None, cv.icon),
+        vol.Optional(CONF_ICON, default=None): vol.Any(None, cv.icon),
         vol.Optional('track', default=False): cv.boolean,
         vol.Optional(CONF_MAC, default=None):
             vol.Any(None, vol.All(cv.string, vol.Upper)),

--- a/homeassistant/components/device_tracker/automatic.py
+++ b/homeassistant/components/device_tracker/automatic.py
@@ -49,8 +49,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_CLIENT_ID): cv.string,
     vol.Required(CONF_SECRET): cv.string,
     vol.Optional(CONF_CURRENT_LOCATION, default=False): cv.boolean,
-    vol.Optional(CONF_DEVICES, default=None):
-        vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_DEVICES): vol.All(cv.ensure_list, [cv.string]),
 })
 
 
@@ -109,7 +108,7 @@ def async_setup_scanner(hass, config, async_see, discovery_info=None):
             _write_refresh_token_to_file, hass, filename,
             session.refresh_token)
         data = AutomaticData(
-            hass, client, session, config[CONF_DEVICES], async_see)
+            hass, client, session, config.get(CONF_DEVICES), async_see)
 
         # Load the initial vehicle data
         vehicles = yield from session.get_vehicles()

--- a/homeassistant/components/device_tracker/mqtt_json.py
+++ b/homeassistant/components/device_tracker/mqtt_json.py
@@ -26,8 +26,8 @@ _LOGGER = logging.getLogger(__name__)
 GPS_JSON_PAYLOAD_SCHEMA = vol.Schema({
     vol.Required(ATTR_LATITUDE): vol.Coerce(float),
     vol.Required(ATTR_LONGITUDE): vol.Coerce(float),
-    vol.Optional(ATTR_GPS_ACCURACY, default=None): vol.Coerce(int),
-    vol.Optional(ATTR_BATTERY_LEVEL, default=None): vol.Coerce(str),
+    vol.Optional(ATTR_GPS_ACCURACY): vol.Coerce(int),
+    vol.Optional(ATTR_BATTERY_LEVEL): vol.Coerce(str),
 }, extra=vol.ALLOW_EXTRA)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(mqtt.SCHEMA_BASE).extend({

--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -33,7 +33,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOSTS): cv.ensure_list,
     vol.Required(CONF_HOME_INTERVAL, default=0): cv.positive_int,
     vol.Optional(CONF_EXCLUDE, default=[]):
-        vol.All(cv.ensure_list, vol.Length(min=1)),
+        vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_OPTIONS, default=DEFAULT_OPTIONS):
         cv.string
 })

--- a/homeassistant/components/device_tracker/tomato.py
+++ b/homeassistant/components/device_tracker/tomato.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_PORT, default=-1): cv.port,
+    vol.Optional(CONF_PORT): cv.port,
     vol.Optional(CONF_SSL, default=False): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=True): vol.Any(
         cv.boolean, cv.isfile),
@@ -45,13 +45,11 @@ class TomatoDeviceScanner(DeviceScanner):
     def __init__(self, config):
         """Initialize the scanner."""
         host, http_id = config[CONF_HOST], config[CONF_HTTP_ID]
-        port = config[CONF_PORT]
+        port = config.get(CONF_PORT)
         username, password = config[CONF_USERNAME], config[CONF_PASSWORD]
         self.ssl, self.verify_ssl = config[CONF_SSL], config[CONF_VERIFY_SSL]
-        if port == -1:
-            port = 80
-            if self.ssl:
-                port = 443
+        if port is None:
+            port = 443 if self.ssl else 80
 
         self.req = requests.Request(
             'POST', 'http{}://{}:{}/update.cgi'.format(

--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -27,7 +27,6 @@ DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 8443
 DEFAULT_VERIFY_SSL = True
 DEFAULT_DETECTION_TIME = timedelta(seconds=300)
-DEFAULT_SSID_FILTER = None
 
 NOTIFICATION_ID = 'unifi_notification'
 NOTIFICATION_TITLE = 'Unifi Device Tracker Setup'
@@ -42,8 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         cv.boolean, cv.isfile),
     vol.Optional(CONF_DETECTION_TIME, default=DEFAULT_DETECTION_TIME): vol.All(
         cv.time_period, cv.positive_timedelta),
-    vol.Optional(CONF_SSID_FILTER, default=DEFAULT_SSID_FILTER): vol.All(
-        cv.ensure_list, [cv.string])
+    vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string])
 })
 
 

--- a/homeassistant/components/history.py
+++ b/homeassistant/components/history.py
@@ -241,12 +241,12 @@ def async_setup(hass, config):
     filters = Filters()
     exclude = config[DOMAIN].get(CONF_EXCLUDE)
     if exclude:
-        filters.excluded_entities = exclude[CONF_ENTITIES]
-        filters.excluded_domains = exclude[CONF_DOMAINS]
+        filters.excluded_entities = exclude.get(CONF_ENTITIES, [])
+        filters.excluded_domains = exclude.get(CONF_DOMAINS, [])
     include = config[DOMAIN].get(CONF_INCLUDE)
     if include:
-        filters.included_entities = include[CONF_ENTITIES]
-        filters.included_domains = include[CONF_DOMAINS]
+        filters.included_entities = include.get(CONF_ENTITIES, [])
+        filters.included_domains = include.get(CONF_DOMAINS, [])
     use_include_order = config[DOMAIN].get(CONF_ORDER)
 
     hass.http.register_view(HistoryPeriodView(filters, use_include_order))

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -180,7 +180,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
         }},
         vol.Optional(CONF_LOCAL_IP, default=DEFAULT_LOCAL_IP): cv.string,
-        vol.Optional(CONF_LOCAL_PORT, default=DEFAULT_LOCAL_PORT): cv.port,
+        vol.Optional(CONF_LOCAL_PORT): cv.port,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -310,7 +310,7 @@ def setup(hass, config):
     bound_system_callback = partial(_system_callback_handler, hass, config)
     hass.data[DATA_HOMEMATIC] = homematic = HMConnection(
         local=config[DOMAIN].get(CONF_LOCAL_IP),
-        localport=config[DOMAIN].get(CONF_LOCAL_PORT),
+        localport=config[DOMAIN].get(CONF_LOCAL_PORT, DEFAULT_LOCAL_PORT),
         remotes=remotes,
         systemcallback=bound_system_callback,
         interface_id='homeassistant'

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -73,22 +73,23 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_SERVER_HOST = '0.0.0.0'
 DEFAULT_DEVELOPMENT = '0'
-DEFAULT_LOGIN_ATTEMPT_THRESHOLD = -1
+NO_LOGIN_ATTEMPT_THRESHOLD = -1
 
 HTTP_SCHEMA = vol.Schema({
-    vol.Optional(CONF_API_PASSWORD, default=None): cv.string,
+    vol.Optional(CONF_API_PASSWORD): cv.string,
     vol.Optional(CONF_SERVER_HOST, default=DEFAULT_SERVER_HOST): cv.string,
     vol.Optional(CONF_SERVER_PORT, default=SERVER_PORT): cv.port,
     vol.Optional(CONF_BASE_URL): cv.string,
-    vol.Optional(CONF_SSL_CERTIFICATE, default=None): cv.isfile,
-    vol.Optional(CONF_SSL_KEY, default=None): cv.isfile,
+    vol.Optional(CONF_SSL_CERTIFICATE): cv.isfile,
+    vol.Optional(CONF_SSL_KEY): cv.isfile,
     vol.Optional(CONF_CORS_ORIGINS, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_USE_X_FORWARDED_FOR, default=False): cv.boolean,
     vol.Optional(CONF_TRUSTED_NETWORKS, default=[]):
         vol.All(cv.ensure_list, [ip_network]),
     vol.Optional(CONF_LOGIN_ATTEMPTS_THRESHOLD,
-                 default=DEFAULT_LOGIN_ATTEMPT_THRESHOLD): cv.positive_int,
+                 default=NO_LOGIN_ATTEMPT_THRESHOLD):
+        vol.Any(cv.positive_int, NO_LOGIN_ATTEMPT_THRESHOLD),
     vol.Optional(CONF_IP_BAN_ENABLED, default=True): cv.boolean
 })
 
@@ -105,11 +106,11 @@ def async_setup(hass, config):
     if conf is None:
         conf = HTTP_SCHEMA({})
 
-    api_password = conf[CONF_API_PASSWORD]
+    api_password = conf.get(CONF_API_PASSWORD)
     server_host = conf[CONF_SERVER_HOST]
     server_port = conf[CONF_SERVER_PORT]
-    ssl_certificate = conf[CONF_SSL_CERTIFICATE]
-    ssl_key = conf[CONF_SSL_KEY]
+    ssl_certificate = conf.get(CONF_SSL_CERTIFICATE)
+    ssl_key = conf.get(CONF_SSL_KEY)
     cors_origins = conf[CONF_CORS_ORIGINS]
     use_x_forwarded_for = conf[CONF_USE_X_FORWARDED_FOR]
     trusted_networks = conf[CONF_TRUSTED_NETWORKS]

--- a/homeassistant/components/ihc/__init__.py
+++ b/homeassistant/components/ihc/__init__.py
@@ -46,7 +46,7 @@ AUTO_SETUP_SCHEMA = vol.Schema({
             vol.All({
                 vol.Required(CONF_XPATH): cv.string,
                 vol.Required(CONF_NODE): cv.string,
-                vol.Optional(CONF_TYPE, default=None): cv.string,
+                vol.Optional(CONF_TYPE): cv.string,
                 vol.Optional(CONF_INVERTING, default=False): cv.boolean,
             })
         ]),

--- a/homeassistant/components/image_processing/opencv.py
+++ b/homeassistant/components/image_processing/opencv.py
@@ -42,7 +42,7 @@ DEFAULT_TIMEOUT = 10
 SCAN_INTERVAL = timedelta(seconds=2)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_CLASSIFIER, default=None): {
+    vol.Optional(CONF_CLASSIFIER): {
         cv.string: vol.Any(
             cv.isfile,
             vol.Schema({
@@ -60,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def _create_processor_from_config(hass, camera_entity, config):
     """Create an OpenCV processor from configuration."""
-    classifier_config = config[CONF_CLASSIFIER]
+    classifier_config = config.get(CONF_CLASSIFIER)
     name = '{} {}'.format(
         config[CONF_NAME], split_entity_id(camera_entity)[1].replace('_', ' '))
 
@@ -93,7 +93,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return
 
     entities = []
-    if config[CONF_CLASSIFIER] is None:
+    if CONF_CLASSIFIER not in config:
         dest_path = hass.config.path(DEFAULT_CLASSIFIER_PATH)
         _get_default_classifier(dest_path)
         config[CONF_CLASSIFIER] = {

--- a/homeassistant/components/image_processing/seven_segments.py
+++ b/homeassistant/components/image_processing/seven_segments.py
@@ -33,7 +33,7 @@ DEFAULT_BINARY = 'ssocr'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_EXTRA_ARGUMENTS, default=''): cv.string,
-    vol.Optional(CONF_DIGITS, default=-1): cv.positive_int,
+    vol.Optional.get(CONF_DIGITS, -1): cv.positive_int,
     vol.Optional(CONF_HEIGHT, default=0): cv.positive_int,
     vol.Optional(CONF_SSOCR_BIN, default=DEFAULT_BINARY): cv.string,
     vol.Optional(CONF_THRESHOLD, default=0): cv.positive_int,
@@ -73,7 +73,7 @@ class ImageProcessingSsocr(ImageProcessingEntity):
         self.filepath = os.path.join(self.hass.config.config_dir, 'ocr.png')
         crop = ['crop', str(config[CONF_X_POS]), str(config[CONF_Y_POS]),
                 str(config[CONF_WIDTH]), str(config[CONF_HEIGHT])]
-        digits = ['-d', str(config[CONF_DIGITS])]
+        digits = ['-d', str(config.get(CONF_DIGITS, -1))]
         rotate = ['rotate', str(config[CONF_ROTATE])]
         threshold = ['-t', str(config[CONF_THRESHOLD])]
         extra_arguments = config[CONF_EXTRA_ARGUMENTS].split(' ')

--- a/homeassistant/components/image_processing/seven_segments.py
+++ b/homeassistant/components/image_processing/seven_segments.py
@@ -33,7 +33,7 @@ DEFAULT_BINARY = 'ssocr'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_EXTRA_ARGUMENTS, default=''): cv.string,
-    vol.Optional.get(CONF_DIGITS, -1): cv.positive_int,
+    vol.Optional(CONF_DIGITS): cv.positive_int,
     vol.Optional(CONF_HEIGHT, default=0): cv.positive_int,
     vol.Optional(CONF_SSOCR_BIN, default=DEFAULT_BINARY): cv.string,
     vol.Optional(CONF_THRESHOLD, default=0): cv.positive_int,

--- a/homeassistant/components/insteon_plm.py
+++ b/homeassistant/components/insteon_plm.py
@@ -26,8 +26,7 @@ CONF_OVERRIDE = 'device_override'
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_PORT): cv.string,
-        vol.Optional(CONF_OVERRIDE, default=[]): vol.All(
-            cv.ensure_list_csv, vol.Length(min=1))
+        vol.Optional(CONF_OVERRIDE, default=[]): cv.ensure_list_csv,
     })
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -84,7 +84,7 @@ DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(ATTR_MODE, default=MODE_RGBW):
         vol.All(cv.string, vol.In([MODE_RGBW, MODE_RGB])),
-    vol.Optional(CONF_PROTOCOL, default=None):
+    vol.Optional(CONF_PROTOCOL):
         vol.All(cv.string, vol.In(['ledenet'])),
 })
 
@@ -104,7 +104,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         device = {}
         device['name'] = device_config[CONF_NAME]
         device['ipaddr'] = ipaddr
-        device[CONF_PROTOCOL] = device_config[CONF_PROTOCOL]
+        device[CONF_PROTOCOL] = device_config.get(CONF_PROTOCOL)
         device[ATTR_MODE] = device_config[ATTR_MODE]
         light = FluxLight(device)
         lights.append(light)

--- a/homeassistant/components/light/lifx_legacy.py
+++ b/homeassistant/components/light/lifx_legacy.py
@@ -41,8 +41,8 @@ SUPPORT_LIFX = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_RGB_COLOR |
                 SUPPORT_TRANSITION)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_SERVER, default=None): cv.string,
-    vol.Optional(CONF_BROADCAST, default=None): cv.string,
+    vol.Optional(CONF_SERVER): cv.string,
+    vol.Optional(CONF_BROADCAST): cv.string,
 })
 
 

--- a/homeassistant/components/light/template.py
+++ b/homeassistant/components/light/template.py
@@ -35,11 +35,11 @@ CONF_LEVEL_TEMPLATE = 'level_template'
 LIGHT_SCHEMA = vol.Schema({
     vol.Required(CONF_ON_ACTION): cv.SCRIPT_SCHEMA,
     vol.Required(CONF_OFF_ACTION): cv.SCRIPT_SCHEMA,
-    vol.Optional(CONF_VALUE_TEMPLATE, default=None): cv.template,
-    vol.Optional(CONF_ICON_TEMPLATE, default=None): cv.template,
-    vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE, default=None): cv.template,
-    vol.Optional(CONF_LEVEL_ACTION, default=None): cv.SCRIPT_SCHEMA,
-    vol.Optional(CONF_LEVEL_TEMPLATE, default=None): cv.template,
+    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_ICON_TEMPLATE): cv.template,
+    vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
+    vol.Optional(CONF_LEVEL_ACTION): cv.SCRIPT_SCHEMA,
+    vol.Optional(CONF_LEVEL_TEMPLATE): cv.template,
     vol.Optional(CONF_FRIENDLY_NAME): cv.string,
     vol.Optional(CONF_ENTITY_ID): cv.entity_ids
 })
@@ -56,14 +56,14 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     for device, device_config in config[CONF_LIGHTS].items():
         friendly_name = device_config.get(CONF_FRIENDLY_NAME, device)
-        state_template = device_config[CONF_VALUE_TEMPLATE]
+        state_template = device_config.get(CONF_VALUE_TEMPLATE)
         icon_template = device_config.get(CONF_ICON_TEMPLATE)
         entity_picture_template = device_config.get(
             CONF_ENTITY_PICTURE_TEMPLATE)
         on_action = device_config[CONF_ON_ACTION]
         off_action = device_config[CONF_OFF_ACTION]
         level_action = device_config.get(CONF_LEVEL_ACTION)
-        level_template = device_config[CONF_LEVEL_TEMPLATE]
+        level_template = device_config.get(CONF_LEVEL_TEMPLATE)
 
         template_entity_ids = set()
 

--- a/homeassistant/components/media_player/clementine.py
+++ b/homeassistant/components/media_player/clementine.py
@@ -37,7 +37,7 @@ SUPPORT_CLEMENTINE = SUPPORT_PAUSE | SUPPORT_VOLUME_STEP | \
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_ACCESS_TOKEN, default=None): cv.positive_int,
+    vol.Optional(CONF_ACCESS_TOKEN): cv.positive_int,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
 })

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -43,12 +43,12 @@ SUPPORT_MEDIA_MODES = SUPPORT_PLAY_MEDIA | \
 
 DENON_ZONE_SCHEMA = vol.Schema({
     vol.Required(CONF_ZONE): vol.In(CONF_VALID_ZONES, CONF_INVALID_ZONES_ERR),
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_SHOW_ALL_SOURCES, default=DEFAULT_SHOW_SOURCES):
         cv.boolean,
     vol.Optional(CONF_ZONES):
@@ -80,7 +80,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if zones is not None:
         add_zones = {}
         for entry in zones:
-            add_zones[entry[CONF_ZONE]] = entry[CONF_NAME]
+            add_zones[entry[CONF_ZONE]] = entry.get(CONF_NAME)
     else:
         add_zones = None
 

--- a/homeassistant/components/media_player/emby.py
+++ b/homeassistant/components/media_player/emby.py
@@ -45,7 +45,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
     vol.Required(CONF_API_KEY): cv.string,
-    vol.Optional(CONF_PORT, default=None): cv.port,
+    vol.Optional(CONF_PORT): cv.port,
     vol.Optional(CONF_AUTO_HIDE, default=DEFAULT_AUTO_HIDE): cv.boolean,
 })
 

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -86,7 +86,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_TCP_PORT, default=DEFAULT_TCP_PORT): cv.port,
     vol.Optional(CONF_PROXY_SSL, default=DEFAULT_PROXY_SSL): cv.boolean,
-    vol.Optional(CONF_TURN_ON_ACTION, default=None): cv.SCRIPT_SCHEMA,
+    vol.Optional(CONF_TURN_ON_ACTION): cv.SCRIPT_SCHEMA,
     vol.Optional(CONF_TURN_OFF_ACTION):
         vol.Any(cv.SCRIPT_SCHEMA, vol.In(DEPRECATED_TURN_OFF_ACTIONS)),
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,

--- a/homeassistant/components/media_player/lg_netcast.py
+++ b/homeassistant/components/media_player/lg_netcast.py
@@ -38,7 +38,7 @@ SUPPORT_LGTV = SUPPORT_PAUSE | SUPPORT_VOLUME_STEP | \
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_ACCESS_TOKEN, default=None):
+    vol.Optional(CONF_ACCESS_TOKEN):
         vol.All(cv.string, vol.Length(max=6)),
 })
 

--- a/homeassistant/components/notify/apns.py
+++ b/homeassistant/components/notify/apns.py
@@ -39,7 +39,7 @@ PLATFORM_SCHEMA = vol.Schema({
 
 REGISTER_SERVICE_SCHEMA = vol.Schema({
     vol.Required(ATTR_PUSH_ID): cv.string,
-    vol.Optional(ATTR_NAME, default=None): cv.string,
+    vol.Optional(ATTR_NAME): cv.string,
 })
 
 

--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -22,8 +22,6 @@ CONF_TARGET_PARAMETER_NAME = 'target_param_name'
 CONF_TITLE_PARAMETER_NAME = 'title_param_name'
 DEFAULT_MESSAGE_PARAM_NAME = 'message'
 DEFAULT_METHOD = 'GET'
-DEFAULT_TARGET_PARAM_NAME = None
-DEFAULT_TITLE_PARAM_NAME = None
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
@@ -32,14 +30,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_METHOD, default=DEFAULT_METHOD):
         vol.In(['POST', 'GET', 'POST_JSON']),
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_TARGET_PARAMETER_NAME,
-                 default=DEFAULT_TARGET_PARAM_NAME): cv.string,
-    vol.Optional(CONF_TITLE_PARAMETER_NAME,
-                 default=DEFAULT_TITLE_PARAM_NAME): cv.string,
-    vol.Optional(CONF_DATA,
-                 default=None): dict,
-    vol.Optional(CONF_DATA_TEMPLATE,
-                 default=None): {cv.match_all: cv.template_complex}
+    vol.Optional(CONF_TARGET_PARAMETER_NAME): cv.string,
+    vol.Optional(CONF_TITLE_PARAMETER_NAME): cv.string,
+    vol.Optional(CONF_DATA): dict,
+    vol.Optional(CONF_DATA_TEMPLATE): {cv.match_all: cv.template_complex}
 })
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -63,15 +63,15 @@ CONNECT_RETRY_WAIT = 3
 
 FILTER_SCHEMA = vol.Schema({
     vol.Optional(CONF_EXCLUDE, default={}): vol.Schema({
-        vol.Optional(CONF_ENTITIES, default=[]): cv.entity_ids,
-        vol.Optional(CONF_DOMAINS, default=[]):
+        vol.Optional(CONF_ENTITIES): cv.entity_ids,
+        vol.Optional(CONF_DOMAINS):
             vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_EVENT_TYPES, default=[]):
+        vol.Optional(CONF_EVENT_TYPES):
             vol.All(cv.ensure_list, [cv.string])
     }),
     vol.Optional(CONF_INCLUDE, default={}): vol.Schema({
-        vol.Optional(CONF_ENTITIES, default=[]): cv.entity_ids,
-        vol.Optional(CONF_DOMAINS, default=[]):
+        vol.Optional(CONF_ENTITIES): cv.entity_ids,
+        vol.Optional(CONF_DOMAINS):
             vol.All(cv.ensure_list, [cv.string])
     })
 })

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -31,7 +31,7 @@ CONF_DEVICE_CACHE = 'harmony_device_cache'
 SERVICE_SYNC = 'harmony_sync'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(ATTR_ACTIVITY, default=None): cv.string,
+    vol.Required(ATTR_ACTIVITY): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(ATTR_DELAY_SECS, default=DEFAULT_DELAY_SECS):
         vol.Coerce(float),

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -74,7 +74,7 @@ DEVICE_DEFAULTS_SCHEMA = vol.Schema({
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_PORT): vol.Any(cv.port, cv.string),
-        vol.Optional.get(CONF_HOST): cv.string,
+        vol.Optional(CONF_HOST): cv.string,
         vol.Optional(CONF_WAIT_FOR_ACK, default=True): cv.boolean,
         vol.Optional(CONF_RECONNECT_INTERVAL,
                      default=DEFAULT_RECONNECT_INTERVAL): int,

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -74,7 +74,7 @@ DEVICE_DEFAULTS_SCHEMA = vol.Schema({
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_PORT): vol.Any(cv.port, cv.string),
-        vol.Optional(CONF_HOST, default=None): cv.string,
+        vol.Optional.get(CONF_HOST): cv.string,
         vol.Optional(CONF_WAIT_FOR_ACK, default=True): cv.boolean,
         vol.Optional(CONF_RECONNECT_INTERVAL,
                      default=DEFAULT_RECONNECT_INTERVAL): int,
@@ -175,7 +175,7 @@ def async_setup(hass, config):
                     hass.data[DATA_DEVICE_REGISTER][event_type], event)
 
     # When connecting to tcp host instead of serial port (optional)
-    host = config[DOMAIN][CONF_HOST]
+    host = config[DOMAIN].get(CONF_HOST)
     # TCP port when host configured, otherwise serial port
     port = config[DOMAIN][CONF_PORT]
 

--- a/homeassistant/components/sensor/bom.py
+++ b/homeassistant/components/sensor/bom.py
@@ -88,7 +88,7 @@ def validate_station(station):
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Inclusive(CONF_ZONE_ID, 'Deprecated partial station ID'): cv.string,
     vol.Inclusive(CONF_WMO_ID, 'Deprecated partial station ID'): cv.string,
-    vol.Optional(CONF_NAME, default=None): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_STATION): validate_station,
     vol.Required(CONF_MONITORED_CONDITIONS, default=[]):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),

--- a/homeassistant/components/sensor/daikin.py
+++ b/homeassistant/components/sensor/daikin.py
@@ -24,7 +24,7 @@ from homeassistant.util.unit_system import UnitSystem
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_TYPES.keys()):
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 

--- a/homeassistant/components/sensor/daikin.py
+++ b/homeassistant/components/sensor/daikin.py
@@ -23,7 +23,7 @@ from homeassistant.util.unit_system import UnitSystem
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_NAME, default=None): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_TYPES.keys()):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -39,7 +39,7 @@ RECONNECT_INTERVAL = 5
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
-    vol.Optional(CONF_HOST, default=None): cv.string,
+    vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_DSMR_VERSION, default=DEFAULT_DSMR_VERSION): vol.All(
         cv.string, vol.In(['5', '4', '2.2'])),
     vol.Optional(CONF_RECONNECT_INTERVAL, default=30): int,
@@ -96,7 +96,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     # Creates an asyncio.Protocol factory for reading DSMR telegrams from
     # serial and calls update_entities_telegram to update entities on arrival
-    if config[CONF_HOST]:
+    if CONF_HOST in config:
         reader_factory = partial(
             create_tcp_dsmr_reader, config[CONF_HOST], config[CONF_PORT],
             config[CONF_DSMR_VERSION], update_entities_telegram,

--- a/homeassistant/components/sensor/dwd_weather_warnings.py
+++ b/homeassistant/components/sensor/dwd_weather_warnings.py
@@ -47,8 +47,9 @@ MONITORED_CONDITIONS = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_REGION_NAME): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
+    vol.Optional(CONF_MONITORED_CONDITIONS,
+                 default=list(MONITORED_CONDITIONS)):
+    vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
 })
 
 

--- a/homeassistant/components/sensor/envirophat.py
+++ b/homeassistant/components/sensor/envirophat.py
@@ -45,7 +45,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_DISPLAY_OPTIONS, default=SENSOR_TYPES):
+    vol.Required(CONF_DISPLAY_OPTIONS, default=list(SENSOR_TYPES)):
         [vol.In(SENSOR_TYPES)],
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_USE_LEDS, default=False): cv.boolean

--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -33,9 +33,8 @@ STATE_CURRENT_BANS = 'current_bans'
 STATE_ALL_BANS = 'total_bans'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_JAILS, default=[]):
-        vol.All(cv.ensure_list, vol.Length(min=1)),
-    vol.Optional(CONF_FILE_PATH, default=DEFAULT_LOG): cv.isfile,
+    vol.Required(CONF_JAILS): vol.All(cv.ensure_list, vol.Length(min=1)),
+    vol.Optional(CONF_FILE_PATH): cv.isfile,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
@@ -46,7 +45,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     jails = config.get(CONF_JAILS)
     scan_interval = config.get(CONF_SCAN_INTERVAL)
-    log_file = config.get(CONF_FILE_PATH)
+    log_file = config.get(CONF_FILE_PATH, DEFAULT_LOG)
 
     device_list = []
     log_parser = BanLogParser(scan_interval, log_file)

--- a/homeassistant/components/sensor/google_wifi.py
+++ b/homeassistant/components/sensor/google_wifi.py
@@ -69,8 +69,9 @@ MONITORED_CONDITIONS = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
+    vol.Optional(CONF_MONITORED_CONDITIONS,
+                 default=list(MONITORED_CONDITIONS)):
+    vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/sensor/gtfs.py
+++ b/homeassistant/components/sensor/gtfs.py
@@ -39,8 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DESTINATION): cv.string,
     vol.Required(CONF_DATA): cv.string,
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_OFFSET, default=datetime.timedelta(0)):
-        cv.time_period_dict,
+    vol.Optional(CONF_OFFSET, default=0): cv.time_period,
 })
 
 

--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -49,13 +49,7 @@ ATTR_VALUE = 'value'
 
 def exactly_two_period_keys(conf):
     """Ensure exactly 2 of CONF_PERIOD_KEYS are provided."""
-    provided = 0
-
-    for param in CONF_PERIOD_KEYS:
-        if param in conf and conf[param] is not None:
-            provided += 1
-
-    if provided != 2:
+    if sum(param in conf for param in CONF_PERIOD_KEYS) != 2:
         raise vol.Invalid('You must provide exactly 2 of the following:'
                           ' start, end, duration')
     return conf
@@ -64,9 +58,9 @@ def exactly_two_period_keys(conf):
 PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Required(CONF_STATE): cv.string,
-    vol.Optional(CONF_START, default=None): cv.template,
-    vol.Optional(CONF_END, default=None): cv.template,
-    vol.Optional(CONF_DURATION, default=None): cv.time_period,
+    vol.Optional(CONF_START): cv.template,
+    vol.Optional(CONF_END): cv.template,
+    vol.Optional(CONF_DURATION): cv.time_period,
     vol.Optional(CONF_TYPE, default=CONF_TYPE_TIME): vol.In(CONF_TYPE_KEYS),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 }), exactly_two_period_keys)

--- a/homeassistant/components/sensor/hp_ilo.py
+++ b/homeassistant/components/sensor/hp_ilo.py
@@ -51,8 +51,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
             vol.Required(CONF_NAME): cv.string,
             vol.Required(CONF_SENSOR_TYPE):
                 vol.All(cv.string, vol.In(SENSOR_TYPES)),
-            vol.Optional(CONF_UNIT_OF_MEASUREMENT, default=None): cv.string,
-            vol.Optional(CONF_VALUE_TEMPLATE, default=None): cv.template
+            vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+            vol.Optional(CONF_VALUE_TEMPLATE): cv.template
         })]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
@@ -85,8 +85,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             sensor_name='{} {}'.format(
                 config.get(CONF_NAME), monitored_variable[CONF_NAME]),
             sensor_type=monitored_variable[CONF_SENSOR_TYPE],
-            sensor_value_template=monitored_variable[CONF_VALUE_TEMPLATE],
-            unit_of_measurement=monitored_variable[CONF_UNIT_OF_MEASUREMENT])
+            sensor_value_template=monitored_variable.get(CONF_VALUE_TEMPLATE),
+            unit_of_measurement=monitored_variable.get(
+                CONF_UNIT_OF_MEASUREMENT))
         devices.append(new_device)
 
     add_devices(devices, True)

--- a/homeassistant/components/sensor/irish_rail_transport.py
+++ b/homeassistant/components/sensor/irish_rail_transport.py
@@ -42,9 +42,9 @@ TIME_STR_FORMAT = '%H:%M'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_STATION): cv.string,
-    vol.Optional(CONF_DIRECTION, default=None): cv.string,
-    vol.Optional(CONF_DESTINATION, default=None): cv.string,
-    vol.Optional(CONF_STOPS_AT, default=None): cv.string,
+    vol.Optional(CONF_DIRECTION): cv.string,
+    vol.Optional(CONF_DESTINATION): cv.string,
+    vol.Optional(CONF_STOPS_AT): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
 })
 

--- a/homeassistant/components/sensor/loopenergy.py
+++ b/homeassistant/components/sensor/loopenergy.py
@@ -51,10 +51,8 @@ GAS_SCHEMA = vol.Schema({
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ELEC): vol.All(
-        dict, ELEC_SCHEMA),
-    vol.Optional(CONF_GAS, default={}): vol.All(
-        dict, GAS_SCHEMA)
+    vol.Required(CONF_ELEC): ELEC_SCHEMA,
+    vol.Optional(CONF_GAS): GAS_SCHEMA
 })
 
 
@@ -63,7 +61,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import pyloopenergy
 
     elec_config = config.get(CONF_ELEC)
-    gas_config = config.get(CONF_GAS)
+    gas_config = config.get(CONF_GAS, {})
 
     # pylint: disable=too-many-function-args
     controller = pyloopenergy.LoopEnergy(

--- a/homeassistant/components/sensor/lyft.py
+++ b/homeassistant/components/sensor/lyft.py
@@ -37,7 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_START_LONGITUDE): cv.longitude,
     vol.Optional(CONF_END_LATITUDE): cv.latitude,
     vol.Optional(CONF_END_LONGITUDE): cv.longitude,
-    vol.Optional(CONF_PRODUCT_IDS, default=None):
+    vol.Optional(CONF_PRODUCT_IDS):
         vol.All(cv.ensure_list, [cv.string]),
 })
 

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -46,7 +46,7 @@ SENSOR_TYPES = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_MAC): cv.string,
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_TYPES):
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_MEDIAN, default=DEFAULT_MEDIAN): cv.positive_int,

--- a/homeassistant/components/sensor/nut.py
+++ b/homeassistant/components/sensor/nut.py
@@ -126,9 +126,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_ALIAS, default=None): cv.string,
-    vol.Optional(CONF_USERNAME, default=None): cv.string,
-    vol.Optional(CONF_PASSWORD, default=None): cv.string,
+    vol.Optional(CONF_ALIAS): cv.string,
+    vol.Optional(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_PASSWORD): cv.string,
     vol.Required(CONF_RESOURCES, default=[]):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })

--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -32,7 +32,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_TYPES):
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })

--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -47,7 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_FORECAST, default=False): cv.boolean,
-    vol.Optional(CONF_LANGUAGE, default=None): cv.string,
+    vol.Optional(CONF_LANGUAGE): cv.string,
 })
 
 

--- a/homeassistant/components/sensor/pi_hole.py
+++ b/homeassistant/components/sensor/pi_hole.py
@@ -59,8 +59,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
     vol.Optional(CONF_LOCATION, default=DEFAULT_LOCATION): cv.string,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
+    vol.Optional(CONF_MONITORED_CONDITIONS,
+                 default=list(MONITORED_CONDITIONS)):
+    vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
 })
 
 

--- a/homeassistant/components/sensor/pilight.py
+++ b/homeassistant/components/sensor/pilight.py
@@ -26,7 +26,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_VARIABLE): cv.string,
     vol.Required(CONF_PAYLOAD): vol.Schema(dict),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_UNIT_OF_MEASUREMENT, default=None): cv.string,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
 })
 
 

--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -97,9 +97,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS):
         vol.All(cv.ensure_list, [vol.In(_MONITORED_CONDITIONS)]),
-    vol.Optional(CONF_NICS, default=None): cv.ensure_list,
-    vol.Optional(CONF_DRIVES, default=None): cv.ensure_list,
-    vol.Optional(CONF_VOLUMES, default=None): cv.ensure_list,
+    vol.Optional(CONF_NICS): cv.ensure_list,
+    vol.Optional(CONF_DRIVES): cv.ensure_list,
+    vol.Optional(CONF_VOLUMES): cv.ensure_list,
 })
 
 
@@ -133,33 +133,21 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 api, variable, _MEMORY_MON_COND[variable]))
 
     # Network sensors
-    nics = config[CONF_NICS]
-    if nics is None:
-        nics = api.data["system_stats"]["nics"].keys()
-
-    for nic in nics:
+    for nic in config.get(CONF_NICS, api.data["system_stats"]["nics"]):
         sensors += [QNAPNetworkSensor(api, variable,
                                       _NETWORK_MON_COND[variable], nic)
                     for variable in config[CONF_MONITORED_CONDITIONS]
                     if variable in _NETWORK_MON_COND]
 
     # Drive sensors
-    drives = config[CONF_DRIVES]
-    if drives is None:
-        drives = api.data["smart_drive_health"].keys()
-
-    for drive in drives:
+    for drive in config.get(CONF_DRIVES, api.data["smart_drive_health"]):
         sensors += [QNAPDriveSensor(api, variable,
                                     _DRIVE_MON_COND[variable], drive)
                     for variable in config[CONF_MONITORED_CONDITIONS]
                     if variable in _DRIVE_MON_COND]
 
     # Volume sensors
-    volumes = config[CONF_VOLUMES]
-    if volumes is None:
-        volumes = api.data["volumes"].keys()
-
-    for volume in volumes:
+    for volume in config.get(CONF_VOLUMES, api.data["volumes"]):
         sensors += [QNAPVolumeSensor(api, variable,
                                      _VOLUME_MON_COND[variable], volume)
                     for variable in config[CONF_MONITORED_CONDITIONS]

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -35,7 +35,7 @@ PLATFORM_SCHEMA = vol.Schema({
         cv.string: {
             vol.Optional(CONF_NAME): cv.string,
             vol.Required(CONF_SENSOR_TYPE): cv.string,
-            vol.Optional(CONF_UNIT_OF_MEASUREMENT, default=None): cv.string,
+            vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
             vol.Optional(CONF_ALIASES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
             # deprecated config options
@@ -61,7 +61,7 @@ def devices_from_config(domain_config, hass=None):
     """Parse configuration and add Rflink sensor devices."""
     devices = []
     for device_id, config in domain_config[CONF_DEVICES].items():
-        if not config[ATTR_UNIT_OF_MEASUREMENT]:
+        if ATTR_UNIT_OF_MEASUREMENT not in config:
             config[ATTR_UNIT_OF_MEASUREMENT] = lookup_unit_for_sensor_type(
                 config[CONF_SENSOR_TYPE])
         remove_deprecated(config)

--- a/homeassistant/components/sensor/sensehat.py
+++ b/homeassistant/components/sensor/sensehat.py
@@ -32,7 +32,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_DISPLAY_OPTIONS, default=SENSOR_TYPES):
+    vol.Required(CONF_DISPLAY_OPTIONS, default=list(SENSOR_TYPES)):
         [vol.In(SENSOR_TYPES)],
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_IS_HAT_ATTACHED, default=True): cv.boolean

--- a/homeassistant/components/sensor/synologydsm.py
+++ b/homeassistant/components/sensor/synologydsm.py
@@ -78,8 +78,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS):
         vol.All(cv.ensure_list, [vol.In(_MONITORED_CONDITIONS)]),
-    vol.Optional(CONF_DISKS, default=None): cv.ensure_list,
-    vol.Optional(CONF_VOLUMES, default=None): cv.ensure_list,
+    vol.Optional(CONF_DISKS): cv.ensure_list,
+    vol.Optional(CONF_VOLUMES): cv.ensure_list,
 })
 
 
@@ -106,22 +106,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                    if variable in _UTILISATION_MON_COND]
 
         # Handle all volumes
-        volumes = config['volumes']
-        if volumes is None:
-            volumes = api.storage.volumes
-
-        for volume in volumes:
+        for volume in config.get(CONF_VOLUMES, api.storage.volumes):
             sensors += [SynoNasStorageSensor(
                 api, variable, _STORAGE_VOL_MON_COND[variable], volume)
                         for variable in monitored_conditions
                         if variable in _STORAGE_VOL_MON_COND]
 
         # Handle all disks
-        disks = config['disks']
-        if disks is None:
-            disks = api.storage.disks
-
-        for disk in disks:
+        for disk in config.get(CONF_DISKS, api.storage.disks):
             sensors += [SynoNasStorageSensor(
                 api, variable, _STORAGE_DSK_MON_COND[variable], disk)
                         for variable in monitored_conditions

--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -48,7 +48,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_RESOURCES, default=['disk_use']):
+    vol.Optional(CONF_RESOURCES, default={CONF_TYPE: 'disk_use'}):
         vol.All(cv.ensure_list, [vol.Schema({
             vol.Required(CONF_TYPE): vol.In(SENSOR_TYPES),
             vol.Optional(CONF_ARG): cv.string,

--- a/homeassistant/components/sensor/vultr.py
+++ b/homeassistant/components/sensor/vultr.py
@@ -30,8 +30,9 @@ MONITORED_CONDITIONS = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SUBSCRIPTION): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)])
+    vol.Optional(CONF_MONITORED_CONDITIONS,
+                 default=list(MONITORED_CONDITIONS)):
+    vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)])
 })
 
 

--- a/homeassistant/components/sensor/yweather.py
+++ b/homeassistant/components/sensor/yweather.py
@@ -42,7 +42,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_WOEID, default=None): cv.string,
+    vol.Optional(CONF_WOEID): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_FORECAST, default=0):
         vol.All(vol.Coerce(int), vol.Range(min=0, max=5)),

--- a/homeassistant/components/sensor/zabbix.py
+++ b/homeassistant/components/sensor/zabbix.py
@@ -26,7 +26,7 @@ _ZABBIX_ID_LIST_SCHEMA = vol.Schema([int])
 _ZABBIX_TRIGGER_SCHEMA = vol.Schema({
     vol.Optional(_CONF_HOSTIDS, default=[]): _ZABBIX_ID_LIST_SCHEMA,
     vol.Optional(_CONF_INDIVIDUAL, default=False): cv.boolean(True),
-    vol.Optional(CONF_NAME, default=None): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
 })
 
 # SCAN_INTERVAL = 30

--- a/homeassistant/components/sensor/zabbix.py
+++ b/homeassistant/components/sensor/zabbix.py
@@ -25,7 +25,7 @@ _CONF_INDIVIDUAL = 'individual'
 _ZABBIX_ID_LIST_SCHEMA = vol.Schema([int])
 _ZABBIX_TRIGGER_SCHEMA = vol.Schema({
     vol.Optional(_CONF_HOSTIDS, default=[]): _ZABBIX_ID_LIST_SCHEMA,
-    vol.Optional(_CONF_INDIVIDUAL, default=False): cv.boolean(True),
+    vol.Optional(_CONF_INDIVIDUAL, default=False): cv.boolean,
     vol.Optional(CONF_NAME): cv.string,
 })
 

--- a/homeassistant/components/statsd.py
+++ b/homeassistant/components/statsd.py
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_PREFIX, default=DEFAULT_PREFIX): cv.string,
         vol.Optional(CONF_RATE, default=DEFAULT_RATE):
             vol.All(vol.Coerce(int), vol.Range(min=1)),
-        vol.Optional(CONF_VALUE_MAP, default=None): dict,
+        vol.Optional(CONF_VALUE_MAP): dict,
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -45,8 +45,8 @@ MP1_TYPES = ['mp1']
 SWITCH_TYPES = RM_TYPES + SP1_TYPES + SP2_TYPES + MP1_TYPES
 
 SWITCH_SCHEMA = vol.Schema({
-    vol.Optional(CONF_COMMAND_OFF, default=None): cv.string,
-    vol.Optional(CONF_COMMAND_ON, default=None): cv.string,
+    vol.Optional(CONF_COMMAND_OFF): cv.string,
+    vol.Optional(CONF_COMMAND_ON): cv.string,
     vol.Optional(CONF_FRIENDLY_NAME): cv.string,
 })
 

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -37,12 +37,12 @@ REGISTERS_SCHEMA = vol.Schema({
     vol.Required(CONF_COMMAND_ON): cv.positive_int,
     vol.Required(CONF_COMMAND_OFF): cv.positive_int,
     vol.Optional(CONF_VERIFY_STATE, default=True): cv.boolean,
-    vol.Optional(CONF_VERIFY_REGISTER, default=None):
+    vol.Optional(CONF_VERIFY_REGISTER):
         cv.positive_int,
     vol.Optional(CONF_REGISTER_TYPE, default=REGISTER_TYPE_HOLDING):
         vol.In([REGISTER_TYPE_HOLDING, REGISTER_TYPE_INPUT]),
-    vol.Optional(CONF_STATE_ON, default=None): cv.positive_int,
-    vol.Optional(CONF_STATE_OFF, default=None): cv.positive_int,
+    vol.Optional(CONF_STATE_ON): cv.positive_int,
+    vol.Optional(CONF_STATE_OFF): cv.positive_int,
 })
 
 COILS_SCHEMA = vol.Schema({

--- a/homeassistant/components/switch/raspihats.py
+++ b/homeassistant/components/switch/raspihats.py
@@ -25,7 +25,7 @@ _CHANNELS_SCHEMA = vol.Schema([{
     vol.Required(CONF_INDEX): cv.positive_int,
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_INVERT_LOGIC, default=False): cv.boolean,
-    vol.Optional(CONF_INITIAL_STATE, default=None): cv.boolean,
+    vol.Optional(CONF_INITIAL_STATE): cv.boolean,
 }])
 
 _I2C_HATS_SCHEMA = vol.Schema([{
@@ -56,7 +56,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                         board, address, channel_config[CONF_INDEX],
                         channel_config[CONF_NAME],
                         channel_config[CONF_INVERT_LOGIC],
-                        channel_config[CONF_INITIAL_STATE]
+                        channel_config.get(CONF_INITIAL_STATE)
                     )
                 )
         except I2CHatsException as ex:

--- a/homeassistant/components/switch/rest.py
+++ b/homeassistant/components/switch/rest.py
@@ -17,7 +17,6 @@ from homeassistant.const import (
     CONF_PASSWORD)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.template import Template
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,8 +25,8 @@ CONF_BODY_ON = 'body_on'
 CONF_IS_ON_TEMPLATE = 'is_on_template'
 
 DEFAULT_METHOD = 'post'
-DEFAULT_BODY_OFF = Template('OFF')
-DEFAULT_BODY_ON = Template('ON')
+DEFAULT_BODY_OFF = 'OFF'
+DEFAULT_BODY_ON = 'ON'
 DEFAULT_NAME = 'REST Switch'
 DEFAULT_TIMEOUT = 10
 

--- a/homeassistant/components/switch/rpi_pfio.py
+++ b/homeassistant/components/switch/rpi_pfio.py
@@ -26,7 +26,7 @@ CONF_PORTS = 'ports'
 DEFAULT_INVERT_LOGIC = False
 
 PORT_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_NAME, default=None): cv.string,
+    vol.Optional(ATTR_NAME): cv.string,
     vol.Optional(ATTR_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
 })
 
@@ -42,7 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     switches = []
     ports = config.get(CONF_PORTS)
     for port, port_entity in ports.items():
-        name = port_entity[ATTR_NAME]
+        name = port_entity.get(ATTR_NAME)
         invert_logic = port_entity[ATTR_INVERT_LOGIC]
 
         switches.append(RPiPFIOSwitch(port, name, invert_logic))

--- a/homeassistant/components/weather/yweather.py
+++ b/homeassistant/components/weather/yweather.py
@@ -50,7 +50,7 @@ CONDITION_CLASSES = {
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_WOEID, default=None): cv.string,
+    vol.Optional(CONF_WOEID): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -81,7 +81,7 @@ CALL_SERVICE_MESSAGE_SCHEMA = vol.Schema({
     vol.Required('type'): TYPE_CALL_SERVICE,
     vol.Required('domain'): str,
     vol.Required('service'): str,
-    vol.Optional('service_data', default=None): dict
+    vol.Optional('service_data'): dict
 })
 
 GET_STATES_MESSAGE_SCHEMA = vol.Schema({
@@ -451,7 +451,7 @@ class ActiveConnection:
         def call_service_helper(msg):
             """Call a service and fire complete message."""
             yield from self.hass.services.async_call(
-                msg['domain'], msg['service'], msg['service_data'], True)
+                msg['domain'], msg['service'], msg.get('service_data'), True)
             self.send_message_outside(result_message(msg['id']))
 
         self.hass.async_add_job(call_service_helper(msg))

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -90,11 +90,9 @@ def _fix_conf_defaults(config):
     return config
 
 
-DEFAULT_GATEWAY_CONFIG = [{CONF_MAC: None, CONF_KEY: None}]
-
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_GATEWAYS, default=DEFAULT_GATEWAY_CONFIG):
+        vol.Optional(CONF_GATEWAYS, default={}):
             vol.All(cv.ensure_list, [GATEWAY_CONFIG], [_fix_conf_defaults]),
         vol.Optional(CONF_INTERFACE, default='any'): cv.string,
         vol.Optional(CONF_DISCOVERY_RETRY, default=3): cv.positive_int

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -68,7 +68,7 @@ SERVICE_SCHEMA_REMOVE_DEVICE = vol.Schema({
 
 GATEWAY_CONFIG = vol.Schema({
     vol.Optional(CONF_MAC, default=None): vol.Any(GW_MAC, None),
-    vol.Optional(CONF_KEY, default=None):
+    vol.Optional(CONF_KEY):
         vol.All(cv.string, vol.Length(min=16, max=16)),
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=9898): cv.port,

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -45,8 +45,7 @@ DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_RADIO_TYPE, default=RadioType.ezsp):
-            cv.enum(RadioType),
+        vol.Optional(CONF_RADIO_TYPE, default='ezsp'): cv.enum(RadioType),
         CONF_USB_PATH: cv.string,
         vol.Optional(CONF_BAUDRATE, default=57600): cv.positive_int,
         CONF_DATABASE: cv.string,

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -3,7 +3,7 @@ pyyaml>=3.11,<4
 pytz>=2017.02
 pip>=8.0.3
 jinja2>=2.10
-voluptuous==0.10.5
+voluptuous==0.11.1
 typing>=3,<4
 aiohttp==2.3.10
 yarl==1.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,7 +4,7 @@ pyyaml>=3.11,<4
 pytz>=2017.02
 pip>=8.0.3
 jinja2>=2.10
-voluptuous==0.10.5
+voluptuous==0.11.1
 typing>=3,<4
 aiohttp==2.3.10
 yarl==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ REQUIRES = [
     'pytz>=2017.02',
     'pip>=8.0.3',
     'jinja2>=2.10',
-    'voluptuous==0.10.5',
+    'voluptuous==0.11.1',
     'typing>=3,<4',
     'aiohttp==2.3.10',   # If updated, check if yarl also needs an update!
     'yarl==1.1.0',

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -401,12 +401,12 @@ class TestComponentHistory(unittest.TestCase):
         filters = history.Filters()
         exclude = config[history.DOMAIN].get(history.CONF_EXCLUDE)
         if exclude:
-            filters.excluded_entities = exclude[history.CONF_ENTITIES]
-            filters.excluded_domains = exclude[history.CONF_DOMAINS]
+            filters.excluded_entities = exclude.get(history.CONF_ENTITIES, [])
+            filters.excluded_domains = exclude.get(history.CONF_DOMAINS, [])
         include = config[history.DOMAIN].get(history.CONF_INCLUDE)
         if include:
-            filters.included_entities = include[history.CONF_ENTITIES]
-            filters.included_domains = include[history.CONF_DOMAINS]
+            filters.included_entities = include.get(history.CONF_ENTITIES, [])
+            filters.included_domains = include.get(history.CONF_DOMAINS, [])
 
         hist = history.get_significant_states(
             self.hass, zero, four, filters=filters)

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -8,7 +8,6 @@ from homeassistant.components.rflink import (
     CONF_RECONNECT_INTERVAL, SERVICE_SEND_COMMAND)
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_STOP_COVER)
-from tests.common import assert_setup_component
 
 
 @asyncio.coroutine

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -12,8 +12,7 @@ from tests.common import assert_setup_component
 
 
 @asyncio.coroutine
-def mock_rflink(hass, config, domain, monkeypatch, failures=None,
-                platform_count=1):
+def mock_rflink(hass, config, domain, monkeypatch, failures=None):
     """Create mock Rflink asyncio protocol, test component setup."""
     transport, protocol = (Mock(), Mock())
 
@@ -47,9 +46,7 @@ def mock_rflink(hass, config, domain, monkeypatch, failures=None,
         'rflink.protocol.create_rflink_connection',
         mock_create)
 
-    # verify instantiation of component with given config
-    with assert_setup_component(platform_count, domain):
-        yield from async_setup_component(hass, domain, config)
+    yield from async_setup_component(hass, domain, config)
 
     # hook into mock config for injecting events
     event_callback = mock_create.call_args_list[0][1]['event_callback']
@@ -164,7 +161,7 @@ def test_send_command(hass, monkeypatch):
 
     # setup mocking rflink module
     _, _, protocol, _ = yield from mock_rflink(
-        hass, config, domain, monkeypatch, platform_count=5)
+        hass, config, domain, monkeypatch)
 
     hass.async_add_job(
         hass.services.async_call(domain, SERVICE_SEND_COMMAND,
@@ -188,7 +185,7 @@ def test_send_command_invalid_arguments(hass, monkeypatch):
 
     # setup mocking rflink module
     _, _, protocol, _ = yield from mock_rflink(
-        hass, config, domain, monkeypatch, platform_count=5)
+        hass, config, domain, monkeypatch)
 
     # one argument missing
     hass.async_add_job(

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -50,6 +50,9 @@ class TestCheckConfig(unittest.TestCase):
             # Py34: AssertionError
             asyncio.set_event_loop(asyncio.new_event_loop())
 
+        # Will allow seeing full diff
+        self.maxDiff = None
+
     # pylint: disable=no-self-use,invalid-name
     def test_config_platform_valid(self):
         """Test a valid platform setup."""
@@ -176,8 +179,6 @@ class TestCheckConfig(unittest.TestCase):
                                         'login_attempts_threshold': -1,
                                         'server_host': '0.0.0.0',
                                         'server_port': 8123,
-                                        'ssl_certificate': None,
-                                        'ssl_key': None,
                                         'trusted_networks': [],
                                         'use_x_forwarded_for': False}},
                 'except': {},


### PR DESCRIPTION
Bump voluptuous to 0.11.1

**Note for breaking change**
Custom components only: voluptuous now requires default values for config keys to be valid values.


## [0.11.0]

**Changes**:

- [#293](https://github.com/alecthomas/voluptuous/pull/293): Support Python 3.6.
- [#294](https://github.com/alecthomas/voluptuous/pull/294): Drop support for Python 2.6, 3.1 and 3.2.
- [#318](https://github.com/alecthomas/voluptuous/pull/318): Allow to use nested schema and allow any validator to be compiled.
- [#324](https://github.com/alecthomas/voluptuous/pull/324):
  Default values MUST now pass validation just as any regular value. This is a backward incompatible change if a schema uses default values that don't pass validation against the specified schema.
- [#328](https://github.com/alecthomas/voluptuous/pull/328):
  Modify `__lt__` in Marker class to allow comparison with non Marker objects, such as str and int.

**New**:

- [#307](https://github.com/alecthomas/voluptuous/pull/307): Add description field to `Marker` instances.
- [#311](https://github.com/alecthomas/voluptuous/pull/311): Add `Schema.infer` method for basic schema inference.
- [#314](https://github.com/alecthomas/voluptuous/pull/314): Add `SomeOf` validator.

**Fixes**:

- [#279](https://github.com/alecthomas/voluptuous/pull/279):
  Treat Python 2 old-style classes like types when validating.
- [#280](https://github.com/alecthomas/voluptuous/pull/280): Make
  `IsDir()`, `IsFile()` and `PathExists()` consistent between different Python versions.
- [#290](https://github.com/alecthomas/voluptuous/pull/290): Use absolute imports to avoid import conflicts.
- [#291](https://github.com/alecthomas/voluptuous/pull/291): Fix `Coerce` validator to catch `decimal.InvalidOperation`.
- [#298](https://github.com/alecthomas/voluptuous/pull/298): Make `Schema([])` usage consistent with `Schema({})`.
- [#303](https://github.com/alecthomas/voluptuous/pull/303): Allow partial validation when using validate decorator.
- [#316](https://github.com/alecthomas/voluptuous/pull/316): Make `Schema.__eq__` deterministic.
- [#319](https://github.com/alecthomas/voluptuous/pull/319): Replace implementation of `Maybe(s)` with `Any(None, s)` to allow it to be compiled.
