### PR TITLE
Update pychromecast to 2.0.0

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['pychromecast==1.0.3']
+REQUIREMENTS = ['pychromecast==2.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -678,7 +678,7 @@ pybbox==0.0.5-alpha
 # pybluez==0.22
 
 # homeassistant.components.media_player.cast
-pychromecast==1.0.3
+pychromecast==2.0.0
 
 # homeassistant.components.media_player.cmus
 pycmus==0.1.0


### PR DESCRIPTION
## Description:
Update PyChromecast to 2.0.0

Especially big thanks to @OttoWinter for fixing the cast group issue 🎉 

- Drop Python 2 support (balloob/pychromecast#211 - @balloob) (Breaking change!)
- Fixes for discovery, FreeBSD Socket creation (balloob/pychromecast#215 - @d8ahazard)
- FIx grouped Chromecasts and channel close (balloob/pychromecast#216 - @OttoWinter)
- Fix SSL issues on Windows (balloob/pychromecast#212 - @d8ahazard)
- Don't sleep when there are no tries remaining (balloob/pychromecast#204 - @erik)


**Related issue (if applicable):** fixes #12502 #11945 #11905 

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  platform: cast
```

## Checklist:
  - [x] The code change is tested and works locally.
