### PR TITLE
Use load_yaml_config_file in config component #13015

### DIFF
--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -1,6 +1,5 @@
 """Component to configure Home Assistant via an API."""
 import asyncio
-import os
 
 import voluptuous as vol
 

--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -9,7 +9,9 @@ from homeassistant.const import EVENT_COMPONENT_LOADED, CONF_ID
 from homeassistant.setup import (
     async_prepare_setup_platform, ATTR_COMPONENT)
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.util.yaml import load_yaml, dump
+from homeassistant.util.yaml import dump
+from homeassistant.config import load_yaml_config_file
+from homeassistant.exceptions import HomeAssistantError
 
 DOMAIN = 'config'
 DEPENDENCIES = ['http']
@@ -144,9 +146,10 @@ class BaseEditConfigView(HomeAssistantView):
     @asyncio.coroutine
     def read_config(self, hass):
         """Read the config."""
-        current = yield from hass.async_add_job(
-            _read, hass.config.path(self.path))
-        if not current:
+        try:
+            current = yield from hass.async_add_job(
+                load_yaml_config_file, hass.config.path(self.path))
+        except HomeAssistantError:
             current = self._empty_config()
         return current
 
@@ -188,14 +191,6 @@ class EditIdBasedConfigView(BaseEditConfigView):
             data.append(value)
 
         value.update(new_value)
-
-
-def _read(path):
-    """Read YAML helper."""
-    if not os.path.isfile(path):
-        return None
-
-    return load_yaml(path)
 
 
 def _write(path, data):


### PR DESCRIPTION
## Description:
As part of #12792 correctly loading of the dict was moved into `load_yaml_config_file`.

Unfortunately `bootstrap.async_from_config_dict` is also called from the config component, that implemented it's own version of a load yaml. This still caused `None` to be passed in.

Another fix would be reverting the check_config change to `bootstrap.async_from_config_dict`

**Related issue (if applicable):** fixes #13015 

## Example entry for `configuration.yaml` (if applicable):
You need config and another empty DOMAIN

```yaml
config:
python_scripts:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
