### PR TITLE
Bump pyloopenergy to 0.0.18. Fixes hassio connect issues.

### DIFF
--- a/homeassistant/components/sensor/loopenergy.py
+++ b/homeassistant/components/sensor/loopenergy.py
@@ -17,7 +17,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyloopenergy==0.0.17']
+REQUIREMENTS = ['pyloopenergy==0.0.18']
 
 CONF_ELEC = 'electricity'
 CONF_GAS = 'gas'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -782,7 +782,7 @@ pylgtv==0.1.7
 pylitejet==0.1
 
 # homeassistant.components.sensor.loopenergy
-pyloopenergy==0.0.17
+pyloopenergy==0.0.18
 
 # homeassistant.components.lutron_caseta
 pylutron-caseta==0.3.0


### PR DESCRIPTION
## Description:
Bump pyloopenergy to 0.0.18. This upgrades the version of the socket_io library used which fixes some hassio connect issues, as well as perhaps other unreliability issues.

Thanks to @adsmf for his detective work.

**Related issue (if applicable):** fixes #8137 #9687 #12689

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
