### PR TITLE
Allow renaming entities in entity registry

### DIFF
--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -13,7 +13,8 @@ from homeassistant.util.yaml import load_yaml, dump
 
 DOMAIN = 'config'
 DEPENDENCIES = ['http']
-SECTIONS = ('core', 'customize', 'group', 'hassbian', 'automation', 'script')
+SECTIONS = ('core', 'customize', 'group', 'hassbian', 'automation', 'script',
+            'entity_registry')
 ON_DEMAND = ('zwave',)
 FEATURE_FLAGS = ('config_entries',)
 

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -1,0 +1,55 @@
+"""HTTP views to interact with the entity registry."""
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.http.data_validator import RequestDataValidator
+from homeassistant.helpers.entity_registry import async_get_registry
+
+
+async def async_setup(hass):
+    """Enable the Entity Registry views."""
+    hass.http.register_view(ConfigManagerEntityView)
+    return True
+
+
+class ConfigManagerEntityView(HomeAssistantView):
+    """View to interact with an entity registry entry."""
+
+    url = '/api/config/entity_registry/{entity_id}'
+    name = 'api:config:entity_registry:entity'
+
+    async def get(self, request, entity_id):
+        """Get the entity registry settings for an entity."""
+        hass = request.app['hass']
+        registry = await async_get_registry(hass)
+        entry = registry.entities.get(entity_id)
+
+        if entry is None:
+            return self.json_message('Entry not found', 404)
+
+        return self.json(_entry_dict(entry))
+
+    @RequestDataValidator(vol.Schema({
+        # If passed in, we update value. Passing None will remove old value.
+        vol.Optional('name'): vol.Any(str, None),
+    }))
+    async def post(self, request, entity_id, data):
+        """Update the entity registry settings for an entity."""
+        hass = request.app['hass']
+        registry = await async_get_registry(hass)
+
+        if entity_id not in registry.entities:
+            return self.json_message('Entry not found', 404)
+
+        entry = registry.async_update_entity(entity_id, **data)
+        return self.json(_entry_dict(entry))
+
+
+@callback
+def _entry_dict(entry):
+    """Helper to convert entry to API format."""
+    return {
+        'entity_id': entry.entity_id,
+        'name': entry.name
+    }

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -40,8 +40,8 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class DemoLight(Light):
     """Representation of a demo light."""
 
-    def __init__(self, unique_id, name, state, available=False, rgb=None, ct=None,
-                 brightness=180, xy_color=(.5, .5), white=200,
+    def __init__(self, unique_id, name, state, available=False, rgb=None,
+                 ct=None, brightness=180, xy_color=(.5, .5), white=200,
                  effect_list=None, effect=None):
         """Initialize the light."""
         self._unique_id = unique_id

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -28,11 +28,11 @@ SUPPORT_DEMO = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_EFFECT |
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up the demo light platform."""
     add_devices_callback([
-        DemoLight("Bed Light", False, True, effect_list=LIGHT_EFFECT_LIST,
+        DemoLight(1, "Bed Light", False, True, effect_list=LIGHT_EFFECT_LIST,
                   effect=LIGHT_EFFECT_LIST[0]),
-        DemoLight("Ceiling Lights", True, True,
+        DemoLight(2, "Ceiling Lights", True, True,
                   LIGHT_COLORS[0], LIGHT_TEMPS[1]),
-        DemoLight("Kitchen Lights", True, True,
+        DemoLight(3, "Kitchen Lights", True, True,
                   LIGHT_COLORS[1], LIGHT_TEMPS[0])
     ])
 
@@ -40,10 +40,11 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
 class DemoLight(Light):
     """Representation of a demo light."""
 
-    def __init__(self, name, state, available=False, rgb=None, ct=None,
+    def __init__(self, unique_id, name, state, available=False, rgb=None, ct=None,
                  brightness=180, xy_color=(.5, .5), white=200,
                  effect_list=None, effect=None):
         """Initialize the light."""
+        self._unique_id = unique_id
         self._name = name
         self._state = state
         self._rgb = rgb
@@ -63,6 +64,11 @@ class DemoLight(Light):
     def name(self) -> str:
         """Return the name of the light if any."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return unique ID for light."""
+        return self._unique_id
 
     @property
     def available(self) -> bool:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -340,6 +340,12 @@ class Entity(object):
         else:
             self.hass.states.async_remove(self.entity_id)
 
+    @callback
+    def async_registry_updated(self, old, new):
+        """Called when the entity registry has been updated."""
+        self.registry_name = new.name
+        self.async_schedule_update_ha_state()
+
     def __eq__(self, other):
         """Return the comparison."""
         if not isinstance(other, self.__class__):

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,5 +1,6 @@
 """Test the helper method for writing tests."""
 import asyncio
+from datetime import timedelta
 import functools as ft
 import os
 import sys
@@ -298,7 +299,7 @@ def mock_registry(hass, mock_entries=None):
     """Mock the Entity Registry."""
     registry = entity_registry.EntityRegistry(hass)
     registry.entities = mock_entries or {}
-    hass.data[entity_platform.DATA_REGISTRY] = registry
+    hass.data[entity_registry.DATA_REGISTRY] = registry
     return registry
 
 
@@ -359,6 +360,32 @@ class MockPlatform(object):
 
         if setup_platform is None and async_setup_platform is None:
             self.async_setup_platform = mock_coro_func()
+
+
+class MockEntityPlatform(entity_platform.EntityPlatform):
+    """Mock class with some mock defaults."""
+
+    def __init__(
+        self, hass,
+        logger=None,
+        domain='test_domain',
+        platform_name='test_platform',
+        scan_interval=timedelta(seconds=15),
+        parallel_updates=0,
+        entity_namespace=None,
+        async_entities_added_callback=lambda: None
+    ):
+        """Initialize a mock entity platform."""
+        super().__init__(
+            hass=hass,
+            logger=logger,
+            domain=domain,
+            platform_name=platform_name,
+            scan_interval=scan_interval,
+            parallel_updates=parallel_updates,
+            entity_namespace=entity_namespace,
+            async_entities_added_callback=async_entities_added_callback,
+        )
 
 
 class MockToggleDevice(entity.ToggleEntity):

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -118,7 +118,6 @@ async def test_update_entity_no_changes(hass, client):
     assert state.name == 'name of entity'
 
 
-
 async def test_get_nonexisting_entity(client):
     """Test get entry."""
     resp = await client.get(

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -1,0 +1,135 @@
+"""Test entity_registry API."""
+import pytest
+
+from homeassistant.setup import async_setup_component
+from homeassistant.helpers.entity_registry import RegistryEntry
+from homeassistant.components.config import entity_registry
+from tests.common import mock_registry, MockEntity, MockEntityPlatform
+
+
+@pytest.fixture
+def client(hass, test_client):
+    """Fixture that can interact with the config manager API."""
+    hass.loop.run_until_complete(async_setup_component(hass, 'http', {}))
+    hass.loop.run_until_complete(entity_registry.async_setup(hass))
+    yield hass.loop.run_until_complete(test_client(hass.http.app))
+
+
+async def test_get_entity(hass, client):
+    """Test get entry."""
+    mock_registry(hass, {
+        'test_domain.name': RegistryEntry(
+            entity_id='test_domain.name',
+            unique_id='1234',
+            platform='test_platform',
+            name='Hello World'
+        ),
+        'test_domain.no_name': RegistryEntry(
+            entity_id='test_domain.no_name',
+            unique_id='6789',
+            platform='test_platform',
+        ),
+    })
+
+    resp = await client.get(
+        '/api/config/entity_registry/test_domain.name')
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == {
+        'entity_id': 'test_domain.name',
+        'name': 'Hello World'
+    }
+
+    resp = await client.get(
+        '/api/config/entity_registry/test_domain.no_name')
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == {
+        'entity_id': 'test_domain.no_name',
+        'name': None
+    }
+
+
+async def test_update_entity(hass, client):
+    """Test get entry."""
+    mock_registry(hass, {
+        'test_domain.world': RegistryEntry(
+            entity_id='test_domain.world',
+            unique_id='1234',
+            # Using component.async_add_entities is equal to platform "domain"
+            platform='test_platform',
+            name='before update'
+        )
+    })
+    platform = MockEntityPlatform(hass)
+    entity = MockEntity(unique_id='1234')
+    await platform.async_add_entities([entity])
+
+    state = hass.states.get('test_domain.world')
+    assert state is not None
+    assert state.name == 'before update'
+
+    resp = await client.post(
+        '/api/config/entity_registry/test_domain.world', json={
+            'name': 'after update'
+        })
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == {
+        'entity_id': 'test_domain.world',
+        'name': 'after update'
+    }
+
+    state = hass.states.get('test_domain.world')
+    assert state.name == 'after update'
+
+
+async def test_update_entity_no_changes(hass, client):
+    """Test get entry."""
+    mock_registry(hass, {
+        'test_domain.world': RegistryEntry(
+            entity_id='test_domain.world',
+            unique_id='1234',
+            # Using component.async_add_entities is equal to platform "domain"
+            platform='test_platform',
+            name='name of entity'
+        )
+    })
+    platform = MockEntityPlatform(hass)
+    entity = MockEntity(unique_id='1234')
+    await platform.async_add_entities([entity])
+
+    state = hass.states.get('test_domain.world')
+    assert state is not None
+    assert state.name == 'name of entity'
+
+    resp = await client.post(
+        '/api/config/entity_registry/test_domain.world', json={
+            'name': 'name of entity'
+        })
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == {
+        'entity_id': 'test_domain.world',
+        'name': 'name of entity'
+    }
+
+    state = hass.states.get('test_domain.world')
+    assert state.name == 'name of entity'
+
+
+
+async def test_get_nonexisting_entity(client):
+    """Test get entry."""
+    resp = await client.get(
+        '/api/config/entity_registry/test_domain.non_existing')
+    assert resp.status == 404
+
+
+async def test_update_nonexisting_entity(client):
+    """Test get entry."""
+    resp = await client.post(
+        '/api/config/entity_registry/test_domain.non_existing', json={
+            'name': 'some name'
+        })
+    assert resp.status == 404


### PR DESCRIPTION
## Description:
This adds support for making changes to the entity registry. Currently only name is supported. Also includes an API so we can integrate it from the frontend.

Changing the name (or removing name override) is instantly reflected in the state machine.


## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
