### PR TITLE
Xiaomi MiIO Vacuum: Use a unique data key per domain

### DIFF
--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Xiaomi Vacuum cleaner'
 ICON = 'mdi:roomba'
-PLATFORM = 'xiaomi_miio'
+DATA_KEY = 'vacuum.xiaomi_miio'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -88,8 +88,8 @@ SUPPORT_XIAOMI = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PAUSE | \
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Xiaomi vacuum cleaner robot platform."""
     from miio import Vacuum
-    if PLATFORM not in hass.data:
-        hass.data[PLATFORM] = {}
+    if DATA_KEY not in hass.data:
+        hass.data[DATA_KEY] = {}
 
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
@@ -100,7 +100,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     vacuum = Vacuum(host, token)
 
     mirobo = MiroboVacuum(name, vacuum)
-    hass.data[PLATFORM][host] = mirobo
+    hass.data[DATA_KEY][host] = mirobo
 
     async_add_devices([mirobo], update_before_add=True)
 
@@ -112,10 +112,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                   if key != ATTR_ENTITY_ID}
         entity_ids = service.data.get(ATTR_ENTITY_ID)
         if entity_ids:
-            target_vacuums = [vac for vac in hass.data[PLATFORM].values()
+            target_vacuums = [vac for vac in hass.data[DATA_KEY].values()
                               if vac.entity_id in entity_ids]
         else:
-            target_vacuums = hass.data[PLATFORM].values()
+            target_vacuums = hass.data[DATA_KEY].values()
 
         update_tasks = []
         for vacuum in target_vacuums:

--- a/tests/components/vacuum/test_xiaomi_miio.py
+++ b/tests/components/vacuum/test_xiaomi_miio.py
@@ -16,13 +16,15 @@ from homeassistant.components.vacuum.xiaomi_miio import (
     ATTR_DO_NOT_DISTURB_START, ATTR_DO_NOT_DISTURB_END, ATTR_ERROR,
     ATTR_MAIN_BRUSH_LEFT, ATTR_SIDE_BRUSH_LEFT, ATTR_FILTER_LEFT,
     ATTR_CLEANING_COUNT, ATTR_CLEANED_TOTAL_AREA, ATTR_CLEANING_TOTAL_TIME,
-    CONF_HOST, CONF_NAME, CONF_TOKEN, PLATFORM,
+    CONF_HOST, CONF_NAME, CONF_TOKEN,
     SERVICE_MOVE_REMOTE_CONTROL, SERVICE_MOVE_REMOTE_CONTROL_STEP,
     SERVICE_START_REMOTE_CONTROL, SERVICE_STOP_REMOTE_CONTROL)
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES, CONF_PLATFORM, STATE_OFF,
     STATE_ON)
 from homeassistant.setup import async_setup_component
+
+PLATFORM = 'xiaomi_miio'
 
 # calls made when device status is requested
 status_calls = [mock.call.Vacuum().status(),


### PR DESCRIPTION
Service calls of foreign domains (light.xiaomi_miio, fan.xiaomi_miio) reached all xiaomi_miio devices in the past because all xiaomi_miio components shared a common data key.