### PR TITLE
Update to latest python-nest

### DIFF
--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_STRUCTURE, CONF_FILENAME, CONF_BINARY_SENSORS, CONF_SENSORS,
     CONF_MONITORED_CONDITIONS)
 
-REQUIREMENTS = ['python-nest==3.1.0']
+REQUIREMENTS = ['python-nest==3.7.0']
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -952,7 +952,7 @@ python-mpd2==0.5.5
 python-mystrom==0.3.8
 
 # homeassistant.components.nest
-python-nest==3.1.0
+python-nest==3.7.0
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1


### PR DESCRIPTION
Due to an upstream bug some devices will be assigned a where_id that is not
visible in the nest API. As a result we can't get a friendly name for the
where_id.

A workaround has been released for python-nest in version 3.7.0. Update the
home assistant requirements to python-nest==3.7.0 to work around this issue.

References:
https://nestdevelopers.io/t/missing-where-name-from-some-devices/1202
https://github.com/jkoelker/python-nest/issues/127
https://github.com/jkoelker/python-nest/pull/128

Fixes #12589
Fixes #13074

Also this might be a fix for #12950 as well but I have not yet confirmed that as we are awaiting more data from the reporter of the issue.

## Description:


**Related issue (if applicable):** fixes #12589 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54