### PR TITLE
Added switch component to Amcrest IP Camera.

### DIFF
--- a/homeassistant/components/amcrest.py
+++ b/homeassistant/components/amcrest.py
@@ -13,11 +13,11 @@ from requests.exceptions import HTTPError, ConnectTimeout
 
 from homeassistant.const import (
     CONF_NAME, CONF_HOST, CONF_PORT, CONF_USERNAME, CONF_PASSWORD,
-    CONF_SENSORS, CONF_SCAN_INTERVAL, HTTP_BASIC_AUTHENTICATION)
+    CONF_SENSORS, CONF_SWITCHES, CONF_SCAN_INTERVAL, HTTP_BASIC_AUTHENTICATION)
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['amcrest==1.2.1']
+REQUIREMENTS = ['amcrest==1.2.2']
 DEPENDENCIES = ['ffmpeg']
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,6 +63,12 @@ SENSORS = {
     'ptz_preset': ['PTZ Preset', None, 'mdi:camera-iris'],
 }
 
+# Switch types are defined like: Name, icon
+SWITCHES = {
+    'motion_detection': ['Motion Detection', 'mdi:run-fast'],
+    'motion_recording': ['Motion Recording', 'mdi:record-rec']
+}
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.All(cv.ensure_list, [vol.Schema({
         vol.Required(CONF_HOST): cv.string,
@@ -81,6 +87,8 @@ CONFIG_SCHEMA = vol.Schema({
             cv.time_period,
         vol.Optional(CONF_SENSORS):
             vol.All(cv.ensure_list, [vol.In(SENSORS)]),
+        vol.Optional(CONF_SWITCHES):
+            vol.All(cv.ensure_list, [vol.In(SWITCHES)]),
     })])
 }, extra=vol.ALLOW_EXTRA)
 
@@ -114,6 +122,7 @@ def setup(hass, config):
         name = device.get(CONF_NAME)
         resolution = RESOLUTION_LIST[device.get(CONF_RESOLUTION)]
         sensors = device.get(CONF_SENSORS)
+        switches = device.get(CONF_SWITCHES)
         stream_source = STREAM_SOURCE_LIST[device.get(CONF_STREAM_SOURCE)]
 
         username = device.get(CONF_USERNAME)
@@ -141,6 +150,13 @@ def setup(hass, config):
                 hass, 'sensor', DOMAIN, {
                     CONF_NAME: name,
                     CONF_SENSORS: sensors,
+                }, config)
+
+        if switches:
+            discovery.load_platform(
+                hass, 'switch', DOMAIN, {
+                    CONF_NAME: name,
+                    CONF_SWITCHES: switches
                 }, config)
 
     return True

--- a/homeassistant/components/switch/amcrest.py
+++ b/homeassistant/components/switch/amcrest.py
@@ -11,12 +11,11 @@ from homeassistant.components.amcrest import (
     DATA_AMCREST, SWITCHES)
 
 from homeassistant.const import (
-    CONF_NAME, CONF_SWITCHES, STATE_UNKNOWN, STATE_OFF, STATE_ON)
+    CONF_NAME, CONF_SWITCHES, STATE_OFF, STATE_ON)
 from homeassistant.helpers.entity import ToggleEntity
 
 DEPENDENCIES = ['amcrest']
 
-REQUIREMENTS = ['amcrest==1.2.2']
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -70,8 +69,6 @@ class AmcrestSwitch(ToggleEntity):
             self._camera.motion_detection = 'true'
         elif self._setting == 'motion_recording':
             self._camera.motion_recording = 'true'
-        else:
-            _LOGGER.error("Can't turn on unknown setting: %s", self._setting)
 
     def turn_off(self, **kwargs):
         """Turn setting off."""
@@ -79,8 +76,6 @@ class AmcrestSwitch(ToggleEntity):
             self._camera.motion_detection = 'false'
         elif self._setting == 'motion_recording':
             self._camera.motion_recording = 'false'
-        else:
-            _LOGGER.error("Can't turn on unknown setting: %s", self._setting)
 
     def update(self):
         """Update setting state."""
@@ -90,11 +85,6 @@ class AmcrestSwitch(ToggleEntity):
             detection = self._camera.is_motion_detector_on()
         elif self._setting == 'motion_recording':
             detection = self._camera.is_record_on_motion_detection()
-        else:
-            _LOGGER.error("Can't update state for unknown setting: %s",
-                          self._setting)
-            self._state = STATE_UNKNOWN
-            return
 
         self._state = STATE_ON if detection else STATE_OFF
 

--- a/homeassistant/components/switch/amcrest.py
+++ b/homeassistant/components/switch/amcrest.py
@@ -7,21 +7,19 @@ https://home-assistant.io/components/switch.amcrest/
 import asyncio
 import logging
 
-from homeassistant.components.amcrest import (
-    DATA_AMCREST, SWITCHES)
-
+from homeassistant.components.amcrest import DATA_AMCREST, SWITCHES
 from homeassistant.const import (
     CONF_NAME, CONF_SWITCHES, STATE_OFF, STATE_ON)
 from homeassistant.helpers.entity import ToggleEntity
 
-DEPENDENCIES = ['amcrest']
-
 _LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['amcrest']
 
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-    """Set up the IP camera switch platform."""
+    """Set up the IP Amcrest camera switch platform."""
     if discovery_info is None:
         return
 
@@ -38,10 +36,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
 
 class AmcrestSwitch(ToggleEntity):
-    """An abstract class for an IP camera setting."""
+    """Representation of an Amcrest IP camera switch."""
 
     def __init__(self, setting, camera):
-        """Initialize the switch."""
+        """Initialize the Amcrest switch."""
         self._setting = setting
         self._camera = camera
         self._name = SWITCHES[setting][0]

--- a/homeassistant/components/switch/amcrest.py
+++ b/homeassistant/components/switch/amcrest.py
@@ -47,12 +47,7 @@ class AmcrestSwitch(ToggleEntity):
         self._camera = camera
         self._name = SWITCHES[setting][0]
         self._icon = SWITCHES[setting][1]
-        self._state = STATE_UNKNOWN
-
-    @property
-    def should_poll(self):
-        """Poll for status regularly."""
-        return True
+        self._state = None
 
     @property
     def name(self):

--- a/homeassistant/components/switch/amcrest.py
+++ b/homeassistant/components/switch/amcrest.py
@@ -1,0 +1,109 @@
+"""
+Support for toggling Amcrest IP camera settings.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.amcrest/
+"""
+import asyncio
+import logging
+
+from homeassistant.components.amcrest import (
+    DATA_AMCREST, SWITCHES)
+
+from homeassistant.const import (
+    CONF_NAME, CONF_SWITCHES, STATE_UNKNOWN, STATE_OFF, STATE_ON)
+from homeassistant.helpers.entity import ToggleEntity
+
+DEPENDENCIES = ['amcrest']
+
+REQUIREMENTS = ['amcrest==1.2.2']
+_LOGGER = logging.getLogger(__name__)
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the IP camera switch platform."""
+    if discovery_info is None:
+        return
+
+    name = discovery_info[CONF_NAME]
+    switches = discovery_info[CONF_SWITCHES]
+    camera = hass.data[DATA_AMCREST][name].device
+
+    all_switches = []
+
+    for setting in switches:
+        all_switches.append(AmcrestSwitch(setting, camera))
+
+    async_add_devices(all_switches, True)
+
+
+class AmcrestSwitch(ToggleEntity):
+    """An abstract class for an IP camera setting."""
+
+    def __init__(self, setting, camera):
+        """Initialize the switch."""
+        self._setting = setting
+        self._camera = camera
+        self._name = SWITCHES[setting][0]
+        self._icon = SWITCHES[setting][1]
+        self._state = STATE_UNKNOWN
+
+    @property
+    def should_poll(self):
+        """Poll for status regularly."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the switch if any."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the switch."""
+        return self._state
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._state == STATE_ON
+
+    def turn_on(self, **kwargs):
+        """Turn setting on."""
+        if self._setting == 'motion_detection':
+            self._camera.motion_detection = 'true'
+        elif self._setting == 'motion_recording':
+            self._camera.motion_recording = 'true'
+        else:
+            _LOGGER.error("Can't turn on unknown setting: %s", self._setting)
+
+    def turn_off(self, **kwargs):
+        """Turn setting off."""
+        if self._setting == 'motion_detection':
+            self._camera.motion_detection = 'false'
+        elif self._setting == 'motion_recording':
+            self._camera.motion_recording = 'false'
+        else:
+            _LOGGER.error("Can't turn on unknown setting: %s", self._setting)
+
+    def update(self):
+        """Update setting state."""
+        _LOGGER.debug("Polling state for setting: %s ", self._name)
+
+        if self._setting == 'motion_detection':
+            detection = self._camera.is_motion_detector_on()
+        elif self._setting == 'motion_recording':
+            detection = self._camera.is_record_on_motion_detection()
+        else:
+            _LOGGER.error("Can't update state for unknown setting: %s",
+                          self._setting)
+            self._state = STATE_UNKNOWN
+            return
+
+        self._state = STATE_ON if detection else STATE_OFF
+
+    @property
+    def icon(self):
+        """Return the icon for the switch."""
+        return self._icon

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -95,7 +95,6 @@ alarmdecoder==1.13.2
 alpha_vantage==1.9.0
 
 # homeassistant.components.amcrest
-# homeassistant.components.switch.amcrest
 amcrest==1.2.2
 
 # homeassistant.components.media_player.anthemav

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -95,7 +95,8 @@ alarmdecoder==1.13.2
 alpha_vantage==1.9.0
 
 # homeassistant.components.amcrest
-amcrest==1.2.1
+# homeassistant.components.switch.amcrest
+amcrest==1.2.2
 
 # homeassistant.components.media_player.anthemav
 anthemav==1.1.8


### PR DESCRIPTION
## Description:
This PR adds a switch component to the existing Amcrest IP camera platform. There are currently implemented switches for toggling motion detection, as well as recording on motion detection. This PR is based on #7876, which was closed due to inactivity. 

**Related issue (if applicable):** None

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4862

## Example entry for `configuration.yaml` (if applicable):
```yaml
amcrest:
  - host: HOST_IP
    username: !secret amcrest_username
    password: !secret amcrest_password
    sensors:
      - motion_detector
      - sdcard
      - ptz_preset
    switches:
      - motion_detection
      - motion_recording
    resolution: low
    port: 80
    stream_source: rtsp
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
