### PR TITLE
Xiaomi Air Purifier: Set speed service fixed

### DIFF
--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -302,7 +302,7 @@ class XiaomiAirPurifier(FanEntity):
 
         yield from self._try_command(
             "Setting operation mode of the air purifier failed.",
-            self._air_purifier.set_mode, OperationMode[speed])
+            self._air_purifier.set_mode, OperationMode(speed))
 
     @asyncio.coroutine
     def async_set_buzzer_on(self):


### PR DESCRIPTION
Fixes: 
```
2018-02-22 21:10:29 ERROR (MainThread) [homeassistant.core] Error executing service <ServiceCall fan.turn_on: entity_id=[‘fan.air_purifier’], speed=auto>
Traceback (most recent call last):
File “/usr/local/lib/python3.5/dist-packages/homeassistant/core.py”, line 1010, in _event_to_service_call
yield from service_handler.func(service_call)
File “/usr/local/lib/python3.5/dist-packages/homeassistant/components/fan/init.py”, line 218, in async_handle_fan_service
yield from getattr(fan, method[‘method’])(**params)
File “/home/pi/.homeassistant/custom_components/fan/xiaomi_miio.py”, line 327, in async_turn_on
result = yield from self.async_set_speed(speed)
File “/home/pi/.homeassistant/custom_components/fan/xiaomi_miio.py”, line 552, in async_set_speed
self._device.set_mode, OperationMode[speed])
File “/usr/lib/python3.5/enum.py”, line 277, in getitem
return cls.member_map[name]
KeyError: ‘auto’
```
