### PR TITLE
bump fedex version

### DIFF
--- a/homeassistant/components/sensor/fedex.py
+++ b/homeassistant/components/sensor/fedex.py
@@ -19,7 +19,7 @@ from homeassistant.util import Throttle
 from homeassistant.util.dt import now, parse_date
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['fedexdeliverymanager==1.0.5']
+REQUIREMENTS = ['fedexdeliverymanager==1.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -268,7 +268,7 @@ evohomeclient==0.2.5
 fastdotcom==0.0.3
 
 # homeassistant.components.sensor.fedex
-fedexdeliverymanager==1.0.5
+fedexdeliverymanager==1.0.6
 
 # homeassistant.components.feedreader
 # homeassistant.components.sensor.geo_rss_events


### PR DESCRIPTION
## Description:

Bump the fedex dependency version to fix a login issue.


**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/12724


## Checklist:
  - [x] The code change is tested and works locally.


If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
