### PR TITLE
Add consider_home and source_type to device_tracker.see service

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -107,7 +107,7 @@ SERVICE_SEE_PAYLOAD_SCHEMA = vol.Schema(vol.All(
         ATTR_LOCATION_NAME: cv.string,
         ATTR_GPS: cv.gps,
         ATTR_GPS_ACCURACY: cv.positive_int,
-        ATTR_BATTERY: cv.string,
+        ATTR_BATTERY: cv.positive_int,
         ATTR_ATTRIBUTES: dict,
         ATTR_SOURCE_TYPE: vol.In(SOURCE_TYPES),
         ATTR_CONSIDER_HOME: cv.time_period,
@@ -125,7 +125,7 @@ def is_on(hass: HomeAssistantType, entity_id: str = None):
 def see(hass: HomeAssistantType, mac: str = None, dev_id: str = None,
         host_name: str = None, location_name: str = None,
         gps: GPSType = None, gps_accuracy=None,
-        battery=None, attributes: dict = None):
+        battery: int = None, attributes: dict = None):
     """Call service to notify you see device."""
     data = {key: value for key, value in
             ((ATTR_MAC, mac),
@@ -254,10 +254,11 @@ class DeviceTracker(object):
                                 dev.mac)
 
     def see(self, mac: str = None, dev_id: str = None, host_name: str = None,
-            location_name: str = None, gps: GPSType = None, gps_accuracy=None,
-            battery: str = None, attributes: dict = None,
-            source_type: str = SOURCE_TYPE_GPS, picture: str = None,
-            icon: str = None, consider_home: timedelta = None):
+            location_name: str = None, gps: GPSType = None,
+            gps_accuracy: int = None, battery: int = None,
+            attributes: dict = None, source_type: str = SOURCE_TYPE_GPS,
+            picture: str = None, icon: str = None,
+            consider_home: timedelta = None):
         """Notify the device tracker that you see a device."""
         self.hass.add_job(
             self.async_see(mac, dev_id, host_name, location_name, gps,
@@ -266,12 +267,13 @@ class DeviceTracker(object):
         )
 
     @asyncio.coroutine
-    def async_see(self, mac: str = None, dev_id: str = None,
-                  host_name: str = None, location_name: str = None,
-                  gps: GPSType = None, gps_accuracy=None, battery: str = None,
-                  attributes: dict = None, source_type: str = SOURCE_TYPE_GPS,
-                  picture: str = None, icon: str = None,
-                  consider_home: timedelta = None):
+    def async_see(
+            self, mac: str = None, dev_id: str = None, host_name: str = None,
+            location_name: str = None, gps: GPSType = None,
+            gps_accuracy: int = None, battery: int = None,
+            attributes: dict = None, source_type: str = SOURCE_TYPE_GPS,
+            picture: str = None, icon: str = None,
+            consider_home: timedelta = None):
         """Notify the device tracker that you see a device.
 
         This method is a coroutine.
@@ -399,9 +401,10 @@ class Device(Entity):
     host_name = None  # type: str
     location_name = None  # type: str
     gps = None  # type: GPSType
-    gps_accuracy = 0
+    gps_accuracy = 0  # type: int
     last_seen = None  # type: dt_util.dt.datetime
-    battery = None  # type: str
+    consider_home = None  # type: dt_util.dt.timedelta
+    battery = None  # type: int
     attributes = None  # type: dict
     vendor = None  # type: str
     icon = None  # type: str
@@ -491,7 +494,7 @@ class Device(Entity):
 
     @asyncio.coroutine
     def async_seen(self, host_name: str = None, location_name: str = None,
-                   gps: GPSType = None, gps_accuracy=0, battery: str = None,
+                   gps: GPSType = None, gps_accuracy=0, battery: int = None,
                    attributes: dict = None,
                    source_type: str = SOURCE_TYPE_GPS,
                    consider_home: timedelta = None):

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -207,18 +207,14 @@ def async_setup(hass: HomeAssistantType, config: ConfigType):
         args = {key: value for key, value in call.data.items() if key in
                 (ATTR_MAC, ATTR_DEV_ID, ATTR_HOST_NAME, ATTR_LOCATION_NAME,
                  ATTR_GPS, ATTR_GPS_ACCURACY, ATTR_BATTERY, ATTR_ATTRIBUTES,
-                 ATTR_SOURCE_TYPE)}
-
-        try:
-            consider_home = call.data[ATTR_CONSIDER_HOME]
-        except KeyError:
-            pass
-        else:
-            args[ATTR_CONSIDER_HOME] = timedelta(seconds=int(consider_home))
+                 ATTR_SOURCE_TYPE, ATTR_CONSIDER_HOME)}
 
         yield from tracker.async_see(**args)
 
-    hass.services.async_register(DOMAIN, SERVICE_SEE, async_see_service)
+    hass.services.async_register(
+        DOMAIN, SERVICE_SEE, async_see_service,
+        schema=vol.Schema({ATTR_CONSIDER_HOME: cv.time_period},
+                          extra=vol.ALLOW_EXTRA))
 
     # restore
     yield from tracker.async_setup_tracked_device()

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -101,17 +101,18 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
 })
 SERVICE_SEE_PAYLOAD_SCHEMA = vol.Schema(vol.All(
     cv.has_at_least_one_key(ATTR_MAC, ATTR_DEV_ID), {
-    ATTR_MAC: cv.string,
-    ATTR_DEV_ID: cv.string,
-    ATTR_HOST_NAME: cv.string,
-    ATTR_LOCATION_NAME: cv.string,
-    ATTR_GPS: cv.gps,
-    ATTR_GPS_ACCURACY: cv.positive_int,
-    ATTR_BATTERY: cv.string,
-    ATTR_ATTRIBUTES: dict,
-    ATTR_SOURCE_TYPE: vol.In(SOURCE_TYPES),
-    ATTR_CONSIDER_HOME: cv.time_period,
-}))
+        ATTR_MAC: cv.string,
+        ATTR_DEV_ID: cv.string,
+        ATTR_HOST_NAME: cv.string,
+        ATTR_LOCATION_NAME: cv.string,
+        ATTR_GPS: cv.gps,
+        ATTR_GPS_ACCURACY: cv.positive_int,
+        ATTR_BATTERY: cv.string,
+        ATTR_ATTRIBUTES: dict,
+        ATTR_SOURCE_TYPE: vol.In(SOURCE_TYPES),
+        ATTR_CONSIDER_HOME: cv.time_period,
+    }))
+
 
 @bind_hass
 def is_on(hass: HomeAssistantType, entity_id: str = None):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -36,6 +36,7 @@ latitude = vol.All(vol.Coerce(float), vol.Range(min=-90, max=90),
                    msg='invalid latitude')
 longitude = vol.All(vol.Coerce(float), vol.Range(min=-180, max=180),
                     msg='invalid longitude')
+gps = vol.ExactSequence([latitude, longitude])
 sun_event = vol.All(vol.Lower, vol.Any(SUN_EVENT_SUNSET, SUN_EVENT_SUNRISE))
 port = vol.All(vol.Coerce(int), vol.Range(min=1, max=65535))
 


### PR DESCRIPTION
## Description:
Exposes `consider_home` ~~(in seconds)~~ and `source_type` to the `device_tracker.see` service. 

As a prerequisite, this also adds `consider_home` to `device_tracker.DeviceTracker.async_see`. This sets the `consider_home` attribute of `device_tracker.Device`.

This is useful for the following reasons:
  - `source_type`: the caller of the service can identify the source of the information
  - `consider_home`: the caller of the service may have more/dynamic information on how long this event means the device is likely to be present.

As an example, this allows a completely event-driven device tracker for OpenWRT [which I implemented](https://github.com/mueslo/openwrt_hass_devicetracker), i.e. without any scanners or cron jobs. Based on the association event, one of two timeouts is chosen. This drastically reduces the amount of calls made to keep an up-to-date mirror of device presence, typical wifi association events occur very infrequently if a device stays connected. The event-driven design completely removes the delay of newly-connected devices due to scanning taking place only every 12 seconds. When a device connects to an OpenWRT access point running the above package it is registered in Home Assistant in **less than 1 second**. 

Also adds `voluptuous` validation to `device_tracker.see` service calls and fixes the `battery` attribute being treated as `str` in some places. There may be in issue with `gpslogger`, as it treats it as `float`, but it does not have any tests so I can't check it as the calls made by the mobile apps to the `gpslogger` endpoint are unknown to me.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works. 