### PR TITLE
Component deconz: Fix dark attribute on presence sensors

### DIFF
--- a/homeassistant/components/binary_sensor/deconz.py
+++ b/homeassistant/components/binary_sensor/deconz.py
@@ -99,6 +99,6 @@ class DeconzBinarySensor(BinarySensorDevice):
         attr = {
             ATTR_BATTERY_LEVEL: self._sensor.battery,
         }
-        if self._sensor.type == PRESENCE:
+        if self._sensor.type in PRESENCE:
             attr['dark'] = self._sensor.dark
         return attr


### PR DESCRIPTION
pydeconz changed PRESENCE to be an array in v25, so this code hasn't worked since that change.
This simple change fixes it to work with any pydeconz version since v25 (18 Jan 2018)