### PR TITLE
Converted shopping list to use json util and added default override for json util

### DIFF
--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -8,6 +8,8 @@ import voluptuous as vol
 from homeassistant.const import HTTP_NOT_FOUND, HTTP_BAD_REQUEST
 from homeassistant.core import callback
 from homeassistant.components import http
+from homeassistant.components.http.data_validator import (
+    RequestDataValidator)
 from homeassistant.helpers import intent
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.json import load_json, save_json
@@ -192,7 +194,7 @@ class CreateShoppingListItemView(http.HomeAssistantView):
     url = '/api/shopping_list/item'
     name = "api:shopping_list:item"
 
-    @http.RequestDataValidator(vol.Schema({
+    @RequestDataValidator(vol.Schema({
         vol.Required('name'): str,
     }))
     @asyncio.coroutine

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -1,8 +1,6 @@
 """Component to manage a shopping list."""
 import asyncio
-import json
 import logging
-import os
 import uuid
 
 import voluptuous as vol
@@ -10,11 +8,9 @@ import voluptuous as vol
 from homeassistant.const import HTTP_NOT_FOUND, HTTP_BAD_REQUEST
 from homeassistant.core import callback
 from homeassistant.components import http
-from homeassistant.components.http.data_validator import (
-    RequestDataValidator)
 from homeassistant.helpers import intent
 import homeassistant.helpers.config_validation as cv
-
+from homeassistant.util.json import load_json, save_json
 
 DOMAIN = 'shopping_list'
 DEPENDENCIES = ['http']
@@ -101,18 +97,13 @@ class ShoppingData:
         """Load items."""
         def load():
             """Load the items synchronously."""
-            path = self.hass.config.path(PERSISTENCE)
-            if not os.path.isfile(path):
-                return []
-            with open(path) as file:
-                return json.loads(file.read())
+            return load_json(self.hass.config.path(PERSISTENCE), default=[])
 
         self.items = yield from self.hass.async_add_job(load)
 
     def save(self):
         """Save the items."""
-        with open(self.hass.config.path(PERSISTENCE), 'wt') as file:
-            file.write(json.dumps(self.items, sort_keys=True, indent=4))
+        save_json(self.hass.config.path(PERSISTENCE), self.items)
 
 
 class AddItemIntent(intent.IntentHandler):
@@ -201,7 +192,7 @@ class CreateShoppingListItemView(http.HomeAssistantView):
     url = '/api/shopping_list/item'
     name = "api:shopping_list:item"
 
-    @RequestDataValidator(vol.Schema({
+    @http.RequestDataValidator(vol.Schema({
         vol.Required('name'): str,
     }))
     @asyncio.coroutine

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -9,7 +9,8 @@ from homeassistant.exceptions import HomeAssistantError
 _LOGGER = logging.getLogger(__name__)
 
 
-def load_json(filename: str) -> Union[List, Dict]:
+def load_json(filename: str, default: Union[List, Dict] = {}) \
+        -> Union[List, Dict]:
     """Load JSON data from a file and return as dict or list.
 
     Defaults to returning empty dict if file is not found.
@@ -26,7 +27,7 @@ def load_json(filename: str) -> Union[List, Dict]:
     except OSError as error:
         _LOGGER.exception('JSON file reading failed: %s', filename)
         raise HomeAssistantError(error)
-    return {}  # (also evaluates to False)
+    return default  # (also evaluates to False)
 
 
 def save_json(filename: str, config: Union[List, Dict]):

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -8,8 +8,10 @@ from homeassistant.exceptions import HomeAssistantError
 
 _LOGGER = logging.getLogger(__name__)
 
+_UNDEFINED = object()
 
-def load_json(filename: str, default: Union[List, Dict] = {}) \
+
+def load_json(filename: str, default: Union[List, Dict] = _UNDEFINED) \
         -> Union[List, Dict]:
     """Load JSON data from a file and return as dict or list.
 
@@ -27,7 +29,7 @@ def load_json(filename: str, default: Union[List, Dict] = {}) \
     except OSError as error:
         _LOGGER.exception('JSON file reading failed: %s', filename)
         raise HomeAssistantError(error)
-    return default  # (also evaluates to False)
+    return {} if default is _UNDEFINED else default
 
 
 def save_json(filename: str, config: Union[List, Dict]):


### PR DESCRIPTION
## Description:
Converted shopping list to use json (according to the issue). Also added a default override for loading json, to prevent scripts from having to implement handling of return values they don't expect.

**Related issue (if applicable):** fixes #10269
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
