### PR TITLE
Fix async method call in sync context

### DIFF
--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -330,7 +330,7 @@ class Icloud(DeviceScanner):
             return
 
         zones = (self.hass.states.get(entity_id) for entity_id
-                 in sorted(self.hass.states.async_entity_ids('zone')))
+                 in sorted(self.hass.states.entity_ids('zone')))
 
         distances = []
         for zone_state in zones:


### PR DESCRIPTION
iCloud device tracker was calling an async method from a sync context as pointed out by @MartinHjelmare here: https://github.com/home-assistant/home-assistant/pull/12399#discussion_r171473363