### PR TITLE
bmw_connected_drive bugfix - updated to bimmer_connected 0.4.1

### DIFF
--- a/homeassistant/components/bmw_connected_drive.py
+++ b/homeassistant/components/bmw_connected_drive.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD
 )
 
-REQUIREMENTS = ['bimmer_connected==0.3.0']
+REQUIREMENTS = ['bimmer_connected==0.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -136,7 +136,7 @@ beautifulsoup4==4.6.0
 bellows==0.5.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.3.0
+bimmer_connected==0.4.1
 
 # homeassistant.components.blink
 blinkpy==0.6.0


### PR DESCRIPTION
## Description:
Fixed parsing bug in bmw_connected_drive sensors in the bimmer_connected library. Now updating to new version of the library.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/12698

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
no changes

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
