### PR TITLE
[SQL Sensor] partial revert of #12452

### DIFF
--- a/homeassistant/components/sensor/sql.py
+++ b/homeassistant/components/sensor/sql.py
@@ -131,22 +131,21 @@ class SQLSensor(Entity):
         try:
             sess = self.sessionmaker()
             result = sess.execute(self._query)
+
+            if not result.returns_rows or result.rowcount == 0:
+                _LOGGER.warning("%s returned no results", self._query)
+                self._state = None
+                self._attributes = {}
+                return
+
+            for res in result:
+                _LOGGER.debug("result = %s", res.items())
+                data = res[self._column_name]
+                self._attributes = {k: v for k, v in res.items()}
         except sqlalchemy.exc.SQLAlchemyError as err:
             _LOGGER.error("Error executing query %s: %s", self._query, err)
-            return
         finally:
             sess.close()
-
-        if not result.returns_rows or result.rowcount == 0:
-            _LOGGER.warning("%s returned no results", self._query)
-            self._state = None
-            self._attributes = {}
-            return
-
-        for res in result:
-            _LOGGER.debug("result = %s", res.items())
-            data = res[self._column_name]
-            self._attributes = {k: v for k, v in res.items()}
 
         if self._template is not None:
             self._state = self._template.async_render_with_possible_json_value(

--- a/homeassistant/components/sensor/sql.py
+++ b/homeassistant/components/sensor/sql.py
@@ -144,6 +144,7 @@ class SQLSensor(Entity):
                 self._attributes = {k: v for k, v in res.items()}
         except sqlalchemy.exc.SQLAlchemyError as err:
             _LOGGER.error("Error executing query %s: %s", self._query, err)
+            return
         finally:
             sess.close()
 


### PR DESCRIPTION
## Description:

This PR addresses:
https://community.home-assistant.io/t/sql-sensor-errors-after-upgrade-to-0-64-3/45969

#12452 moved close() to immediately after the query execution, and was validated with test against MySQL. This worked well for databases that have connection pools (everyone except SQLite).

Explanation of the problem can be traced to:
http://docs.sqlalchemy.org/en/latest/core/pooling.html#sqlalchemy.pool.NullPool

The current PR, moves the session close() back to after all objects related to sqlalchemy can be invalidated.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
