### PR TITLE
Fix issue with guest August lock being included

### DIFF
--- a/homeassistant/components/august.py
+++ b/homeassistant/components/august.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _CONFIGURING = {}
 
-REQUIREMENTS = ['py-august==0.3.0']
+REQUIREMENTS = ['py-august==0.4.0']
 
 DEFAULT_TIMEOUT = 10
 ACTIVITY_FETCH_LIMIT = 10
@@ -159,7 +159,7 @@ class AugustData:
         self._api = api
         self._access_token = access_token
         self._doorbells = self._api.get_doorbells(self._access_token) or []
-        self._locks = self._api.get_locks(self._access_token) or []
+        self._locks = self._api.get_operable_locks(self._access_token) or []
         self._house_ids = [d.house_id for d in self._doorbells + self._locks]
 
         self._doorbell_detail_by_id = {}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -619,7 +619,7 @@ pushetta==1.0.15
 pwmled==1.2.1
 
 # homeassistant.components.august
-py-august==0.3.0
+py-august==0.4.0
 
 # homeassistant.components.canary
 py-canary==0.4.0


### PR DESCRIPTION
## Description:
Fixed issue with guest lock being included in Home Assistant. When getting the status of a lock that is owned by guest, August will return 403 which results in error in August component.

**Related issue (if applicable):** fixes #12735

## Checklist:
  - [ ] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54