### PR TITLE
check_config script evolution

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -5,7 +5,6 @@ import logging.handlers
 import os
 import sys
 from time import time
-from collections import OrderedDict
 
 from typing import Any, Optional, Dict
 
@@ -115,14 +114,6 @@ def async_from_config_dict(config: Dict[str, Any],
     # Merge packages
     conf_util.merge_packages_config(
         config, core_config.get(conf_util.CONF_PACKAGES, {}))
-
-    # Make a copy because we are mutating it.
-    # Use OrderedDict in case original one was one.
-    # Convert values to dictionaries if they are None
-    new_config = OrderedDict()
-    for key, value in config.items():
-        new_config[key] = value or {}
-    config = new_config
 
     hass.config_entries = config_entries.ConfigEntries(hass, config)
     yield from hass.config_entries.async_load()

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -5,6 +5,7 @@ import logging.handlers
 import os
 import sys
 from time import time
+from collections import OrderedDict
 
 from typing import Any, Optional, Dict
 
@@ -110,6 +111,9 @@ def async_from_config_dict(config: Dict[str, Any],
 
     if not loader.PREPARED:
         yield from hass.async_add_job(loader.prepare, hass)
+
+    # Make a copy because we are mutating it.
+    config = OrderedDict(config)
 
     # Merge packages
     conf_util.merge_packages_config(

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -689,7 +689,6 @@ def check_ha_config_file(config_dir):
 
     def _pack_error(package, component, config, message):
         """Handle errors from packages: _log_pkg_error."""
-        print("XXXXXXXXXXXXXXXXXXXXX")
         message = "Package {} setup failed. Component {} {}".format(
             package, component, message)
         domain = 'homeassistant.packages.{}.{}'.format(package, component)
@@ -718,12 +717,13 @@ def check_ha_config_file(config_dir):
         core_config = CORE_CONFIG_SCHEMA(core_config)
         all_success[CONF_CORE] = core_config
     except vol.Invalid as err:
-        all_errors.append(err, CONF_CORE, core_config)
+        all_errors.append((err, CONF_CORE, core_config))
         core_config = {}
 
     # Merge packages
     with patch('homeassistant.config._log_pkg_error', side_effect=_pack_error):
         merge_packages_config(config, core_config.get(CONF_PACKAGES, {}))
+    del core_config[CONF_PACKAGES]
 
     # Filter out repeating config sections
     components = set(key.split(' ')[0] for key in config.keys())

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -205,17 +205,15 @@ def check(config_dir, secrets=False):
 
         loader.prepare(HassConfig(config_dir))
 
-        all_success, all_errors = config_util.check_ha_config_file(config_dir)
+        res['components'] = config_util.check_ha_config_file(config_dir)
 
         res['secret_cache'] = OrderedDict(yaml.__SECRET_CACHE)
-        res['components'] = all_success
 
-        for (msg, domain, config) in all_errors:
-            if not domain:
-                domain = ERROR_STR
-            res['except'].setdefault(domain, []).append(msg)
-            if config:
-                res['except'].setdefault(domain, []).append(config)
+        for err in res['components'].errors:
+            domain = err.domain or ERROR_STR
+            res['except'].setdefault(domain, []).append(err.message)
+            if err.config:
+                res['except'].setdefault(domain, []).append(err.config)
 
     except Exception as err:  # pylint: disable=broad-except
         print(color('red', 'Fatal error while loading config:'), str(err))

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -1,9 +1,12 @@
 """Test check_config script."""
 import asyncio
 import logging
+import os  # noqa: F401 pylint: disable=unused-import
 import unittest
+from unittest.mock import patch
 
 import homeassistant.scripts.check_config as check_config
+from homeassistant.config import YAML_CONFIG_FILE
 from homeassistant.loader import set_component
 from tests.common import patch_yaml_files, get_test_config_dir
 
@@ -21,21 +24,14 @@ BASE_CONFIG = (
 )
 
 
-def change_yaml_files(check_dict):
-    """Change the ['yaml_files'] property and remove the configuration path.
-
-    Also removes other files like service.yaml that gets loaded.
-    """
+def normalize_yaml_files(check_dict):
+    """Remove configuration path from ['yaml_files']."""
     root = get_test_config_dir()
-    keys = check_dict['yaml_files'].keys()
-    check_dict['yaml_files'] = []
-    for key in sorted(keys):
-        if not key.startswith('/'):
-            check_dict['yaml_files'].append(key)
-        if key.startswith(root):
-            check_dict['yaml_files'].append('...' + key[len(root):])
+    return [key.replace(root, '...')
+            for key in sorted(check_dict['yaml_files'].keys())]
 
 
+# pylint: disable=unsubscriptable-object
 class TestCheckConfig(unittest.TestCase):
     """Tests for the homeassistant.scripts.check_config module."""
 
@@ -51,176 +47,165 @@ class TestCheckConfig(unittest.TestCase):
             asyncio.set_event_loop(asyncio.new_event_loop())
 
         # Will allow seeing full diff
-        self.maxDiff = None
+        self.maxDiff = None  # pylint: disable=invalid-name
 
     # pylint: disable=no-self-use,invalid-name
-    def test_config_platform_valid(self):
+    @patch('os.path.isfile', return_value=True)
+    def test_config_platform_valid(self, isfile_patch):
         """Test a valid platform setup."""
         files = {
-            'light.yaml': BASE_CONFIG + 'light:\n  platform: demo',
+            YAML_CONFIG_FILE: BASE_CONFIG + 'light:\n  platform: demo',
         }
         with patch_yaml_files(files):
-            res = check_config.check(get_test_config_dir('light.yaml'))
-            change_yaml_files(res)
-            self.assertDictEqual({
-                'components': {'light': [{'platform': 'demo'}], 'group': None},
-                'except': {},
-                'secret_cache': {},
-                'secrets': {},
-                'yaml_files': ['.../light.yaml']
-            }, res)
+            res = check_config.check(get_test_config_dir())
+            assert res['components'].keys() == {'homeassistant', 'light'}
+            assert res['components']['light'] == [{'platform': 'demo'}]
+            assert res['except'] == {}
+            assert res['secret_cache'] == {}
+            assert res['secrets'] == {}
+            assert len(res['yaml_files']) == 1
 
-    def test_config_component_platform_fail_validation(self):
+    @patch('os.path.isfile', return_value=True)
+    def test_config_component_platform_fail_validation(self, isfile_patch):
         """Test errors if component & platform not found."""
         files = {
-            'component.yaml': BASE_CONFIG + 'http:\n  password: err123',
+            YAML_CONFIG_FILE: BASE_CONFIG + 'http:\n  password: err123',
         }
         with patch_yaml_files(files):
-            res = check_config.check(get_test_config_dir('component.yaml'))
-            change_yaml_files(res)
-
-            self.assertDictEqual({}, res['components'])
-            res['except'].pop(check_config.ERROR_STR)
-            self.assertDictEqual(
-                {'http': {'password': 'err123'}},
-                res['except']
-            )
-            self.assertDictEqual({}, res['secret_cache'])
-            self.assertDictEqual({}, res['secrets'])
-            self.assertListEqual(['.../component.yaml'], res['yaml_files'])
+            res = check_config.check(get_test_config_dir())
+            assert res['components'].keys() == {'homeassistant'}
+            assert res['except'].keys() == {'http'}
+            assert res['except']['http'][1] == {'http': {'password': 'err123'}}
+            assert res['secret_cache'] == {}
+            assert res['secrets'] == {}
+            assert len(res['yaml_files']) == 1
 
         files = {
-            'platform.yaml': (BASE_CONFIG + 'mqtt:\n\n'
-                              'light:\n  platform: mqtt_json'),
+            YAML_CONFIG_FILE: (BASE_CONFIG + 'mqtt:\n\n'
+                               'light:\n  platform: mqtt_json'),
         }
         with patch_yaml_files(files):
-            res = check_config.check(get_test_config_dir('platform.yaml'))
-            change_yaml_files(res)
-            self.assertDictEqual(
-                {'mqtt': {
-                    'keepalive': 60,
-                    'port': 1883,
-                    'protocol': '3.1.1',
-                    'discovery': False,
-                    'discovery_prefix': 'homeassistant',
-                    'tls_version': 'auto',
-                },
-                 'light': [],
-                 'group': None},
-                res['components']
-            )
-            self.assertDictEqual(
-                {'light.mqtt_json': {'platform': 'mqtt_json'}},
-                res['except']
-            )
-            self.assertDictEqual({}, res['secret_cache'])
-            self.assertDictEqual({}, res['secrets'])
-            self.assertListEqual(['.../platform.yaml'], res['yaml_files'])
+            res = check_config.check(get_test_config_dir())
+            assert res['components'].keys() == {
+                'homeassistant', 'light', 'mqtt'}
+            assert res['components']['light'] == []
+            assert res['components']['mqtt'] == {
+                'keepalive': 60,
+                'port': 1883,
+                'protocol': '3.1.1',
+                'discovery': False,
+                'discovery_prefix': 'homeassistant',
+                'tls_version': 'auto',
+            }
+            assert res['except'].keys() == {'light.mqtt_json'}
+            assert res['except']['light.mqtt_json'][1] == {
+                'platform': 'mqtt_json'}
+            assert res['secret_cache'] == {}
+            assert res['secrets'] == {}
+            assert len(res['yaml_files']) == 1
 
-    def test_component_platform_not_found(self):
+    @patch('os.path.isfile', return_value=True)
+    def test_component_platform_not_found(self, isfile_patch):
         """Test errors if component or platform not found."""
         # Make sure they don't exist
         set_component('beer', None)
-        set_component('light.beer', None)
         files = {
-            'badcomponent.yaml': BASE_CONFIG + 'beer:',
-            'badplatform.yaml': BASE_CONFIG + 'light:\n  platform: beer',
+            YAML_CONFIG_FILE: BASE_CONFIG + 'beer:',
         }
         with patch_yaml_files(files):
-            res = check_config.check(get_test_config_dir('badcomponent.yaml'))
-            change_yaml_files(res)
-            self.assertDictEqual({}, res['components'])
-            self.assertDictEqual({
-                    check_config.ERROR_STR: [
-                        'Component not found: beer',
-                        'Setup failed for beer: Component not found.']
-                }, res['except'])
-            self.assertDictEqual({}, res['secret_cache'])
-            self.assertDictEqual({}, res['secrets'])
-            self.assertListEqual(['.../badcomponent.yaml'], res['yaml_files'])
+            res = check_config.check(get_test_config_dir())
+            assert res['components'].keys() == {'homeassistant'}
+            assert res['except'] == {
+                check_config.ERROR_STR: ['Component not found: beer']}
+            assert res['secret_cache'] == {}
+            assert res['secrets'] == {}
+            assert len(res['yaml_files']) == 1
 
-            res = check_config.check(get_test_config_dir('badplatform.yaml'))
-            change_yaml_files(res)
-            assert res['components'] == {'light': [], 'group': None}
+        set_component('light.beer', None)
+        files = {
+            YAML_CONFIG_FILE: BASE_CONFIG + 'light:\n  platform: beer',
+        }
+        with patch_yaml_files(files):
+            res = check_config.check(get_test_config_dir())
+            assert res['components'].keys() == {'homeassistant', 'light'}
+            assert res['components']['light'] == []
             assert res['except'] == {
                 check_config.ERROR_STR: [
                     'Platform not found: light.beer',
                 ]}
-            self.assertDictEqual({}, res['secret_cache'])
-            self.assertDictEqual({}, res['secrets'])
-            self.assertListEqual(['.../badplatform.yaml'], res['yaml_files'])
+            assert res['secret_cache'] == {}
+            assert res['secrets'] == {}
+            assert len(res['yaml_files']) == 1
 
-    def test_secrets(self):
+    @patch('os.path.isfile', return_value=True)
+    def test_secrets(self, isfile_patch):
         """Test secrets config checking method."""
+        secrets_path = get_test_config_dir('secrets.yaml')
+
         files = {
-            get_test_config_dir('secret.yaml'): (
-                BASE_CONFIG +
+            get_test_config_dir(YAML_CONFIG_FILE): BASE_CONFIG + (
                 'http:\n'
                 '  api_password: !secret http_pw'),
-            'secrets.yaml': ('logger: debug\n'
-                             'http_pw: abc123'),
+            secrets_path: (
+                'logger: debug\n'
+                'http_pw: abc123'),
         }
 
         with patch_yaml_files(files):
-            config_path = get_test_config_dir('secret.yaml')
-            secrets_path = get_test_config_dir('secrets.yaml')
 
-            res = check_config.check(config_path)
-            change_yaml_files(res)
+            res = check_config.check(get_test_config_dir(), True)
 
-            # convert secrets OrderedDict to dict for assertequal
-            for key, val in res['secret_cache'].items():
-                res['secret_cache'][key] = dict(val)
+            assert res['except'] == {}
+            assert res['components'].keys() == {'homeassistant', 'http'}
+            assert res['components']['http'] == {
+                'api_password': 'abc123',
+                'cors_allowed_origins': [],
+                'ip_ban_enabled': True,
+                'login_attempts_threshold': -1,
+                'server_host': '0.0.0.0',
+                'server_port': 8123,
+                'trusted_networks': [],
+                'use_x_forwarded_for': False}
+            assert res['secret_cache'] == {secrets_path: {'http_pw': 'abc123'}}
+            assert res['secrets'] == {'http_pw': 'abc123'}
+            assert normalize_yaml_files(res) == [
+                '.../configuration.yaml', '.../secrets.yaml']
 
-            self.assertDictEqual({
-                'components': {'http': {'api_password': 'abc123',
-                                        'cors_allowed_origins': [],
-                                        'ip_ban_enabled': True,
-                                        'login_attempts_threshold': -1,
-                                        'server_host': '0.0.0.0',
-                                        'server_port': 8123,
-                                        'trusted_networks': [],
-                                        'use_x_forwarded_for': False}},
-                'except': {},
-                'secret_cache': {secrets_path: {'http_pw': 'abc123'}},
-                'secrets': {'http_pw': 'abc123'},
-                'yaml_files': ['.../secret.yaml', '.../secrets.yaml']
-            }, res)
-
-    def test_package_invalid(self): \
+    @patch('os.path.isfile', return_value=True)
+    def test_package_invalid(self, isfile_patch): \
             # pylint: disable=no-self-use,invalid-name
         """Test a valid platform setup."""
         files = {
-            'bad.yaml': BASE_CONFIG + ('  packages:\n'
-                                       '    p1:\n'
-                                       '      group: ["a"]'),
+            YAML_CONFIG_FILE: BASE_CONFIG + (
+                '  packages:\n'
+                '    p1:\n'
+                '      group: ["a"]'),
         }
         with patch_yaml_files(files):
-            res = check_config.check(get_test_config_dir('bad.yaml'))
-            change_yaml_files(res)
+            res = check_config.check(get_test_config_dir())
 
-            err = res['except'].pop('homeassistant.packages.p1')
-            assert res['except'] == {}
-            assert err == {'group': ['a']}
-            assert res['yaml_files'] == ['.../bad.yaml']
-
-            assert res['components'] == {}
+            assert res['except'].keys() == {'homeassistant.packages.p1.group'}
+            assert res['except']['homeassistant.packages.p1.group'][1] == \
+                {'group': ['a']}
+            assert len(res['except']) == 1
+            assert res['components'].keys() == {'homeassistant'}
+            assert len(res['components']) == 1
             assert res['secret_cache'] == {}
             assert res['secrets'] == {}
+            assert len(res['yaml_files']) == 1
 
     def test_bootstrap_error(self): \
             # pylint: disable=no-self-use,invalid-name
         """Test a valid platform setup."""
         files = {
-            'badbootstrap.yaml': BASE_CONFIG + 'automation: !include no.yaml',
+            YAML_CONFIG_FILE: BASE_CONFIG + 'automation: !include no.yaml',
         }
         with patch_yaml_files(files):
-            res = check_config.check(get_test_config_dir('badbootstrap.yaml'))
-            change_yaml_files(res)
-
+            res = check_config.check(get_test_config_dir(YAML_CONFIG_FILE))
             err = res['except'].pop(check_config.ERROR_STR)
             assert len(err) == 1
             assert res['except'] == {}
-            assert res['components'] == {}
+            assert res['components'] == {}  # No components, load failed
             assert res['secret_cache'] == {}
             assert res['secrets'] == {}
+            assert res['yaml_files'] == {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,11 +158,11 @@ class TestConfig(unittest.TestCase):
     def test_load_yaml_config_preserves_key_order(self):
         """Test removal of library."""
         with open(YAML_PATH, 'w') as f:
-            f.write('hello: 0\n')
+            f.write('hello: 2\n')
             f.write('world: 1\n')
 
         self.assertEqual(
-            [('hello', 0), ('world', 1)],
+            [('hello', 2), ('world', 1)],
             list(config_util.load_yaml_config_file(YAML_PATH).items()))
 
     @mock.patch('homeassistant.util.location.detect_location_info',


### PR DESCRIPTION
## Description:
The `check_config` script #2657 relies on some serious patching to test user configuration. It certainly helped me to understand unit testing... In #5609 it got incorporated into services/check upon restart, spawning another process and capturing the script output. It works, but it's slow... this also contains a record amount of slowest entries in all Travis jobs.

This PR will ~~replace `async_check_ha_config_file` used by the check_config service,~~ removing the need for patches, or the speed penalty of the current script method.

Using the commandline script you can still access `---files`, `--secrets` and `--info all` to print options. These however still require patching to extract the interesting parts from the yaml processor.


Test behaviour using:
```bash
hass --script check_config
```

## Todo:
  - [x] Add the actual validation of the component and platform SCHEMAs.
  - [x] Add some tests
  - [x] ~~Eventually make `--new` the standard and remove the old parts of the script.~~
