### PR TITLE
Update ZHA deps that don't use old crypto lib

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -17,8 +17,8 @@ from homeassistant.helpers import discovery, entity
 from homeassistant.util import slugify
 
 REQUIREMENTS = [
-    'bellows==0.5.0',
-    'zigpy==0.0.1',
+    'bellows==0.5.1',
+    'zigpy==0.0.3',
     'zigpy-xbee==0.0.2',
 ]
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -133,7 +133,7 @@ batinfo==0.4.2
 beautifulsoup4==4.6.0
 
 # homeassistant.components.zha
-bellows==0.5.0
+bellows==0.5.1
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.3.0
@@ -1298,4 +1298,4 @@ ziggo-mediabox-xl==1.0.0
 zigpy-xbee==0.0.2
 
 # homeassistant.components.zha
-zigpy==0.0.1
+zigpy==0.0.3


### PR DESCRIPTION
## Description:
0.64 included an update to ZHA integration that used old crypto lib that caused conflicts with other deps. This has been [fixed](https://github.com/zigpy/zigpy/pull/26) and updated version is included in this PR.

**Related issue (if applicable):** #12715
