### PR TITLE
Clarify cloud error

### DIFF
--- a/homeassistant/components/cloud/auth_api.py
+++ b/homeassistant/components/cloud/auth_api.py
@@ -1,7 +1,4 @@
 """Package to communicate with the authentication API."""
-import logging
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class CloudError(Exception):

--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -90,9 +90,7 @@ class CloudIoT:
             while not client.closed:
                 msg = yield from client.receive()
 
-                if msg.type in (WSMsgType.ERROR, WSMsgType.CLOSED,
-                                WSMsgType.CLOSING):
-                    disconnect_warn = 'Connection cancelled.'
+                if msg.type in (WSMsgType.CLOSED, WSMsgType.CLOSING):
                     break
 
                 elif msg.type != WSMsgType.TEXT:
@@ -131,8 +129,8 @@ class CloudIoT:
                 _LOGGER.debug("Publishing message: %s", response)
                 yield from client.send_json(response)
 
-        except auth_api.CloudError:
-            _LOGGER.warning("Unable to connect: Unable to refresh token.")
+        except auth_api.CloudError as err:
+            _LOGGER.warning("Unable to connect: %s", err)
 
         except client_exceptions.WSServerHandshakeError as err:
             if err.code == 401:

--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -148,7 +148,9 @@ class CloudIoT:
                 _LOGGER.exception("Unexpected error")
 
         finally:
-            if disconnect_warn is not None:
+            if disconnect_warn is None:
+                _LOGGER.info("Connection closed")
+            else:
                 _LOGGER.warning("Connection closed: %s", disconnect_warn)
 
             if remove_hass_stop_listener is not None:

--- a/tests/components/cloud/test_iot.py
+++ b/tests/components/cloud/test_iot.py
@@ -162,7 +162,7 @@ def test_cloud_getting_disconnected_by_server(mock_client, caplog, mock_cloud):
 
     yield from conn.connect()
 
-    assert 'Connection closed: Connection cancelled.' in caplog.text
+    assert 'Connection closed' in caplog.text
     assert 'connect' in str(mock_cloud.hass.async_add_job.mock_calls[-1][1][0])
 
 
@@ -197,13 +197,13 @@ def test_cloud_sending_invalid_json(mock_client, caplog, mock_cloud):
 
 @asyncio.coroutine
 def test_cloud_check_token_raising(mock_client, caplog, mock_cloud):
-    """Test cloud sending invalid JSON."""
+    """Test cloud unable to check token."""
     conn = iot.CloudIoT(mock_cloud)
-    mock_client.receive.side_effect = auth_api.CloudError
+    mock_client.receive.side_effect = auth_api.CloudError("BLA")
 
     yield from conn.connect()
 
-    assert 'Unable to connect: Unable to refresh token.' in caplog.text
+    assert 'Unable to connect: BLA' in caplog.text
     assert 'connect' in str(mock_cloud.hass.async_add_job.mock_calls[-1][1][0])
 
 


### PR DESCRIPTION
## Description:
The cloud error "Unable to refresh token" was confusing people. Also, by not printing the error it was also confusing me to what is actually going wrong (it is usually solved by the auto retry logic)

