### PR TITLE
Optimize logbook SQL query again

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -47,6 +47,11 @@ CONFIG_SCHEMA = vol.Schema({
     }),
 }, extra=vol.ALLOW_EXTRA)
 
+ALL_EVENT_TYPES = [
+    EVENT_STATE_CHANGED, EVENT_LOGBOOK_ENTRY,
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+]
+
 GROUP_BY_MINUTES = 15
 
 CONTINUOUS_DOMAINS = ['proximity', 'sensor']
@@ -266,15 +271,18 @@ def humanify(events):
 
 def _get_events(hass, config, start_day, end_day):
     """Get events for a period of time."""
-    from homeassistant.components.recorder.models import Events
+    from homeassistant.components.recorder.models import Events, States
     from homeassistant.components.recorder.util import (
         execute, session_scope)
 
     with session_scope(hass=hass) as session:
-        query = session.query(Events).order_by(
-            Events.time_fired).filter(
-                (Events.time_fired > start_day) &
-                (Events.time_fired < end_day))
+        query = session.query(Events).order_by(Events.time_fired) \
+            .outerjoin(States, (Events.event_id == States.event_id))  \
+            .filter(Events.event_type.in_(ALL_EVENT_TYPES)) \
+            .filter((Events.time_fired > start_day)
+                    & (Events.time_fired < end_day)) \
+            .filter((States.last_updated == States.last_changed)
+                    | (States.state_id.is_(None)))
         events = execute(query)
     return humanify(_exclude_events(events, config))
 


### PR DESCRIPTION
## Description:

This brings back #12608. It was reverted in #12762 because of [a report](https://github.com/home-assistant/home-assistant/issues/12754#issuecomment-369033850) that it slowed the logbook down to be unusable. I have worked with @jjlawren to analyze this issue and it is fully fixed by the index that #12825 proposes.

Also note that reverting the optimization made the logbook similarly unusable [with other workloads](https://github.com/home-assistant/home-assistant/pull/12762#issuecomment-369749784).

I believe the index and this optimization in tandem will avoid the pathological slowdown in both scenarios (I'm afraid to say "all scenarios" because databases are strange and we support so many of them).

The last line of the patch compares a field with NULL to include rows with no match in the outer join. I have changed this field from `last_updated` to `state_id` to make it more clear that this is about missing rows and not the value of some particular field.

## Checklist:
  - [X] The code change is tested and works locally.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [ ] Tests have been added to verify that the new code works.
