### PR TITLE
Move recorder query out of event loop

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -256,34 +256,35 @@ class Recorder(threading.Thread):
                 self.hass.bus.async_listen_once(
                     EVENT_HOMEASSISTANT_START, notify_hass_started)
 
-            if self.keep_days and self.purge_interval:
-                @callback
-                def async_purge(now):
-                    """Trigger the purge and schedule the next run."""
-                    self.queue.put(
-                        PurgeTask(self.keep_days, repack=not self.did_vacuum))
-                    self.hass.helpers.event.async_track_point_in_time(
-                        async_purge, now + timedelta(days=self.purge_interval))
-
-                earliest = dt_util.utcnow() + timedelta(minutes=30)
-                run = latest = dt_util.utcnow() + \
-                    timedelta(days=self.purge_interval)
-                with session_scope(session=self.get_session()) as session:
-                    event = session.query(Events).first()
-                    if event is not None:
-                        session.expunge(event)
-                        run = dt_util.as_utc(event.time_fired) + \
-                            timedelta(days=self.keep_days+self.purge_interval)
-                run = min(latest, max(run, earliest))
-                self.hass.helpers.event.async_track_point_in_time(
-                    async_purge, run)
-
         self.hass.add_job(register)
         result = hass_started.result()
 
         # If shutdown happened before HASS finished starting
         if result is shutdown_task:
             return
+
+        # Start periodic purge
+        if self.keep_days and self.purge_interval:
+            @callback
+            def async_purge(now):
+                """Trigger the purge and schedule the next run."""
+                self.queue.put(
+                    PurgeTask(self.keep_days, repack=not self.did_vacuum))
+                self.hass.helpers.event.async_track_point_in_time(
+                    async_purge, now + timedelta(days=self.purge_interval))
+
+            earliest = dt_util.utcnow() + timedelta(minutes=30)
+            run = latest = dt_util.utcnow() + \
+                timedelta(days=self.purge_interval)
+            with session_scope(session=self.get_session()) as session:
+                event = session.query(Events).first()
+                if event is not None:
+                    session.expunge(event)
+                    run = dt_util.as_utc(event.time_fired) + timedelta(
+                        days=self.keep_days+self.purge_interval)
+            run = min(latest, max(run, earliest))
+
+            self.hass.helpers.event.track_point_in_time(async_purge, run)
 
         while True:
             event = self.queue.get()


### PR DESCRIPTION
## Description:

The initialization of the recorder purge nowadays does a SQL query and should therefore no longer run in the event loop.

This is a simplified version of #12605 because @balloob, @dgomes and @OverloadUT made me realize that our locking is apparently correct after all (a "session" is a transaction, not a connection).

I got confused because the existing code still fails on Python 3.4. I now think this is because the "memory" driver used in tests [is not thread-safe in old SQLite](http://docs.sqlalchemy.org/en/latest/dialects/sqlite.html#using-a-memory-database-in-multiple-threads) (though I was unable to check this assumption).


## Checklist:
  - [X] The code change is tested and works locally.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. 🎉
  - [X] Tests have been added to verify that the new code works.