### PR TITLE
Set event_id foreign key in recorded states

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -319,6 +319,7 @@ class Recorder(threading.Thread):
                     with session_scope(session=self.get_session()) as session:
                         dbevent = Events.from_event(event)
                         session.add(dbevent)
+                        session.flush()
 
                         if event.event_type == EVENT_STATE_CHANGED:
                             dbstate = States.from_event(event)

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -42,6 +42,7 @@ class TestRecorder(unittest.TestCase):
         with session_scope(hass=self.hass) as session:
             db_states = list(session.query(States))
             assert len(db_states) == 1
+            assert db_states[0].event_id > 0
             state = db_states[0].to_native()
 
         assert state == self.hass.states.get(entity_id)


### PR DESCRIPTION
## Description:

It turns out that the recorder tables Events and States are not connected because the foreign key is NULL. We actually do transfer the ID but the Events SQL record has not been created at that time so the object is still missing its ID.

Flushing the session fixes this, at least with SQLite.

**Related issue (if applicable):** fixes #12573

## Checklist:
  - [X] The code change is tested and works locally.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [X] Tests have been added to verify that the new code works.
