### PR TITLE
Added config validator for future group platforms

### DIFF
--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -43,7 +43,7 @@ DEFAULT_TIMEOUT = 10
 DEFAULT_CONFIDENCE = 80
 
 SOURCE_SCHEMA = vol.Schema({
-    vol.Required(CONF_ENTITY_ID): cv.entity_id,
+    vol.Required(CONF_ENTITY_ID): cv.entity_domain('camera'),
     vol.Optional(CONF_NAME): cv.string,
 })
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -150,7 +150,7 @@ def entity_ids(value: Union[str, Sequence]) -> Sequence[str]:
 def entities_domain(domain: str):
     """Validate that entities belong to domain."""
     def validate(values: Union[str, Sequence]) -> Sequence[str]:
-        """Test if entitiy domain is domain."""
+        """Test if entity domain is domain."""
         values = entity_ids(values)
         for ent_id in values:
             if split_entity_id(ent_id)[0] != domain:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -147,6 +147,15 @@ def entity_ids(value: Union[str, Sequence]) -> Sequence[str]:
     return [entity_id(ent_id) for ent_id in value]
 
 
+def entity_domain(domain: str):
+    """Validate that entity belong to domain."""
+    def validate(value: Any) -> str:
+        """Test if entity domain is domain."""
+        ent_domain = entities_domain(domain)
+        return ent_domain(value)[0]
+    return validate
+
+
 def entities_domain(domain: str):
     """Validate that entities belong to domain."""
     def validate(values: Union[str, Sequence]) -> Sequence[str]:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_ALIAS, CONF_ENTITY_ID, CONF_VALUE_TEMPLATE, WEEKDAYS,
     CONF_CONDITION, CONF_BELOW, CONF_ABOVE, CONF_TIMEOUT, SUN_EVENT_SUNSET,
     SUN_EVENT_SUNRISE, CONF_UNIT_SYSTEM_IMPERIAL, CONF_UNIT_SYSTEM_METRIC)
-from homeassistant.core import valid_entity_id
+from homeassistant.core import valid_entity_id, split_entity_id
 from homeassistant.exceptions import TemplateError
 import homeassistant.util.dt as dt_util
 from homeassistant.util import slugify as util_slugify
@@ -145,6 +145,31 @@ def entity_ids(value: Union[str, Sequence]) -> Sequence[str]:
         value = [ent_id.strip() for ent_id in value.split(',')]
 
     return [entity_id(ent_id) for ent_id in value]
+
+
+class EntitiesDomain():
+    """Class validator if entities belong to domain."""
+
+    def __init__(self, domain: str):
+        """Initialize validator."""
+        self.domain = domain
+
+    def __call__(self, value: Union[str, Sequence]) -> Sequence[str]:
+        """Validate user input."""
+        if value is None or value == []:
+            raise vol.Invalid("Entities can not be None")
+        if isinstance(value, str):
+            value = [ent_id for ent_id in value.split(',')]
+
+        entities = []
+        for ent_id in value:
+            ent_id = entity_id(ent_id.strip())
+            if split_entity_id(ent_id)[0] == self.domain:
+                entities.append(ent_id)
+            else:
+                raise vol.Invalid("Entity ID does not belog to domain")
+
+        return entities
 
 
 def enum(enumClass):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -147,29 +147,16 @@ def entity_ids(value: Union[str, Sequence]) -> Sequence[str]:
     return [entity_id(ent_id) for ent_id in value]
 
 
-class EntitiesDomain():
-    """Class validator if entities belong to domain."""
-
-    def __init__(self, domain: str):
-        """Initialize validator."""
-        self.domain = domain
-
-    def __call__(self, value: Union[str, Sequence]) -> Sequence[str]:
-        """Validate user input."""
-        if value is None or value == []:
-            raise vol.Invalid("Entities can not be None")
-        if isinstance(value, str):
-            value = [ent_id for ent_id in value.split(',')]
-
-        entities = []
-        for ent_id in value:
-            ent_id = entity_id(ent_id.strip())
-            if split_entity_id(ent_id)[0] == self.domain:
-                entities.append(ent_id)
-            else:
-                raise vol.Invalid("Entity ID does not belog to domain")
-
-        return entities
+def entities_domain(domain: str):
+    """Validate that entities belong to domain."""
+    def validate(values: Union[str, Sequence]) -> Sequence[str]:
+        """Test if entitiy domain is domain."""
+        values = entity_ids(values)
+        for ent_id in values:
+            if split_entity_id(ent_id)[0] != domain:
+                raise vol.Invalid("Entity ID does not belong to domain")
+        return values
+    return validate
 
 
 def enum(enumClass):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -154,7 +154,9 @@ def entities_domain(domain: str):
         values = entity_ids(values)
         for ent_id in values:
             if split_entity_id(ent_id)[0] != domain:
-                raise vol.Invalid("Entity ID does not belong to domain")
+                raise vol.Invalid(
+                    "Entity ID '{}' does not belong to domain '{}'"
+                    .format(ent_id, domain))
         return values
     return validate
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -166,18 +166,18 @@ def test_entity_ids():
 
 def test_entities_domain():
     """Test entities domain validation."""
-    schema = vol.Schema(cv.EntitiesDomain('sensor'))
+    schema = vol.Schema(cv.entities_domain('sensor'))
 
     options = (
         None,
         '',
-        [],
         'invalid_entity',
         ['sensor.light', 'cover.demo'],
         ['sensor.light', 'sensor_invalid'],
     )
 
     for value in options:
+        print(value)
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 
@@ -192,7 +192,7 @@ def test_entities_domain():
     assert schema('sensor.LIGHT, sensor.demo ') == [
         'sensor.light', 'sensor.demo'
     ]
-    assert schema(['sensor.light ', 'SENSOR.demo']) == [
+    assert schema(['sensor.light', 'SENSOR.demo']) == [
         'sensor.light', 'sensor.demo'
     ]
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -164,6 +164,23 @@ def test_entity_ids():
     ]
 
 
+def test_entity_domain():
+    """Test entity domain validation."""
+    schema = vol.Schema(cv.entity_domain('sensor'))
+
+    options = (
+        'invalid_entity',
+        'cover.demo',
+    )
+
+    for value in options:
+        with pytest.raises(vol.MultipleInvalid):
+            print(value)
+            schema(value)
+
+    assert schema('sensor.LIGHT') == 'sensor.light'
+
+
 def test_entities_domain():
     """Test entities domain validation."""
     schema = vol.Schema(cv.entities_domain('sensor'))

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -164,6 +164,39 @@ def test_entity_ids():
     ]
 
 
+def test_entities_domain():
+    """Test entities domain validation."""
+    schema = vol.Schema(cv.EntitiesDomain('sensor'))
+
+    options = (
+        None,
+        '',
+        [],
+        'invalid_entity',
+        ['sensor.light', 'cover.demo'],
+        ['sensor.light', 'sensor_invalid'],
+    )
+
+    for value in options:
+        with pytest.raises(vol.MultipleInvalid):
+            schema(value)
+
+    options = (
+        'sensor.light',
+        ['SENSOR.light'],
+        ['sensor.light', 'sensor.demo']
+    )
+    for value in options:
+        schema(value)
+
+    assert schema('sensor.LIGHT, sensor.demo ') == [
+        'sensor.light', 'sensor.demo'
+    ]
+    assert schema(['sensor.light ', 'SENSOR.demo']) == [
+        'sensor.light', 'sensor.demo'
+    ]
+
+
 def test_ensure_list_csv():
     """Test ensure_list_csv."""
     schema = vol.Schema(cv.ensure_list_csv)
@@ -453,6 +486,7 @@ def test_deprecated(caplog):
     )
 
     deprecated_schema({'venus': True})
+    # pylint: disable=len-as-condition
     assert len(caplog.records) == 0
 
     deprecated_schema({'mars': True})

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -177,7 +177,6 @@ def test_entities_domain():
     )
 
     for value in options:
-        print(value)
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 


### PR DESCRIPTION
## Description:
As response to https://github.com/home-assistant/architecture/issues/13#issuecomment-367073814 I added a first version of entities domain validation to `helpers/config_validation` so that other PR's for different group platforms can start using it.

Different group platforms currently as PR:
* home-assistant/home-assistant/pull/12229
* home-assistant/home-assistant/pull/11323
* home-assistant/home-assistant/pull/12303

**Related issue (if applicable):** https://github.com/home-assistant/architecture/issues/13


## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
