### PR TITLE
Revert "Cast automatically drop connection (#12635)"

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/media_player.cast/
 # pylint: disable=import-error
 import logging
 import threading
-import functools
 
 import voluptuous as vol
 
@@ -35,7 +34,6 @@ CONF_IGNORE_CEC = 'ignore_cec'
 CAST_SPLASH = 'https://home-assistant.io/images/cast/splash.png'
 
 DEFAULT_PORT = 8009
-SOCKET_CLIENT_RETRIES = 10
 
 SUPPORT_CAST = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
     SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PREVIOUS_TRACK | \
@@ -78,7 +76,7 @@ def _setup_internal_discovery(hass: HomeAssistantType) -> None:
         try:
             # pylint: disable=protected-access
             chromecast = pychromecast._get_chromecast_from_host(
-                mdns, blocking=True, tries=SOCKET_CLIENT_RETRIES)
+                mdns, blocking=True)
         except pychromecast.ChromecastConnectionError:
             _LOGGER.debug("Can't set up cast with mDNS info %s. "
                           "Assuming it's not a Chromecast", mdns)
@@ -183,9 +181,8 @@ async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
     else:
         # Manually add a "normal" Chromecast, we can do that without discovery.
         try:
-            func = functools.partial(pychromecast.Chromecast, *want_host,
-                                     tries=SOCKET_CLIENT_RETRIES)
-            chromecast = await hass.async_add_job(func)
+            chromecast = await hass.async_add_job(
+                pychromecast.Chromecast, *want_host)
         except pychromecast.ChromecastConnectionError as err:
             _LOGGER.warning("Can't set up chromecast on %s: %s",
                             want_host[0], err)

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -123,7 +123,7 @@ def test_internal_discovery_callback_only_generates_once(hass):
                return_value=chromecast) as gen_chromecast:
         discover_cast('the-service', chromecast)
         mdns = (chromecast.host, chromecast.port, chromecast.uuid, None, None)
-        gen_chromecast.assert_called_once_with(mdns, blocking=True, tries=10)
+        gen_chromecast.assert_called_once_with(mdns, blocking=True)
 
         discover_cast('the-service', chromecast)
         gen_chromecast.reset_mock()


### PR DESCRIPTION
## Description:

TL;DR; Revert #12635 as a temporary workaround for #12968. 

Some cast devices restart at night and cause the max retries logic to stop the connection, thus breaking some cast devices every night. The original purpose of #12635 was to not have to many stale socket clients around, that error has been in the integration for a long time and didn't cause issues of the same kind of magnitude as #12968. So I propose that we revert the automatically dropping connections while keeping the good parts of it (`PlatformNotReady`) for now.

I'm working on a refactor for this platform where the `entity` is responsible for the `pychromecast.Chromecast` objects but haven't had enough time to get that fully tested and ready. I hope to get that in the next major release. (+ then probably the release after that hopefully an even bigger cast platform refactor that would also make the integration finally async-aware...)

**Related issue (if applicable):** fixes #12968

<!--- Don't mind me ;) just testing whether the comment feature has a bug. The issue can be closed anyway with this PR. fixes #13090 --->

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: cast
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
