### PR TITLE
Added cover.group platform (replaces #12303)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,6 +48,7 @@ homeassistant/components/camera/yi.py @bachya
 homeassistant/components/climate/ephember.py @ttroy50
 homeassistant/components/climate/eq3btsmart.py @rytilahti
 homeassistant/components/climate/sensibo.py @andrey-git
+homeassistant/components/cover/group.py @cdce8p
 homeassistant/components/cover/template.py @PhracturedBlue
 homeassistant/components/device_tracker/automatic.py @armills
 homeassistant/components/device_tracker/tile.py @bachya

--- a/homeassistant/components/cover/group.py
+++ b/homeassistant/components/cover/group.py
@@ -31,7 +31,7 @@ KEY_OPEN_CLOSE = 'open_close'
 KEY_STOP = 'stop'
 KEY_POSITION = 'position'
 
-DEFAULT_NAME = 'Group Cover'
+DEFAULT_NAME = 'Cover Group'
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -122,7 +122,7 @@ class GroupCover(CoverDevice):
 
     @property
     def should_poll(self):
-        """Disable polling for the MultiCover."""
+        """Disable polling for cover group."""
         return False
 
     @property
@@ -261,7 +261,10 @@ class GroupCover(CoverDevice):
         return supported_features
 
     async def async_update(self):
-        """Update state and attributes."""
+        """Update state and attributes.
+
+        Update_cover_position must be executed after update_attr_is_closed.
+        """
         self._is_closed = self.update_attr_is_closed()
         self._cover_position = self.update_attr_cover_position()
         self._tilt_position = self.update_attr_tilt_position()

--- a/homeassistant/components/cover/group.py
+++ b/homeassistant/components/cover/group.py
@@ -1,0 +1,269 @@
+"""
+This platform allows several cover to be grouped into one cover.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/cover.group/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.components.cover import (
+    DOMAIN, PLATFORM_SCHEMA, CoverDevice, ATTR_POSITION,
+    ATTR_CURRENT_POSITION, ATTR_TILT_POSITION, ATTR_CURRENT_TILT_POSITION,
+    SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_STOP, SUPPORT_SET_POSITION,
+    SUPPORT_OPEN_TILT, SUPPORT_CLOSE_TILT,
+    SUPPORT_STOP_TILT, SUPPORT_SET_TILT_POSITION,
+    open_cover, open_cover_tilt, close_cover, close_cover_tilt, stop_cover,
+    stop_cover_tilt, set_cover_position, set_cover_tilt_position)
+from homeassistant.const import (
+    CONF_ENTITIES, CONF_NAME, ATTR_SUPPORTED_FEATURES, STATE_CLOSED)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_state_change
+
+_LOGGER = logging.getLogger(__name__)
+
+TILT_FEATURES = SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT | \
+                SUPPORT_STOP_TILT | SUPPORT_SET_TILT_POSITION
+
+KEY_OPEN_CLOSE = 'open_close'
+KEY_STOP = 'stop'
+KEY_POSITION = 'position'
+
+DEFAULT_NAME = 'Group Cover'
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Required(CONF_ENTITIES): cv.entities_domain(DOMAIN),
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Group Cover platform."""
+    async_add_devices(
+        [GroupCover(config.get(CONF_NAME), config.get(CONF_ENTITIES))])
+
+
+class GroupCover(CoverDevice):
+    """Representation of a GroupCover."""
+
+    def __init__(self, name, entities):
+        """Initialize a GroupCover entity."""
+        self._name = name
+        self._tilt = False
+
+        self.entities = entities
+        self.covers = {KEY_OPEN_CLOSE: set(), KEY_STOP: set(),
+                       KEY_POSITION: set()}
+        self.tilts = {KEY_OPEN_CLOSE: set(), KEY_STOP: set(),
+                      KEY_POSITION: set()}
+
+    def update_supported_features(self, entity_id, old_state, new_state):
+        """Update dictionaries with supported features."""
+        if new_state is None:
+            for value in self.covers.values():
+                value.discard(entity_id)
+            for value in self.tilts.values():
+                value.discard(entity_id)
+                tilt = True if value else False
+            self._tilt = tilt
+            return
+
+        if old_state is None:
+            features = new_state.attributes[ATTR_SUPPORTED_FEATURES]
+            if features & (SUPPORT_OPEN | SUPPORT_CLOSE):
+                self.covers[KEY_OPEN_CLOSE].add(entity_id)
+            if features & (SUPPORT_STOP):
+                self.covers[KEY_STOP].add(entity_id)
+            if features & (SUPPORT_SET_POSITION):
+                self.covers[KEY_POSITION].add(entity_id)
+            if features & (SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT):
+                self.tilts[KEY_OPEN_CLOSE].add(entity_id)
+                self._tilt = True
+            if features & (SUPPORT_STOP_TILT):
+                self.tilts[KEY_STOP].add(entity_id)
+                self._tilt = True
+            if features & (SUPPORT_SET_TILT_POSITION):
+                self.tilts[KEY_POSITION].add(entity_id)
+                self._tilt = True
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
+        @callback
+        def state_change_listener(entity, old_state, new_state):
+            """Handle cover state changes and update state."""
+            self.update_supported_features(entity, old_state, new_state)
+            self.async_schedule_update_ha_state(True)
+
+        for entity_id in self.entities:
+            new_state = self.hass.states.get(entity_id)
+            self.update_supported_features(entity_id, None, new_state)
+        async_track_state_change(self.hass, self.entities,
+                                 state_change_listener)
+
+    @property
+    def name(self):
+        """Return the name of the cover."""
+        return self._name
+
+    @property
+    def assumed_state(self):
+        """Enable buttons even if at end position."""
+        return True
+
+    @property
+    def should_poll(self):
+        """Disable polling for the MultiCover."""
+        return False
+
+    @property
+    def is_closed(self):
+        """Return if all covers in group are closed."""
+        if not self.covers[KEY_OPEN_CLOSE]:
+            return False
+        for entity_id in self.covers[KEY_OPEN_CLOSE]:
+            state = self.hass.states.get(entity_id)
+            if state is None or state.state != STATE_CLOSED:
+                return False
+        return True
+
+    @property
+    def current_cover_position(self):
+        """Return current position for all covers.
+
+        None is unknown. pos if all have the same position.
+        Else 0 if closed or 100 is fully open.
+        """
+        position = -1
+        for entity_id in self.covers[KEY_POSITION]:
+            state = self.hass.states.get(entity_id)
+            pos = state.attributes.get(ATTR_CURRENT_POSITION)
+            if position == -1:
+                position = pos
+            elif position != pos:
+                position = -1
+                break
+
+        if position != -1:
+            return position
+
+        return 0 if self.is_closed else 100
+
+    @property
+    def current_cover_tilt_position(self):
+        """Return current tilt position for all covers.
+
+        None is unknown. pos if all have the same tilt position.
+        Else 100 for tilt open.
+        """
+        if self._tilt is False:
+            return None
+
+        position = -1
+        for entity_id in self.tilts[KEY_POSITION]:
+            state = self.hass.states.get(entity_id)
+            pos = state.attributes.get(ATTR_CURRENT_TILT_POSITION)
+            if position == -1:
+                position = pos
+            elif position != pos:
+                position = -1
+                break
+
+        if position != -1:
+            return position
+
+        return 100
+
+    @property
+    def state_attributes(self):
+        """Return the current position as attribute."""
+        data = {}
+        current_cover = self.current_cover_position
+        current_tilt = self.current_cover_tilt_position
+        if current_cover is not None:
+            data[ATTR_CURRENT_POSITION] = current_cover
+        if current_tilt is not None:
+            data[ATTR_CURRENT_TILT_POSITION] = current_tilt
+        return data
+
+    @property
+    def supported_features(self):
+        """Flag supported features for a cover."""
+        supported_features = 0
+
+        if self.covers[KEY_OPEN_CLOSE] != set():
+            supported_features |= SUPPORT_OPEN | SUPPORT_CLOSE
+
+        if self.covers[KEY_STOP] != set():
+            supported_features |= SUPPORT_STOP
+
+        if self.covers[KEY_POSITION] != set():
+            supported_features |= SUPPORT_SET_POSITION
+
+        if self._tilt:
+            supported_features |= TILT_FEATURES
+
+        return supported_features
+
+    @asyncio.coroutine
+    def async_open_cover(self, **kwargs):
+        """Move the covers up."""
+        _LOGGER.debug("Open covers called")
+        self.hass.add_job(open_cover, self.hass,
+                          self.covers[KEY_OPEN_CLOSE])
+
+    @asyncio.coroutine
+    def async_close_cover(self, **kwargs):
+        """Move the covers down."""
+        _LOGGER.debug("Close covers called")
+        self.hass.add_job(close_cover, self.hass,
+                          self.covers[KEY_OPEN_CLOSE])
+
+    @asyncio.coroutine
+    def async_stop_cover(self, **kwargs):
+        """Fire the stop action."""
+        _LOGGER.debug("Stop covers called")
+        self.hass.add_job(stop_cover, self.hass,
+                          self.covers[KEY_STOP])
+
+    @asyncio.coroutine
+    def async_set_cover_position(self, **kwargs):
+        """Set covers position."""
+        position = kwargs[ATTR_POSITION]
+        _LOGGER.debug("Set cover position called: %d", position)
+        self.hass.add_job(set_cover_position, self.hass,
+                          position, self.covers[KEY_POSITION])
+
+    @asyncio.coroutine
+    def async_open_cover_tilt(self, **kwargs):
+        """Tilt covers open."""
+        _LOGGER.debug("Open tilts called")
+        self.hass.add_job(open_cover_tilt, self.hass,
+                          self.tilts[KEY_OPEN_CLOSE])
+
+    @asyncio.coroutine
+    def async_close_cover_tilt(self, **kwargs):
+        """Tilt covers closed."""
+        _LOGGER.debug("Close tilts called")
+        self.hass.add_job(close_cover_tilt, self.hass,
+                          self.tilts[KEY_OPEN_CLOSE])
+
+    @asyncio.coroutine
+    def async_stop_cover_tilt(self, **kwargs):
+        """Stop cover tilt."""
+        _LOGGER.debug("Stop tilts called")
+        self.hass.add_job(stop_cover_tilt, self.hass,
+                          self.tilts[KEY_STOP])
+
+    @asyncio.coroutine
+    def async_set_cover_tilt_position(self, **kwargs):
+        """Set tilt position."""
+        tilt_position = kwargs[ATTR_TILT_POSITION]
+        _LOGGER.debug("Set tilt position called: %d", tilt_position)
+        self.hass.add_job(set_cover_tilt_position, self.hass,
+                          tilt_position, self.tilts[KEY_POSITION])

--- a/homeassistant/components/cover/group.py
+++ b/homeassistant/components/cover/group.py
@@ -81,43 +81,37 @@ class CoverGroup(CoverDevice):
         else:
             features = new_state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
-            # pylint: disable=expression-not-assigned
-            self._covers[KEY_OPEN_CLOSE].add(entity_id) \
-                if features & (SUPPORT_OPEN | SUPPORT_CLOSE) \
-                else self._covers[KEY_OPEN_CLOSE].discard(entity_id)
+            if features & (SUPPORT_OPEN | SUPPORT_CLOSE):
+                self._covers[KEY_OPEN_CLOSE].add(entity_id)
+            else:
+                self._covers[KEY_OPEN_CLOSE].discard(entity_id)
 
-            # pylint: disable=expression-not-assigned
-            self._covers[KEY_STOP].add(entity_id) \
-                if features & (SUPPORT_STOP) \
-                else self._covers[KEY_STOP].discard(entity_id)
+            if features & (SUPPORT_STOP):
+                self._covers[KEY_STOP].add(entity_id)
+            else:
+                self._covers[KEY_STOP].discard(entity_id)
 
-            # pylint: disable=expression-not-assigned
-            self._covers[KEY_POSITION].add(entity_id) \
-                if features & (SUPPORT_SET_POSITION) \
-                else self._covers[KEY_POSITION].discard(entity_id)
+            if features & (SUPPORT_SET_POSITION):
+                self._covers[KEY_POSITION].add(entity_id)
+            else:
+                self._covers[KEY_POSITION].discard(entity_id)
 
-            # pylint: disable=expression-not-assigned
-            self._tilts[KEY_OPEN_CLOSE].add(entity_id) \
-                if features & (SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT) \
-                else self._tilts[KEY_OPEN_CLOSE].discard(entity_id)
+            if features & (SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT):
+                self._tilts[KEY_OPEN_CLOSE].add(entity_id)
+            else:
+                self._tilts[KEY_OPEN_CLOSE].discard(entity_id)
 
-            # pylint: disable=expression-not-assigned
-            self._tilts[KEY_STOP].add(entity_id) \
-                if features & (SUPPORT_STOP_TILT) \
-                else self._tilts[KEY_STOP].discard(entity_id)
+            if features & (SUPPORT_STOP_TILT):
+                self._tilts[KEY_STOP].add(entity_id)
+            else:
+                self._tilts[KEY_STOP].discard(entity_id)
 
-            # pylint: disable=expression-not-assigned
-            self._tilts[KEY_POSITION].add(entity_id) \
-                if features & (SUPPORT_SET_TILT_POSITION) \
-                else self._tilts[KEY_POSITION].discard(entity_id)
+            if features & (SUPPORT_SET_TILT_POSITION):
+                self._tilts[KEY_POSITION].add(entity_id)
+            else:
+                self._tilts[KEY_POSITION].discard(entity_id)
 
-        tilt = False
-        for values in self._tilts.values():
-            if not values:
-                break
-        else:
-            tilt = True
-        self._tilt = tilt
+        self._tilt = any(values for values in self._tilts.values())
 
         if update_state:
             self.async_schedule_update_ha_state(True)
@@ -128,7 +122,7 @@ class CoverGroup(CoverDevice):
             new_state = self.hass.states.get(entity_id)
             self.update_supported_features(entity_id, None, new_state,
                                            update_state=False)
-        self.async_schedule_update_ha_state(True)
+        await self.async_update()
         async_track_state_change(self.hass, self._entities,
                                  self.update_supported_features)
 

--- a/homeassistant/components/cover/group.py
+++ b/homeassistant/components/cover/group.py
@@ -44,14 +44,14 @@ async def async_setup_platform(hass, config, async_add_devices,
                                discovery_info=None):
     """Set up the Group Cover platform."""
     async_add_devices(
-        [GroupCover(config[CONF_NAME], config[CONF_ENTITIES])])
+        [CoverGroup(config[CONF_NAME], config[CONF_ENTITIES])])
 
 
-class GroupCover(CoverDevice):
-    """Representation of a GroupCover."""
+class CoverGroup(CoverDevice):
+    """Representation of a CoverGroup."""
 
     def __init__(self, name, entities):
-        """Initialize a GroupCover entity."""
+        """Initialize a CoverGroup entity."""
         self._name = name
         self._tilt = False
 

--- a/tests/components/cover/test_group.py
+++ b/tests/components/cover/test_group.py
@@ -6,20 +6,26 @@ import homeassistant.util.dt as dt_util
 
 from homeassistant import setup
 from homeassistant.components import cover
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION, ATTR_CURRENT_TILT_POSITION, DOMAIN)
+from homeassistant.components.cover.group import DEFAULT_NAME
+from homeassistant.const import (
+    ATTR_ASSUMED_STATE, ATTR_FRIENDLY_NAME, ATTR_SUPPORTED_FEATURES,
+    CONF_ENTITIES, STATE_OPEN, STATE_CLOSED)
 from tests.common import (
     assert_setup_component, get_test_home_assistant, fire_time_changed)
 
-GROUP_COVER = 'cover.cover_group'
+COVER_GROUP = 'cover.cover_group'
 DEMO_COVER = 'cover.kitchen_window'
 DEMO_COVER_POS = 'cover.hall_window'
 DEMO_COVER_TILT = 'cover.living_room_window'
 DEMO_TILT = 'cover.tilt_demo'
 
 CONFIG = {
-    'cover': [
+    DOMAIN: [
         {'platform': 'demo'},
         {'platform': 'group',
-         'entities': [
+         CONF_ENTITIES: [
              DEMO_COVER, DEMO_COVER_POS, DEMO_COVER_TILT, DEMO_TILT]}
     ]
 }
@@ -37,245 +43,308 @@ class TestMultiCover(unittest.TestCase):
         self.hass.stop()
 
     def test_attributes(self):
-        """Test state attributes after setup."""
-        with assert_setup_component(2, 'cover'):
-            assert setup.setup_component(self.hass, 'cover', CONFIG)
+        """Test handling of state attributes."""
+        config = {DOMAIN: {'platform': 'group', CONF_ENTITIES: [
+            DEMO_COVER, DEMO_COVER_POS, DEMO_COVER_TILT, DEMO_TILT]}}
 
-        state = self.hass.states.get(GROUP_COVER)
+        with assert_setup_component(1, DOMAIN):
+            assert setup.setup_component(self.hass, DOMAIN, config)
+
+        state = self.hass.states.get(COVER_GROUP)
         attr = state.attributes
+        self.assertEqual(state.state, STATE_CLOSED)
+        self.assertEqual(attr.get(ATTR_FRIENDLY_NAME), DEFAULT_NAME)
+        self.assertEqual(attr.get(ATTR_ASSUMED_STATE), None)
+        self.assertEqual(attr.get(ATTR_SUPPORTED_FEATURES), 0)
+        self.assertEqual(attr.get(ATTR_CURRENT_POSITION), None)
+        self.assertEqual(attr.get(ATTR_CURRENT_TILT_POSITION), None)
 
-        self.assertEqual(state.state, 'open')
-        self.assertEqual(attr.get('current_position'), 100)
-        self.assertEqual(attr.get('current_tilt_position'), 50)
-        self.assertEqual(attr.get('supported_features'), 255)
-        self.assertTrue(attr.get('assumed_state'))
-
-    def test_current_cover_position(self):
-        """Test different current cover positions."""
-        with assert_setup_component(2, 'cover'):
-            setup.setup_component(self.hass, 'cover', CONFIG)
-
-        self.assertEqual(self.hass.states.get(GROUP_COVER)
-                         .attributes.get('current_position'), 100)
-
+        # Add Entity that supports open / close / stop
         self.hass.states.set(
-            DEMO_COVER_POS, 'open',
-            {'current_position': 70, 'supported_features': 15})
+            DEMO_COVER, STATE_OPEN, {ATTR_SUPPORTED_FEATURES: 11})
         self.hass.block_till_done()
 
-        self.assertEqual(self.hass.states.get(GROUP_COVER)
-                         .attributes.get('current_position'), 70)
+        state = self.hass.states.get(COVER_GROUP)
+        attr = state.attributes
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(attr.get(ATTR_ASSUMED_STATE), None)
+        self.assertEqual(attr.get(ATTR_SUPPORTED_FEATURES), 11)
+        self.assertEqual(attr.get(ATTR_CURRENT_POSITION), None)
+        self.assertEqual(attr.get(ATTR_CURRENT_TILT_POSITION), None)
 
-        self.hass.states.remove(DEMO_COVER_POS)
+        # Add Entity that supports set_cover_position
         self.hass.states.set(
-            DEMO_COVER_TILT, 'open',
-            {'current_position': 80, 'supported_features': 15})
+            DEMO_COVER_POS, STATE_OPEN,
+            {ATTR_SUPPORTED_FEATURES: 4, ATTR_CURRENT_POSITION: 70})
         self.hass.block_till_done()
 
-        self.assertEqual(self.hass.states.get(GROUP_COVER)
-                         .attributes.get('current_position'), 80)
+        state = self.hass.states.get(COVER_GROUP)
+        attr = state.attributes
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(attr.get(ATTR_ASSUMED_STATE), None)
+        self.assertEqual(attr.get(ATTR_SUPPORTED_FEATURES), 15)
+        self.assertEqual(attr.get(ATTR_CURRENT_POSITION), 70)
+        self.assertEqual(attr.get(ATTR_CURRENT_TILT_POSITION), None)
 
-        self.hass.states.remove(DEMO_COVER_TILT)
-        self.hass.states.set(DEMO_COVER, 'closed',
-                             {'supported_features': 11, 'assumed_state': True})
+        # Add Entity that supports open tilt / close tilt / stop tilt
+        self.hass.states.set(
+            DEMO_TILT, STATE_OPEN, {ATTR_SUPPORTED_FEATURES: 112})
         self.hass.block_till_done()
 
-        self.assertEqual(self.hass.states.get(GROUP_COVER).state, 'closed')
+        state = self.hass.states.get(COVER_GROUP)
+        attr = state.attributes
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(attr.get(ATTR_ASSUMED_STATE), None)
+        self.assertEqual(attr.get(ATTR_SUPPORTED_FEATURES), 127)
+        self.assertEqual(attr.get(ATTR_CURRENT_POSITION), 70)
+        self.assertEqual(attr.get(ATTR_CURRENT_TILT_POSITION), None)
+
+        # Add Entity that supports set_tilt_position
+        self.hass.states.set(
+            DEMO_COVER_TILT, STATE_OPEN,
+            {ATTR_SUPPORTED_FEATURES: 128, ATTR_CURRENT_TILT_POSITION: 60})
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(COVER_GROUP)
+        attr = state.attributes
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(attr.get(ATTR_ASSUMED_STATE), None)
+        self.assertEqual(attr.get(ATTR_SUPPORTED_FEATURES), 255)
+        self.assertEqual(attr.get(ATTR_CURRENT_POSITION), 70)
+        self.assertEqual(attr.get(ATTR_CURRENT_TILT_POSITION), 60)
+
+        # ### Test assumed state ###
+        # ##########################
+
+        # For covers
+        self.hass.states.set(
+            DEMO_COVER, STATE_OPEN,
+            {ATTR_SUPPORTED_FEATURES: 4, ATTR_CURRENT_POSITION: 100})
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(COVER_GROUP)
+        attr = state.attributes
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(attr.get(ATTR_ASSUMED_STATE), True)
+        self.assertEqual(attr.get(ATTR_SUPPORTED_FEATURES), 244)
+        self.assertEqual(attr.get(ATTR_CURRENT_POSITION), 100)
+        self.assertEqual(attr.get(ATTR_CURRENT_TILT_POSITION), 60)
 
         self.hass.states.remove(DEMO_COVER)
         self.hass.block_till_done()
-
-        self.assertEqual(self.hass.states.get(GROUP_COVER).state, 'closed')
-
-    def test_current_tilt_position(self):
-        """Test different current cover tilt positions."""
-        with assert_setup_component(2, 'cover'):
-            assert setup.setup_component(self.hass, 'cover', CONFIG)
-
-        self.hass.states.set(
-            DEMO_TILT, 'open',
-            {'current_tilt_position': 60, 'supported_features': 255})
+        self.hass.states.remove(DEMO_COVER_POS)
         self.hass.block_till_done()
 
-        self.assertEqual(self.hass.states.get(GROUP_COVER)
-                         .attributes.get('current_tilt_position'), 100)
+        state = self.hass.states.get(COVER_GROUP)
+        attr = state.attributes
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(attr.get(ATTR_ASSUMED_STATE), None)
+        self.assertEqual(attr.get(ATTR_SUPPORTED_FEATURES), 240)
+        self.assertEqual(attr.get(ATTR_CURRENT_POSITION), None)
+        self.assertEqual(attr.get(ATTR_CURRENT_TILT_POSITION), 60)
 
+        # For tilts
         self.hass.states.set(
-            DEMO_TILT, 'open',
-            {'current_tilt_position': 50, 'supported_features': 255})
+            DEMO_TILT, STATE_OPEN,
+            {ATTR_SUPPORTED_FEATURES: 128, ATTR_CURRENT_TILT_POSITION: 100})
         self.hass.block_till_done()
 
-        self.assertEqual(self.hass.states.get(GROUP_COVER)
-                         .attributes.get('current_tilt_position'), 50)
+        state = self.hass.states.get(COVER_GROUP)
+        attr = state.attributes
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(attr.get(ATTR_ASSUMED_STATE), True)
+        self.assertEqual(attr.get(ATTR_SUPPORTED_FEATURES), 128)
+        self.assertEqual(attr.get(ATTR_CURRENT_POSITION), None)
+        self.assertEqual(attr.get(ATTR_CURRENT_TILT_POSITION), 100)
+
+        self.hass.states.remove(DEMO_COVER_TILT)
+        self.hass.states.set(DEMO_TILT, STATE_CLOSED)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(COVER_GROUP)
+        attr = state.attributes
+        self.assertEqual(state.state, STATE_CLOSED)
+        self.assertEqual(attr.get(ATTR_ASSUMED_STATE), None)
+        self.assertEqual(attr.get(ATTR_SUPPORTED_FEATURES), 0)
+        self.assertEqual(attr.get(ATTR_CURRENT_POSITION), None)
+        self.assertEqual(attr.get(ATTR_CURRENT_TILT_POSITION), None)
+
+        self.hass.states.set(
+            DEMO_TILT, STATE_CLOSED, {ATTR_ASSUMED_STATE: True})
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(COVER_GROUP)
+        attr = state.attributes
+        self.assertEqual(attr.get(ATTR_ASSUMED_STATE), True)
 
     def test_open_covers(self):
         """Test open cover function."""
-        with assert_setup_component(2, 'cover'):
-            assert setup.setup_component(self.hass, 'cover', CONFIG)
+        with assert_setup_component(2, DOMAIN):
+            assert setup.setup_component(self.hass, DOMAIN, CONFIG)
 
-        cover.open_cover(self.hass, GROUP_COVER)
+        cover.open_cover(self.hass, COVER_GROUP)
         self.hass.block_till_done()
         for _ in range(10):
             future = dt_util.utcnow() + timedelta(seconds=1)
             fire_time_changed(self.hass, future)
             self.hass.block_till_done()
 
-        state = self.hass.states.get(GROUP_COVER)
-        self.assertEqual(state.state, 'open')
-        self.assertEqual(state.attributes.get('current_position'), 100)
+        state = self.hass.states.get(COVER_GROUP)
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(state.attributes.get(ATTR_CURRENT_POSITION), 100)
 
-        self.assertEqual(self.hass.states.get(DEMO_COVER).state, 'open')
+        self.assertEqual(self.hass.states.get(DEMO_COVER).state, STATE_OPEN)
         self.assertEqual(self.hass.states.get(DEMO_COVER_POS)
-                         .attributes.get('current_position'), 100)
+                         .attributes.get(ATTR_CURRENT_POSITION), 100)
         self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
-                         .attributes.get('current_position'), 100)
+                         .attributes.get(ATTR_CURRENT_POSITION), 100)
 
     def test_close_covers(self):
         """Test close cover function."""
-        with assert_setup_component(2, 'cover'):
-            assert setup.setup_component(self.hass, 'cover', CONFIG)
+        with assert_setup_component(2, DOMAIN):
+            assert setup.setup_component(self.hass, DOMAIN, CONFIG)
 
-        cover.close_cover(self.hass, GROUP_COVER)
+        cover.close_cover(self.hass, COVER_GROUP)
         self.hass.block_till_done()
         for _ in range(10):
             future = dt_util.utcnow() + timedelta(seconds=1)
             fire_time_changed(self.hass, future)
             self.hass.block_till_done()
 
-        state = self.hass.states.get(GROUP_COVER)
-        self.assertEqual(state.state, 'closed')
-        self.assertEqual(state.attributes.get('current_position'), 0)
+        state = self.hass.states.get(COVER_GROUP)
+        self.assertEqual(state.state, STATE_CLOSED)
+        self.assertEqual(state.attributes.get(ATTR_CURRENT_POSITION), 0)
 
-        self.assertEqual(self.hass.states.get(DEMO_COVER).state, 'closed')
+        self.assertEqual(self.hass.states.get(DEMO_COVER).state, STATE_CLOSED)
         self.assertEqual(self.hass.states.get(DEMO_COVER_POS)
-                         .attributes.get('current_position'), 0)
+                         .attributes.get(ATTR_CURRENT_POSITION), 0)
         self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
-                         .attributes.get('current_position'), 0)
+                         .attributes.get(ATTR_CURRENT_POSITION), 0)
 
     def test_stop_covers(self):
         """Test stop cover function."""
-        with assert_setup_component(2, 'cover'):
-            assert setup.setup_component(self.hass, 'cover', CONFIG)
+        with assert_setup_component(2, DOMAIN):
+            assert setup.setup_component(self.hass, DOMAIN, CONFIG)
 
-        cover.open_cover(self.hass, GROUP_COVER)
+        cover.open_cover(self.hass, COVER_GROUP)
         self.hass.block_till_done()
         future = dt_util.utcnow() + timedelta(seconds=1)
         fire_time_changed(self.hass, future)
         self.hass.block_till_done()
-        cover.stop_cover(self.hass, GROUP_COVER)
+        cover.stop_cover(self.hass, COVER_GROUP)
         self.hass.block_till_done()
         future = dt_util.utcnow() + timedelta(seconds=1)
         fire_time_changed(self.hass, future)
         self.hass.block_till_done()
 
-        state = self.hass.states.get(GROUP_COVER)
-        self.assertEqual(state.state, 'open')
-        self.assertEqual(state.attributes.get('current_position'), 100)
+        state = self.hass.states.get(COVER_GROUP)
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(state.attributes.get(ATTR_CURRENT_POSITION), 100)
 
-        self.assertEqual(self.hass.states.get(DEMO_COVER).state, 'open')
+        self.assertEqual(self.hass.states.get(DEMO_COVER).state, STATE_OPEN)
         self.assertEqual(self.hass.states.get(DEMO_COVER_POS)
-                         .attributes.get('current_position'), 20)
+                         .attributes.get(ATTR_CURRENT_POSITION), 20)
         self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
-                         .attributes.get('current_position'), 80)
+                         .attributes.get(ATTR_CURRENT_POSITION), 80)
 
     def test_set_cover_position(self):
         """Test set cover position function."""
-        with assert_setup_component(2, 'cover'):
-            assert setup.setup_component(self.hass, 'cover', CONFIG)
+        with assert_setup_component(2, DOMAIN):
+            assert setup.setup_component(self.hass, DOMAIN, CONFIG)
 
-        cover.set_cover_position(self.hass, 50, GROUP_COVER)
+        cover.set_cover_position(self.hass, 50, COVER_GROUP)
         self.hass.block_till_done()
         for _ in range(4):
             future = dt_util.utcnow() + timedelta(seconds=1)
             fire_time_changed(self.hass, future)
             self.hass.block_till_done()
 
-        state = self.hass.states.get(GROUP_COVER)
-        self.assertEqual(state.state, 'open')
-        self.assertEqual(state.attributes.get('current_position'), 50)
+        state = self.hass.states.get(COVER_GROUP)
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(state.attributes.get(ATTR_CURRENT_POSITION), 50)
 
-        self.assertEqual(self.hass.states.get(DEMO_COVER).state, 'closed')
+        self.assertEqual(self.hass.states.get(DEMO_COVER).state, STATE_CLOSED)
         self.assertEqual(self.hass.states.get(DEMO_COVER_POS)
-                         .attributes.get('current_position'), 50)
+                         .attributes.get(ATTR_CURRENT_POSITION), 50)
         self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
-                         .attributes.get('current_position'), 50)
+                         .attributes.get(ATTR_CURRENT_POSITION), 50)
 
     def test_open_tilts(self):
         """Test open tilt function."""
-        with assert_setup_component(2, 'cover'):
-            assert setup.setup_component(self.hass, 'cover', CONFIG)
+        with assert_setup_component(2, DOMAIN):
+            assert setup.setup_component(self.hass, DOMAIN, CONFIG)
 
-        cover.open_cover_tilt(self.hass, GROUP_COVER)
+        cover.open_cover_tilt(self.hass, COVER_GROUP)
         self.hass.block_till_done()
         for _ in range(5):
             future = dt_util.utcnow() + timedelta(seconds=1)
             fire_time_changed(self.hass, future)
             self.hass.block_till_done()
 
-        state = self.hass.states.get(GROUP_COVER)
-        self.assertEqual(state.state, 'open')
-        self.assertEqual(state.attributes.get('current_tilt_position'), 100)
+        state = self.hass.states.get(COVER_GROUP)
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(state.attributes.get(ATTR_CURRENT_TILT_POSITION), 100)
 
         self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
-                         .attributes.get('current_tilt_position'), 100)
+                         .attributes.get(ATTR_CURRENT_TILT_POSITION), 100)
 
     def test_close_tilts(self):
         """Test close tilt function."""
-        with assert_setup_component(2, 'cover'):
-            assert setup.setup_component(self.hass, 'cover', CONFIG)
+        with assert_setup_component(2, DOMAIN):
+            assert setup.setup_component(self.hass, DOMAIN, CONFIG)
 
-        cover.close_cover_tilt(self.hass, GROUP_COVER)
+        cover.close_cover_tilt(self.hass, COVER_GROUP)
         self.hass.block_till_done()
         for _ in range(5):
             future = dt_util.utcnow() + timedelta(seconds=1)
             fire_time_changed(self.hass, future)
             self.hass.block_till_done()
 
-        state = self.hass.states.get(GROUP_COVER)
-        self.assertEqual(state.state, 'open')
-        self.assertEqual(state.attributes.get('current_tilt_position'), 0)
+        state = self.hass.states.get(COVER_GROUP)
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(state.attributes.get(ATTR_CURRENT_TILT_POSITION), 0)
 
         self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
-                         .attributes.get('current_tilt_position'), 0)
+                         .attributes.get(ATTR_CURRENT_TILT_POSITION), 0)
 
     def test_stop_tilts(self):
         """Test stop tilts function."""
-        with assert_setup_component(2, 'cover'):
-            assert setup.setup_component(self.hass, 'cover', CONFIG)
+        with assert_setup_component(2, DOMAIN):
+            assert setup.setup_component(self.hass, DOMAIN, CONFIG)
 
-        cover.open_cover_tilt(self.hass, GROUP_COVER)
+        cover.open_cover_tilt(self.hass, COVER_GROUP)
         self.hass.block_till_done()
         future = dt_util.utcnow() + timedelta(seconds=1)
         fire_time_changed(self.hass, future)
         self.hass.block_till_done()
-        cover.stop_cover_tilt(self.hass, GROUP_COVER)
+        cover.stop_cover_tilt(self.hass, COVER_GROUP)
         self.hass.block_till_done()
         future = dt_util.utcnow() + timedelta(seconds=1)
         fire_time_changed(self.hass, future)
         self.hass.block_till_done()
 
-        state = self.hass.states.get(GROUP_COVER)
-        self.assertEqual(state.state, 'open')
-        self.assertEqual(state.attributes.get('current_tilt_position'), 60)
+        state = self.hass.states.get(COVER_GROUP)
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(state.attributes.get(ATTR_CURRENT_TILT_POSITION), 60)
 
         self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
-                         .attributes.get('current_tilt_position'), 60)
+                         .attributes.get(ATTR_CURRENT_TILT_POSITION), 60)
 
     def test_set_tilt_positions(self):
         """Test set tilt position function."""
-        with assert_setup_component(2, 'cover'):
-            assert setup.setup_component(self.hass, 'cover', CONFIG)
+        with assert_setup_component(2, DOMAIN):
+            assert setup.setup_component(self.hass, DOMAIN, CONFIG)
 
-        cover.set_cover_tilt_position(self.hass, 80, GROUP_COVER)
+        cover.set_cover_tilt_position(self.hass, 80, COVER_GROUP)
         self.hass.block_till_done()
         for _ in range(3):
             future = dt_util.utcnow() + timedelta(seconds=1)
             fire_time_changed(self.hass, future)
             self.hass.block_till_done()
 
-        state = self.hass.states.get(GROUP_COVER)
-        self.assertEqual(state.state, 'open')
-        self.assertEqual(state.attributes.get('current_tilt_position'), 80)
+        state = self.hass.states.get(COVER_GROUP)
+        self.assertEqual(state.state, STATE_OPEN)
+        self.assertEqual(state.attributes.get(ATTR_CURRENT_TILT_POSITION), 80)
 
         self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
-                         .attributes.get('current_tilt_position'), 80)
+                         .attributes.get(ATTR_CURRENT_TILT_POSITION), 80)

--- a/tests/components/cover/test_group.py
+++ b/tests/components/cover/test_group.py
@@ -1,0 +1,313 @@
+"""The tests for the group cover platform."""
+
+import unittest
+from datetime import timedelta
+import homeassistant.util.dt as dt_util
+
+from homeassistant import setup
+from homeassistant.components import cover
+from tests.common import (
+    assert_setup_component, get_test_home_assistant, fire_time_changed)
+
+GROUP_COVER = 'cover.group_cover'
+DEMO_COVER = 'cover.kitchen_window'
+DEMO_COVER_POS = 'cover.hall_window'
+DEMO_COVER_TILT = 'cover.living_room_window'
+DEMO_TILT = 'cover.tilt_demo'
+
+CONFIG = {
+    'cover': [
+        {'platform': 'demo'},
+        {'platform': 'group',
+         'entities': [
+             DEMO_COVER, DEMO_COVER_POS, DEMO_COVER_TILT, DEMO_TILT]}
+    ]
+}
+
+
+class TestMultiCover(unittest.TestCase):
+    """Test the group cover platform."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_attributes(self):
+        """Test state attributes after setup."""
+        with assert_setup_component(2, 'cover'):
+            assert setup.setup_component(self.hass, 'cover', CONFIG)
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(GROUP_COVER)
+        attr = state.attributes
+
+        self.assertEqual(state.state, 'open')
+        self.assertEqual(attr.get('current_position'), 100)
+        self.assertEqual(attr.get('current_tilt_position'), 50)
+        self.assertEqual(attr.get('supported_features'), 255)
+        self.assertTrue(attr.get('assumed_state'))
+
+    def test_current_cover_position(self):
+        """Test different current cover positions."""
+        with assert_setup_component(2, 'cover'):
+            setup.setup_component(self.hass, 'cover', CONFIG)
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        self.assertEqual(self.hass.states.get(GROUP_COVER)
+                         .attributes.get('current_position'), 100)
+
+        self.hass.states.set(
+            DEMO_COVER_POS, 'open',
+            {'current_position': 70, 'supported_features': 15})
+        self.hass.block_till_done()
+
+        self.assertEqual(self.hass.states.get(GROUP_COVER)
+                         .attributes.get('current_position'), 70)
+
+        self.hass.states.remove(DEMO_COVER_POS)
+        self.hass.states.set(
+            DEMO_COVER_TILT, 'open',
+            {'current_position': 80, 'supported_features': 15})
+        self.hass.block_till_done()
+
+        self.assertEqual(self.hass.states.get(GROUP_COVER)
+                         .attributes.get('current_position'), 80)
+
+        self.hass.states.remove(DEMO_COVER_TILT)
+        self.hass.states.set(DEMO_COVER, 'closed')
+        self.hass.block_till_done()
+
+        self.assertEqual(self.hass.states.get(GROUP_COVER).state, 'closed')
+
+        self.hass.states.remove(DEMO_COVER)
+        self.hass.block_till_done()
+
+        self.assertEqual(self.hass.states.get(GROUP_COVER).state, 'open')
+
+    def test_current_tilt_position(self):
+        """Test different current cover tilt positions."""
+        with assert_setup_component(2, 'cover'):
+            assert setup.setup_component(self.hass, 'cover', CONFIG)
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        self.hass.states.set(
+            DEMO_TILT, 'open',
+            {'current_tilt_position': 60, 'supported_features': 255})
+        self.hass.block_till_done()
+
+        self.assertEqual(self.hass.states.get(GROUP_COVER)
+                         .attributes.get('current_tilt_position'), 100)
+
+        self.hass.states.set(
+            DEMO_TILT, 'open',
+            {'current_tilt_position': 50, 'supported_features': 255})
+        self.hass.block_till_done()
+
+        self.assertEqual(self.hass.states.get(GROUP_COVER)
+                         .attributes.get('current_tilt_position'), 50)
+
+    def test_open_covers(self):
+        """Test open cover function."""
+        with assert_setup_component(2, 'cover'):
+            assert setup.setup_component(self.hass, 'cover', CONFIG)
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        cover.open_cover(self.hass, GROUP_COVER)
+        self.hass.block_till_done()
+        for _ in range(10):
+            future = dt_util.utcnow() + timedelta(seconds=1)
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        state = self.hass.states.get(GROUP_COVER)
+        self.assertEqual(state.state, 'open')
+        self.assertEqual(state.attributes.get('current_position'), 100)
+
+        self.assertEqual(self.hass.states.get(DEMO_COVER).state, 'open')
+        self.assertEqual(self.hass.states.get(DEMO_COVER_POS)
+                         .attributes.get('current_position'), 100)
+        self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
+                         .attributes.get('current_position'), 100)
+
+    def test_close_covers(self):
+        """Test close cover function."""
+        with assert_setup_component(2, 'cover'):
+            assert setup.setup_component(self.hass, 'cover', CONFIG)
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        cover.close_cover(self.hass, GROUP_COVER)
+        self.hass.block_till_done()
+        for _ in range(10):
+            future = dt_util.utcnow() + timedelta(seconds=1)
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        state = self.hass.states.get(GROUP_COVER)
+        self.assertEqual(state.state, 'closed')
+        self.assertEqual(state.attributes.get('current_position'), 0)
+
+        self.assertEqual(self.hass.states.get(DEMO_COVER).state, 'closed')
+        self.assertEqual(self.hass.states.get(DEMO_COVER_POS)
+                         .attributes.get('current_position'), 0)
+        self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
+                         .attributes.get('current_position'), 0)
+
+    def test_stop_covers(self):
+        """Test stop cover function."""
+        with assert_setup_component(2, 'cover'):
+            assert setup.setup_component(self.hass, 'cover', CONFIG)
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        cover.open_cover(self.hass, GROUP_COVER)
+        self.hass.block_till_done()
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        fire_time_changed(self.hass, future)
+        self.hass.block_till_done()
+        cover.stop_cover(self.hass, GROUP_COVER)
+        self.hass.block_till_done()
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        fire_time_changed(self.hass, future)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(GROUP_COVER)
+        self.assertEqual(state.state, 'open')
+        self.assertEqual(state.attributes.get('current_position'), 100)
+
+        self.assertEqual(self.hass.states.get(DEMO_COVER).state, 'open')
+        self.assertEqual(self.hass.states.get(DEMO_COVER_POS)
+                         .attributes.get('current_position'), 20)
+        self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
+                         .attributes.get('current_position'), 80)
+
+    def test_set_cover_position(self):
+        """Test set cover position function."""
+        with assert_setup_component(2, 'cover'):
+            assert setup.setup_component(self.hass, 'cover', CONFIG)
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        cover.set_cover_position(self.hass, 50, GROUP_COVER)
+        self.hass.block_till_done()
+        for _ in range(4):
+            future = dt_util.utcnow() + timedelta(seconds=1)
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        state = self.hass.states.get(GROUP_COVER)
+        self.assertEqual(state.state, 'open')
+        self.assertEqual(state.attributes.get('current_position'), 50)
+
+        self.assertEqual(self.hass.states.get(DEMO_COVER).state, 'closed')
+        self.assertEqual(self.hass.states.get(DEMO_COVER_POS)
+                         .attributes.get('current_position'), 50)
+        self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
+                         .attributes.get('current_position'), 50)
+
+    def test_open_tilts(self):
+        """Test open tilt function."""
+        with assert_setup_component(2, 'cover'):
+            assert setup.setup_component(self.hass, 'cover', CONFIG)
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        cover.open_cover_tilt(self.hass, GROUP_COVER)
+        self.hass.block_till_done()
+        for _ in range(5):
+            future = dt_util.utcnow() + timedelta(seconds=1)
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        state = self.hass.states.get(GROUP_COVER)
+        self.assertEqual(state.state, 'open')
+        self.assertEqual(state.attributes.get('current_tilt_position'), 100)
+
+        self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
+                         .attributes.get('current_tilt_position'), 100)
+
+    def test_close_tilts(self):
+        """Test close tilt function."""
+        with assert_setup_component(2, 'cover'):
+            assert setup.setup_component(self.hass, 'cover', CONFIG)
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        cover.close_cover_tilt(self.hass, GROUP_COVER)
+        self.hass.block_till_done()
+        for _ in range(5):
+            future = dt_util.utcnow() + timedelta(seconds=1)
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        state = self.hass.states.get(GROUP_COVER)
+        self.assertEqual(state.state, 'open')
+        self.assertEqual(state.attributes.get('current_tilt_position'), 0)
+
+        self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
+                         .attributes.get('current_tilt_position'), 0)
+
+    def test_stop_tilts(self):
+        """Test stop tilts function."""
+        with assert_setup_component(2, 'cover'):
+            assert setup.setup_component(self.hass, 'cover', CONFIG)
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        cover.open_cover_tilt(self.hass, GROUP_COVER)
+        self.hass.block_till_done()
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        fire_time_changed(self.hass, future)
+        self.hass.block_till_done()
+        cover.stop_cover_tilt(self.hass, GROUP_COVER)
+        self.hass.block_till_done()
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        fire_time_changed(self.hass, future)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(GROUP_COVER)
+        self.assertEqual(state.state, 'open')
+        self.assertEqual(state.attributes.get('current_tilt_position'), 60)
+
+        self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
+                         .attributes.get('current_tilt_position'), 60)
+
+    def test_set_tilt_positions(self):
+        """Test set tilt position function."""
+        with assert_setup_component(2, 'cover'):
+            assert setup.setup_component(self.hass, 'cover', CONFIG)
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        cover.set_cover_tilt_position(self.hass, 80, GROUP_COVER)
+        self.hass.block_till_done()
+        for _ in range(3):
+            future = dt_util.utcnow() + timedelta(seconds=1)
+            fire_time_changed(self.hass, future)
+            self.hass.block_till_done()
+
+        state = self.hass.states.get(GROUP_COVER)
+        self.assertEqual(state.state, 'open')
+        self.assertEqual(state.attributes.get('current_tilt_position'), 80)
+
+        self.assertEqual(self.hass.states.get(DEMO_COVER_TILT)
+                         .attributes.get('current_tilt_position'), 80)

--- a/tests/components/cover/test_group.py
+++ b/tests/components/cover/test_group.py
@@ -9,7 +9,7 @@ from homeassistant.components import cover
 from tests.common import (
     assert_setup_component, get_test_home_assistant, fire_time_changed)
 
-GROUP_COVER = 'cover.group_cover'
+GROUP_COVER = 'cover.cover_group'
 DEMO_COVER = 'cover.kitchen_window'
 DEMO_COVER_POS = 'cover.hall_window'
 DEMO_COVER_TILT = 'cover.living_room_window'

--- a/tests/components/cover/test_group.py
+++ b/tests/components/cover/test_group.py
@@ -41,9 +41,6 @@ class TestMultiCover(unittest.TestCase):
         with assert_setup_component(2, 'cover'):
             assert setup.setup_component(self.hass, 'cover', CONFIG)
 
-        self.hass.start()
-        self.hass.block_till_done()
-
         state = self.hass.states.get(GROUP_COVER)
         attr = state.attributes
 
@@ -57,9 +54,6 @@ class TestMultiCover(unittest.TestCase):
         """Test different current cover positions."""
         with assert_setup_component(2, 'cover'):
             setup.setup_component(self.hass, 'cover', CONFIG)
-
-        self.hass.start()
-        self.hass.block_till_done()
 
         self.assertEqual(self.hass.states.get(GROUP_COVER)
                          .attributes.get('current_position'), 100)
@@ -97,9 +91,6 @@ class TestMultiCover(unittest.TestCase):
         with assert_setup_component(2, 'cover'):
             assert setup.setup_component(self.hass, 'cover', CONFIG)
 
-        self.hass.start()
-        self.hass.block_till_done()
-
         self.hass.states.set(
             DEMO_TILT, 'open',
             {'current_tilt_position': 60, 'supported_features': 255})
@@ -120,9 +111,6 @@ class TestMultiCover(unittest.TestCase):
         """Test open cover function."""
         with assert_setup_component(2, 'cover'):
             assert setup.setup_component(self.hass, 'cover', CONFIG)
-
-        self.hass.start()
-        self.hass.block_till_done()
 
         cover.open_cover(self.hass, GROUP_COVER)
         self.hass.block_till_done()
@@ -146,9 +134,6 @@ class TestMultiCover(unittest.TestCase):
         with assert_setup_component(2, 'cover'):
             assert setup.setup_component(self.hass, 'cover', CONFIG)
 
-        self.hass.start()
-        self.hass.block_till_done()
-
         cover.close_cover(self.hass, GROUP_COVER)
         self.hass.block_till_done()
         for _ in range(10):
@@ -170,9 +155,6 @@ class TestMultiCover(unittest.TestCase):
         """Test stop cover function."""
         with assert_setup_component(2, 'cover'):
             assert setup.setup_component(self.hass, 'cover', CONFIG)
-
-        self.hass.start()
-        self.hass.block_till_done()
 
         cover.open_cover(self.hass, GROUP_COVER)
         self.hass.block_till_done()
@@ -200,9 +182,6 @@ class TestMultiCover(unittest.TestCase):
         with assert_setup_component(2, 'cover'):
             assert setup.setup_component(self.hass, 'cover', CONFIG)
 
-        self.hass.start()
-        self.hass.block_till_done()
-
         cover.set_cover_position(self.hass, 50, GROUP_COVER)
         self.hass.block_till_done()
         for _ in range(4):
@@ -225,9 +204,6 @@ class TestMultiCover(unittest.TestCase):
         with assert_setup_component(2, 'cover'):
             assert setup.setup_component(self.hass, 'cover', CONFIG)
 
-        self.hass.start()
-        self.hass.block_till_done()
-
         cover.open_cover_tilt(self.hass, GROUP_COVER)
         self.hass.block_till_done()
         for _ in range(5):
@@ -247,9 +223,6 @@ class TestMultiCover(unittest.TestCase):
         with assert_setup_component(2, 'cover'):
             assert setup.setup_component(self.hass, 'cover', CONFIG)
 
-        self.hass.start()
-        self.hass.block_till_done()
-
         cover.close_cover_tilt(self.hass, GROUP_COVER)
         self.hass.block_till_done()
         for _ in range(5):
@@ -268,9 +241,6 @@ class TestMultiCover(unittest.TestCase):
         """Test stop tilts function."""
         with assert_setup_component(2, 'cover'):
             assert setup.setup_component(self.hass, 'cover', CONFIG)
-
-        self.hass.start()
-        self.hass.block_till_done()
 
         cover.open_cover_tilt(self.hass, GROUP_COVER)
         self.hass.block_till_done()
@@ -294,9 +264,6 @@ class TestMultiCover(unittest.TestCase):
         """Test set tilt position function."""
         with assert_setup_component(2, 'cover'):
             assert setup.setup_component(self.hass, 'cover', CONFIG)
-
-        self.hass.start()
-        self.hass.block_till_done()
 
         cover.set_cover_tilt_position(self.hass, 80, GROUP_COVER)
         self.hass.block_till_done()

--- a/tests/components/cover/test_group.py
+++ b/tests/components/cover/test_group.py
@@ -76,7 +76,8 @@ class TestMultiCover(unittest.TestCase):
                          .attributes.get('current_position'), 80)
 
         self.hass.states.remove(DEMO_COVER_TILT)
-        self.hass.states.set(DEMO_COVER, 'closed')
+        self.hass.states.set(DEMO_COVER, 'closed',
+                             {'supported_features': 11, 'assumed_state': True})
         self.hass.block_till_done()
 
         self.assertEqual(self.hass.states.get(GROUP_COVER).state, 'closed')
@@ -84,7 +85,7 @@ class TestMultiCover(unittest.TestCase):
         self.hass.states.remove(DEMO_COVER)
         self.hass.block_till_done()
 
-        self.assertEqual(self.hass.states.get(GROUP_COVER).state, 'open')
+        self.assertEqual(self.hass.states.get(GROUP_COVER).state, 'closed')
 
     def test_current_tilt_position(self):
         """Test different current cover tilt positions."""


### PR DESCRIPTION
## Description:
This component allows for easy setup of a `cover group` (control several covers with one entity). To achieve the same with current components, it is necessary to use a combination of `cover.template`, `scripts` and a `sensor.template` as seen here https://home-assistant.io/components/cover.template/#multiple-covers

This is the replacement for #12303 
Related discussion in home-assistant/architecture/issues/13

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4638

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  - platform: group
    name: My Cover Group
    entities:
      - cover.hall_window
      - cover.living_room_window
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

---

## Summary (old PR)

* Related: #12229
* Changed `self.hass.add_job(self.hass.services.async_call(DOMAIN, SERVICE_START_COVER, {...}))` to `self.hass.add_job(start_cover, self.hass, ...)`
