### PR TITLE
Glances Docker Sensors

### DIFF
--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -159,7 +159,7 @@ class GlancesSensor(Entity):
             elif self.type == 'docker_count':
                 count = 0
                 for container in value['docker']['containers']:
-                    if container['Status'] = 'running':
+                    if container['Status'] == 'running':
                         count += 1
                 self._state = count
 

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -156,7 +156,7 @@ class GlancesSensor(Entity):
                     if sensor['label'] == 'CPU':
                         self._state = sensor['value']
                 self._state = None
-            elif self.type == 'docker_count':
+            elif self.type == 'docker_active':
                 count = 0
                 for container in value['docker']['containers']:
                     if container['Status'] == 'running':

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -43,6 +43,8 @@ SENSOR_TYPES = {
     'process_sleeping': ['Sleeping', 'Count', 'mdi:memory'],
     'cpu_temp': ['CPU Temp', TEMP_CELSIUS, 'mdi:thermometer'],
     'docker_active': ['Containers active', '', 'mdi:docker'],
+    'docker_cpu_use': ['Containers CPU used', '%', 'mdi:docker'],
+    'docker_memory_use': ['Containers RAM used', 'MiB', 'mdi:docker'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -162,6 +164,16 @@ class GlancesSensor(Entity):
                     if container['Status'] == 'running':
                         count += 1
                 self._state = count
+            elif self.type == 'docker_cpu_use':
+                use = 0.0
+                for container in value['docker']['containers']:
+                    use += container['cpu']['total']
+                self._state = round(use, 1)
+            elif self.type == 'docker_memory_use':
+                use = 0.0
+                for container in value['docker']['containers']:
+                    use += container['memory']['usage']
+                self._state = round(use / 1024**2, 1)
 
 
 class GlancesData(object):

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -42,6 +42,7 @@ SENSOR_TYPES = {
     'process_thread': ['Thread', 'Count', 'mdi:memory'],
     'process_sleeping': ['Sleeping', 'Count', 'mdi:memory'],
     'cpu_temp': ['CPU Temp', TEMP_CELSIUS, 'mdi:thermometer'],
+    'docker_active': ['Docker containers active', 'Count', 'mdi:docker'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -155,6 +156,12 @@ class GlancesSensor(Entity):
                     if sensor['label'] == 'CPU':
                         self._state = sensor['value']
                 self._state = None
+            elif self.type == 'docker_count':
+                count = 0
+                for container in value['docker']['containers']:
+                    if container['Status'] = 'running':
+                        count += 1
+                self._state = count
 
 
 class GlancesData(object):

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -42,7 +42,7 @@ SENSOR_TYPES = {
     'process_thread': ['Thread', 'Count', 'mdi:memory'],
     'process_sleeping': ['Sleeping', 'Count', 'mdi:memory'],
     'cpu_temp': ['CPU Temp', TEMP_CELSIUS, 'mdi:thermometer'],
-    'docker_active': ['Docker containers active', 'Count', 'mdi:docker'],
+    'docker_active': ['Containers active', '', 'mdi:docker'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
## Description:
Added three new sensors from Docker object in API. Shows total active containers, total CPU use and total memory use

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
https://github.com/home-assistant/home-assistant.github.io/pull/4873

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: glances
    host: IP_ADDRESS
    resources:
      - 'disk_use_percent'
      - 'disk_use'
      - 'disk_free'
      - 'memory_use_percent'
      - 'memory_use'
      - 'memory_free'
      - 'swap_use_percent'
      - 'swap_use'
      - 'swap_free'
      - 'processor_load'
      - 'process_running'
      - 'process_total'
      - 'process_thread'
      - 'process_sleeping'
      - 'cpu_temp'
      - 'docker_active'
      - 'docker_cpu_use'
      - 'docker_memory_use'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
