### PR TITLE
Convert decimals from SQL results

### DIFF
--- a/homeassistant/components/sensor/sql.py
+++ b/homeassistant/components/sensor/sql.py
@@ -4,6 +4,7 @@ Sensor from an SQL Query.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.sql/
 """
+import decimal
 import logging
 
 import voluptuous as vol
@@ -131,17 +132,20 @@ class SQLSensor(Entity):
         try:
             sess = self.sessionmaker()
             result = sess.execute(self._query)
+            self._attributes = {}
 
             if not result.returns_rows or result.rowcount == 0:
                 _LOGGER.warning("%s returned no results", self._query)
                 self._state = None
-                self._attributes = {}
                 return
 
             for res in result:
                 _LOGGER.debug("result = %s", res.items())
                 data = res[self._column_name]
-                self._attributes = {k: v for k, v in res.items()}
+                for key, value in res.items():
+                    if isinstance(value, decimal.Decimal):
+                        value = float(decimal)
+                    self._attributes[key] = value
         except sqlalchemy.exc.SQLAlchemyError as err:
             _LOGGER.error("Error executing query %s: %s", self._query, err)
             return

--- a/tests/components/sensor/test_sql.py
+++ b/tests/components/sensor/test_sql.py
@@ -29,7 +29,7 @@ class TestSQLSensor(unittest.TestCase):
                 'db_url': 'sqlite://',
                 'queries': [{
                     'name': 'count_tables',
-                    'query': 'SELECT count(*) value FROM sqlite_master;',
+                    'query': 'SELECT 5 as value',
                     'column': 'value',
                 }]
             }
@@ -38,7 +38,8 @@ class TestSQLSensor(unittest.TestCase):
         assert setup_component(self.hass, 'sensor', config)
 
         state = self.hass.states.get('sensor.count_tables')
-        self.assertEqual(state.state, '0')
+        assert state.state == '5'
+        assert state.attributes['value'] == 5
 
     def test_invalid_query(self):
         """Test the SQL sensor for invalid queries."""


### PR DESCRIPTION
## Description:
Some adapters for SQL Alchemy will return data wrapped in Decimal. This should not be added to the state machine as it blows up the JSON conversion.

**Related issue (if applicable):** fixes #13021, #13050

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
