### PR TITLE
Enable pytradfri requirement during builds

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1004,7 +1004,7 @@ pytouchline==0.7
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-# pytradfri[async]==4.1.0
+pytradfri[async]==4.1.0
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -31,7 +31,6 @@ COMMENT_REQUIREMENTS = (
     'envirophat',
     'i2csense',
     'credstash',
-    'pytradfri',
     'bme680',
 )
 


### PR DESCRIPTION
## Description:

This was disabled pending the 3.4 support removal.

fixes #10376 

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.