### PR TITLE
Fix the "is this a namespace" test

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -151,6 +151,8 @@ def get_component(comp_name) -> Optional[ModuleType]:
             # the import custom_components.switch would succeed.
             if module.__spec__.origin == 'namespace':
                 continue
+            if "NamespaceLoader" in str(module.__spec__.loader):
+                continue
 
             _LOGGER.info("Loaded %s from %s", comp_name, path)
 


### PR DESCRIPTION
## Description:

My Python installation (Debian testing, Py3.6.4) doesn't set
`module.__spec__.origin` to 'namespace'. (Its value is None.)

I have been unable to find a better solution than the attached patch.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

