### PR TITLE
Cast unique_id and async discovery

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -74,6 +74,7 @@ def _setup_internal_discovery(hass: HomeAssistantType) -> None:
 
         _LOGGER.debug("Discovered new chromecast %s", mdns)
         try:
+            # pylint: disable=protected-access
             chromecast = pychromecast._get_chromecast_from_host(
                 mdns, blocking=True)
         except pychromecast.ChromecastConnectionError:

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/media_player.cast/
 # pylint: disable=import-error
 import asyncio
 import logging
-from typing import Tuple
 
 import voluptuous as vol
 

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -105,14 +105,14 @@ def _async_create_cast_device(hass, chromecast):
     if chromecast.uuid is None:
         # Found a cast without UUID, we don't store it because we won't be able
         # to update it anyway.
-        return CastDevice(hass, chromecast)
+        return CastDevice(chromecast)
 
     # Found a cast with UUID
     added_casts = hass.data[ADDED_CAST_DEVICES_KEY]
     old_cast_device = added_casts.get(chromecast.uuid)
     if old_cast_device is None:
         # -> New cast device
-        cast_device = CastDevice(hass, chromecast)
+        cast_device = CastDevice(chromecast)
         added_casts[chromecast.uuid] = cast_device
         return cast_device
 
@@ -196,13 +196,12 @@ def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
 class CastDevice(MediaPlayerDevice):
     """Representation of a Cast device on the network."""
 
-    def __init__(self, hass, chromecast):
+    def __init__(self, chromecast):
         """Initialize the Cast device."""
         self.cast = None  # type: pychromecast.Chromecast
         self.cast_status = None
         self.media_status = None
         self.media_status_received = None
-        self._hass = hass
 
         self.async_set_chromecast(chromecast)
 
@@ -446,5 +445,5 @@ class CastDevice(MediaPlayerDevice):
             return
         _LOGGER.debug("Disconnecting existing chromecast object")
         old_key = (self.cast.host, self.cast.port, self.cast.uuid)
-        self._hass.data[KNOWN_CHROMECASTS_KEY].pop(old_key)
+        self.hass.data[KNOWN_CHROMECASTS_KEY].pop(old_key)
         self.cast.disconnect(blocking=False)

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -184,10 +184,14 @@ def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
             _LOGGER.warning("Can't set up chromecast on %s", want_host[0])
             raise
         key = (chromecast.host, chromecast.port, chromecast.uuid)
-        hass.data[KNOWN_CHROMECASTS_KEY][key] = chromecast
         cast_device = _async_create_cast_device(hass, chromecast)
         if cast_device is not None:
+            hass.data[KNOWN_CHROMECASTS_KEY][key] = chromecast
             async_add_devices([cast_device])
+        else:
+            # Some other entity already has this chromecast, throw this one
+            # away.
+            chromecast.disconnect(blocking=False)
 
 
 class CastDevice(MediaPlayerDevice):
@@ -443,4 +447,4 @@ class CastDevice(MediaPlayerDevice):
         _LOGGER.debug("Disconnecting existing chromecast object")
         old_key = (self.cast.host, self.cast.port, self.cast.uuid)
         self.hass.data[KNOWN_CHROMECASTS_KEY].pop(old_key)
-        self.hass.async_add_job(self.cast.disconnect)
+        self.cast.disconnect(blocking=False)

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -1,12 +1,15 @@
 """The tests for the Cast Media player platform."""
 # pylint: disable=protected-access
-import unittest
-from unittest.mock import patch, MagicMock
+import asyncio
+from typing import Optional
+from unittest.mock import patch, MagicMock, Mock
+from uuid import UUID
 
 import pytest
 
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.components.media_player import cast
-from tests.common import get_test_home_assistant
 
 
 @pytest.fixture(autouse=True)
@@ -18,83 +21,217 @@ def cast_mock():
         yield
 
 
-class FakeChromeCast(object):
-    """A fake Chrome Cast."""
-
-    def __init__(self, host, port):
-        """Initialize the fake Chrome Cast."""
-        self.host = host
-        self.port = port
+FakeUUID = UUID('57355bce-9364-4aa6-ac1e-eb849dccf9e2')
 
 
-class TestCastMediaPlayer(unittest.TestCase):
-    """Test the media_player module."""
+def get_fake_chromecast(host='192.168.178.42', port=8009,
+                        uuid: Optional[UUID] = FakeUUID):
+    return MagicMock(host=host, port=port, uuid=uuid)
 
-    def setUp(self):
-        """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
 
-    def tearDown(self):
-        """Stop everything that was started."""
-        self.hass.stop()
+@asyncio.coroutine
+def async_setup_cast(hass, config=None, discovery_info=None):
+    """Helper to setup the cast platform."""
+    if config is None:
+        config = {}
+    add_devices = Mock()
 
-    @patch('homeassistant.components.media_player.cast.CastDevice')
-    @patch('pychromecast.get_chromecasts')
-    def test_filter_duplicates(self, mock_get_chromecasts, mock_device):
-        """Test filtering of duplicates."""
-        mock_get_chromecasts.return_value = [
-            FakeChromeCast('some_host', cast.DEFAULT_PORT)
-        ]
+    yield from cast.async_setup_platform(hass, config, add_devices,
+                                         discovery_info=discovery_info)
+    yield from hass.async_block_till_done()
 
-        # Test chromecasts as if they were hardcoded in configuration.yaml
-        cast.setup_platform(self.hass, {
-            'host': 'some_host'
-        }, lambda _: _)
+    return add_devices
 
-        assert mock_device.called
 
-        mock_device.reset_mock()
-        assert not mock_device.called
+@asyncio.coroutine
+def async_setup_cast_internal_discovery(hass, config=None,
+                                        discovery_info=None,
+                                        no_from_host_patch=False):
+    listener = MagicMock(services={})
 
-        # Test chromecasts as if they were automatically discovered
-        cast.setup_platform(self.hass, {}, lambda _: _, {
-            'host': 'some_host',
-            'port': cast.DEFAULT_PORT,
-        })
-        assert not mock_device.called
+    with patch('pychromecast.start_discovery',
+               return_value=(listener, None)) as start_discovery:
+        add_devices = yield from async_setup_cast(hass, config, discovery_info)
+        yield from hass.async_block_till_done()
+        yield from hass.async_block_till_done()
 
-    @patch('homeassistant.components.media_player.cast.CastDevice')
-    @patch('pychromecast.get_chromecasts')
-    @patch('pychromecast.Chromecast')
-    def test_fallback_cast(self, mock_chromecast, mock_get_chromecasts,
-                           mock_device):
-        """Test falling back to creating Chromecast when not discovered."""
-        mock_get_chromecasts.return_value = [
-            FakeChromeCast('some_host', cast.DEFAULT_PORT)
-        ]
+        assert start_discovery.call_count == 1
 
-        # Test chromecasts as if they were hardcoded in configuration.yaml
-        cast.setup_platform(self.hass, {
-            'host': 'some_other_host'
-        }, lambda _: _)
+        discovery_callback = start_discovery.call_args[0][0]
 
-        assert mock_chromecast.called
-        assert mock_device.called
+    def discover_chromecast(service_name, chromecast):
+        listener.services[service_name] = (
+            chromecast.host, chromecast.port, chromecast.uuid, None, None)
+        if no_from_host_patch:
+            discovery_callback(service_name)
+        else:
+            with patch('pychromecast._get_chromecast_from_host',
+                       return_value=chromecast):
+                discovery_callback(service_name)
 
-    @patch('homeassistant.components.media_player.cast.CastDevice')
-    @patch('pychromecast.get_chromecasts')
-    @patch('pychromecast.Chromecast')
-    def test_fallback_cast_group(self, mock_chromecast, mock_get_chromecasts,
-                                 mock_device):
-        """Test not creating Cast Group when not discovered."""
-        mock_get_chromecasts.return_value = [
-            FakeChromeCast('some_host', cast.DEFAULT_PORT)
-        ]
+    return discover_chromecast, add_devices
 
-        # Test chromecasts as if they were automatically discovered
-        cast.setup_platform(self.hass, {}, lambda _: _, {
-            'host': 'some_other_host',
-            'port': 43546,
-        })
-        assert not mock_chromecast.called
-        assert not mock_device.called
+
+@asyncio.coroutine
+def test_start_discovery_called_once(hass):
+    """Test pychromecast.start_discovery called exactly once."""
+    with patch('pychromecast.start_discovery',
+               return_value=(None, None)) as start_discovery:
+        yield from async_setup_cast(hass)
+
+        assert start_discovery.call_count == 1
+
+        yield from async_setup_cast(hass)
+        assert start_discovery.call_count == 1
+
+
+@asyncio.coroutine
+def test_stop_discovery_called_on_stop(hass):
+    """Test pychromecast.stop_discovery called on shutdown."""
+    with patch('pychromecast.start_discovery',
+               return_value=(None, 'the-browser')) as start_discovery:
+        yield from async_setup_cast(hass)
+
+        assert start_discovery.call_count == 1
+
+    with patch('pychromecast.stop_discovery') as stop_discovery:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        yield from hass.async_block_till_done()
+
+        stop_discovery.assert_called_once_with('the-browser')
+
+    with patch('pychromecast.start_discovery',
+               return_value=(None, 'the-browser')) as start_discovery:
+        yield from async_setup_cast(hass)
+
+        assert start_discovery.call_count == 1
+
+
+@asyncio.coroutine
+def test_internal_discovery_callback_only_generates_once(hass):
+    """Test _get_chromecast_from_host only called once per device."""
+
+    discover_cast, _ = yield from async_setup_cast_internal_discovery(
+        hass, no_from_host_patch=True)
+    chromecast = get_fake_chromecast()
+
+    with patch('pychromecast._get_chromecast_from_host',
+               return_value=chromecast) as gen_chromecast:
+        discover_cast('the-service', chromecast)
+        mdns = (chromecast.host, chromecast.port, chromecast.uuid, None, None)
+        gen_chromecast.assert_called_once_with(mdns, blocking=True)
+
+        discover_cast('the-service', chromecast)
+        gen_chromecast.reset_mock()
+        assert gen_chromecast.call_count == 0
+
+
+@asyncio.coroutine
+def test_internal_discovery_callback_calls_dispatcher(hass):
+    """Test internal discovery calls dispatcher."""
+    discover_cast, _ = yield from async_setup_cast_internal_discovery(hass)
+    chromecast = get_fake_chromecast()
+
+    with patch('pychromecast._get_chromecast_from_host',
+               return_value=chromecast):
+        signal = MagicMock()
+
+        async_dispatcher_connect(hass, 'cast_discovered', signal)
+        discover_cast('the-service', chromecast)
+        yield from hass.async_block_till_done()
+
+        signal.assert_called_once_with(chromecast)
+
+
+@asyncio.coroutine
+def test_internal_discovery_callback_with_connection_error(hass):
+    """Test internal discovery not calling dispatcher on ConnectionError."""
+    import pychromecast  # imports mock pychromecast
+
+    pychromecast.ChromecastConnectionError = IOError
+
+    discover_cast, _ = yield from async_setup_cast_internal_discovery(
+        hass, no_from_host_patch=True)
+    chromecast = get_fake_chromecast()
+
+    with patch('pychromecast._get_chromecast_from_host',
+               side_effect=pychromecast.ChromecastConnectionError):
+        signal = MagicMock()
+
+        async_dispatcher_connect(hass, 'cast_discovered', signal)
+        discover_cast('the-service', chromecast)
+        yield from hass.async_block_till_done()
+
+        assert signal.call_count == 0
+
+
+def test_create_cast_device_without_uuid(hass):
+    chromecast = get_fake_chromecast(uuid=None)
+    cast_device = cast._async_create_cast_device(hass, chromecast)
+    assert cast_device is not None
+
+
+def test_create_cast_device_with_uuid(hass):
+    added_casts = hass.data[cast.ADDED_CAST_DEVICES_KEY] = {}
+    chromecast = get_fake_chromecast()
+    cast_device = cast._async_create_cast_device(hass, chromecast)
+    assert cast_device is not None
+    assert chromecast.uuid in added_casts
+
+    with patch.object(cast_device, 'async_set_chromecast') as mock_set:
+        assert cast._async_create_cast_device(hass, chromecast) is None
+        assert mock_set.call_count == 0
+
+        chromecast = get_fake_chromecast(host='192.168.178.1')
+        assert cast._async_create_cast_device(hass, chromecast) is None
+        assert mock_set.call_count == 1
+        mock_set.assert_called_once_with(chromecast)
+
+
+@asyncio.coroutine
+def test_normal_chromecast_not_starting_discovery(hass):
+    chromecast = get_fake_chromecast()
+
+    with patch('pychromecast.Chromecast', return_value=chromecast):
+        add_devices = yield from async_setup_cast(hass, {'host': 'host1'})
+        assert add_devices.call_count == 1
+
+        # Same entity twice
+        add_devices = yield from async_setup_cast(hass, {'host': 'host1'})
+        assert add_devices.call_count == 0
+
+        hass.data[cast.ADDED_CAST_DEVICES_KEY] = {}
+        add_devices = yield from async_setup_cast(
+            hass, discovery_info={'host': 'host1', 'port': 8009})
+        assert add_devices.call_count == 1
+
+        hass.data[cast.ADDED_CAST_DEVICES_KEY] = {}
+        add_devices = yield from async_setup_cast(
+            hass, discovery_info={'host': 'host1', 'port': 42})
+        assert add_devices.call_count == 0
+
+
+@asyncio.coroutine
+def test_replay_past_chromecasts(hass):
+    cast_group1 = get_fake_chromecast(host='host1', port=42)
+    cast_group2 = get_fake_chromecast(host='host2', port=42, uuid=UUID(
+        '9462202c-e747-4af5-a66b-7dce0e1ebc09'))
+
+    discover_cast, add_dev1 = yield from async_setup_cast_internal_discovery(
+        hass, discovery_info={'host': 'host1', 'port': 42})
+    discover_cast('service2', cast_group2)
+    yield from hass.async_block_till_done()
+    assert add_dev1.call_count == 0
+
+    discover_cast('service1', cast_group1)
+    yield from hass.async_block_till_done()
+    yield from hass.async_block_till_done()  # having jobs that add jobs
+    yield from hass.async_block_till_done()  # having jobs that add jobs
+    assert add_dev1.call_count == 1
+
+    add_dev2 = yield from async_setup_cast(
+        hass, discovery_info={'host': 'host2', 'port': 42})
+    yield from hass.async_block_till_done()
+    yield from hass.async_block_till_done()
+    yield from hass.async_block_till_done()  # having jobs that add jobs
+    assert add_dev2.call_count == 1

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -21,11 +21,13 @@ def cast_mock():
         yield
 
 
+# pylint: disable=invalid-name
 FakeUUID = UUID('57355bce-9364-4aa6-ac1e-eb849dccf9e2')
 
 
 def get_fake_chromecast(host='192.168.178.42', port=8009,
                         uuid: Optional[UUID] = FakeUUID):
+    """Generate a Fake Chromecast object with the specified arguments."""
     return MagicMock(host=host, port=port, uuid=uuid)
 
 
@@ -47,6 +49,7 @@ def async_setup_cast(hass, config=None, discovery_info=None):
 def async_setup_cast_internal_discovery(hass, config=None,
                                         discovery_info=None,
                                         no_from_host_patch=False):
+    """Setup the cast platform and the discovery."""
     listener = MagicMock(services={})
 
     with patch('pychromecast.start_discovery',
@@ -60,6 +63,7 @@ def async_setup_cast_internal_discovery(hass, config=None,
         discovery_callback = start_discovery.call_args[0][0]
 
     def discover_chromecast(service_name, chromecast):
+        """Discover a chromecast device."""
         listener.services[service_name] = (
             chromecast.host, chromecast.port, chromecast.uuid, None, None)
         if no_from_host_patch:
@@ -110,7 +114,6 @@ def test_stop_discovery_called_on_stop(hass):
 @asyncio.coroutine
 def test_internal_discovery_callback_only_generates_once(hass):
     """Test _get_chromecast_from_host only called once per device."""
-
     discover_cast, _ = yield from async_setup_cast_internal_discovery(
         hass, no_from_host_patch=True)
     chromecast = get_fake_chromecast()
@@ -166,12 +169,14 @@ def test_internal_discovery_callback_with_connection_error(hass):
 
 
 def test_create_cast_device_without_uuid(hass):
+    """Test create a cast device without a UUID."""
     chromecast = get_fake_chromecast(uuid=None)
     cast_device = cast._async_create_cast_device(hass, chromecast)
     assert cast_device is not None
 
 
 def test_create_cast_device_with_uuid(hass):
+    """Test create cast devices with UUID."""
     added_casts = hass.data[cast.ADDED_CAST_DEVICES_KEY] = {}
     chromecast = get_fake_chromecast()
     cast_device = cast._async_create_cast_device(hass, chromecast)
@@ -190,6 +195,7 @@ def test_create_cast_device_with_uuid(hass):
 
 @asyncio.coroutine
 def test_normal_chromecast_not_starting_discovery(hass):
+    """Test cast platform not starting discovery when not required."""
     chromecast = get_fake_chromecast()
 
     with patch('pychromecast.Chromecast', return_value=chromecast):
@@ -213,6 +219,7 @@ def test_normal_chromecast_not_starting_discovery(hass):
 
 @asyncio.coroutine
 def test_replay_past_chromecasts(hass):
+    """Test cast platform re-playing past chromecasts when adding new one."""
     cast_group1 = get_fake_chromecast(host='host1', port=42)
     cast_group2 = get_fake_chromecast(host='host2', port=42, uuid=UUID(
         '9462202c-e747-4af5-a66b-7dce0e1ebc09'))

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -226,12 +226,9 @@ def test_replay_past_chromecasts(hass):
     discover_cast('service1', cast_group1)
     yield from hass.async_block_till_done()
     yield from hass.async_block_till_done()  # having jobs that add jobs
-    yield from hass.async_block_till_done()  # having jobs that add jobs
     assert add_dev1.call_count == 1
 
     add_dev2 = yield from async_setup_cast(
         hass, discovery_info={'host': 'host2', 'port': 42})
     yield from hass.async_block_till_done()
-    yield from hass.async_block_till_done()
-    yield from hass.async_block_till_done()  # having jobs that add jobs
     assert add_dev2.call_count == 1


### PR DESCRIPTION
## Description:

🏔 This PR adds a `unique_id` to the [cast platform](https://home-assistant.io/components/media_player.cast/). While doing so, it makes the platform **faster** by using async discovery and it tries to make the cast code base a bit easier to understand.

⚠️ This needs to be tested ... like, a lot. From the past we know that the cast platform is very fragmented and there are many weird errors that result from 3rd party cast products. While I've tested this over the last 1 ½ days, I can't guarantee it will work for all devices, especially for audio groups.

My Chromecast Audio broke some time ago and my new one is only arriving in about a week (living in the mountains does have its downsides 😕). But then I'll also be able to try audio groups.

Related: #12395, #12405

Fixes #12565, fixes #11905, fixes #7959, probably #11945 (fewer socket_client threads created)

Added benefit: Home Assistant startup time is significantly reduced and those pesky "Setup of platform media_player.cast is taking over 10 seconds." long entries are removed.

## Example entry for `configuration.yaml` (if applicable):
```yaml
discovery:
media_player:
  - platform: cast
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
