### PR TITLE
Disable asuswrt tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -353,6 +353,7 @@ omit =
     homeassistant/components/cover/scsgate.py
     homeassistant/components/device_tracker/actiontec.py
     homeassistant/components/device_tracker/aruba.py
+    homeassistant/components/device_tracker/asuswrt.py
     homeassistant/components/device_tracker/automatic.py
     homeassistant/components/device_tracker/bbox.py
     homeassistant/components/device_tracker/bluetooth_le_tracker.py

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -19,6 +19,7 @@ from homeassistant.components.device_tracker.asuswrt import (
 from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
                                  CONF_HOST)
 
+import pytest
 from tests.common import (
     get_test_home_assistant, get_test_config_dir, assert_setup_component,
     mock_component)
@@ -119,6 +120,10 @@ def teardown_module():
     os.remove(FAKEFILE)
 
 
+@pytest.mark.skip(
+    reason="These tests are performing actual failing network calls. They "
+    "need to be cleaned up before they are re-enabled. They're frequently "
+    "failing in Travis.")
 class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
     """Tests for the ASUSWRT device tracker platform."""
 
@@ -469,6 +474,10 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         self.assertEqual({}, scanner._get_leases(NEIGH_DEVICES.copy()))
 
 
+@pytest.mark.skip(
+    reason="These tests are performing actual failing network calls. They "
+    "need to be cleaned up before they are re-enabled. They're frequently "
+    "failing in Travis.")
 class TestSshConnection(unittest.TestCase):
     """Testing SshConnection."""
 
@@ -509,6 +518,10 @@ class TestSshConnection(unittest.TestCase):
         self.assertIsNone(self.connection._ssh)
 
 
+@pytest.mark.skip(
+    reason="These tests are performing actual failing network calls. They "
+    "need to be cleaned up before they are re-enabled. They're frequently "
+    "failing in Travis.")
 class TestTelnetConnection(unittest.TestCase):
     """Testing TelnetConnection."""
 


### PR DESCRIPTION
## Description:
Some of these tests are performing actual failing network calls. They need to be cleaned up before they are re-enabled. They're running slow and frequently failing on timeouts in Travis.