### PR TITLE
Fix for moisture sensors in isy994

### DIFF
--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -56,7 +56,7 @@ def setup_platform(hass, config: ConfigType,
         else:
             device_type = _detect_device_type(node)
             subnode_id = int(node.nid[-1])
-            if (device_type == 'opening' or device_type == "moisture"):
+            if (device_type == 'opening' or device_type == 'moisture'):
                 # These sensors use an optional "negative" subnode 2 to snag
                 # all state changes
                 if subnode_id == 2:

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -56,21 +56,14 @@ def setup_platform(hass, config: ConfigType,
         else:
             device_type = _detect_device_type(node)
             subnode_id = int(node.nid[-1])
-            if device_type == 'opening':
-                # Door/window sensors use an optional "negative" node
-                if subnode_id == 4:
+            if (device_type == 'opening' or device_type == "moisture"):
+                # These sensors use an optional "negative" subnode 2 to snag
+                # all state changes
+                if subnode_id == 2:
+                    parent_device.add_negative_node(node)
+                elif subnode_id == 4:
                     # Subnode 4 is the heartbeat node, which we will represent
                     # as a separate binary_sensor
-                    device = ISYBinarySensorHeartbeat(node, parent_device)
-                    parent_device.add_heartbeat_device(device)
-                    devices.append(device)
-                elif subnode_id == 2:
-                    parent_device.add_negative_node(node)
-            elif device_type == 'moisture':
-                # Moisture nodes have a subnode 2, but we ignore it because
-                # it's just the inverse of the primary node.
-                if subnode_id == 4:
-                    # Heartbeat node
                     device = ISYBinarySensorHeartbeat(node, parent_device)
                     parent_device.add_heartbeat_device(device)
                     devices.append(device)


### PR DESCRIPTION
## Description:

Insteon moisture sensors on the isy994 were not showing state changes on the front end when wet.  This looks to be because the dry->wet state change only sent a ST message on node 1 instead of a DOFF that would be captured by the positive node.

By registering the negative node in this change, the DON state change on node 2 is captured and dry->wet state changes are now shown on the front end.

The change consolidates opening and moisture cases into the same conditional since now identical, and put the nodes in ascending order.

## Checklist:
  - [x] The code change is tested and works locally.
