### PR TITLE
Bump pyHik version, digest auth, more device support

### DIFF
--- a/homeassistant/components/binary_sensor/hikvision.py
+++ b/homeassistant/components/binary_sensor/hikvision.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_SSL, EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_START,
     ATTR_LAST_TRIP_TIME, CONF_CUSTOMIZE)
 
-REQUIREMENTS = ['pyhik==0.1.4']
+REQUIREMENTS = ['pyhik==0.1.8']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_IGNORED = 'ignored'
@@ -48,6 +48,9 @@ DEVICE_CLASS_MAP = {
     'Face Detection': 'motion',
     'Scene Change Detection': 'motion',
     'I/O': None,
+    'Unattended Baggage': 'motion',
+    'Attended Baggage': 'motion',
+    'Recording Failure': None,
 }
 
 CUSTOMIZE_SCHEMA = vol.Schema({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -736,7 +736,7 @@ pyfttt==0.3
 pyharmony==1.0.20
 
 # homeassistant.components.binary_sensor.hikvision
-pyhik==0.1.4
+pyhik==0.1.8
 
 # homeassistant.components.hive
 pyhiveapi==0.2.11


### PR DESCRIPTION
## Description:
Bump the pyHik version to the latest for the Hikvision Camera Binary Sensors.  Latest version now supports digest auth, more sensor types, and changes to the connection watchdog to work better with v5.5.0 firmware cameras.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
