### PR TITLE
Clarify a comment regarding the versions of Python

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,5 +13,5 @@ astral==1.5
 certifi>=2017.4.17
 attrs==17.4.0
 
-# Breaks Python 3.6 and is not needed for our supported Pythons
+# Breaks Python 3.6 and is not needed for our supported Python versions
 enum34==1000000000.0.0


### PR DESCRIPTION
Description:
Use "Python versions" in place of "Pythons" in a comment

