### PR TITLE
Make nest thermostat fan optional

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -55,7 +55,8 @@ class NestThermostat(ClimateDevice):
         self._fan_list = [STATE_ON, STATE_AUTO]
 
         # Set the default supported features
-        self._support_flags = flags = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_AWAY_MODE)
+        self._support_flags = (SUPPORT_TARGET_TEMPERATURE |
+                               SUPPORT_OPERATION_MODE | SUPPORT_AWAY_MODE)
 
         # Not all nest devices support cooling and heating remove unused
         self._operation_list = [STATE_OFF]
@@ -69,7 +70,8 @@ class NestThermostat(ClimateDevice):
 
         if self.device.can_heat and self.device.can_cool:
             self._operation_list.append(STATE_AUTO)
-            self._support_flags = (self._support_flags | SUPPORT_TARGET_TEMPERATURE_HIGH |
+            self._support_flags = (self._support_flags |
+                                   SUPPORT_TARGET_TEMPERATURE_HIGH |
                                    SUPPORT_TARGET_TEMPERATURE_LOW)
 
         self._operation_list.append(STATE_ECO)

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -29,9 +29,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 NEST_MODE_HEAT_COOL = 'heat-cool'
 
-SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_HIGH |
-                 SUPPORT_TARGET_TEMPERATURE_LOW | SUPPORT_OPERATION_MODE |
-                 SUPPORT_AWAY_MODE | SUPPORT_FAN_MODE)
+# SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_HIGH |
+#                  SUPPORT_TARGET_TEMPERATURE_LOW | SUPPORT_OPERATION_MODE |
+#                  SUPPORT_AWAY_MODE | SUPPORT_FAN_MODE)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -94,8 +94,13 @@ class NestThermostat(ClimateDevice):
 
     @property
     def supported_features(self):
+        flags = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_HIGH |
+                 SUPPORT_TARGET_TEMPERATURE_LOW | SUPPORT_OPERATION_MODE | SUPPORT_AWAY_MODE)
+        # If the device has a fan, add the fan as feature
+        if self._has_fan:
+            flags = (flags | SUPPORT_FAN_MODE)
         """Return the list of supported features."""
-        return SUPPORT_FLAGS
+        return flags
 
     @property
     def unique_id(self):
@@ -205,11 +210,14 @@ class NestThermostat(ClimateDevice):
     @property
     def fan_list(self):
         """List of available fan modes."""
-        return self._fan_list
+        if self._has_fan:
+            return self._fan_list
+        return None
 
     def set_fan_mode(self, fan):
         """Turn fan on/off."""
-        self.device.fan = fan.lower()
+        if self._has_fan:
+            self.device.fan = fan.lower()
 
     @property
     def min_temp(self):

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -98,6 +98,7 @@ class NestThermostat(ClimateDevice):
                  SUPPORT_TARGET_TEMPERATURE_LOW | SUPPORT_OPERATION_MODE | SUPPORT_AWAY_MODE)
         # If the device has a fan, add the fan as feature
         if self._has_fan:
+            _LOGGER.info("NEST HAS A FAN!!")
             flags = (flags | SUPPORT_FAN_MODE)
         """Return the list of supported features."""
         return flags


### PR DESCRIPTION
## Description:
Only adds the fan feature to the nest thermostat when the device actually has a fan. This fixes issues with homebridge-homeassistant failing to work when there is no fan. Similarly, the high and low temperature features are only supported when the thermostat can both heat and cool.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
