### PR TITLE
Fix netatmo sensor warning from invalid Voluptuous default

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -18,8 +18,6 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_MODULE = 'modules'
-
 CONF_MODULES = 'modules'
 CONF_STATION = 'station'
 
@@ -54,7 +52,7 @@ SENSOR_TYPES = {
 }
 
 MODULE_SCHEMA = vol.Schema({
-    vol.Required(cv.string, default=[]):
+    vol.Required(cv.string):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 


### PR DESCRIPTION
## Description:

This avoids a warning during startup and also removes an unused constant.

**Related issue (if applicable):** fixes #12861

## Checklist:
  - [X] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
