### PR TITLE
Show the error message when Zabbix fails to log in

### DIFF
--- a/homeassistant/components/zabbix.py
+++ b/homeassistant/components/zabbix.py
@@ -52,8 +52,8 @@ def setup(hass, config):
     try:
         zapi.login(username, password)
         _LOGGER.info("Connected to Zabbix API Version %s", zapi.api_version())
-    except ZabbixAPIException as e:
-        _LOGGER.error("Unable to login to the Zabbix API: %s", e)
+    except ZabbixAPIException as login_exception:
+        _LOGGER.error("Unable to login to the Zabbix API: %s", login_exception)
         return False
 
     hass.data[DOMAIN] = zapi

--- a/homeassistant/components/zabbix.py
+++ b/homeassistant/components/zabbix.py
@@ -52,8 +52,8 @@ def setup(hass, config):
     try:
         zapi.login(username, password)
         _LOGGER.info("Connected to Zabbix API Version %s", zapi.api_version())
-    except ZabbixAPIException:
-        _LOGGER.error("Unable to login to the Zabbix API")
+    except ZabbixAPIException as e:
+        _LOGGER.error("Unable to login to the Zabbix API: %s", e)
         return False
 
     hass.data[DOMAIN] = zapi


### PR DESCRIPTION
## Description:
Currently, zabbix issues show the message "Unable to log into the zabbix API" in the log whatever the actual error is (username/password, http connectivity, ssl issues, etc.). This is not useful for troubleshooting/debugging. The exception raised by PyZabbix contains a more detailed error message, which I have added to the log.

**Related issue (if applicable):** N/A, no current issue

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A, no documentation changes

## Example entry for `configuration.yaml` (if applicable):
N/A, no configuration changes

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
