### PR TITLE
Cryptodome fix for python-broadlink

### DIFF
--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -19,7 +19,9 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['broadlink==0.5']
+REQUIREMENTS = [
+    'https://github.com/balloob/python-broadlink/archive/'
+    '53c864b3540598f835457f4d37672651509e7ac6.zip#broadlink==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -22,7 +22,9 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 from homeassistant.util.dt import utcnow
 
-REQUIREMENTS = ['broadlink==0.5']
+REQUIREMENTS = [
+    'https://github.com/balloob/python-broadlink/archive/'
+    '53c864b3540598f835457f4d37672651509e7ac6.zip#broadlink==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -165,10 +165,6 @@ boto3==1.4.7
 # homeassistant.scripts.credstash
 botocore==1.7.34
 
-# homeassistant.components.sensor.broadlink
-# homeassistant.components.switch.broadlink
-broadlink==0.5
-
 # homeassistant.components.sensor.buienradar
 # homeassistant.components.weather.buienradar
 buienradar==0.91
@@ -369,6 +365,10 @@ httplib2==0.10.3
 
 # homeassistant.components.media_player.braviatv
 https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
+
+# homeassistant.components.sensor.broadlink
+# homeassistant.components.switch.broadlink
+https://github.com/balloob/python-broadlink/archive/53c864b3540598f835457f4d37672651509e7ac6.zip#broadlink==0.5.1
 
 # homeassistant.components.media_player.spotify
 https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f86c90aa26b2.zip#spotipy==2.4.4


### PR DESCRIPTION
## Description:
Temporary point the broadlink requirement at a fork that uses pycryptodome to fix master.

PR upstream: https://github.com/mjg59/python-broadlink/pull/150

Will make sure that this is not part of 0.65.

CC @Danielhiversen 

For more info, see https://github.com/home-assistant/home-assistant/pull/12715#issuecomment-368793955
