### PR TITLE
Sense Component - add support for individual device realtime usage sensors

### DIFF
--- a/homeassistant/components/sensor/sense.py
+++ b/homeassistant/components/sensor/sense.py
@@ -56,6 +56,21 @@ VALID_SENSORS.append(DEVICES_NAME.lower())
 CONSUMPTION_ICON = 'mdi:flash'
 PRODUCTION_ICON = 'mdi:white-balance-sunny'
 
+DEVICE_ICON_TO_MDI_MAP = {
+    'alwayson': 'mdi:sync',
+    'cup': 'mdi:coffee',
+    'fan': 'mdi:fan',
+    'fridge': 'mdi:fridge',
+    'home': 'mdi:help',
+    'lightbulb': 'mdi:lightbulb',
+    'microwave': 'mdi:waves',
+    'stove': 'mdi:stove',
+    'toaster_oven': 'mdi:stove',
+    'tv': 'mdi:television',
+    'washer': 'mdi:washing-machine'
+}
+
+
 MIN_TIME_BETWEEN_DAILY_UPDATES = timedelta(seconds=300)
 MIN_TIME_BETWEEN_REALTIME_UPDATES = timedelta(seconds=30)
 
@@ -221,28 +236,11 @@ class SenseDevice(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-        # A handful of Sense icons happen to match mdi icons
-        if (self._icon == 'fridge' or
-                self._icon == 'lightbulb' or
-                self._icon == 'stove' or
-                self._icon == 'fan'):
-            return 'mdi:{}'.format(self._icon)
-        elif self._icon == 'microwave':
-            return 'mdi:waves'
-        elif self._icon == 'alwayson':
-            return 'mdi:sync'
-        elif self._icon == 'home':  # the other/unknown
-            return 'mdi:help'
-        elif self._icon == 'tv':
-            return 'mdi:television'
-        elif self._icon == 'cup':
-            return 'mdi:coffee'
-        elif self._icon == 'toaster_oven':
-            return 'mdi:stove'
-        elif self._icon == 'washer':
-            return 'mdi:washing-machine'
-
-        return CONSUMPTION_ICON
+        try:
+            icon = DEVICE_ICON_TO_MDI_MAP[self._icon]
+        except KeyError:
+            icon = CONSUMPTION_ICON
+        return icon
 
     def update(self):
         """Get the latest data, update state."""


### PR DESCRIPTION
## Description:
Hello! I've extended the existing Sense component to include another feature of Sense, which is current power usage of individual detected devices.

This is my first set of PRs against the home-assistant project, so any constructive criticisms are greatly appreciated!

I've removed the checkboxes below that are not applicable, since there are no new files and no new dependencies. This just builds on features of the underlying sense-energy library that weren't previously used by home assistant.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4882

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: sense
  email: SENSE_EMAIL
  password: SENSE_PASSWORD
  monitored_conditions:
    - active_usage
    - active_production
    - daily_usage
    - daily_production
    - devices
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
