### PR TITLE
Intent: Set light color

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -236,7 +236,7 @@ def preprocess_turn_on_alternatives(params):
         except ValueError:
             _LOGGER.warning('Got unknown color %s, falling back to white',
                             color_name)
-            params[ATTR_RGB_COLOR] = color_util.color_name_to_rgb('white')
+            params[ATTR_RGB_COLOR] = (255, 255, 255)
 
     kelvin = params.pop(ATTR_KELVIN, None)
     if kelvin is not None:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -21,6 +21,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers import intent
 from homeassistant.loader import bind_hass
 import homeassistant.util.color as color_util
 
@@ -228,7 +229,12 @@ def preprocess_turn_on_alternatives(params):
 
     color_name = params.pop(ATTR_COLOR_NAME, None)
     if color_name is not None:
-        params[ATTR_RGB_COLOR] = color_util.color_name_to_rgb(color_name)
+        try:
+            params[ATTR_RGB_COLOR] = color_util.color_name_to_rgb(color_name)
+        except ValueError:
+            _LOGGER.warning('Got unknown color %s, falling back to white',
+                            color_name)
+            params[ATTR_RGB_COLOR] = color_util.color_name_to_rgb('white')
 
     kelvin = params.pop(ATTR_KELVIN, None)
     if kelvin is not None:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -15,7 +15,7 @@ import voluptuous as vol
 from homeassistant.components import group
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TOGGLE, SERVICE_TURN_OFF, SERVICE_TURN_ON,
-    STATE_ON, ATTR_SUPPORTED_FEATURES)
+    STATE_ON)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
@@ -261,12 +261,11 @@ class SetColorIntentHandler(intent.IntentHandler):
         """Handle the hass intent."""
         hass = intent_obj.hass
         slots = self.async_validate_slots(intent_obj.slots)
-        response = intent_obj.create_response()
-        state = intent_obj.match_state(
+        state = hass.helpers.intent.async_match_state(
             slots['name']['value'],
             [state for state in hass.states.async_all()
              if state.domain == DOMAIN])
-        intent_obj.test_feature(state, SUPPORT_RGB_COLOR, 'changing colors')
+        intent.async_test_feature(state, SUPPORT_RGB_COLOR, 'changing colors')
 
         await hass.services.async_call(
             DOMAIN, SERVICE_TURN_ON, {
@@ -274,8 +273,9 @@ class SetColorIntentHandler(intent.IntentHandler):
                 ATTR_RGB_COLOR: slots['color']['value']
             })
 
-        # Use original passed in value of the color because we don't represent
-        # that internally.
+        # Use original passed in value of the color because we don't have human
+        # readable names for that internally.
+        response = intent_obj.create_response()
         response.async_set_speech('Changed the color of {} to {}'.format(
             state.name, intent_obj.slots['color']['value']))
         return response

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -292,7 +292,7 @@ class SetIntentHandler(intent.IntentHandler):
 
         response = intent_obj.create_response()
 
-        if len(speech_parts) == 0:
+        if not speech_parts:  # No attributes changed
             speech = 'Turned on {}'.format(state.name)
         else:
             parts = ['Changed {} to'.format(state.name)]

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -59,6 +59,8 @@ async def async_handle(hass, platform, intent_type, slots=None,
         result = await handler.async_handle(intent)
         return result
     except vol.Invalid as err:
+        _LOGGER.warning('Received invalid slot info for %s: %s',
+                        intent_type, err)
         raise InvalidSlotInfo(
             'Received invalid slot info for {}'.format(intent_type)) from err
     except IntentHandleError:
@@ -167,7 +169,7 @@ class ServiceIntentHandler(IntentHandler):
     """
 
     slot_schema = {
-        'name': cv.string,
+        vol.Required('name'): cv.string,
     }
 
     def __init__(self, intent_type, domain, service, speech):

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -105,7 +105,7 @@ def async_match_state(hass, name, states=None):
 
 @callback
 def async_test_feature(state, feature, feature_name):
-    """Find a state that matches the name."""
+    """Test is state supports a feature."""
     if state.attributes.get(ATTR_SUPPORTED_FEATURES, 0) & feature == 0:
         raise IntentHandleError(
             'Entity {} does not support {}'.format(
@@ -181,32 +181,13 @@ class ServiceIntentHandler(IntentHandler):
         """Handle the hass intent."""
         hass = intent_obj.hass
         slots = self.async_validate_slots(intent_obj.slots)
-        response = intent_obj.create_response()
         state = async_match_state(hass, slots['name']['value'])
 
-<<<<<<< HEAD
-        name = slots['name']['value']
-        entities = {state.entity_id: state.name for state
-                    in hass.states.async_all()}
-
-        matches = fuzzymatch(name, entities)
-        entity_id = matches[0] if matches else None
-        _LOGGER.debug("%s matched entity: %s", name, entity_id)
+        await hass.services.async_call(self.domain, self.service, {
+            ATTR_ENTITY_ID: state.entity_id
+        })
 
         response = intent_obj.create_response()
-        if not entity_id:
-            response.async_set_speech(
-                "Could not find entity id matching {}.".format(name))
-            _LOGGER.error("Could not find entity id matching %s", name)
-            return response
-
-=======
->>>>>>> Add Light Set Color intent
-        await hass.services.async_call(
-            self.domain, self.service, {
-                ATTR_ENTITY_ID: state.entity_id
-            })
-
         response.async_set_speech(self.speech.format(state.name))
         return response
 

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -4,6 +4,7 @@ import re
 
 import voluptuous as vol
 
+from homeassistant.const import ATTR_SUPPORTED_FEATURES
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
@@ -33,6 +34,8 @@ def async_register(hass, handler):
     if intents is None:
         intents = hass.data[DATA_KEY] = {}
 
+    assert handler.intent_type is not None, 'intent_type cannot be None'
+
     if handler.intent_type in intents:
         _LOGGER.warning('Intent %s is being overwritten by %s.',
                         handler.intent_type, handler)
@@ -58,33 +61,31 @@ async def async_handle(hass, platform, intent_type, slots=None,
     except vol.Invalid as err:
         raise InvalidSlotInfo(
             'Received invalid slot info for {}'.format(intent_type)) from err
+    except IntentHandleError:
+        raise
     except Exception as err:
-        raise IntentHandleError(
+        raise IntentUnexpectedError(
             'Error handling {}'.format(intent_type)) from err
 
 
 class IntentError(HomeAssistantError):
     """Base class for intent related errors."""
 
-    pass
-
 
 class UnknownIntent(IntentError):
     """When the intent is not registered."""
-
-    pass
 
 
 class InvalidSlotInfo(IntentError):
     """When the slot data is invalid."""
 
-    pass
-
 
 class IntentHandleError(IntentError):
     """Error while handling intent."""
 
-    pass
+
+class IntentUnexpectedError(IntentError):
+    """Unexpected error while handling intent."""
 
 
 class IntentHandler:
@@ -122,16 +123,17 @@ class IntentHandler:
         return '<{} - {}>'.format(self.__class__.__name__, self.intent_type)
 
 
-def fuzzymatch(name, entities):
+def _fuzzymatch(name, items, key):
     """Fuzzy matching function."""
     matches = []
     pattern = '.*?'.join(name)
     regex = re.compile(pattern, re.IGNORECASE)
-    for entity_id, entity_name in entities.items():
-        match = regex.search(entity_name)
+    for item in items:
+        match = regex.search(key(item))
         if match:
-            matches.append((len(match.group()), match.start(), entity_id))
-    return [x for _, _, x in sorted(matches)]
+            matches.append((len(match.group()), match.start(), item))
+
+    return sorted(matches)[0][2] if matches else None
 
 
 class ServiceIntentHandler(IntentHandler):
@@ -156,7 +158,9 @@ class ServiceIntentHandler(IntentHandler):
         hass = intent_obj.hass
         slots = self.async_validate_slots(intent_obj.slots)
         response = intent_obj.create_response()
+        state = intent_obj.match_state(slots['name']['value'])
 
+<<<<<<< HEAD
         name = slots['name']['value']
         entities = {state.entity_id: state.name for state
                     in hass.states.async_all()}
@@ -172,13 +176,14 @@ class ServiceIntentHandler(IntentHandler):
             _LOGGER.error("Could not find entity id matching %s", name)
             return response
 
+=======
+>>>>>>> Add Light Set Color intent
         await hass.services.async_call(
             self.domain, self.service, {
-                ATTR_ENTITY_ID: entity_id
+                ATTR_ENTITY_ID: state.entity_id
             })
 
-        response.async_set_speech(
-            self.speech.format(name))
+        response.async_set_speech(self.speech.format(state.name))
         return response
 
 
@@ -199,6 +204,29 @@ class Intent:
     def create_response(self):
         """Create a response."""
         return IntentResponse(self)
+
+    @callback
+    def match_state(self, name, states=None):
+        """Find a state that matches the name."""
+        if states is None:
+            states = self.hass.states.async_all()
+
+        entity = _fuzzymatch(name, states, lambda state: state.name)
+
+        if entity is None:
+            raise IntentHandleError('Unable to find entity {}'.format(name))
+
+        return entity
+
+    @callback
+    def test_feature(self, state, feature, feature_name):
+        """Find a state that matches the name."""
+        features = state.attributes.get(ATTR_SUPPORTED_FEATURES)
+
+        if features is None or features & feature == 0:
+            raise IntentHandleError(
+                'Entity {} does not support {}'.format(
+                    state.name, feature_name))
 
 
 class IntentResponse:

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -1,11 +1,8 @@
 """Color util methods."""
-import logging
 import math
 import colorsys
 
 from typing import Tuple
-
-_LOGGER = logging.getLogger(__name__)
 
 # Official CSS3 colors from w3.org:
 # https://www.w3.org/TR/2010/PR-css3-color-20101028/#html4
@@ -171,8 +168,7 @@ def color_name_to_rgb(color_name):
     # spaces in it as well for matching purposes
     hex_value = COLORS.get(color_name.replace(' ', '').lower())
     if not hex_value:
-        _LOGGER.error('unknown color supplied %s default to white', color_name)
-        hex_value = COLORS['white']
+        raise ValueError('Unknown color')
 
     return hex_value
 

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -7,7 +7,7 @@ from homeassistant.setup import setup_component
 import homeassistant.loader as loader
 from homeassistant.const import (
     ATTR_ENTITY_ID, STATE_ON, STATE_OFF, CONF_PLATFORM,
-    SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE)
+    SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE, ATTR_SUPPORTED_FEATURES)
 import homeassistant.components.light as light
 from homeassistant.helpers.intent import IntentHandleError
 
@@ -309,7 +309,7 @@ class TestLight(unittest.TestCase):
 async def test_set_color_intent(hass):
     """Test the set color intent."""
     hass.states.async_set('light.hello_2', 'off', {
-        light.ATTR_SUPPORTED_FEATURES: light.SUPPORT_RGB_COLOR
+        ATTR_SUPPORTED_FEATURES: light.SUPPORT_RGB_COLOR
     })
     hass.states.async_set('switch.hello', 'off')
     calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -393,3 +393,4 @@ async def test_intent_set_color_and_brightness(hass):
     assert call.service == SERVICE_TURN_ON
     assert call.data.get(ATTR_ENTITY_ID) == 'light.hello_2'
     assert call.data.get(light.ATTR_RGB_COLOR) == (0, 0, 255)
+    assert call.data.get(light.ATTR_BRIGHTNESS_PCT) == 20

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -283,7 +283,7 @@ def test_turn_on_multiple_intent(hass):
     )
     yield from hass.async_block_till_done()
 
-    assert response.speech['plain']['speech'] == 'Turned on test lights'
+    assert response.speech['plain']['speech'] == 'Turned on test lights 2'
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == 'light'

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -2,6 +2,9 @@
 import unittest
 import homeassistant.util.color as color_util
 
+import pytest
+import voluptuous as vol
+
 
 class TestColorUtil(unittest.TestCase):
     """Test color util methods."""
@@ -150,10 +153,10 @@ class TestColorUtil(unittest.TestCase):
         self.assertEqual((72, 61, 139),
                          color_util.color_name_to_rgb('darkslate blue'))
 
-    def test_color_name_to_rgb_unknown_name_default_white(self):
+    def test_color_name_to_rgb_unknown_name_raises_value_error(self):
         """Test color_name_to_rgb."""
-        self.assertEqual((255, 255, 255),
-                         color_util.color_name_to_rgb('not a color'))
+        with pytest.raises(ValueError):
+            color_util.color_name_to_rgb('not a color')
 
     def test_color_rgb_to_rgbw(self):
         """Test color_rgb_to_rgbw."""
@@ -280,3 +283,13 @@ class ColorTemperatureToRGB(unittest.TestCase):
         rgb = color_util.color_temperature_to_rgb(6500)
         self.assertGreater(rgb[0], rgb[1])
         self.assertGreater(rgb[0], rgb[2])
+
+
+def test_get_color_in_voluptuous():
+    """Test using the get method in color validation."""
+    schema = vol.Schema(color_util.color_name_to_rgb)
+
+    with pytest.raises(vol.Invalid):
+        schema('not a color')
+
+    assert schema('red') == (255, 0, 0)


### PR DESCRIPTION
## Description:
Add an intent for changing the color of a light.

I initially tried to add this logic into `helpers.intent.ServiceIntentHandler` but failed miserably. I realized that for the set color service to be supported, I needed to add support for:

 - define custom slot schema (add color)
 - customize entities that we match (because we only want to match light entities)
 - customize service data based on slots
 - define custom response formatting (in case we want to add color to the response)

So after hacking it into it, I realized that I made it only more confusing. So instead, I went with another approach: make reusable pieces of functionality to quickly add together a new intent handler.

I borrowed a trick from aiohttp: if you raise `IntentHandlerError`, it should be converted to speech for the end user (Snips, Alexa, etc). That way we can have reusable helper methods that can trigger a response when they encounter an error.

CC @tschmidty69 

**Related issue (if applicable):** #12087

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
