### PR TITLE
Qwikswitch async & updates

### DIFF
--- a/homeassistant/components/light/qwikswitch.py
+++ b/homeassistant/components/light/qwikswitch.py
@@ -8,6 +8,7 @@ import logging
 
 DEPENDENCIES = ['qwikswitch']
 
+
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Add lights from the main Qwikswitch component."""

--- a/homeassistant/components/light/qwikswitch.py
+++ b/homeassistant/components/light/qwikswitch.py
@@ -6,19 +6,15 @@ https://home-assistant.io/components/light.qwikswitch/
 """
 import logging
 
-import homeassistant.components.qwikswitch as qwikswitch
-
-_LOGGER = logging.getLogger(__name__)
-
 DEPENDENCIES = ['qwikswitch']
-
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the lights from the main Qwikswitch component."""
+    """Add lights from the main Qwikswitch component."""
     if discovery_info is None:
-        _LOGGER.error("Configure Qwikswitch component failed")
+        logging.getLogger(__name__).error(
+            "Configure Qwikswitch Light component failed")
         return False
 
-    add_devices(qwikswitch.QSUSB['light'])
+    add_devices(hass.data['qwikswitch']['light'])
     return True

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -33,10 +33,6 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_BUTTON_EVENTS): vol.Coerce(str)
     })}, extra=vol.ALLOW_EXTRA)
 
-QSUSB = {}
-
-SUPPORT_QWIKSWITCH = SUPPORT_BRIGHTNESS
-
 
 class QSToggleEntity(object):
     """Representation of a Qwikswitch Entity.
@@ -53,22 +49,15 @@ class QSToggleEntity(object):
     [3] /components/switch/__init__.py
     """
 
-    def __init__(self, qsitem, qsusb):
+    def __init__(self, qsid, qsusb):
         """Initialize the ToggleEntity."""
-        from pyqwikswitch import (QS_ID, QS_NAME, QSType, PQS_VALUE, PQS_TYPE)
-        self._id = qsitem[QS_ID]
-        self._name = qsitem[QS_NAME]
-        self._value = qsitem[PQS_VALUE]
-        self._qsusb = qsusb
-        self._dim = qsitem[PQS_TYPE] == QSType.dimmer
-        QSUSB[self._id] = self
+        from pyqwikswitch import (QS_NAME, QSDATA, QS_TYPE, QSType)
+        self._id = qsid
+        self._qsusb = qsusb.devices
+        dev = qsusb.devices[qsid]
+        self._dim = dev[QS_TYPE] == QSType.dimmer
+        self._name = dev[QSDATA][QS_NAME]
 
-    @property
-    def brightness(self):
-        """Return the brightness of this light between 0..100."""
-        return self._value if self._dim else None
-
-    # pylint: disable=no-self-use
     @property
     def should_poll(self):
         """No polling needed."""
@@ -82,29 +71,16 @@ class QSToggleEntity(object):
     @property
     def is_on(self):
         """Check if device is on (non-zero)."""
-        return self._value > 0
-
-    def update_value(self, value):
-        """Decode the QSUSB value and update the Home assistant state."""
-        if value != self._value:
-            self._value = value
-            # pylint: disable=no-member
-            super().schedule_update_ha_state()  # Part of Entity/ToggleEntity
-        return self._value
+        return self._qsusb[self._id, 1] > 0
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        newvalue = 255
-        if ATTR_BRIGHTNESS in kwargs:
-            newvalue = kwargs[ATTR_BRIGHTNESS]
-        if self._qsusb.set(self._id, round(min(newvalue, 255)/2.55)) >= 0:
-            self.update_value(newvalue)
+        new = kwargs.get(ATTR_BRIGHTNESS, 255)
+        self._qsusb.set_value(self._id, new)
 
-    # pylint: disable=unused-argument
-    def turn_off(self, **kwargs):
+    def turn_off(self, **kwargs):  # pylint: disable=unused-argument
         """Turn the device off."""
-        if self._qsusb.set(self._id, 0) >= 0:
-            self.update_value(0)
+        self._qsusb.set_value(self._id, 0)
 
 
 class QSSwitch(QSToggleEntity, SwitchDevice):
@@ -117,16 +93,23 @@ class QSLight(QSToggleEntity, Light):
     """Light based on a Qwikswitch relay/dimmer module."""
 
     @property
+    def brightness(self):
+        """Return the brightness of this light (0-255)."""
+        return self._qsusb[self._id, 1] if self._dim else None
+
+    @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_QWIKSWITCH
+        return SUPPORT_BRIGHTNESS if self._dim else None
 
 
 def setup(hass, config):
     """Set up the QSUSB component."""
+    from pyqwikswitch.threaded import QSUsb
     from pyqwikswitch import (
-        QSUsb, CMD_BUTTONS, QS_NAME, QS_ID, QS_CMD, PQS_VALUE, PQS_TYPE,
-        QSType)
+        CMD_BUTTONS, QS_CMD, QSDATA, QS_ID, QS_NAME, QS_TYPE, QSType)
+
+    hass.data[DOMAIN] = {}
 
     # Override which cmd's in /&listen packets will fire events
     # By default only buttons of type [TOGGLE,SCENE EXE,LEVEL]
@@ -136,42 +119,55 @@ def setup(hass, config):
     url = config[DOMAIN][CONF_URL]
     dimmer_adjust = config[DOMAIN][CONF_DIMMER_ADJUST]
 
-    qsusb = QSUsb(url, _LOGGER, dimmer_adjust)
 
-    def _stop(event):
+    def callback_value_changed(qsdevices, key, new): \
+            # pylint: disable=unused-argument
+        """Update entiry values based on device change."""
+        entity = hass.data[DOMAIN].get(key)
+        _LOGGER.debug("callback_value_changed %s=%s [%s]", entity, new, key)
+        if entity is not None:
+            entity.schedule_update_ha_state()  # Part of Entity/ToggleEntity
+
+    qsusb = QSUsb(url=url, dim_adj=dimmer_adjust,
+                  callback_value_changed=callback_value_changed)
+
+    def _stop(event):  # pylint: disable=unused-argument
         """Stop the listener queue and clean up."""
         nonlocal qsusb
         qsusb.stop()
         qsusb = None
-        global QSUSB
-        QSUSB = {}
+        hass.data[DOMAIN] = {}
         _LOGGER.info("Waiting for long poll to QSUSB to time out")
 
     hass.bus.listen(EVENT_HOMEASSISTANT_STOP, _stop)
 
     # Discover all devices in QSUSB
-    devices = qsusb.devices()
-    QSUSB['switch'] = []
-    QSUSB['light'] = []
-    for item in devices:
-        if item[PQS_TYPE] == QSType.relay and (item[QS_NAME].lower()
-                                               .endswith(' switch')):
-            item[QS_NAME] = item[QS_NAME][:-7]  # Remove ' switch' postfix
-            QSUSB['switch'].append(QSSwitch(item, qsusb))
-        elif item[PQS_TYPE] in [QSType.relay, QSType.dimmer]:
-            QSUSB['light'].append(QSLight(item, qsusb))
+    qsusb.update_from_devices()
+    hass.data[DOMAIN]['switch'] = []
+    hass.data[DOMAIN]['light'] = []
+    for _id, item in qsusb.devices:
+        if (item[QS_TYPE] == QSType.relay and
+                item[QSDATA][QS_NAME].lower().endswith(' switch')):
+            item[QSDATA][QS_NAME] = item[QSDATA][QS_NAME][:-7]  # Remove switch
+            new_dev = QSSwitch(_id, qsusb)
+            hass.data[DOMAIN]['switch'].append(new_dev)
+            hass.data[DOMAIN][_id] = new_dev
+        elif item[QS_TYPE] in [QSType.relay, QSType.dimmer]:
+            new_dev = QSLight(_id, qsusb)
+            hass.data[DOMAIN]['light'].append(new_dev)
+            hass.data[DOMAIN][_id] = new_dev
         else:
             _LOGGER.warning("Ignored unknown QSUSB device: %s", item)
 
     # Load platforms
     for comp_name in ('switch', 'light'):
-        if QSUSB[comp_name]:
+        if hass.data[DOMAIN][comp_name]:
             load_platform(hass, comp_name, 'qwikswitch', {}, config)
 
-    def qs_callback(item):
+
+    def callback_qs_listen(item):
         """Typically a button press or update signal."""
         if qsusb is None:  # Shutting down
-            _LOGGER.info("Button press or updating signal done")
             return
 
         # If button pressed, fire a hass event
@@ -180,17 +176,12 @@ def setup(hass, config):
             return
 
         # Update all ha_objects
-        qsreply = qsusb.devices()
-        if qsreply is False:
-            return
-        for itm in qsreply:
-            if itm[QS_ID] in QSUSB:
-                QSUSB[itm[QS_ID]].update_value(
-                    round(min(itm[PQS_VALUE], 100) * 2.55))
+        qsusb.update_from_devices()
 
-    def _start(event):
+    def _start(event):  # pylint: disable=unused-argument
         """Start listening."""
-        qsusb.listen(callback=qs_callback, timeout=30)
+        qsusb.listen(callback_qs_listen, 30)
+
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, _start)
 
     return True

--- a/homeassistant/components/switch/qwikswitch.py
+++ b/homeassistant/components/switch/qwikswitch.py
@@ -6,19 +6,15 @@ https://home-assistant.io/components/switch.qwikswitch/
 """
 import logging
 
-import homeassistant.components.qwikswitch as qwikswitch
-
-_LOGGER = logging.getLogger(__name__)
-
 DEPENDENCIES = ['qwikswitch']
-
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Add switched from the main Qwikswitch component."""
+    """Add switches from the main Qwikswitch component."""
     if discovery_info is None:
-        _LOGGER.error("Configure Qwikswitch component")
+        logging.getLogger(__name__).error(
+            "Configure Qwikswitch Switch component failed")
         return False
 
-    add_devices(qwikswitch.QSUSB['switch'])
+    add_devices(hass.data['qwikswitch']['switch'])
     return True

--- a/homeassistant/components/switch/qwikswitch.py
+++ b/homeassistant/components/switch/qwikswitch.py
@@ -8,6 +8,7 @@ import logging
 
 DEPENDENCIES = ['qwikswitch']
 
+
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Add switches from the main Qwikswitch component."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -853,7 +853,7 @@ pyowm==2.8.0
 pypollencom==1.1.1
 
 # homeassistant.components.qwikswitch
-pyqwikswitch==0.4
+pyqwikswitch==0.5
 
 # homeassistant.components.rainbird
 pyrainbird==0.1.3


### PR DESCRIPTION
## Description:
Added async to qwikswitch library & HA component, but should hav no impact on user settings. 

Old library used 2 dedicated threads for long poll & worker.

* Qwikswitch async
* pyqwikswitch 0.5
* Qwikswitch brightness fixes
* No more global vars --> hass.data

## Example entry for `configuration.yaml` (if applicable):
```yaml
qwikswitch:
  url: http://127.0.0.1:2020
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - N/A: Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - N/A New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
