### PR TITLE
Yeelight version bumped

### DIFF
--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -26,7 +26,7 @@ from homeassistant.components.light import (
     Light, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['yeelight==0.3.3']
+REQUIREMENTS = ['yeelight==0.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1292,7 +1292,7 @@ yahoo-finance==1.4.0
 yahooweather==0.10
 
 # homeassistant.components.light.yeelight
-yeelight==0.3.3
+yeelight==0.4.0
 
 # homeassistant.components.light.yeelightsunflower
 yeelightsunflower==0.0.8


### PR DESCRIPTION
Fixes the bulb type detection. At the moment all yeelights (color & white) has the same `supported_features`. As far as this issue is fixed the color wheel and color temperature selector will disappear for white bulbs again.

https://github.com/skorokithakis/python-yeelight/pull/5