### PR TITLE
Silence harmless sonos data structure warnings

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -32,6 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # Quiet down soco logging to just actual problems.
 logging.getLogger('soco').setLevel(logging.WARNING)
+logging.getLogger('soco.data_structures_entry').setLevel(logging.ERROR)
 _SOCO_SERVICES_LOGGER = logging.getLogger('soco.services')
 
 SUPPORT_SONOS = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE |\


### PR DESCRIPTION
## Description:

The recent Sonos rework [increased the allowed logging](https://github.com/home-assistant/home-assistant/pull/12126/files#diff-c2c59d6a4e3a2ef8974db0999bf9091aL36) because it appeared that SoCo did not produce logs at that level in normal operation.

However, a frequent but harmless warning has now been reported. This PR turns the logging level back down for the module emitting that warning.

I have not yet managed to produce the warning myself so the change is untested for the time being.

**Related issue (if applicable):** fixes #12745

## Checklist:
  - [ ] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable.</s>
  - [ ] <s>New dependencies are only imported inside functions that use them.</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>
