### PR TITLE
Fixes notify.html5 for notifications on FireFox

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -404,8 +404,11 @@ class HTML5NotificationService(BaseNotificationService):
             jwt_token = jwt.encode(jwt_claims, jwt_secret).decode('utf-8')
             payload[ATTR_DATA][ATTR_JWT] = jwt_token
 
-            # Only pass the gcm key if we're actually using GCM, if we don't, notifications break on FireFox
-            gcm_key = self._gcm_key if 'googleapis.com' in info[ATTR_SUBSCRIPTION][ATTR_ENDPOINT] else None
+            # Only pass the gcm key if we're actually using GCM
+            # If we don't, notifications break on FireFox
+            gcm_key = self._gcm_key \
+                if 'googleapis.com' in info[ATTR_SUBSCRIPTION][ATTR_ENDPOINT] \
+                else None
             response = WebPusher(info[ATTR_SUBSCRIPTION]).send(
                 json.dumps(payload), gcm_key=gcm_key, ttl='86400'
             )

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -404,8 +404,11 @@ class HTML5NotificationService(BaseNotificationService):
             jwt_token = jwt.encode(jwt_claims, jwt_secret).decode('utf-8')
             payload[ATTR_DATA][ATTR_JWT] = jwt_token
 
+            # Only pass the gcm key if we're actually using GCM, if we don't, notifications break on FireFox
+            gcm_key = self._gcm_key if 'googleapis.com' in info[ATTR_SUBSCRIPTION][ATTR_ENDPOINT] else None
             response = WebPusher(info[ATTR_SUBSCRIPTION]).send(
-                json.dumps(payload), gcm_key=self._gcm_key, ttl='86400')
+                json.dumps(payload), gcm_key=gcm_key, ttl='86400'
+            )
 
             # pylint: disable=no-member
             if response.status_code == 410:


### PR DESCRIPTION
## Description:

This small PR fixes the broken HTML5 notifications on FireFox. For notification endpoints other than GCM, no `gcm_key` should be passed to `pywebpush.WebPusher.send()`, or the notification will not be send.

**Related issue:** fixes #11643 

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: html5
    gcm_api_key: !secret gcm_server_key
    gcm_sender_id: !secret gcm_sender_id
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~~Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~~

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
