### PR TITLE
script/lint Fix: Check if $files is empty, don't try to execute it

### DIFF
--- a/script/lint
+++ b/script/lint
@@ -8,7 +8,7 @@ if [ "$1" = "--changed" ]; then
   echo "================================================="
   echo "FILES CHANGED (git diff upstream/dev... --name-only)"
   echo "================================================="
-  if $files >/dev/null; then
+  if [ -z "$files" ] ; then
     echo "No python file changed"
     exit
   fi


### PR DESCRIPTION
## Description
Quick fix-up of the recent `script/lint` change.