### PR TITLE
Update core HSV color scaling to standard scales:

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -287,17 +287,17 @@ class HueLight(Light):
             if self.info.get('manufacturername') == 'OSRAM':
                 color_hue, sat = color_util.color_xy_to_hs(
                     *kwargs[ATTR_XY_COLOR])
-                command['hue'] = color_hue
-                command['sat'] = sat
+                command['hue'] = color_hue / 360 * 65535
+                command['sat'] = sat / 100 * 255
             else:
                 command['xy'] = kwargs[ATTR_XY_COLOR]
         elif ATTR_RGB_COLOR in kwargs:
             if self.info.get('manufacturername') == 'OSRAM':
                 hsv = color_util.color_RGB_to_hsv(
                     *(int(val) for val in kwargs[ATTR_RGB_COLOR]))
-                command['hue'] = hsv[0]
-                command['sat'] = hsv[1]
-                command['bri'] = hsv[2]
+                command['hue'] = hsv[0] / 360 * 65535
+                command['sat'] = hsv[1] / 100 * 255
+                command['bri'] = hsv[2] / 100 * 255
             else:
                 xyb = color_util.color_RGB_to_xy(
                     *(int(val) for val in kwargs[ATTR_RGB_COLOR]))

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -169,13 +169,15 @@ def find_hsbk(**kwargs):
     if ATTR_RGB_COLOR in kwargs:
         hue, saturation, brightness = \
             color_util.color_RGB_to_hsv(*kwargs[ATTR_RGB_COLOR])
-        saturation = convert_8_to_16(saturation)
-        brightness = convert_8_to_16(brightness)
+        hue = hue / 360 * 65535
+        saturation = saturation / 100 * 65535
+        brightness = brightness / 100 * 65535
         kelvin = 3500
 
     if ATTR_XY_COLOR in kwargs:
         hue, saturation = color_util.color_xy_to_hs(*kwargs[ATTR_XY_COLOR])
-        saturation = convert_8_to_16(saturation)
+        hue = hue / 360 * 65535
+        saturation = saturation / 100 * 65535
         kelvin = 3500
 
     if ATTR_COLOR_TEMP in kwargs:
@@ -612,8 +614,11 @@ class LIFXColor(LIFXLight):
         """Return the RGB value."""
         hue, sat, bri, _ = self.device.color
 
-        return color_util.color_hsv_to_RGB(
-            hue, convert_16_to_8(sat), convert_16_to_8(bri))
+        hue = hue / 65535 * 360
+        sat = sat / 65535 * 100
+        bri = bri / 65535 * 100
+
+        return color_util.color_hsv_to_RGB(hue, sat, bri)
 
 
 class LIFXStrip(LIFXColor):

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -300,16 +300,26 @@ def color_hsb_to_RGB(fH: float, fS: float, fB: float) -> Tuple[int, int, int]:
 
 
 # pylint: disable=invalid-sequence-index
-def color_RGB_to_hsv(iR: int, iG: int, iB: int) -> Tuple[int, int, int]:
-    """Convert an rgb color to its hsv representation."""
+def color_RGB_to_hsv(iR: int, iG: int, iB: int) -> Tuple[float, float, float]:
+    """Convert an rgb color to its hsv representation.
+
+    Hue is scaled 0-360
+    Sat is scaled 0-100
+    Val is scaled 0-100
+    """
     fHSV = colorsys.rgb_to_hsv(iR/255.0, iG/255.0, iB/255.0)
-    return (int(fHSV[0]*65536), int(fHSV[1]*255), int(fHSV[2]*255))
+    return round(fHSV[0]*360, 3), round(fHSV[1]*100, 3), round(fHSV[2]*100, 3)
 
 
 # pylint: disable=invalid-sequence-index
-def color_hsv_to_RGB(iH: int, iS: int, iV: int) -> Tuple[int, int, int]:
-    """Convert an hsv color into its rgb representation."""
-    fRGB = colorsys.hsv_to_rgb(iH/65536, iS/255, iV/255)
+def color_hsv_to_RGB(iH: float, iS: float, iV: float) -> Tuple[int, int, int]:
+    """Convert an hsv color into its rgb representation.
+
+    Hue is scaled 0-360
+    Sat is scaled 0-100
+    Val is scaled 0-100
+    """
+    fRGB = colorsys.hsv_to_rgb(iH/360, iS/100, iV/100)
     return (int(fRGB[0]*255), int(fRGB[1]*255), int(fRGB[2]*255))
 
 

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -44,16 +44,16 @@ class TestColorUtil(unittest.TestCase):
         self.assertEqual((0, 0, 0),
                          color_util.color_RGB_to_hsv(0, 0, 0))
 
-        self.assertEqual((0, 0, 255),
+        self.assertEqual((0, 0, 100),
                          color_util.color_RGB_to_hsv(255, 255, 255))
 
-        self.assertEqual((43690, 255, 255),
+        self.assertEqual((240, 100, 100),
                          color_util.color_RGB_to_hsv(0, 0, 255))
 
-        self.assertEqual((21845, 255, 255),
+        self.assertEqual((120, 100, 100),
                          color_util.color_RGB_to_hsv(0, 255, 0))
 
-        self.assertEqual((0, 255, 255),
+        self.assertEqual((0, 100, 100),
                          color_util.color_RGB_to_hsv(255, 0, 0))
 
     def test_color_hsv_to_RGB(self):
@@ -62,16 +62,16 @@ class TestColorUtil(unittest.TestCase):
                          color_util.color_hsv_to_RGB(0, 0, 0))
 
         self.assertEqual((255, 255, 255),
-                         color_util.color_hsv_to_RGB(0, 0, 255))
+                         color_util.color_hsv_to_RGB(0, 0, 100))
 
         self.assertEqual((0, 0, 255),
-                         color_util.color_hsv_to_RGB(43690, 255, 255))
+                         color_util.color_hsv_to_RGB(240, 100, 100))
 
         self.assertEqual((0, 255, 0),
-                         color_util.color_hsv_to_RGB(21845, 255, 255))
+                         color_util.color_hsv_to_RGB(120, 100, 100))
 
         self.assertEqual((255, 0, 0),
-                         color_util.color_hsv_to_RGB(0, 255, 255))
+                         color_util.color_hsv_to_RGB(0, 100, 100))
 
     def test_color_hsb_to_RGB(self):
         """Test color_hsb_to_RGB."""
@@ -92,19 +92,19 @@ class TestColorUtil(unittest.TestCase):
 
     def test_color_xy_to_hs(self):
         """Test color_xy_to_hs."""
-        self.assertEqual((8609, 255),
+        self.assertEqual((47.294, 100),
                          color_util.color_xy_to_hs(1, 1))
 
-        self.assertEqual((6950, 32),
+        self.assertEqual((38.182, 12.941),
                          color_util.color_xy_to_hs(.35, .35))
 
-        self.assertEqual((62965, 255),
+        self.assertEqual((345.882, 100),
                          color_util.color_xy_to_hs(1, 0))
 
-        self.assertEqual((21845, 255),
+        self.assertEqual((120, 100),
                          color_util.color_xy_to_hs(0, 1))
 
-        self.assertEqual((40992, 255),
+        self.assertEqual((225.176, 100),
                          color_util.color_xy_to_hs(0, 0))
 
     def test_rgb_hex_to_rgb_list(self):


### PR DESCRIPTION
## Description:
Related to https://github.com/home-assistant/home-assistant/pull/11288

This PR updates the scaling used internally in hass for HSV values. The current scales were pretty much directly catered to the hue platform. This PR introduces some more standardized scales, before we open up HSV as part of the light API.

Hue is scaled 0-360
Sat is scaled 0-100
Val is scaled 0-100
