### PR TITLE
Add new platform for VeSync switches

### DIFF
--- a/homeassistant/components/switch/vesync.py
+++ b/homeassistant/components/switch/vesync.py
@@ -27,32 +27,29 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     switches = []
 
-    try:
-        manager = VeSync(config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
-    except ValueError:
-        _LOGGER.error("Unable to setup VeSync platform")
-    else:
-        if manager.login():
-            manager.update()
+    manager = VeSync(config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
 
-            if manager.devices is not None and manager.devices:
+    if not manager.login():
+        _LOGGER.error("Unable to login to VeSync")
+        return
 
-                if len(manager.devices) == 1:
-                    count_string = 'switch'
-                else:
-                    count_string = 'switches'
+    manager.update()
 
-                _LOGGER.info("Discovered %d VeSync %s",
-                             len(manager.devices), count_string)
-
-                for switch in manager.devices:
-                    switches.append(VeSyncSwitchHA(switch))
-                    _LOGGER.info("Added a VeSync switch named '%s'",
-                                 switch.device_name)
-            else:
-                _LOGGER.info("No VeSync devices found")
+    if manager.devices is not None and manager.devices:
+        if len(manager.devices) == 1:
+            count_string = 'switch'
         else:
-            _LOGGER.info("Unable to login to VeSync")
+            count_string = 'switches'
+
+        _LOGGER.info("Discovered %d VeSync %s",
+                        len(manager.devices), count_string)
+
+        for switch in manager.devices:
+            switches.append(VeSyncSwitchHA(switch))
+            _LOGGER.info("Added a VeSync switch named '%s'",
+                            switch.device_name)
+    else:
+        _LOGGER.info("No VeSync devices found")
 
     add_devices(switches)
 

--- a/homeassistant/components/switch/vesync.py
+++ b/homeassistant/components/switch/vesync.py
@@ -84,12 +84,12 @@ class VeSyncSwitchHA(SwitchDevice):
     @property
     def available(self) -> bool:
         """Return True if switch is available."""
-        return bool(self.smartplug.connection_status == "online")
+        return self.smartplug.connection_status == "online"
 
     @property
     def is_on(self):
         """Return True if switch is on."""
-        return bool(self.smartplug.device_status == "on")
+        return self.smartplug.device_status == "on"
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""

--- a/homeassistant/components/switch/vesync.py
+++ b/homeassistant/components/switch/vesync.py
@@ -15,9 +15,6 @@ REQUIREMENTS = ['pyvesync==0.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 
-API_BASE_URL = 'https://smartapi.vesync.com'
-API_RATE_LIMIT = 30
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,

--- a/homeassistant/components/switch/vesync.py
+++ b/homeassistant/components/switch/vesync.py
@@ -42,12 +42,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             count_string = 'switches'
 
         _LOGGER.info("Discovered %d VeSync %s",
-                        len(manager.devices), count_string)
+                     len(manager.devices), count_string)
 
         for switch in manager.devices:
             switches.append(VeSyncSwitchHA(switch))
             _LOGGER.info("Added a VeSync switch named '%s'",
-                            switch.device_name)
+                         switch.device_name)
     else:
         _LOGGER.info("No VeSync devices found")
 

--- a/homeassistant/components/switch/vesync.py
+++ b/homeassistant/components/switch/vesync.py
@@ -1,0 +1,110 @@
+"""
+Support for Etekcity VeSync switches.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.vesync/
+"""
+import logging
+import voluptuous as vol
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
+import homeassistant.helpers.config_validation as cv
+
+
+REQUIREMENTS = ['pyvesync==0.1.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+API_BASE_URL = 'https://smartapi.vesync.com'
+API_RATE_LIMIT = 30
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the VeSync switch platform."""
+    from pyvesync.vesync import VeSync
+
+    switches = []
+
+    try:
+        manager = VeSync(config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
+    except ValueError:
+        _LOGGER.error("Unable to setup VeSync platform")
+    else:
+        if manager.login():
+            manager.update()
+
+            if manager.devices is not None and manager.devices:
+
+                if len(manager.devices) == 1:
+                    count_string = 'switch'
+                else:
+                    count_string = 'switches'
+
+                _LOGGER.info("Discovered %d VeSync %s",
+                             len(manager.devices), count_string)
+
+                for switch in manager.devices:
+                    switches.append(VeSyncSwitchHA(switch))
+                    _LOGGER.info("Added a VeSync switch named '%s'",
+                                 switch.device_name)
+            else:
+                _LOGGER.info("No VeSync devices found")
+        else:
+            _LOGGER.info("Unable to login to VeSync")
+
+    add_devices(switches)
+
+
+class VeSyncSwitchHA(SwitchDevice):
+    """Representation of a VeSync switch."""
+
+    def __init__(self, plug):
+        """Initialize the VeSync switch device."""
+        self.smartplug = plug
+
+    @property
+    def unique_id(self):
+        """Return the ID of this switch."""
+        return self.smartplug.cid
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self.smartplug.device_name
+
+    @property
+    def current_power_w(self):
+        """Return the current power usage in W."""
+        return self.smartplug.get_power()
+
+    @property
+    def today_energy_kwh(self):
+        """Return the today total energy usage in kWh."""
+        return self.smartplug.get_kwh_today()
+
+    @property
+    def available(self) -> bool:
+        """Return True if switch is available."""
+        return bool(self.smartplug.connection_status == "online")
+
+    @property
+    def is_on(self):
+        """Return True if switch is on."""
+        return bool(self.smartplug.device_status == "on")
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        self.smartplug.turn_on()
+
+    def turn_off(self, **kwargs):
+        """Turn the switch off."""
+        self.smartplug.turn_off()
+
+    def update(self):
+        """Handle data changes for node values."""
+        self.smartplug.update()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1023,6 +1023,9 @@ pyunifi==2.13
 # homeassistant.components.vera
 pyvera==0.2.41
 
+# homeassistant.components.switch.vesync
+pyvesync==0.1.1
+
 # homeassistant.components.media_player.vizio
 pyvizio==0.0.2
 
@@ -1229,9 +1232,6 @@ uvcclient==0.10.1
 
 # homeassistant.components.climate.venstar
 venstarcolortouch==0.6
-
-# homeassistant.components.switch.vesync
-pyvesync==0.1.1
 
 # homeassistant.components.config.config_entries
 voluptuous-serialize==1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1230,6 +1230,9 @@ uvcclient==0.10.1
 # homeassistant.components.climate.venstar
 venstarcolortouch==0.6
 
+# homeassistant.components.switch.vesync
+pyvesync==0.1.1
+
 # homeassistant.components.config.config_entries
 voluptuous-serialize==1
 


### PR DESCRIPTION
## Description:

This PR adds support for a new platform of switches from Etekcity called VeSync smart switches. These switches are capable of toggling power to a device as well as providing electricity metrics for current power in watts and a measure of daily energy in kWh.

**Related issue (if applicable):** None

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4864

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: vesync
    username: !secret vesync_username
    password: !secret vesync_password
```

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
