### PR TITLE
Fix formatting of minutes for sleep start in the fitbit sensor

### DIFF
--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -463,7 +463,8 @@ class FitbitSensor(Entity):
                         hours -= 12
                     elif hours == 0:
                         hours = 12
-                    self._state = '{}:{:02d} {}'.format(hours, minutes, setting)
+                    self._state = '{}:{:02d} {}'.format(hours, minutes,
+                                                        setting)
                 else:
                     self._state = raw_state
             else:

--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -463,7 +463,7 @@ class FitbitSensor(Entity):
                         hours -= 12
                     elif hours == 0:
                         hours = 12
-                    self._state = '{}:{} {}'.format(hours, minutes, setting)
+                    self._state = '{}:{:02d} {}'.format(hours, minutes, setting)
                 else:
                     self._state = raw_state
             else:


### PR DESCRIPTION
## Description:
Modified the sleep start formatting to include a leading 0 in the minutes for the fitbit sensor.

**Related issue (if applicable):** fixes #12594 
```
## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.