### PR TITLE
LimitlessLED assumed state

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -290,7 +290,8 @@ class LimitlessLEDGroup(Light):
     def limitlessled_temperature(self):
         """Convert Home Assistant color temperature units to percentage."""
         width = self.max_mireds - self.min_mireds
-        return 1 - (self._temperature - self.min_mireds) / width
+        temperature = 1 - (self._temperature - self.min_mireds) / width
+        return max(0, min(1, temperature))
 
     def limitlessled_brightness(self):
         """Convert Home Assistant brightness units to percentage."""

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -244,11 +244,11 @@ class LimitlessLEDGroup(Light):
         # Set up transition.
         args = {}
         if self.config[CONF_FADE] and not self.is_on and self._brightness:
-            args['brightness'] = _from_hass_brightness(self._brightness)
+            args['brightness'] = self.limitlessled_brightness()
 
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]
-            args['brightness'] = _from_hass_brightness(self._brightness)
+            args['brightness'] = self.limitlessled_brightness()
 
         if ATTR_RGB_COLOR in kwargs and self._supported & SUPPORT_RGB_COLOR:
             self._color = kwargs[ATTR_RGB_COLOR]
@@ -257,7 +257,7 @@ class LimitlessLEDGroup(Light):
                 pipeline.white()
                 self._color = WHITE
             else:
-                args['color'] = _from_hass_color(self._color)
+                args['color'] = self.limitlessled_color()
 
         if ATTR_COLOR_TEMP in kwargs:
             if self._supported & SUPPORT_RGB_COLOR:
@@ -265,7 +265,7 @@ class LimitlessLEDGroup(Light):
             self._color = WHITE
             if self._supported & SUPPORT_COLOR_TEMP:
                 self._temperature = kwargs[ATTR_COLOR_TEMP]
-                args['temperature'] = self._from_hass_temperature()
+                args['temperature'] = self.limitlessled_temperature()
 
         if args:
             pipeline.transition(transition_time, **args)
@@ -287,28 +287,16 @@ class LimitlessLEDGroup(Light):
                 pipeline.white()
                 self._color = WHITE
 
-    def _from_hass_temperature(self):
+    def limitlessled_temperature(self):
         """Convert Home Assistant color temperature units to percentage."""
         width = self.max_mireds - self.min_mireds
         return 1 - (self._temperature - self.min_mireds) / width
 
+    def limitlessled_brightness(self):
+        """Convert Home Assistant brightness units to percentage."""
+        return self._brightness / 255
 
-def _from_hass_brightness(brightness):
-    """Convert Home Assistant brightness units to percentage."""
-    return brightness / 255
-
-
-def _to_hass_brightness(brightness):
-    """Convert percentage to Home Assistant brightness units."""
-    return int(brightness * 255)
-
-
-def _from_hass_color(color):
-    """Convert Home Assistant RGB list to Color tuple."""
-    from limitlessled import Color
-    return Color(*tuple(color))
-
-
-def _to_hass_color(color):
-    """Convert from Color tuple to Home Assistant RGB list."""
-    return list([int(c) for c in color])
+    def limitlessled_color(self):
+        """Convert Home Assistant RGB list to Color tuple."""
+        from limitlessled import Color
+        return Color(*tuple(self._color))


### PR DESCRIPTION
## Breaking change note:

Several changes to LimitlessLED behavior, see the link for a description.

## Description:

The LimitlessLED hardware is unable to report its state back to Home Assistant.

This PR changes the integration to accept that fact by declaring the platform "assumed state" and not trust the HA state.

The change has significant impact on how the LimitlessLED integration works. Home Assistant used to change the physical lighting to achieve a known state. That will no longer happen:
* bulbs are not powered off during HA startup (fixes #11028)
* the UI now has individual power on/off buttons (fixes #10815)
* HA will not revert settings made with other light controllers
* switching between color/white light modes can alter the bulb brightness but HA will not update its assumed brightness state

While at it, I added this unrelated one-liner fix:
* setting a white temperature automatically switches to white mode (fixes #8587)

If you prefer an unreliable toggle for the switch, you can get it back with this configuration:
```yaml
homeassistant:
  customize_domain:
    light:
      assumed_state: false
```

If you really, really want Home Assistant to always show the actual state, you must avoid using other light controllers and you must now manually reset lights during startup:
```yaml
automation:
  - alias: "Reset all lights on startup"
    trigger:
      - platform: homeassistant
        event: start
    action:
      - service: light.turn_on
        data:
          kelvin: 3000
          brightness_pct: 100
      - service: light.turn_off
```

After making the same rework in three classes, I decided that this integration does not benefit from inheritance and I refactored it a bit (this is a separate commit in this PR).

CC @happyleavesaoc 

**Related issue (if applicable):** fixes #11028, fixes #10815, fixes #8587, fixes #11913

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4701

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable.</s>
  - [ ] <s>New dependencies are only imported inside functions that use them.</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>