### PR TITLE
Remove rounding of temperature reading

### DIFF
--- a/homeassistant/components/sensor/lacrosse.py
+++ b/homeassistant/components/sensor/lacrosse.py
@@ -157,7 +157,7 @@ class LaCrosseSensor(Entity):
             self._expiration_trigger = async_track_point_in_utc_time(
                 self.hass, self.value_is_expired, expiration_at)
 
-        self._temperature = round(lacrosse_sensor.temperature * 2) / 2
+        self._temperature = lacrosse_sensor.temperature
         self._humidity = lacrosse_sensor.humidity
         self._low_battery = lacrosse_sensor.low_battery
         self._new_battery = lacrosse_sensor.new_battery


### PR DESCRIPTION
With homeassistant 0.65.0 the filter sensor is introduced. Now there
is a common way to filter the peaks comming from the readings.

## Checklist:
  - [ ] The code change is tested and works locally.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
