### PR TITLE
Fix alpha_vantage default options

### DIFF
--- a/homeassistant/components/sensor/alpha_vantage.py
+++ b/homeassistant/components/sensor/alpha_vantage.py
@@ -70,8 +70,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     from alpha_vantage.foreignexchange import ForeignExchange
 
     api_key = config.get(CONF_API_KEY)
-    symbols = config.get(CONF_SYMBOLS)
-    conversions = config.get(CONF_FOREIGN_EXCHANGE)
+    symbols = config.get(CONF_SYMBOLS, [])
+    conversions = config.get(CONF_FOREIGN_EXCHANGE, [])
 
     if not symbols and not conversions:
         msg = 'Warning: No symbols or currencies configured.'


### PR DESCRIPTION
## Description:
fixed bug in parsing config data. Now undefined symbols or foreign_exchanges to not trigger an exception any more

**Related issue (if applicable):** fixes #12673

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: alpha_vantage
    api_key: <api key>
    symbols:
    - symbol: MSFT
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
