### PR TITLE
Xiaomi Aqara Gateway: IndexError (list index out of range) fixed

### DIFF
--- a/homeassistant/components/sensor/xiaomi_aqara.py
+++ b/homeassistant/components/sensor/xiaomi_aqara.py
@@ -10,8 +10,8 @@ _LOGGER = logging.getLogger(__name__)
 SENSOR_TYPES = {
     'temperature': [TEMP_CELSIUS, 'mdi:thermometer'],
     'humidity': ['%', 'mdi:water-percent'],
-    'illumination': ['lm'],
-    'lux': ['lx'],
+    'illumination': ['lm', 'mdi:weather-sunset'],
+    'lux': ['lx', 'mdi:weather-sunset'],
     'pressure': ['hPa', 'mdi:gauge']
 }
 


### PR DESCRIPTION
#12814 cannot work:

```
>>> try:
...   print(SENSOR_TYPES.get("lux")[1])
... except TypeError:
...   print("none")
...
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
IndexError: list index out of range
```