### PR TITLE
Fix Sonos group discovery

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -432,6 +432,10 @@ class SonosDevice(MediaPlayerDevice):
         """Add event subscriptions."""
         player = self.soco
 
+        # New player available, build the current group topology
+        for device in self.hass.data[DATA_SONOS].devices:
+            device.process_zonegrouptopology_event(None)
+
         queue = _ProcessSonosEventQueue(self.process_avtransport_event)
         player.avTransport.subscribe(auto_renew=True, event_queue=queue)
 
@@ -517,11 +521,11 @@ class SonosDevice(MediaPlayerDevice):
 
     def process_zonegrouptopology_event(self, event):
         """Process a zone group topology event coming from a player."""
-        if not hasattr(event, 'zone_player_uui_ds_in_group'):
+        if event and not hasattr(event, 'zone_player_uui_ds_in_group'):
             return
 
         with self.hass.data[DATA_SONOS].topology_lock:
-            group = event.zone_player_uui_ds_in_group
+            group = event and event.zone_player_uui_ds_in_group
             if group:
                 # New group information is pushed
                 coordinator_uid, *slave_uids = group.split(',')

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -122,11 +122,13 @@ class SoCoMock():
         return
 
 
-def fake_add_device(devices, update_befor_add=False):
-    """Fake add device / update."""
-    if update_befor_add:
-        for speaker in devices:
-            speaker.update()
+def add_devices_factory(hass):
+    """Add devices factory."""
+    def add_devices(devices, update_befor_add=False):
+        """Fake add device."""
+        hass.data[sonos.DATA_SONOS].devices = devices
+
+    return add_devices
 
 
 class TestSonosMediaPlayer(unittest.TestCase):
@@ -156,7 +158,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch('socket.create_connection', side_effect=socket.error())
     def test_ensure_setup_discovery(self, *args):
         """Test a single device using the autodiscovery provided by HASS."""
-        sonos.setup_platform(self.hass, {}, fake_add_device, {
+        sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass), {
             'host': '192.0.2.1'
         })
 
@@ -260,7 +262,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch('socket.create_connection', side_effect=socket.error())
     def test_ensure_setup_sonos_discovery(self, *args):
         """Test a single device using the autodiscovery provided by Sonos."""
-        sonos.setup_platform(self.hass, {}, fake_add_device)
+        sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass))
         devices = self.hass.data[sonos.DATA_SONOS].devices
         self.assertEqual(len(devices), 1)
         self.assertEqual(devices[0].name, 'Kitchen')
@@ -270,7 +272,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(SoCoMock, 'set_sleep_timer')
     def test_sonos_set_sleep_timer(self, set_sleep_timerMock, *args):
         """Ensuring soco methods called for sonos_set_sleep_timer service."""
-        sonos.setup_platform(self.hass, {}, fake_add_device, {
+        sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass), {
             'host': '192.0.2.1'
         })
         device = self.hass.data[sonos.DATA_SONOS].devices[-1]
@@ -284,7 +286,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(SoCoMock, 'set_sleep_timer')
     def test_sonos_clear_sleep_timer(self, set_sleep_timerMock, *args):
         """Ensuring soco methods called for sonos_clear_sleep_timer service."""
-        sonos.setup_platform(self.hass, {}, mock.MagicMock(), {
+        sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass), {
             'host': '192.0.2.1'
         })
         device = self.hass.data[sonos.DATA_SONOS].devices[-1]
@@ -298,7 +300,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch('socket.create_connection', side_effect=socket.error())
     def test_update_alarm(self, soco_mock, alarm_mock, *args):
         """Ensuring soco methods called for sonos_set_sleep_timer service."""
-        sonos.setup_platform(self.hass, {}, fake_add_device, {
+        sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass), {
             'host': '192.0.2.1'
         })
         device = self.hass.data[sonos.DATA_SONOS].devices[-1]
@@ -328,7 +330,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     @mock.patch.object(soco.snapshot.Snapshot, 'snapshot')
     def test_sonos_snapshot(self, snapshotMock, *args):
         """Ensuring soco methods called for sonos_snapshot service."""
-        sonos.setup_platform(self.hass, {}, fake_add_device, {
+        sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass), {
             'host': '192.0.2.1'
         })
         device = self.hass.data[sonos.DATA_SONOS].devices[-1]
@@ -346,7 +348,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         """Ensuring soco methods called for sonos_restor service."""
         from soco.snapshot import Snapshot
 
-        sonos.setup_platform(self.hass, {}, fake_add_device, {
+        sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass), {
             'host': '192.0.2.1'
         })
         device = self.hass.data[sonos.DATA_SONOS].devices[-1]


### PR DESCRIPTION
## Description:

I did not test `discovery:` very well with the recent Sonos rework and it turns out that two races are possible because it adds devices one by one:
* We could `schedule_update_ha_state` on a slave that was not yet `async_added_to_hass`.
* Slaves discovered after their group coordinator were not linked properly.

## Example entry for `configuration.yaml` (if applicable):
```yaml
discovery:
```

## Checklist:
  - [X] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully.
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).</s>
  - [ ] <s>New dependencies are only imported inside functions that use them ([example][ex-import]).</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54