### PR TITLE
WIP Plex purge unavailable clients

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -436,7 +436,8 @@ class PlexClient(MediaPlayerDevice):
         self._media_image_url = thumb_url
 
     def set_availability(self, available):
-        """Sets the device as available/unavailable and notes the time it was set unavailable"""
+        """Sets the device as available/unavailable and
+            notes the time it was set unavailable"""
         if not available:
             self._clear_media_details()
             if self._marked_unavailable is None:
@@ -518,7 +519,7 @@ class PlexClient(MediaPlayerDevice):
 
     @property
     def unavailable_time(self):
-        """Returns the timedelta showing how long client has been unavailable"""
+        """Returns the timedelta of how long client has been unavailable"""
         if self._marked_unavailable:
             return datetime.datetime.now() - self._marked_unavailable
         return None

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -200,7 +200,7 @@ def setup_plexserver(
             print("************************Adding")
             add_devices_callback(new_plex_clients)
 
-        # Figure out if device is unavailable and if it should be removed or not
+        # Figure out if device is unavailable and if it should be removed
         for cid in hass.data[PLEX_DATA].keys():
             cclient = plex_clients[cid]
             config_purge_int = config.get(CONF_CLIENT_PURGE_INTERVAL)

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -197,20 +197,17 @@ def setup_plexserver(
                 client.force_idle()
 
         if new_plex_clients:
-            print("************************Adding")
             add_devices_callback(new_plex_clients)
 
         # Figure out if device is unavailable and if it should be removed
         for cid in hass.data[PLEX_DATA].keys():
             cclient = plex_clients[cid]
             config_purge_int = config.get(CONF_CLIENT_PURGE_INTERVAL)
-            print("Is marked: ", cclient.marked_for_purge)
             cclient.set_availability(cid in available_ids)
             if config.get(CONF_PURGE_UNAVAILABLE_CLIENTS)\
                     and cclient.unavailable_time is not None \
                     and cclient.marked_for_purge is not True \
                     and cclient.unavailable_time.seconds > config_purge_int:
-                print("Purging********************")
                 cclient.mark_for_purge()
                 hass.helpers.event.async_call_later(60, cclient.async_remove())
 

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -414,7 +414,7 @@ class PlexClient(MediaPlayerDevice):
 
         self._media_image_url = thumb_url
 
-    def set_availability(self,available):
+    def set_availability(self, available):
         if not available:
             self._clear_media_details()
         self._is_device_available = available


### PR DESCRIPTION
Fully Fixes: https://github.com/home-assistant/home-assistant/issues/10074

Adds two new cfg options:
CONF_PURGE_UNAVAILABLE_CLIENTS = 'purge_unavailable_clients' (bool default TRUE)
CONF_CLIENT_PURGE_INTERVAL = 'client_purge_interval' (INT default 0)

These options need to be added to docs

This keeps previous expected behaviour of removing unavailable clients immediately but allows users that to fine tune that behaviour and can also be disabled if required.


supersedes: https://github.com/home-assistant/home-assistant/pull/12811
