### PR TITLE
Fix numeric_state condition spamming on unavailable state

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID, CONF_VALUE_TEMPLATE, CONF_CONDITION,
     WEEKDAYS, CONF_STATE, CONF_ZONE, CONF_BEFORE,
     CONF_AFTER, CONF_WEEKDAY, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET,
-    CONF_BELOW, CONF_ABOVE)
+    CONF_BELOW, CONF_ABOVE, STATE_UNAVAILABLE, STATE_UNKNOWN)
 from homeassistant.exceptions import TemplateError, HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.sun import get_astral_event_date
@@ -159,6 +159,9 @@ def async_numeric_state(hass: HomeAssistant, entity, below=None, above=None,
         except TemplateError as ex:
             _LOGGER.error("Template error: %s", ex)
             return False
+
+    if value in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+        return False
 
     try:
         value = float(value)

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -146,3 +146,21 @@ class TestConditionHelper:
                    return_value=dt.now().replace(hour=21)):
             assert not condition.time(after=sixam, before=sixpm)
             assert condition.time(after=sixpm, before=sixam)
+
+    def test_if_numeric_state_not_raise_on_unavailable(self):
+        """Test numeric_state doesn't raise on unavailable/unknown state."""
+        test = condition.from_config({
+            'condition': 'numeric_state',
+            'entity_id': 'sensor.temperature',
+            'below': 42
+        })
+
+        with patch('homeassistant.helpers.condition._LOGGER.warning') \
+                as logwarn:
+            self.hass.states.set('sensor.temperature', 'unavailable')
+            assert not test(self.hass)
+            assert len(logwarn.mock_calls) == 0
+
+            self.hass.states.set('sensor.temperature', 'unknown')
+            assert not test(self.hass)
+            assert len(logwarn.mock_calls) == 0


### PR DESCRIPTION
## Description:

When a sensor reports an `unknown` or `unavailable` state, `numeric_state` conditions based off of this sensor will spam the logs:

<img width="842" alt="screen shot 2018-02-20 at 13 21 09" src="https://user-images.githubusercontent.com/6833237/36423637-09cb0ea4-1641-11e8-8f87-0c5ab3d5e9e5.png">

Note this doesn't change actually any behavior, it simply doesn't spam the log on these two specific values.

## Example entry for `configuration.yaml` (if applicable):
```yaml
condition: numeric_state
entity_id: sensor.temperature
below: 42
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
