### PR TITLE
Run asyncio event loop in debug mode during tests

### DIFF
--- a/homeassistant/components/camera/arlo.py
+++ b/homeassistant/components/camera/arlo.py
@@ -49,8 +49,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up an Arlo IP Camera."""
     arlo = hass.data.get(DATA_ARLO)
     if not arlo:
@@ -60,7 +59,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     for camera in arlo.cameras:
         cameras.append(ArloCam(hass, camera, config))
 
-    async_add_devices(cameras, True)
+    add_devices(cameras, True)
 
 
 class ArloCam(Camera):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -229,7 +229,7 @@ class GenericThermostat(ClimateDevice):
         """List of available operation modes."""
         return self._operation_list
 
-    def set_operation_mode(self, operation_mode):
+    async def async_set_operation_mode(self, operation_mode):
         """Set operation mode."""
         if operation_mode == STATE_HEAT:
             self._current_operation = STATE_HEAT

--- a/tests/common.py
+++ b/tests/common.py
@@ -109,7 +109,6 @@ def get_test_home_assistant():
 @asyncio.coroutine
 def async_test_home_assistant(loop):
     """Return a Home Assistant object pointing at test config dir."""
-    loop.set_debug(True)
     hass = ha.HomeAssistant(loop)
     hass.config_entries = config_entries.ConfigEntries(hass, {})
     hass.config_entries._entries = []

--- a/tests/common.py
+++ b/tests/common.py
@@ -109,6 +109,7 @@ def get_test_home_assistant():
 @asyncio.coroutine
 def async_test_home_assistant(loop):
     """Return a Home Assistant object pointing at test config dir."""
+    loop.set_debug(True)
     hass = ha.HomeAssistant(loop)
     hass.config_entries = config_entries.ConfigEntries(hass, {})
     hass.config_entries._entries = []

--- a/tests/components/cover/test_template.py
+++ b/tests/components/cover/test_template.py
@@ -135,7 +135,7 @@ class TestTemplateCover(unittest.TestCase):
         entity = self.hass.states.get('cover.test')
         attrs = dict()
         attrs['position'] = 42
-        self.hass.states.async_set(
+        self.hass.states.set(
             entity.entity_id, entity.state,
             attributes=attrs)
         self.hass.block_till_done()
@@ -148,7 +148,7 @@ class TestTemplateCover(unittest.TestCase):
         self.hass.block_till_done()
         entity = self.hass.states.get('cover.test')
         attrs['position'] = 0.0
-        self.hass.states.async_set(
+        self.hass.states.set(
             entity.entity_id, entity.state,
             attributes=attrs)
         self.hass.block_till_done()

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -309,7 +309,7 @@ def test_value_discovery_existing_entity(hass, mock_openzwave):
         'current_temperature'] is None
 
     def mock_update(self):
-        self.hass.async_add_job(self.async_update_ha_state)
+        self.hass.add_job(self.async_update_ha_state)
 
     with patch.object(zwave.node_entity.ZWaveBaseEntity,
                       'maybe_schedule_update', new=mock_update):
@@ -356,7 +356,7 @@ def test_power_schemes(hass, mock_openzwave):
         'switch.mock_node_mock_value').attributes
 
     def mock_update(self):
-        self.hass.async_add_job(self.async_update_ha_state)
+        self.hass.add_job(self.async_update_ha_state)
 
     with patch.object(zwave.node_entity.ZWaveBaseEntity,
                       'maybe_schedule_update', new=mock_update):


### PR DESCRIPTION
## Description:
This runs the asyncio event loop in debug mode during tests. This will cause it to raise when calling async methods from a sync context

This would have caught the MQTT bug that was released in 0.64. It also found some more bugs by just enabling it.

It still won't detect I/O inside event loop, but it's a good start.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
