### PR TITLE
Add notifications to downloader.py

### DIFF
--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -136,7 +136,7 @@ def setup(hass, config):
 
                     _LOGGER.debug("Downloading of %s done", url)
                     hass.bus.fire(
-                         "{}.{}".format(DOMAIN, DOWNLOAD_COMPLETED_EVENT), {
+                         "{}_{}".format(DOMAIN, DOWNLOAD_COMPLETED_EVENT), {
                                 'url': url,
                                 'filename': filename
                                 })
@@ -144,7 +144,7 @@ def setup(hass, config):
             except requests.exceptions.ConnectionError:
                 _LOGGER.exception("ConnectionError occurred for %s", url)
                 hass.bus.fire(
-                    "{}.{}".format(DOMAIN, DOWNLOAD_FAILED_EVENT), {
+                    "{}_{}".format(DOMAIN, DOWNLOAD_FAILED_EVENT), {
                             'url': url,
                             'filename': filename
                             })

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -135,17 +135,19 @@ def setup(hass, config):
                             fil.write(chunk)
 
                     _LOGGER.debug("Downloading of %s done", url)
-                    hass.bus.fire("{}.{}".format(DOMAIN, DOWNLOAD_COMPLETED_EVENT), {
-                        'url': url,
-                        'filename': filename
-                    })
+                    hass.bus.fire(
+                         "{}.{}".format(DOMAIN, DOWNLOAD_COMPLETED_EVENT), {
+                                'url': url,
+                                'filename': filename
+                                })
 
             except requests.exceptions.ConnectionError:
                 _LOGGER.exception("ConnectionError occurred for %s", url)
-                hass.bus.fire("{}.{}".format(DOMAIN, DOWNLOAD_FAILED_EVENT), {
-                        'url': url,
-                        'filename': filename
-                    })
+                hass.bus.fire(
+                    "{}.{}".format(DOMAIN, DOWNLOAD_FAILED_EVENT), {
+                            'url': url,
+                            'filename': filename
+                            })
 
                 # Remove file if we started downloading but failed
                 if final_path and os.path.isfile(final_path):

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -136,18 +136,18 @@ def setup(hass, config):
 
                     _LOGGER.debug("Downloading of %s done", url)
                     hass.bus.fire(
-                         "{}_{}".format(DOMAIN, DOWNLOAD_COMPLETED_EVENT), {
-                                'url': url,
-                                'filename': filename
-                                })
+                        "{}_{}".format(DOMAIN, DOWNLOAD_COMPLETED_EVENT), {
+                            'url': url,
+                            'filename': filename
+                            })
 
             except requests.exceptions.ConnectionError:
                 _LOGGER.exception("ConnectionError occurred for %s", url)
                 hass.bus.fire(
                     "{}_{}".format(DOMAIN, DOWNLOAD_FAILED_EVENT), {
-                            'url': url,
-                            'filename': filename
-                            })
+                        'url': url,
+                        'filename': filename
+                        })
 
                 # Remove file if we started downloading but failed
                 if final_path and os.path.isfile(final_path):

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -25,6 +25,8 @@ ATTR_OVERWRITE = 'overwrite'
 CONF_DOWNLOAD_DIR = 'download_dir'
 
 DOMAIN = 'downloader'
+DOWNLOAD_FAILED_EVENT = 'download_failed'
+DOWNLOAD_COMPLETED_EVENT = 'download_completed'
 
 SERVICE_DOWNLOAD_FILE = 'download_file'
 
@@ -133,19 +135,17 @@ def setup(hass, config):
                             fil.write(chunk)
 
                     _LOGGER.debug("Downloading of %s done", url)
-                    hass.components.persistent_notification.create(
-                        "Info: {} download finished successfully"
-                        "".format(filename),
-                        title='Download Request',
-                        notification_id='download_request')
+                    hass.bus.fire("{}.{}".format(DOMAIN, DOWNLOAD_COMPLETED_EVENT), {
+                        'url': url,
+                        'filename': filename
+                    })
 
             except requests.exceptions.ConnectionError:
                 _LOGGER.exception("ConnectionError occurred for %s", url)
-                hass.components.persistent_notification.create(
-                    "Error: {} download failed"
-                    "".format(filename),
-                    title='Download Request',
-                    notification_id='download_request')
+                hass.bus.fire("{}.{}".format(DOMAIN, DOWNLOAD_FAILED_EVENT), {
+                        'url': url,
+                        'filename': filename
+                    })
 
                 # Remove file if we started downloading but failed
                 if final_path and os.path.isfile(final_path):

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -134,16 +134,16 @@ def setup(hass, config):
 
                     _LOGGER.debug("Downloading of %s done", url)
                     hass.components.persistent_notification.create(
-                                    'Info: {} download finished successfully'.format(filename),
-                                    title='Download Request',
-                                    notification_id='download_request')
+                        'Info: {} download finished successfully'.format(filename),
+                        title='Download Request',
+                        notification_id='download_request')
 
             except requests.exceptions.ConnectionError:
                 _LOGGER.exception("ConnectionError occurred for %s", url)
                 hass.components.persistent_notification.create(
-                                    'Error: {} download failed'.format(filename),
-                                    title='Download Request',
-                                    notification_id='download_request')
+                        'Error: {} download failed'.format(filename),
+                        title='Download Request',
+                        notification_id='download_request')
 
                 # Remove file if we started downloading but failed
                 if final_path and os.path.isfile(final_path):

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -142,10 +142,10 @@ def setup(hass, config):
             except requests.exceptions.ConnectionError:
                 _LOGGER.exception("ConnectionError occurred for %s", url)
                 hass.components.persistent_notification.create(
-                        "Error: {} download failed"
-                        "".format(filename),
-                        title='Download Request',
-                        notification_id='download_request')
+                    "Error: {} download failed"
+                    "".format(filename),
+                    title='Download Request',
+                    notification_id='download_request')
 
                 # Remove file if we started downloading but failed
                 if final_path and os.path.isfile(final_path):

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -134,14 +134,16 @@ def setup(hass, config):
 
                     _LOGGER.debug("Downloading of %s done", url)
                     hass.components.persistent_notification.create(
-                        'Info: {} download finished successfully'.format(filename),
+                        "Info: {} download finished successfully"
+                        "".format(filename),
                         title='Download Request',
                         notification_id='download_request')
 
             except requests.exceptions.ConnectionError:
                 _LOGGER.exception("ConnectionError occurred for %s", url)
                 hass.components.persistent_notification.create(
-                        'Error: {} download failed'.format(filename),
+                        "Error: {} download failed"
+                        "".format(filename),
                         title='Download Request',
                         notification_id='download_request')
 

--- a/homeassistant/components/downloader.py
+++ b/homeassistant/components/downloader.py
@@ -133,9 +133,17 @@ def setup(hass, config):
                             fil.write(chunk)
 
                     _LOGGER.debug("Downloading of %s done", url)
+                    hass.components.persistent_notification.create(
+                                    'Info: {} download finished successfully'.format(filename),
+                                    title='Download Request',
+                                    notification_id='download_request')
 
             except requests.exceptions.ConnectionError:
                 _LOGGER.exception("ConnectionError occurred for %s", url)
+                hass.components.persistent_notification.create(
+                                    'Error: {} download failed'.format(filename),
+                                    title='Download Request',
+                                    notification_id='download_request')
 
                 # Remove file if we started downloading but failed
                 if final_path and os.path.isfile(final_path):


### PR DESCRIPTION
## Description:
Fire an event when download is completed or failed.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4916

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
