### PR TITLE
Fix dead Sonos web interface even more

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -129,7 +129,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         """Avoid SoCo 0.14 event thread dying from invalid xml."""
         try:
             return orig_parse_event_xml(xml)
-        except soco.exceptions.SoCoException:
+        # pylint: disable=broad-except
+        except Exception as ex:
+            _LOGGER.debug("Dodged exception: %s %s", type(ex), str(ex))
             return {}
 
     soco.events.parse_event_xml = safe_parse_event_xml


### PR DESCRIPTION
## Description:

A followup to #12796, keeping the SoCo event thread alive in even more situations, [like this one](https://github.com/SoCo/SoCo/blob/v0.14/soco/data_structures.py#L172).

This should fix the web UI dying with several popular music services that I do not use. The issue was debugged with a lot of help from @chubRock1, thanks!

## Checklist:
  - [X] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).</s>
  - [ ] <s>New dependencies are only imported inside functions that use them ([example][ex-import]).</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54