### PR TITLE
Logitech Pop support for emulated_hue component

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -106,7 +106,7 @@ def setup(hass, yaml_config):
     server.register_view(HueOneLightStateView(config))
     server.register_view(HueOneLightChangeView(config))
     server.register_view(HueGroupView(config))
-    
+
     upnp_listener = UPNPResponderThread(
         config.host_ip_addr, config.listen_port,
         config.upnp_bind_multicast, config.advertise_ip,

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -21,7 +21,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util.json import load_json, save_json
 from .hue_api import (
     HueUsernameView, HueAllLightsStateView, HueOneLightStateView,
-    HueOneLightChangeView)
+    HueOneLightChangeView, HueGroupView)
 from .upnp import DescriptionXmlView, UPNPResponderThread
 
 DOMAIN = 'emulated_hue'
@@ -105,7 +105,8 @@ def setup(hass, yaml_config):
     server.register_view(HueAllLightsStateView(config))
     server.register_view(HueOneLightStateView(config))
     server.register_view(HueOneLightChangeView(config))
-
+    server.register_view(HueGroupView(config))
+    
     upnp_listener = UPNPResponderThread(
         config.host_ip_addr, config.listen_port,
         config.upnp_bind_multicast, config.advertise_ip,

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -52,7 +52,7 @@ class HueUsernameView(HomeAssistantView):
 
 
 class HueGroupView(HomeAssistantView):
-    """Dummy group handler to get Logitech Pop working."""
+    """Group handler to get Logitech Pop working."""
 
     url = '/api/{username}/groups/0/action'
     name = 'emulated_hue:groups:state'
@@ -64,10 +64,14 @@ class HueGroupView(HomeAssistantView):
 
     @core.callback
     def put(self, request, username):
-        """Dummy handler."""
-        return self.json([{'error': {'address': '/groups/0/action/scene',
-                           'type': 7, 'description': 'invalid value, dummy ' +
-                                                     'for parameter, scene'}}])
+        """Process a request to make the Logitech Pop working."""
+        return self.json([{
+            'error': {
+                'address': '/groups/0/action/scene',
+                'type': 7,
+                'description': 'invalid value, dummy for parameter, scene'
+            }
+        }])
 
 
 class HueAllLightsStateView(HomeAssistantView):

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -65,9 +65,11 @@ class HueGroupView(HomeAssistantView):
 
     @core.callback
     def put(self, request, username):
-        return self.json([{'error': {'address': '/groups/0/action/scene', 'type':7, 'description': 'invalid value, dummy for parameter, scene'}}])
+        return self.json([{'error': {'address': '/groups/0/action/scene',
+                           'type':7, 'description': 'invalid value, dummy ' +
+                           'for parameter, scene'}}])
 
-    
+
 class HueAllLightsStateView(HomeAssistantView):
     """Handle requests for getting and setting info about entities."""
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -51,6 +51,23 @@ class HueUsernameView(HomeAssistantView):
         return self.json([{'success': {'username': '12345678901234567890'}}])
 
 
+class HueGroupView(HomeAssistantView):
+    """Dummy Handler for group to get Logitech Pop working"""
+    """Credit to ahertz - https://github.com/bwssytems/ha-bridge/issues/623"""
+
+    url = '/api/{username}/groups/0/action'
+    name = 'emulated_hue:groups:state'
+    requires_auth = False
+
+    def __init__(self, config):
+        """Initialize the instance of the view."""
+        self.config = config
+
+    @core.callback
+    def put(self, request, username):
+        return self.json([{'error': {'address': '/groups/0/action/scene', 'type':7, 'description': 'invalid value, dummy for parameter, scene'}}])
+
+    
 class HueAllLightsStateView(HomeAssistantView):
     """Handle requests for getting and setting info about entities."""
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -52,9 +52,8 @@ class HueUsernameView(HomeAssistantView):
 
 
 class HueGroupView(HomeAssistantView):
-    """Dummy Handler for group to get Logitech Pop working"""
-    """Credit to ahertz - https://github.com/bwssytems/ha-bridge/issues/623"""
-
+    """Dummy group handler to get Logitech Pop working."""
+    
     url = '/api/{username}/groups/0/action'
     name = 'emulated_hue:groups:state'
     requires_auth = False
@@ -65,6 +64,7 @@ class HueGroupView(HomeAssistantView):
 
     @core.callback
     def put(self, request, username):
+        """Dummy handler.""" 
         return self.json([{'error': {'address': '/groups/0/action/scene',
                            'type': 7, 'description': 'invalid value, dummy ' +
                                                      'for parameter, scene'}}])

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -66,8 +66,8 @@ class HueGroupView(HomeAssistantView):
     @core.callback
     def put(self, request, username):
         return self.json([{'error': {'address': '/groups/0/action/scene',
-                           'type':7, 'description': 'invalid value, dummy ' +
-                           'for parameter, scene'}}])
+                           'type': 7, 'description': 'invalid value, dummy ' +
+                                                     'for parameter, scene'}}])
 
 
 class HueAllLightsStateView(HomeAssistantView):

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -53,7 +53,7 @@ class HueUsernameView(HomeAssistantView):
 
 class HueGroupView(HomeAssistantView):
     """Dummy group handler to get Logitech Pop working."""
-    
+
     url = '/api/{username}/groups/0/action'
     name = 'emulated_hue:groups:state'
     requires_auth = False
@@ -64,7 +64,7 @@ class HueGroupView(HomeAssistantView):
 
     @core.callback
     def put(self, request, username):
-        """Dummy handler.""" 
+        """Dummy handler."""
         return self.json([{'error': {'address': '/groups/0/action/scene',
                            'type': 7, 'description': 'invalid value, dummy ' +
                                                      'for parameter, scene'}}])


### PR DESCRIPTION
## Description:

Added a bit of code that would make the emulated_hue component work with the Logitech Pop based on information discovered from ha-bridge here (so full credit the contributors and maintainer of ha-bridge):

https://github.com/bwssytems/ha-bridge/issues/623

Note: first time contributing, please excuse any misstep

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
