### PR TITLE
Harmony: make activity optional

### DIFF
--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -31,7 +31,7 @@ CONF_DEVICE_CACHE = 'harmony_device_cache'
 SERVICE_SYNC = 'harmony_sync'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(ATTR_ACTIVITY): cv.string,
+    vol.Optional(ATTR_ACTIVITY): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(ATTR_DELAY_SECS, default=DEFAULT_DELAY_SECS):
         vol.Coerce(float),


### PR DESCRIPTION
During voluptuous upgrade I removed a `default` from a `vol.Required`, making the `Required` actually be enforced. Based on the code it looked like it was always meant to be ~~required~~ optional. Seems like it was not. This fixes it.

Reported: https://community.home-assistant.io/t/0-64-over-1000-integrations-new-homekit-bmw-august/44834/2?u=balloob