### PR TITLE
Quote services.yaml string

### DIFF
--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -178,4 +178,4 @@ xiaomi_miio_set_delayed_turn_off:
       example: 'light.xiaomi_miio'
     time_period:
       description: Time period for the delayed turn off.
-      example: 5, '0:05', {'minutes': 5}
+      example: "5, '0:05', {'minutes': 5}"


### PR DESCRIPTION
## Description:

Fixes a recent error in `dev`:
```
homeassistant.exceptions.HomeAssistantError: mapping values are not allowed here
  in ".../homeassistant/components/light/services.yaml", line 181, column 37
```

## Checklist:
  - [X] The code change is tested and works locally.
