### PR TITLE
Make Sensibo climate registry_entity compliant

### DIFF
--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -248,6 +248,11 @@ class SensiboClimate(ClimateDevice):
         return self._temperatures_list[-1] \
             if self._temperatures_list else super().max_temp
 
+    @property
+    def unique_id(self):
+        """Return unique ID based on Sensibo ID."""
+        return self._id
+
     @asyncio.coroutine
     def async_set_temperature(self, **kwargs):
         """Set new target temperature."""


### PR DESCRIPTION
## Description:

Make Sensibo climate registry_entity compliant by adding a `unique_id` equal to the device ID.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
