### PR TITLE
Fix MQTT async_add_job in sync context

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -588,7 +588,7 @@ class MQTT(object):
 
     def _mqtt_on_message(self, _mqttc, _userdata, msg):
         """Message received callback."""
-        self.hass.async_add_job(self._mqtt_handle_message, msg)
+        self.hass.add_job(self._mqtt_handle_message, msg)
 
     @callback
     def _mqtt_handle_message(self, msg):


### PR DESCRIPTION
## Description:

`_mqtt_on_message` is called in a sync context and we're calling `async_add_job` in there, [that's not correct](https://github.com/home-assistant/home-assistant/issues/12716#issuecomment-368855188). Also: Should we replace `async_run_job` with `async_add_job` inside `_mqtt_handle_message` (https://github.com/home-assistant/home-assistant/issues/12716#issuecomment-368756496)? I mean callbacks shouldn't really do any "work" and therefore shouldn't affect performance, and using `add_job` in my opinion just adds some overhead.

**Related issue (if applicable):** fixes #12716

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt:
  broker: brokah
```

## Checklist:
  - [ ] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
