### PR TITLE
Add the Gamerscore and Tier of the account

### DIFF
--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -69,7 +69,9 @@ class XboxSensor(Entity):
         if profile.get('success', True) and profile.get('code') is None:
             self.success_init = True
             self._gamertag = profile.get('gamertag')
+            self._gamerscore = profile.get('gamerscore')
             self._picture = profile.get('gamerpicSmallSslImagePath')
+            self._tier = profile.get('tier')
         else:
             _LOGGER.error("Can't get user profile %s. "
                           "Error Code: %s Description: %s",
@@ -97,6 +99,8 @@ class XboxSensor(Entity):
                 attributes[
                     '{} {}'.format(device.get('type'), title.get('placement'))
                 ] = title.get('name')
+                attributes['gamerscore'] = self._gamerscore
+                attributes['tier'] = self._tier
 
         return attributes
 

--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -94,13 +94,14 @@ class XboxSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         attributes = {}
+        attributes['gamerscore'] = self._gamerscore
+        attributes['tier'] = self._tier
+
         for device in self._presence:
             for title in device.get('titles'):
                 attributes[
                     '{} {}'.format(device.get('type'), title.get('placement'))
                 ] = title.get('name')
-                attributes['gamerscore'] = self._gamerscore
-                attributes['tier'] = self._tier
 
         return attributes
 


### PR DESCRIPTION
## Description:

Added the Gamerscore and Tier of the account.

The tier is the subscription type of the Xbox Live account, so Silver (which is now called Free) or Gold (paid).

## Checklist:
  - [x] The code change is tested and works locally.