### PR TITLE
Allow ignoring call service events in mqtt_eventstream

### DIFF
--- a/homeassistant/components/mqtt_eventstream.py
+++ b/homeassistant/components/mqtt_eventstream.py
@@ -20,8 +20,6 @@ from homeassistant.core import EventOrigin, State
 import homeassistant.helpers.config_validation as cv
 from homeassistant.remote import JSONEncoder
 
-import homeassistant.const as has_const
-
 DOMAIN = 'mqtt_eventstream'
 DEPENDENCIES = ['mqtt']
 
@@ -29,9 +27,6 @@ CONF_PUBLISH_TOPIC = 'publish_topic'
 CONF_SUBSCRIBE_TOPIC = 'subscribe_topic'
 CONF_PUBLISH_EVENTSTREAM_RECEIVED = 'publish_eventstream_received'
 CONF_IGNORE_EVENT = 'ignore_event'
-
-EVENT_TYPES = [has_const.__dict__[x]
-               for x in has_const.__dict__.keys() if x.startswith('EVENT_')]
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/mqtt_eventstream.py
+++ b/homeassistant/components/mqtt_eventstream.py
@@ -31,7 +31,7 @@ CONF_PUBLISH_EVENTSTREAM_RECEIVED = 'publish_eventstream_received'
 CONF_IGNORE_EVENT = 'ignore_event'
 
 EVENT_TYPES = [has_const.__dict__[x]
-    for x in has_const.__dict__.keys() if x.startswith('EVENT_')]
+               for x in has_const.__dict__.keys() if x.startswith('EVENT_')]
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/mqtt_eventstream.py
+++ b/homeassistant/components/mqtt_eventstream.py
@@ -103,7 +103,7 @@ def async_setup(hass, config):
 
                 if state:
                     event_data[key] = state
-        
+
         if ignore_call_service and event_type == EVENT_CALL_SERVICE:
             return
 

--- a/homeassistant/components/mqtt_eventstream.py
+++ b/homeassistant/components/mqtt_eventstream.py
@@ -26,12 +26,15 @@ DEPENDENCIES = ['mqtt']
 CONF_PUBLISH_TOPIC = 'publish_topic'
 CONF_SUBSCRIBE_TOPIC = 'subscribe_topic'
 CONF_PUBLISH_EVENTSTREAM_RECEIVED = 'publish_eventstream_received'
+CONF_IGNORE_EVENT_CALL_SERVICE = 'ignore_call_service'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_PUBLISH_TOPIC): valid_publish_topic,
         vol.Optional(CONF_SUBSCRIBE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_PUBLISH_EVENTSTREAM_RECEIVED, default=False):
+            cv.boolean,
+        vol.Optional(CONF_IGNORE_EVENT_CALL_SERVICE, default=False):
             cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
@@ -44,6 +47,7 @@ def async_setup(hass, config):
     conf = config.get(DOMAIN, {})
     pub_topic = conf.get(CONF_PUBLISH_TOPIC)
     sub_topic = conf.get(CONF_SUBSCRIBE_TOPIC)
+    ignore_call_service = conf.get(CONF_IGNORE_EVENT_CALL_SERVICE)
 
     @callback
     def _event_publisher(event):
@@ -99,6 +103,9 @@ def async_setup(hass, config):
 
                 if state:
                     event_data[key] = state
+        
+        if ignore_call_service and event_type == EVENT_CALL_SERVICE:
+            return
 
         hass.bus.async_fire(
             event_type,

--- a/homeassistant/components/mqtt_eventstream.py
+++ b/homeassistant/components/mqtt_eventstream.py
@@ -53,7 +53,7 @@ def async_setup(hass, config):
     pub_topic = conf.get(CONF_PUBLISH_TOPIC)
     sub_topic = conf.get(CONF_SUBSCRIBE_TOPIC)
     ignore_event = conf.get(CONF_IGNORE_EVENT)
-    print(ignore_event)
+
     @callback
     def _event_publisher(event):
         """Handle events by publishing them on the MQTT queue."""

--- a/homeassistant/components/mqtt_eventstream.py
+++ b/homeassistant/components/mqtt_eventstream.py
@@ -39,8 +39,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_SUBSCRIBE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_PUBLISH_EVENTSTREAM_RECEIVED, default=False):
             cv.boolean,
-        vol.Optional(CONF_IGNORE_EVENT, default=[]):
-            vol.All(cv.ensure_list, [vol.In(EVENT_TYPES)])
+        vol.Optional(CONF_IGNORE_EVENT, default=[]): cv.ensure_list
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/tests/components/test_mqtt_eventstream.py
+++ b/tests/components/test_mqtt_eventstream.py
@@ -30,7 +30,8 @@ class TestMqttEventStream(object):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def add_eventstream(self, sub_topic=None, pub_topic=None, ignore_event=None):
+    def add_eventstream(self, sub_topic=None, pub_topic=None,
+                        ignore_event=None):
         """Add a mqtt_eventstream component."""
         config = {}
         if sub_topic:

--- a/tests/components/test_mqtt_eventstream.py
+++ b/tests/components/test_mqtt_eventstream.py
@@ -30,13 +30,15 @@ class TestMqttEventStream(object):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def add_eventstream(self, sub_topic=None, pub_topic=None):
+    def add_eventstream(self, sub_topic=None, pub_topic=None, ignore_event=None):
         """Add a mqtt_eventstream component."""
         config = {}
         if sub_topic:
             config['subscribe_topic'] = sub_topic
         if pub_topic:
             config['publish_topic'] = pub_topic
+        if ignore_event:
+            config['ignore_event'] = ignore_event
         return setup_component(self.hass, eventstream.DOMAIN, {
             eventstream.DOMAIN: config})
 
@@ -144,3 +146,59 @@ class TestMqttEventStream(object):
         self.hass.block_till_done()
 
         assert 1 == len(calls)
+
+    @patch('homeassistant.components.mqtt.async_publish')
+    def test_ignored_event_doesnt_send_over_stream(self, mock_pub):
+        """"Test the ignoring of sending events if defined."""
+
+        assert self.add_eventstream(pub_topic='bar',
+                                    ignore_event=['state_changed'])
+        self.hass.block_till_done()
+
+        e_id = 'entity.test_id'
+        event = {}
+        event['event_type'] = EVENT_STATE_CHANGED
+        new_state = {
+            "state": "on",
+            "entity_id": e_id,
+            "attributes": {},
+        }
+        event['event_data'] = {"new_state": new_state, "entity_id": e_id}
+
+        # Reset the mock because it will have already gotten calls for the
+        # mqtt_eventstream state change on initialization, etc.
+        mock_pub.reset_mock()
+
+        # Set a state of an entity
+        mock_state_change_event(self.hass, State(e_id, 'on'))
+        self.hass.block_till_done()
+
+        assert not mock_pub.called
+
+    @patch('homeassistant.components.mqtt.async_publish')
+    def test_wrong_ignored_event_sends_over_stream(self, mock_pub):
+        """"Test the ignoring of sending events if defined."""
+
+        assert self.add_eventstream(pub_topic='bar',
+                                    ignore_event=['statee_changed'])
+        self.hass.block_till_done()
+
+        e_id = 'entity.test_id'
+        event = {}
+        event['event_type'] = EVENT_STATE_CHANGED
+        new_state = {
+            "state": "on",
+            "entity_id": e_id,
+            "attributes": {},
+        }
+        event['event_data'] = {"new_state": new_state, "entity_id": e_id}
+
+        # Reset the mock because it will have already gotten calls for the
+        # mqtt_eventstream state change on initialization, etc.
+        mock_pub.reset_mock()
+
+        # Set a state of an entity
+        mock_state_change_event(self.hass, State(e_id, 'on'))
+        self.hass.block_till_done()
+
+        assert mock_pub.called

--- a/tests/components/test_mqtt_eventstream.py
+++ b/tests/components/test_mqtt_eventstream.py
@@ -151,7 +151,6 @@ class TestMqttEventStream(object):
     @patch('homeassistant.components.mqtt.async_publish')
     def test_ignored_event_doesnt_send_over_stream(self, mock_pub):
         """"Test the ignoring of sending events if defined."""
-
         assert self.add_eventstream(pub_topic='bar',
                                     ignore_event=['state_changed'])
         self.hass.block_till_done()
@@ -179,7 +178,6 @@ class TestMqttEventStream(object):
     @patch('homeassistant.components.mqtt.async_publish')
     def test_wrong_ignored_event_sends_over_stream(self, mock_pub):
         """"Test the ignoring of sending events if defined."""
-
         assert self.add_eventstream(pub_topic='bar',
                                     ignore_event=['statee_changed'])
         self.hass.block_till_done()


### PR DESCRIPTION
## Description:

This allows a setting a configuration value (False by default to continue the current behavior) which will ignore call service events.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4705

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt_eventstream:
  publish_topic: slaves/theoffice
  subscribe_topic: master/topic
  ignore_call_service: True
```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
