### PR TITLE
Add add_devices back to rpi_camera

### DIFF
--- a/homeassistant/components/camera/rpi_camera.py
+++ b/homeassistant/components/camera/rpi_camera.py
@@ -106,6 +106,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("'%s' is not a whitelisted directory", file_path)
         return False
 
+    add_devices([RaspberryCamera(setup_config)])
 
 class RaspberryCamera(Camera):
     """Representation of a Raspberry Pi camera."""

--- a/homeassistant/components/camera/rpi_camera.py
+++ b/homeassistant/components/camera/rpi_camera.py
@@ -108,6 +108,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     add_devices([RaspberryCamera(setup_config)])
 
+
 class RaspberryCamera(Camera):
     """Representation of a Raspberry Pi camera."""
 


### PR DESCRIPTION
## Description:
add_devices was removed in an older commit, but it is needed for the camera to work.
This PR will add the line back.

**Related issue (if applicable):** fixes #12693

## Checklist:
  - [ ] The code change is tested and works locally.
