### PR TITLE
Fix flaky light group test

### DIFF
--- a/tests/components/light/test_group.py
+++ b/tests/components/light/test_group.py
@@ -325,9 +325,11 @@ async def test_service_calls(hass):
                                            'light.kitchen_lights']}
     ]})
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get('light.group_light').state == 'on'
     light.async_toggle(hass, 'light.group_light')
+    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     assert hass.states.get('light.bed_light').state == 'off'
@@ -336,12 +338,14 @@ async def test_service_calls(hass):
 
     light.async_turn_on(hass, 'light.group_light')
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get('light.bed_light').state == 'on'
     assert hass.states.get('light.ceiling_lights').state == 'on'
     assert hass.states.get('light.kitchen_lights').state == 'on'
 
     light.async_turn_off(hass, 'light.group_light')
+    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     assert hass.states.get('light.bed_light').state == 'off'
@@ -350,6 +354,7 @@ async def test_service_calls(hass):
 
     light.async_turn_on(hass, 'light.group_light', brightness=128,
                         effect='Random', rgb_color=(42, 255, 255))
+    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get('light.bed_light')


### PR DESCRIPTION
## Description:
https://travis-ci.org/home-assistant/home-assistant/jobs/348247842#L994
https://github.com/home-assistant/home-assistant/pull/12229#issuecomment-370002908

The new `light.group` test introduced a flaky test. It's caused by having an async state change listener that is a callback. Callbacks are not tracked by the core when tracking jobs and thus will not be waited for when calling `hass.async_block_till_done()`. They can usually be flushed out by doing a `sleep(0)` which `async_block_till_done` does, but if a callback calls another callback, that won't work.

So for this case, let's switch to calling `async_block_till_done` twice.

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
