### PR TITLE
Tox: Removed py34

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, lint, requirements, typing
+envlist = py35, py36, lint, requirements, typing
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
## Description:
Removed py34 form `tox.ini`.

**Related issue (if applicable):** #12610 
