### PR TITLE
KWB Easyfire component stability fixes

### DIFF
--- a/homeassistant/components/sensor/kwb.py
+++ b/homeassistant/components/sensor/kwb.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pykwb==0.0.8']
+REQUIREMENTS = ['pykwb==0.0.10']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,3 +111,8 @@ class KWBSensor(Entity):
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._sensor.unit_of_measurement
+
+    def update(self):
+        """Check and restart pykwb."""
+        if (not self._easyfire.is_alive()):
+            self._easyfire.run_thread()

--- a/homeassistant/components/sensor/kwb.py
+++ b/homeassistant/components/sensor/kwb.py
@@ -114,5 +114,5 @@ class KWBSensor(Entity):
 
     def update(self):
         """Check and restart pykwb."""
-        if (not self._easyfire.is_alive()):
+        if not self._easyfire.is_alive():
             self._easyfire.run_thread()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -763,7 +763,7 @@ pyitachip2ir==0.0.7
 pykira==0.1.1
 
 # homeassistant.components.sensor.kwb
-pykwb==0.0.8
+pykwb==0.0.10
 
 # homeassistant.components.sensor.lacrosse
 pylacrosse==0.3.1


### PR DESCRIPTION
## Description:

This is a fix of an issue where the pykwb thread would stop running if network connectivity is flaky or something similar. The PR addresses this by checking on update() if the thread is running and restarting it if necessary.

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
