### PR TITLE
Support to hide accessories in HomeKit

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -30,6 +30,7 @@ BRIDGE_NAME = 'Home Assistant'
 CONF_PIN_CODE = 'pincode'
 
 HOMEKIT_FILE = '.homekit.state'
+HOMEKIT_HIDDEN = 'homekit_hidden'
 
 
 def valid_pin(value):
@@ -75,6 +76,12 @@ def import_types():
 
 def get_accessory(hass, state):
     """Take state and return an accessory object if supported."""
+
+    # Do not add accessories that should be hidden in HomeKit
+    hidden = state.attributes.get(HOMEKIT_HIDDEN)
+    if hidden:
+        return None
+
     if state.domain == 'sensor':
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         if unit == TEMP_CELSIUS or unit == TEMP_FAHRENHEIT:


### PR DESCRIPTION
## Description:

Add support to hide accessories in HomeKit by setting `homekit_hidden: True` in customize.yaml.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4857

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**