### PR TITLE
Reinstate our old virtual env check in favor of pip

### DIFF
--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -39,6 +39,6 @@ def pip_kwargs(config_dir):
     kwargs = {
         'constraints': os.path.join(os.path.dirname(__file__), CONSTRAINT_FILE)
     }
-    if not pkg_util.running_under_virtualenv():
+    if not pkg_util.is_virtual_env():
         kwargs['target'] = os.path.join(config_dir, 'deps')
     return kwargs

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -7,7 +7,6 @@ import sys
 import threading
 from urllib.parse import urlparse
 
-from pip.locations import running_under_virtualenv
 from typing import Optional
 
 import pkg_resources
@@ -15,6 +14,13 @@ import pkg_resources
 _LOGGER = logging.getLogger(__name__)
 
 INSTALL_LOCK = threading.Lock()
+
+
+def is_virtual_env():
+    """Return if we run in a virtual environtment."""
+    # Check supports venv && virtualenv
+    return (getattr(sys, 'base_prefix', sys.prefix) != sys.prefix or
+            hasattr(sys, 'real_prefix'))
 
 
 def install_package(package: str, upgrade: bool = True,
@@ -37,7 +43,7 @@ def install_package(package: str, upgrade: bool = True,
         if constraints is not None:
             args += ['--constraint', constraints]
         if target:
-            assert not running_under_virtualenv()
+            assert not is_virtual_env()
             # This only works if not running in venv
             args += ['--user']
             env['PYTHONUSERBASE'] = os.path.abspath(target)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -24,7 +24,7 @@ class TestRequirements:
         self.hass.stop()
 
     @mock.patch('os.path.dirname')
-    @mock.patch('homeassistant.util.package.running_under_virtualenv',
+    @mock.patch('homeassistant.util.package.is_virtual_env',
                 return_value=True)
     @mock.patch('homeassistant.util.package.install_package',
                 return_value=True)
@@ -43,7 +43,7 @@ class TestRequirements:
             constraints=os.path.join('ha_package_path', CONSTRAINT_FILE))
 
     @mock.patch('os.path.dirname')
-    @mock.patch('homeassistant.util.package.running_under_virtualenv',
+    @mock.patch('homeassistant.util.package.is_virtual_env',
                 return_value=False)
     @mock.patch('homeassistant.util.package.install_package',
                 return_value=True)

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -68,8 +68,8 @@ def mock_env_copy():
 
 @pytest.fixture
 def mock_venv():
-    """Mock homeassistant.util.package.running_under_virtualenv."""
-    with patch('homeassistant.util.package.running_under_virtualenv') as mock:
+    """Mock homeassistant.util.package.is_virtual_env."""
+    with patch('homeassistant.util.package.is_virtual_env') as mock:
         mock.return_value = True
         yield mock
 


### PR DESCRIPTION
## Description:
We were importing a method from pip to check for virtual environments. This had the unintended consequence of importing a whole load of pip into memory for a 2 line function!

We've had a similar function in Home Assistant before which I've reinstated in favor of importing pip.

Old method: https://github.com/home-assistant/home-assistant/blob/c532a28a98cb796244634eec5db9de367ab15f1d/homeassistant/util/environment.py

CC @MartinHjelmare 

**Related issue (if applicable):** fixes #11493
