### PR TITLE
Adding Roku hub and remote

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -190,6 +190,9 @@ omit =
     homeassistant/components/rfxtrx.py
     homeassistant/components/*/rfxtrx.py
 
+    homeassistant/components/roku.py
+    homeassistant/components/*/roku.py
+
     homeassistant/components/rpi_gpio.py
     homeassistant/components/*/rpi_gpio.py
 
@@ -451,7 +454,6 @@ omit =
     homeassistant/components/media_player/philips_js.py
     homeassistant/components/media_player/pioneer.py
     homeassistant/components/media_player/plex.py
-    homeassistant/components/media_player/roku.py
     homeassistant/components/media_player/russound_rio.py
     homeassistant/components/media_player/russound_rnet.py
     homeassistant/components/media_player/snapcast.py

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -39,6 +39,7 @@ SERVICE_TELLDUSLIVE = 'tellstick'
 SERVICE_HUE = 'philips_hue'
 SERVICE_DECONZ = 'deconz'
 SERVICE_DAIKIN = 'daikin'
+SERVICE_ROKU = 'roku'
 
 SERVICE_HANDLERS = {
     SERVICE_HASS_IOS_APP: ('ios', None),
@@ -48,6 +49,7 @@ SERVICE_HANDLERS = {
     SERVICE_HASSIO: ('hassio', None),
     SERVICE_AXIS: ('axis', None),
     SERVICE_APPLE_TV: ('apple_tv', None),
+    SERVICE_ROKU: ('roku', None),
     SERVICE_WINK: ('wink', None),
     SERVICE_XIAOMI_GW: ('xiaomi_aqara', None),
     SERVICE_TELLDUSLIVE: ('tellduslive', None),
@@ -57,7 +59,6 @@ SERVICE_HANDLERS = {
     'google_cast': ('media_player', 'cast'),
     'panasonic_viera': ('media_player', 'panasonic_viera'),
     'plex_mediaserver': ('media_player', 'plex'),
-    'roku': ('media_player', 'roku'),
     'sonos': ('media_player', 'sonos'),
     'yamaha': ('media_player', 'yamaha'),
     'logitech_mediaserver': ('media_player', 'squeezebox'),

--- a/homeassistant/components/remote/roku.py
+++ b/homeassistant/components/remote/roku.py
@@ -1,0 +1,66 @@
+"""
+Support for the Roku remote.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/remote.roku/
+"""
+
+from homeassistant.components import remote
+from homeassistant.const import (
+    CONF_NAME, CONF_HOST)
+
+DEPENDENCIES = ['roku']
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Roku remote platform."""
+    if not discovery_info:
+        return
+
+    name = discovery_info[CONF_NAME]
+    host = discovery_info[CONF_HOST]
+    add_devices([RokuRemote(host, name)])
+
+
+class RokuRemote(remote.RemoteDevice):
+    """Representation of a Roku remote on the network."""
+
+    def __init__(self, host, name):
+        """Initialize the Roku device."""
+        from roku import Roku
+
+        self._roku = Roku(host)
+        self._name = name
+        self._unique_id = self._roku.device_info.sernum
+
+    @property
+    def should_poll(self):
+        """Device should not be polled."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return an unique ID."""
+        return self._unique_id
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return True
+
+    def send_command(self, command, **kwargs):
+        """Send a command to one device."""
+        # Send commands in specified order but schedule only one coroutine
+        def _send_commands():
+            for single_command in command:
+                if not hasattr(self._roku, single_command):
+                    continue
+
+                getattr(self._roku, single_command)()
+
+        _send_commands()

--- a/homeassistant/components/roku.py
+++ b/homeassistant/components/roku.py
@@ -1,0 +1,135 @@
+"""
+Support for roku platform.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/roku/
+"""
+import logging
+
+import voluptuous as vol
+
+from typing import Sequence, TypeVar, Union
+from homeassistant.components.discovery import SERVICE_ROKU
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['python-roku==3.1.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'roku'
+
+SERVICE_SCAN = 'roku_scan'
+
+ATTR_ROKU = 'roku'
+
+DATA_ROKU = 'data_roku'
+DATA_ENTITIES = 'data_roku_entities'
+
+DEFAULT_NAME = 'Roku'
+
+NOTIFICATION_ID = 'roku_notification'
+NOTIFICATION_TITLE = 'Roku Setup'
+NOTIFICATION_SCAN_ID = 'roku_scan_notification'
+NOTIFICATION_SCAN_TITLE = 'Roku Scan'
+
+T = TypeVar('T')
+
+
+# This version of ensure_list interprets an empty dict as no value
+def ensure_list(value: Union[T, Sequence[T]]) -> Sequence[T]:
+    """Wrap value in list if it is not one."""
+    if value is None or (isinstance(value, dict) and not value):
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.All(ensure_list, [vol.Schema({
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    })])
+}, extra=vol.ALLOW_EXTRA)
+
+# Currently no attributes but it might change later
+ROKU_SCAN_SCHEMA = vol.Schema({})
+
+
+def scan_for_rokus(hass):
+    """Scan for devices and present a notification of the ones found."""
+    from roku import Roku, RokuException
+
+    rokus = Roku.discover()
+
+    devices = []
+    for roku in rokus:
+        try:
+            r_info = roku.device_info
+        except RokuException:  # skip non-roku device
+            continue
+        devices.append('Name: {0}<br />Host: {1}<br />'.format(
+            r_info.userdevicename if r_info.userdevicename
+            else "{} {}".format(r_info.modelname, r_info.sernum),
+            roku.host))
+
+    if not devices:
+        devices = ['No device(s) found']
+
+    hass.components.persistent_notification.create(
+        'The following devices were found:<br /><br />' +
+        '<br /><br />'.join(devices),
+        title=NOTIFICATION_SCAN_TITLE,
+        notification_id=NOTIFICATION_SCAN_ID)
+
+
+def setup(hass, config):
+    """Set up the Roku component."""
+    if DATA_ROKU not in hass.data:
+        hass.data[DATA_ROKU] = {}
+
+    def service_handler(service):
+        """Handle service calls."""
+        if service.service == SERVICE_SCAN:
+            hass.add_job(scan_for_rokus, hass)
+            return
+
+    def roku_discovered(service, info):
+        """Set up an Roku that was auto discovered."""
+        _setup_roku(hass, {
+            CONF_NAME: info['name'],
+            CONF_HOST: info['host'],
+        })
+
+    discovery.listen(hass, SERVICE_ROKU, roku_discovered)
+
+    for conf in config.get(DOMAIN, []):
+        _setup_roku(hass, conf)
+
+    hass.services.register(
+        DOMAIN, SERVICE_SCAN, service_handler,
+        schema=ROKU_SCAN_SCHEMA)
+
+    return True
+
+
+def _setup_roku(hass, roku_config):
+    """Set up a Roku."""
+    from roku import Roku
+    host = roku_config.get(CONF_HOST)
+
+    if host in hass.data[DATA_ROKU]:
+        return
+
+    roku = Roku(host)
+    r_info = roku.device_info
+
+    hass.data[DATA_ROKU][host] = {
+        ATTR_ROKU: r_info.sernum
+    }
+
+    discovery.load_platform(
+        hass, 'media_player', DOMAIN, roku_config)
+
+    discovery.load_platform(
+        hass, 'remote', DOMAIN, roku_config)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -940,6 +940,7 @@ python-pushover==0.3
 # homeassistant.components.sensor.ripple
 python-ripple-api==0.0.3
 
+# homeassistant.components.roku
 # homeassistant.components.media_player.roku
 python-roku==3.1.5
 


### PR DESCRIPTION
## Description:
Modifying Roku to include a remote.  Due to use of a new autodiscovery mechanism, prior autodiscovered Roku mediaplayers names will change.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4713

## Example entry for `configuration.yaml` (if applicable):
```yaml
roku:
    host: 192.168.1.100
    name: Roku
```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
