### PR TITLE
Make ubus dhcp name resolution optional

### DIFF
--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -23,7 +23,8 @@ CONF_DHCP_SOFTWARE = 'dhcp_software'
 DEFAULT_DHCP_SOFTWARE = 'dnsmasq'
 DHCP_SOFTWARES = [
     'dnsmasq',
-    'odhcpd'
+    'odhcpd',
+    'none'
 ]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -40,8 +41,10 @@ def get_scanner(hass, config):
     dhcp_sw = config[DOMAIN][CONF_DHCP_SOFTWARE]
     if dhcp_sw == 'dnsmasq':
         scanner = DnsmasqUbusDeviceScanner(config[DOMAIN])
-    else:
+    elif dhcp_sw == 'odhcpd':
         scanner = OdhcpdUbusDeviceScanner(config[DOMAIN])
+    else:
+        scanner = UbusDeviceScanner(config[DOMAIN])
 
     return scanner if scanner.success_init else None
 
@@ -92,8 +95,8 @@ class UbusDeviceScanner(DeviceScanner):
         return self.last_results
 
     def _generate_mac2name(self):
-        """Must be implemented depending on the software."""
-        raise NotImplementedError
+        """Return empty MAC to name dict. Overriden if DHCP server is set."""
+        self.mac2name = dict()
 
     @_refresh_on_access_denied
     def get_device_name(self, device):


### PR DESCRIPTION
## Description:
For the case that a separate DHCP server is used or the device is a dumb WiFi access point, allow device name resolution to be disabled.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4751

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: ubus
    host: 192.168.1.1
    username: root
    password: password
    dhcp_software: none
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
