### PR TITLE
Add optional words to conversation utterances

### DIFF
--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -156,9 +156,10 @@ def async_setup(hass, config):
     hass.services.async_register(
         ha.DOMAIN, SERVICE_TOGGLE, async_handle_turn_service)
     hass.helpers.intent.async_register(intent.ServiceIntentHandler(
-        intent.INTENT_TURN_ON, ha.DOMAIN, SERVICE_TURN_ON, "Turned on {}"))
+        intent.INTENT_TURN_ON, ha.DOMAIN, SERVICE_TURN_ON, "Turned {} on"))
     hass.helpers.intent.async_register(intent.ServiceIntentHandler(
-        intent.INTENT_TURN_OFF, ha.DOMAIN, SERVICE_TURN_OFF, "Turned off {}"))
+        intent.INTENT_TURN_OFF, ha.DOMAIN, SERVICE_TURN_OFF,
+        "Turned {} off"))
     hass.helpers.intent.async_register(intent.ServiceIntentHandler(
         intent.INTENT_TOGGLE, ha.DOMAIN, SERVICE_TOGGLE, "Toggled {}"))
 

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -98,17 +98,21 @@ def async_setup(hass, config):
 
     hass.http.register_view(ConversationProcessView)
 
+    # We strip trailing 's' from name because our state matcher will fail
+    # if a letter is not there. By removing 's' we can match singular and
+    # plural names.
+
     async_register(hass, intent.INTENT_TURN_ON, [
-        'Turn [the] [a] {name} on',
-        'Turn on [the] [a] [an] {name}',
+        'Turn [the] [a] {name}[s] on',
+        'Turn on [the] [a] [an] {name}[s]',
     ])
     async_register(hass, intent.INTENT_TURN_OFF, [
-        'Turn [the] [a] [an] {name} off',
-        'Turn off [the] [a] [an] {name}',
+        'Turn [the] [a] [an] {name}[s] off',
+        'Turn off [the] [a] [an] {name}[s]',
     ])
     async_register(hass, intent.INTENT_TOGGLE, [
-        'Toggle [the] [a] [an] {name}',
-        '[the] [a] [an] {name} toggle',
+        'Toggle [the] [a] [an] {name}[s]',
+        '[the] [a] [an] {name}[s] toggle',
     ])
 
     return True
@@ -131,7 +135,7 @@ def _create_matcher(utterance):
 
         if group_match is not None:
             pattern.append(
-                '(?P<{}>{})'.format(group_match.groups()[0], r'[\w ]+'))
+                '(?P<{}>{}?)'.format(group_match.groups()[0], r'[\w ]+'))
         elif optional_match is not None:
             pattern.append('(?:{}\s+)?'.format(optional_match.groups()[0]))
 

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -120,9 +120,9 @@ def async_setup(hass, config):
 
 def _create_matcher(utterance):
     """Create a regex that matches the utterance."""
-    parts = re.split(r'({\w+}|\[\w+\]\s+)', utterance)
+    parts = re.split(r'({\w+}|\[\w+\]\s*)', utterance)
     group_matcher = re.compile(r'{(\w+)}')
-    optional_matcher = re.compile(r'\[(\w+)\]\s+')
+    optional_matcher = re.compile(r'\[(\w+)\]\s*')
 
     pattern = ['^']
     for part in parts:
@@ -135,9 +135,9 @@ def _create_matcher(utterance):
 
         if group_match is not None:
             pattern.append(
-                '(?P<{}>{}?)'.format(group_match.groups()[0], r'[\w ]+'))
+                '(?P<{}>{}?)\s*'.format(group_match.groups()[0], r'[\w ]+'))
         elif optional_match is not None:
-            pattern.append(r'(?:{}\s+)?'.format(optional_match.groups()[0]))
+            pattern.append(r'(?:{}\s*)?'.format(optional_match.groups()[0]))
 
     pattern.append('$')
     return re.compile(''.join(pattern), re.I)

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -137,7 +137,7 @@ def _create_matcher(utterance):
             pattern.append(
                 '(?P<{}>{}?)'.format(group_match.groups()[0], r'[\w ]+'))
         elif optional_match is not None:
-            pattern.append('(?:{}\s+)?'.format(optional_match.groups()[0]))
+            pattern.append(r'(?:{}\s+)?'.format(optional_match.groups()[0]))
 
     pattern.append('$')
     return re.compile(''.join(pattern), re.I)

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -120,9 +120,9 @@ def async_setup(hass, config):
 
 def _create_matcher(utterance):
     """Create a regex that matches the utterance."""
-    parts = re.split(r'({\w+}|\[\w+\]\s*)', utterance)
+    parts = re.split(r'({\w+}|\[[\w\s]+\]\s*)', utterance)
     group_matcher = re.compile(r'{(\w+)}')
-    optional_matcher = re.compile(r'\[(\w+)\]\s*')
+    optional_matcher = re.compile(r'\[([\w\s]+)\]\s*')
 
     pattern = ['^']
     for part in parts:
@@ -135,7 +135,7 @@ def _create_matcher(utterance):
 
         if group_match is not None:
             pattern.append(
-                '(?P<{}>{}?)\s*'.format(group_match.groups()[0], r'[\w ]+'))
+                r'(?P<{}>[\w ]+?)\s*'.format(group_match.groups()[0]))
         elif optional_match is not None:
             pattern.append(r'(?:{}\s*)?'.format(optional_match.groups()[0]))
 

--- a/homeassistant/components/conversation.py
+++ b/homeassistant/components/conversation.py
@@ -117,24 +117,32 @@ async def async_setup(hass, config):
 
 def _create_matcher(utterance):
     """Create a regex that matches the utterance."""
-    parts = re.split(r'({\w+}|\[[\w\s]+\]\s*)', utterance)
+    # Split utterance into parts that are type: NORMAL, GROUP or OPTIONAL
+    # Pattern matches (GROUP|OPTIONAL): Change light to [the color] {name}
+    parts = re.split(r'({\w+}|\[[\w\s]+\] *)', utterance)
+    # Pattern to extract name from GROUP part. Matches {name}
     group_matcher = re.compile(r'{(\w+)}')
-    optional_matcher = re.compile(r'\[([\w\s]+)\]\s*')
+    # Pattern to extract text from OPTIONAL part. Matches [the color]
+    optional_matcher = re.compile(r'\[([\w ]+)\] *')
 
     pattern = ['^']
     for part in parts:
         group_match = group_matcher.match(part)
         optional_match = optional_matcher.match(part)
 
+        # Normal part
         if group_match is None and optional_match is None:
             pattern.append(part)
             continue
 
+        # Group part
         if group_match is not None:
             pattern.append(
                 r'(?P<{}>[\w ]+?)\s*'.format(group_match.groups()[0]))
+
+        # Optional part
         elif optional_match is not None:
-            pattern.append(r'(?:{}\s*)?'.format(optional_match.groups()[0]))
+            pattern.append(r'(?:{} *)?'.format(optional_match.groups()[0]))
 
     pattern.append('$')
     return re.compile(''.join(pattern), re.I)

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -43,7 +43,7 @@ def async_setup(hass, config):
     hass.http.register_view(ClearCompletedItemsView)
 
     hass.components.conversation.async_register(INTENT_ADD_ITEM, [
-        'Add {item} to my shopping list',
+        'Add [the] [a] [an] {item} to my shopping list',
     ])
     hass.components.conversation.async_register(INTENT_LAST_ITEMS, [
         'What is on my shopping list'

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -100,7 +100,8 @@ def async_match_state(hass, name, states=None):
     state = _fuzzymatch(name, states, lambda state: state.name)
 
     if state is None:
-        raise IntentHandleError('Unable to find entity {}'.format(name))
+        raise IntentHandleError(
+            'Unable to find an entity called {}'.format(name))
 
     return state
 

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -311,3 +311,12 @@ def test_create_matcher():
     match = pattern.match('turn kitchen lights on')
     assert match is not None
     assert match.groupdict()['name'] == 'kitchen light'
+
+    # Optional 2 words
+    pattern = conversation._create_matcher('Turn [the great] {name} on')
+    match = pattern.match('turn the great kitchen lights on')
+    assert match is not None
+    assert match.groupdict()['name'] == 'kitchen lights'
+    match = pattern.match('turn kitchen lights on')
+    assert match is not None
+    assert match.groupdict()['name'] == 'kitchen lights'

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -305,3 +305,10 @@ def test_create_matcher():
     match = pattern.match('turn on a kitchen light')
     assert match is not None
     assert match.groupdict()['name'] == 'kitchen light'
+
+    # Strip plural
+    pattern = conversation._create_matcher('Turn {name}[s] on')
+    print(pattern)
+    match = pattern.match('turn kitchen lights on')
+    assert match is not None
+    assert match.groupdict()['name'] == 'kitchen light'

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -237,7 +237,7 @@ def test_http_api(hass, test_client):
     calls = async_mock_service(hass, 'homeassistant', 'turn_on')
 
     resp = yield from client.post('/api/conversation/process', json={
-        'text': 'Turn kitchen on'
+        'text': 'Turn the kitchen on'
     })
     assert resp.status == 200
 
@@ -267,3 +267,41 @@ def test_http_api_wrong_data(hass, test_client):
     resp = yield from client.post('/api/conversation/process', json={
     })
     assert resp.status == 400
+
+
+def test_create_matcher():
+    """Test the create matcher method."""
+    # Basic sentence
+    pattern = conversation._create_matcher('Hello world')
+    assert pattern.match('Hello world') is not None
+
+    # Match a part
+    pattern = conversation._create_matcher('Hello {name}')
+    match = pattern.match('hello world')
+    assert match is not None
+    assert match.groupdict()['name'] == 'world'
+    no_match = pattern.match('Hello world, how are you?')
+    assert no_match is None
+
+    # Optional and matching part
+    pattern = conversation._create_matcher('Turn on [the] {name}')
+    match = pattern.match('turn on the kitchen lights')
+    assert match is not None
+    assert match.groupdict()['name'] == 'kitchen lights'
+    match = pattern.match('turn on kitchen lights')
+    assert match is not None
+    assert match.groupdict()['name'] == 'kitchen lights'
+    match = pattern.match('turn off kitchen lights')
+    assert match is None
+
+    # Two different optional parts, 1 matching part
+    pattern = conversation._create_matcher('Turn on [the] [a] {name}')
+    match = pattern.match('turn on the kitchen lights')
+    assert match is not None
+    assert match.groupdict()['name'] == 'kitchen lights'
+    match = pattern.match('turn on kitchen lights')
+    assert match is not None
+    assert match.groupdict()['name'] == 'kitchen lights'
+    match = pattern.match('turn on a kitchen light')
+    assert match is not None
+    assert match.groupdict()['name'] == 'kitchen light'

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -308,7 +308,6 @@ def test_create_matcher():
 
     # Strip plural
     pattern = conversation._create_matcher('Turn {name}[s] on')
-    print(pattern)
     match = pattern.match('turn kitchen lights on')
     assert match is not None
     assert match.groupdict()['name'] == 'kitchen light'

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -212,7 +212,7 @@ def test_turn_on_intent(hass):
     )
     yield from hass.async_block_till_done()
 
-    assert response.speech['plain']['speech'] == 'Turned on test light'
+    assert response.speech['plain']['speech'] == 'Turned test light on'
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == 'light'
@@ -234,7 +234,7 @@ def test_turn_off_intent(hass):
     )
     yield from hass.async_block_till_done()
 
-    assert response.speech['plain']['speech'] == 'Turned off test light'
+    assert response.speech['plain']['speech'] == 'Turned test light off'
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == 'light'
@@ -283,7 +283,7 @@ def test_turn_on_multiple_intent(hass):
     )
     yield from hass.async_block_till_done()
 
-    assert response.speech['plain']['speech'] == 'Turned on test lights 2'
+    assert response.speech['plain']['speech'] == 'Turned test lights 2 on'
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == 'light'


### PR DESCRIPTION
## Description:
This adds the ability to add optional words to registered utterances in the conversation component.

The built-in turn on and turn off intents are now able to match "Turn on the kitchen lights", "Turn on the kitchen lights", "Turn on a kitchen light" by defining `Turn on [the] [a] [an] {name}[s]`

CC @tschmidty69 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/4779

## Example entry for `configuration.yaml` (if applicable):
```yaml
conversation:
  intents:
    ColorLight:
     - Change the lights to [the color] {color}

intent_script:
  ColorLight:
    speech:
      text: Changed the lights to {{ color }}.
    action:
      service: light.turn_on
      data_template:
        rgb_color:
          - "{% if color == 'red' %}255{% else %}0{% endif %}"
          - "{% if color == 'green' %}255{% else %}0{% endif %}"
          - "{% if color == 'blue' %}255{% else %}0{% endif %}"
```

![image](https://user-images.githubusercontent.com/1444314/36775650-ca43ac6e-1c17-11e8-8017-27b00a209b6a.png)


## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
