### PR TITLE
Support for security systems controlled by IFTTT

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -309,6 +309,7 @@ omit =
     homeassistant/components/alarm_control_panel/canary.py
     homeassistant/components/alarm_control_panel/concord232.py
     homeassistant/components/alarm_control_panel/ialarm.py
+    homeassistant/components/alarm_control_panel/ifttt.py
     homeassistant/components/alarm_control_panel/manual_mqtt.py
     homeassistant/components/alarm_control_panel/nx584.py
     homeassistant/components/alarm_control_panel/simplisafe.py

--- a/homeassistant/components/alarm_control_panel/ifttt.py
+++ b/homeassistant/components/alarm_control_panel/ifttt.py
@@ -76,25 +76,25 @@ class IFTTTAlarmPanel(alarm.AlarmControlPanel):
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""
-        if not self._check_code(code)
+        if not self._check_code(code):
             return
         self.set_alarm_state(STATE_ALARM_DISARMED, code)
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
-        if not self._check_code(code)
+        if not self._check_code(code):
             return
         self.set_alarm_state(STATE_ALARM_ARMED_AWAY, code)
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
-        if not self._check_code(code)
+        if not self._check_code(code):
             return
         self.set_alarm_state(STATE_ALARM_ARMED_HOME, code)
 
     def alarm_arm_night(self, code=None):
         """Send arm night command."""
-        if not self._check_code(code)
+        if not self._check_code(code):
             return
         self.set_alarm_state(STATE_ALARM_ARMED_NIGHT, code)
 

--- a/homeassistant/components/alarm_control_panel/ifttt.py
+++ b/homeassistant/components/alarm_control_panel/ifttt.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_NAME, CONF_CODE)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['requests>=2.18.4', 'pyfttt>=0.3']
+REQUIREMENTS = ['requests==2.18.4', 'pyfttt==0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/alarm_control_panel/ifttt.py
+++ b/homeassistant/components/alarm_control_panel/ifttt.py
@@ -52,7 +52,6 @@ class IFTTTAlarmPanel(alarm.AlarmControlPanel):
 
     def __init__(self, name, webhook_key, code):
         """Initialize the alarm control panel."""
-
         self._name = name
         self._webhook_key = webhook_key
         self._code = code

--- a/homeassistant/components/alarm_control_panel/ifttt.py
+++ b/homeassistant/components/alarm_control_panel/ifttt.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME, SERVICE_ALARM_ARM_HOME,
     STATE_ALARM_ARMED_NIGHT, SERVICE_ALARM_ARM_NIGHT,
     STATE_ALARM_DISARMED, SERVICE_ALARM_DISARM,
-    CONF_NAME)
+    CONF_NAME, CONF_CODE)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['requests>=2.18.4', 'pyfttt>=0.3']
@@ -33,6 +33,7 @@ STATE_TO_SERVICE = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_WEBHOOK_KEY): cv.string,
+    vol.Optional(CONF_CODE, default=None): cv.string,
 })
 
 
@@ -40,19 +41,21 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a control panel managed through IFTTT."""
     name = config.get(CONF_NAME)
     webhook_key = config.get(CONF_WEBHOOK_KEY)
+    code = config.get(CONF_CODE)
 
-    alarmpanel = IFTTTAlarmPanel(name, webhook_key)
+    alarmpanel = IFTTTAlarmPanel(name, webhook_key, code)
     add_devices([alarmpanel], True)
 
 
 class IFTTTAlarmPanel(alarm.AlarmControlPanel):
     """Representation of an alarm control panel controlled throught IFTTT."""
 
-    def __init__(self, name, webhook_key):
+    def __init__(self, name, webhook_key, code):
         """Initialize the alarm control panel."""
 
         self._name = name
         self._webhook_key = webhook_key
+        self._code = code
         # Set default state to disarmed
         self._state = STATE_ALARM_DISARMED
 
@@ -66,23 +69,36 @@ class IFTTTAlarmPanel(alarm.AlarmControlPanel):
         """Return the state of the device."""
         return self._state
 
+    @property
+    def code_format(self):
+        """Return one or more characters."""
+        return None if self._code is None else '.+'
+
     def alarm_disarm(self, code=None):
         """Send disarm command."""
-        self.set_alarm_state(STATE_ALARM_DISARMED)
+        if not self._check_code(code)
+            return
+        self.set_alarm_state(STATE_ALARM_DISARMED, code)
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
-        self.set_alarm_state(STATE_ALARM_ARMED_AWAY)
+        if not self._check_code(code)
+            return
+        self.set_alarm_state(STATE_ALARM_ARMED_AWAY, code)
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
-        self.set_alarm_state(STATE_ALARM_ARMED_HOME)
+        if not self._check_code(code)
+            return
+        self.set_alarm_state(STATE_ALARM_ARMED_HOME, code)
 
     def alarm_arm_night(self, code=None):
         """Send arm night command."""
-        self.set_alarm_state(STATE_ALARM_ARMED_NIGHT)
+        if not self._check_code(code)
+            return
+        self.set_alarm_state(STATE_ALARM_ARMED_NIGHT, code)
 
-    def set_alarm_state(self, state):
+    def set_alarm_state(self, state, code):
         """Call the IFTTT webhook to change the alarm state."""
         import pyfttt
         import requests
@@ -98,3 +114,6 @@ class IFTTTAlarmPanel(alarm.AlarmControlPanel):
             _LOGGER.debug("Called IFTTT webhook to set state {}", state)
         except requests.exceptions.RequestException:
             _LOGGER.exception("Error communicating with IFTTT")
+
+    def _check_code(self, code):
+        return self._code is None or self._code == code

--- a/homeassistant/components/alarm_control_panel/ifttt.py
+++ b/homeassistant/components/alarm_control_panel/ifttt.py
@@ -1,0 +1,100 @@
+"""
+Interfaces with alarm control panels that have to be controlled through IFTTT.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_control_panel.ifttt_securitysystem/
+"""
+import logging
+import voluptuous as vol
+
+import homeassistant.components.alarm_control_panel as alarm
+from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
+from homeassistant.const import (
+    STATE_ALARM_ARMED_AWAY, SERVICE_ALARM_ARM_AWAY,
+    STATE_ALARM_ARMED_HOME, SERVICE_ALARM_ARM_HOME,
+    STATE_ALARM_ARMED_NIGHT, SERVICE_ALARM_ARM_NIGHT,
+    STATE_ALARM_DISARMED, SERVICE_ALARM_DISARM,
+    CONF_NAME)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['requests>=2.18.4', 'pyfttt>=0.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_WEBHOOK_KEY = "webhook_key"
+DEFAULT_NAME = "Home"
+
+STATE_TO_SERVICE = {
+    STATE_ALARM_ARMED_AWAY: SERVICE_ALARM_ARM_AWAY,
+    STATE_ALARM_ARMED_HOME: SERVICE_ALARM_ARM_HOME,
+    STATE_ALARM_ARMED_NIGHT: SERVICE_ALARM_ARM_NIGHT,
+    STATE_ALARM_DISARMED: SERVICE_ALARM_DISARM}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Required(CONF_WEBHOOK_KEY): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up a control panel managed through IFTTT."""
+    name = config.get(CONF_NAME)
+    webhook_key = config.get(CONF_WEBHOOK_KEY)
+
+    alarmpanel = IFTTTAlarmPanel(name, webhook_key)
+    add_devices([alarmpanel], True)
+
+
+class IFTTTAlarmPanel(alarm.AlarmControlPanel):
+    """Representation of an alarm control panel controlled throught IFTTT."""
+
+    def __init__(self, name, webhook_key):
+        """Initialize the alarm control panel."""
+
+        self._name = name
+        self._webhook_key = webhook_key
+        # Set default state to disarmed
+        self._state = STATE_ALARM_DISARMED
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    def alarm_disarm(self, code=None):
+        """Send disarm command."""
+        self.set_alarm_state(STATE_ALARM_DISARMED)
+
+    def alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        self.set_alarm_state(STATE_ALARM_ARMED_AWAY)
+
+    def alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        self.set_alarm_state(STATE_ALARM_ARMED_HOME)
+
+    def alarm_arm_night(self, code=None):
+        """Send arm night command."""
+        self.set_alarm_state(STATE_ALARM_ARMED_NIGHT)
+
+    def set_alarm_state(self, state):
+        """Call the IFTTT webhook to change the alarm state."""
+        import pyfttt
+        import requests
+
+        try:
+            # Translate the state to a service/event name
+            event = STATE_TO_SERVICE[state]
+
+            # Send the webhook request
+            pyfttt.send_event(self._webhook_key, event)
+            # IFTTT should be configured to also call the API to change state
+
+            _LOGGER.debug("Called IFTTT webhook to set state {}", state)
+        except requests.exceptions.RequestException:
+            _LOGGER.exception("Error communicating with IFTTT")

--- a/homeassistant/components/alarm_control_panel/ifttt.py
+++ b/homeassistant/components/alarm_control_panel/ifttt.py
@@ -27,7 +27,7 @@ EVENT_ALARM_DISARM = "alarm_disarm"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_CODE, default=None): cv.string,
+    vol.Optional(CONF_CODE): cv.string,
 })
 
 

--- a/homeassistant/components/alarm_control_panel/ifttt.py
+++ b/homeassistant/components/alarm_control_panel/ifttt.py
@@ -111,7 +111,7 @@ class IFTTTAlarmPanel(alarm.AlarmControlPanel):
             pyfttt.send_event(self._webhook_key, event)
             # IFTTT should be configured to also call the API to change state
 
-            _LOGGER.debug("Called IFTTT webhook to set state {}", state)
+            _LOGGER.debug("Called IFTTT webhook to set state %s", state)
         except requests.exceptions.RequestException:
             _LOGGER.exception("Error communicating with IFTTT")
 

--- a/homeassistant/components/alarm_control_panel/services.yaml
+++ b/homeassistant/components/alarm_control_panel/services.yaml
@@ -69,3 +69,13 @@ alarmdecoder_alarm_toggle_chime:
     code:
       description: A required code to toggle the alarm control panel chime with.
       example: 1234
+
+push_alarm_state:
+  description: Update the alarm state to the specified value.
+  fields:
+    entity_id:
+      description: Name of the alarm control panel which state has to be updated.
+      example: 'alarm_control_panel.downstairs'
+    state:
+      description: The state to which the alarm control panel has to be set.
+      example: 'armed_night'

--- a/homeassistant/components/alarm_control_panel/services.yaml
+++ b/homeassistant/components/alarm_control_panel/services.yaml
@@ -70,7 +70,7 @@ alarmdecoder_alarm_toggle_chime:
       description: A required code to toggle the alarm control panel chime with.
       example: 1234
 
-push_alarm_state:
+ifttt_push_alarm_state:
   description: Update the alarm state to the specified value.
   fields:
     entity_id:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -737,7 +737,6 @@ pyfido==2.1.0
 pyflexit==0.3
 
 # homeassistant.components.ifttt
-# homeassistant.components.alarm_control_panel.ifttt
 pyfttt==0.3
 
 # homeassistant.components.remote.harmony
@@ -1059,9 +1058,6 @@ raincloudy==0.0.4
 
 # homeassistant.components.switch.rainmachine
 regenmaschine==0.4.1
-
-# homeassistant.components.alarm_control_panel.ifttt
-requests==2.18.4
 
 # homeassistant.components.python_script
 restrictedpython==4.0b2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -737,6 +737,7 @@ pyfido==2.1.0
 pyflexit==0.3
 
 # homeassistant.components.ifttt
+# homeassistant.components.alarm_control_panel.ifttt
 pyfttt==0.3
 
 # homeassistant.components.remote.harmony
@@ -1058,6 +1059,9 @@ raincloudy==0.0.4
 
 # homeassistant.components.switch.rainmachine
 regenmaschine==0.4.1
+
+# homeassistant.components.alarm_control_panel.ifttt
+requests==2.18.4
 
 # homeassistant.components.python_script
 restrictedpython==4.0b2


### PR DESCRIPTION
## Description:

Added support for security systems that have no open API but can be controlled via IFTTT (e.g. piper, ismartalarm, ...). To set the security system to a specific state, a webhook call is made to change the device state. Furthermore, applets have to be made to call home assistant's REST API when the device's state has changed.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4878

## Example entry for `configuration.yaml` (if applicable):
```yaml
ifttt:
  key: !secret webhook_key

alarm_control_panel:
  - platform: ifttt
    name: "IFTTT Alarm"
    code: !secret alarm_code
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.