### PR TITLE
Logbook speedup

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -170,6 +170,8 @@ def humanify(events):
     - if 2+ sensor updates in GROUP_BY_MINUTES, show last
     - if home assistant stop and start happen in same minute call it restarted
     """
+    domain_prefixes = tuple('{}.'.format(dom) for dom in CONTINUOUS_DOMAINS)
+
     # Group events in batches of GROUP_BY_MINUTES
     for _, g_events in groupby(
             events,
@@ -189,8 +191,7 @@ def humanify(events):
             if event.event_type == EVENT_STATE_CHANGED:
                 entity_id = event.data.get('entity_id')
 
-                if entity_id.startswith(tuple('{}.'.format(
-                        domain) for domain in CONTINUOUS_DOMAINS)):
+                if entity_id.startswith(domain_prefixes):
                     last_sensor_event[entity_id] = event
 
             elif event.event_type == EVENT_HOMEASSISTANT_STOP:

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -372,7 +372,8 @@ class TestComponentLogbook(unittest.TestCase):
         eventB = self.create_state_changed_event(pointA, entity_id2, 20,
                                                  {'auto': True})
 
-        entries = list(logbook.humanify((eventA, eventB)))
+        events = logbook._exclude_events((eventA, eventB), {})
+        entries = list(logbook.humanify(events))
 
         self.assertEqual(1, len(entries))
         self.assert_entry(entries[0], pointA, 'bla', domain='switch',
@@ -389,7 +390,8 @@ class TestComponentLogbook(unittest.TestCase):
         eventB = self.create_state_changed_event(
             pointA, entity_id2, 20, last_changed=pointA, last_updated=pointB)
 
-        entries = list(logbook.humanify((eventA, eventB)))
+        events = logbook._exclude_events((eventA, eventB), {})
+        entries = list(logbook.humanify(events))
 
         self.assertEqual(1, len(entries))
         self.assert_entry(entries[0], pointA, 'bla', domain='switch',


### PR DESCRIPTION
## Description:

The logbook often turns event data into a `State` object twice before dropping an event.

This PR optimizes that down to zero `State` constructions for discarded events:
* Some filters are moved earlier, before the final `State` construction
* All filters are rewritten to work directly on event data, removing the first `State` construction completely

This gives me a solid 45% reduction on logbook loading so I wanted to get it out for comments even if I have not tested it much yet.

Credits to @OverloadUT for pointing me in this direction.

<s>**Related issue (if applicable):** fixes #<home-assistant issue number goes here></s>

## Checklist:
  - [X] The code change is tested and works locally.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [X] Tests have been added to verify that the new code works.
