### PR TITLE
Xiaomi Aqara: Don't call async from sync

### DIFF
--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -182,19 +182,19 @@ def setup(hass, config):
 
     gateway_only_schema = _add_gateway_to_schema(xiaomi, vol.Schema({}))
 
-    hass.services.async_register(
+    hass.services.register(
         DOMAIN, SERVICE_PLAY_RINGTONE, play_ringtone_service,
         schema=_add_gateway_to_schema(xiaomi, SERVICE_SCHEMA_PLAY_RINGTONE))
 
-    hass.services.async_register(
+    hass.services.register(
         DOMAIN, SERVICE_STOP_RINGTONE, stop_ringtone_service,
         schema=gateway_only_schema)
 
-    hass.services.async_register(
+    hass.services.register(
         DOMAIN, SERVICE_ADD_DEVICE, add_device_service,
         schema=gateway_only_schema)
 
-    hass.services.async_register(
+    hass.services.register(
         DOMAIN, SERVICE_REMOVE_DEVICE, remove_device_service,
         schema=_add_gateway_to_schema(xiaomi, SERVICE_SCHEMA_REMOVE_DEVICE))
 


### PR DESCRIPTION
## Description:
Call sync version of register.

Found by @arsaboo after running asyncio in debug mode via `hass.loop.set_debug(True)`:

```
Error during setup of component xiaomi_aqara
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/setup.py", line 145, in _async_setup_component
    component.setup, hass, processed_config)
  File "/usr/lib/python3.6/asyncio/futures.py", line 332, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.6/asyncio/tasks.py", line 250, in _wakeup
    future.result()
  File "/usr/lib/python3.6/asyncio/futures.py", line 245, in result
    raise self._exception
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/xiaomi_aqara.py", line 187, in setup
    schema=_add_gateway_to_schema(xiaomi, SERVICE_SCHEMA_PLAY_RINGTONE))
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/core.py", line 861, in async_register
    {ATTR_DOMAIN: domain, ATTR_SERVICE: service}
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/core.py", line 409, in async_fire
    self._hass.async_add_job(func, event)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/core.py", line 220, in async_add_job
    self.loop.call_soon(target, *args)
  File "/usr/lib/python3.6/asyncio/base_events.py", line 576, in call_soon
    self._check_thread()
  File "/usr/lib/python3.6/asyncio/base_events.py", line 615, in _check_thread
    "Non-thread-safe operation invoked on an event loop other "
RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one
```

