### PR TITLE
Add Tahoma scenes

### DIFF
--- a/homeassistant/components/scene/tahoma.py
+++ b/homeassistant/components/scene/tahoma.py
@@ -33,7 +33,6 @@ class TahomaScene(Scene):
         self.controller = controller
         self._name = self.tahoma_scene.name
 
-
     def activate(self, **kwargs):
         """Activate the scene."""
         self.controller.launch_action_group(self.tahoma_scene.oid)

--- a/homeassistant/components/scene/tahoma.py
+++ b/homeassistant/components/scene/tahoma.py
@@ -1,0 +1,49 @@
+"""
+Support for Tahoma scenes.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/scene.tahoma/
+"""
+import logging
+
+from homeassistant.components.scene import Scene
+from homeassistant.components.tahoma import (
+    DOMAIN as TAHOMA_DOMAIN)
+
+DEPENDENCIES = ['tahoma']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Tahoma scenes."""
+    controller = hass.data[TAHOMA_DOMAIN]['controller']
+    scenes = []
+    for scene in hass.data[TAHOMA_DOMAIN]['scenes']:
+        scenes.append(TahomaScene(scene, controller))
+    add_devices(scenes, True)
+
+
+class TahomaScene(Scene):
+    """Representation of a Tahoma scene entity."""
+
+    def __init__(self, tahoma_scene, controller):
+        """Initialize the scene."""
+        self.tahoma_scene = tahoma_scene
+        self.controller = controller
+        self._name = self.tahoma_scene.name
+
+
+    def activate(self, **kwargs):
+        """Activate the scene."""
+        self.controller.launch_action_group(self.tahoma_scene.oid)
+
+    @property
+    def name(self):
+        """Return the name of the scene."""
+        return self._name
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the scene."""
+        return {'tahoma_scene_oid': self.tahoma_scene.oid}

--- a/homeassistant/components/scene/tahoma.py
+++ b/homeassistant/components/scene/tahoma.py
@@ -33,7 +33,7 @@ class TahomaScene(Scene):
         self.controller = controller
         self._name = self.tahoma_scene.name
 
-    def activate(self, **kwargs):
+    def activate(self):
         """Activate the scene."""
         self.controller.launch_action_group(self.tahoma_scene.oid)
 

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['tahoma-api==0.0.11']
+REQUIREMENTS = ['tahoma-api==0.0.12']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -71,7 +71,7 @@ def setup(hass, config):
     hass.data[DOMAIN] = {
         'controller': api,
         'devices': defaultdict(list),
-        'scenes':[]
+        'scenes': []
     }
 
     for device in devices:

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 TAHOMA_COMPONENTS = [
-    'sensor', 'cover'
+    'scene', 'sensor', 'cover'
 ]
 
 TAHOMA_TYPES = {
@@ -63,13 +63,15 @@ def setup(hass, config):
     try:
         api.get_setup()
         devices = api.get_devices()
+        scenes = api.get_action_groups()
     except RequestException:
         _LOGGER.exception("Error when getting devices from the Tahoma API")
         return False
 
     hass.data[DOMAIN] = {
         'controller': api,
-        'devices': defaultdict(list)
+        'devices': defaultdict(list),
+        'scenes':[]
     }
 
     for device in devices:
@@ -81,6 +83,9 @@ def setup(hass, config):
                                 _device.type, _device.label)
                 continue
             hass.data[DOMAIN]['devices'][device_type].append(_device)
+
+    for scene in scenes:
+        hass.data[DOMAIN]['scenes'].append(scene)
 
     for component in TAHOMA_COMPONENTS:
         discovery.load_platform(hass, component, DOMAIN, {}, config)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1144,7 +1144,7 @@ steamodd==4.21
 suds-py3==1.3.3.0
 
 # homeassistant.components.tahoma
-tahoma-api==0.0.11
+tahoma-api==0.0.12
 
 # homeassistant.components.sensor.tank_utility
 tank_utility==1.4.0


### PR DESCRIPTION
## Description:

This adds scenarios from Tahoma into HomeAssistant! Upon restart of HomeAssistant they will automatically be added to your setup!


Finally got around to implementing these scenes from the Tahoma component. They can be added in the Tahoma interface. This cuts down on API calls is a big way. Now only 1 call is needed to move any amount of covers!

This has been running in my own setup for a couple of days, it works great.

Also fixes #12516 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4698

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
