### PR TITLE
Fix getting state from iglo

### DIFF
--- a/homeassistant/components/light/iglo.py
+++ b/homeassistant/components/light/iglo.py
@@ -17,7 +17,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
-REQUIREMENTS = ['iglo==1.2.5']
+REQUIREMENTS = ['iglo==1.2.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,13 +56,13 @@ class IGloLamp(Light):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        return int((self._lamp.state['brightness'] / 200.0) * 255)
+        return int((self._lamp.state()['brightness'] / 200.0) * 255)
 
     @property
     def color_temp(self):
         """Return the color temperature."""
         return color_util.color_temperature_kelvin_to_mired(
-            self._lamp.state['white'])
+            self._lamp.state()['white'])
 
     @property
     def min_mireds(self):
@@ -79,12 +79,12 @@ class IGloLamp(Light):
     @property
     def rgb_color(self):
         """Return the RGB value."""
-        return self._lamp.state['rgb']
+        return self._lamp.state()['rgb']
 
     @property
     def effect(self):
         """Return the current effect."""
-        return self._lamp.state['effect']
+        return self._lamp.state()['effect']
 
     @property
     def effect_list(self):
@@ -100,7 +100,7 @@ class IGloLamp(Light):
     @property
     def is_on(self):
         """Return true if light is on."""
-        return self._lamp.state['on']
+        return self._lamp.state()['on']
 
     def turn_on(self, **kwargs):
         """Turn the light on."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -400,7 +400,7 @@ https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 # i2csense==0.0.4
 
 # homeassistant.components.light.iglo
-iglo==1.2.5
+iglo==1.2.6
 
 # homeassistant.components.ihc
 ihcsdk==2.1.1


### PR DESCRIPTION
## Description:
Upgrade iGlo library and revert to using `lamp.state()` as a method instead of `@property` which is not working in production docker images.


## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
