### PR TITLE
Sensor template don't exit early on TemplateError

### DIFF
--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -166,10 +166,10 @@ class SensorTemplate(Entity):
                 # Common during HA startup - so just a warning
                 _LOGGER.warning('Could not render template %s,'
                                 ' the state is unknown.', self._name)
-                return
-            self._state = None
-            _LOGGER.error('Could not render template %s: %s', self._name, ex)
-
+            else:
+                self._state = None
+                _LOGGER.error('Could not render template %s: %s', self._name,
+                              ex)
         for property_name, template in (
                 ('_icon', self._icon_template),
                 ('_entity_picture', self._entity_picture_template),
@@ -187,7 +187,7 @@ class SensorTemplate(Entity):
                     _LOGGER.warning('Could not render %s template %s,'
                                     ' the state is unknown.',
                                     friendly_property_name, self._name)
-                    return
+                    continue
 
                 try:
                     setattr(self, property_name,

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -53,7 +53,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         friendly_name_template = device_config.get(CONF_FRIENDLY_NAME_TEMPLATE)
         unit_of_measurement = device_config.get(ATTR_UNIT_OF_MEASUREMENT)
 
-        entity_ids = []
+        entity_ids = set()
         manual_entity_ids = device_config.get(ATTR_ENTITY_ID)
 
         for template in (state_template, icon_template,
@@ -69,10 +69,12 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             if template_entity_ids == MATCH_ALL:
                 entity_ids = MATCH_ALL
             else:
-                entity_ids += template_entity_ids
+                entity_ids |= set(template_entity_ids)
 
         if manual_entity_ids is not None:
             entity_ids = manual_entity_ids
+        elif entity_ids != MATCH_ALL:
+            entity_ids = list(entity_ids)
 
         sensors.append(
             SensorTemplate(

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -131,6 +131,33 @@ class TestTemplateSensor:
         state = self.hass.states.get('sensor.test_template_sensor')
         assert state.attributes['friendly_name'] == 'It Works.'
 
+    def test_friendly_name_template_with_unknown_state(self):
+        """Test friendly_name template with an unknown value_template."""
+        with assert_setup_component(1):
+            assert setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test_template_sensor': {
+                            'value_template': "{{ states.fourohfour.state }}",
+                            'friendly_name_template':
+                                "It {{ states.sensor.test_state.state }}."
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('sensor.test_template_sensor')
+        assert state.attributes['friendly_name'] == 'It .'
+
+        self.hass.states.set('sensor.test_state', 'Works')
+        self.hass.block_till_done()
+        state = self.hass.states.get('sensor.test_template_sensor')
+        assert state.attributes['friendly_name'] == 'It Works.'
+
     def test_template_syntax_error(self):
         """Test templating syntax error."""
         with assert_setup_component(0):


### PR DESCRIPTION
## Description:

The different attributes of a template sensor were executed updated after each other. If one template at the beginning failed to render, we wouldn't even *try* to render the other ones. As template rendering failing is not something that should have side effects such as this one, we should evaluate *all* templates even though some failed.

While adding tests, I then noticed that we **do not** track entities from templated attributes such as friendly name. I believe that's not correct, so I changed that too.

There's a small issue with our previous entity id tracking. If the you have something like `value_template: "State"` and `extract_entities()` can't find any entities, we end up tracking **all** state changes, not very good speed-wise... Especially since users can still manually specifies which entities to track.

But, in an effort not have a breaking change here, I let it stay the old way.

**Related issue (if applicable):** fixes #13028

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: template
    sensors:
      forecast_3:
          friendly_name_template: >-
            {%- set date = as_timestamp(now()) + (3 * 86400 ) -%}
            {{ date | timestamp_custom("%A (%-d/%-m)") }}
          value_template: >
            {{states.sensor.dark_sky_daily_high_temperature_3.state|round(0)}}°/{{states.sensor.dark_sky_daily_low_temperature_3.state|round(0)}}°/{{states.sensor.dark_sky_precip_probability_3.state|round(0)}}
          entity_picture_template: >-
            {{ '/local/icons/dark_sky/' ~ states.sensor.dark_sky_icon_3.state ~ '.png'}}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
