### PR TITLE
Support for multiple min-max sensors

### DIFF
--- a/homeassistant/components/sensor/min_max.py
+++ b/homeassistant/components/sensor/min_max.py
@@ -9,12 +9,13 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    CONF_NAME, STATE_UNKNOWN, CONF_TYPE, ATTR_UNIT_OF_MEASUREMENT)
 from homeassistant.core import callback
-from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import ENTITY_ID_FORMAT, PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_SENSORS, CONF_FRIENDLY_NAME, CONF_TYPE,
+    ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.event import async_track_state_change
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,9 +34,6 @@ ATTR_TO_PROPERTY = [
     ATTR_LAST,
 ]
 
-CONF_ENTITY_IDS = 'entity_ids'
-CONF_ROUND_DIGITS = 'round_digits'
-
 ICON = 'mdi:calculator'
 
 SENSOR_TYPES = {
@@ -45,26 +43,41 @@ SENSOR_TYPES = {
     ATTR_LAST: 'last',
 }
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+CONF_ENTITY_IDS = 'entity_ids'
+CONF_ROUND_DIGITS = 'round_digits'
+
+SENSOR_SCHEMA = vol.Schema({
     vol.Optional(CONF_TYPE, default=SENSOR_TYPES[ATTR_MAX_VALUE]):
         vol.All(cv.string, vol.In(SENSOR_TYPES.values())),
-    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_FRIENDLY_NAME): cv.string,
     vol.Required(CONF_ENTITY_IDS): cv.entity_ids,
     vol.Optional(CONF_ROUND_DIGITS, default=2): vol.Coerce(int),
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SENSORS): vol.Schema({cv.slug: SENSOR_SCHEMA})
 })
 
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the min/max/mean sensor."""
-    entity_ids = config.get(CONF_ENTITY_IDS)
-    name = config.get(CONF_NAME)
-    sensor_type = config.get(CONF_TYPE)
-    round_digits = config.get(CONF_ROUND_DIGITS)
+    sensors = []
 
-    async_add_devices(
-        [MinMaxSensor(hass, entity_ids, name, sensor_type, round_digits)],
-        True)
+    for device, device_config in config[CONF_SENSORS].items():
+        entity_ids = device_config.get(CONF_ENTITY_IDS)
+        friendly_name = device_config.get(CONF_FRIENDLY_NAME, device)
+        sensor_type = device_config.get(CONF_TYPE)
+        round_digits = device_config.get(CONF_ROUND_DIGITS)
+        sensors.append(
+            MinMaxSensor(hass, device, entity_ids, friendly_name,
+                         sensor_type, round_digits))
+
+    if not sensors:
+        _LOGGER.error("No min_max sensors added.")
+        return False
+
+    async_add_devices(sensors, True)
     return True
 
 
@@ -72,9 +85,10 @@ def calc_min(sensor_values):
     """Calculate min value, honoring unknown states."""
     val = STATE_UNKNOWN
     for sval in sensor_values:
-        if sval != STATE_UNKNOWN:
-            if val == STATE_UNKNOWN or val > sval:
-                val = sval
+        if sval == STATE_UNKNOWN:
+            continue
+        if val == STATE_UNKNOWN or val > sval:
+            val = sval
     return val
 
 
@@ -82,9 +96,10 @@ def calc_max(sensor_values):
     """Calculate max value, honoring unknown states."""
     val = STATE_UNKNOWN
     for sval in sensor_values:
-        if sval != STATE_UNKNOWN:
-            if val == STATE_UNKNOWN or val < sval:
-                val = sval
+        if sval == STATE_UNKNOWN:
+            continue
+        if val == STATE_UNKNOWN or val < sval:
+            val = sval
     return val
 
 
@@ -93,9 +108,10 @@ def calc_mean(sensor_values, round_digits):
     val = 0
     count = 0
     for sval in sensor_values:
-        if sval != STATE_UNKNOWN:
-            val += sval
-            count += 1
+        if sval == STATE_UNKNOWN:
+            continue
+        val += sval
+        count += 1
     if count == 0:
         return STATE_UNKNOWN
     return round(val/count, round_digits)
@@ -104,19 +120,17 @@ def calc_mean(sensor_values, round_digits):
 class MinMaxSensor(Entity):
     """Representation of a min/max sensor."""
 
-    def __init__(self, hass, entity_ids, name, sensor_type, round_digits):
+    def __init__(self, hass, device_id, entity_ids, friendly_name,
+                 sensor_type, round_digits):
         """Initialize the min/max sensor."""
         self._hass = hass
+        self._name = friendly_name
         self._entity_ids = entity_ids
         self._sensor_type = sensor_type
         self._round_digits = round_digits
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, device_id, hass=hass)
 
-        if name:
-            self._name = name
-        else:
-            self._name = '{} sensor'.format(
-                next(v for k, v in SENSOR_TYPES.items()
-                     if self._sensor_type == v)).capitalize()
         self._unit_of_measurement = None
         self._unit_of_measurement_mismatch = False
         self.min_value = self.max_value = self.mean = self.last = STATE_UNKNOWN
@@ -132,12 +146,11 @@ class MinMaxSensor(Entity):
                 hass.async_add_job(self.async_update_ha_state, True)
                 return
 
+            new_unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
             if self._unit_of_measurement is None:
-                self._unit_of_measurement = new_state.attributes.get(
-                    ATTR_UNIT_OF_MEASUREMENT)
+                self._unit_of_measurement = new_unit
 
-            if self._unit_of_measurement != new_state.attributes.get(
-                    ATTR_UNIT_OF_MEASUREMENT):
+            if self._unit_of_measurement != new_unit:
                 _LOGGER.warning(
                     "Units of measurement do not match for entity %s",
                     self.entity_id)
@@ -148,7 +161,7 @@ class MinMaxSensor(Entity):
                 self.last = float(new_state.state)
             except ValueError:
                 _LOGGER.warning("Unable to store state. "
-                                "Only numerical states are supported")
+                                "Only numerical states are supported.")
 
             hass.async_add_job(self.async_update_ha_state, True)
 

--- a/tests/components/sensor/test_min_max.py
+++ b/tests/components/sensor/test_min_max.py
@@ -1,292 +1,231 @@
 """The test for the min/max sensor platform."""
 import unittest
 
-from homeassistant.setup import setup_component
+from homeassistant import setup
 from homeassistant.const import (
     STATE_UNKNOWN, ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS, TEMP_FAHRENHEIT)
-from tests.common import get_test_home_assistant
+from tests.common import assert_setup_component, get_test_home_assistant
+
+
+CONFIG = {
+    'sensor': [
+        {'platform': 'min_max',
+         'sensors': {
+             'test_min_max': {
+                 'entity_ids': [
+                     'sensor.test_1',
+                     'sensor.test_2',
+                     'sensor.test_3'
+                 ]}
+         }}
+    ]
+}
+
+MIN_MAX_SENSOR = 'sensor.test_min_max'
+CONFIG_MIN_MAX = CONFIG['sensor'][0]['sensors']['test_min_max']
+
+
+VALUES = [17, 20, 15.3]
+COUNT = len(VALUES)
+MIN = min(VALUES)
+MAX = max(VALUES)
+MEAN = round(sum(VALUES) / COUNT, 2)
+MEAN_1_DIGIT = round(sum(VALUES) / COUNT, 1)
+MEAN_4_DIGITS = round(sum(VALUES) / COUNT, 4)
 
 
 class TestMinMaxSensor(unittest.TestCase):
     """Test the min/max sensor."""
 
-    def setup_method(self, method):
+    def setUp(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.values = [17, 20, 15.3]
-        self.count = len(self.values)
-        self.min = min(self.values)
-        self.max = max(self.values)
-        self.mean = round(sum(self.values) / self.count, 2)
-        self.mean_1_digit = round(sum(self.values) / self.count, 1)
-        self.mean_4_digits = round(sum(self.values) / self.count, 4)
 
-    def teardown_method(self, method):
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 
     def test_min_sensor(self):
         """Test the min sensor."""
-        config = {
-            'sensor': {
-                'platform': 'min_max',
-                'name': 'test_min',
-                'type': 'min',
-                'entity_ids': [
-                    'sensor.test_1',
-                    'sensor.test_2',
-                    'sensor.test_3',
-                ]
-            }
-        }
+        CONFIG_MIN_MAX['type'] = 'min'
+        CONFIG_MIN_MAX.pop('round_digits', '')
+        with assert_setup_component(1, 'sensor'):
+            setup.setup_component(self.hass, 'sensor', CONFIG)
 
-        assert setup_component(self.hass, 'sensor', config)
+        entity_ids = CONFIG_MIN_MAX['entity_ids']
 
-        entity_ids = config['sensor']['entity_ids']
-
-        for entity_id, value in dict(zip(entity_ids, self.values)).items():
+        for entity_id, value in dict(zip(entity_ids, VALUES)).items():
             self.hass.states.set(entity_id, value)
             self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test_min')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
 
-        self.assertEqual(str(float(self.min)), state.state)
-        self.assertEqual(self.max, state.attributes.get('max_value'))
-        self.assertEqual(self.mean, state.attributes.get('mean'))
+        self.assertEqual(str(float(MIN)), state.state)
+        self.assertEqual(MAX, state.attributes.get('max_value'))
+        self.assertEqual(MEAN, state.attributes.get('mean'))
 
     def test_max_sensor(self):
         """Test the max sensor."""
-        config = {
-            'sensor': {
-                'platform': 'min_max',
-                'name': 'test_max',
-                'type': 'max',
-                'entity_ids': [
-                    'sensor.test_1',
-                    'sensor.test_2',
-                    'sensor.test_3',
-                ]
-            }
-        }
+        CONFIG_MIN_MAX['type'] = 'max'
+        CONFIG_MIN_MAX.pop('round_digits', '')
+        with assert_setup_component(1, 'sensor'):
+            setup.setup_component(self.hass, 'sensor', CONFIG)
 
-        assert setup_component(self.hass, 'sensor', config)
+        entity_ids = CONFIG_MIN_MAX['entity_ids']
 
-        entity_ids = config['sensor']['entity_ids']
-
-        for entity_id, value in dict(zip(entity_ids, self.values)).items():
+        for entity_id, value in dict(zip(entity_ids, VALUES)).items():
             self.hass.states.set(entity_id, value)
             self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test_max')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
 
-        self.assertEqual(str(float(self.max)), state.state)
-        self.assertEqual(self.min, state.attributes.get('min_value'))
-        self.assertEqual(self.mean, state.attributes.get('mean'))
+        self.assertEqual(str(float(MAX)), state.state)
+        self.assertEqual(MIN, state.attributes.get('min_value'))
+        self.assertEqual(MEAN, state.attributes.get('mean'))
 
     def test_mean_sensor(self):
         """Test the mean sensor."""
-        config = {
-            'sensor': {
-                'platform': 'min_max',
-                'name': 'test_mean',
-                'type': 'mean',
-                'entity_ids': [
-                    'sensor.test_1',
-                    'sensor.test_2',
-                    'sensor.test_3',
-                ]
-            }
-        }
+        CONFIG_MIN_MAX['type'] = 'mean'
+        CONFIG_MIN_MAX.pop('round_digits', '')
+        with assert_setup_component(1, 'sensor'):
+            setup.setup_component(self.hass, 'sensor', CONFIG)
 
-        assert setup_component(self.hass, 'sensor', config)
+        entity_ids = CONFIG_MIN_MAX['entity_ids']
 
-        entity_ids = config['sensor']['entity_ids']
-
-        for entity_id, value in dict(zip(entity_ids, self.values)).items():
+        for entity_id, value in dict(zip(entity_ids, VALUES)).items():
             self.hass.states.set(entity_id, value)
             self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test_mean')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
 
-        self.assertEqual(str(float(self.mean)), state.state)
-        self.assertEqual(self.min, state.attributes.get('min_value'))
-        self.assertEqual(self.max, state.attributes.get('max_value'))
+        self.assertEqual(str(float(MEAN)), state.state)
+        self.assertEqual(MIN, state.attributes.get('min_value'))
+        self.assertEqual(MAX, state.attributes.get('max_value'))
 
     def test_mean_1_digit_sensor(self):
         """Test the mean with 1-digit precision sensor."""
-        config = {
-            'sensor': {
-                'platform': 'min_max',
-                'name': 'test_mean',
-                'type': 'mean',
-                'round_digits': 1,
-                'entity_ids': [
-                    'sensor.test_1',
-                    'sensor.test_2',
-                    'sensor.test_3',
-                ]
-            }
-        }
+        CONFIG_MIN_MAX['type'] = 'mean'
+        CONFIG_MIN_MAX['round_digits'] = 1
+        with assert_setup_component(1, 'sensor'):
+            setup.setup_component(self.hass, 'sensor', CONFIG)
 
-        assert setup_component(self.hass, 'sensor', config)
+        entity_ids = CONFIG_MIN_MAX['entity_ids']
 
-        entity_ids = config['sensor']['entity_ids']
-
-        for entity_id, value in dict(zip(entity_ids, self.values)).items():
+        for entity_id, value in dict(zip(entity_ids, VALUES)).items():
             self.hass.states.set(entity_id, value)
             self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test_mean')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
 
-        self.assertEqual(str(float(self.mean_1_digit)), state.state)
-        self.assertEqual(self.min, state.attributes.get('min_value'))
-        self.assertEqual(self.max, state.attributes.get('max_value'))
+        self.assertEqual(str(float(MEAN_1_DIGIT)), state.state)
+        self.assertEqual(MIN, state.attributes.get('min_value'))
+        self.assertEqual(MAX, state.attributes.get('max_value'))
 
     def test_mean_4_digit_sensor(self):
-        """Test the mean with 1-digit precision sensor."""
-        config = {
-            'sensor': {
-                'platform': 'min_max',
-                'name': 'test_mean',
-                'type': 'mean',
-                'round_digits': 4,
-                'entity_ids': [
-                    'sensor.test_1',
-                    'sensor.test_2',
-                    'sensor.test_3',
-                ]
-            }
-        }
+        """Test the mean with 4-digit precision sensor."""
+        CONFIG_MIN_MAX['type'] = 'mean'
+        CONFIG_MIN_MAX['round_digits'] = 4
+        with assert_setup_component(1, 'sensor'):
+            setup.setup_component(self.hass, 'sensor', CONFIG)
 
-        assert setup_component(self.hass, 'sensor', config)
+        entity_ids = CONFIG_MIN_MAX['entity_ids']
 
-        entity_ids = config['sensor']['entity_ids']
-
-        for entity_id, value in dict(zip(entity_ids, self.values)).items():
+        for entity_id, value in dict(zip(entity_ids, VALUES)).items():
             self.hass.states.set(entity_id, value)
             self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test_mean')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
 
-        self.assertEqual(str(float(self.mean_4_digits)), state.state)
-        self.assertEqual(self.min, state.attributes.get('min_value'))
-        self.assertEqual(self.max, state.attributes.get('max_value'))
+        self.assertEqual(str(float(MEAN_4_DIGITS)), state.state)
+        self.assertEqual(MIN, state.attributes.get('min_value'))
+        self.assertEqual(MAX, state.attributes.get('max_value'))
 
     def test_not_enough_sensor_value(self):
         """Test that there is nothing done if not enough values available."""
-        config = {
-            'sensor': {
-                'platform': 'min_max',
-                'name': 'test_max',
-                'type': 'max',
-                'entity_ids': [
-                    'sensor.test_1',
-                    'sensor.test_2',
-                    'sensor.test_3',
-                ]
-            }
-        }
+        CONFIG_MIN_MAX['type'] = 'max'
+        CONFIG_MIN_MAX.pop('round_digits', '')
+        with assert_setup_component(1, 'sensor'):
+            setup.setup_component(self.hass, 'sensor', CONFIG)
 
-        assert setup_component(self.hass, 'sensor', config)
-
-        entity_ids = config['sensor']['entity_ids']
+        entity_ids = CONFIG_MIN_MAX['entity_ids']
 
         self.hass.states.set(entity_ids[0], STATE_UNKNOWN)
         self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test_max')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
         self.assertEqual(STATE_UNKNOWN, state.state)
 
-        self.hass.states.set(entity_ids[1], self.values[1])
+        self.hass.states.set(entity_ids[1], VALUES[1])
         self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test_max')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
         self.assertNotEqual(STATE_UNKNOWN, state.state)
 
         self.hass.states.set(entity_ids[2], STATE_UNKNOWN)
         self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test_max')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
         self.assertNotEqual(STATE_UNKNOWN, state.state)
 
         self.hass.states.set(entity_ids[1], STATE_UNKNOWN)
         self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test_max')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
         self.assertEqual(STATE_UNKNOWN, state.state)
 
+    # pylint: disable=invalid-name
     def test_different_unit_of_measurement(self):
         """Test for different unit of measurement."""
-        config = {
-            'sensor': {
-                'platform': 'min_max',
-                'name': 'test',
-                'type': 'mean',
-                'entity_ids': [
-                    'sensor.test_1',
-                    'sensor.test_2',
-                    'sensor.test_3',
-                ]
-            }
-        }
+        CONFIG_MIN_MAX['type'] = 'mean'
+        CONFIG_MIN_MAX.pop('round_digits', '')
+        with assert_setup_component(1, 'sensor'):
+            setup.setup_component(self.hass, 'sensor', CONFIG)
 
-        assert setup_component(self.hass, 'sensor', config)
+        entity_ids = CONFIG_MIN_MAX['entity_ids']
 
-        entity_ids = config['sensor']['entity_ids']
-
-        self.hass.states.set(entity_ids[0], self.values[0],
+        self.hass.states.set(entity_ids[0], VALUES[0],
                              {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
         self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
 
-        self.assertEqual(str(float(self.values[0])), state.state)
+        self.assertEqual(str(float(VALUES[0])), state.state)
         self.assertEqual('°C', state.attributes.get('unit_of_measurement'))
 
-        self.hass.states.set(entity_ids[1], self.values[1],
+        self.hass.states.set(entity_ids[1], VALUES[1],
                              {ATTR_UNIT_OF_MEASUREMENT: TEMP_FAHRENHEIT})
         self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
 
         self.assertEqual(STATE_UNKNOWN, state.state)
         self.assertEqual('ERR', state.attributes.get('unit_of_measurement'))
 
-        self.hass.states.set(entity_ids[2], self.values[2],
+        self.hass.states.set(entity_ids[2], VALUES[2],
                              {ATTR_UNIT_OF_MEASUREMENT: '%'})
         self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test')
+        state = self.hass.states.get(MIN_MAX_SENSOR)
 
         self.assertEqual(STATE_UNKNOWN, state.state)
         self.assertEqual('ERR', state.attributes.get('unit_of_measurement'))
 
     def test_last_sensor(self):
         """Test the last sensor."""
-        config = {
-            'sensor': {
-                'platform': 'min_max',
-                'name': 'test_last',
-                'type': 'last',
-                'entity_ids': [
-                    'sensor.test_1',
-                    'sensor.test_2',
-                    'sensor.test_3',
-                ]
-            }
-        }
+        CONFIG_MIN_MAX['type'] = 'last'
+        CONFIG_MIN_MAX.pop('round_digits', '')
+        with assert_setup_component(1, 'sensor'):
+            setup.setup_component(self.hass, 'sensor', CONFIG)
 
-        assert setup_component(self.hass, 'sensor', config)
+        entity_ids = CONFIG_MIN_MAX['entity_ids']
+        state = self.hass.states.get(MIN_MAX_SENSOR)
 
-        entity_ids = config['sensor']['entity_ids']
-        state = self.hass.states.get('sensor.test_last')
-
-        for entity_id, value in dict(zip(entity_ids, self.values)).items():
+        for entity_id, value in dict(zip(entity_ids, VALUES)).items():
             self.hass.states.set(entity_id, value)
             self.hass.block_till_done()
-            state = self.hass.states.get('sensor.test_last')
+            state = self.hass.states.get(MIN_MAX_SENSOR)
             self.assertEqual(str(float(value)), state.state)
 
-        self.assertEqual(self.min, state.attributes.get('min_value'))
-        self.assertEqual(self.max, state.attributes.get('max_value'))
-        self.assertEqual(self.mean, state.attributes.get('mean'))
+        self.assertEqual(MIN, state.attributes.get('min_value'))
+        self.assertEqual(MAX, state.attributes.get('max_value'))
+        self.assertEqual(MEAN, state.attributes.get('mean'))


### PR DESCRIPTION
## Description:
I updated the component schema, to account for multiple `min_max sensors`. Other changes include:
* Changed `name` to `friendly_name`
* Small improvements
* Updated tests

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4700

## Breaking changes
The `min/max` sensor now supports adding multiple sensors without the need to add a new platform entry. For information on how to update your configurations file, refer to the component page [Min/Max Sensor](https://home-assistant.io/components/sensor.min_max/).

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: min_max
    sensors:
      my_max_sensor:
        entity_ids:
          - sensor.kitchen_temperature
          - sensor.living_room_temperature
          - sensor.office_temperature
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
