### PR TITLE
Added file path validity checks to file sensor

### DIFF
--- a/homeassistant/components/sensor/file.py
+++ b/homeassistant/components/sensor/file.py
@@ -25,7 +25,7 @@ DEFAULT_NAME = 'File'
 ICON = 'mdi:file'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_FILE_PATH): cv.string,
+    vol.Required(CONF_FILE_PATH): cv.isfile,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
@@ -43,8 +43,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if value_template is not None:
         value_template.hass = hass
 
-    async_add_devices(
-        [FileSensor(name, file_path, unit, value_template)], True)
+    if hass.config.is_allowed_path(file_path):
+        async_add_devices(
+            [FileSensor(name, file_path, unit, value_template)], True)
+    else:
+        _LOGGER.error("'%s' is not a whitelisted directory", file_path)
 
 
 class FileSensor(Entity):

--- a/tests/components/sensor/test_file.py
+++ b/tests/components/sensor/test_file.py
@@ -18,6 +18,8 @@ class TestFileSensor(unittest.TestCase):
     def setup_method(self, method):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
+        # Patch out 'is_allowed_path' as the mock files aren't allowed
+        self.hass.config.is_allowed_path = Mock(return_value=True)
         mock_registry(self.hass)
 
     def teardown_method(self, method):


### PR DESCRIPTION
## Description:
Added file validity checks to file sensor, checking for whitelisted/valid paths and using `isfile` for the config variable.

**Related issue (if applicable):** fixes #12493

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
