### PR TITLE
bump usps version

### DIFF
--- a/homeassistant/components/usps.py
+++ b/homeassistant/components/usps.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import (config_validation as cv, discovery)
 from homeassistant.util import Throttle
 from homeassistant.util.dt import now
 
-REQUIREMENTS = ['myusps==1.2.2']
+REQUIREMENTS = ['myusps==1.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,6 +24,7 @@ DATA_USPS = 'data_usps'
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 COOKIE = 'usps_cookies.pickle'
 CACHE = 'usps_cache'
+CONF_DRIVER = 'driver'
 
 USPS_TYPE = ['sensor', 'camera']
 
@@ -32,6 +33,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_NAME, default=DOMAIN): cv.string,
+        vol.Optional(CONF_DRIVER): cv.string
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -42,13 +44,15 @@ def setup(hass, config):
     username = conf.get(CONF_USERNAME)
     password = conf.get(CONF_PASSWORD)
     name = conf.get(CONF_NAME)
+    driver = conf.get(CONF_DRIVER)
 
     import myusps
     try:
         cookie = hass.config.path(COOKIE)
         cache = hass.config.path(CACHE)
         session = myusps.get_session(username, password,
-                                     cookie_path=cookie, cache_path=cache)
+                                     cookie_path=cookie, cache_path=cache,
+                                     driver=driver)
     except myusps.USPSError:
         _LOGGER.exception('Could not connect to My USPS')
         return False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -501,7 +501,7 @@ mychevy==0.1.1
 mycroftapi==2.0
 
 # homeassistant.components.usps
-myusps==1.2.2
+myusps==1.3.2
 
 # homeassistant.components.media_player.nad
 # homeassistant.components.media_player.nadtcp


### PR DESCRIPTION
## Description:

Fixes `usps` platform. Dependency `myusps` now leverages Selenium webdriver to overcome login issues. This is a breaking change since the user must now have additional dependencies installed - either `google-chrome` and `chromedriver`, or `phantomjs`. There is a new config option `driver` that allows the user to specify their preference, though `phantomjs` is the default. Doc PR forthcoming that will outline choices and make suggestions based on user's OS.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/10325, https://github.com/home-assistant/home-assistant/issues/9143, https://github.com/happyleavesaoc/python-myusps/issues/9

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant/pull/12465

## Example entry for `configuration.yaml` (if applicable):
```yaml
usps:
  username: !secret myusps_username
  password: !secret myusps_password
  name: 'USPS'
  driver: 'chrome'
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
