### PR TITLE
Fix for serial_pm naming bug

### DIFF
--- a/homeassistant/components/sensor/serial_pm.py
+++ b/homeassistant/components/sensor/serial_pm.py
@@ -48,7 +48,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     dev = []
 
     for pmname in coll.supported_values():
-        if config.get(CONF_NAME) is None:
+        if config.get(CONF_NAME) is not None:
             name = '{} PM{}'.format(config.get(CONF_NAME), pmname)
         else:
             name = 'PM{}'.format(pmname)


### PR DESCRIPTION
## Description:

CONF_NAME is being ignored when using the `serial_pm` module. The if statement is wrong.


## Example entry for `configuration.yaml`
```yaml

sensor:
   - platform: serial_pm
     serial_device: /dev/ttyUSB0
     name: Living Room
     brand: novafitness,sds021

```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
