### PR TITLE
Bugfix: Input Datatime config schema

### DIFF
--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -43,8 +43,8 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         cv.slug: vol.All({
             vol.Optional(CONF_NAME): cv.string,
-            vol.Required(CONF_HAS_DATE): cv.boolean,
-            vol.Required(CONF_HAS_TIME): cv.boolean,
+            vol.Optional(CONF_HAS_DATE): cv.boolean,
+            vol.Optional(CONF_HAS_TIME): cv.boolean,
             vol.Optional(CONF_ICON): cv.icon,
             vol.Optional(CONF_INITIAL): cv.string,
         }, cv.has_at_least_one_key_value((CONF_HAS_DATE, True),

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -43,8 +43,8 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         cv.slug: vol.All({
             vol.Optional(CONF_NAME): cv.string,
-            vol.Optional(CONF_HAS_DATE): cv.boolean,
-            vol.Optional(CONF_HAS_TIME): cv.boolean,
+            vol.Optional(CONF_HAS_DATE, default=False): cv.boolean,
+            vol.Optional(CONF_HAS_TIME, default=False): cv.boolean,
             vol.Optional(CONF_ICON): cv.icon,
             vol.Optional(CONF_INITIAL): cv.string,
         }, cv.has_at_least_one_key_value((CONF_HAS_DATE, True),


### PR DESCRIPTION
## Description:
`Has_at_least_one_key_value` only works if parameter are optional


## Example entry for `configuration.yaml` (if applicable):
```yaml
input_datetime:
  both_date_and_time:
    name: Input with both date and time
    has_date: true
    has_time: true
  only_date:
    name: Input with only date
    has_date: true
  only_time:
    name: Input with only time
    has_time: true
```

## Checklist:
  - [x] The code change is tested and works locally.
