### PR TITLE
Added media_title() method to display currently-selected source

### DIFF
--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -161,6 +161,11 @@ class OnkyoDevice(MediaPlayerDevice):
         return self._current_source
 
     @property
+    def media_title(self):
+        """Title of current playing media."""
+        return self._current_source
+
+    @property
     def source_list(self):
         """List of available input sources."""
         return self._source_list


### PR DESCRIPTION
## Description:
Onkyo media player now shows the currently-selected source in the top-level media_player display, the same as the Pioneer media_player does.

## Checklist:
  - [x ] The code change is tested and works locally.

