### PR TITLE
Better errors from unknown secrets

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -140,6 +140,9 @@ def run(script_args: List) -> int:
 
         print(color(C_HEAD, 'Used Secrets:'))
         for skey, sval in res['secrets'].items():
+            if sval is None:
+                print(' -', skey + ':', color('red', "not found"))
+                continue
             print(' -', skey + ':', sval, color('cyan', '[from:', flatsecret
                                                 .get(skey, 'keyring') + ']'))
 
@@ -308,7 +311,8 @@ def check_ha_config_file(config_dir):
             return result.add_error("File configuration.yaml not found.")
         config = load_yaml_config_file(config_path)
     except HomeAssistantError as err:
-        return result.add_error(err)
+        return result.add_error(
+            "Error loading {}: {}".format(config_path, err))
     finally:
         yaml.clear_secret_cache()
 

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -288,8 +288,7 @@ def _secret_yaml(loader: SafeLineLoader,
             # Catch if package installed and no config
             credstash = None
 
-    _LOGGER.error("Secret %s not defined", node.value)
-    raise HomeAssistantError(node.value)
+    raise HomeAssistantError("Secret {} not defined".format(node.value))
 
 
 yaml.SafeLoader.add_constructor('!include', _include_yaml)


### PR DESCRIPTION
## Description:
Clear up errors from unknown secrets.

- During real startup this now raises a single error. During check_config this is also clear if secrets fail
- Better `--secrets` for unknown
- Align `check_Config` config load error with bootstrap

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `lazytox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
