### PR TITLE
Ensure we have valid config AFTER merging packages #13015

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -113,14 +113,16 @@ def async_from_config_dict(config: Dict[str, Any],
         yield from hass.async_add_job(loader.prepare, hass)
 
     # Make a copy because we are mutating it.
-    new_config = OrderedDict()
-    for key, value in config.items():
-        new_config[key] = value or {}
-    config = new_config
+    config = OrderedDict(config)
 
     # Merge packages
     conf_util.merge_packages_config(
         config, core_config.get(conf_util.CONF_PACKAGES, {}))
+
+    # Ensure we have no None values after merge
+    for key, value in config.items():
+        if not value:
+            config[key] = {}
 
     hass.config_entries = config_entries.ConfigEntries(hass, config)
     yield from hass.config_entries.async_load()

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -562,6 +562,9 @@ def merge_packages_config(config, packages, _log_pkg_error=_log_pkg_error):
                     continue
 
                 if merge_type == 'dict':
+                    if comp_conf is None:
+                        comp_conf = OrderedDict()
+
                     if not isinstance(comp_conf, dict):
                         _log_pkg_error(
                             pack_name, comp_name, config,

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -326,6 +326,11 @@ def check_ha_config_file(config_dir):
         config, core_config.get(CONF_PACKAGES, {}), _pack_error)
     del core_config[CONF_PACKAGES]
 
+    # Ensure we have no None values after merge
+    for key, value in config.items():
+        if not value:
+            config[key] = {}
+
     # Filter out repeating config sections
     components = set(key.split(' ')[0] for key in config.keys())
 


### PR DESCRIPTION
## Description:
My initial diagnosis for #13015 did not include empty components inside packages

This fixes it for #13015 and `check_config` which will currently suffer from the same fate


## Example entry for `configuration.yaml` (if applicable):
```yaml
homeassistant:
   packages:
      one:
         python_script:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
