### PR TITLE
 Synology Chat as a notification platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -498,6 +498,7 @@ omit =
     homeassistant/components/notify/simplepush.py
     homeassistant/components/notify/slack.py
     homeassistant/components/notify/smtp.py
+    homeassistant/components/notify/synology_chat.py
     homeassistant/components/notify/syslog.py
     homeassistant/components/notify/telegram.py
     homeassistant/components/notify/telstra.py

--- a/homeassistant/components/notify/synology_chat.py
+++ b/homeassistant/components/notify/synology_chat.py
@@ -44,7 +44,7 @@ class SynologyChatNotificationService(BaseNotificationService):
             'text': message
         }
 
-        to_send = 'payload=' + json.dumps(data)
+        to_send = 'payload={}'.format(json.dumps(data))
 
         response = requests.post(self._resource, data=to_send, timeout=10)
 

--- a/homeassistant/components/notify/synology_chat.py
+++ b/homeassistant/components/notify/synology_chat.py
@@ -12,13 +12,12 @@ import voluptuous as vol
 
 from homeassistant.components.notify import (
     BaseNotificationService, PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_RESOURCE, CONF_NAME)
+from homeassistant.const import CONF_RESOURCE
 import homeassistant.helpers.config_validation as cv
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
-    vol.Required(CONF_NAME): cv.string,
 })
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/notify/synology_chat.py
+++ b/homeassistant/components/notify/synology_chat.py
@@ -1,0 +1,56 @@
+"""
+RESTful platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.rest/
+"""
+import logging
+import json
+
+import requests
+import voluptuous as vol
+
+from homeassistant.components.notify import (
+    ATTR_TARGET, ATTR_TITLE, ATTR_TITLE_DEFAULT, BaseNotificationService,
+    PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_RESOURCE, CONF_NAME)
+import homeassistant.helpers.config_validation as cv
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_RESOURCE): cv.url,
+    vol.Required(CONF_NAME): cv.string,
+})
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the Synology Chat notification service."""
+    resource = config.get(CONF_RESOURCE)
+
+    return SynologyChatNotificationService(
+        hass, resource)
+
+class SynologyChatNotificationService(BaseNotificationService):
+    """Implementation of a notification service for Synology Chat."""
+
+    def __init__(self, hass, resource):
+        """Initialize the service."""
+        self._resource = resource
+        self._hass = hass
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to a user."""
+        data = {
+            'text': message 
+        }
+
+        to_send = 'payload=' + json.dumps(data)
+
+        response = requests.post(self._resource, data=to_send, timeout=10)
+
+        if response.status_code not in (200, 201):
+            _LOGGER.exception(
+                "Error sending message. Response %d: %s:",
+                response.status_code, response.reason)

--- a/homeassistant/components/notify/synology_chat.py
+++ b/homeassistant/components/notify/synology_chat.py
@@ -2,7 +2,7 @@
 SynologyChat platform for notify component.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/notify.synologychat/
+https://home-assistant.io/components/notify.synology_chat/
 """
 import logging
 import json

--- a/homeassistant/components/notify/synology_chat.py
+++ b/homeassistant/components/notify/synology_chat.py
@@ -1,8 +1,8 @@
 """
-RESTful platform for notify component.
+SynologyChat platform for notify component.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/notify.rest/
+https://home-assistant.io/components/notify.synologychat/
 """
 import logging
 import json
@@ -28,17 +28,15 @@ def get_service(hass, config, discovery_info=None):
     """Get the Synology Chat notification service."""
     resource = config.get(CONF_RESOURCE)
 
-    return SynologyChatNotificationService(
-        hass, resource)
+    return SynologyChatNotificationService(resource)
 
 
 class SynologyChatNotificationService(BaseNotificationService):
     """Implementation of a notification service for Synology Chat."""
 
-    def __init__(self, hass, resource):
+    def __init__(self, resource):
         """Initialize the service."""
         self._resource = resource
-        self._hass = hass
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""

--- a/homeassistant/components/notify/synology_chat.py
+++ b/homeassistant/components/notify/synology_chat.py
@@ -43,7 +43,7 @@ class SynologyChatNotificationService(BaseNotificationService):
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
         data = {
-            'text': message 
+            'text': message
         }
 
         to_send = 'payload=' + json.dumps(data)

--- a/homeassistant/components/notify/synology_chat.py
+++ b/homeassistant/components/notify/synology_chat.py
@@ -11,8 +11,7 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.notify import (
-    ATTR_TARGET, ATTR_TITLE, ATTR_TITLE_DEFAULT, BaseNotificationService,
-    PLATFORM_SCHEMA)
+    BaseNotificationService, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_RESOURCE, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
@@ -31,6 +30,7 @@ def get_service(hass, config, discovery_info=None):
 
     return SynologyChatNotificationService(
         hass, resource)
+
 
 class SynologyChatNotificationService(BaseNotificationService):
     """Implementation of a notification service for Synology Chat."""


### PR DESCRIPTION
## Description:
New notification platform to push messages to your Synology Chat

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4730

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: synology_chat
    name: syno_chat
    resource: https://your.synology.install/webapi/entry.cgi?api=SYNO.Chat.External&method=incoming&version=1&token=123454

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [na] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [na] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [na] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
