### PR TITLE
Fix efergy end point for instant readings (#12622, #12701)

### DIFF
--- a/homeassistant/components/sensor/efergy.py
+++ b/homeassistant/components/sensor/efergy.py
@@ -119,9 +119,9 @@ class EfergySensor(Entity):
         """Get the Efergy monitor data from the web service."""
         try:
             if self.type == 'instant_readings':
-                url_string = _RESOURCE + 'getInstant?token=' + self.app_token
+                url_string = _RESOURCE + 'getCurrentValuesSummary?token=' + self.app_token
                 response = get(url_string, timeout=10)
-                self._state = response.json()['reading']
+                self._state = next(iter(response.json()[0]['data'][0].values()))
             elif self.type == 'amount':
                 url_string = _RESOURCE + 'getEnergy?token=' + self.app_token \
                     + '&offset=' + self.utc_offset + '&period=' \


### PR DESCRIPTION
## Description:
The 'getInstant' endpoint appears to be broken, but similar values can be taken from the get 'getCurrentValuesSummary' endpoint instead. Update to targeted endpoint and JSON filtering to retrieve this value.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
#12622, #12701

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>