### PR TITLE
update html5 to async/await tests

### DIFF
--- a/tests/components/notify/test_html5.py
+++ b/tests/components/notify/test_html5.py
@@ -62,7 +62,7 @@ async def mock_client(hass, test_client, registrations=None):
             }
         })
 
-    return (await test_client(hass.http.app))
+    return await test_client(hass.http.app)
 
 
 class TestHtml5Notify(object):

--- a/tests/components/notify/test_html5.py
+++ b/tests/components/notify/test_html5.py
@@ -1,5 +1,4 @@
 """Test HTML5 notify platform."""
-import asyncio
 import json
 from unittest.mock import patch, MagicMock, mock_open
 from aiohttp.hdrs import AUTHORIZATION
@@ -50,21 +49,20 @@ REGISTER_URL = '/api/notify.html5'
 PUBLISH_URL = '/api/notify.html5/callback'
 
 
-@asyncio.coroutine
-def mock_client(hass, test_client, registrations=None):
+async def mock_client(hass, test_client, registrations=None):
     """Create a test client for HTML5 views."""
     if registrations is None:
         registrations = {}
 
     with patch('homeassistant.components.notify.html5._load_config',
                return_value=registrations):
-        yield from async_setup_component(hass, 'notify', {
+        await async_setup_component(hass, 'notify', {
             'notify': {
                 'platform': 'html5'
             }
         })
 
-    return (yield from test_client(hass.http.app))
+    return (await test_client(hass.http.app))
 
 
 class TestHtml5Notify(object):
@@ -118,14 +116,12 @@ class TestHtml5Notify(object):
         assert payload['icon'] == 'beer.png'
 
 
-@asyncio.coroutine
-def test_registering_new_device_view(hass, test_client):
+async def test_registering_new_device_view(hass, test_client):
     """Test that the HTML view works."""
-    client = yield from mock_client(hass, test_client)
+    client = await mock_client(hass, test_client)
 
     with patch('homeassistant.components.notify.html5.save_json') as mock_save:
-        resp = yield from client.post(REGISTER_URL,
-                                      data=json.dumps(SUBSCRIPTION_1))
+        resp = await client.post(REGISTER_URL, data=json.dumps(SUBSCRIPTION_1))
 
     assert resp.status == 200
     assert len(mock_save.mock_calls) == 1
@@ -134,14 +130,12 @@ def test_registering_new_device_view(hass, test_client):
     }
 
 
-@asyncio.coroutine
-def test_registering_new_device_expiration_view(hass, test_client):
+async def test_registering_new_device_expiration_view(hass, test_client):
     """Test that the HTML view works."""
-    client = yield from mock_client(hass, test_client)
+    client = await mock_client(hass, test_client)
 
     with patch('homeassistant.components.notify.html5.save_json') as mock_save:
-        resp = yield from client.post(REGISTER_URL,
-                                      data=json.dumps(SUBSCRIPTION_4))
+        resp = await client.post(REGISTER_URL, data=json.dumps(SUBSCRIPTION_4))
 
     assert resp.status == 200
     assert mock_save.mock_calls[0][1][1] == {
@@ -149,32 +143,27 @@ def test_registering_new_device_expiration_view(hass, test_client):
     }
 
 
-@asyncio.coroutine
-def test_registering_new_device_fails_view(hass, test_client):
+async def test_registering_new_device_fails_view(hass, test_client):
     """Test subs. are not altered when registering a new device fails."""
     registrations = {}
-    client = yield from mock_client(hass, test_client, registrations)
+    client = await mock_client(hass, test_client, registrations)
 
     with patch('homeassistant.components.notify.html5.save_json',
                side_effect=HomeAssistantError()):
-        resp = yield from client.post(REGISTER_URL,
-                                      data=json.dumps(SUBSCRIPTION_4))
+        resp = await client.post(REGISTER_URL, data=json.dumps(SUBSCRIPTION_4))
 
     assert resp.status == 500
     assert registrations == {}
 
 
-@asyncio.coroutine
-def test_registering_existing_device_view(hass, test_client):
+async def test_registering_existing_device_view(hass, test_client):
     """Test subscription is updated when registering existing device."""
     registrations = {}
-    client = yield from mock_client(hass, test_client, registrations)
+    client = await mock_client(hass, test_client, registrations)
 
     with patch('homeassistant.components.notify.html5.save_json') as mock_save:
-        yield from client.post(REGISTER_URL,
-                               data=json.dumps(SUBSCRIPTION_1))
-        resp = yield from client.post(REGISTER_URL,
-                                      data=json.dumps(SUBSCRIPTION_4))
+        await client.post(REGISTER_URL, data=json.dumps(SUBSCRIPTION_1))
+        resp = await client.post(REGISTER_URL, data=json.dumps(SUBSCRIPTION_4))
 
     assert resp.status == 200
     assert mock_save.mock_calls[0][1][1] == {
@@ -185,18 +174,15 @@ def test_registering_existing_device_view(hass, test_client):
     }
 
 
-@asyncio.coroutine
-def test_registering_existing_device_fails_view(hass, test_client):
+async def test_registering_existing_device_fails_view(hass, test_client):
     """Test sub. is not updated when registering existing device fails."""
     registrations = {}
-    client = yield from mock_client(hass, test_client, registrations)
+    client = await mock_client(hass, test_client, registrations)
 
     with patch('homeassistant.components.notify.html5.save_json') as mock_save:
-        yield from client.post(REGISTER_URL,
-                               data=json.dumps(SUBSCRIPTION_1))
+        await client.post(REGISTER_URL, data=json.dumps(SUBSCRIPTION_1))
         mock_save.side_effect = HomeAssistantError
-        resp = yield from client.post(REGISTER_URL,
-                                      data=json.dumps(SUBSCRIPTION_4))
+        resp = await client.post(REGISTER_URL, data=json.dumps(SUBSCRIPTION_4))
 
     assert resp.status == 500
     assert registrations == {
@@ -204,42 +190,40 @@ def test_registering_existing_device_fails_view(hass, test_client):
     }
 
 
-@asyncio.coroutine
-def test_registering_new_device_validation(hass, test_client):
+async def test_registering_new_device_validation(hass, test_client):
     """Test various errors when registering a new device."""
-    client = yield from mock_client(hass, test_client)
+    client = await mock_client(hass, test_client)
 
-    resp = yield from client.post(REGISTER_URL, data=json.dumps({
+    resp = await client.post(REGISTER_URL, data=json.dumps({
         'browser': 'invalid browser',
         'subscription': 'sub info',
     }))
     assert resp.status == 400
 
-    resp = yield from client.post(REGISTER_URL, data=json.dumps({
+    resp = await client.post(REGISTER_URL, data=json.dumps({
         'browser': 'chrome',
     }))
     assert resp.status == 400
 
     with patch('homeassistant.components.notify.html5.save_json',
                return_value=False):
-        resp = yield from client.post(REGISTER_URL, data=json.dumps({
+        resp = await client.post(REGISTER_URL, data=json.dumps({
             'browser': 'chrome',
             'subscription': 'sub info',
         }))
     assert resp.status == 400
 
 
-@asyncio.coroutine
-def test_unregistering_device_view(hass, test_client):
+async def test_unregistering_device_view(hass, test_client):
     """Test that the HTML unregister view works."""
     registrations = {
         'some device': SUBSCRIPTION_1,
         'other device': SUBSCRIPTION_2,
     }
-    client = yield from mock_client(hass, test_client, registrations)
+    client = await mock_client(hass, test_client, registrations)
 
     with patch('homeassistant.components.notify.html5.save_json') as mock_save:
-        resp = yield from client.delete(REGISTER_URL, data=json.dumps({
+        resp = await client.delete(REGISTER_URL, data=json.dumps({
             'subscription': SUBSCRIPTION_1['subscription'],
         }))
 
@@ -250,14 +234,14 @@ def test_unregistering_device_view(hass, test_client):
     }
 
 
-@asyncio.coroutine
-def test_unregister_device_view_handle_unknown_subscription(hass, test_client):
+async def test_unregister_device_view_handle_unknown_subscription(hass,
+                                                                  test_client):
     """Test that the HTML unregister view handles unknown subscriptions."""
     registrations = {}
-    client = yield from mock_client(hass, test_client, registrations)
+    client = await mock_client(hass, test_client, registrations)
 
     with patch('homeassistant.components.notify.html5.save_json') as mock_save:
-        resp = yield from client.delete(REGISTER_URL, data=json.dumps({
+        resp = await client.delete(REGISTER_URL, data=json.dumps({
             'subscription': SUBSCRIPTION_3['subscription']
         }))
 
@@ -266,18 +250,17 @@ def test_unregister_device_view_handle_unknown_subscription(hass, test_client):
     assert len(mock_save.mock_calls) == 0
 
 
-@asyncio.coroutine
-def test_unregistering_device_view_handles_save_error(hass, test_client):
+async def test_unregistering_device_view_handles_save_error(hass, test_client):
     """Test that the HTML unregister view handles save errors."""
     registrations = {
         'some device': SUBSCRIPTION_1,
         'other device': SUBSCRIPTION_2,
     }
-    client = yield from mock_client(hass, test_client, registrations)
+    client = await mock_client(hass, test_client, registrations)
 
     with patch('homeassistant.components.notify.html5.save_json',
                side_effect=HomeAssistantError()):
-        resp = yield from client.delete(REGISTER_URL, data=json.dumps({
+        resp = await client.delete(REGISTER_URL, data=json.dumps({
             'subscription': SUBSCRIPTION_1['subscription'],
         }))
 
@@ -288,11 +271,10 @@ def test_unregistering_device_view_handles_save_error(hass, test_client):
     }
 
 
-@asyncio.coroutine
-def test_callback_view_no_jwt(hass, test_client):
+async def test_callback_view_no_jwt(hass, test_client):
     """Test that the notification callback view works without JWT."""
-    client = yield from mock_client(hass, test_client)
-    resp = yield from client.post(PUBLISH_URL, data=json.dumps({
+    client = await mock_client(hass, test_client)
+    resp = await client.post(PUBLISH_URL, data=json.dumps({
         'type': 'push',
         'tag': '3bc28d69-0921-41f1-ac6a-7a627ba0aa72'
     }))
@@ -300,16 +282,15 @@ def test_callback_view_no_jwt(hass, test_client):
     assert resp.status == 401, resp.response
 
 
-@asyncio.coroutine
-def test_callback_view_with_jwt(hass, test_client):
+async def test_callback_view_with_jwt(hass, test_client):
     """Test that the notification callback view works with JWT."""
     registrations = {
         'device': SUBSCRIPTION_1
     }
-    client = yield from mock_client(hass, test_client, registrations)
+    client = await mock_client(hass, test_client, registrations)
 
     with patch('pywebpush.WebPusher') as mock_wp:
-        yield from hass.services.async_call('notify', 'notify', {
+        await hass.services.async_call('notify', 'notify', {
             'message': 'Hello',
             'target': ['device'],
             'data': {'icon': 'beer.png'}
@@ -331,10 +312,10 @@ def test_callback_view_with_jwt(hass, test_client):
 
     bearer_token = "Bearer {}".format(push_payload['data']['jwt'])
 
-    resp = yield from client.post(PUBLISH_URL, json={
+    resp = await client.post(PUBLISH_URL, json={
         'type': 'push',
     }, headers={AUTHORIZATION: bearer_token})
 
     assert resp.status == 200
-    body = yield from resp.json()
+    body = await resp.json()
     assert body == {"event": "push", "status": "ok"}


### PR DESCRIPTION
## Description: 
async/await syntax tests
tests for https://github.com/home-assistant/home-assistant/pull/12895

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
