### PR TITLE
Add support for FSR61 switches (Enocean)

### DIFF
--- a/homeassistant/components/enocean.py
+++ b/homeassistant/components/enocean.py
@@ -75,7 +75,7 @@ class EnOceanDongle:
             _LOGGER.debug("Received radio packet: %s", temp)
             rxtype = None
             value = None
-            if temp.data[6] == 0x30:
+            if temp.data[6] == 0x30 and temp.data[2] == 0xfe:
                 rxtype = "wallswitch"
                 value = 1
             elif temp.data[6] == 0x20:
@@ -93,6 +93,13 @@ class EnOceanDongle:
             elif temp.data[0] == 0xa5 and temp.data[1] == 0x02:
                 rxtype = "dimmerstatus"
                 value = temp.data[2]
+            elif temp.data[0] == 0xf6 and temp.data[2] == 0x01:
+                rxtype = "switch_status"
+                if temp.data[1] == 0x50:
+                    value = 0
+                elif temp.data[1] == 0x70:
+                    value = 1
+
             for device in self.__devices:
                 if rxtype == "wallswitch" and device.stype == "listener":
                     if temp.sender_int == self._combine_hex(device.dev_id):

--- a/homeassistant/components/switch/enocean.py
+++ b/homeassistant/components/switch/enocean.py
@@ -16,35 +16,44 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_SENDER_ID = 'sender_id'
+
 DEFAULT_NAME = 'EnOcean Switch'
 DEPENDENCIES = ['enocean']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ID): vol.All(cv.ensure_list, [vol.Coerce(int)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SENDER_ID, default=[]): vol.All(cv.ensure_list,
+                                                      [vol.Coerce(int)]),
+    vol.Optional("subtype", default=""): cv.string,
 })
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the EnOcean switch platform."""
     dev_id = config.get(CONF_ID)
+    sender_id = config.get(CONF_SENDER_ID)
     devname = config.get(CONF_NAME)
+    subtype = config.get("subtype")
 
-    add_devices([EnOceanSwitch(dev_id, devname)])
+    add_devices([EnOceanSwitch(dev_id, sender_id, devname, subtype)])
 
 
 class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
     """Representation of an EnOcean switch device."""
 
-    def __init__(self, dev_id, devname):
+    def __init__(self, dev_id, sender_id, devname, subtype):
         """Initialize the EnOcean switch device."""
         enocean.EnOceanDevice.__init__(self)
         self.dev_id = dev_id
+        self._sender_id = sender_id
         self._devname = devname
         self._light = None
         self._on_state = False
         self._on_state2 = False
         self.stype = "switch"
+        self.subtype = subtype
 
     @property
     def is_on(self):
@@ -58,23 +67,43 @@ class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
 
     def turn_on(self, **kwargs):
         """Turn on the switch."""
-        optional = [0x03, ]
-        optional.extend(self.dev_id)
-        optional.extend([0xff, 0x00])
-        self.send_command(data=[0xD2, 0x01, 0x00, 0x64, 0x00,
-                                0x00, 0x00, 0x00, 0x00], optional=optional,
-                          packet_type=0x01)
-        self._on_state = True
+        if self.subtype == "" or self.subtype == "permundo":
+            optional = [0x03, ]
+            optional.extend(self.dev_id)
+            optional.extend([0xff, 0x00])
+            self.send_command(data=[0xD2, 0x01, 0x00, 0x64, 0x00,
+                                    0x00, 0x00, 0x00, 0x00], optional=optional,
+                              packet_type=0x01)
+        elif self.subtype == "fsr61":
+            optional = []
+            data = [0xf6, 0x50]
+            data.extend(self._sender_id)
+            data.extend([0x30])
+            self.send_command(data=data, optional=optional, packet_type=0x01)
+            data = [0xf6, 0x00]
+            data.extend(self._sender_id)
+            data.extend([0x20])
+            self.send_command(data=data, optional=optional, packet_type=0x01)
 
     def turn_off(self, **kwargs):
         """Turn off the switch."""
-        optional = [0x03, ]
-        optional.extend(self.dev_id)
-        optional.extend([0xff, 0x00])
-        self.send_command(data=[0xD2, 0x01, 0x00, 0x00, 0x00,
-                                0x00, 0x00, 0x00, 0x00], optional=optional,
-                          packet_type=0x01)
-        self._on_state = False
+        if self.subtype == "" or self.subtype == "permundo":
+            optional = [0x03, ]
+            optional.extend(self.dev_id)
+            optional.extend([0xff, 0x00])
+            self.send_command(data=[0xD2, 0x01, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x00], optional=optional,
+                              packet_type=0x01)
+        elif self.subtype == "fsr61":
+            optional = []
+            data = [0xf6, 0x70]
+            data.extend(self._sender_id)
+            data.extend([0x30])
+            self.send_command(data=data, optional=optional, packet_type=0x01)
+            data = [0xf6, 0x00]
+            data.extend(self._sender_id)
+            data.extend([0x20])
+            self.send_command(data=data, optional=optional, packet_type=0x01)
 
     def value_changed(self, val):
         """Update the internal state of the switch."""


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** NONE

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4786

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: enocean
    subtype: fsr61
    name: my_fsr61_switch
    id: [0x01,0xa1,0xa9,0x17]
    sender_id: [0xff,0xc6,0xea,0x14]
```

If no subtype is defined, it defaults to the previously only supported subtype `permundo` to satisfy backwards compatibility.

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]). (no new dependencies)
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]). (no new dependencies)
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`. (no new dependencies)
  - [x] New files were added to `.coveragerc`. (no new dependencies)

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
