### PR TITLE
Added support for milight single 1CH dimmer (limitlessLED)

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -19,7 +19,7 @@ from homeassistant.components.light import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import async_get_last_state
 
-REQUIREMENTS = ['limitlessled==1.0.8']
+REQUIREMENTS = ['limitlessled==1.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ DEFAULT_TRANSITION = 0
 DEFAULT_VERSION = 6
 DEFAULT_FADE = False
 
-LED_TYPE = ['rgbw', 'rgbww', 'white', 'bridge-led']
+LED_TYPE = ['rgbw', 'rgbww', 'white', 'bridge-led', 'dimmer']
 
 RGB_BOUNDARY = 40
 
@@ -43,6 +43,7 @@ WHITE = [255, 255, 255]
 
 SUPPORT_LIMITLESSLED_WHITE = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP |
                               SUPPORT_TRANSITION)
+SUPPORT_LIMITLESSLED_DIMMER = (SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION)
 SUPPORT_LIMITLESSLED_RGB = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
                             SUPPORT_FLASH | SUPPORT_RGB_COLOR |
                             SUPPORT_TRANSITION)
@@ -161,9 +162,12 @@ class LimitlessLEDGroup(Light):
         """Initialize a group."""
         from limitlessled.group.rgbw import RgbwGroup
         from limitlessled.group.white import WhiteGroup
+        from limitlessled.group.dimmer import DimmerGroup
         from limitlessled.group.rgbww import RgbwwGroup
         if isinstance(group, WhiteGroup):
             self._supported = SUPPORT_LIMITLESSLED_WHITE
+        elif isinstance(group, DimmerGroup):
+            self._supported = SUPPORT_LIMITLESSLED_DIMMER
         elif isinstance(group, RgbwGroup):
             self._supported = SUPPORT_LIMITLESSLED_RGB
         elif isinstance(group, RgbwwGroup):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -451,7 +451,7 @@ liffylights==0.9.4
 lightify==1.0.6.1
 
 # homeassistant.components.light.limitlessled
-limitlessled==1.0.8
+limitlessled==1.1.0
 
 # homeassistant.components.linode
 linode-api==4.1.4b2


### PR DESCRIPTION

## Description:
Add support for a 1CH (MiLight) LED dimmer see happyleavesaoc/python-limitlessled#27 and happyleavesaoc/python-limitlessled#33


**Related issue (if applicable):** fixes #8521, fixes #11073, fixes #11121
I think this should fix this issue mentioned in the forum: https://community.home-assistant.io/t/milight-wifi-controller-ibox-2-with-led-stripe/28945

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4718

## Example entry for `configuration.yaml` (if applicable):
```yaml
    bridges:
      - host: 192.168.0.42
        groups:
        - number: 1
          name: Kitchen
          type: dimmer
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] ~~New files were added to `.coveragerc`.~~

If the code does not interact with devices:
  - [ ] ~~Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**~~
  - [ ] ~~Tests have been added to verify that the new code works.~~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
