### PR TITLE
Google Assistant: report device as offline if unavailable

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_ENTITY_ID, ATTR_UNIT_OF_MEASUREMENT,
     STATE_OFF, SERVICE_TURN_OFF, SERVICE_TURN_ON,
     TEMP_FAHRENHEIT, TEMP_CELSIUS,
-    CONF_NAME, CONF_TYPE
+    CONF_NAME, CONF_TYPE, STATE_UNAVAILABLE
 )
 from homeassistant.components import (
     switch, light, cover, media_player, group, fan, scene, script, climate,
@@ -470,7 +470,7 @@ def async_devices_query(hass, config, payload):
             continue
 
         state = hass.states.get(devid)
-        if not state:
+        if not state or state.state == STATE_UNAVAILABLE:
             # If we can't find a state, the device is offline
             devices[devid] = {'online': False}
         else:


### PR DESCRIPTION
## Description:
When a device is unavailable, report to Google Assistant that it is offline.

**Related issue (if applicable):** #12935

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
