### PR TITLE
Add Freebox device tracker

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -393,6 +393,7 @@ omit =
     homeassistant/components/device_tracker/bt_home_hub_5.py
     homeassistant/components/device_tracker/cisco_ios.py
     homeassistant/components/device_tracker/ddwrt.py
+    homeassistant/components/device_tracker/freebox.py
     homeassistant/components/device_tracker/fritz.py
     homeassistant/components/device_tracker/google_maps.py
     homeassistant/components/device_tracker/gpslogger.py

--- a/homeassistant/components/device_tracker/freebox.py
+++ b/homeassistant/components/device_tracker/freebox.py
@@ -1,0 +1,145 @@
+"""
+Support for device tracking through Freebox routers.
+
+This tracker keeps track of the devices connected to the configured Freebox.
+
+Example configuration.yaml entry:
+
+device_tracker:
+  - platform: freebox
+    host: foobar.fbox.fr
+    port: 1234
+
+You can find out your Freebox host and port by opening this address in your
+browser: http://mafreebox.freebox.fr/api_version. The returned json should
+contain an api_domain (host) and a https_port (port).
+
+The first time you add your Freebox, you will need to authorize Home Assistant
+by pressing the right button on the facade of the Freebox when prompted to do
+so.
+
+Note that the Freebox waits for some time before marking a device as
+inactive, meaning that there will be a small delay (1 or 2 minutes)
+between the time you disconnect a device and the time it will appear
+as "away" in Hass. You should take this into account when specifying
+consider_home.
+On the contrary, the Freebox immediately reports devices newly connected, so
+they should appear as "home" almost instantly, as soon as Hass refreshes the
+devices states.
+
+"""
+import logging
+from collections import namedtuple
+from datetime import timedelta
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT)
+from homeassistant.util import Throttle
+
+REQUIREMENTS = ['freepybox==0.0.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+FREEBOX_CONFIG_FILE = 'freebox.conf'
+
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_PORT): cv.port
+    }))
+
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
+
+
+def get_scanner(hass, config):
+    """Validate the configuration and return a Bbox scanner."""
+    scanner = FreeboxDeviceScanner(hass, config[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+
+Device = namedtuple('Device', ['id', 'name', 'ip'])
+
+
+def _build_device(device_dict):
+    return Device(
+            device_dict['l2ident']['id'],
+            device_dict['primary_name'],
+            device_dict['l3connectivities'][0]['addr'])
+
+
+class FreeboxDeviceScanner(DeviceScanner):
+    """This class scans for devices connected to the Freebox."""
+
+    def __init__(self, hass, config):
+        """Initialize the scanner."""
+        self.host = config[CONF_HOST]
+        self.port = config[CONF_PORT]
+        self.token_file = hass.config.path(FREEBOX_CONFIG_FILE)
+
+        self.last_results = []  # type: List[Device]
+
+        self.success_init = self._update_info()
+        _LOGGER.info("Scanner initialized")
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+
+        _LOGGER.info("Devices detected: " + str([device.name for device in self.last_results]))
+        return [device.id for device in self.last_results]
+
+    def get_device_name(self, id):
+        """Return the name of the given device or None if we don't know."""
+        for device in self.last_results:
+            if device.id == id:
+                return device.name
+
+        return None
+
+    @Throttle(MIN_TIME_BETWEEN_SCANS)
+    def _update_info(self):
+        """Check the Freebox for devices.
+
+        Returns boolean if scanning successful.
+        """
+        _LOGGER.info('Scanning devices')
+
+        from freepybox import Freepybox
+        import socket
+
+        # Hardcode the app description to avoid invalidating the authentication
+        # file at each new version.
+        # The version can be changed if we want the user to re-authorize HASS
+        # on her Freebox.
+        app_desc = {
+            'app_id': 'hass',
+            'app_name': 'Home Assistant',
+            'app_version': '0.65',
+            'device_name': socket.gethostname()
+        }
+
+        api_version = 'v1'  # Use the lowest working version.
+        fbx = Freepybox(
+            app_desc=app_desc,
+            token_file=self.token_file,
+            api_version=api_version)
+        fbx.open(self.host, self.port)
+        try:
+            hosts = fbx.lan.get_hosts_list()
+        finally:
+            fbx.close()
+
+        last_results = [_build_device(device)
+                        for device in hosts
+                        if device['active']]
+
+        self.last_results = last_results
+
+        _LOGGER.info('Scan successful')
+        return True

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -84,6 +84,7 @@ SERVICE_HANDLERS = {
     'kodi': ('media_player', 'kodi'),
     'volumio': ('media_player', 'volumio'),
     'nanoleaf_aurora': ('light', 'nanoleaf_aurora'),
+    'freebox': ('device_tracker', 'freebox'),
 }
 
 OPTIONAL_SERVICE_HANDLERS = {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -618,6 +618,7 @@ pdunehd==1.3
 # homeassistant.components.media_player.pandora
 pexpect==4.0.1
 
+# homeassistant.components.freebox
 # homeassistant.components.rpi_pfio
 pifacecommon==4.1.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -323,6 +323,9 @@ flux_led==0.21
 # homeassistant.components.sensor.foobot
 foobot_async==0.3.1
 
+# homeassistant.components.device_tracker.freebox
+freepybox==0.0.3
+
 # homeassistant.components.notify.free_mobile
 freesms==0.1.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -81,6 +81,9 @@ aioautomatic==0.6.5
 # homeassistant.components.sensor.dnsip
 aiodns==1.1.1
 
+# homeassistant.components.device_tracker.freebox
+aiofreepybox==0.0.3
+
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0
@@ -322,9 +325,6 @@ flux_led==0.21
 
 # homeassistant.components.sensor.foobot
 foobot_async==0.3.1
-
-# homeassistant.components.device_tracker.freebox
-freepybox==0.0.3
 
 # homeassistant.components.notify.free_mobile
 freesms==0.1.2
@@ -618,7 +618,6 @@ pdunehd==1.3
 # homeassistant.components.media_player.pandora
 pexpect==4.0.1
 
-# homeassistant.components.freebox
 # homeassistant.components.rpi_pfio
 pifacecommon==4.1.2
 


### PR DESCRIPTION
## Description:

This pull request adds a device tracker platform for the Freebox, the server/router of the french FAI Free, along the lines of [PR #10702](https://github.com/home-assistant/home-assistant/pull/10702). It is based on [freepybox](https://github.com/fstercq/freepybox), but it necessitates some changes that have not been released yet.

The platform can be set up automatically through discovery (once [this netdisco commit](https://github.com/home-assistant/netdisco/commit/3a4249b67da0acdfa29183ec66feed9cf3d604fb) will be released), or configured as usual.

There is some documentation in the header of the file, I can make that a full documentation page in home-assistant.github.io if need be.

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: freebox
    host: foobar.fbox.fr
    port: 1234
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
