### PR TITLE
Revert optimized logbook SQL

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -47,11 +47,6 @@ CONFIG_SCHEMA = vol.Schema({
     }),
 }, extra=vol.ALLOW_EXTRA)
 
-ALL_EVENT_TYPES = [
-    EVENT_STATE_CHANGED, EVENT_LOGBOOK_ENTRY,
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
-]
-
 GROUP_BY_MINUTES = 15
 
 CONTINUOUS_DOMAINS = ['proximity', 'sensor']
@@ -271,18 +266,15 @@ def humanify(events):
 
 def _get_events(hass, config, start_day, end_day):
     """Get events for a period of time."""
-    from homeassistant.components.recorder.models import Events, States
+    from homeassistant.components.recorder.models import Events
     from homeassistant.components.recorder.util import (
         execute, session_scope)
 
     with session_scope(hass=hass) as session:
-        query = session.query(Events).order_by(Events.time_fired) \
-            .outerjoin(States, (Events.event_id == States.event_id))  \
-            .filter(Events.event_type.in_(ALL_EVENT_TYPES)) \
-            .filter((Events.time_fired > start_day)
-                    & (Events.time_fired < end_day)) \
-            .filter((States.last_updated == States.last_changed)
-                    | (States.last_updated.is_(None)))
+        query = session.query(Events).order_by(
+            Events.time_fired).filter(
+                (Events.time_fired > start_day) &
+                (Events.time_fired < end_day))
         events = execute(query)
     return humanify(_exclude_events(events, config))
 


### PR DESCRIPTION
## Description:

This reverts #12608. It [was reported](https://github.com/home-assistant/home-assistant/issues/12754#issuecomment-369033850) that this SQL can now go into an expensive loop.

The malfunction seems to depend on the stored data or maybe the MySQL version. I propose to remove the optimization until we know for sure.

## Checklist:
  - [X] The code change is tested and works locally.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>Tests have been added to verify that the new code works.</s>
