### PR TITLE
add ability to set fan on

### DIFF
--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -206,7 +206,7 @@ class Thermostat(ClimateDevice):
                 if event['type'] == 'hold':
                     if event['holdClimateRef'] == 'away':
                         if int(event['endDate'][0:4]) - \
-                                int(event['startDate'][0:4]) <= 1:
+                           int(event['startDate'][0:4]) <= 1:
                             # A temporary hold from away climate is a hold
                             return 'away'
                         # A permanent hold from away climate
@@ -228,7 +228,7 @@ class Thermostat(ClimateDevice):
     def current_operation(self):
         """Return current operation."""
         if self.operation_mode == 'auxHeatOnly' or \
-                        self.operation_mode == 'heatPump':
+           self.operation_mode == 'heatPump':
             return STATE_HEAT
         return self.operation_mode
 
@@ -343,7 +343,7 @@ class Thermostat(ClimateDevice):
                                        self.hold_preference())
         _LOGGER.debug("Setting ecobee hold_temp to: heat=%s, is=%s, "
                       "cool=%s, is=%s", heat_temp, isinstance(
-            heat_temp, (int, float)), cool_temp,
+                          heat_temp, (int, float)), cool_temp,
                       isinstance(cool_temp, (int, float)))
 
         self.update_without_throttle = True
@@ -385,8 +385,7 @@ class Thermostat(ClimateDevice):
         temp = kwargs.get(ATTR_TEMPERATURE)
 
         if self.current_operation == STATE_AUTO and (low_temp is not None or
-                                                             high_temp is
-                                                         not None):
+                                                     high_temp is not None):
             self.set_auto_temp_hold(low_temp, high_temp)
         elif temp is not None:
             self.set_temp_hold(temp)

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -348,19 +348,19 @@ class Thermostat(ClimateDevice):
 
         self.update_without_throttle = True
 
-    def set_fan_mode(self, fan, entity_id=None):
+    def set_fan_mode(self, fan_mode):
         """Set the fan mode.  Valid values are "on" or "auto"."""
-        if (fan.lower() != STATE_ON) and (fan.lower() != STATE_AUTO):
+        if (fan_mode.lower() != STATE_ON) and (fan_mode.lower() != STATE_AUTO):
             error = "Invalid fan_mode value:  Valid values are 'on' or 'auto'"
             _LOGGER.error(error)
             return
 
         cool_temp = self.thermostat['runtime']['desiredCool'] / 10.0
         heat_temp = self.thermostat['runtime']['desiredHeat'] / 10.0
-        self.data.ecobee.set_fan_mode(self.thermostat_index, fan, cool_temp,
+        self.data.ecobee.set_fan_mode(self.thermostat_index, fan_mode, cool_temp,
                                       heat_temp, self.hold_preference())
 
-        _LOGGER.info("Setting fan mode to: %s", fan)
+        _LOGGER.info("Setting fan mode to: %s", fan_mode)
 
     def set_temp_hold(self, temp):
         """Set temperature hold in modes other than auto."""

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -348,7 +348,7 @@ class Thermostat(ClimateDevice):
 
         self.update_without_throttle = True
 
-    def set_fan_mode(self, fan, **kwargs):
+    def set_fan_mode(self, fan, entity_id=None):
         """Set the fan mode.  Valid values are "on" or "auto"."""
         if (fan.lower() != STATE_ON) and (fan.lower() != STATE_AUTO):
             error = "Invalid fan_mode value:  Valid values are 'on' or 'auto'"
@@ -360,7 +360,7 @@ class Thermostat(ClimateDevice):
         self.data.ecobee.set_fan_mode(self.thermostat_index, fan, cool_temp,
                                       heat_temp, self.hold_preference())
 
-        _LOGGER.info("Setting fan mode to: {}".format(fan))
+        _LOGGER.info("Setting fan mode to: %s", fan)
 
     def set_temp_hold(self, temp):
         """Set temperature hold in modes other than auto."""

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -206,7 +206,7 @@ class Thermostat(ClimateDevice):
                 if event['type'] == 'hold':
                     if event['holdClimateRef'] == 'away':
                         if int(event['endDate'][0:4]) - \
-                           int(event['startDate'][0:4]) <= 1:
+                                int(event['startDate'][0:4]) <= 1:
                             # A temporary hold from away climate is a hold
                             return 'away'
                         # A permanent hold from away climate
@@ -228,7 +228,7 @@ class Thermostat(ClimateDevice):
     def current_operation(self):
         """Return current operation."""
         if self.operation_mode == 'auxHeatOnly' or \
-           self.operation_mode == 'heatPump':
+                        self.operation_mode == 'heatPump':
             return STATE_HEAT
         return self.operation_mode
 
@@ -343,7 +343,7 @@ class Thermostat(ClimateDevice):
                                        self.hold_preference())
         _LOGGER.debug("Setting ecobee hold_temp to: heat=%s, is=%s, "
                       "cool=%s, is=%s", heat_temp, isinstance(
-                          heat_temp, (int, float)), cool_temp,
+            heat_temp, (int, float)), cool_temp,
                       isinstance(cool_temp, (int, float)))
 
         self.update_without_throttle = True
@@ -357,8 +357,9 @@ class Thermostat(ClimateDevice):
 
         cool_temp = self.thermostat['runtime']['desiredCool'] / 10.0
         heat_temp = self.thermostat['runtime']['desiredHeat'] / 10.0
-        self.data.ecobee.set_fan_mode(self.thermostat_index, fan_mode, cool_temp,
-                                      heat_temp, self.hold_preference())
+        self.data.ecobee.set_fan_mode(self.thermostat_index, fan_mode,
+                                      cool_temp, heat_temp,
+                                      self.hold_preference())
 
         _LOGGER.info("Setting fan mode to: %s", fan_mode)
 
@@ -384,7 +385,8 @@ class Thermostat(ClimateDevice):
         temp = kwargs.get(ATTR_TEMPERATURE)
 
         if self.current_operation == STATE_AUTO and (low_temp is not None or
-                                                     high_temp is not None):
+                                                             high_temp is
+                                                         not None):
             self.set_auto_temp_hold(low_temp, high_temp)
         elif temp is not None:
             self.set_temp_hold(temp)

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -15,9 +15,9 @@ from homeassistant.components.climate import (
     SUPPORT_AWAY_MODE, SUPPORT_HOLD_MODE, SUPPORT_OPERATION_MODE,
     SUPPORT_TARGET_HUMIDITY_LOW, SUPPORT_TARGET_HUMIDITY_HIGH,
     SUPPORT_AUX_HEAT, SUPPORT_TARGET_TEMPERATURE_HIGH,
-    SUPPORT_TARGET_TEMPERATURE_LOW, SUPPORT_FAN_MODE)
+    SUPPORT_TARGET_TEMPERATURE_LOW)
 from homeassistant.const import (
-    ATTR_ENTITY_ID, STATE_OFF, STATE_ON, ATTR_TEMPERATURE, TEMP_FAHRENHEIT)
+    ATTR_ENTITY_ID, STATE_ON, ATTR_TEMPERATURE, TEMP_FAHRENHEIT)
 import homeassistant.helpers.config_validation as cv
 
 _CONFIGURING = {}
@@ -349,7 +349,7 @@ class Thermostat(ClimateDevice):
         self.update_without_throttle = True
 
     def set_fan_mode(self, fan, **kwargs):
-        """Set the fan mode.  Valid values are "on" or "auto" """
+        """Set the fan mode.  Valid values are "on" or "auto"."""
         if (fan.lower() != STATE_ON) and (fan.lower() != STATE_AUTO):
             error = "Invalid fan_mode value:  Valid values are 'on' or 'auto'"
             _LOGGER.error(error)

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -15,7 +15,7 @@ from homeassistant.components.climate import (
     SUPPORT_AWAY_MODE, SUPPORT_HOLD_MODE, SUPPORT_OPERATION_MODE,
     SUPPORT_TARGET_HUMIDITY_LOW, SUPPORT_TARGET_HUMIDITY_HIGH,
     SUPPORT_AUX_HEAT, SUPPORT_TARGET_TEMPERATURE_HIGH,
-    SUPPORT_TARGET_TEMPERATURE_LOW)
+    SUPPORT_TARGET_TEMPERATURE_LOW, SUPPORT_FAN_MODE)
 from homeassistant.const import (
     ATTR_ENTITY_ID, STATE_OFF, STATE_ON, ATTR_TEMPERATURE, TEMP_FAHRENHEIT)
 import homeassistant.helpers.config_validation as cv
@@ -347,6 +347,24 @@ class Thermostat(ClimateDevice):
                       isinstance(cool_temp, (int, float)))
 
         self.update_without_throttle = True
+
+    def set_fan_mode(self, fan, **kwargs):
+        """Set the fan mode.  Valid values are "on" or "auto" """
+        if fan.lower() == 'on':
+            fan = 'on'
+        elif fan.lower() == 'auto':
+            fan = 'auto'
+        else:
+            error = "Invalid fan_mode value:  Valid values are 'on' or 'auto'"
+            _LOGGER.error(error)
+            return
+
+        cool_temp = self.thermostat['runtime']['desiredCool'] / 10.0
+        heat_temp = self.thermostat['runtime']['desiredHeat'] / 10.0
+        self.data.ecobee.set_fan_mode(self.thermostat_index, fan, cool_temp,
+                                      heat_temp, self.hold_preference())
+
+        _LOGGER.info("Setting fan mode to: {}".format(fan))
 
     def set_temp_hold(self, temp):
         """Set temperature hold in modes other than auto."""

--- a/homeassistant/components/climate/ecobee.py
+++ b/homeassistant/components/climate/ecobee.py
@@ -190,7 +190,7 @@ class Thermostat(ClimateDevice):
         """Return the current fan state."""
         if 'fan' in self.thermostat['equipmentStatus']:
             return STATE_ON
-        return STATE_OFF
+        return STATE_AUTO
 
     @property
     def current_hold_mode(self):
@@ -350,11 +350,7 @@ class Thermostat(ClimateDevice):
 
     def set_fan_mode(self, fan, **kwargs):
         """Set the fan mode.  Valid values are "on" or "auto" """
-        if fan.lower() == 'on':
-            fan = 'on'
-        elif fan.lower() == 'auto':
-            fan = 'auto'
-        else:
+        if (fan.lower() != STATE_ON) and (fan.lower() != STATE_AUTO):
             error = "Invalid fan_mode value:  Valid values are 'on' or 'auto'"
             _LOGGER.error(error)
             return

--- a/homeassistant/components/ecobee.py
+++ b/homeassistant/components/ecobee.py
@@ -16,7 +16,7 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.util import Throttle
 from homeassistant.util.json import save_json
 
-REQUIREMENTS = ['python-ecobee-api==0.0.15']
+REQUIREMENTS = ['python-ecobee-api==0.0.16']
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -901,7 +901,7 @@ python-clementine-remote==1.0.1
 python-digitalocean==1.13.2
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.0.15
+python-ecobee-api==0.0.16
 
 # homeassistant.components.climate.eq3btsmart
 # python-eq3bt==0.1.9

--- a/tests/components/climate/test_ecobee.py
+++ b/tests/components/climate/test_ecobee.py
@@ -3,6 +3,7 @@ import unittest
 from unittest import mock
 import homeassistant.const as const
 import homeassistant.components.climate.ecobee as ecobee
+from homeassistant.components.climate import STATE_AUTO
 
 
 class TestEcobee(unittest.TestCase):
@@ -89,9 +90,9 @@ class TestEcobee(unittest.TestCase):
         """Test fan property."""
         self.assertEqual(const.STATE_ON, self.thermostat.fan)
         self.ecobee['equipmentStatus'] = ''
-        self.assertEqual(const.STATE_OFF, self.thermostat.fan)
+        self.assertEqual(STATE_AUTO, self.thermostat.fan)
         self.ecobee['equipmentStatus'] = 'heatPump, heatPump2'
-        self.assertEqual(const.STATE_OFF, self.thermostat.fan)
+        self.assertEqual(STATE_AUTO, self.thermostat.fan)
 
     def test_current_hold_mode_away_temporary(self):
         """Test current hold mode when away."""
@@ -178,7 +179,7 @@ class TestEcobee(unittest.TestCase):
         self.ecobee['equipmentStatus'] = 'heatPump2'
         self.assertEqual({'actual_humidity': 15,
                           'climate_list': ['Climate1', 'Climate2'],
-                          'fan': 'off',
+                          'fan': 'auto',
                           'fan_min_on_time': 10,
                           'mode': 'Climate1',
                           'operation': 'heat'},
@@ -187,7 +188,7 @@ class TestEcobee(unittest.TestCase):
         self.ecobee['equipmentStatus'] = 'auxHeat2'
         self.assertEqual({'actual_humidity': 15,
                           'climate_list': ['Climate1', 'Climate2'],
-                          'fan': 'off',
+                          'fan': 'auto',
                           'fan_min_on_time': 10,
                           'mode': 'Climate1',
                           'operation': 'heat'},
@@ -195,7 +196,7 @@ class TestEcobee(unittest.TestCase):
         self.ecobee['equipmentStatus'] = 'compCool1'
         self.assertEqual({'actual_humidity': 15,
                           'climate_list': ['Climate1', 'Climate2'],
-                          'fan': 'off',
+                          'fan': 'auto',
                           'fan_min_on_time': 10,
                           'mode': 'Climate1',
                           'operation': 'cool'},
@@ -203,7 +204,7 @@ class TestEcobee(unittest.TestCase):
         self.ecobee['equipmentStatus'] = ''
         self.assertEqual({'actual_humidity': 15,
                           'climate_list': ['Climate1', 'Climate2'],
-                          'fan': 'off',
+                          'fan': 'auto',
                           'fan_min_on_time': 10,
                           'mode': 'Climate1',
                           'operation': 'idle'},
@@ -212,7 +213,7 @@ class TestEcobee(unittest.TestCase):
         self.ecobee['equipmentStatus'] = 'Unknown'
         self.assertEqual({'actual_humidity': 15,
                           'climate_list': ['Climate1', 'Climate2'],
-                          'fan': 'off',
+                          'fan': 'auto',
                           'fan_min_on_time': 10,
                           'mode': 'Climate1',
                           'operation': 'Unknown'},
@@ -450,3 +451,15 @@ class TestEcobee(unittest.TestCase):
         """Test climate list property."""
         self.assertEqual(['Climate1', 'Climate2'],
                          self.thermostat.climate_list)
+
+    def test_set_fan_mode_on(self):
+        self.data.reset_mock()
+        self.thermostat.set_fan_mode('on')
+        self.data.ecobee.set_fan_mode.assert_has_calls(
+            [mock.call(1, 'on', 20, 40, 'nextTransition')])
+
+    def test_set_fan_mode_auto(self):
+        self.data.reset_mock()
+        self.thermostat.set_fan_mode('auto')
+        self.data.ecobee.set_fan_mode.assert_has_calls(
+            [mock.call(1, 'auto', 20, 40, 'nextTransition')])

--- a/tests/components/climate/test_ecobee.py
+++ b/tests/components/climate/test_ecobee.py
@@ -463,3 +463,4 @@ class TestEcobee(unittest.TestCase):
         self.thermostat.set_fan_mode('auto')
         self.data.ecobee.set_fan_mode.assert_has_calls(
             [mock.call(1, 'auto', 20, 40, 'nextTransition')])
+

--- a/tests/components/climate/test_ecobee.py
+++ b/tests/components/climate/test_ecobee.py
@@ -453,14 +453,15 @@ class TestEcobee(unittest.TestCase):
                          self.thermostat.climate_list)
 
     def test_set_fan_mode_on(self):
+        """Test set fan mode to on."""
         self.data.reset_mock()
         self.thermostat.set_fan_mode('on')
         self.data.ecobee.set_fan_mode.assert_has_calls(
             [mock.call(1, 'on', 20, 40, 'nextTransition')])
 
     def test_set_fan_mode_auto(self):
+        """Test set fan mode to auto."""
         self.data.reset_mock()
         self.thermostat.set_fan_mode('auto')
         self.data.ecobee.set_fan_mode.assert_has_calls(
             [mock.call(1, 'auto', 20, 40, 'nextTransition')])
-

--- a/tests/components/climate/test_ecobee.py
+++ b/tests/components/climate/test_ecobee.py
@@ -463,3 +463,4 @@ class TestEcobee(unittest.TestCase):
         self.thermostat.set_fan_mode('auto')
         self.data.ecobee.set_fan_mode.assert_has_calls(
             [mock.call(1, 'auto', 20, 40, 'nextTransition')])
+        

--- a/tests/components/climate/test_ecobee.py
+++ b/tests/components/climate/test_ecobee.py
@@ -463,4 +463,3 @@ class TestEcobee(unittest.TestCase):
         self.thermostat.set_fan_mode('auto')
         self.data.ecobee.set_fan_mode.assert_has_calls(
             [mock.call(1, 'auto', 20, 40, 'nextTransition')])
-        


### PR DESCRIPTION
## Description:  
This adds the ability to turn the fan `on` on ecobee thermostats.  Also changed the "not on" status to `auto` since ecobee doesn't have an `off` status for the fan.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** TODO

## Example entry for `configuration.yaml` (if applicable):
```yaml
ecobee:
  api_key: super_secret_api_key
```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) TODO

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.