### PR TITLE
Unifi WAP: Don't filter by ssid on wired clients

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -95,10 +95,11 @@ class UnifiScanner(DeviceScanner):
             _LOGGER.error("Failed to scan clients: %s", ex)
             clients = []
 
-        # Filter clients to provided SSID list
+        # Filter clients to provided SSID list (ignore wired clients)
         if self._ssid_filter:
             clients = [client for client in clients
-                       if client['essid'] in self._ssid_filter]
+                       if 'essid' in client and client['essid'] in
+                       self._ssid_filter]
 
         self._clients = {
             client['mac']: client


### PR DESCRIPTION
## Description:
The 'essid' key on the clients returned from the Unifi Controller is not present on wired devices, triggering a KeyError with the unfixed code. With this change, if a SSID filter is being applied, it will check for the key first.

## Checklist:
  - [x] The code change is tested and works locally.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
