### PR TITLE
Auto-renew session for Synology camera

### DIFF
--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.aiohttp_client import (
     async_get_clientsession)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['py-synology==0.1.5']
+REQUIREMENTS = ['py-synology==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -632,7 +632,7 @@ py-cpuinfo==3.3.0
 py-melissa-climate==1.0.6
 
 # homeassistant.components.camera.synology
-py-synology==0.1.5
+py-synology==0.2.0
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13


### PR DESCRIPTION
## Description:
Integrated with py-synology:0.2.0. So now when Synology camera session is expired, it'll auto renew during API call.

**Related issue (if applicable):**
fixes #12037, fixes #10153

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
