### PR TITLE
Only run deploy from lint job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,5 @@ deploy:
   script: script/travis_deploy
   on:
     branch: dev
+    condition: $TOXENV = lint
 after_success: coveralls


### PR DESCRIPTION
## Description:
This should prevent us from running the deployment for each job in Travis.