### PR TITLE
Update python-coinbase to 2.1.0

### DIFF
--- a/homeassistant/components/coinbase.py
+++ b/homeassistant/components/coinbase.py
@@ -14,9 +14,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.util import Throttle
 
-REQUIREMENTS = [
-    'https://github.com/balloob/coinbase-python/archive/'
-    '3a35efe13ef728a1cc18204b4f25be1fcb1c6006.zip#coinbase==2.0.8a1']
+REQUIREMENTS = ['coinbase==2.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -178,6 +178,9 @@ caldav==0.5.0
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2
 
+# homeassistant.components.coinbase
+coinbase==2.1.0
+
 # homeassistant.components.sensor.coinmarketcap
 coinmarketcap==4.2.1
 
@@ -365,9 +368,6 @@ httplib2==0.10.3
 
 # homeassistant.components.media_player.braviatv
 https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
-
-# homeassistant.components.coinbase
-https://github.com/balloob/coinbase-python/archive/3a35efe13ef728a1cc18204b4f25be1fcb1c6006.zip#coinbase==2.0.8a1
 
 # homeassistant.components.sensor.broadlink
 # homeassistant.components.switch.broadlink


### PR DESCRIPTION
## Description:
Update python-coinbase to 2.1.0

Changelog:
Change from pycrypto to pycryptodome.

**Related issue (if applicable):** #12715 

It replaces a temporary GitHub package that contained the same change.