### PR TITLE
Script/lint: Changed default from 'all' to 'changed'

### DIFF
--- a/script/lint
+++ b/script/lint
@@ -3,7 +3,9 @@
 
 cd "$(dirname "$0")/.."
 
-if [ "$1" = "--changed" ]; then
+if [ "$1" = "--all" ]; then
+  tox -e lint
+else
   export files="`git diff upstream/dev... --name-only | grep -e '\.py$'`"
   echo "================================================="
   echo "FILES CHANGED (git diff upstream/dev... --name-only)"
@@ -22,6 +24,4 @@ if [ "$1" = "--changed" ]; then
   echo "================"
   pylint $files
   echo
-else
-  tox -e lint
 fi


### PR DESCRIPTION
## Description:
Changed the default behavior of `script/lint`. Instead of checking all files on execution, only the changed ones will be tested for lint errors. Testing all files is still possible with flag `--all` or the call itself: `tox -e lint`.

Response to: #12651