### PR TITLE
Homekit schema gracefully fail with integer

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -35,7 +35,7 @@ def valid_pin(value):
     match = re.match(_RE_VALID_PINCODE, str(value).strip())
     if not match:
         raise vol.Invalid("Pin must be in the format: '123-45-678'")
-    return match
+    return match.group(0)
 
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -35,7 +35,7 @@ def valid_pin(value):
     match = re.match(_RE_VALID_PINCODE, str(value).strip())
     if not match:
         raise vol.Invalid("Pin must be in the format: '123-45-678'")
-    return match[0]
+    return match
 
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.util.decorator import Registry
 TYPES = Registry()
 _LOGGER = logging.getLogger(__name__)
 
-_RE_VALID_PINCODE = re.compile(r"^(\d{3}-\d{2}-\d{3})$")
+_RE_VALID_PINCODE = r"^(\d{3}-\d{2}-\d{3})$"
 
 DOMAIN = 'homekit'
 REQUIREMENTS = ['HAP-python==1.1.7']
@@ -32,8 +32,8 @@ HOMEKIT_FILE = '.homekit.state'
 
 def valid_pin(value):
     """Validate pin code value."""
-    match = _RE_VALID_PINCODE.findall(value.strip())
-    if match == []:
+    match = re.match(_RE_VALID_PINCODE, str(value).strip())
+    if not match:
         raise vol.Invalid("Pin must be in the format: '123-45-678'")
     return match[0]
 

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -73,7 +73,7 @@ class TestHomeKit(unittest.TestCase):
         """Test async_setup with invalid config option."""
         schema = vol.Schema(valid_pin)
 
-        for value in ('', '123-456-78', 'a23-45-678', '12345678'):
+        for value in ('', '123-456-78', 'a23-45-678', '12345678', 1234):
             with self.assertRaises(vol.MultipleInvalid):
                 schema(value)
 


### PR DESCRIPTION
## Description:
Entering a integer pin code failed: (yes, I did not read the manual 😄)


```
  File "/usr/src/app/homeassistant/components/homekit/__init__.py", line 34, in valid_pin
    match = _RE_VALID_PINCODE.findall(value.strip())
AttributeError: 'int' object has no attribute 'strip'
```


## Example entry for `configuration.yaml` (if applicable):
```yaml
homekit:
  pincode: 1234
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
