### PR TITLE
Update netdisco to 1.3.0

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==1.2.4']
+REQUIREMENTS = ['netdisco==1.3.0']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -512,7 +512,7 @@ myusps==1.3.2
 nad_receiver==0.0.9
 
 # homeassistant.components.discovery
-netdisco==1.2.4
+netdisco==1.3.0
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1


### PR DESCRIPTION
Changelog:

- Allow newer zeroconf versions (https://github.com/home-assistant/netdisco/pull/178 - @dotlambda)
- Added a Samsung Printer discoverable (https://github.com/home-assistant/netdisco/pull/174 - @nielstron)
- Add discovery of Huawei routers (https://github.com/home-assistant/netdisco/pull/175 - @scop)
- Add UDN to SSDP discoverables, as discussed in https://github.com/home-assistant/netdisco/pull/165 (https://github.com/home-assistant/netdisco/pull/173 - @rytilahti)
- Add discovery of Freebox servers (https://github.com/home-assistant/netdisco/pull/172 - @stilllman)
- Add support for discovery of TiVo devices providing remote control. (https://github.com/home-assistant/netdisco/pull/170 - @patthoyts)
- Add Yeelight Ceiling Light support (https://github.com/home-assistant/netdisco/pull/168 - @pauln)
- Fixed regular expression for parsing HTTP headers in order to allow 0 or more white spaces between the first colon(:) and field-content. (https://github.com/home-assistant/netdisco/pull/167 - @tango-foxtrot)
- Add support for ASUS routers (https://github.com/home-assistant/netdisco/pull/164 - @scop)
- harmony: Fix module docstring (https://github.com/home-assistant/netdisco/pull/163 - @scop)
- Add manufacturer to SSDP discoverable data (https://github.com/home-assistant/netdisco/pull/165 - @scop) 

