### PR TITLE
Expicitly send Zigbee "Turn On" command after "move_to_level_with_on_off" command

### DIFF
--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -117,9 +117,6 @@ class Light(zha.Entity, light.Light):
                 brightness,
                 duration
             )
-            self._state = 1
-            self.async_schedule_update_ha_state()
-            return
 
         yield from self._endpoint.on_off.on()
         self._state = 1


### PR DESCRIPTION
## Description:
Currently, light.turn_on service turns on dimmable ZHA lights by issuing "move_to_level_with_on_off" command to cluster 0x0008 -- Level Control. Per [ZCL Specs](http://www.zigbee.org/~zigbeeor/wp-content/uploads/2014/10/07-5123-06-zigbee-cluster-library-specification.pdf) section 3.10.2.4.5, the light is supposed to turn on, if the brightness level is increased. Some dimmable lights ignore this provision and turn on the light upon receiving "move_to_level_with_on_off" regardless of the new level, but not [45857GE Zigbee in-wall smart dimmer](https://byjasco.com/products/ge-zigbee-wall-smart-dimmer), which will switch on the lights with "move_to_level_with_on_off" only if the new level is greater than the current/last one. 

This commit changes behavior, so light.turn_on service always sends "on" command for dimmable lights/switches, after issuing "move_to_level_with_on_off" command. For dimmable lights which switch on with "move_to_level_with_on_off" regardless of the level, this change effectively does nothing, since the light will be already on. For dimmable lights which won't switch on upon "move_to_level_with_on_off" (45857GE) it switches the light on specifically after setting the desired level.

**Related issue (if applicable):** fixes #12813

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [n/a] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [n/a] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [n/a] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [n/a] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
