### PR TITLE
Python Spotcrime sensor requires API key, fixes include/exclude

### DIFF
--- a/homeassistant/components/sensor/spotcrime.py
+++ b/homeassistant/components/sensor/spotcrime.py
@@ -70,7 +70,11 @@ class SpotCrimeSensor(Entity):
         self._exclude = exclude
         self.days = days
         self._spotcrime = spotcrime.SpotCrime(
+<<<<<<< 70760b5d3b2e4b66eb6aed4adea191093c554210
             (latitude, longitude), radius, None, None, self.days)
+=======
+            (latitude, longitude), radius, self._include, self._exclude, self.days)
+>>>>>>> Add spotcrime.py to dev
         self._attributes = None
         self._state = None
         self._previous_incidents = set()

--- a/homeassistant/components/sensor/spotcrime.py
+++ b/homeassistant/components/sensor/spotcrime.py
@@ -12,14 +12,14 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
+from homeassistant.const import (CONF_API_KEY,
     CONF_INCLUDE, CONF_EXCLUDE, CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE,
     ATTR_ATTRIBUTION, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_RADIUS)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['spotcrime==1.0.2']
+REQUIREMENTS = ['spotcrime==1.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +34,7 @@ SCAN_INTERVAL = timedelta(minutes=30)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_RADIUS): vol.Coerce(float),
+    vol.Required(CONF_API_KEY): cv.string,
     vol.Inclusive(CONF_LATITUDE, 'coordinates'): cv.latitude,
     vol.Inclusive(CONF_LONGITUDE, 'coordinates'): cv.longitude,
     vol.Optional(CONF_DAYS, default=DEFAULT_DAYS): cv.positive_int,
@@ -49,32 +50,30 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
     name = config[CONF_NAME]
     radius = config[CONF_RADIUS]
+    api_key = config[CONF_API_KEY]
     days = config.get(CONF_DAYS)
     include = config.get(CONF_INCLUDE)
     exclude = config.get(CONF_EXCLUDE)
 
     add_devices([SpotCrimeSensor(
         name, latitude, longitude, radius, include,
-        exclude, days)], True)
+        exclude, api_key, days)], True)
 
 
 class SpotCrimeSensor(Entity):
     """Representation of a Spot Crime Sensor."""
 
     def __init__(self, name, latitude, longitude, radius,
-                 include, exclude, days):
+                 include, exclude, api_key, days):
         """Initialize the Spot Crime sensor."""
         import spotcrime
         self._name = name
         self._include = include
         self._exclude = exclude
+        self.api_key = api_key
         self.days = days
         self._spotcrime = spotcrime.SpotCrime(
-<<<<<<< 70760b5d3b2e4b66eb6aed4adea191093c554210
-            (latitude, longitude), radius, None, None, self.days)
-=======
-            (latitude, longitude), radius, self._include, self._exclude, self.days)
->>>>>>> Add spotcrime.py to dev
+            (latitude, longitude), radius, self._include, self._exclude, self.api_key, self.days)
         self._attributes = None
         self._state = None
         self._previous_incidents = set()

--- a/homeassistant/components/sensor/spotcrime.py
+++ b/homeassistant/components/sensor/spotcrime.py
@@ -12,9 +12,10 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_API_KEY,
-    CONF_INCLUDE, CONF_EXCLUDE, CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE,
-    ATTR_ATTRIBUTION, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_RADIUS)
+from homeassistant.const import (CONF_API_KEY, CONF_INCLUDE, CONF_EXCLUDE,
+                                 CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE,
+                                 ATTR_ATTRIBUTION, ATTR_LATITUDE,
+                                 ATTR_LONGITUDE, CONF_RADIUS)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/sensor/spotcrime.py
+++ b/homeassistant/components/sensor/spotcrime.py
@@ -73,7 +73,8 @@ class SpotCrimeSensor(Entity):
         self.api_key = api_key
         self.days = days
         self._spotcrime = spotcrime.SpotCrime(
-            (latitude, longitude), radius, self._include, self._exclude, self.api_key, self.days)
+            (latitude, longitude), radius, self._include,
+            self._exclude, self.api_key, self.days)
         self._attributes = None
         self._state = None
         self._previous_incidents = set()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1149,7 +1149,7 @@ somecomfort==0.5.0
 speedtest-cli==2.0.0
 
 # homeassistant.components.sensor.spotcrime
-spotcrime==1.0.2
+spotcrime==1.0.3
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator


### PR DESCRIPTION
## Description:
This update changes the sensor to require a user supplied API key as a configuration entry. The default key has been removed from the Spotcrime package and has also been modified to accept a user supplied API key.

**Related issue (if applicable):** fixes #12678
This update also fixes the include/exclude issue mentioned above.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: spotcrime
    name: Spot Crime
    days: 8
    radius: 0.05
    api_key: "your_api_key_here"
    include:
      - Theft
      - Vandalism
      - Other
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in: home-assistant/home-assistant.github.io#4840

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
