### PR TITLE
Fix LIFX color conversions

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -169,15 +169,15 @@ def find_hsbk(**kwargs):
     if ATTR_RGB_COLOR in kwargs:
         hue, saturation, brightness = \
             color_util.color_RGB_to_hsv(*kwargs[ATTR_RGB_COLOR])
-        hue = hue / 360 * 65535
-        saturation = saturation / 100 * 65535
-        brightness = brightness / 100 * 65535
+        hue = int(hue / 360 * 65535)
+        saturation = int(saturation / 100 * 65535)
+        brightness = int(brightness / 100 * 65535)
         kelvin = 3500
 
     if ATTR_XY_COLOR in kwargs:
         hue, saturation = color_util.color_xy_to_hs(*kwargs[ATTR_XY_COLOR])
-        hue = hue / 360 * 65535
-        saturation = saturation / 100 * 65535
+        hue = int(hue / 360 * 65535)
+        saturation = int(saturation / 100 * 65535)
         kelvin = 3500
 
     if ATTR_COLOR_TEMP in kwargs:


### PR DESCRIPTION
## Description:

My bad for not testing #12649 properly. This PR removes the exception below when reading out the `brightness` property _after_ setting a color but _before_ fetching updated values from the device.

CC @armills 

```
2018-03-07 00:52:13 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.6.3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/tasks.py", line 180, in _step
    result = coro.send(None)
  File "/Users/am/home-assistant/homeassistant/helpers/entity.py", line 222, in async_update_ha_state
    attr = self.state_attributes or {}
  File "/Users/am/home-assistant/homeassistant/components/light/__init__.py", line 481, in state_attributes
    value = getattr(self, prop)
  File "/Users/am/home-assistant/homeassistant/components/light/lifx.py", line 443, in brightness
    brightness = convert_16_to_8(self.device.color[2])
  File "/Users/am/home-assistant/homeassistant/components/light/lifx.py", line 383, in convert_16_to_8
    return value >> 8
TypeError: unsupported operand type(s) for >>: 'float' and 'int'
```

## Checklist:
  - [X] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
