### PR TITLE
Fixed rfxtrx binary sensor missing optional keyerror data_bits

### DIFF
--- a/homeassistant/components/binary_sensor/rfxtrx.py
+++ b/homeassistant/components/binary_sensor/rfxtrx.py
@@ -55,13 +55,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if device_id in rfxtrx.RFX_DEVICES:
             continue
 
-        if entity[CONF_DATA_BITS] is not None:
+        if entity.get(CONF_DATA_BITS) is not None:
             _LOGGER.debug(
                 "Masked device id: %s", rfxtrx.get_pt2262_deviceid(
-                    device_id, entity[CONF_DATA_BITS]))
+                    device_id, entity.get(CONF_DATA_BITS)))
 
         _LOGGER.debug("Add %s rfxtrx.binary_sensor (class %s)",
-                      entity[ATTR_NAME], entity[CONF_DEVICE_CLASS])
+                      entity[ATTR_NAME], entity.get(CONF_DEVICE_CLASS))
 
         device = RfxtrxBinarySensor(
             event, entity.get(CONF_NAME), entity.get(CONF_DEVICE_CLASS),


### PR DESCRIPTION
## Description:
Fixed rfxtrx binary sensor missing optional keyerror data_bits

```bash
2018-02-28 11:24:30 ERROR (MainThread) [homeassistant.components.binary_sensor] Error while setting up platform rfxtrx
Traceback (most recent call last):
  File "/usr/src/app/homeassistant/helpers/entity_platform.py", line 84, in async_setup
    SLOW_SETUP_MAX_WAIT, loop=hass.loop)
  File "/usr/local/lib/python3.6/asyncio/tasks.py", line 358, in wait_for
    return fut.result()
  File "/usr/local/lib/python3.6/asyncio/futures.py", line 243, in result
    raise self._exception
  File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/app/homeassistant/components/binary_sensor/rfxtrx.py", line 58, in setup_platform
    if entity[CONF_DATA_BITS] is not None:
KeyError: 'data_bits' 
```

**Related issue (if applicable):** fixes #12776

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: rfxtrx
    devices:
      0b110001008744e10a000070:
        name: Mailbox
        device_class: opening
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
