### PR TITLE
InfluxDB cleanups

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -220,6 +220,10 @@ def setup(hass, config):
                         json['fields'][key] = float(
                             RE_DECIMAL.sub('', new_value))
 
+                # Infinity is not a valid float in InfluxDB
+                if (key, float("inf")) in json['fields'].items():
+                    del json['fields'][key]
+
         json['tags'].update(tags)
 
         return json

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -232,6 +232,7 @@ def setup(hass, config):
         """Shut down the thread."""
         instance.queue.put(None)
         instance.join()
+        influx.close()
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, shutdown)
 

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -35,7 +35,6 @@ CONF_COMPONENT_CONFIG = 'component_config'
 CONF_COMPONENT_CONFIG_GLOB = 'component_config_glob'
 CONF_COMPONENT_CONFIG_DOMAIN = 'component_config_domain'
 CONF_RETRY_COUNT = 'max_retries'
-CONF_RETRY_QUEUE = 'retry_queue_limit'
 
 DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_VERIFY_SSL = True
@@ -53,7 +52,7 @@ COMPONENT_CONFIG_SCHEMA_ENTRY = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(cv.deprecated(CONF_RETRY_QUEUE), vol.Schema({
+    DOMAIN: vol.All(vol.Schema({
         vol.Optional(CONF_HOST): cv.string,
         vol.Inclusive(CONF_USERNAME, 'authentication'): cv.string,
         vol.Inclusive(CONF_PASSWORD, 'authentication'): cv.string,
@@ -71,7 +70,6 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_PORT): cv.port,
         vol.Optional(CONF_SSL): cv.boolean,
         vol.Optional(CONF_RETRY_COUNT, default=0): cv.positive_int,
-        vol.Optional(CONF_RETRY_QUEUE, default=20): cv.positive_int,
         vol.Optional(CONF_DEFAULT_MEASUREMENT): cv.string,
         vol.Optional(CONF_OVERRIDE_MEASUREMENT): cv.string,
         vol.Optional(CONF_TAGS, default={}):

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -213,6 +213,37 @@ class TestInfluxDB(unittest.TestCase):
             )
             mock_client.return_value.write_points.reset_mock()
 
+    def test_event_listener_inf(self, mock_client):
+        """Test the event listener for missing units."""
+        self._setup()
+
+        attrs = {'bignumstring':  "9" * 999}
+        state = mock.MagicMock(
+            state=8, domain='fake', entity_id='fake.entity-id',
+            object_id='entity', attributes=attrs)
+        event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
+        body = [{
+            'measurement': 'fake.entity-id',
+            'tags': {
+                'domain': 'fake',
+                'entity_id': 'entity',
+            },
+            'time': 12345,
+            'fields': {
+                'value': 8,
+            },
+        }]
+        self.handler_method(event)
+        self.hass.data[influxdb.DOMAIN].block_till_done()
+        self.assertEqual(
+            mock_client.return_value.write_points.call_count, 1
+        )
+        self.assertEqual(
+            mock_client.return_value.write_points.call_args,
+            mock.call(body)
+        )
+        mock_client.return_value.write_points.reset_mock()
+
     def test_event_listener_states(self, mock_client):
         """Test the event listener against ignored states."""
         self._setup()


### PR DESCRIPTION
## Description:

Three changes that are so small that I thought I would put them in a single PR:
1. Remove `retry_queue_limit` that was deprecated in 0.63
2. Properly close the influxdb connection on shutdown
3. Do not attempt to store very large integers as "inf" because InfluxDB will reject it. This can happen rather easily when we try turning "2017-06-12 00:00:00.000" into the integer 20170612000000000.

**Related issue (if applicable):** fixes #8530

## Checklist:
  - [X] The code change is tested and works locally.

If the code does not interact with devices:
  - [X] Local tests with `tox` run successfully.
  - [X] Tests have been added to verify that the new code works.
