### PR TITLE
Frontier silicon async

### DIFF
--- a/homeassistant/components/media_player/frontier_silicon.py
+++ b/homeassistant/components/media_player/frontier_silicon.py
@@ -6,6 +6,9 @@ https://home-assistant.io/components/media_player.frontier_silicon/
 """
 import logging
 
+import asyncio
+import time
+
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -19,7 +22,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_PORT, CONF_PASSWORD)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['fsapi==0.0.7']
+REQUIREMENTS = ['afsapi==0.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,14 +44,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 # pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices, discovery_info=None):
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Frontier Silicon platform."""
     import requests
 
     if discovery_info is not None:
-        add_devices(
-            [FSAPIDevice(discovery_info['ssdp_description'],
-                         DEFAULT_PASSWORD)],
+        async_add_devices(
+            [AFSAPIDevice(discovery_info['ssdp_description'],
+                          DEFAULT_PASSWORD)],
             update_before_add=True)
         return True
 
@@ -57,8 +61,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     password = config.get(CONF_PASSWORD)
 
     try:
-        add_devices(
-            [FSAPIDevice(DEVICE_URL.format(host, port), password)],
+        async_add_devices(
+            [AFSAPIDevice(DEVICE_URL.format(host, port), password)],
             update_before_add=True)
         _LOGGER.debug("FSAPI device %s:%s -> %s", host, port, password)
         return True
@@ -69,7 +73,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     return False
 
 
-class FSAPIDevice(MediaPlayerDevice):
+class AFSAPIDevice(MediaPlayerDevice):
     """Representation of a Frontier Silicon device on the network."""
 
     def __init__(self, device_url, password):
@@ -97,9 +101,9 @@ class FSAPIDevice(MediaPlayerDevice):
         connected to the device in between the updates and invalidated the
         existing session (i.e UNDOK).
         """
-        from fsapi import FSAPI
+        from afsapi import AFSAPI
 
-        return FSAPI(self._device_url, self._password)
+        return AFSAPI(self._device_url, self._password)
 
     @property
     def should_poll(self):
@@ -157,17 +161,19 @@ class FSAPIDevice(MediaPlayerDevice):
         """Image url of current playing media."""
         return self._media_image_url
 
-    def update(self):
+    @asyncio.coroutine
+    def async_update(self):
         """Get the latest date and update device state."""
+        start = time.time()
         fs_device = self.fs_device
 
         if not self._name:
-            self._name = fs_device.friendly_name
+            self._name = yield from fs_device.get_friendly_name()
 
         if not self._source_list:
-            self._source_list = fs_device.mode_list
+            self._source_list = yield from fs_device.get_mode_list()
 
-        status = fs_device.play_status
+        status = yield from fs_device.get_play_status()
         self._state = {
             'playing': STATE_PLAYING,
             'paused': STATE_PAUSED,
@@ -176,54 +182,74 @@ class FSAPIDevice(MediaPlayerDevice):
             None: STATE_OFF,
         }.get(status, STATE_UNKNOWN)
 
-        info_name = fs_device.play_info_name
-        info_text = fs_device.play_info_text
+        if self._state != STATE_OFF:
+            info_name = yield from fs_device.get_play_name()
+            info_text = yield from fs_device.get_play_text()
 
-        self._title = ' - '.join(filter(None, [info_name, info_text]))
-        self._artist = fs_device.play_info_artist
-        self._album_name = fs_device.play_info_album
+            self._title = ' - '.join(filter(None, [info_name, info_text]))
+            self._artist = yield from fs_device.get_play_artist()
+            self._album_name = yield from fs_device.get_play_album()
 
-        self._source = fs_device.mode
-        self._mute = fs_device.mute
-        self._media_image_url = fs_device.play_info_graphics
+            self._source = yield from fs_device.get_mode()
+            self._mute = yield from fs_device.get_mute()
+            self._media_image_url = yield from fs_device.get_play_graphic()
+        else:
+            self._title = None
+            self._artist = None
+            self._album_name = None
+
+            self._source = None
+            self._mute = None
+            self._media_image_url = None
+
+        end = time.time()
+        _LOGGER.debug('Frontier Silicon device update took: %s', (end-start))
 
     # Management actions
 
     # power control
-    def turn_on(self):
+    @asyncio.coroutine
+    def async_turn_on(self):
         """Turn on the device."""
-        self.fs_device.power = True
+        yield from self.fs_device.set_power(True)
 
-    def turn_off(self):
+    @asyncio.coroutine
+    def async_turn_off(self):
         """Turn off the device."""
-        self.fs_device.power = False
+        yield from self.fs_device.set_power(False)
 
-    def media_play(self):
+    @asyncio.coroutine
+    def async_media_play(self):
         """Send play command."""
-        self.fs_device.play()
+        yield from self.fs_device.play()
 
-    def media_pause(self):
+    @asyncio.coroutine
+    def async_media_pause(self):
         """Send pause command."""
-        self.fs_device.pause()
+        yield from self.fs_device.pause()
 
-    def media_play_pause(self):
+    @asyncio.coroutine
+    def async_media_play_pause(self):
         """Send play/pause command."""
         if 'playing' in self._state:
-            self.fs_device.pause()
+            yield from self.fs_device.pause()
         else:
-            self.fs_device.play()
+            yield from self.fs_device.play()
 
-    def media_stop(self):
+    @asyncio.coroutine
+    def async_media_stop(self):
         """Send play/pause command."""
-        self.fs_device.pause()
+        yield from self.fs_device.pause()
 
-    def media_previous_track(self):
+    @asyncio.coroutine
+    def async_media_previous_track(self):
         """Send previous track command (results in rewind)."""
-        self.fs_device.prev()
+        yield from self.fs_device.prev()
 
-    def media_next_track(self):
+    @asyncio.coroutine
+    def async_media_next_track(self):
         """Send next track command (results in fast-forward)."""
-        self.fs_device.next()
+        yield from self.fs_device.next()
 
     # mute
     @property
@@ -231,23 +257,30 @@ class FSAPIDevice(MediaPlayerDevice):
         """Boolean if volume is currently muted."""
         return self._mute
 
-    def mute_volume(self, mute):
+    @asyncio.coroutine
+    def async_mute_volume(self, mute):
         """Send mute command."""
-        self.fs_device.mute = mute
+        yield from self.fs_device.set_mute(mute)
 
     # volume
-    def volume_up(self):
+    @asyncio.coroutine
+    def async_volume_up(self):
         """Send volume up command."""
-        self.fs_device.volume += 1
+        volume = yield from self.fs_device.get_volume()
+        yield from self.fs_device.set_volume(volume+1)
 
-    def volume_down(self):
+    @asyncio.coroutine
+    def async_volume_down(self):
         """Send volume down command."""
-        self.fs_device.volume -= 1
+        volume = yield from self.fs_device.get_volume()
+        yield from self.fs_device.set_volume(volume-1)
 
-    def set_volume_level(self, volume):
+    @asyncio.coroutine
+    def async_set_volume_level(self, volume):
         """Set volume command."""
-        self.fs_device.volume = volume
+        yield from self.fs_device.set_volume(volume)
 
-    def select_source(self, source):
+    @asyncio.coroutine
+    def async_select_source(self, source):
         """Select input source."""
-        self.fs_device.mode = source
+        yield from self.fs_device.set_mode(source)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -59,6 +59,9 @@ YesssSMS==0.1.1b3
 # homeassistant.components.abode
 abodepy==0.12.2
 
+# homeassistant.components.media_player.frontier_silicon
+afsapi==0.0.1
+
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.4
 
@@ -291,9 +294,6 @@ freesms==0.1.2
 
 # homeassistant.components.switch.fritzdect
 fritzhome==1.0.4
-
-# homeassistant.components.media_player.frontier_silicon
-afsapi==0.0.1
 
 # homeassistant.components.tts.google
 gTTS-token==1.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -293,7 +293,7 @@ freesms==0.1.2
 fritzhome==1.0.4
 
 # homeassistant.components.media_player.frontier_silicon
-fsapi==0.0.7
+afsapi==0.0.1
 
 # homeassistant.components.tts.google
 gTTS-token==1.1.1


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
