### PR TITLE
zha: Simplify unique ID

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -183,7 +183,7 @@ class ApplicationListener:
 
             component = None
             profile_clusters = ([], [])
-            device_key = "{}-{}".format(str(device.ieee), endpoint_id)
+            device_key = "{}-{}".format(device.ieee, endpoint_id)
             node_config = self._config[DOMAIN][CONF_DEVICE_CONFIG].get(
                 device_key, {})
 
@@ -213,7 +213,7 @@ class ApplicationListener:
                     'in_clusters': {c.cluster_id: c for c in in_clusters},
                     'out_clusters': {c.cluster_id: c for c in out_clusters},
                     'new_join': join,
-                    'unique_id': "{}-{}".format(device.ieee, endpoint_id),
+                    'unique_id': device_key,
                 }
                 discovery_info.update(discovered_info)
                 self._hass.data[DISCOVERY_KEY][device_key] = discovery_info
@@ -234,17 +234,17 @@ class ApplicationListener:
                     continue
 
                 component = zha_const.SINGLE_CLUSTER_DEVICE_CLASS[cluster_type]
+                cluster_key = "{}-{}".format(device_key, cluster_id)
                 discovery_info = {
                     'application_listener': self,
                     'endpoint': endpoint,
                     'in_clusters': {cluster.cluster_id: cluster},
                     'out_clusters': {},
                     'new_join': join,
-                    'unique_id': "{}-{}-{}".format(
-                        device.ieee, endpoint_id, cluster_id),
+                    'unique_id': cluster_key,
+                    'entity_suffix': '_{}'.format(cluster_id),
                 }
                 discovery_info.update(discovered_info)
-                cluster_key = "{}-{}".format(device_key, cluster_id)
                 self._hass.data[DISCOVERY_KEY][cluster_key] = discovery_info
 
                 yield from discovery.async_load_platform(
@@ -272,23 +272,26 @@ class Entity(entity.Entity):
         ieee = endpoint.device.ieee
         ieeetail = ''.join(['%02x' % (o, ) for o in ieee[-4:]])
         if manufacturer and model is not None:
-            self.entity_id = "{}.{}_{}_{}_{}".format(
+            self.entity_id = "{}.{}_{}_{}_{}{}".format(
                 self._domain,
                 slugify(manufacturer),
                 slugify(model),
                 ieeetail,
                 endpoint.endpoint_id,
+                kwargs.get('entity_suffix', ''),
             )
             self._device_state_attributes['friendly_name'] = "{} {}".format(
                 manufacturer,
                 model,
             )
         else:
-            self.entity_id = "{}.zha_{}_{}".format(
+            self.entity_id = "{}.zha_{}_{}{}".format(
                 self._domain,
                 ieeetail,
                 endpoint.endpoint_id,
+                kwargs.get('entity_suffix', ''),
             )
+
         for cluster in in_clusters.values():
             cluster.add_listener(self)
         for cluster in out_clusters.values():
@@ -370,8 +373,7 @@ def get_discovery_info(hass, discovery_info):
 
     discovery_key = discovery_info.get('discovery_key', None)
     all_discovery_info = hass.data.get(DISCOVERY_KEY, {})
-    discovery_info = all_discovery_info.get(discovery_key, None)
-    return discovery_info
+    return all_discovery_info.get(discovery_key, None)
 
 
 @asyncio.coroutine


### PR DESCRIPTION
It turns out we were already calculating exactly the same thing. This also fixes entity IDs generated for devices on the same endpoint.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
