### PR TITLE
cover level can now be set using emulated_hue

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -22,7 +22,7 @@ from homeassistant.components.fan import (
 )
 
 from homeassistant.components.cover import (
-    ATTR_CURRENT_POSITION, ATTR_POSITION, SERVICE_SET_COVER_POSITION, 
+    ATTR_CURRENT_POSITION, ATTR_POSITION, SERVICE_SET_COVER_POSITION,
     SUPPORT_SET_POSITION
 )
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -22,7 +22,8 @@ from homeassistant.components.fan import (
 )
 
 from homeassistant.components.cover import (
-    ATTR_CURRENT_POSITION, ATTR_POSITION, SERVICE_SET_COVER_POSITION, SUPPORT_SET_POSITION
+    ATTR_CURRENT_POSITION, ATTR_POSITION, SERVICE_SET_COVER_POSITION, 
+    SUPPORT_SET_POSITION
 )
 
 from homeassistant.components.http import HomeAssistantView

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -20,6 +20,11 @@ from homeassistant.components.fan import (
     ATTR_SPEED, SUPPORT_SET_SPEED, SPEED_OFF, SPEED_LOW,
     SPEED_MEDIUM, SPEED_HIGH
 )
+
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION, ATTR_POSITION, SERVICE_SET_COVER_POSITION, SUPPORT_SET_POSITION
+)
+
 from homeassistant.components.http import HomeAssistantView
 
 _LOGGER = logging.getLogger(__name__)
@@ -206,8 +211,13 @@ class HueOneLightChangeView(HomeAssistantView):
             domain = entity.domain
             if service == SERVICE_TURN_ON:
                 service = SERVICE_OPEN_COVER
-            else:
+            elif service == SERVICE_TURN_OFF:
                 service = SERVICE_CLOSE_COVER
+            if entity_features & SUPPORT_SET_POSITION:
+                if brightness is not None:
+                    service = SERVICE_SET_COVER_POSITION
+                    data[ATTR_POSITION] = brightness
+
 
         # If the requested entity is a fan, convert to speed
         elif entity.domain == "fan":
@@ -294,7 +304,8 @@ def parse_hue_api_put_light_body(request_json, entity):
 
         elif (entity.domain == "script" or
               entity.domain == "media_player" or
-              entity.domain == "fan"):
+              entity.domain == "fan" or
+              entity.domain == "cover"):
             # Convert 0-255 to 0-100
             level = brightness / 255 * 100
             brightness = round(level)
@@ -335,6 +346,9 @@ def get_entity_state(config, entity):
                 final_brightness = 170
             elif speed == SPEED_HIGH:
                 final_brightness = 255
+        elif entity.domain == "cover":
+            current_position = entity.attributes.get(ATTR_CURRENT_POSITION, 0)
+            final_brightness = round(current_position / 100 * 255)
     else:
         final_state, final_brightness = cached_state
         # Make sure brightness is valid


### PR DESCRIPTION
## Description:
cover support brightness to set their level when using emulated_hue

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
