### PR TITLE
Script/gen_requirements: Ignore package families

### DIFF
--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -5,6 +5,7 @@ import os
 import pkgutil
 import re
 import sys
+import fnmatch
 
 COMMENT_REQUIREMENTS = (
     'RPi.GPIO',
@@ -93,10 +94,7 @@ TEST_REQUIREMENTS = (
 
 IGNORE_PACKAGES = (
     'homeassistant.components.recorder.models',
-)
-
-IGNORE_PACKAGE_FAMILIES = (
-    'homeassistant.components.homekit',
+    'homeassistant.components.homekit.*'
 )
 
 IGNORE_PIN = ('colorlog>2.1,<3', 'keyring>=9.3,<10.0', 'urllib3')
@@ -151,14 +149,6 @@ def comment_requirement(req):
     return any(ign in req for ign in COMMENT_REQUIREMENTS)
 
 
-def check_package_family(package):
-    """Return true if package belongs to one of IGNORE_PACKAGE_FAMILIES."""
-    for family in IGNORE_PACKAGE_FAMILIES:
-        if family in package:
-            return True
-    return False
-
-
 def gather_modules():
     """Collect the information."""
     reqs = {}
@@ -170,11 +160,12 @@ def gather_modules():
         try:
             module = importlib.import_module(package)
         except ImportError:
-            if package in IGNORE_PACKAGES:
-                continue
-            if check_package_family(package):
-                continue
-            errors.append(package)
+            for pattern in IGNORE_PACKAGES:
+                if fnmatch.fnmatch(package, pattern):
+                    break
+            else:
+                errors.append(package)
+            continue
 
         if not getattr(module, 'REQUIREMENTS', None):
             continue

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -93,12 +93,10 @@ TEST_REQUIREMENTS = (
 
 IGNORE_PACKAGES = (
     'homeassistant.components.recorder.models',
-    'homeassistant.components.homekit.accessories',
-    'homeassistant.components.homekit.covers',
-    'homeassistant.components.homekit.security_systems',
-    'homeassistant.components.homekit.sensors',
-    'homeassistant.components.homekit.switches',
-    'homeassistant.components.homekit.thermostats'
+)
+
+IGNORE_PACKAGE_FAMILIES = (
+    'homeassistant.components.homekit',
 )
 
 IGNORE_PIN = ('colorlog>2.1,<3', 'keyring>=9.3,<10.0', 'urllib3')
@@ -153,6 +151,14 @@ def comment_requirement(req):
     return any(ign in req for ign in COMMENT_REQUIREMENTS)
 
 
+def check_package_family(package):
+    """Return true if package belongs to one of IGNORE_PACKAGE_FAMILIES."""
+    for family in IGNORE_PACKAGE_FAMILIES:
+        if family in package:
+            return True
+    return False
+
+
 def gather_modules():
     """Collect the information."""
     reqs = {}
@@ -164,9 +170,11 @@ def gather_modules():
         try:
             module = importlib.import_module(package)
         except ImportError:
-            if package not in IGNORE_PACKAGES:
-                errors.append(package)
-            continue
+            if package in IGNORE_PACKAGES:
+                continue
+            if check_package_family(package):
+                continue
+            errors.append(package)
 
         if not getattr(module, 'REQUIREMENTS', None):
             continue


### PR DESCRIPTION
## Description:
Added an option to exclude whole package families. Instead of providing a list with all packages.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**