### PR TITLE
Telegram_bot three platform support proxy_url and proxy_params

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -237,7 +237,7 @@ def async_setup(hass, config):
         _LOGGER.exception("Error setting up platform %s", p_type)
         return False
 
-    bot = _initialize_bot(p_config)
+    bot = initialize_bot(p_config)
     notify_service = TelegramNotificationService(
         hass,
         bot,
@@ -301,7 +301,7 @@ def async_setup(hass, config):
     return True
 
 
-def _initialize_bot(p_config):
+def initialize_bot(p_config):
     """Initialize telegram bot with proxy support."""
     from telegram import Bot
     from telegram.utils.request import Request

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -237,13 +237,12 @@ def async_setup(hass, config):
         _LOGGER.exception("Error setting up platform %s", p_type)
         return False
 
+    bot = _initialize_bot(p_config)
     notify_service = TelegramNotificationService(
         hass,
-        p_config.get(CONF_API_KEY),
+        bot,
         p_config.get(CONF_ALLOWED_CHAT_IDS),
-        p_config.get(ATTR_PARSER),
-        p_config.get(CONF_PROXY_URL),
-        p_config.get(CONF_PROXY_PARAMS)
+        p_config.get(ATTR_PARSER)
     )
 
     @asyncio.coroutine
@@ -302,15 +301,28 @@ def async_setup(hass, config):
     return True
 
 
+def _initialize_bot(p_config):
+    """Initialize telegram bot with proxy support."""
+    from telegram import Bot
+    from telegram.utils.request import Request
+
+    api_key = p_config.get(CONF_API_KEY)
+    proxy_url = p_config.get(CONF_PROXY_URL)
+    proxy_params = p_config.get(CONF_PROXY_PARAMS)
+
+    request = None
+    if proxy_url is not None:
+        request = Request(proxy_url=proxy_url,
+                          urllib3_proxy_kwargs=proxy_params)
+    return Bot(token=api_key, request=request)
+
+
 class TelegramNotificationService:
     """Implement the notification services for the Telegram Bot domain."""
 
-    def __init__(self, hass, api_key, allowed_chat_ids, parser,
-                 proxy_url=None, proxy_params=None):
+    def __init__(self, hass, bot, allowed_chat_ids, parser):
         """Initialize the service."""
-        from telegram import Bot
         from telegram.parsemode import ParseMode
-        from telegram.utils.request import Request
 
         self.allowed_chat_ids = allowed_chat_ids
         self._default_user = self.allowed_chat_ids[0]
@@ -318,11 +330,7 @@ class TelegramNotificationService:
         self._parsers = {PARSER_HTML: ParseMode.HTML,
                          PARSER_MD: ParseMode.MARKDOWN}
         self._parse_mode = self._parsers.get(parser)
-        request = None
-        if proxy_url is not None:
-            request = Request(proxy_url=proxy_url,
-                              urllib3_proxy_kwargs=proxy_params)
-        self.bot = Bot(token=api_key, request=request)
+        self.bot = bot
         self.hass = hass
 
     def _get_msg_ids(self, msg_data, chat_id):

--- a/homeassistant/components/telegram_bot/broadcast.py
+++ b/homeassistant/components/telegram_bot/broadcast.py
@@ -8,9 +8,8 @@ import asyncio
 import logging
 
 from homeassistant.components.telegram_bot import (
-    PLATFORM_SCHEMA as TELEGRAM_PLATFORM_SCHEMA,
-    CONF_PROXY_URL, CONF_PROXY_PARAMS)
-from homeassistant.const import CONF_API_KEY
+    _initialize_bot,
+    PLATFORM_SCHEMA as TELEGRAM_PLATFORM_SCHEMA)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,18 +20,8 @@ PLATFORM_SCHEMA = TELEGRAM_PLATFORM_SCHEMA
 def async_setup_platform(hass, config):
     """Set up the Telegram broadcast platform."""
     # Check the API key works
-    from telegram import Bot
-    from telegram.utils.request import Request
 
-    api_key = config.get(CONF_API_KEY)
-    proxy_url = config.get(CONF_PROXY_URL)
-    proxy_params = config.get(CONF_PROXY_PARAMS)
-
-    request = None
-    if proxy_url is not None:
-        request = Request(proxy_url=proxy_url,
-                          urllib3_proxy_kwargs=proxy_params)
-    bot = Bot(token=api_key, request=request)
+    bot = _initialize_bot(config)
 
     bot_config = yield from hass.async_add_job(bot.getMe)
     _LOGGER.debug("Telegram broadcast platform setup with bot %s",

--- a/homeassistant/components/telegram_bot/broadcast.py
+++ b/homeassistant/components/telegram_bot/broadcast.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 
 from homeassistant.components.telegram_bot import (
-    _initialize_bot,
+    initialize_bot,
     PLATFORM_SCHEMA as TELEGRAM_PLATFORM_SCHEMA)
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ def async_setup_platform(hass, config):
     """Set up the Telegram broadcast platform."""
     # Check the API key works
 
-    bot = _initialize_bot(config)
+    bot = initialize_bot(config)
 
     bot_config = yield from hass.async_add_job(bot.getMe)
     _LOGGER.debug("Telegram broadcast platform setup with bot %s",

--- a/homeassistant/components/telegram_bot/broadcast.py
+++ b/homeassistant/components/telegram_bot/broadcast.py
@@ -8,7 +8,8 @@ import asyncio
 import logging
 
 from homeassistant.components.telegram_bot import (
-    PLATFORM_SCHEMA as TELEGRAM_PLATFORM_SCHEMA)
+    PLATFORM_SCHEMA as TELEGRAM_PLATFORM_SCHEMA,
+    CONF_PROXY_URL, CONF_PROXY_PARAMS)
 from homeassistant.const import CONF_API_KEY
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,8 +21,19 @@ PLATFORM_SCHEMA = TELEGRAM_PLATFORM_SCHEMA
 def async_setup_platform(hass, config):
     """Set up the Telegram broadcast platform."""
     # Check the API key works
-    import telegram
-    bot = telegram.Bot(config[CONF_API_KEY])
+    from telegram import Bot
+    from telegram.utils.request import Request
+
+    api_key = config.get(CONF_API_KEY)
+    proxy_url = config.get(CONF_PROXY_URL)
+    proxy_params = config.get(CONF_PROXY_PARAMS)
+
+    request = None
+    if proxy_url is not None:
+        request = Request(proxy_url=proxy_url,
+                          urllib3_proxy_kwargs=proxy_params)
+    bot = Bot(token=api_key, request=request)
+
     bot_config = yield from hass.async_add_job(bot.getMe)
     _LOGGER.debug("Telegram broadcast platform setup with bot %s",
                   bot_config['username'])

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -13,11 +13,11 @@ from aiohttp.client_exceptions import ClientError
 from aiohttp.hdrs import CONNECTION, KEEP_ALIVE
 
 from homeassistant.components.telegram_bot import (
+    _initialize_bot,
     CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity,
-    PLATFORM_SCHEMA as TELEGRAM_PLATFORM_SCHEMA,
-    CONF_PROXY_URL, CONF_PROXY_PARAMS)
+    PLATFORM_SCHEMA as TELEGRAM_PLATFORM_SCHEMA)
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, CONF_API_KEY)
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -36,18 +36,7 @@ class WrongHttpStatus(Exception):
 @asyncio.coroutine
 def async_setup_platform(hass, config):
     """Set up the Telegram polling platform."""
-    from telegram import Bot
-    from telegram.utils.request import Request
-
-    api_key = config.get(CONF_API_KEY)
-    proxy_url = config.get(CONF_PROXY_URL)
-    proxy_params = config.get(CONF_PROXY_PARAMS)
-
-    request = None
-    if proxy_url is not None:
-        request = Request(proxy_url=proxy_url,
-                          urllib3_proxy_kwargs=proxy_params)
-    bot = Bot(token=api_key, request=request)
+    bot = _initialize_bot(config)
     pol = TelegramPoll(bot, hass, config[CONF_ALLOWED_CHAT_IDS])
 
     @callback

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -13,7 +13,7 @@ from aiohttp.client_exceptions import ClientError
 from aiohttp.hdrs import CONNECTION, KEEP_ALIVE
 
 from homeassistant.components.telegram_bot import (
-    _initialize_bot,
+    initialize_bot,
     CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity,
     PLATFORM_SCHEMA as TELEGRAM_PLATFORM_SCHEMA)
 from homeassistant.const import (
@@ -36,7 +36,7 @@ class WrongHttpStatus(Exception):
 @asyncio.coroutine
 def async_setup_platform(hass, config):
     """Set up the Telegram polling platform."""
-    bot = _initialize_bot(config)
+    bot = initialize_bot(config)
     pol = TelegramPoll(bot, hass, config[CONF_ALLOWED_CHAT_IDS])
 
     @callback

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -14,7 +14,8 @@ import voluptuous as vol
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.const import KEY_REAL_IP
 from homeassistant.components.telegram_bot import (
-    CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity, PLATFORM_SCHEMA)
+    CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity, PLATFORM_SCHEMA,
+    CONF_PROXY_URL, CONF_PROXY_PARAMS)
 from homeassistant.const import (
     CONF_API_KEY, EVENT_HOMEASSISTANT_STOP, HTTP_BAD_REQUEST,
     HTTP_UNAUTHORIZED, CONF_URL)
@@ -50,7 +51,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def async_setup_platform(hass, config):
     """Set up the Telegram webhooks platform."""
     import telegram
-    bot = telegram.Bot(config[CONF_API_KEY])
+    from telegram import Bot
+    from telegram.utils.request import Request
+
+    api_key = config.get(CONF_API_KEY)
+    proxy_url = config.get(CONF_PROXY_URL)
+    proxy_params = config.get(CONF_PROXY_PARAMS)
+
+    request = None
+    if proxy_url is not None:
+        request = Request(proxy_url=proxy_url,
+                          urllib3_proxy_kwargs=proxy_params)
+    bot = Bot(token=api_key, request=request)
 
     current_status = yield from hass.async_add_job(bot.getWebhookInfo)
     base_url = config.get(CONF_URL, hass.config.api.base_url)

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -15,9 +15,9 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.const import KEY_REAL_IP
 from homeassistant.components.telegram_bot import (
     CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity, PLATFORM_SCHEMA,
-    CONF_PROXY_URL, CONF_PROXY_PARAMS)
+    _initialize_bot)
 from homeassistant.const import (
-    CONF_API_KEY, EVENT_HOMEASSISTANT_STOP, HTTP_BAD_REQUEST,
+    EVENT_HOMEASSISTANT_STOP, HTTP_BAD_REQUEST,
     HTTP_UNAUTHORIZED, CONF_URL)
 import homeassistant.helpers.config_validation as cv
 
@@ -51,18 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def async_setup_platform(hass, config):
     """Set up the Telegram webhooks platform."""
     import telegram
-    from telegram import Bot
-    from telegram.utils.request import Request
-
-    api_key = config.get(CONF_API_KEY)
-    proxy_url = config.get(CONF_PROXY_URL)
-    proxy_params = config.get(CONF_PROXY_PARAMS)
-
-    request = None
-    if proxy_url is not None:
-        request = Request(proxy_url=proxy_url,
-                          urllib3_proxy_kwargs=proxy_params)
-    bot = Bot(token=api_key, request=request)
+    bot = _initialize_bot(config)
 
     current_status = yield from hass.async_add_job(bot.getWebhookInfo)
     base_url = config.get(CONF_URL, hass.config.api.base_url)

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -15,7 +15,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.const import KEY_REAL_IP
 from homeassistant.components.telegram_bot import (
     CONF_ALLOWED_CHAT_IDS, BaseTelegramBotEntity, PLATFORM_SCHEMA,
-    _initialize_bot)
+    initialize_bot)
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP, HTTP_BAD_REQUEST,
     HTTP_UNAUTHORIZED, CONF_URL)
@@ -51,7 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def async_setup_platform(hass, config):
     """Set up the Telegram webhooks platform."""
     import telegram
-    bot = _initialize_bot(config)
+    bot = initialize_bot(config)
 
     current_status = yield from hass.async_add_job(bot.getWebhookInfo)
     base_url = config.get(CONF_URL, hass.config.api.base_url)


### PR DESCRIPTION
## Description:

telegram_bot has a config named proxy_url. But it doesn't work because the code does not use this config when start up. This PR is about to fix the initialize problem


**Related issue (if applicable):** fixes #12860 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** no

## Example entry for `configuration.yaml` (if applicable):
```yaml
telegram_bot:
  - platform: broadcast
    api_key: !secret telegram_bot_token
    allowed_chat_ids:
      - 416326110
    proxy_url: http://192.168.15.17:8888
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
