### PR TITLE
Handle Hue errors better

### DIFF
--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -192,7 +192,7 @@ class HueBridge(object):
             self.bridge = phue.Bridge(
                 self.host,
                 config_file_path=self.hass.config.path(self.filename))
-        except ConnectionRefusedError:  # Wrong host was given
+        except (ConnectionRefusedError, OSError):  # Wrong host was given
             _LOGGER.error("Error connecting to the Hue bridge at %s",
                           self.host)
             return
@@ -201,6 +201,9 @@ class HueBridge(object):
                             self.host)
             self.request_configuration()
             return
+        except Exception:
+            _LOGGER.exception("Unknown error connecting with Hue bridge at %s",
+                              self.host)
 
         # If we came here and configuring this host, mark as done
         if self.config_request_id:

--- a/homeassistant/components/hue.py
+++ b/homeassistant/components/hue.py
@@ -201,7 +201,7 @@ class HueBridge(object):
                             self.host)
             self.request_configuration()
             return
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unknown error connecting with Hue bridge at %s",
                               self.host)
 


### PR DESCRIPTION
## Description:
If a user has 2 networks behind the same IP with both a Hue hub, Hue component would fail to setup.

What would happen is that Home Assistant would get the IP address from the cloud discovery and try to connect. This would raise an OSError and we only handled ConnectionRefusedError. I've also added a generic exception handler to make sure we don't disturb the setup process of other hubs.

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:
```

