### PR TITLE
Xiaomi Air Purifier: The name of the enum must be used here because of the speed_list

### DIFF
--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -302,7 +302,7 @@ class XiaomiAirPurifier(FanEntity):
 
         yield from self._try_command(
             "Setting operation mode of the air purifier failed.",
-            self._air_purifier.set_mode, OperationMode(speed))
+            self._air_purifier.set_mode, OperationMode[speed.title()])
 
     @asyncio.coroutine
     def async_set_buzzer_on(self):


### PR DESCRIPTION
The fan.set_speed example value is lower-case and led to confusion. Both spellings are possible now: Idle & idle

Reverts: #12602 

@balloob @OttoWinter Sorry for the mess. Could you merge this PR into the release branch? 