### PR TITLE
Fix interaction with hyperion on NodeMCU

### DIFF
--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -215,7 +215,7 @@ class Hyperion(Light):
 
             if not response['info']['activeLedColor']:
                 # Get the active effect
-                if response['info']['activeEffects']:
+                if response['info'].get('activeEffects'):
                     self._rgb_color = [175, 0, 255]
                     self._icon = 'mdi:lava-lamp'
                     try:

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -213,7 +213,8 @@ class Hyperion(Light):
             except (KeyError, IndexError):
                 pass
 
-            if not response['info']['activeLedColor']:
+            led_color = response['info']['activeLedColor']
+            if not led_color or led_color[0]['RGB value'] == [0, 0, 0]:
                 # Get the active effect
                 if response['info'].get('activeEffects'):
                     self._rgb_color = [175, 0, 255]


### PR DESCRIPTION
## Description:
Restore hyperion on NodeMCU support which got broken by cdbf2f9293bbaaa1fdff24aece194a52f215b3da.

Hyperion on NodeMCU misses a status entry ('activeEffects') and displays turned off light in a different way.

**Related issue (if applicable):** fixes #11974

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
