### PR TITLE
Config_Validation: Added check for domain list

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -148,25 +148,28 @@ def entity_ids(value: Union[str, Sequence]) -> Sequence[str]:
     return [entity_id(ent_id) for ent_id in value]
 
 
-def entity_domain(domain: str):
-    """Validate that entity belong to domain."""
+def entity_domain(domains: Union[str, Sequence]):
+    """Validate that entity belong to domains."""
     def validate(value: Any) -> str:
-        """Test if entity domain is domain."""
-        ent_domain = entities_domain(domain)
+        """Test if entity domain is in domains."""
+        ent_domain = entities_domain(domains)
         return ent_domain(value)[0]
     return validate
 
 
-def entities_domain(domain: str):
-    """Validate that entities belong to domain."""
+def entities_domain(domains: Union[str, Sequence]):
+    """Validate that entities belong to domains."""
+    if isinstance(domains, str):
+        domains = [domains]
+
     def validate(values: Union[str, Sequence]) -> Sequence[str]:
-        """Test if entity domain is domain."""
+        """Test if entity domain is in domains."""
         values = entity_ids(values)
         for ent_id in values:
-            if split_entity_id(ent_id)[0] != domain:
+            if split_entity_id(ent_id)[0] not in domains:
                 raise vol.Invalid(
-                    "Entity ID '{}' does not belong to domain '{}'"
-                    .format(ent_id, domain))
+                    "Entity ID '{}' does not belong to domains '{}'"
+                    .format(ent_id, domains))
         return values
     return validate
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -180,6 +180,17 @@ def test_entity_domain():
 
     assert schema('sensor.LIGHT') == 'sensor.light'
 
+    # Test with domain list
+    schema = vol.Schema(cv.entities_domain(['input_boolean', 'remote']))
+
+    options = (
+        'input_boolean.demo',
+        'remote.demo',
+    )
+
+    for value in options:
+        assert schema(value)
+
 
 def test_entities_domain():
     """Test entities domain validation."""
@@ -211,6 +222,14 @@ def test_entities_domain():
     assert schema(['sensor.light', 'SENSOR.demo']) == [
         'sensor.light', 'sensor.demo'
     ]
+
+    # Test with domain list
+    schema = vol.Schema(cv.entities_domain(['input_boolean', 'remote']))
+
+    with pytest.raises(vol.MultipleInvalid):
+        schema(['input_boolean.demo', 'remote.demo', 'light.demo'])
+
+    assert schema(['input_boolean.demo', 'remote.demo'])
 
 
 def test_ensure_list_csv():


### PR DESCRIPTION
## Description:
Added the option to `entities_domain` to check if entity belongs to one of a list of domains. This could be useful for a future `switch.group` since `input_boolean` and `remote` expose some of the same functionality.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.