### PR TITLE
Upgrade to aiohttp 3

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -131,7 +131,7 @@ class APIEventStream(HomeAssistantView):
                     msg = "data: {}\n\n".format(payload)
                     _LOGGER.debug('STREAM %s WRITING %s', id(stop_obj),
                                   msg.strip())
-                    response.write(msg.encode("UTF-8"))
+                    yield from response.write(msg.encode("UTF-8"))
                     yield from response.drain()
                 except asyncio.TimeoutError:
                     yield from to_write.put(STREAM_PING_PAYLOAD)

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -132,7 +132,6 @@ class APIEventStream(HomeAssistantView):
                     _LOGGER.debug('STREAM %s WRITING %s', id(stop_obj),
                                   msg.strip())
                     yield from response.write(msg.encode("UTF-8"))
-                    yield from response.drain()
                 except asyncio.TimeoutError:
                     yield from to_write.put(STREAM_PING_PAYLOAD)
 

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -264,9 +264,9 @@ class Camera(Entity):
                                  'boundary=--frameboundary')
         yield from response.prepare(request)
 
-        def write(img_bytes):
+        async def write(img_bytes):
             """Write image to stream."""
-            response.write(bytes(
+            await response.write(bytes(
                 '--frameboundary\r\n'
                 'Content-Type: {}\r\n'
                 'Content-Length: {}\r\n\r\n'.format(
@@ -282,15 +282,14 @@ class Camera(Entity):
                     break
 
                 if img_bytes and img_bytes != last_image:
-                    write(img_bytes)
+                    yield from write(img_bytes)
 
                     # Chrome seems to always ignore first picture,
                     # print it twice.
                     if last_image is None:
-                        write(img_bytes)
+                        yield from write(img_bytes)
 
                     last_image = img_bytes
-                    yield from response.drain()
 
                 yield from asyncio.sleep(.5)
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -279,6 +279,9 @@ class HomeAssistantHTTP(object):
     @asyncio.coroutine
     def start(self):
         """Start the WSGI server."""
+        # We misunderstood the startup signal. You're not allowed to change
+        # anything during startup. Temp workaround.
+        self.app._on_startup.freeze()
         yield from self.app.startup()
 
         if self.ssl_certificate:
@@ -298,10 +301,9 @@ class HomeAssistantHTTP(object):
         # Aiohttp freezes apps after start so that no changes can be made.
         # However in Home Assistant components can be discovered after boot.
         # This will now raise a RunTimeError.
-        # To work around this we now fake that we are frozen.
-        # A more appropriate fix would be to create a new app and
-        # re-register all redirects, views, static paths.
-        self.app._frozen = True  # pylint: disable=protected-access
+        # To work around this we now prevent the router from getting frozen
+        # pylint: disable=protected-access
+        self.app._router.freeze = lambda: None
 
         self._handler = self.app.make_handler(loop=self.hass.loop)
 
@@ -311,10 +313,6 @@ class HomeAssistantHTTP(object):
         except OSError as error:
             _LOGGER.error("Failed to create HTTP server at port %d: %s",
                           self.server_port, error)
-
-        # pylint: disable=protected-access
-        self.app._middlewares = tuple(self.app._prepare_middleware())
-        self.app._frozen = False
 
     @asyncio.coroutine
     def stop(self):

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -281,6 +281,7 @@ class HomeAssistantHTTP(object):
         """Start the WSGI server."""
         # We misunderstood the startup signal. You're not allowed to change
         # anything during startup. Temp workaround.
+        # pylint: disable=protected-access
         self.app._on_startup.freeze()
         yield from self.app.startup()
 
@@ -302,7 +303,6 @@ class HomeAssistantHTTP(object):
         # However in Home Assistant components can be discovered after boot.
         # This will now raise a RunTimeError.
         # To work around this we now prevent the router from getting frozen
-        # pylint: disable=protected-access
         self.app._router.freeze = lambda: None
 
         self._handler = self.app.make_handler(loop=self.hass.loop)

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -39,6 +39,7 @@ class CachingStaticResource(StaticResource):
             raise HTTPNotFound
 
 
+# pylint: disable=too-many-ancestors
 class CachingFileResponse(FileResponse):
     """FileSender class that caches output if not in dev mode."""
 

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -173,10 +173,9 @@ class UpdateShoppingListItemView(http.HomeAssistantView):
     url = '/api/shopping_list/item/{item_id}'
     name = "api:shopping_list:item:id"
 
-    @callback
-    def post(self, request, item_id):
+    async def post(self, request, item_id):
         """Update a shopping list item."""
-        data = yield from request.json()
+        data = await request.json()
 
         try:
             item = request.app['hass'].data[DOMAIN].async_update(item_id, data)

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -116,7 +116,7 @@ async def async_aiohttp_proxy_stream(hass, request, stream, content_type,
                 await response.write_eof()
                 break
 
-            response.write(data)
+            await response.write(data)
 
     except (asyncio.TimeoutError, aiohttp.ClientError):
         # Something went wrong fetching data, close connection gracefully

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,10 +5,8 @@ pip>=8.0.3
 jinja2>=2.10
 voluptuous==0.11.1
 typing>=3,<4
-aiohttp==2.3.10
-yarl==1.1.0
+aiohttp==3.0.6
 async_timeout==2.0.0
-chardet==3.0.4
 astral==1.5
 certifi>=2017.4.17
 attrs==17.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,10 +6,8 @@ pip>=8.0.3
 jinja2>=2.10
 voluptuous==0.11.1
 typing>=3,<4
-aiohttp==2.3.10
-yarl==1.1.0
+aiohttp==3.0.6
 async_timeout==2.0.0
-chardet==3.0.4
 astral==1.5
 certifi>=2017.4.17
 attrs==17.4.0

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,8 @@ REQUIRES = [
     'jinja2>=2.10',
     'voluptuous==0.11.1',
     'typing>=3,<4',
-    'aiohttp==2.3.10',   # If updated, check if yarl also needs an update!
-    'yarl==1.1.0',
+    'aiohttp==3.0.6',
     'async_timeout==2.0.0',
-    'chardet==3.0.4',
     'astral==1.5',
     'certifi>=2017.4.17',
     'attrs==17.4.0',

--- a/tests/helpers/test_aiohttp_client.py
+++ b/tests/helpers/test_aiohttp_client.py
@@ -3,6 +3,7 @@ import asyncio
 import unittest
 
 import aiohttp
+import pytest
 
 from homeassistant.core import EVENT_HOMEASSISTANT_CLOSE
 from homeassistant.setup import async_setup_component
@@ -10,6 +11,19 @@ import homeassistant.helpers.aiohttp_client as client
 from homeassistant.util.async import run_callback_threadsafe
 
 from tests.common import get_test_home_assistant
+
+
+@pytest.fixture
+def camera_client(hass, test_client):
+    """Fixture to fetch camera streams."""
+    assert hass.loop.run_until_complete(async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'mjpeg',
+            'mjpeg_url': 'http://example.com/mjpeg_stream',
+        }}))
+
+    yield hass.loop.run_until_complete(test_client(hass.http.app))
 
 
 class TestHelpersAiohttpClient(unittest.TestCase):
@@ -119,41 +133,38 @@ class TestHelpersAiohttpClient(unittest.TestCase):
 
 
 @asyncio.coroutine
-def test_async_aiohttp_proxy_stream(aioclient_mock, hass, test_client):
+def test_async_aiohttp_proxy_stream(aioclient_mock, camera_client):
     """Test that it fetches the given url."""
     aioclient_mock.get('http://example.com/mjpeg_stream', content=[
         b'Frame1', b'Frame2', b'Frame3'
     ])
 
-    result = yield from async_setup_component(hass, 'camera', {
-        'camera': {
-            'name': 'config_test',
-            'platform': 'mjpeg',
-            'mjpeg_url': 'http://example.com/mjpeg_stream',
-        }})
-    assert result, 'Failed to setup camera'
-
-    client = yield from test_client(hass.http.app)
-
-    resp = yield from client.get('/api/camera_proxy_stream/camera.config_test')
+    resp = yield from camera_client.get(
+        '/api/camera_proxy_stream/camera.config_test')
 
     assert resp.status == 200
     assert aioclient_mock.call_count == 1
     body = yield from resp.text()
     assert body == 'Frame3Frame2Frame1'
 
-    aioclient_mock.clear_requests()
-    aioclient_mock.get(
-        'http://example.com/mjpeg_stream', exc=asyncio.TimeoutError(),
-        content=[b'Frame1', b'Frame2', b'Frame3'])
 
-    resp = yield from client.get('/api/camera_proxy_stream/camera.config_test')
+@asyncio.coroutine
+def test_async_aiohttp_proxy_stream_timeout(aioclient_mock, camera_client):
+    """Test that it fetches the given url."""
+    aioclient_mock.get(
+        'http://example.com/mjpeg_stream', exc=asyncio.TimeoutError())
+
+    resp = yield from camera_client.get(
+        '/api/camera_proxy_stream/camera.config_test')
     assert resp.status == 504
 
-    aioclient_mock.clear_requests()
-    aioclient_mock.get(
-        'http://example.com/mjpeg_stream', exc=aiohttp.ClientError(),
-        content=[b'Frame1', b'Frame2', b'Frame3'])
 
-    resp = yield from client.get('/api/camera_proxy_stream/camera.config_test')
+@asyncio.coroutine
+def test_async_aiohttp_proxy_stream_client_err(aioclient_mock, camera_client):
+    """Test that it fetches the given url."""
+    aioclient_mock.get(
+        'http://example.com/mjpeg_stream', exc=aiohttp.ClientError())
+
+    resp = yield from camera_client.get(
+        '/api/camera_proxy_stream/camera.config_test')
     assert resp.status == 502


### PR DESCRIPTION
## Description:
This upgrades Home Assistant to aiohttp 3.

[Changes Overview](http://aiohttp.readthedocs.io/en/stable/whats_new_3_0.html#aiohttp-whats-new-3-0)
[Detailed changelog](http://aiohttp.readthedocs.io/en/stable/changes.html#aiohttp-changes)


## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
