### PR TITLE
Add support for Zillow Zestimate sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -645,6 +645,7 @@ omit =
     homeassistant/components/sensor/worxlandroid.py
     homeassistant/components/sensor/xbox_live.py
     homeassistant/components/sensor/zamg.py
+    homeassistant/components/sensor/zestimate.py
     homeassistant/components/shiftr.py
     homeassistant/components/spc.py
     homeassistant/components/switch/acer_projector.py

--- a/homeassistant/components/sensor/zestimate.py
+++ b/homeassistant/components/sensor/zestimate.py
@@ -4,11 +4,10 @@ Support for zestimate data from zillow.com.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.zestimate/
 """
-import logging
 from datetime import timedelta
-
-import voluptuous as vol
+import logging
 import requests
+import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_API_KEY,
@@ -32,7 +31,7 @@ ZESTIMATE = '{}:{}'.format(DEFAULT_NAME, NAME)
 ICON = 'mdi:home-variant'
 
 ATTR_AMOUNT = 'amount'
-ATTR_CHANGE = 'amount_change_30days'
+ATTR_CHANGE = 'amount_change_30_days'
 ATTR_CURRENCY = 'amount_currency'
 ATTR_LAST_UPDATED = 'amount_last_updated'
 ATTR_VAL_HI = 'valuation_range_high'
@@ -50,7 +49,7 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Zestimate sensor."""
+    """Set up the Zestimate sensor."""
     name = config.get(CONF_NAME)
     properties = config[CONF_ZPID]
     params = {'zws-id': config[CONF_API_KEY]}
@@ -84,25 +83,17 @@ class ZestimateDataSensor(Entity):
         try:
             return round(float(self._state), 1)
         except ValueError:
-            return STATE_UNKNOWN
+            return None
 
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
         attributes = {}
         if self.data is not None:
-            attributes['Amount'] = self.data[ATTR_AMOUNT]
-            attributes['Currency'] = self.data[ATTR_CURRENCY]
-            attributes['Last Update'] = self.data[ATTR_LAST_UPDATED]
-            attributes['+/- Change'] = self.data[ATTR_CHANGE]
-            attributes['Valuation Range High'] = self.data[ATTR_VAL_HI]
-            attributes['Valuation Range Low'] = self.data[ATTR_VAL_LOW]
-        attributes['Address'] = self.address
+            attributes = self.data
+        attributes['address'] = self.address
         attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
-        if attributes is not None:
-            return attributes
-        else:
-            return None
+        return attributes
 
     @property
     def icon(self):
@@ -121,10 +112,10 @@ class ZestimateDataSensor(Entity):
             if error_code != 0:
                 _LOGGER.error('The API returned: %s',
                               data_dict['message']['text'])
-                return False
+                return
         except requests.exceptions.ConnectionError:
             _LOGGER.error('Unable to retrieve data from %s', _RESOURCE)
-            return False
+            return
         data = data_dict['response'][NAME]
         details = {}
         details[ATTR_AMOUNT] = data['amount']['#text']
@@ -138,5 +129,5 @@ class ZestimateDataSensor(Entity):
         if self.data is not None:
             self._state = self.data[ATTR_AMOUNT]
         else:
-            self._state = STATE_UNKNOWN
+            self._state = None
             _LOGGER.error('Unable to parase Zestimate data from response')

--- a/homeassistant/components/sensor/zestimate.py
+++ b/homeassistant/components/sensor/zestimate.py
@@ -1,0 +1,173 @@
+"""
+Support for zestimate data from zillow.com.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.zestimate/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+import requests
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_API_KEY,
+                                 CONF_NAME, STATE_UNKNOWN, ATTR_ATTRIBUTION)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+REQUIREMENTS = ['xmltodict==0.11.0']
+
+_LOGGER = logging.getLogger(__name__)
+_RESOURCE = 'http://www.zillow.com/webservice/GetZestimate.htm'
+
+CONF_ZPID = 'zpid'
+CONF_ATTRIBUTION = "Data provided by Zillow.com"
+
+DEFAULT_NAME = 'Zestimate'
+NAME = 'zestimate'
+ZESTIMATE = '{}:{}'.format(DEFAULT_NAME, NAME)
+
+ICON = 'mdi:home-variant'
+
+ATTR_LOCATION = 'location'
+ATTR_UPDATE = 'update'
+ATTR_AMOUNT = 'amount'
+ATTR_CHANGE = 'amount_change_30days'
+ATTR_CURRENCY = 'amount_currency'
+ATTR_LAST_UPDATED = 'amount_last_updated'
+ATTR_VAL_HIGH = 'valuation_range_high'
+ATTR_VAL_LOW = 'valuation_range_low'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_ZPID): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+# Return cached results if last scan was less then this time ago.
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Zestimate sensor."""
+    import xmltodict
+
+    name = config.get(CONF_NAME)
+    properties = config[CONF_ZPID]
+    params = {'zws-id': config[CONF_API_KEY]}
+
+    sensors = []
+    for zpid in properties:
+        params['zpid'] = zpid
+        try:
+            response = requests.get(_RESOURCE, params=params, timeout=5)
+            data = response.content.decode('utf-8')
+            data_dict = xmltodict.parse(data).get(ZESTIMATE)
+            error_code = int(data_dict['message']['code'])
+            if error_code != 0:
+                _LOGGER.error('The API returned: %s',
+                              data_dict['message']['text'])
+                return False
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error('The URL is not accessible')
+            return False
+
+        data = ZestimateData(params)
+        sensors.append(ZestimateDataSensor(name, data))
+    add_devices(sensors, True)
+
+
+class ZestimateDataSensor(Entity):
+    """Implementation of a Zestimate sensor."""
+
+    def __init__(self, name, data):
+        """Initialize the sensor."""
+        self.data = data
+        self._name = name
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        try:
+            return round(float(self._state), 1)
+        except ValueError:
+            return STATE_UNKNOWN
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attributes = {}
+        if self.data.measurings is not None:
+            if ATTR_AMOUNT in self.data.measurings:
+                data = self.data.measurings
+                attributes[ATTR_AMOUNT] = data[ATTR_AMOUNT]
+                attributes[ATTR_CURRENCY] = data[ATTR_CURRENCY]
+                attributes[ATTR_LAST_UPDATED] = data[ATTR_LAST_UPDATED]
+                attributes[ATTR_CHANGE] = data[ATTR_CHANGE]
+                attributes[ATTR_VAL_HIGH] = data[ATTR_VAL_HIGH]
+                attributes[ATTR_VAL_LOW] = data[ATTR_VAL_LOW]
+
+            attributes[ATTR_LOCATION] = self.data.address
+            attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+            return attributes
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return ICON
+
+    def update(self):
+        """Get the latest data and update the states."""
+        self.data.update()
+        if self.data.measurings is not None:
+            if ATTR_LAST_UPDATED not in self.data.measurings:
+                self._state = STATE_UNKNOWN
+            else:
+                self._state = self.data.measurings[ATTR_AMOUNT]
+
+
+class ZestimateData(object):
+    """The Class for handling data retrieval."""
+
+    def __init__(self, params):
+        """Initialize the data object."""
+        self.params = params
+        self.address = None
+        self.measurings = None
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest data from hydrodata.ch."""
+        import xmltodict
+
+        details = {}
+        try:
+            response = requests.get(_RESOURCE, params=self.params, timeout=5)
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error('Unable to retrieve data from %s', _RESOURCE)
+
+        try:
+            decoded = response.content.decode('utf-8')
+            to_dict = xmltodict.parse(decoded)
+            response = to_dict.get(ZESTIMATE)['response']
+            data = response[NAME]
+            details[ATTR_AMOUNT] = data['amount']['#text']
+            details[ATTR_CURRENCY] = data['amount']['@currency']
+            details[ATTR_LAST_UPDATED] = data['last-updated']
+            details[ATTR_CHANGE] = int(data['valueChange']['#text'])
+            details[ATTR_VAL_HIGH] = int(data['valuationRange']['high']['#text'])
+            details[ATTR_VAL_LOW] = int(data['valuationRange']['low']['#text'])
+
+            self.address = response['address']['street']
+            self.measurings = details
+        except AttributeError:
+            self.measurings = None

--- a/homeassistant/components/sensor/zestimate.py
+++ b/homeassistant/components/sensor/zestimate.py
@@ -37,7 +37,7 @@ ATTR_AMOUNT = 'amount'
 ATTR_CHANGE = 'amount_change_30days'
 ATTR_CURRENCY = 'amount_currency'
 ATTR_LAST_UPDATED = 'amount_last_updated'
-ATTR_VAL_HIGH = 'valuation_range_high'
+ATTR_VAL_HI = 'valuation_range_high'
 ATTR_VAL_LOW = 'valuation_range_low'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -113,7 +113,7 @@ class ZestimateDataSensor(Entity):
                 attributes[ATTR_CURRENCY] = data[ATTR_CURRENCY]
                 attributes[ATTR_LAST_UPDATED] = data[ATTR_LAST_UPDATED]
                 attributes[ATTR_CHANGE] = data[ATTR_CHANGE]
-                attributes[ATTR_VAL_HIGH] = data[ATTR_VAL_HIGH]
+                attributes[ATTR_VAL_HI] = data[ATTR_VAL_HI]
                 attributes[ATTR_VAL_LOW] = data[ATTR_VAL_LOW]
 
             attributes[ATTR_LOCATION] = self.data.address
@@ -164,7 +164,7 @@ class ZestimateData(object):
             details[ATTR_CURRENCY] = data['amount']['@currency']
             details[ATTR_LAST_UPDATED] = data['last-updated']
             details[ATTR_CHANGE] = int(data['valueChange']['#text'])
-            details[ATTR_VAL_HIGH] = int(data['valuationRange']['high']['#text'])
+            details[ATTR_VAL_HI] = int(data['valuationRange']['high']['#text'])
             details[ATTR_VAL_LOW] = int(data['valuationRange']['low']['#text'])
 
             self.address = response['address']['street']

--- a/homeassistant/components/sensor/zestimate.py
+++ b/homeassistant/components/sensor/zestimate.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/sensor.zestimate/
 """
 from datetime import timedelta
 import logging
+
 import requests
 import voluptuous as vol
 

--- a/homeassistant/components/sensor/zestimate.py
+++ b/homeassistant/components/sensor/zestimate.py
@@ -51,7 +51,6 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Zestimate sensor."""
-
     name = config.get(CONF_NAME)
     properties = config[CONF_ZPID]
     params = {'zws-id': config[CONF_API_KEY]}
@@ -136,7 +135,6 @@ class ZestimateDataSensor(Entity):
         details[ATTR_VAL_LOW] = int(data['valuationRange']['low']['#text'])
         self.address = data_dict['response']['address']['street']
         self.data = details
-
         if self.data is not None:
             self._state = self.data[ATTR_AMOUNT]
         else:

--- a/homeassistant/components/sensor/zestimate.py
+++ b/homeassistant/components/sensor/zestimate.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_API_KEY,
-                                 CONF_NAME, STATE_UNKNOWN, ATTR_ATTRIBUTION)
+                                 CONF_NAME, ATTR_ATTRIBUTION)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1247,6 +1247,7 @@ xknx==0.7.18
 # homeassistant.components.sensor.swiss_hydrological_data
 # homeassistant.components.sensor.ted5000
 # homeassistant.components.sensor.yr
+# homeassistant.components.sensor.zestimate
 xmltodict==0.11.0
 
 # homeassistant.components.sensor.yahoo_finance


### PR DESCRIPTION
## Description:
Adds support for the Zillow Zestimate as a sensor.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4812

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: zestimate
    name: Zillow Zestimate
    api_key: <zillow API key>
    zpid:
      - <zpid 1>
      - <zpid 2>
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.