### PR TITLE
Keep auto groups during group reload

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -258,8 +258,7 @@ def async_setup(hass, config):
     @asyncio.coroutine
     def reload_service_handler(service):
         """Remove all user-defined groups and load new ones from config."""
-        # pylint: disable=protected-access
-        auto = list(filter(lambda e: not e._user_defined, component.entities))
+        auto = list(filter(lambda e: not e.user_defined, component.entities))
 
         conf = yield from component.async_prepare_reload()
         if conf is None:
@@ -412,7 +411,7 @@ class Group(Entity):
         self.group_off = None
         self.visible = visible
         self.control = control
-        self._user_defined = user_defined
+        self.user_defined = user_defined
         self._order = order
         self._assumed_state = False
         self._async_unsub_state_changed = None
@@ -502,7 +501,7 @@ class Group(Entity):
             ATTR_ENTITY_ID: self.tracking,
             ATTR_ORDER: self._order,
         }
-        if not self._user_defined:
+        if not self.user_defined:
             data[ATTR_AUTO] = True
         if self.view:
             data[ATTR_VIEW] = True

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -257,11 +257,16 @@ def async_setup(hass, config):
 
     @asyncio.coroutine
     def reload_service_handler(service):
-        """Remove all groups and load new ones from config."""
+        """Remove all user-defined groups and load new ones from config."""
+        # pylint: disable=protected-access
+        auto = list(filter(lambda e: not e._user_defined, component.entities))
+
         conf = yield from component.async_prepare_reload()
         if conf is None:
             return
         yield from _async_process_config(hass, conf, component)
+
+        yield from component.async_add_entities(auto)
 
     hass.services.async_register(
         DOMAIN, SERVICE_RELOAD, reload_service_handler,

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -348,9 +348,15 @@ class TestComponentsGroup(unittest.TestCase):
             'empty_group': {'name': 'Empty Group', 'entities': None},
         }})
 
+        group.Group.create_group(
+            self.hass, 'all tests',
+            ['test.one', 'test.two'],
+            user_defined=False)
+
         assert sorted(self.hass.states.entity_ids()) == \
-            ['group.empty_group', 'group.second_group', 'group.test_group']
-        assert self.hass.bus.listeners['state_changed'] == 2
+            ['group.all_tests', 'group.empty_group', 'group.second_group',
+             'group.test_group']
+        assert self.hass.bus.listeners['state_changed'] == 3
 
         with patch('homeassistant.config.load_yaml_config_file', return_value={
             'group': {
@@ -362,8 +368,9 @@ class TestComponentsGroup(unittest.TestCase):
             group.reload(self.hass)
             self.hass.block_till_done()
 
-        assert self.hass.states.entity_ids() == ['group.hello']
-        assert self.hass.bus.listeners['state_changed'] == 1
+        assert sorted(self.hass.states.entity_ids()) == \
+            ['group.all_tests', 'group.hello']
+        assert self.hass.bus.listeners['state_changed'] == 2
 
     def test_changing_group_visibility(self):
         """Test that a group can be hidden and shown."""


### PR DESCRIPTION
## Description:

This addresses the quite popular bug report that auto/"all" groups are lost when reloading groups from the UI. It seems to work but I am 80% certain that this is a wrong approach?

**Related issue (if applicable):** fixes #12012

## Checklist:
  - [X] The code change is tested and works locally.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [ ] Tests have been added to verify that the new code works.
