### PR TITLE
Add SQL index to states.event_id

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -143,6 +143,9 @@ def _apply_update(engine, new_version, old_version):
         _drop_index(engine, "states", "ix_states_entity_id_created")
 
         _create_index(engine, "states", "ix_states_entity_id_last_updated")
+    elif new_version == 5:
+        # Create supporting index for States.event_id foreign key
+        _create_index(engine, "states", "ix_states_event_id")
     else:
         raise ValueError("No schema migration defined for version {}"
                          .format(new_version))

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -16,7 +16,7 @@ from homeassistant.remote import JSONEncoder
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ class States(Base):   # type: ignore
     entity_id = Column(String(255))
     state = Column(String(255))
     attributes = Column(Text)
-    event_id = Column(Integer, ForeignKey('events.event_id'))
+    event_id = Column(Integer, ForeignKey('events.event_id'), index=True)
     last_changed = Column(DateTime(timezone=True), default=datetime.utcnow)
     last_updated = Column(DateTime(timezone=True), default=datetime.utcnow,
                           index=True)


### PR DESCRIPTION
## Description:

The `States.event_id` field references `Event.event_id` but until now there was no index on the former. This potentially makes `Event` purging slow (as reported in #12797) because each removed event does a `States` table scan to check that it is not referenced.

MySQL users will have this index already, automatically added due to the foreign key. However, because we did not actually write `States.event_id` values until #12580, this index can be useless (ignored due to low cardinality statistics). I tested that the migration code properly removes this automatic index.

This index should also make it possible to return and even improve the optimization in #12608.

**Related issue (if applicable):** fixes #12797

## Checklist:
  - [X] The code change is tested and works locally.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [ ] Tests have been added to verify that the new code works.
