### PR TITLE
Cast Python 3.5 Async Await Syntax

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.cast/
 """
 # pylint: disable=import-error
-import asyncio
 import logging
 import threading
 import functools
@@ -135,9 +134,8 @@ def _async_create_cast_device(hass, chromecast):
     return None
 
 
-@asyncio.coroutine
-def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
-                         async_add_devices, discovery_info=None):
+async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
+                               async_add_devices, discovery_info=None):
     """Set up the cast platform."""
     import pychromecast
 
@@ -187,7 +185,7 @@ def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
         try:
             func = functools.partial(pychromecast.Chromecast, *want_host,
                                      tries=SOCKET_CLIENT_RETRIES)
-            chromecast = yield from hass.async_add_job(func)
+            chromecast = await hass.async_add_job(func)
         except pychromecast.ChromecastConnectionError as err:
             _LOGGER.warning("Can't set up chromecast on %s: %s",
                             want_host[0], err)
@@ -439,8 +437,7 @@ class CastDevice(MediaPlayerDevice):
         self.cast_status = self.cast.status
         self.media_status = self.cast.media_controller.status
 
-    @asyncio.coroutine
-    def async_will_remove_from_hass(self):
+    async def async_will_remove_from_hass(self) -> None:
         """Disconnect Chromecast object when removed."""
         self._async_disconnect()
 


### PR DESCRIPTION
## Description:

`hass-repo-pr-count++` 😉

 - [x] Convert media_player.cast to `async`/`await` syntax

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
discovery:
media_player:
  - platform: cast
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
