### PR TITLE
is_allowed_path: Also unit test folder 

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1064,7 +1064,7 @@ class Config(object):
         """Check if the path is valid for access from outside."""
         assert path is not None
 
-        parent = pathlib.Path(path).parent
+        parent = pathlib.Path(path)
         try:
             parent = parent.resolve()  # pylint: disable=no-member
         except (FileNotFoundError, RuntimeError, PermissionError):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -809,6 +809,7 @@ class TestConfig(unittest.TestCase):
 
             valid = [
                 test_file,
+                tmp_dir
             ]
             for path in valid:
                 assert self.config.is_allowed_path(path)


### PR DESCRIPTION
## Description:
Fix is_allowed_path and unit test

**Related issue (if applicable):** fixes #12788 #12807


## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
