### PR TITLE
Roomba timeout

### DIFF
--- a/homeassistant/components/vacuum/roomba.py
+++ b/homeassistant/components/vacuum/roomba.py
@@ -16,6 +16,7 @@ from homeassistant.components.vacuum import (
     SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME)
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
 
@@ -94,11 +95,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                  host, username)
 
     try:
-        with async_timeout.timeout(10):
+        with async_timeout.timeout(9):
             yield from hass.async_add_job(roomba.connect)
     except asyncio.TimeoutError:
-        _LOGGER.error("Could not connect to Roomba %s", host)
-        return False
+        raise PlatformNotReady
 
     roomba_vac = RoombaVacuum(name, roomba)
     hass.data[PLATFORM][host] = roomba_vac


### PR DESCRIPTION
## Description:
Add a timeout to the Roomba connection. ~~You will have to restart HASS to enable the Roomba again, but it should not block startup.~~

I would appreciate some feedback from someone with a Roomba!

~~Ideally we should continue scanning periodically for the Roomba, but probably better if someone with a unit to test can look into this~~


**Related issue (if applicable):** fixes #12019

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
vacuum:
  roomba:
```

## Checklist:
  - [x] pylint / flake8 passes
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
