### PR TITLE
Add toggle_mode option to rflink switches

### DIFF
--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -45,6 +45,7 @@ CONF_IGNORE_DEVICES = 'ignore_devices'
 CONF_RECONNECT_INTERVAL = 'reconnect_interval'
 CONF_SIGNAL_REPETITIONS = 'signal_repetitions'
 CONF_WAIT_FOR_ACK = 'wait_for_ack'
+CONF_TOGGLE_MODE = 'toggle_mode'
 
 DATA_DEVICE_REGISTER = 'rflink_device_register'
 DATA_ENTITY_LOOKUP = 'rflink_entity_lookup'
@@ -247,7 +248,8 @@ class RflinkDevice(Entity):
 
     def __init__(self, device_id, hass, name=None, aliases=None, group=True,
                  group_aliases=None, nogroup_aliases=None, fire_event=False,
-                 signal_repetitions=DEFAULT_SIGNAL_REPETITIONS):
+                 signal_repetitions=DEFAULT_SIGNAL_REPETITIONS,
+                 toggle_mode=False):
         """Initialize the device."""
         self.hass = hass
 
@@ -260,6 +262,7 @@ class RflinkDevice(Entity):
 
         self._should_fire_event = fire_event
         self._signal_repetitions = signal_repetitions
+        self.toggle_mode = toggle_mode
 
     def handle_event(self, event):
         """Handle incoming event for device type."""
@@ -431,7 +434,9 @@ class SwitchableRflinkDevice(RflinkCommand):
         self.cancel_queued_send_commands()
 
         command = event['command']
-        if command in ['on', 'allon']:
+        if self.toggle_mode:
+            self._state = self._state in [STATE_UNKNOWN, False]
+        elif command in ['on', 'allon']:
             self._state = True
         elif command in ['off', 'alloff']:
             self._state = False

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -11,9 +11,9 @@ from homeassistant.components.rflink import (
     CONF_ALIASES, CONF_ALIASSES, CONF_DEVICE_DEFAULTS, CONF_DEVICES,
     CONF_FIRE_EVENT, CONF_GROUP, CONF_GROUP_ALIASES, CONF_GROUP_ALIASSES,
     CONF_NOGROUP_ALIASES, CONF_NOGROUP_ALIASSES, CONF_SIGNAL_REPETITIONS,
-    DATA_ENTITY_GROUP_LOOKUP, DATA_ENTITY_LOOKUP, DEVICE_DEFAULTS_SCHEMA,
-    DOMAIN, EVENT_KEY_COMMAND, SwitchableRflinkDevice, cv, remove_deprecated,
-    vol)
+    CONF_TOGGLE_MODE, DATA_ENTITY_GROUP_LOOKUP, DATA_ENTITY_LOOKUP,
+    DEVICE_DEFAULTS_SCHEMA, DOMAIN, EVENT_KEY_COMMAND, SwitchableRflinkDevice,
+    cv, remove_deprecated, vol)
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
 from homeassistant.helpers.deprecation import get_deprecated
@@ -36,6 +36,7 @@ PLATFORM_SCHEMA = vol.Schema({
             vol.Optional(CONF_NOGROUP_ALIASES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(CONF_FIRE_EVENT): cv.boolean,
+            vol.Optional(CONF_TOGGLE_MODE): cv.boolean,
             vol.Optional(CONF_SIGNAL_REPETITIONS): vol.Coerce(int),
             vol.Optional(CONF_GROUP, default=True): cv.boolean,
             # deprecated config options

--- a/tests/components/switch/test_rflink.py
+++ b/tests/components/switch/test_rflink.py
@@ -310,3 +310,100 @@ def test_not_firing_default(hass, monkeypatch):
     yield from hass.async_block_till_done()
 
     assert not calls, 'an event has been fired'
+
+
+@asyncio.coroutine
+def test_toggle_mode(hass, monkeypatch):
+    """If a switch is in toggle mode, any command will toggle it."""
+    config = {
+        'rflink': {
+            'port': '/dev/ttyABC0',
+        },
+        DOMAIN: {
+            'platform': 'rflink',
+            'devices': {
+                'protocol_0_0': {
+                    'name': 'test',
+                    'toggle_mode': True,
+                },
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, _, _, _ = yield from mock_rflink(
+        hass, config, DOMAIN, monkeypatch)
+
+    assert hass.states.get(DOMAIN + '.test').state == 'off'
+
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get(DOMAIN + '.test').state == 'on'
+
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get(DOMAIN + '.test').state == 'off'
+
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'alloff',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get(DOMAIN + '.test').state == 'on'
+
+
+@asyncio.coroutine
+def test_default_no_toggle(hass, monkeypatch):
+    """By default, switches should not toggle."""
+    config = {
+        'rflink': {
+            'port': '/dev/ttyABC0',
+        },
+        DOMAIN: {
+            'platform': 'rflink',
+            'devices': {
+                'protocol_0_0': {
+                    'name': 'test',
+                },
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, _, _, _ = yield from mock_rflink(
+        hass, config, DOMAIN, monkeypatch)
+
+    assert hass.states.get(DOMAIN + '.test').state == 'off'
+
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get(DOMAIN + '.test').state == 'on'
+
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get(DOMAIN + '.test').state == 'on'
+
+    event_callback({
+        'id': 'protocol_0_0',
+        'command': 'alloff',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get(DOMAIN + '.test').state == 'off'


### PR DESCRIPTION
## Description:

This PR introduces a `toggle` behaviour to rflink switches. This makes the switch consider any rflink command (on/off/allon/alloff) as a toggle event.

I own 433 MHz push switches that only send `on` events. This allows me to use them to turn equipment on/off without adding complex automation rules. Using the `aliases` feature, this allows to use a set of buttons as toggles for a single entity, effectively implementing a two-way switch for lights.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4754

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: rflink
  devices:
    eurodomest_09c651_06:
      name: "Test toggle switch"
      toggle_mode: true
      aliases:
        - eurodomest_09c651_05
        - ev1527_0639ae_08
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
