### PR TITLE
Fix harmony duplicate detection

### DIFF
--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -71,7 +71,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             port)
 
         # Ignore hub name when checking if this hub is known - ip and port only
-        if host and host[1:] in (h.host for h in DEVICES):
+        if host[1:] in ((h.host, h.port) for h in DEVICES):
             _LOGGER.debug("Discovered host already known: %s", host)
             return
     elif CONF_HOST in config:
@@ -139,7 +139,7 @@ class HarmonyRemote(remote.RemoteDevice):
         _LOGGER.debug("HarmonyRemote device init started for: %s", name)
         self._name = name
         self.host = host
-        self._port = port
+        self.port = port
         self._state = None
         self._current_activity = None
         self._default_activity = activity


### PR DESCRIPTION
## Description:

The matching was wrong so manually configured devices would show up twice if `discovery` was enabled.

**Related issue (if applicable):** reported in https://community.home-assistant.io/t/2-harmony-hubs-basic-config-errors/44886/3

## Checklist:
  - [X] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).</s>
  - [ ] <s>New dependencies are only imported inside functions that use them ([example][ex-import]).</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54