### PR TITLE
Update samsungctl library to latest version

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import dt as dt_util
 
-REQUIREMENTS = ['samsungctl==0.7.1', 'wakeonlan==1.0.0']
+REQUIREMENTS = ['samsungctl[websocket]==0.7.1', 'wakeonlan==1.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import dt as dt_util
 
-REQUIREMENTS = ['samsungctl==0.6.0', 'wakeonlan==1.0.0']
+REQUIREMENTS = ['samsungctl==0.7.1', 'wakeonlan==1.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1079,7 +1079,7 @@ russound_rio==0.1.4
 rxv==0.5.1
 
 # homeassistant.components.media_player.samsungtv
-samsungctl==0.7.1
+samsungctl[websocket]==0.7.1
 
 # homeassistant.components.satel_integra
 satel_integra==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1079,7 +1079,7 @@ russound_rio==0.1.4
 rxv==0.5.1
 
 # homeassistant.components.media_player.samsungtv
-samsungctl==0.6.0
+samsungctl==0.7.1
 
 # homeassistant.components.satel_integra
 satel_integra==0.1.0


### PR DESCRIPTION
## Description:
Updates `media_player.samsungtv`'s dependency to latest version: `samsungctl version 0.7.1`

**Related issue (if applicable):** fixes #12760 

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: samsungtv
    host: 192.168.0.10
```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.