### PR TITLE
Add a device tracker component relying on PhoneTrack OC

### DIFF
--- a/homeassistant/components/device_tracker/phonetrack_oc.py
+++ b/homeassistant/components/device_tracker/phonetrack_oc.py
@@ -1,0 +1,61 @@
+"""
+Support for PhoneTrackOC device tracking.
+"""
+import logging
+import urllib.parse
+from datetime import timedelta
+
+import requests
+
+from homeassistant.const import CONF_DEVICES, CONF_TOKEN, CONF_URL
+from homeassistant.helpers.event import track_time_interval
+from homeassistant.util import slugify, Throttle
+
+_LOGGER = logging.getLogger(__name__)
+
+UPDATE_INTERVAL = timedelta(minutes=5)
+
+
+def setup_scanner(hass, config: dict, see, discovery_info=None):
+    """Setup the PhoneTrack-OC scanner."""
+    PhoneTrackOCDeviceTracker(hass, config, see)
+    return True
+
+
+class PhoneTrackOCDeviceTracker(object):
+    """
+    A device tracker fetching last position from the PhoneTrackOC Nextcloud
+    app.
+    """
+    def __init__(self, hass, config: dict, see):
+        """Initialize the PhoneTrackOC tracking."""
+        self.hass = hass
+        self.url = config.get(CONF_URL)
+        self.token = config.get(CONF_TOKEN)
+        self.devices = config.get(CONF_DEVICES)
+        self.see = see
+        self._update_info()
+
+        track_time_interval(
+            self.hass, self._update_info, UPDATE_INTERVAL
+        )
+
+    @Throttle(UPDATE_INTERVAL)
+    def _update_info(self, now=None):
+        """Update the device info."""
+        _LOGGER.debug("Updating devices %s", now)
+        data = requests.get(urllib.parse.urljoin(self.url, self.token)).json()
+        data = data[self.token]
+        for device in self.devices:
+            if device not in data.keys():
+                _LOGGER.info('Device %s is not available.', device)
+                continue
+            lat, lon = data[device]['lat'], data[device]['lon']
+            accuracy = data[device]['accuracy']
+            battery = data[device]['batterylevel']
+            self.see(
+                dev_id=slugify(device),
+                gps=(lat, lon), gps_accuracy=accuracy,
+                battery=battery
+            )
+        return True


### PR DESCRIPTION
Hi,

## Description:

I already have a working location tracking in my NextCloud instance with PhoneTrack OC (a NextCloud app) and OwnTracks on my phone sending it its position. Then, I thought about writing a custom component to fetch my location from my Nextcloud instance directly. Here is my first PR to Home-Assistant with this custom component.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: phonetrack_oc
    url: http://cloud.example.org
    token: TOKEN_FROM_PHONETRACK_OC
    devices:
      - MyDevice
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54


This is my very first component written for Home-Assistant. If I understand correctly, I should make a separate PR for the doc, to https://github.com/home-assistant/home-assistant.github.io? Is is possible to have a confirmation my component code is ok, before handling the doc PR?

Additionnally, I'm not sure which tests I should write. This is used on my personal instance and works fine. It is interacting with the PhoneTrack-OC app in Nextcloud, but I'm not really sure how I should write the tests. Am I just supposed to mock the HTTP calls?

Thanks!