### PR TITLE
Fix cast doing I/O in event loop

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -182,7 +182,8 @@ def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
     else:
         # Manually add a "normal" Chromecast, we can do that without discovery.
         try:
-            chromecast = pychromecast.Chromecast(*want_host)
+            chromecast = yield from hass.async_add_job(
+                pychromecast.Chromecast, *want_host)
         except pychromecast.ChromecastConnectionError:
             _LOGGER.warning("Can't set up chromecast on %s", want_host[0])
             raise


### PR DESCRIPTION
## Description:

Follow-up on #12474.

We're doing I/O inside `async_setup_platform`, because the `pychromecast.Chromecast` constructor calls some http endpoint on the chromecast. We shouldn't do that. I've now looked through the code again, and have not found another instance of this.

Thanks to @rytilahti for pointing this out!

~~Though this should fix the issue, we could also additionally wrap the whole call in a timeout, to make it even more secure:~~ (Doesn't work since `pychromecast.Chromecast` isn't a coroutine)

```python
with async_timeout.timeout(30, loop=hass.loop):
    chromecast = yield from hass.async_add_job(
        pychromecast.Chromecast, *want_host)
```

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: cast
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works. (Dunno how we can check whether a mock object was called from within the event loop)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
