### PR TITLE
RFC - Adds folder_watcher component

### DIFF
--- a/homeassistant/components/sensor/folder_watcher.py
+++ b/homeassistant/components/sensor/folder_watcher.py
@@ -1,0 +1,116 @@
+"""
+Sensor for monitoring activity on a folder.
+"""
+import datetime
+from datetime import timedelta
+import logging
+import os
+import voluptuous as vol
+
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_FOLDER_PATH = 'folder'
+
+SCAN_INTERVAL = timedelta(seconds=1)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_FOLDER_PATH): cv.isdir,
+})
+
+
+def get_timestamp(dir_entry):
+    """Return the timestamp of file modification."""
+    mtime = dir_entry.stat().st_mtime
+    return datetime.datetime.fromtimestamp(mtime).isoformat()
+
+
+def get_files(path):
+    """Return the dict of files and timestamps."""
+    files = {}
+    with os.scandir(path) as it:
+        for entry in it:
+            if not entry.name.startswith('.') and entry.is_file():
+                files[entry.name] = get_timestamp(entry)
+    return files
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the folder watcher."""
+    folder_path = config.get(CONF_FOLDER_PATH)
+    if not hass.config.is_allowed_path(folder_path):
+        _LOGGER.error("folder %s is not valid or allowed", folder_path)
+    else:
+        folder_watcher = Watcher(folder_path, hass)
+        add_devices([folder_watcher], True)
+
+
+class Watcher(Entity):
+    """Class for watching a folder, state recorded in a dict."""
+
+    ICON = 'mdi:folder'
+
+    def __init__(self, folder_path, hass):
+        self._folder_path = os.path.join(folder_path, '')  # Ass trailing /
+        self._hass = hass
+        self._updated = False
+        self._files = get_files(self._folder_path)
+        self._name = os.path.split(
+            os.path.split(self._folder_path)[0])[1] + "_watcher"
+        self._state = None
+
+    def update(self):
+        """Update the watcher."""
+        current_files = []
+        previous_files = list(self._files.keys())
+
+        with os.scandir(self._folder_path) as folder:
+            for entry in folder:
+                if not entry.name.startswith('.') and entry.is_file():
+                    mtime = get_timestamp(entry)
+                    fname = entry.name
+                    current_files.append(fname)  # Keep record of current files
+
+                    # If file not in files list, add the entry
+                    if fname not in self._files:
+                        self._hass.bus.fire('file_added', {'file': fname})
+                        self._state = fname + " added"
+                        self._files[fname] = mtime
+
+                    # If exists and modified, update timestamp
+                    elif fname in self._files and self._files[fname] != mtime:
+                        self._hass.bus.fire('file_modified', {'file': fname})
+                        self._state = fname + " modified"
+                        self._files[fname] = mtime
+
+            # Check if any files deleted
+            for fname in list(set(previous_files) - set(current_files)):
+                self._hass.bus.fire('file_deleted', {'file': fname})
+                self._state = fname + " deleted"
+                self._files.pop(fname, None)  # Delete the entry
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self.ICON
+
+    @property
+    def device_state_attributes(self):
+        """Return other details about the sensor state."""
+        attr = {
+            'path': self._folder_path
+            }
+        return attr


### PR DESCRIPTION
## Description:
Request For Comments - folder_watcher emulates [Watchdog](https://github.com/gorakhargosh/watchdog), and fires an event on a file addition, modification or deletion. The state is the sensor is the last event. Note that you may need to add the folder to your `whitelist_external_dirs`.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: folder_watcher
    folder: /images
```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
