### PR TITLE
Fix async lifx_set_state

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -221,7 +221,7 @@ class LIFXManager(object):
             tasks = []
             for light in self.service_to_entities(service):
                 if service.service == SERVICE_LIFX_SET_STATE:
-                    task = light.async_set_state(**service.data)
+                    task = light.set_state(**service.data)
                 tasks.append(self.hass.async_add_job(task))
             if tasks:
                 await asyncio.wait(tasks, loop=self.hass.loop)


### PR DESCRIPTION
## Description:

Hotfix for #12973.

**Related issue (if applicable):** [reported in forum](https://community.home-assistant.io/t/lifx-set-state-not-working-in-0-65-0/46401)

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.