### PR TITLE
Add support for input boolean to Google Assistant

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -5,6 +5,7 @@ from homeassistant.components import (
     cover,
     group,
     fan,
+    input_boolean,
     media_player,
     light,
     scene,
@@ -182,6 +183,7 @@ class OnOffTrait(_Trait):
         """Test if state is supported."""
         return domain in (
             group.DOMAIN,
+            input_boolean.DOMAIN,
             switch.DOMAIN,
             fan.DOMAIN,
             light.DOMAIN,

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -9,8 +9,9 @@ from homeassistant.components import (
     climate,
     cover,
     fan,
-    media_player,
+    input_boolean,
     light,
+    media_player,
     scene,
     script,
     switch,
@@ -135,6 +136,43 @@ async def test_onoff_group(hass):
     assert len(off_calls) == 1
     assert off_calls[0].data == {
         ATTR_ENTITY_ID: 'group.bla',
+    }
+
+
+async def test_onoff_input_boolean(hass):
+    """Test OnOff trait support for input_boolean domain."""
+    assert trait.OnOffTrait.supported(media_player.DOMAIN, 0)
+
+    trt_on = trait.OnOffTrait(State('input_boolean.bla', STATE_ON))
+
+    assert trt_on.sync_attributes() == {}
+
+    assert trt_on.query_attributes() == {
+        'on': True
+    }
+
+    trt_off = trait.OnOffTrait(State('input_boolean.bla', STATE_OFF))
+    assert trt_off.query_attributes() == {
+        'on': False
+    }
+
+    on_calls = async_mock_service(hass, input_boolean.DOMAIN, SERVICE_TURN_ON)
+    await trt_on.execute(hass, trait.COMMAND_ONOFF, {
+        'on': True
+    })
+    assert len(on_calls) == 1
+    assert on_calls[0].data == {
+        ATTR_ENTITY_ID: 'input_boolean.bla',
+    }
+
+    off_calls = async_mock_service(hass, input_boolean.DOMAIN,
+                                   SERVICE_TURN_OFF)
+    await trt_on.execute(hass, trait.COMMAND_ONOFF, {
+        'on': False
+    })
+    assert len(off_calls) == 1
+    assert off_calls[0].data == {
+        ATTR_ENTITY_ID: 'input_boolean.bla',
     }
 
 


### PR DESCRIPTION
## Description:
Add support for turning on/off Input Boolean via Google Assistant.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
