### PR TITLE
Fix sensibo default IDs to be according to schema

### DIFF
--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -29,7 +29,7 @@ REQUIREMENTS = ['pysensibo==1.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
-ALL = 'all'
+ALL = ['all']
 TIMEOUT = 10
 
 SERVICE_ASSUME_STATE = 'sensibo_assume_state'


### PR DESCRIPTION
## Description:

Fix sensibo default IDs to be according to schema.

**Related issue (if applicable):** fixes #12757

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: sensibo
    api_key: deadbeef
```

## Checklist:
  - [x] The code change is tested and works locally.
