### PR TITLE
BMW device tracker - fix toggling state if vehicle tracking is disabled

### DIFF
--- a/homeassistant/components/device_tracker/bmw_connected_drive.py
+++ b/homeassistant/components/device_tracker/bmw_connected_drive.py
@@ -36,8 +36,17 @@ class BMWDeviceTracker(object):
         self.vehicle = vehicle
 
     def update(self) -> None:
-        """Update the device info."""
+        """Update the device info.
+
+        Only update the state in home assistant if tracking in
+        the car is enabled.
+        """
         dev_id = slugify(self.vehicle.name)
+
+        if not self.vehicle.state.is_vehicle_tracking_enabled:
+            _LOGGER.debug('Tracking is disabled for vehicle %s', dev_id)
+            return
+
         _LOGGER.debug('Updating %s', dev_id)
         attrs = {
             'trackr_id': dev_id,

--- a/homeassistant/components/device_tracker/bmw_connected_drive.py
+++ b/homeassistant/components/device_tracker/bmw_connected_drive.py
@@ -48,13 +48,8 @@ class BMWDeviceTracker(object):
             return
 
         _LOGGER.debug('Updating %s', dev_id)
-        attrs = {
-            'trackr_id': dev_id,
-            'id': dev_id,
-            'name': self.vehicle.name
-        }
+
         self._see(
             dev_id=dev_id, host_name=self.vehicle.name,
-            gps=self.vehicle.state.gps_position, attributes=attrs,
-            icon='mdi:car'
+            gps=self.vehicle.state.gps_position, icon='mdi:car'
         )


### PR DESCRIPTION
## Description:
If remote tracking is disabled in the vehicle, the position was toggling in the device tracker. Now, the position in the device trackier is only updated if remote tracking is enabled. 

**Related issue (if applicable):** fixes #https://github.com/home-assistant/home-assistant/issues/12698

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
no changes

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
