### PR TITLE
Fix sensibo's min/max_temp properties

### DIFF
--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -240,13 +240,13 @@ class SensiboClimate(ClimateDevice):
     def min_temp(self):
         """Return the minimum temperature."""
         return self._temperatures_list[0] \
-            if self._temperatures_list else super().min_temp()
+            if self._temperatures_list else super().min_temp
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
         return self._temperatures_list[-1] \
-            if self._temperatures_list else super().max_temp()
+            if self._temperatures_list else super().max_temp
 
     @asyncio.coroutine
     def async_set_temperature(self, **kwargs):


### PR DESCRIPTION
The super class has these as properties, not regular methods

## Description:

I've simply fixed the references to min_temp and max_temp to be properties, not method calls. I was getting exceptions about trying to call a 'float' object otherwise.

**Related issue (if applicable):** 
No open issue

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
na

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [na] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [na] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [na] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [na] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [na] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
