### PR TITLE
Fix light group update before add

### DIFF
--- a/homeassistant/components/light/group.py
+++ b/homeassistant/components/light/group.py
@@ -45,7 +45,7 @@ async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                                async_add_devices, discovery_info=None) -> None:
     """Initialize light.group platform."""
     async_add_devices([GroupLight(config.get(CONF_NAME),
-                                  config[CONF_ENTITIES])])
+                                  config[CONF_ENTITIES])], True)
 
 
 class GroupLight(light.Light):

--- a/tests/components/light/test_group.py
+++ b/tests/components/light/test_group.py
@@ -2,7 +2,6 @@
 from unittest.mock import MagicMock
 
 import asynctest
-import pytest
 
 from homeassistant.components import light
 from homeassistant.components.light import group
@@ -317,7 +316,6 @@ async def test_supported_features(hass):
     assert state.attributes['supported_features'] == 41
 
 
-@pytest.mark.skip
 async def test_service_calls(hass):
     """Test service calls."""
     await async_setup_component(hass, 'light', {'light': [


### PR DESCRIPTION
## Description:

See https://github.com/home-assistant/home-assistant/pull/12843#issuecomment-370017258

I've tried the tests for group.py around 20 times now and this seems to resolve the flakey test issue as well.

Also: the Home Assistant core PR has been merged, but the docs PR hasn't; if someone could take a look at that before 0.65 is released, that would be awesome 🎉: https://github.com/home-assistant/home-assistant.github.io/pull/4739

## Example entry for `configuration.yaml` (if applicable):
```yaml
light: 
  - platform: group
    entities:
      - light.light_1
      - light.light_2
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works. (Well, the tests, while flakey, seem to have *spotted* this bug in the first place... 🤓)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
