### PR TITLE
Implement Hue available property

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -261,10 +261,13 @@ class HueLight(Light):
         """Return true if device is on."""
         if self.is_group:
             return self.info['state']['any_on']
-        elif self.allow_unreachable:
-            return self.info['state']['on']
-        return self.info['state']['reachable'] and \
-            self.info['state']['on']
+        return self.info['state']['on']
+
+    @property
+    def available(self):
+        """Return if light is available."""
+        return (self.is_group or self.allow_unreachable or
+                self.info['state']['reachable'])
 
     @property
     def supported_features(self):

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -501,3 +501,45 @@ class TestHueLight(unittest.TestCase):
 
         light = self.buildLight(info={}, is_group=True)
         self.assertIsNone(light.unique_id)
+
+
+def test_available():
+    """Test available property."""
+    light = hue_light.HueLight(
+        info={'state': {'reachable': False}},
+        allow_unreachable=False,
+        is_group=False,
+
+        light_id=None,
+        bridge=mock.Mock(),
+        update_lights_cb=None,
+        allow_in_emulated_hue=False,
+    )
+
+    assert light.available is False
+
+    light = hue_light.HueLight(
+        info={'state': {'reachable': False}},
+        allow_unreachable=True,
+        is_group=False,
+
+        light_id=None,
+        bridge=mock.Mock(),
+        update_lights_cb=None,
+        allow_in_emulated_hue=False,
+    )
+
+    assert light.available is True
+
+    light = hue_light.HueLight(
+        info={'state': {'reachable': False}},
+        allow_unreachable=False,
+        is_group=True,
+
+        light_id=None,
+        bridge=mock.Mock(),
+        update_lights_cb=None,
+        allow_in_emulated_hue=False,
+    )
+
+    assert light.available is True


### PR DESCRIPTION
## Description:
Report Hue lights as unavailable when they are not reachable.

**Related issue (if applicable):** #12935

## Checklist:
If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
