### PR TITLE
Addresses issues with Pollen.com API troubles

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -12,9 +12,8 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    ATTR_ATTRIBUTION, ATTR_STATE, CONF_MONITORED_CONDITIONS
-)
+from homeassistant.const import (ATTR_ATTRIBUTION, ATTR_STATE,
+                                 CONF_MONITORED_CONDITIONS)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle, slugify
 
@@ -39,48 +38,33 @@ MIN_TIME_UPDATE_AVERAGES = timedelta(hours=12)
 MIN_TIME_UPDATE_INDICES = timedelta(minutes=10)
 
 CONDITIONS = {
-    'allergy_average_forecasted': (
-        'Allergy Index: Forecasted Average',
-        'AllergyAverageSensor',
-        'allergy_average_data',
-        {'data_attr': 'extended_data'},
-        'mdi:flower'
-    ),
-    'allergy_average_historical': (
-        'Allergy Index: Historical Average',
-        'AllergyAverageSensor',
-        'allergy_average_data',
-        {'data_attr': 'historic_data'},
-        'mdi:flower'
-    ),
-    'allergy_index_today': (
-        'Allergy Index: Today',
-        'AllergyIndexSensor',
-        'allergy_index_data',
-        {'key': 'Today'},
-        'mdi:flower'
-    ),
-    'allergy_index_tomorrow': (
-        'Allergy Index: Tomorrow',
-        'AllergyIndexSensor',
-        'allergy_index_data',
-        {'key': 'Tomorrow'},
-        'mdi:flower'
-    ),
-    'allergy_index_yesterday': (
-        'Allergy Index: Yesterday',
-        'AllergyIndexSensor',
-        'allergy_index_data',
-        {'key': 'Yesterday'},
-        'mdi:flower'
-    ),
-    'disease_average_forecasted': (
-        'Cold & Flu: Forecasted Average',
-        'AllergyAverageSensor',
-        'disease_average_data',
-        {'data_attr': 'extended_data'},
-        'mdi:snowflake'
-    )
+    'allergy_average_forecasted':
+    ('Allergy Index: Forecasted Average', 'AllergyAverageSensor',
+     'allergy_average_data', {
+         'data_attr': 'extended_data'
+     }, 'mdi:flower'),
+    'allergy_average_historical': ('Allergy Index: Historical Average',
+                                   'AllergyAverageSensor',
+                                   'allergy_average_data', {
+                                       'data_attr': 'historic_data'
+                                   }, 'mdi:flower'),
+    'allergy_index_today': ('Allergy Index: Today', 'AllergyIndexSensor',
+                            'allergy_index_data', {
+                                'key': 'Today'
+                            }, 'mdi:flower'),
+    'allergy_index_tomorrow': ('Allergy Index: Tomorrow', 'AllergyIndexSensor',
+                               'allergy_index_data', {
+                                   'key': 'Tomorrow'
+                               }, 'mdi:flower'),
+    'allergy_index_yesterday': ('Allergy Index: Yesterday',
+                                'AllergyIndexSensor', 'allergy_index_data', {
+                                    'key': 'Yesterday'
+                                }, 'mdi:flower'),
+    'disease_average_forecasted': ('Cold & Flu: Forecasted Average',
+                                   'AllergyAverageSensor',
+                                   'disease_average_data', {
+                                       'data_attr': 'extended_data'
+                                   }, 'mdi:snowflake')
 }
 
 RATING_MAPPING = [{
@@ -105,11 +89,11 @@ RATING_MAPPING = [{
     'maximum': 12
 }]
 
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ZIP_CODE): cv.string,
+    vol.Required(CONF_ZIP_CODE):
+    cv.string,
     vol.Required(CONF_MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [vol.In(CONDITIONS)]),
+    vol.All(cv.ensure_list, [vol.In(CONDITIONS)]),
 })
 
 
@@ -136,23 +120,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     sensors = []
     for condition in config[CONF_MONITORED_CONDITIONS]:
         name, sensor_class, data_key, params, icon = CONDITIONS[condition]
-        sensors.append(classes[sensor_class](
-            datas[data_key],
-            params,
-            name,
-            icon,
-            config[CONF_ZIP_CODE]
-        ))
+        sensors.append(classes[sensor_class](datas[data_key], params, name,
+                                             icon, config[CONF_ZIP_CODE]))
 
     add_devices(sensors, True)
 
 
 def calculate_trend(list_of_nums):
     """Calculate the most common rating as a trend."""
-    ratings = list(
-        r['label'] for n in list_of_nums
-        for r in RATING_MAPPING
-        if r['minimum'] <= n <= r['maximum'])
+    ratings = list(r['label'] for n in list_of_nums for r in RATING_MAPPING
+                   if r['minimum'] <= n <= r['maximum'])
     return max(set(ratings), key=ratings.count)
 
 
@@ -211,21 +188,23 @@ class AllergyAverageSensor(BaseSensor):
 
         try:
             data_attr = getattr(self.data, self._data_params['data_attr'])
-            indices = [
-                p['Index']
-                for p in data_attr['Location']['periods']
-            ]
+            indices = [p['Index'] for p in data_attr['Location']['periods']]
+            self._attrs[ATTR_TREND] = calculate_trend(indices)
         except KeyError:
             _LOGGER.error("Pollen.com API didn't return any data")
             return
 
+        try:
+            self._attrs[ATTR_CITY] = data_attr['Location']['City'].title()
+            self._attrs[ATTR_STATE] = data_attr['Location']['State']
+            self._attrs[ATTR_ZIP_CODE] = data_attr['Location']['ZIP']
+        except KeyError:
+            _LOGGER.debug('Location data not included in API response')
+            self._attrs[ATTR_CITY] = None
+            self._attrs[ATTR_STATE] = None
+            self._attrs[ATTR_ZIP_CODE] = None
+
         average = round(mean(indices), 1)
-
-        self._attrs[ATTR_TREND] = calculate_trend(indices)
-        self._attrs[ATTR_CITY] = data_attr['Location']['City'].title()
-        self._attrs[ATTR_STATE] = data_attr['Location']['State']
-        self._attrs[ATTR_ZIP_CODE] = data_attr['Location']['ZIP']
-
         [rating] = [
             i['label'] for i in RATING_MAPPING
             if i['minimum'] <= average <= i['maximum']
@@ -245,31 +224,51 @@ class AllergyIndexSensor(BaseSensor):
 
         try:
             location_data = self.data.current_data['Location']
+            [period] = [
+                p for p in location_data['periods']
+                if p['Type'] == self._data_params['key']
+            ]
+            [rating] = [
+                i['label'] for i in RATING_MAPPING
+                if i['minimum'] <= period['Index'] <= i['maximum']
+            ]
+            self._attrs[ATTR_ALLERGEN_GENUS] = period['Triggers'][0]['Genus']
+            self._attrs[ATTR_ALLERGEN_NAME] = period['Triggers'][0]['Name']
+            self._attrs[ATTR_ALLERGEN_TYPE] = period['Triggers'][0][
+                'PlantType']
+            self._attrs[ATTR_RATING] = rating
+
         except KeyError:
             _LOGGER.error("Pollen.com API didn't return any data")
             return
 
-        [period] = [
-            p for p in location_data['periods']
-            if p['Type'] == self._data_params['key']
-        ]
+        try:
+            self._attrs[ATTR_CITY] = location_data['City'].title()
+            self._attrs[ATTR_STATE] = location_data['State']
+            self._attrs[ATTR_ZIP_CODE] = location_data['ZIP']
+        except KeyError:
+            _LOGGER.debug('Location data not included in API response')
+            self._attrs[ATTR_CITY] = None
+            self._attrs[ATTR_STATE] = None
+            self._attrs[ATTR_ZIP_CODE] = None
 
-        self._attrs[ATTR_ALLERGEN_GENUS] = period['Triggers'][0]['Genus']
-        self._attrs[ATTR_ALLERGEN_NAME] = period['Triggers'][0]['Name']
-        self._attrs[ATTR_ALLERGEN_TYPE] = period['Triggers'][0]['PlantType']
-        self._attrs[ATTR_OUTLOOK] = self.data.outlook_data['Outlook']
-        self._attrs[ATTR_SEASON] = self.data.outlook_data['Season']
-        self._attrs[ATTR_TREND] = self.data.outlook_data[
-            'Trend'].title()
-        self._attrs[ATTR_CITY] = location_data['City'].title()
-        self._attrs[ATTR_STATE] = location_data['State']
-        self._attrs[ATTR_ZIP_CODE] = location_data['ZIP']
+        try:
+            self._attrs[ATTR_OUTLOOK] = self.data.outlook_data['Outlook']
+        except KeyError:
+            _LOGGER.debug('Outlook data not included in API response')
+            self._attrs[ATTR_OUTLOOK] = None
 
-        [rating] = [
-            i['label'] for i in RATING_MAPPING
-            if i['minimum'] <= period['Index'] <= i['maximum']
-        ]
-        self._attrs[ATTR_RATING] = rating
+        try:
+            self._attrs[ATTR_SEASON] = self.data.outlook_data['Season']
+        except KeyError:
+            _LOGGER.debug('Season data not included in API response')
+            self._attrs[ATTR_SEASON] = None
+
+        try:
+            self._attrs[ATTR_TREND] = self.data.outlook_data['Trend'].title()
+        except KeyError:
+            _LOGGER.debug('Trend data not included in API response')
+            self._attrs[ATTR_TREND] = None
 
         self._state = period['Index']
         self._unit = 'index'
@@ -289,8 +288,7 @@ class DataBase(object):
         data = {}
         try:
             data = getattr(getattr(self._client, module), operation)()
-            _LOGGER.debug('Received "%s_%s" data: %s', module,
-                          operation, data)
+            _LOGGER.debug('Received "%s_%s" data: %s', module, operation, data)
         except HTTPError as exc:
             _LOGGER.error('An error occurred while retrieving data')
             _LOGGER.debug(exc)

--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -12,8 +12,9 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (ATTR_ATTRIBUTION, ATTR_STATE,
-                                 CONF_MONITORED_CONDITIONS)
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, ATTR_STATE, CONF_MONITORED_CONDITIONS
+)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle, slugify
 
@@ -38,33 +39,48 @@ MIN_TIME_UPDATE_AVERAGES = timedelta(hours=12)
 MIN_TIME_UPDATE_INDICES = timedelta(minutes=10)
 
 CONDITIONS = {
-    'allergy_average_forecasted':
-    ('Allergy Index: Forecasted Average', 'AllergyAverageSensor',
-     'allergy_average_data', {
-         'data_attr': 'extended_data'
-     }, 'mdi:flower'),
-    'allergy_average_historical': ('Allergy Index: Historical Average',
-                                   'AllergyAverageSensor',
-                                   'allergy_average_data', {
-                                       'data_attr': 'historic_data'
-                                   }, 'mdi:flower'),
-    'allergy_index_today': ('Allergy Index: Today', 'AllergyIndexSensor',
-                            'allergy_index_data', {
-                                'key': 'Today'
-                            }, 'mdi:flower'),
-    'allergy_index_tomorrow': ('Allergy Index: Tomorrow', 'AllergyIndexSensor',
-                               'allergy_index_data', {
-                                   'key': 'Tomorrow'
-                               }, 'mdi:flower'),
-    'allergy_index_yesterday': ('Allergy Index: Yesterday',
-                                'AllergyIndexSensor', 'allergy_index_data', {
-                                    'key': 'Yesterday'
-                                }, 'mdi:flower'),
-    'disease_average_forecasted': ('Cold & Flu: Forecasted Average',
-                                   'AllergyAverageSensor',
-                                   'disease_average_data', {
-                                       'data_attr': 'extended_data'
-                                   }, 'mdi:snowflake')
+    'allergy_average_forecasted': (
+        'Allergy Index: Forecasted Average',
+        'AllergyAverageSensor',
+        'allergy_average_data',
+        {'data_attr': 'extended_data'},
+        'mdi:flower'
+    ),
+    'allergy_average_historical': (
+        'Allergy Index: Historical Average',
+        'AllergyAverageSensor',
+        'allergy_average_data',
+        {'data_attr': 'historic_data'},
+        'mdi:flower'
+    ),
+    'allergy_index_today': (
+        'Allergy Index: Today',
+        'AllergyIndexSensor',
+        'allergy_index_data',
+        {'key': 'Today'},
+        'mdi:flower'
+    ),
+    'allergy_index_tomorrow': (
+        'Allergy Index: Tomorrow',
+        'AllergyIndexSensor',
+        'allergy_index_data',
+        {'key': 'Tomorrow'},
+        'mdi:flower'
+    ),
+    'allergy_index_yesterday': (
+        'Allergy Index: Yesterday',
+        'AllergyIndexSensor',
+        'allergy_index_data',
+        {'key': 'Yesterday'},
+        'mdi:flower'
+    ),
+    'disease_average_forecasted': (
+        'Cold & Flu: Forecasted Average',
+        'AllergyAverageSensor',
+        'disease_average_data',
+        {'data_attr': 'extended_data'},
+        'mdi:snowflake'
+    )
 }
 
 RATING_MAPPING = [{
@@ -90,10 +106,9 @@ RATING_MAPPING = [{
 }]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ZIP_CODE):
-    cv.string,
+    vol.Required(CONF_ZIP_CODE): cv.string,
     vol.Required(CONF_MONITORED_CONDITIONS):
-    vol.All(cv.ensure_list, [vol.In(CONDITIONS)]),
+        vol.All(cv.ensure_list, [vol.In(CONDITIONS)]),
 })
 
 
@@ -120,16 +135,23 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     sensors = []
     for condition in config[CONF_MONITORED_CONDITIONS]:
         name, sensor_class, data_key, params, icon = CONDITIONS[condition]
-        sensors.append(classes[sensor_class](datas[data_key], params, name,
-                                             icon, config[CONF_ZIP_CODE]))
+        sensors.append(classes[sensor_class](
+            datas[data_key],
+            params,
+            name,
+            icon,
+            config[CONF_ZIP_CODE]
+        ))
 
     add_devices(sensors, True)
 
 
 def calculate_trend(list_of_nums):
     """Calculate the most common rating as a trend."""
-    ratings = list(r['label'] for n in list_of_nums for r in RATING_MAPPING
-                   if r['minimum'] <= n <= r['maximum'])
+    ratings = list(
+        r['label'] for n in list_of_nums
+        for r in RATING_MAPPING
+        if r['minimum'] <= n <= r['maximum'])
     return max(set(ratings), key=ratings.count)
 
 


### PR DESCRIPTION
## Description:
Addresses a recently revealed 500 error within the Pollen.com API. In short:

1. As long as crucial data is returned from the API, sensors are created; non-crucial data is merely ignored (whereas previously, the sensor would fail to show).
2. Any API issues are properly caught and logged (currently logged under `DEBUG` – found that any other level spammed the logs way too much without a way to address).

**Related issue (if applicable):** fixes #12916

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
- platform: pollen
  zip_code: "00544"
  monitored_conditions:
    - allergy_average_forecasted
    - allergy_average_historical
    - allergy_index_today
    - allergy_index_tomorrow
    - allergy_index_yesterday
    - disease_average_forecasted
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
