### PR TITLE
Check color temp range for google assistant

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -330,9 +330,20 @@ class ColorTemperatureTrait(_Trait):
 
     async def execute(self, hass, command, params):
         """Execute a color temperature command."""
+        temp = color_util.color_temperature_kelvin_to_mired(
+            params['color']['temperature'])
+        min_temp = self.state.attributes[light.ATTR_MIN_MIREDS]
+        max_temp = self.state.attributes[light.ATTR_MAX_MIREDS]
+
+        if temp < min_temp or temp > max_temp:
+            raise SmartHomeError(
+                ERR_VALUE_OUT_OF_RANGE,
+                "Temperature should be between {} and {}".format(min_temp,
+                                                                 max_temp))
+
         await hass.services.async_call(light.DOMAIN, SERVICE_TURN_ON, {
             ATTR_ENTITY_ID: self.state.entity_id,
-            light.ATTR_KELVIN: params['color']['temperature'],
+            light.ATTR_COLOR_TEMP: temp,
         }, blocking=True)
 
 


### PR DESCRIPTION
## Description:
Check if the color temperature that we're setting is within range of the light. Raise if not.


## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
