### PR TITLE
Fix DarkSky floating-point math

### DIFF
--- a/homeassistant/components/weather/darksky.py
+++ b/homeassistant/components/weather/darksky.py
@@ -96,7 +96,7 @@ class DarkSkyWeather(WeatherEntity):
     @property
     def humidity(self):
         """Return the humidity."""
-        return self._ds_currently.get('humidity') * 100.0
+        return round(self._ds_currently.get('humidity') * 100.0, 2)
 
     @property
     def wind_speed(self):


### PR DESCRIPTION
## Description:

DarkSky delivers relative humidity from 0-100% as a 0-1 decimal value,
so we convert it by multiplying by 100.0. Unfortunately, due to floating
point math, the display of a raw value of 0.29 ends up looking like
28.999999999999996% relative humidity.

This change rounds the value to two decimal places.

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
