### PR TITLE
Fix sonos default errorcodes

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -271,7 +271,7 @@ def soco_error(errorcodes=None):
             try:
                 return funct(*args, **kwargs)
             except SoCoUPnPException as err:
-                if err.error_code in errorcodes:
+                if errorcodes and err.error_code in errorcodes:
                     pass
                 else:
                     _LOGGER.error("Error on %s with %s", funct.__name__, err)


### PR DESCRIPTION
## Description:

This avoids a `NoneType` exception when no errors are flagged to be ignored.

## Checklist:
  - [X] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable.</s>
  - [ ] <s>New dependencies are only imported inside functions that use them.</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>
