### PR TITLE
Adding RoomHinting to GoogleAssistant to allow for room annotations.

### DIFF
--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -27,7 +27,7 @@ from .const import (
     CONF_EXPOSE_BY_DEFAULT, DEFAULT_EXPOSE_BY_DEFAULT, CONF_EXPOSED_DOMAINS,
     DEFAULT_EXPOSED_DOMAINS, CONF_AGENT_USER_ID, CONF_API_KEY,
     SERVICE_REQUEST_SYNC, REQUEST_SYNC_BASE_URL, CONF_ENTITY_CONFIG,
-    CONF_EXPOSE, CONF_ALIASES
+    CONF_EXPOSE, CONF_ALIASES, CONF_ROOM_HINT
 )
 from .auth import GoogleAssistantAuthView
 from .http import async_register_http
@@ -43,7 +43,8 @@ ENTITY_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_TYPE): vol.In(MAPPING_COMPONENT),
     vol.Optional(CONF_EXPOSE): cv.boolean,
-    vol.Optional(CONF_ALIASES): vol.All(cv.ensure_list, [cv.string])
+    vol.Optional(CONF_ALIASES): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_ROOM_HINT): cv.string
 })
 
 CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -13,6 +13,7 @@ CONF_CLIENT_ID = 'client_id'
 CONF_ALIASES = 'aliases'
 CONF_AGENT_USER_ID = 'agent_user_id'
 CONF_API_KEY = 'api_key'
+CONF_ROOM_HINT = 'room'
 
 DEFAULT_EXPOSE_BY_DEFAULT = True
 DEFAULT_EXPOSED_DOMAINS = [

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -33,7 +33,8 @@ from .const import (
     TRAIT_ONOFF, TRAIT_BRIGHTNESS, TRAIT_COLOR_TEMP,
     TRAIT_RGB_COLOR, TRAIT_SCENE, TRAIT_TEMPERATURE_SETTING,
     TYPE_LIGHT, TYPE_SCENE, TYPE_SWITCH, TYPE_THERMOSTAT,
-    CONF_ALIASES, CLIMATE_SUPPORTED_MODES, CLIMATE_MODE_HEATCOOL
+    CONF_ALIASES, CONF_ROOM_HINT, CLIMATE_SUPPORTED_MODES,
+    CLIMATE_MODE_HEATCOOL
 )
 
 HANDLERS = Registry()
@@ -123,6 +124,11 @@ def entity_to_device(entity: Entity, config: Config, units: UnitSystem):
     aliases = entity_config.get(CONF_ALIASES)
     if aliases:
         device['name']['nicknames'] = aliases
+
+    # add room hint if annotated
+    room = entity_config.get(CONF_ROOM_HINT)
+    if room:
+        device['roomHint'] = room
 
     # add trait if entity supports feature
     if class_data[2]:


### PR DESCRIPTION
## Description:

[Not for merge yet]  Added the roomHint attribute to the devices return for the QUERY intent for Google Assistant.  According to the documentation available from Google, this will allow disambiguation between devices with similar names based on a provided room.  While this can currently be achieved within the Google Assistant application by associating exposed devices into a "Room", each user needs to do this locally on their app.

**However**, the attribute doesn't appear to be lit up yet on the Google side, even though it's in the documentation. I've reached out to developer support at this point, and I'm waiting to hear back.  I'll update the PR as required based on what I hear back.

Submitting at this point in order to allow for review.

Docs from Google:

https://developers.google.com/actions/smarthome/create-app

> roomHint: String. Optional. If the partner's cloud configuration includes placing devices in rooms, the name of the room can be provided here; the Assistant will attempt to align the room with those in the HomeGraph.

https://developers.google.com/actions/smarthome/faq

> Q: Do device names need to be unique?
>
>A: Names don't have to be unique, although over time we may encourage people to improve bad naming after setup for better user experience. If a user has two lamps in your house called “lamp”, where one has roomHint as “bedroom”, the other as “living room”, saying “OK Google, turn on the living room lamp” will only turn on the one that’s in the living room.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#

Docs pending. Holding off for any required changes first.

## Example entry for `configuration.yaml` (if applicable):
```yaml
entity_config:
  light.bedroom_lamp:
    expose: True
    room: bedroom
    name: Lamp
```

## Checklist:
  - [ x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

