### PR TITLE
Bump frontend to 20180228.1

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.const import CONF_NAME, EVENT_THEMES_UPDATED
 from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['home-assistant-frontend==20180228.0', 'user-agents==1.1.0']
+REQUIREMENTS = ['home-assistant-frontend==20180228.1']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log']
@@ -553,6 +553,8 @@ def _is_latest(js_option, request):
 
     Set according to user's preference and URL override.
     """
+    import hass_frontend
+
     if request is None:
         return js_option == 'latest'
 
@@ -573,25 +575,5 @@ def _is_latest(js_option, request):
         return js_option == 'latest'
 
     useragent = request.headers.get('User-Agent')
-    if not useragent:
-        return False
 
-    from user_agents import parse
-    useragent = parse(useragent)
-
-    # on iOS every browser is a Safari which we support from version 11.
-    if useragent.os.family == 'iOS':
-        # Was >= 10, temp setting it to 12 to work around issue #11387
-        return useragent.os.version[0] >= 12
-
-    family_min_version = {
-        'Chrome': 54,          # Object.values
-        'Chrome Mobile': 54,
-        'Firefox': 47,         # Object.values
-        'Firefox Mobile': 47,
-        'Opera': 41,           # Object.values
-        'Edge': 14,            # Array.prototype.includes added in 14
-        'Safari': 10,          # Many features not supported by 9
-    }
-    version = family_min_version.get(useragent.browser.family)
-    return version and useragent.browser.version[0] >= version
+    return useragent and hass_frontend.version(useragent)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -349,7 +349,7 @@ hipnotify==1.0.8
 holidays==0.9.3
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180228.0
+home-assistant-frontend==20180228.1
 
 # homeassistant.components.camera.onvif
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a
@@ -1209,9 +1209,6 @@ uber_rides==0.6.0
 
 # homeassistant.components.sensor.ups
 upsmychoice==1.0.6
-
-# homeassistant.components.frontend
-user-agents==1.1.0
 
 # homeassistant.components.camera.uvc
 uvcclient==0.10.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -75,7 +75,7 @@ hbmqtt==0.9.1
 holidays==0.9.3
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180228.0
+home-assistant-frontend==20180228.1
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb


### PR DESCRIPTION
## Description:
Update frontend to 20180228.1. Includes moving the user agent mapping to version piece to the frontend.

Frontend PR (included in this): https://github.com/home-assistant/home-assistant-polymer/pull/955

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
