### PR TITLE
Add config flow for Hue

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -163,7 +163,7 @@ class ConfigManagerFlowResourceView(HomeAssistantView):
         hass = request.app['hass']
 
         try:
-            hass.config_entries.async_abort(flow_id)
+            hass.config_entries.flow.async_abort(flow_id)
         except config_entries.UnknownFlow:
             return self.json_message('Invalid flow specified', 404)
 

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -19,7 +19,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery, aiohttp_client
 from homeassistant import config_entries
 
-REQUIREMENTS = ['phue==1.0', 'aiohue==0.1.0']
+REQUIREMENTS = ['phue==1.0', 'aiohue==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -21,7 +21,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery, aiohttp_client
 from homeassistant import config_entries
 
-REQUIREMENTS = ['phue==1.0', 'aiohue==0.2.0']
+REQUIREMENTS = ['phue==1.0', 'aiohue==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/hue/
 """
 import json
+from functools import partial
 import logging
 import os
 import socket
@@ -15,9 +16,10 @@ import voluptuous as vol
 from homeassistant.components.discovery import SERVICE_HUE
 from homeassistant.const import CONF_FILENAME, CONF_HOST
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers import discovery
+from homeassistant.helpers import discovery, aiohttp_client
+from homeassistant import config_entries
 
-REQUIREMENTS = ['phue==1.0']
+REQUIREMENTS = ['phue==1.0', 'aiohue==0.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -133,13 +135,14 @@ def bridge_discovered(hass, service, discovery_info):
 
 
 def setup_bridge(host, hass, filename=None, allow_unreachable=False,
-                 allow_in_emulated_hue=True, allow_hue_groups=True):
+                 allow_in_emulated_hue=True, allow_hue_groups=True,
+                 username=None):
     """Set up a given Hue bridge."""
     # Only register a device once
     if socket.gethostbyname(host) in hass.data[DOMAIN]:
         return
 
-    bridge = HueBridge(host, hass, filename, allow_unreachable,
+    bridge = HueBridge(host, hass, filename, username, allow_unreachable,
                        allow_in_emulated_hue, allow_hue_groups)
     bridge.setup()
 
@@ -164,13 +167,14 @@ def _find_host_from_config(hass, filename=PHUE_CONFIG_FILE):
 class HueBridge(object):
     """Manages a single Hue bridge."""
 
-    def __init__(self, host, hass, filename, allow_unreachable=False,
+    def __init__(self, host, hass, filename, username, allow_unreachable=False,
                  allow_in_emulated_hue=True, allow_hue_groups=True):
         """Initialize the system."""
         self.host = host
         self.bridge_id = socket.gethostbyname(host)
         self.hass = hass
         self.filename = filename
+        self.username = username
         self.allow_unreachable = allow_unreachable
         self.allow_in_emulated_hue = allow_in_emulated_hue
         self.allow_hue_groups = allow_hue_groups
@@ -189,10 +193,14 @@ class HueBridge(object):
         import phue
 
         try:
-            self.bridge = phue.Bridge(
-                self.host,
-                config_file_path=self.hass.config.path(self.filename))
-        except (ConnectionRefusedError, OSError):  # Wrong host was given
+            kwargs = {}
+            if self.username is not None:
+                kwargs['username'] = self.username
+            if self.filename is not None:
+                kwargs['config_file_path'] = \
+                    self.hass.config.path(self.filename)
+            self.bridge = phue.Bridge(self.host, **kwargs)
+        except OSError:  # Wrong host was given
             _LOGGER.error("Error connecting to the Hue bridge at %s",
                           self.host)
             return
@@ -260,3 +268,104 @@ class HueBridge(object):
     def set_group(self, light_id, command):
         """Change light settings for a group. See phue for detail."""
         return self.bridge.set_group(light_id, command)
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class HueFlowHandler(config_entries.ConfigFlowHandler):
+    """Handle a Hue config flow."""
+
+    VERSION = 1
+
+    def __init__(self):
+        """Initialize the Hue flow."""
+        self.host = None
+
+    @property
+    def _websession(self):
+        """Return a websession.
+
+        Cannot assign in init because hass variable is not set yet.
+        """
+        return aiohttp_client.async_get_clientsession(self.hass)
+
+    async def async_step_init(self, user_input=None):
+        """Handle a flow start."""
+        from aiohue.discovery import discover_nupnp
+
+        if user_input is not None:
+            self.host = user_input['host']
+            return await self.async_step_link()
+
+        bridges = await discover_nupnp(websession=self._websession)
+
+        if not bridges:
+            return self.async_abort(
+                reason='No Philips Hue bridges discovered.'
+            )
+
+        # Find already configured hosts
+        configured_hosts = set(
+            entry.data['host'] for entry
+            in self.hass.config_entries.async_entries(DOMAIN))
+
+        hosts = [bridge.host for bridge in bridges
+                 if bridge.host not in configured_hosts]
+
+        if not hosts:
+            return self.async_abort(
+                reason='All Philips Hue bridges are already configured.'
+            )
+
+        elif len(hosts) == 1:
+            self.host = hosts[0]
+            return await self.async_step_link()
+
+        return self.async_show_form(
+            step_id='init',
+            title='Pick Hue Bridge',
+            data_schema=vol.Schema({
+                'host': vol.In(hosts)
+            })
+        )
+
+    async def async_step_link(self, user_input=None):
+        """Attempt to link with the Hue bridge."""
+        import aiohue
+        errors = {}
+
+        if user_input is not None:
+            bridge = aiohue.Bridge(self.host, websession=self._websession)
+            try:
+                # Create auth token
+                await bridge.create_user('home-assistant')
+                # Fetches name and id
+                await bridge.initialize()
+            except aiohue.LinkButtonNotPressed:
+                errors['base'] = 'Failed to register, please try again.'
+            except aiohue.AiohueException:
+                errors['base'] = 'Unknown linking error occurred.'
+                _LOGGER.exception('Uknown Hue linking error occurred')
+            else:
+                return self.async_create_entry(
+                    title=bridge.config.name,
+                    data={
+                        'host': bridge.host,
+                        'bridge_id': bridge.config.bridgeid,
+                        'username': bridge.username,
+                    }
+                )
+
+        return self.async_show_form(
+            step_id='link',
+            title='Link Hub',
+            description=CONFIG_INSTRUCTIONS,
+            errors=errors,
+        )
+
+
+async def async_setup_entry(hass, entry):
+    """Set up a bridge for a config entry."""
+    await hass.async_add_job(partial(
+        setup_bridge, entry.data['host'], hass,
+        username=entry.data['username']))
+    return True

--- a/homeassistant/components/spc.py
+++ b/homeassistant/components/spc.py
@@ -219,7 +219,8 @@ class SpcWebGateway:
         url = self._build_url(resource)
         try:
             _LOGGER.debug("Attempting to retrieve SPC data from %s", url)
-            session = aiohttp.ClientSession()
+            session = \
+                self._hass.helpers.aiohttp_client.async_get_clientsession()
             with async_timeout.timeout(10, loop=self._hass.loop):
                 action = session.get if use_get else session.put
                 response = yield from action(url)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -126,7 +126,8 @@ _LOGGER = logging.getLogger(__name__)
 HANDLERS = Registry()
 # Components that have config flows. In future we will auto-generate this list.
 FLOWS = [
-    'config_entry_example'
+    'config_entry_example',
+    'hue',
 ]
 
 SOURCE_USER = 'user'

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -35,14 +35,7 @@ def async_get_clientsession(hass, verify_ssl=True):
         key = DATA_CLIENTSESSION_NOTVERIFY
 
     if key not in hass.data:
-        connector = _async_get_connector(hass, verify_ssl)
-        clientsession = aiohttp.ClientSession(
-            loop=hass.loop,
-            connector=connector,
-            headers={USER_AGENT: SERVER_SOFTWARE}
-        )
-        _async_register_clientsession_shutdown(hass, clientsession)
-        hass.data[key] = clientsession
+        hass.data[key] = async_create_clientsession(hass, verify_ssl)
 
     return hass.data[key]
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -75,6 +75,9 @@ aiodns==1.1.1
 # homeassistant.components.http
 aiohttp_cors==0.6.0
 
+# homeassistant.components.hue
+aiohue==0.1.0
+
 # homeassistant.components.sensor.imap
 aioimaplib==0.7.13
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -76,7 +76,7 @@ aiodns==1.1.1
 aiohttp_cors==0.6.0
 
 # homeassistant.components.hue
-aiohue==0.1.0
+aiohue==0.2.0
 
 # homeassistant.components.sensor.imap
 aioimaplib==0.7.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -76,7 +76,7 @@ aiodns==1.1.1
 aiohttp_cors==0.6.0
 
 # homeassistant.components.hue
-aiohue==0.2.0
+aiohue==0.3.0
 
 # homeassistant.components.sensor.imap
 aioimaplib==0.7.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -35,7 +35,7 @@ aioautomatic==0.6.5
 aiohttp_cors==0.6.0
 
 # homeassistant.components.hue
-aiohue==0.2.0
+aiohue==0.3.0
 
 # homeassistant.components.notify.apns
 apns2==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -34,6 +34,9 @@ aioautomatic==0.6.5
 # homeassistant.components.http
 aiohttp_cors==0.6.0
 
+# homeassistant.components.hue
+aiohue==0.2.0
+
 # homeassistant.components.notify.apns
 apns2==0.3.0
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -37,6 +37,7 @@ COMMENT_REQUIREMENTS = (
 TEST_REQUIREMENTS = (
     'aioautomatic',
     'aiohttp_cors',
+    'aiohue',
     'apns2',
     'caldav',
     'coinmarketcap',

--- a/tests/components/test_hue.py
+++ b/tests/components/test_hue.py
@@ -212,7 +212,8 @@ class TestHueBridge(unittest.TestCase):
         mock_bridge = mock_phue.Bridge
         mock_bridge.side_effect = ConnectionRefusedError()
 
-        bridge = hue.HueBridge('localhost', self.hass, hue.PHUE_CONFIG_FILE)
+        bridge = hue.HueBridge(
+            'localhost', self.hass, hue.PHUE_CONFIG_FILE, None)
         bridge.setup()
         self.assertFalse(bridge.configured)
         self.assertTrue(bridge.config_request_id is None)
@@ -228,7 +229,8 @@ class TestHueBridge(unittest.TestCase):
         mock_phue.PhueRegistrationException = Exception
         mock_bridge.side_effect = mock_phue.PhueRegistrationException(1, 2)
 
-        bridge = hue.HueBridge('localhost', self.hass, hue.PHUE_CONFIG_FILE)
+        bridge = hue.HueBridge(
+            'localhost', self.hass, hue.PHUE_CONFIG_FILE, None)
         bridge.setup()
         self.assertFalse(bridge.configured)
         self.assertFalse(bridge.config_request_id is None)
@@ -250,7 +252,8 @@ class TestHueBridge(unittest.TestCase):
             None,
         ]
 
-        bridge = hue.HueBridge('localhost', self.hass, hue.PHUE_CONFIG_FILE)
+        bridge = hue.HueBridge(
+            'localhost', self.hass, hue.PHUE_CONFIG_FILE, None)
         bridge.setup()
         self.assertFalse(bridge.configured)
         self.assertFalse(bridge.config_request_id is None)
@@ -291,7 +294,8 @@ class TestHueBridge(unittest.TestCase):
             ConnectionRefusedError(),
         ]
 
-        bridge = hue.HueBridge('localhost', self.hass, hue.PHUE_CONFIG_FILE)
+        bridge = hue.HueBridge(
+            'localhost', self.hass, hue.PHUE_CONFIG_FILE, None)
         bridge.setup()
         self.assertFalse(bridge.configured)
         self.assertFalse(bridge.config_request_id is None)
@@ -332,7 +336,8 @@ class TestHueBridge(unittest.TestCase):
             mock_phue.PhueRegistrationException(1, 2),
         ]
 
-        bridge = hue.HueBridge('localhost', self.hass, hue.PHUE_CONFIG_FILE)
+        bridge = hue.HueBridge(
+            'localhost', self.hass, hue.PHUE_CONFIG_FILE, None)
         bridge.setup()
         self.assertFalse(bridge.configured)
         self.assertFalse(bridge.config_request_id is None)
@@ -364,7 +369,7 @@ class TestHueBridge(unittest.TestCase):
         """Test the hue_activate_scene service."""
         with patch('homeassistant.helpers.discovery.load_platform'):
             bridge = hue.HueBridge('localhost', self.hass,
-                                   hue.PHUE_CONFIG_FILE)
+                                   hue.PHUE_CONFIG_FILE, None)
             bridge.setup()
 
             # No args

--- a/tests/components/test_hue.py
+++ b/tests/components/test_hue.py
@@ -4,13 +4,17 @@ import logging
 import unittest
 from unittest.mock import call, MagicMock, patch
 
+import aiohue
+import pytest
+import voluptuous as vol
+
 from homeassistant.components import configurator, hue
 from homeassistant.const import CONF_FILENAME, CONF_HOST
 from homeassistant.setup import setup_component, async_setup_component
 
 from tests.common import (
     assert_setup_component, get_test_home_assistant, get_test_config_dir,
-    MockDependency
+    MockDependency, MockConfigEntry, mock_coro
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -398,15 +402,187 @@ class TestHueBridge(unittest.TestCase):
             bridge.bridge.run_scene.assert_called_once_with('group', 'scene')
 
 
-@asyncio.coroutine
-def test_setup_no_host(hass, requests_mock):
+async def test_setup_no_host(hass, requests_mock):
     """No host specified in any way."""
     requests_mock.get(hue.API_NUPNP, json=[])
     with MockDependency('phue') as mock_phue:
-        result = yield from async_setup_component(
+        result = await async_setup_component(
             hass, hue.DOMAIN, {hue.DOMAIN: {}})
         assert result
 
         mock_phue.Bridge.assert_not_called()
 
         assert hass.data[hue.DOMAIN] == {}
+
+
+async def test_flow_works(hass, aioclient_mock):
+    """Test config flow ."""
+    aioclient_mock.get(hue.API_NUPNP, json=[
+        {'internalipaddress': '1.2.3.4', 'id': 'bla'}
+    ])
+
+    flow = hue.HueFlowHandler()
+    flow.hass = hass
+    await flow.async_step_init()
+
+    with patch('aiohue.Bridge') as mock_bridge:
+        def mock_constructor(host, websession):
+            mock_bridge.host = host
+            return mock_bridge
+
+        mock_bridge.side_effect = mock_constructor
+        mock_bridge.username = 'username-abc'
+        mock_bridge.config.name = 'Mock Bridge'
+        mock_bridge.config.bridgeid = 'bridge-id-1234'
+        mock_bridge.create_user.return_value = mock_coro()
+        mock_bridge.initialize.return_value = mock_coro()
+
+        result = await flow.async_step_link(user_input={})
+
+    assert mock_bridge.host == '1.2.3.4'
+    assert len(mock_bridge.create_user.mock_calls) == 1
+    assert len(mock_bridge.initialize.mock_calls) == 1
+
+    assert result['type'] == 'create_entry'
+    assert result['title'] == 'Mock Bridge'
+    assert result['data'] == {
+        'host': '1.2.3.4',
+        'bridge_id': 'bridge-id-1234',
+        'username': 'username-abc'
+    }
+
+
+async def test_flow_no_discovered_bridges(hass, aioclient_mock):
+    """Test config flow discovers no bridges."""
+    aioclient_mock.get(hue.API_NUPNP, json=[])
+    flow = hue.HueFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+    assert result['type'] == 'abort'
+
+
+async def test_flow_all_discovered_bridges_exist(hass, aioclient_mock):
+    """Test config flow discovers only already configured bridges."""
+    aioclient_mock.get(hue.API_NUPNP, json=[
+        {'internalipaddress': '1.2.3.4', 'id': 'bla'}
+    ])
+    MockConfigEntry(domain='hue', data={
+        'host': '1.2.3.4'
+    }).add_to_hass(hass)
+    flow = hue.HueFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+    assert result['type'] == 'abort'
+
+
+async def test_flow_one_bridge_discovered(hass, aioclient_mock):
+    """Test config flow discovers one bridge."""
+    aioclient_mock.get(hue.API_NUPNP, json=[
+        {'internalipaddress': '1.2.3.4', 'id': 'bla'}
+    ])
+    flow = hue.HueFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'link'
+
+
+async def test_flow_two_bridges_discovered(hass, aioclient_mock):
+    """Test config flow discovers two bridges."""
+    aioclient_mock.get(hue.API_NUPNP, json=[
+        {'internalipaddress': '1.2.3.4', 'id': 'bla'},
+        {'internalipaddress': '5.6.7.8', 'id': 'beer'}
+    ])
+    flow = hue.HueFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'init'
+
+    with pytest.raises(vol.Invalid):
+        assert result['data_schema']({'host': '0.0.0.0'})
+
+    result['data_schema']({'host': '1.2.3.4'})
+    result['data_schema']({'host': '5.6.7.8'})
+
+
+async def test_flow_two_bridges_discovered_one_new(hass, aioclient_mock):
+    """Test config flow discovers two bridges."""
+    aioclient_mock.get(hue.API_NUPNP, json=[
+        {'internalipaddress': '1.2.3.4', 'id': 'bla'},
+        {'internalipaddress': '5.6.7.8', 'id': 'beer'}
+    ])
+    MockConfigEntry(domain='hue', data={
+        'host': '1.2.3.4'
+    }).add_to_hass(hass)
+    flow = hue.HueFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'link'
+    assert flow.host == '5.6.7.8'
+
+
+async def test_flow_timeout_discovery(hass):
+    """Test config flow ."""
+    flow = hue.HueFlowHandler()
+    flow.hass = hass
+
+    with patch('aiohue.discovery.discover_nupnp',
+               side_effect=asyncio.TimeoutError):
+        result = await flow.async_step_init()
+
+    assert result['type'] == 'abort'
+
+
+async def test_flow_link_timeout(hass):
+    """Test config flow ."""
+    flow = hue.HueFlowHandler()
+    flow.hass = hass
+
+    with patch('aiohue.Bridge.create_user',
+               side_effect=asyncio.TimeoutError):
+        result = await flow.async_step_link({})
+
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'link'
+    assert result['errors'] == {
+        'base': 'Failed to register, please try again.'
+    }
+
+
+async def test_flow_link_button_not_pressed(hass):
+    """Test config flow ."""
+    flow = hue.HueFlowHandler()
+    flow.hass = hass
+
+    with patch('aiohue.Bridge.create_user',
+               side_effect=aiohue.LinkButtonNotPressed):
+        result = await flow.async_step_link({})
+
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'link'
+    assert result['errors'] == {
+        'base': 'Failed to register, please try again.'
+    }
+
+
+async def test_flow_link_unknown_host(hass):
+    """Test config flow ."""
+    flow = hue.HueFlowHandler()
+    flow.hass = hass
+
+    with patch('aiohue.Bridge.create_user',
+               side_effect=aiohue.RequestError):
+        result = await flow.async_step_link({})
+
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'link'
+    assert result['errors'] == {
+        'base': 'Failed to register, please try again.'
+    }

--- a/tests/test_util/__init__.py
+++ b/tests/test_util/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the test utilities."""

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -1,13 +1,10 @@
 """Aiohttp test utils."""
 import asyncio
 from contextlib import contextmanager
-import functools
 import json as _json
 from unittest import mock
 from urllib.parse import urlparse, parse_qs
 import yarl
-
-from aiohttp.client_exceptions import ClientResponseError
 
 
 class AiohttpClientMocker:

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -79,9 +79,9 @@ class AiohttpClientMocker:
         self._cookies.clear()
         self.mock_calls.clear()
 
-    def create_session(self):
+    def create_session(self, loop):
         """Create a ClientSession that is bound to this mocker."""
-        session = ClientSession()
+        session = ClientSession(loop=loop)
         session._request = self.match_request
         return session
 
@@ -212,5 +212,5 @@ def mock_aiohttp_client():
 
     with mock.patch(
         'homeassistant.helpers.aiohttp_client.async_create_clientsession',
-            side_effect=lambda *args: mocker.create_session()):
+            side_effect=lambda hass, *args: mocker.create_session(hass.loop)):
         yield mocker

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -6,6 +6,8 @@ from unittest import mock
 from urllib.parse import urlparse, parse_qs
 import yarl
 
+from aiohttp.client_exceptions import ClientResponseError
+
 
 class AiohttpClientMocker:
     """Mock Aiohttp client requests."""

--- a/tests/test_util/test_aiohttp.py
+++ b/tests/test_util/test_aiohttp.py
@@ -1,0 +1,22 @@
+"""Tests for our aiohttp mocker."""
+from .aiohttp import AiohttpClientMocker
+
+import pytest
+
+
+async def test_matching_url():
+    """Test we can match urls."""
+    mocker = AiohttpClientMocker()
+    mocker.get('http://example.com')
+    await mocker.match_request('get', 'http://example.com/')
+
+    mocker.clear_requests()
+
+    with pytest.raises(AssertionError):
+        await mocker.match_request('get', 'http://example.com/')
+
+    mocker.clear_requests()
+
+    mocker.get('http://example.com?a=1')
+    await mocker.match_request('get', 'http://example.com/',
+                               params={'a': 1, 'b': 2})


### PR DESCRIPTION
## Description:
This PR adds a config flow for Philips Hue to allow users to configure it via the UI.

The library that we use to control Philips Hue lights is bad (and unmaintained). It forces everything via a file and will even do auto lookups. It will also not correctly handle if an auth token has been revoked.

Instead of trying to hack around the shortcomings of Phue, I wrote [aiohue](https://github.com/balloob/aiohue). It supports registering, fetching config and reading/controlling lights and groups. Oh, and it's async 👍 The goal will be to eventually migrate all of Hue to this lib. For now it's only used to handle authentication in the config flow.

![hue-flow](https://user-images.githubusercontent.com/1444314/36888321-d5b0de8a-1da9-11e8-953e-b0ea9ae06bf2.gif)

A reminder that the config entry config for Hue will live besides the existing config.

To do:
  - [x] add tests (all config flows need full test coverage)

Out of scope for this PR:
  - Have discovery trigger the config flow instead of configurator

Requires https://github.com/home-assistant/home-assistant-polymer/pull/960 for frontend to work.

## Example entry for `configuration.yaml` (if applicable):
```yaml
config:
  config_entries: 1
```

(then navigate to config panel)

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
