### PR TITLE
Intents: Fix when 2 states match with same name

### DIFF
--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -97,12 +97,12 @@ def async_match_state(hass, name, states=None):
     if states is None:
         states = hass.states.async_all()
 
-    entity = _fuzzymatch(name, states, lambda state: state.name)
+    state = _fuzzymatch(name, states, lambda state: state.name)
 
-    if entity is None:
+    if state is None:
         raise IntentHandleError('Unable to find entity {}'.format(name))
 
-    return entity
+    return state
 
 
 @callback
@@ -154,12 +154,13 @@ def _fuzzymatch(name, items, key):
     matches = []
     pattern = '.*?'.join(name)
     regex = re.compile(pattern, re.IGNORECASE)
-    for item in items:
+    for idx, item in enumerate(items):
         match = regex.search(key(item))
         if match:
-            matches.append((len(match.group()), match.start(), item))
+            # Add index so we pick first match in case same group and start
+            matches.append((len(match.group()), match.start(), idx, item))
 
-    return sorted(matches)[0][2] if matches else None
+    return sorted(matches)[0][3] if matches else None
 
 
 class ServiceIntentHandler(IntentHandler):

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -1,0 +1,12 @@
+"""Tests for the intent helpers."""
+from homeassistant.core import State
+from homeassistant.helpers import intent
+
+
+def test_async_match_state():
+    """Test async_match_state helper."""
+    state1 = State('light.kitchen', 'on')
+    state2 = State('switch.kitchen', 'on')
+
+    state = intent.async_match_state(None, 'kitch', [state1, state2])
+    assert state is state1


### PR DESCRIPTION
## Description:
When 2 states have the exact same name, the intent matcher to find a state would fail because it would try to compare 2 state objects using `<`. This adds the index to the comparison so that in case all other things are equal, we pick the first match.

CC @tschmidty69 

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
