### PR TITLE
Added unique_id to Plex Media player

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -289,7 +289,10 @@ class PlexClient(MediaPlayerDevice):
         self._media_episode = None
         self._media_season = None
         self._media_series_title = None
-
+        if self.machine_identifier:
+            self._unique_id = str(self.machine_identifier)
+        else:
+            self._unique_id = None
         self.refresh(device, session)
 
         # Assign custom entity ID if desired
@@ -459,8 +462,8 @@ class PlexClient(MediaPlayerDevice):
 
     @property
     def unique_id(self):
-        """Return the id of this plex client."""
-        return self.machine_identifier
+        """Return a unique id."""
+        return self._unique_id
 
     @property
     def name(self):


### PR DESCRIPTION
Adds `unique_id` to Plex. 

**Related issue (if applicable):** fixes #12353 

## Checklist:
  - [x] The code change is tested and works locally.
