### PR TITLE
Remove unused cloud APIs

### DIFF
--- a/homeassistant/components/cloud/auth_api.py
+++ b/homeassistant/components/cloud/auth_api.py
@@ -17,14 +17,6 @@ class UserNotConfirmed(CloudError):
     """Raised when a user has not confirmed email yet."""
 
 
-class ExpiredCode(CloudError):
-    """Raised when an expired code is encountered."""
-
-
-class InvalidCode(CloudError):
-    """Raised when an invalid code is submitted."""
-
-
 class PasswordChangeRequired(CloudError):
     """Raised when a password change is required."""
 
@@ -42,10 +34,8 @@ class UnknownError(CloudError):
 AWS_EXCEPTIONS = {
     'UserNotFoundException': UserNotFound,
     'NotAuthorizedException': Unauthenticated,
-    'ExpiredCodeException': ExpiredCode,
     'UserNotConfirmedException': UserNotConfirmed,
     'PasswordResetRequiredException': PasswordChangeRequired,
-    'CodeMismatchException': InvalidCode,
 }
 
 
@@ -65,17 +55,6 @@ def register(cloud, email, password):
     cognito.add_base_attributes()
     try:
         cognito.register(email, password)
-    except ClientError as err:
-        raise _map_aws_exception(err)
-
-
-def confirm_register(cloud, confirmation_code, email):
-    """Confirm confirmation code after registration."""
-    from botocore.exceptions import ClientError
-
-    cognito = _cognito(cloud)
-    try:
-        cognito.confirm_sign_up(confirmation_code, email)
     except ClientError as err:
         raise _map_aws_exception(err)
 
@@ -103,18 +82,6 @@ def forgot_password(cloud, email):
 
     try:
         cognito.initiate_forgot_password()
-    except ClientError as err:
-        raise _map_aws_exception(err)
-
-
-def confirm_forgot_password(cloud, confirmation_code, email, new_password):
-    """Confirm forgotten password code and change password."""
-    from botocore.exceptions import ClientError
-
-    cognito = _cognito(cloud, username=email)
-
-    try:
-        cognito.confirm_forgot_password(confirmation_code, new_password)
     except ClientError as err:
         raise _map_aws_exception(err)
 

--- a/tests/components/cloud/test_auth_api.py
+++ b/tests/components/cloud/test_auth_api.py
@@ -94,24 +94,6 @@ def test_register_fails(mock_cognito):
         auth_api.register(cloud, 'email@home-assistant.io', 'password')
 
 
-def test_confirm_register(mock_cognito):
-    """Test confirming a registration of an account."""
-    cloud = MagicMock()
-    auth_api.confirm_register(cloud, '123456', 'email@home-assistant.io')
-    assert len(mock_cognito.confirm_sign_up.mock_calls) == 1
-    result_code, result_user = mock_cognito.confirm_sign_up.mock_calls[0][1]
-    assert result_user == 'email@home-assistant.io'
-    assert result_code == '123456'
-
-
-def test_confirm_register_fails(mock_cognito):
-    """Test an error during confirmation of an account."""
-    cloud = MagicMock()
-    mock_cognito.confirm_sign_up.side_effect = aws_error('SomeError')
-    with pytest.raises(auth_api.CloudError):
-        auth_api.confirm_register(cloud, '123456', 'email@home-assistant.io')
-
-
 def test_resend_email_confirm(mock_cognito):
     """Test starting forgot password flow."""
     cloud = MagicMock()
@@ -141,27 +123,6 @@ def test_forgot_password_fails(mock_cognito):
     mock_cognito.initiate_forgot_password.side_effect = aws_error('SomeError')
     with pytest.raises(auth_api.CloudError):
         auth_api.forgot_password(cloud, 'email@home-assistant.io')
-
-
-def test_confirm_forgot_password(mock_cognito):
-    """Test confirming forgot password."""
-    cloud = MagicMock()
-    auth_api.confirm_forgot_password(
-        cloud, '123456', 'email@home-assistant.io', 'new password')
-    assert len(mock_cognito.confirm_forgot_password.mock_calls) == 1
-    result_code, result_password = \
-        mock_cognito.confirm_forgot_password.mock_calls[0][1]
-    assert result_code == '123456'
-    assert result_password == 'new password'
-
-
-def test_confirm_forgot_password_fails(mock_cognito):
-    """Test failure when confirming forgot password."""
-    cloud = MagicMock()
-    mock_cognito.confirm_forgot_password.side_effect = aws_error('SomeError')
-    with pytest.raises(auth_api.CloudError):
-        auth_api.confirm_forgot_password(
-            cloud, '123456', 'email@home-assistant.io', 'new password')
 
 
 def test_check_token_writes_new_token_on_refresh(mock_cognito):

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -232,53 +232,6 @@ def test_register_view_unknown_error(mock_cognito, cloud_client):
 
 
 @asyncio.coroutine
-def test_confirm_register_view(mock_cognito, cloud_client):
-    """Test logging out."""
-    req = yield from cloud_client.post('/api/cloud/confirm_register', json={
-        'email': 'hello@bla.com',
-        'confirmation_code': '123456'
-    })
-    assert req.status == 200
-    assert len(mock_cognito.confirm_sign_up.mock_calls) == 1
-    result_code, result_email = mock_cognito.confirm_sign_up.mock_calls[0][1]
-    assert result_email == 'hello@bla.com'
-    assert result_code == '123456'
-
-
-@asyncio.coroutine
-def test_confirm_register_view_bad_data(mock_cognito, cloud_client):
-    """Test logging out."""
-    req = yield from cloud_client.post('/api/cloud/confirm_register', json={
-        'email': 'hello@bla.com',
-        'not_confirmation_code': '123456'
-    })
-    assert req.status == 400
-    assert len(mock_cognito.confirm_sign_up.mock_calls) == 0
-
-
-@asyncio.coroutine
-def test_confirm_register_view_request_timeout(mock_cognito, cloud_client):
-    """Test timeout while logging out."""
-    mock_cognito.confirm_sign_up.side_effect = asyncio.TimeoutError
-    req = yield from cloud_client.post('/api/cloud/confirm_register', json={
-        'email': 'hello@bla.com',
-        'confirmation_code': '123456'
-    })
-    assert req.status == 502
-
-
-@asyncio.coroutine
-def test_confirm_register_view_unknown_error(mock_cognito, cloud_client):
-    """Test unknown error while logging out."""
-    mock_cognito.confirm_sign_up.side_effect = auth_api.UnknownError
-    req = yield from cloud_client.post('/api/cloud/confirm_register', json={
-        'email': 'hello@bla.com',
-        'confirmation_code': '123456'
-    })
-    assert req.status == 502
-
-
-@asyncio.coroutine
 def test_forgot_password_view(mock_cognito, cloud_client):
     """Test logging out."""
     req = yield from cloud_client.post('/api/cloud/forgot_password', json={
@@ -357,62 +310,4 @@ def test_resend_confirm_view_unknown_error(mock_cognito, cloud_client):
     req = yield from cloud_client.post('/api/cloud/resend_confirm', json={
         'email': 'hello@bla.com',
     })
-    assert req.status == 502
-
-
-@asyncio.coroutine
-def test_confirm_forgot_password_view(mock_cognito, cloud_client):
-    """Test logging out."""
-    req = yield from cloud_client.post(
-        '/api/cloud/confirm_forgot_password', json={
-            'email': 'hello@bla.com',
-            'confirmation_code': '123456',
-            'new_password': 'hello2',
-        })
-    assert req.status == 200
-    assert len(mock_cognito.confirm_forgot_password.mock_calls) == 1
-    result_code, result_new_password = \
-        mock_cognito.confirm_forgot_password.mock_calls[0][1]
-    assert result_code == '123456'
-    assert result_new_password == 'hello2'
-
-
-@asyncio.coroutine
-def test_confirm_forgot_password_view_bad_data(mock_cognito, cloud_client):
-    """Test logging out."""
-    req = yield from cloud_client.post(
-        '/api/cloud/confirm_forgot_password', json={
-            'email': 'hello@bla.com',
-            'not_confirmation_code': '123456',
-            'new_password': 'hello2',
-        })
-    assert req.status == 400
-    assert len(mock_cognito.confirm_forgot_password.mock_calls) == 0
-
-
-@asyncio.coroutine
-def test_confirm_forgot_password_view_request_timeout(mock_cognito,
-                                                      cloud_client):
-    """Test timeout while logging out."""
-    mock_cognito.confirm_forgot_password.side_effect = asyncio.TimeoutError
-    req = yield from cloud_client.post(
-        '/api/cloud/confirm_forgot_password', json={
-            'email': 'hello@bla.com',
-            'confirmation_code': '123456',
-            'new_password': 'hello2',
-        })
-    assert req.status == 502
-
-
-@asyncio.coroutine
-def test_confirm_forgot_password_view_unknown_error(mock_cognito,
-                                                    cloud_client):
-    """Test unknown error while logging out."""
-    mock_cognito.confirm_forgot_password.side_effect = auth_api.UnknownError
-    req = yield from cloud_client.post(
-        '/api/cloud/confirm_forgot_password', json={
-            'email': 'hello@bla.com',
-            'confirmation_code': '123456',
-            'new_password': 'hello2',
-        })
     assert req.status == 502


### PR DESCRIPTION
## Description:
Remove no longer used Cloud APIs.

Depends on https://github.com/home-assistant/home-assistant-polymer/pull/967


## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
