### PR TITLE
Remove automatic sqlite vacuum

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -165,7 +165,6 @@ class Recorder(threading.Thread):
         self.hass = hass
         self.keep_days = keep_days
         self.purge_interval = purge_interval
-        self.did_vacuum = False
         self.queue = queue.Queue()  # type: Any
         self.recording_start = dt_util.utcnow()
         self.db_url = uri
@@ -269,7 +268,7 @@ class Recorder(threading.Thread):
             def async_purge(now):
                 """Trigger the purge and schedule the next run."""
                 self.queue.put(
-                    PurgeTask(self.keep_days, repack=not self.did_vacuum))
+                    PurgeTask(self.keep_days, repack=False))
                 self.hass.helpers.event.async_track_point_in_time(
                     async_purge, now + timedelta(days=self.purge_interval))
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -66,6 +66,5 @@ def purge_old_data(instance, purge_days, repack):
         _LOGGER.debug("Vacuuming SQLite to free space")
         try:
             instance.engine.execute("VACUUM")
-            instance.did_vacuum = True
         except exc.OperationalError as err:
             _LOGGER.error("Error vacuuming SQLite: %s.", err)

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -2,6 +2,7 @@
 import json
 from datetime import datetime, timedelta
 import unittest
+from unittest.mock import patch
 
 from homeassistant.components import recorder
 from homeassistant.components.recorder.const import DATA_INSTANCE
@@ -199,10 +200,12 @@ class TestRecorderPurge(unittest.TestCase):
                 event.event_type for event in events.all()))
 
             # run purge method - correct service data, with repack
-            service_data['repack'] = True
-            self.assertFalse(self.hass.data[DATA_INSTANCE].did_vacuum)
-            self.hass.services.call('recorder', 'purge',
-                                    service_data=service_data)
-            self.hass.block_till_done()
-            self.hass.data[DATA_INSTANCE].block_till_done()
-            self.assertTrue(self.hass.data[DATA_INSTANCE].did_vacuum)
+            with patch('homeassistant.components.recorder.purge._LOGGER') \
+                    as mock_logger:
+                service_data['repack'] = True
+                self.hass.services.call('recorder', 'purge',
+                                        service_data=service_data)
+                self.hass.block_till_done()
+                self.hass.data[DATA_INSTANCE].block_till_done()
+                self.assertEqual(mock_logger.debug.mock_calls[4][1][0],
+                                 "Vacuuming SQLite to free space")


### PR DESCRIPTION
## Description:

As agreed in #11903, this removes the automatic SQLite vacuum that follows the first periodic purge after each startup.

## Checklist:
  - [X] The code change is tested and works locally.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] Tests have been added to verify that the new code works.
