### PR TITLE
Lint script tweaks

### DIFF
--- a/script/lazytox.py
+++ b/script/lazytox.py
@@ -94,7 +94,9 @@ async def git():
     """Exec git."""
     if len(sys.argv) > 2 and sys.argv[1] == '--':
         return sys.argv[2:]
-    _, log = await async_exec('git', 'diff', 'upstream/dev...', '--name-only')
+    _, log = await async_exec('git', 'merge-base', 'upstream/dev', 'HEAD')
+    merge_base = log.splitlines()[0]
+    _, log = await async_exec('git', 'diff', merge_base, '--name-only')
     return log.splitlines()
 
 

--- a/script/lint
+++ b/script/lint
@@ -19,5 +19,5 @@ flake8 --doctests $files
 echo "================"
 echo "LINT with pylint"
 echo "================"
-pylint $files
+pylint $(echo "$files" | grep -v '^tests.*')
 echo

--- a/script/lint
+++ b/script/lint
@@ -3,10 +3,10 @@
 
 cd "$(dirname "$0")/.."
 
-export files="`git diff upstream/dev... --diff-filter=d --name-only | grep -e '\.py$'`"
-echo "================================================="
-echo "FILES CHANGED (git diff upstream/dev... --diff-filter=d --name-only)"
-echo "================================================="
+export files="$(git diff $(git merge-base upstream/dev HEAD) --diff-filter=d --name-only | grep -e '\.py$')"
+echo '================================================='
+echo 'FILES CHANGED (git diff $(git merge-base upstream/dev HEAD) --diff-filter=d --name-only)'
+echo '================================================='
 if [ -z "$files" ] ; then
   echo "No python file changed. Rather use: tox -e lint"
   exit

--- a/script/lint
+++ b/script/lint
@@ -5,7 +5,7 @@ cd "$(dirname "$0")/.."
 
 export files="$(git diff $(git merge-base upstream/dev HEAD) --diff-filter=d --name-only | grep -e '\.py$')"
 echo '================================================='
-echo 'FILES CHANGED (git diff $(git merge-base upstream/dev HEAD) --diff-filter=d --name-only)'
+echo '=                FILES CHANGED                  ='
 echo '================================================='
 if [ -z "$files" ] ; then
   echo "No python file changed. Rather use: tox -e lint"


### PR DESCRIPTION
## Description:
This PR introduces two new changes to our lint script:

1) The git diff command is tweaked, so that it also catches changes in the working tree that have not been committed. When performing a git diff of `upstream/dev...`, git is diffing against the current HEAD, but does not include working tree files. By manually calculating a merge-base SHA to diff against, git will still diff those files.

2) `pylint` is skipped for changes in the `tests` directory, since we don't check that directory with `pylint` in Travis anyway. It tends to produce a lot of noise.