### PR TITLE
Be more tolerant of unpredictable data returned from Canary

### DIFF
--- a/homeassistant/components/canary.py
+++ b/homeassistant/components/canary.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_TIMEOUT
 from homeassistant.helpers import discovery
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['py-canary==0.4.0']
+REQUIREMENTS = ['py-canary==0.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -622,7 +622,7 @@ pwmled==1.2.1
 py-august==0.3.0
 
 # homeassistant.components.canary
-py-canary==0.4.0
+py-canary==0.4.1
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==3.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -121,7 +121,7 @@ prometheus_client==0.1.0
 pushbullet.py==0.11.0
 
 # homeassistant.components.canary
-py-canary==0.4.0
+py-canary==0.4.1
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Description:
Upgraded to py-canary:0.4.1 so that we're now more tolerant of unpredictable data returned from Canary. Details are in https://github.com/snjoetw/py-canary/pull/2 (Thanks @outlyer)

**Related issue (if applicable):** fixes #12473


## Checklist:
  - [ ] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54