### PR TITLE
Plex mark devices unavailable if they 'vanish' and clear media

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -416,7 +416,8 @@ class PlexClient(MediaPlayerDevice):
 
     def set_availability(self, available):
         """Set the device as available/unavailable and
-            note the time it was set unavailable."""
+        note the time it was set unavailable.
+        """
         if not available:
             self._clear_media_details()
         self._is_device_available = available

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -188,7 +188,7 @@ def setup_plexserver(
             # force devices to idle that do not have a valid session
             if client.session is None:
                 client.force_idle()
-                
+
             client.set_availability(client.machine_identifier
                                     in available_client_ids)
 

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -415,9 +415,7 @@ class PlexClient(MediaPlayerDevice):
         self._media_image_url = thumb_url
 
     def set_availability(self, available):
-        """Set the device as available/unavailable and
-        note the time it was set unavailable.
-        """
+        """Set the device as available/unavailable noting time."""
         if not available:
             self._clear_media_details()
         self._is_device_available = available

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -415,6 +415,8 @@ class PlexClient(MediaPlayerDevice):
         self._media_image_url = thumb_url
 
     def set_availability(self, available):
+        """Set the device as available/unavailable and
+            note the time it was set unavailable."""
         if not available:
             self._clear_media_details()
         self._is_device_available = available
@@ -482,7 +484,7 @@ class PlexClient(MediaPlayerDevice):
 
     @property
     def available(self):
-        """Returns the availability of the client"""
+        """Return the availability of the client."""
         return self._is_device_available
 
     @property

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -414,7 +414,7 @@ class PlexClient(MediaPlayerDevice):
 
         self._media_image_url = thumb_url
 
-    def set_availability(self,available):
+    def set_availability(self, available):
         if not available:
             self._clear_media_details()
         self._is_device_available = available

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -192,8 +192,8 @@ def setup_plexserver(
         if new_plex_clients:
             add_devices_callback(new_plex_clients)
 
-        for id in hass.data[PLEX_DATA].keys():
-            plex_clients[id].set_availability(id in available_ids)
+        for cid in hass.data[PLEX_DATA].keys():
+            plex_clients[cid].set_availability(cid in available_ids)
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update_sessions():


### PR DESCRIPTION
Partial Fix for:
https://github.com/home-assistant/home-assistant/issues/10074

if a client vanishes it will persist in UI however it is marked Unavailable and media images are cleared