### PR TITLE
Add more info to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,50 +4,45 @@
 - Frontend (user interface of Home Assistant in your browser) related issues have to be reported here: https://github.com/home-assistant/home-assistant-polymer/issues
 - This is for bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
 - Answer all question as detailed as possible, write the information inside the backticks. Do not delete any text from this template!
-
 -->
-**1. Home Assistant version:**
-```
 
-```
+**1. Home Assistant version:**
 <!--
 - Frontend -> developer tools -> info
 - Or use this command: hass --version
 -->
+```
+
+```
 
 **2.a) I run Hass.io or the Docker image**:
-```
-
-```
 <!--
 - Yes / No
 -->
+```
+
+```
 
 **2.b) ...No, I run an installation with this Python version:**
-```
-
-```
 <!--
 - Minimum supported version is Python 3.5.3
 - Use this command: python3 --version
 -->
+```
+
+```
 
 **3. Component/platform:**
-```
-
-```
 <!--
-- example: components/updater.py
+- Please add the link to the documention at https://www.home-assistant.io/components/ of the component/platform in question.
 -->
-**4. Description of problem:**
-```
 
-```
+
+**4. Description of problem:**
+
 
 **5. Expected:**
-```
 
-```
 
 **6. Problem-relevant `configuration.yaml` entries and steps to reproduce:**
 ```yaml
@@ -59,11 +54,9 @@
 3. 
 
 **7. Traceback (if applicable):**
-```bash
+```
 
 ```
 
 **8. Additional info:**
-```
 
-```

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 - Make sure you are running the latest version of Home Assistant before reporting an issue
 - Do not report issues for components if you are using custom components
 - Frontend (UI) related issues have to be reported here: https://github.com/home-assistant/home-assistant-polymer/issues
-- This is fpr bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
+- This is for bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
 -->
 **Home Assistant release (`hass --version`):**
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,10 @@
 
 
 **Python release (`python3 --version`):**
-<!-- If you run Hass.io: "Hass.io" -->
+<!--
+- Minumum supported version is Python 3.5.3
+- If you run Hass.io: "Hass.io"
+-->
 
 **Component/platform:**
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,28 +1,55 @@
 <!-- READ THIS FIRST:
-- Make sure you are running the latest version of Home Assistant before reporting an issue
-- Do not report issues for components if you are using custom components
+- Make sure you are running the latest version of Home Assistant before reporting an issue: https://github.com/home-assistant/home-assistant/releases
+- Do not report issues for components if you are using custom components: files in <config-dir>/custom_components
 - Frontend (user interface of Home Assistant in your browser) related issues have to be reported here: https://github.com/home-assistant/home-assistant-polymer/issues
 - This is for bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
+- Answer all question as detailed as possible, write the information inside the backticks. Do not delete any text from this template!
+
 -->
-**Home Assistant release (`hass --version`):**
+**1. Home Assistant version:**
+```
 
+```
+<!--
+- Frontend -> developer tools -> info
+- Or use this command: hass --version
+-->
 
-**Python release (`python3 --version`):**
+**2.a) I run Hass.io or the Docker image**:
+```
+
+```
+<!--
+- Yes / No
+-->
+
+**2.b) ...No, I run an installation with this Python version:**
+```
+
+```
 <!--
 - Minimum supported version is Python 3.5.3
-- If you run Hass.io: "3.6.4"
+- Use this command: python3 --version
 -->
 
-**Component/platform:**
+**3. Component/platform:**
+```
 
+```
+<!--
+- example: components/updater.py
+-->
+**4. Description of problem:**
+```
 
-**Description of problem:**
+```
 
+**5. Expected:**
+```
 
-**Expected:**
+```
 
-
-**Problem-relevant `configuration.yaml` entries and steps to reproduce:**
+**6. Problem-relevant `configuration.yaml` entries and steps to reproduce:**
 ```yaml
 
 ```
@@ -31,10 +58,12 @@
 2. 
 3. 
 
-**Traceback (if applicable):**
+**7. Traceback (if applicable):**
 ```bash
 
 ```
 
-**Additional info:**
+**8. Additional info:**
+```
 
+```

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!-- READ THIS FIRST:
 - Make sure you are running the latest version of Home Assistant before reporting an issue
 - Do not report issues for components if you are using custom components
-- Frontend (UI) related issues have to be reported here: https://github.com/home-assistant/home-assistant-polymer/issues
+- Frontend (user interface of Home Assistant in your browser) related issues have to be reported here: https://github.com/home-assistant/home-assistant-polymer/issues
 - This is for bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
 -->
 **Home Assistant release (`hass --version`):**
@@ -9,8 +9,8 @@
 
 **Python release (`python3 --version`):**
 <!--
-- Minumum supported version is Python 3.5.3
-- If you run Hass.io: "Hass.io"
+- Minimum supported version is Python 3.5.3
+- If you run Hass.io: "3.6.4"
 -->
 
 **Component/platform:**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,14 @@
-Make sure you are running the latest version of Home Assistant before reporting an issue.
-
-You should only file an issue if you found a bug. Feature and enhancement requests should go in [the Feature Requests section](https://community.home-assistant.io/c/feature-requests) of our community forum:
-
+<!-- READ THIS FIRST:
+- Make sure you are running the latest version of Home Assistant before reporting an issue
+- Do not report issues for components if you are using custom components
+- Frontend (UI) related issues have to be reported here: https://github.com/home-assistant/home-assistant-polymer/issues
+- This is fpr bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
+-->
 **Home Assistant release (`hass --version`):**
 
 
 **Python release (`python3 --version`):**
-
+<!-- If you run Hass.io: "Hass.io" -->
 
 **Component/platform:**
 


### PR DESCRIPTION
- added `read this first`, new: no custom components, link to frontend repo
- pyhton version not required for Hass.io

```
<!-- READ THIS FIRST:
- Make sure you are running the latest version of Home Assistant before reporting an issue
- Do not report issues for components if you are using custom components
- Frontend (UI) related issues have to be reported here: https://github.com/home-assistant/home-assistant-polymer/issues
- This is fpr bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
-->
**Home Assistant release (`hass --version`):**


**Python release (`python3 --version`):**
<!--
- Minumum supported version is Python 3.5.3
- If you run Hass.io: "Hass.io"
-->
```