### PR TITLE
Perform check_config service in current process

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -665,10 +665,8 @@ async def async_check_ha_config_file(hass):
     """
     from homeassistant.scripts.check_config import check_ha_config_file
 
-    def _load_hass_yaml_config():
-        return check_ha_config_file(hass.config.config_dir)
-
-    res = await hass.async_add_job(_load_hass_yaml_config)
+    res = await hass.async_add_job(
+        check_ha_config_file, hass.config.config_dir)
 
     if not res.errors:
         return None

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -1,5 +1,4 @@
 """Module to help with parsing and generating configuration files."""
-import asyncio
 from collections import OrderedDict
 # pylint: disable=no-name-in-module
 from distutils.version import LooseVersion  # pylint: disable=import-error
@@ -7,7 +6,6 @@ import logging
 import os
 import re
 import shutil
-import sys
 # pylint: disable=unused-import
 from typing import Any, List, Tuple  # NOQA
 
@@ -665,22 +663,16 @@ async def async_check_ha_config_file(hass):
 
     This method is a coroutine.
     """
-    proc = await asyncio.create_subprocess_exec(
-        sys.executable, '-m', 'homeassistant', '--script',
-        'check_config', '--config', hass.config.config_dir,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT, loop=hass.loop)
+    from homeassistant.scripts.check_config import check_ha_config_file
 
-    # Wait for the subprocess exit
-    log, _ = await proc.communicate()
-    exit_code = await proc.wait()
+    def _load_hass_yaml_config():
+        return check_ha_config_file(hass.config.config_dir)
 
-    # Convert to ASCII
-    log = RE_ASCII.sub('', log.decode())
+    res = await hass.async_add_job(_load_hass_yaml_config)
 
-    if exit_code != 0 or RE_YAML_ERROR.search(log):
-        return log
-    return None
+    if not res.errors:
+        return None
+    return '\n'.join([err.message for err in res.errors])
 
 
 @callback


### PR DESCRIPTION
## Description:
Run check_config directly instead of executing the script in a subprocess

## Checklist:
  - [x] The code change is tested and works locally.

If the code does not interact with devices:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
