### PR TITLE
Fix config 404

### DIFF
--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -159,7 +159,7 @@ class EditKeyBasedConfigView(BaseEditConfigView):
 
     def _get_value(self, hass, data, config_key):
         """Get value."""
-        return data.get(config_key, {})
+        return data.get(config_key)
 
     def _write_value(self, hass, data, config_key, new_value):
         """Set value."""


### PR DESCRIPTION
## Description:
Return a 404 when fetching a key from a config that doesn't exist.

Related to https://github.com/home-assistant/home-assistant-polymer/pull/908