### PR TITLE
WIP: Add initial log view implementation

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -51,6 +51,7 @@ def setup(hass, config):
     hass.http.register_view(APIDomainServicesView)
     hass.http.register_view(APIComponentsView)
     hass.http.register_view(APITemplateView)
+    hass.http.register_view(APILoggerView)
 
     log_path = hass.data.get(DATA_LOGGING, None)
     if log_path:
@@ -70,6 +71,64 @@ class APIStatusView(HomeAssistantView):
         """Retrieve if API is running."""
         return self.json_message('API running.')
 
+
+class APILoggerView(HomeAssistantView):
+    """View to handle logger settings."""
+
+    url = "/api/logger"
+    name = "api:logger"
+
+    # NOTE, this is a dupe from components.logger
+    LOGSEVERITY = {
+        50: 'CRITICAL',
+        50: 'FATAL',
+        40: 'ERROR',
+        30: 'WARNING',
+        30: 'WARN',
+        20: 'INFO',
+        10: 'DEBUG',
+        0: 'NOTSET'
+    }
+
+    @asyncio.coroutine
+    def get(self, request):
+        """Return all the available loggers as a JSON object."""
+        loggers = {k: APILoggerView.LOGSEVERITY[v.getEffectiveLevel()]
+                   for k, v in logging.Logger.manager.loggerDict.items()
+                   if isinstance(v, logging.Logger)}
+        return self.json(loggers)
+
+    @asyncio.coroutine
+    def post(self, request):
+        """Update the given loggers with accompanying log levels."""
+        hass = request.app['hass']
+        try:
+            data = yield from request.json()
+        except ValueError:
+            return self.json_message('Invalid JSON specified',
+                                     HTTP_BAD_REQUEST)
+
+        current_loggers = logging.Logger.manager.loggerDict
+        loggers_to_update = {}
+        for to_change, new_level in data.items():
+            if new_level not in APILoggerView.LOGSEVERITY.values():
+                return self.json_message('Invalid log level: %s', HTTP_BAD_REQUEST)
+
+            if to_change not in current_loggers:
+                return self.json_message('Invalid logger specified: %s' % to_change,
+                                         HTTP_BAD_REQUEST)
+
+            loggers_to_update[to_change] = new_level
+
+        # After verifying the changes we will go through and update the
+        # log levels as requested.
+        # TODO This should probably be done in the logger.set_level?
+        for logger, level in loggers_to_update.items():
+            logging.getLogger(to_change).setLevel(level)
+
+        yield from hass.services.async_call("logger", "set_level", data, True)
+
+        return self.json({"changed": data})
 
 class APIEventStream(HomeAssistantView):
     """View to handle EventStream requests."""

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -112,11 +112,13 @@ class APILoggerView(HomeAssistantView):
         loggers_to_update = {}
         for to_change, new_level in data.items():
             if new_level not in APILoggerView.LOGSEVERITY.values():
-                return self.json_message('Invalid log level: %s', HTTP_BAD_REQUEST)
+                return self.json_message('Invalid log level: %s' % new_level,
+                                         HTTP_BAD_REQUEST)
 
             if to_change not in current_loggers:
-                return self.json_message('Invalid logger specified: %s' % to_change,
-                                         HTTP_BAD_REQUEST)
+                return self.json_message(
+                    'Invalid logger specified: %s' % to_change,
+                    HTTP_BAD_REQUEST)
 
             loggers_to_update[to_change] = new_level
 


### PR DESCRIPTION
## Description:
The current logger settings can be queried by calling /api/logger
A post request on the same containing a dictionary keyed with
name of the logger and value being a text presentation of logging's level.

This is the initial PR, there are a couple of open questions:
1. Currently setting the real logger level (and not just the filter used by homeassistant) is set in the API. Should this rather be a part of the `component.logger`'s `set_level`?
2. The issue of duplicate log levels (this dupes the values from `components.logger`), how to handle?
3. Changing a configuration of adjusts all sub-loggers, although this seems to be python logger's behavior. Is that ok?

Example:
`$ curl -X GET -H "x-ha-access: X" -H "Content-Type: application/json" http://x.local:8123/api/logger`

Redacted output:
```
{
   "homeassistant.components.light.xiaomi_aqara" : "NOTSET",
   "miio.airpurifier" : "NOTSET",
   "limitlessled" : "NOTSET",
   "sqlalchemy.orm.query.Query" : "WARN",
   "pip.req.req_uninstall" : "NOTSET",
   "miio.airqualitymonitor" : "NOTSET",
   "homeassistant.components.recorder.purge" : "NOTSET",
   "pip._vendor.distlib.scripts" : "NOTSET",
   "aiohttp.client" : "NOTSET",
   "pip.commands.list" : "NOTSET",
   "homeassistant.components.light" : "NOTSET",
   "sqlalchemy.orm.strategies.DeferredColumnLoader" : "WARN",
   "sqlalchemy.dialects.postgresql" : "WARN",
   "limitlessled.pipeline" : "NOTSET",
   "urllib3" : "WARN",
   "homeassistant.remote" : "NOTSET",
   "homeassistant.components.binary_sensor" : "NOTSET",
   "urllib3.poolmanager" : "WARN",
   "homeassistant.components.ecobee" : "NOTSET",
   "sqlalchemy.orm.strategies.DoNothingLoader" : "WARN",
   "homeassistant.loader" : "NOTSET"
}
```

`$ curl -X POST -H "x-ha-access: X" -H "Content-Type: application/json" http://x:8123/api/logger -d '{"homeassistant": "DEBUG"}'`

```
{"changed": {"homeassistant": "DEBUG"}}
```


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
