### PR TITLE
Fix a problem with calling `deconz.close`

### DIFF
--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -148,7 +148,7 @@ def async_setup_deconz(hass, config, deconz_config):
     def deconz_shutdown(event):
         """
         Wrap the call to deconz.close.
-        
+
         Used as an argument to EventBus.async_listen_once - EventBus calls
         this method with the event as the first argument, which should not
         be passed on to deconz.close.

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -147,10 +147,11 @@ def async_setup_deconz(hass, config, deconz_config):
     @callback
     def deconz_shutdown(event):
         """
-        Wraps the call to deconz.close. Used as an argument to
-        EventBus.async_listen_once - EventBus calls this method with the
-        event as the first argument, which should not be passed on to
-        deconz.close.
+        Wrap the call to deconz.close.
+        
+        Used as an argument to EventBus.async_listen_once - EventBus calls
+        this method with the event as the first argument, which should not
+        be passed on to deconz.close.
         """
         deconz.close()
 

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 from homeassistant.components.discovery import SERVICE_DECONZ
 from homeassistant.const import (
     CONF_API_KEY, CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -143,7 +144,12 @@ def async_setup_deconz(hass, config, deconz_config):
     hass.services.async_register(
         DOMAIN, 'configure', async_configure, schema=SERVICE_SCHEMA)
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, deconz.close)
+    @callback
+    def deconz_shutdown(event):
+        deconz = hass.data[DOMAIN]
+        deconz.close()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, deconz_shutdown)
     return True
 
 

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -146,7 +146,12 @@ def async_setup_deconz(hass, config, deconz_config):
 
     @callback
     def deconz_shutdown(event):
-        deconz = hass.data[DOMAIN]
+        """
+        Wraps the call to deconz.close. Used as an argument to
+        EventBus.async_listen_once - EventBus calls this method with the
+        event as the first argument, which should not be passed on to
+        deconz.close.
+        """
         deconz.close()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, deconz_shutdown)


### PR DESCRIPTION
## Description:

The event object (`EVENT_HOMEASSISTANT_STOP`) is sent as an argument to
the callable passed to `async_listen_once`. However, `deconz.close` is a bound method
that takes no arguments. Therefore, it needs a wrapper to discard the event
object.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
