### PR TITLE
correct air index unit

### DIFF
--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -210,7 +210,7 @@ class AirQualityIndexSensor(AirVisualBaseSensor):
     @property
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
-        return 'PSI'
+        return 'AQI'
 
     def update(self):
         """Update the status of the sensor."""


### PR DESCRIPTION
AirVisual's air index unit is AQI (Air Quality Index), not PSI (Pressure per Square Inch). More details can be found at https://airvisual.com/

Cheers,