### PR TITLE
Thread safety fixes for recorder session_scope

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -10,7 +10,7 @@ def migrate_schema(instance):
     """Check if the schema needs to be upgraded."""
     from .models import SchemaChanges, SCHEMA_VERSION
 
-    with session_scope(session=instance.get_session()) as session:
+    with session_scope(recorder=instance) as session:
         res = session.query(SchemaChanges).order_by(
             SchemaChanges.change_id.desc()).first()
         current_version = getattr(res, 'schema_version', None)

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -17,7 +17,7 @@ def purge_old_data(instance, purge_days, repack):
     purge_before = dt_util.utcnow() - timedelta(days=purge_days)
     _LOGGER.debug("Purging events before %s", purge_before)
 
-    with session_scope(session=instance.get_session()) as session:
+    with session_scope(recorder=instance) as session:
         delete_states = session.query(States) \
                             .filter((States.last_updated < purge_before))
 


### PR DESCRIPTION
## Description:

This adds a lock to the context manager for recorder sessions, like recommended in the [SQLAlchemy documentation](http://docs.sqlalchemy.org/en/latest/orm/session_basics.html#is-the-session-thread-safe):

> If there are in fact multiple threads participating in the same task, then you may consider sharing the session and its objects between those threads; however, in this extremely unusual scenario the application would need to ensure that a proper locking scheme is implemented so that there isn’t _concurrent_ access to the `Session` or its state.

The lack of a lock caused concurrent access that made our tests fail occasionally:
```
DEBUG:homeassistant.components.recorder:Connected to recorder database
INFO:sqlalchemy.engine.base.Engine:BEGIN (implicit)
INFO:sqlalchemy.engine.base.Engine:BEGIN (implicit)
INFO:sqlalchemy.engine.base.Engine:SELECT events.event_id AS events_event_id, events.event_type AS events_event_type, events.event_data AS events_event_data, events.origin AS events_origin, events.time_fired AS events_time_fired, events.created AS events_created 
FROM events
 LIMIT ? OFFSET ?
INFO:sqlalchemy.engine.base.Engine:INSERT INTO events (event_type, event_data, origin, time_fired, created) VALUES (?, ?, ?, ?, ?)
INFO:sqlalchemy.engine.base.Engine:(1, 0)
INFO:sqlalchemy.engine.base.Engine:('service_registered', '{"service": "purge", "domain": "recorder"}', 'LOCAL', '2018-02-22 18:39:17.779537', '2018-02-22 18:39:17.835652')
INFO:sqlalchemy.engine.base.Engine:COMMIT
INFO:sqlalchemy.engine.base.Engine:COMMIT
ERROR:homeassistant.components.recorder.util:Error executing query: (sqlite3.OperationalError) cannot commit - no transaction is active (Background on this error at: http://sqlalche.me/e/e3q8)
```

With a lock we can have a deadlock if sessions are accidentally nested (like the purge test did). I don't know if we should have a locking timeout and some noise to better detect this situation in production?

## Checklist:
  - [X] The code change is tested and works locally.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. 🎉
  - [X] Tests have been added to verify that the new code works.