### PR TITLE
Map Alexa StepVolume responses to volume_up/down

### DIFF
--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -515,17 +515,15 @@ def test_media_player(hass):
 
     call, _ = yield from assert_request_calls_service(
         'Alexa.StepSpeaker', 'AdjustVolume', 'media_player#test',
-        'media_player.volume_set',
+        'media_player.volume_up',
         hass,
         payload={'volumeSteps': 20})
-    assert call.data['volume_level'] == 0.95
 
     call, _ = yield from assert_request_calls_service(
         'Alexa.StepSpeaker', 'AdjustVolume', 'media_player#test',
-        'media_player.volume_set',
+        'media_player.volume_down',
         hass,
         payload={'volumeSteps': -20})
-    assert call.data['volume_level'] == 0.55
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

It turns out I misunderstood which media_player services are available when a media player supports StepVolume. This PR maps the Alexa StepSpeaker messages to the volume_up and volume_down services.

Currently Alexa allows you to specify the number of steps but the media player  volume_up and volume_down services don't support this. For now I just look to see if the steps are +/- and call up/down accordingly.

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54