### PR TITLE
Pin lokalise script to working version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script: travis_wait 30 tox --develop
 services:
   - docker
 before_deploy:
-  - docker pull lokalise/lokalise-cli
+  - docker pull lokalise/lokalise-cli@sha256:79b3108211ed1fcc9f7b09a011bfc53c240fc2f3b7fa7f0c8390f593271b4cd7
 deploy:
   skip_cleanup: true
   provider: script

--- a/script/translations_download
+++ b/script/translations_download
@@ -26,10 +26,9 @@ FILE_FORMAT=json
 
 mkdir -p ${LOCAL_DIR}
 
-docker pull lokalise/lokalise-cli
 docker run \
      -v ${LOCAL_DIR}:/opt/dest/locale \
-     lokalise/lokalise-cli lokalise \
+     lokalise/lokalise-cli@sha256:79b3108211ed1fcc9f7b09a011bfc53c240fc2f3b7fa7f0c8390f593271b4cd7 lokalise \
      --token ${LOKALISE_TOKEN} \
      export ${PROJECT_ID} \
      --export_empty skip \

--- a/script/translations_upload
+++ b/script/translations_upload
@@ -33,10 +33,9 @@ fi
 
 script/translations_upload_merge.py
 
-docker pull lokalise/lokalise-cli
 docker run \
     -v ${LOCAL_FILE}:/opt/src/${LOCAL_FILE} \
-    lokalise/lokalise-cli lokalise \
+    lokalise/lokalise-cli@sha256:79b3108211ed1fcc9f7b09a011bfc53c240fc2f3b7fa7f0c8390f593271b4cd7 lokalise \
     --token ${LOKALISE_TOKEN} \
     import ${PROJECT_ID} \
     --file /opt/src/${LOCAL_FILE} \


### PR DESCRIPTION
## Description:
There was a recent regression in the Lokalise upload script that caused it to fail: https://travis-ci.org/home-assistant/home-assistant/jobs/349988656#L650

This PR pins the script to a working version. Unfortunately Lokalise upstream isn't tagging any version numbers, so we're just pinned to the last working digest for now.

See also: https://github.com/home-assistant/home-assistant-polymer/pull/976