### PR TITLE
Don't allow to use a old unsecure library

### DIFF
--- a/homeassistant/components/coinbase.py
+++ b/homeassistant/components/coinbase.py
@@ -14,7 +14,9 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['coinbase==2.0.7']
+REQUIREMENTS = [
+    'https://github.com/balloob/coinbase-python/archive/'
+    '3a35efe13ef728a1cc18204b4f25be1fcb1c6006.zip#coinbase==2.0.8a1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -19,7 +19,9 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['broadlink==0.5']
+REQUIREMENTS = [
+    'https://github.com/balloob/python-broadlink/archive/'
+    '3580ff2eaccd267846f14246d6ede6e30671f7c6.zip#broadlink==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -22,7 +22,9 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 from homeassistant.util.dt import utcnow
 
-REQUIREMENTS = ['broadlink==0.5']
+REQUIREMENTS = [
+    'https://github.com/balloob/python-broadlink/archive/'
+    '3580ff2eaccd267846f14246d6ede6e30671f7c6.zip#broadlink==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -15,3 +15,6 @@ attrs==17.4.0
 
 # Breaks Python 3.6 and is not needed for our supported Python versions
 enum34==1000000000.0.0
+
+# This is a old unmaintained library and is replaced with pycryptodome
+pycrypto==1000000000.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -165,10 +165,6 @@ boto3==1.4.7
 # homeassistant.scripts.credstash
 botocore==1.7.34
 
-# homeassistant.components.sensor.broadlink
-# homeassistant.components.switch.broadlink
-broadlink==0.5
-
 # homeassistant.components.sensor.buienradar
 # homeassistant.components.weather.buienradar
 buienradar==0.91
@@ -369,6 +365,10 @@ httplib2==0.10.3
 
 # homeassistant.components.media_player.braviatv
 https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
+
+# homeassistant.components.sensor.broadlink
+# homeassistant.components.switch.broadlink
+https://github.com/balloob/python-broadlink/archive/3580ff2eaccd267846f14246d6ede6e30671f7c6.zip#broadlink==0.5.1
 
 # homeassistant.components.media_player.spotify
 https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f86c90aa26b2.zip#spotipy==2.4.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -175,9 +175,6 @@ caldav==0.5.0
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2
 
-# homeassistant.components.coinbase
-coinbase==2.0.7
-
 # homeassistant.components.sensor.coinmarketcap
 coinmarketcap==4.2.1
 
@@ -365,6 +362,9 @@ httplib2==0.10.3
 
 # homeassistant.components.media_player.braviatv
 https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
+
+# homeassistant.components.coinbase
+https://github.com/balloob/coinbase-python/archive/3a35efe13ef728a1cc18204b4f25be1fcb1c6006.zip#coinbase==2.0.8a1
 
 # homeassistant.components.sensor.broadlink
 # homeassistant.components.switch.broadlink

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -112,6 +112,9 @@ CONSTRAINT_PATH = os.path.join(os.path.dirname(__file__),
 CONSTRAINT_BASE = """
 # Breaks Python 3.6 and is not needed for our supported Python versions
 enum34==1000000000.0.0
+
+# This is a old unmaintained library and is replaced with pycryptodome
+pycrypto==1000000000.0.0
 """
 
 


### PR DESCRIPTION
## Description:

Fix: #12709
Fix: #12682
Fix: #12675

Need update:
- [x] zigpy: https://github.com/zigpy/zigpy/pull/26
- [ ] broadlink: https://github.com/mjg59/python-broadlink/pull/150
- [ ] coinbase: https://github.com/coinbase/coinbase-python/pull/72