### PR TITLE
Tibber: retry if we fail to connect at startup

### DIFF
--- a/homeassistant/components/sensor/tibber.py
+++ b/homeassistant/components/sensor/tibber.py
@@ -46,7 +46,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             yield from home.update_info()
             dev.append(TibberSensor(home))
     except (asyncio.TimeoutError, aiohttp.ClientError):
-        raise PlatformNotReady()
+        raise PlatformNotReady() from None
 
     async_add_devices(dev, True)
 

--- a/homeassistant/components/sensor/tibber.py
+++ b/homeassistant/components/sensor/tibber.py
@@ -46,7 +46,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             yield from home.update_info()
             dev.append(TibberSensor(home))
     except (asyncio.TimeoutError, aiohttp.ClientError):
-        raise PlatformNotReady
+        raise PlatformNotReady()
 
     async_add_devices(dev, True)
 

--- a/homeassistant/components/sensor/tibber.py
+++ b/homeassistant/components/sensor/tibber.py
@@ -50,6 +50,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     async_add_devices(dev, True)
 
+
 class TibberSensor(Entity):
     """Representation of an Tibber sensor."""
 

--- a/homeassistant/components/sensor/tibber.py
+++ b/homeassistant/components/sensor/tibber.py
@@ -45,7 +45,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         for home in tibber_connection.get_homes():
             yield from home.update_info()
             dev.append(TibberSensor(home))
-    except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+    except (asyncio.TimeoutError, aiohttp.ClientError):
         raise PlatformNotReady
 
     async_add_devices(dev, True)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -644,7 +644,7 @@ pyHS100==0.3.0
 pyRFXtrx==0.21.1
 
 # homeassistant.components.sensor.tibber
-pyTibber==0.2.1
+pyTibber==0.3.0
 
 # homeassistant.components.switch.dlink
 pyW215==0.6.0


### PR DESCRIPTION
## Description:

Tibber: retry if we fail to connect at startup

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: tibber
    access_token: d1007ead2dc84a2b82f0de19451c5fb22112f7ae11d19bf2bedb224a003ff74a
```

## Checklist:
  - [x] The code change is tested and works locally.
