### PR TITLE
Disable certificate verification for the python API

### DIFF
--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -86,7 +86,7 @@ class API(object):
         try:
             if method == METH_GET:
                 return requests.get(
-                    url, params=data, timeout=timeout, headers=self._headers)
+                    url, params=data, timeout=timeout, headers=self._headers, verify=False)
 
             return requests.request(
                 method, url, data=data, timeout=timeout,

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -86,7 +86,8 @@ class API(object):
         try:
             if method == METH_GET:
                 return requests.get(
-                    url, params=data, timeout=timeout, headers=self._headers, verify=False)
+                    url, params=data, timeout=timeout,
+                    headers=self._headers, verify=False)
 
             return requests.request(
                 method, url, data=data, timeout=timeout,


### PR DESCRIPTION
Disable certificate verification for the python API so that we can use a self-signed certificate

**Related issue (if applicable):** fixes #11831 

Tested:

```
Python 3.5.2+ (default, Sep 22 2016, 12:18:14) 
[GCC 6.2.0 20160927] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import remote as remote
>>> 
>>> 
>>> api = remote.API("ip", "pwd", use_ssl = True)
>>> print(remote.validate_api(api))
/usr/local/lib/python3.5/dist-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
ok
```