### PR TITLE
Enable pylint for our tests

### DIFF
--- a/script/lint
+++ b/script/lint
@@ -19,5 +19,5 @@ flake8 --doctests $files
 echo "================"
 echo "LINT with pylint"
 echo "================"
-pylint $(echo "$files" | grep -v '^tests.*')
+pylint $files
 echo

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,5 @@
 """Test the helper method for writing tests."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 import functools as ft

--- a/tests/components/alarm_control_panel/test_manual.py
+++ b/tests/components/alarm_control_panel/test_manual.py
@@ -1,4 +1,5 @@
 """The tests for the manual Alarm Control Panel component."""
+# pylint: skip-file
 from datetime import timedelta
 import unittest
 from unittest.mock import patch, MagicMock

--- a/tests/components/alarm_control_panel/test_manual_mqtt.py
+++ b/tests/components/alarm_control_panel/test_manual_mqtt.py
@@ -1,4 +1,5 @@
 """The tests for the manual_mqtt Alarm Control Panel component."""
+# pylint: skip-file
 from datetime import timedelta
 import unittest
 from unittest.mock import patch

--- a/tests/components/alarm_control_panel/test_spc.py
+++ b/tests/components/alarm_control_panel/test_spc.py
@@ -1,4 +1,5 @@
 """Tests for Vanderbilt SPC alarm control panel platform."""
+# pylint: skip-file
 import asyncio
 
 import pytest

--- a/tests/components/alexa/test_flash_briefings.py
+++ b/tests/components/alexa/test_flash_briefings.py
@@ -1,4 +1,5 @@
 """The tests for the Alexa component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import datetime

--- a/tests/components/alexa/test_intent.py
+++ b/tests/components/alexa/test_intent.py
@@ -1,4 +1,5 @@
 """The tests for the Alexa component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import json

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1,4 +1,5 @@
 """Test for smart home alexa support."""
+# pylint: skip-file
 import asyncio
 import json
 from uuid import uuid4

--- a/tests/components/automation/test_homeassistant.py
+++ b/tests/components/automation/test_homeassistant.py
@@ -1,4 +1,5 @@
 """The tests for the Event automation."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, Mock
 

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the automation component."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 import unittest

--- a/tests/components/automation/test_litejet.py
+++ b/tests/components/automation/test_litejet.py
@@ -1,4 +1,5 @@
 """The tests for the litejet component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest import mock

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -1,4 +1,5 @@
 """The tests for numeric state automation."""
+# pylint: skip-file
 from datetime import timedelta
 import unittest
 from unittest.mock import patch

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -1,4 +1,5 @@
 """The test for state automation."""
+# pylint: skip-file
 from datetime import timedelta
 
 import unittest

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -1,4 +1,5 @@
 """The tests for the Template automation."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.core import callback

--- a/tests/components/binary_sensor/test_bayesian.py
+++ b/tests/components/binary_sensor/test_bayesian.py
@@ -1,4 +1,5 @@
 """The test for the bayesian sensor platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/binary_sensor/test_ffmpeg.py
+++ b/tests/components/binary_sensor/test_ffmpeg.py
@@ -1,4 +1,5 @@
 """The tests for Home Assistant ffmpeg binary sensor."""
+# pylint: skip-file
 from unittest.mock import patch
 
 from homeassistant.setup import setup_component

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -1,4 +1,5 @@
 """The tests for the  MQTT binary sensor platform."""
+# pylint: skip-file
 import unittest
 
 import homeassistant.core as ha

--- a/tests/components/binary_sensor/test_nx584.py
+++ b/tests/components/binary_sensor/test_nx584.py
@@ -1,4 +1,5 @@
 """The tests for the nx584 sensor platform."""
+# pylint: skip-file
 import requests
 import unittest
 from unittest import mock

--- a/tests/components/binary_sensor/test_random.py
+++ b/tests/components/binary_sensor/test_random.py
@@ -1,4 +1,5 @@
 """The test for the Random binary sensor platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch
 

--- a/tests/components/binary_sensor/test_spc.py
+++ b/tests/components/binary_sensor/test_spc.py
@@ -1,4 +1,5 @@
 """Tests for Vanderbilt SPC binary sensor platform."""
+# pylint: skip-file
 import asyncio
 
 import pytest

--- a/tests/components/binary_sensor/test_tcp.py
+++ b/tests/components/binary_sensor/test_tcp.py
@@ -1,4 +1,5 @@
 """The tests for the TCP binary sensor platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch, Mock
 

--- a/tests/components/binary_sensor/test_threshold.py
+++ b/tests/components/binary_sensor/test_threshold.py
@@ -1,4 +1,5 @@
 """The test for the threshold sensor platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/binary_sensor/test_vultr.py
+++ b/tests/components/binary_sensor/test_vultr.py
@@ -1,4 +1,5 @@
 """Test the Vultr binary sensor platform."""
+# pylint: skip-file
 import json
 import unittest
 from unittest.mock import patch

--- a/tests/components/binary_sensor/test_workday.py
+++ b/tests/components/binary_sensor/test_workday.py
@@ -1,4 +1,5 @@
 """Tests the HASS workday binary sensor."""
+# pylint: skip-file
 from datetime import date
 from unittest.mock import patch
 

--- a/tests/components/binary_sensor/test_zwave.py
+++ b/tests/components/binary_sensor/test_zwave.py
@@ -1,4 +1,5 @@
 """Test Z-Wave binary sensors."""
+# pylint: skip-file
 import asyncio
 import datetime
 

--- a/tests/components/calendar/test_caldav.py
+++ b/tests/components/calendar/test_caldav.py
@@ -1,4 +1,5 @@
 """The tests for the webdav calendar component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import datetime
 import logging

--- a/tests/components/calendar/test_google.py
+++ b/tests/components/calendar/test_google.py
@@ -1,4 +1,5 @@
 """The tests for the google calendar component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import logging
 import unittest

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the camera component."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, mock_open
 

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -1,4 +1,5 @@
 """The tests for local file camera component."""
+# pylint: skip-file
 import asyncio
 from unittest import mock
 

--- a/tests/components/camera/test_uvc.py
+++ b/tests/components/camera/test_uvc.py
@@ -1,4 +1,5 @@
 """The tests for UVC camera module."""
+# pylint: skip-file
 import socket
 import unittest
 from unittest import mock

--- a/tests/components/climate/test_demo.py
+++ b/tests/components/climate/test_demo.py
@@ -1,4 +1,5 @@
 """The tests for the demo climate component."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.util.unit_system import (

--- a/tests/components/climate/test_ecobee.py
+++ b/tests/components/climate/test_ecobee.py
@@ -1,4 +1,5 @@
 """The test for the Ecobee thermostat module."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 import homeassistant.const as const

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -1,4 +1,5 @@
 """The tests for the generic_thermostat."""
+# pylint: skip-file
 import asyncio
 import datetime
 import unittest

--- a/tests/components/climate/test_honeywell.py
+++ b/tests/components/climate/test_honeywell.py
@@ -1,4 +1,5 @@
 """The test the Honeywell thermostat module."""
+# pylint: skip-file
 import socket
 import unittest
 from unittest import mock

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the climate component."""
+# pylint: skip-file
 import asyncio
 
 from homeassistant.components.climate import SET_TEMPERATURE_SCHEMA

--- a/tests/components/climate/test_melissa.py
+++ b/tests/components/climate/test_melissa.py
@@ -1,4 +1,5 @@
 """Test for Melissa climate component."""
+# pylint: skip-file
 import unittest
 from unittest.mock import Mock, patch
 import json

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -1,4 +1,5 @@
 """The tests for the mqtt climate component."""
+# pylint: skip-file
 import unittest
 import copy
 

--- a/tests/components/climate/test_zwave.py
+++ b/tests/components/climate/test_zwave.py
@@ -1,4 +1,5 @@
 """Test Z-Wave climate devices."""
+# pylint: skip-file
 import pytest
 
 from homeassistant.components.climate import zwave

--- a/tests/components/cloud/test_auth_api.py
+++ b/tests/components/cloud/test_auth_api.py
@@ -1,4 +1,5 @@
 """Tests for the tools to communicate with the cloud."""
+# pylint: skip-file
 from unittest.mock import MagicMock, patch
 
 from botocore.exceptions import ClientError

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -1,4 +1,5 @@
 """Tests for the HTTP API for the cloud component."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, MagicMock
 

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -1,4 +1,5 @@
 """Test the cloud component."""
+# pylint: skip-file
 import asyncio
 import json
 from unittest.mock import patch, MagicMock, mock_open

--- a/tests/components/cloud/test_iot.py
+++ b/tests/components/cloud/test_iot.py
@@ -1,4 +1,5 @@
 """Test the cloud.iot module."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, MagicMock, PropertyMock
 

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -1,4 +1,5 @@
 """Test config entries API."""
+# pylint: skip-file
 
 import asyncio
 from collections import OrderedDict

--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -1,4 +1,5 @@
 """Test hassbian config."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -1,4 +1,5 @@
 """Test entity_registry API."""
+# pylint: skip-file
 import pytest
 
 from homeassistant.setup import async_setup_component

--- a/tests/components/config/test_group.py
+++ b/tests/components/config/test_group.py
@@ -1,4 +1,5 @@
 """Test Group config panel."""
+# pylint: skip-file
 import asyncio
 import json
 from unittest.mock import patch, MagicMock

--- a/tests/components/config/test_hassbian.py
+++ b/tests/components/config/test_hassbian.py
@@ -1,4 +1,5 @@
 """Test hassbian config."""
+# pylint: skip-file
 import asyncio
 import os
 from unittest.mock import patch

--- a/tests/components/config/test_init.py
+++ b/tests/components/config/test_init.py
@@ -1,4 +1,5 @@
 """Test config init."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -1,4 +1,5 @@
 """Test Z-Wave config panel."""
+# pylint: skip-file
 import asyncio
 import json
 from unittest.mock import MagicMock, patch

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the counter component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import unittest

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -1,4 +1,5 @@
 """The tests for the ASUSWRT device tracker platform."""
+# pylint: skip-file
 import os
 from datetime import timedelta
 import unittest

--- a/tests/components/device_tracker/test_automatic.py
+++ b/tests/components/device_tracker/test_automatic.py
@@ -1,4 +1,5 @@
 """Test the automatic device tracker platform."""
+# pylint: skip-file
 import asyncio
 from datetime import datetime
 import logging

--- a/tests/components/device_tracker/test_bt_home_hub_5.py
+++ b/tests/components/device_tracker/test_bt_home_hub_5.py
@@ -1,4 +1,5 @@
 """The tests for the BT Home Hub 5 device tracker platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch
 

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the device tracker component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import json

--- a/tests/components/device_tracker/test_locative.py
+++ b/tests/components/device_tracker/test_locative.py
@@ -1,4 +1,5 @@
 """The tests the for Locative device tracker platform."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 

--- a/tests/components/device_tracker/test_meraki.py
+++ b/tests/components/device_tracker/test_meraki.py
@@ -1,4 +1,5 @@
 """The tests the for Meraki device tracker."""
+# pylint: skip-file
 import asyncio
 import json
 

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT device tracker platform."""
+# pylint: skip-file
 import asyncio
 import unittest
 from unittest.mock import patch

--- a/tests/components/device_tracker/test_mqtt_json.py
+++ b/tests/components/device_tracker/test_mqtt_json.py
@@ -1,4 +1,5 @@
 """The tests for the JSON MQTT device tracker platform."""
+# pylint: skip-file
 import asyncio
 import json
 import unittest

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -1,4 +1,5 @@
 """The tests for the Owntracks device tracker."""
+# pylint: skip-file
 import asyncio
 import json
 import unittest

--- a/tests/components/device_tracker/test_owntracks_http.py
+++ b/tests/components/device_tracker/test_owntracks_http.py
@@ -1,4 +1,5 @@
 """Test the owntracks_http platform."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 

--- a/tests/components/device_tracker/test_tomato.py
+++ b/tests/components/device_tracker/test_tomato.py
@@ -1,4 +1,5 @@
 """The tests for the Tomato device tracker platform."""
+# pylint: skip-file
 from unittest import mock
 import pytest
 import requests

--- a/tests/components/device_tracker/test_tplink.py
+++ b/tests/components/device_tracker/test_tplink.py
@@ -1,4 +1,5 @@
 """The tests for the tplink device tracker platform."""
+# pylint: skip-file
 
 import os
 import unittest

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -1,4 +1,5 @@
 """The tests for the Unifi WAP device tracker platform."""
+# pylint: skip-file
 from unittest import mock
 from pyunifi.controller import APIError
 import homeassistant.util.dt as dt_util

--- a/tests/components/device_tracker/test_upc_connect.py
+++ b/tests/components/device_tracker/test_upc_connect.py
@@ -1,4 +1,5 @@
 """The tests for the UPC ConnextBox device tracker platform."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 import logging

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -1,4 +1,5 @@
 """The tests for the emulated Hue component."""
+# pylint: skip-file
 import asyncio
 import json
 from unittest.mock import patch

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -1,4 +1,5 @@
 """Test the Emulated Hue component."""
+# pylint: skip-file
 import json
 
 from unittest.mock import patch, Mock, mock_open

--- a/tests/components/fan/test_dyson.py
+++ b/tests/components/fan/test_dyson.py
@@ -1,4 +1,5 @@
 """Test the Dyson fan component."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 

--- a/tests/components/fan/test_mqtt.py
+++ b/tests/components/fan/test_mqtt.py
@@ -1,4 +1,5 @@
 """Test MQTT fans."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -1,4 +1,5 @@
 """The tests for the Google Assistant component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import json

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1,4 +1,5 @@
 """Tests for the Google Assistant traits."""
+# pylint: skip-file
 import pytest
 
 from homeassistant.const import (

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Hass.io."""
+# pylint: skip-file
 import os
 from unittest.mock import patch, Mock
 

--- a/tests/components/hassio/test_handler.py
+++ b/tests/components/hassio/test_handler.py
@@ -1,4 +1,5 @@
 """The tests for the hassio component."""
+# pylint: skip-file
 import asyncio
 
 import aiohttp

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -1,4 +1,5 @@
 """The tests for the hassio component."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, Mock, MagicMock
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the hassio component."""
+# pylint: skip-file
 import asyncio
 import os
 from unittest.mock import patch, Mock

--- a/tests/components/http/__init__.py
+++ b/tests/components/http/__init__.py
@@ -1,4 +1,5 @@
 """Tests for the HTTP component."""
+# pylint: skip-file
 from ipaddress import ip_address
 
 from aiohttp import web

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -1,4 +1,5 @@
 """The tests for the Home Assistant HTTP component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 from ipaddress import ip_network
 from unittest.mock import patch

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -1,4 +1,5 @@
 """The tests for the Home Assistant HTTP component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 from unittest.mock import patch, mock_open
 

--- a/tests/components/http/test_cors.py
+++ b/tests/components/http/test_cors.py
@@ -1,4 +1,5 @@
 """Test cors for the HTTP component."""
+# pylint: skip-file
 from unittest.mock import patch
 
 from aiohttp import web

--- a/tests/components/http/test_data_validator.py
+++ b/tests/components/http/test_data_validator.py
@@ -1,4 +1,5 @@
 """Test data validator decorator."""
+# pylint: skip-file
 from unittest.mock import Mock
 
 from aiohttp import web

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Home Assistant HTTP component."""
+# pylint: skip-file
 from homeassistant.setup import async_setup_component
 
 import homeassistant.components.http as http

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the image_processing component."""
+# pylint: skip-file
 from unittest.mock import patch, PropertyMock
 
 from homeassistant.core import callback

--- a/tests/components/image_processing/test_microsoft_face_detect.py
+++ b/tests/components/image_processing/test_microsoft_face_detect.py
@@ -1,4 +1,5 @@
 """The tests for the microsoft face detect platform."""
+# pylint: skip-file
 from unittest.mock import patch, PropertyMock
 
 from homeassistant.core import callback

--- a/tests/components/image_processing/test_microsoft_face_identify.py
+++ b/tests/components/image_processing/test_microsoft_face_identify.py
@@ -1,4 +1,5 @@
 """The tests for the microsoft face identify platform."""
+# pylint: skip-file
 from unittest.mock import patch, PropertyMock
 
 from homeassistant.core import callback

--- a/tests/components/image_processing/test_openalpr_cloud.py
+++ b/tests/components/image_processing/test_openalpr_cloud.py
@@ -1,4 +1,5 @@
 """The tests for the openalpr cloud platform."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, PropertyMock
 

--- a/tests/components/image_processing/test_openalpr_local.py
+++ b/tests/components/image_processing/test_openalpr_local.py
@@ -1,4 +1,5 @@
 """The tests for the openalpr local platform."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, PropertyMock, MagicMock
 

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -1,4 +1,5 @@
 """Philips Hue lights platform tests."""
+# pylint: skip-file
 
 import logging
 import unittest

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Light component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import unittest
 import os

--- a/tests/components/light/test_litejet.py
+++ b/tests/components/light/test_litejet.py
@@ -1,4 +1,5 @@
 """The tests for the litejet component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest import mock

--- a/tests/components/light/test_mochad.py
+++ b/tests/components/light/test_mochad.py
@@ -1,4 +1,5 @@
 """The tests for the mochad light platform."""
+# pylint: skip-file
 import unittest
 import unittest.mock as mock
 

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -87,6 +87,7 @@ light:
   brightness: true
   brightness_scale: 99
 """
+# pylint: skip-file
 
 import json
 import unittest

--- a/tests/components/light/test_mqtt_template.py
+++ b/tests/components/light/test_mqtt_template.py
@@ -26,6 +26,7 @@ If your light doesn't support white value feature, omit `white_value_template`.
 
 If your light doesn't support RGB feature, omit `(red|green|blue)_template`.
 """
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -4,6 +4,7 @@ Test setup of rflink lights component/platform. State tracking and
 control of Rflink switch devices.
 
 """
+# pylint: skip-file
 
 import asyncio
 

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx light platform."""
+# pylint: skip-file
 import unittest
 
 import pytest

--- a/tests/components/light/test_zwave.py
+++ b/tests/components/light/test_zwave.py
@@ -1,4 +1,5 @@
 """Test Z-Wave lights."""
+# pylint: skip-file
 from unittest.mock import patch, MagicMock
 
 import homeassistant.components.zwave

--- a/tests/components/lock/test_mqtt.py
+++ b/tests/components/lock/test_mqtt.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT lock platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/lock/test_zwave.py
+++ b/tests/components/lock/test_zwave.py
@@ -1,4 +1,5 @@
 """Test Z-Wave locks."""
+# pylint: skip-file
 import asyncio
 
 from unittest.mock import patch, MagicMock

--- a/tests/components/mailbox/test_init.py
+++ b/tests/components/mailbox/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the mailbox component."""
+# pylint: skip-file
 import asyncio
 from hashlib import sha1
 

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -1,4 +1,5 @@
 """The tests for the Demo Media player platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch
 import asyncio

--- a/tests/components/media_player/test_monoprice.py
+++ b/tests/components/media_player/test_monoprice.py
@@ -1,4 +1,5 @@
 """The tests for Monoprice Media player platform."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 import voluptuous as vol

--- a/tests/components/media_player/test_samsungtv.py
+++ b/tests/components/media_player/test_samsungtv.py
@@ -1,4 +1,5 @@
 """Tests for samsungtv Components."""
+# pylint: skip-file
 import unittest
 from subprocess import CalledProcessError
 

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -1,4 +1,5 @@
 """The tests for the Demo Media player platform."""
+# pylint: skip-file
 import datetime
 import socket
 import unittest

--- a/tests/components/media_player/test_soundtouch.py
+++ b/tests/components/media_player/test_soundtouch.py
@@ -1,4 +1,5 @@
 """Test the Soundtouch component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest import mock

--- a/tests/components/media_player/test_universal.py
+++ b/tests/components/media_player/test_universal.py
@@ -1,4 +1,5 @@
 """The tests for the Universal Media player platform."""
+# pylint: skip-file
 from copy import copy
 import unittest
 

--- a/tests/components/media_player/test_webostv.py
+++ b/tests/components/media_player/test_webostv.py
@@ -1,4 +1,5 @@
 """The tests for the LG webOS media player platform."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT component."""
+# pylint: skip-file
 import asyncio
 import unittest
 from unittest import mock

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT component embedded server."""
+# pylint: skip-file
 from unittest.mock import Mock, MagicMock, patch
 
 from homeassistant.setup import setup_component

--- a/tests/components/notify/test_apns.py
+++ b/tests/components/notify/test_apns.py
@@ -1,4 +1,5 @@
 """The tests for the APNS component."""
+# pylint: skip-file
 import io
 import unittest
 from unittest.mock import Mock, patch, mock_open

--- a/tests/components/notify/test_command_line.py
+++ b/tests/components/notify/test_command_line.py
@@ -1,4 +1,5 @@
 """The tests for the command line notification platform."""
+# pylint: skip-file
 import os
 import tempfile
 import unittest

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -1,4 +1,5 @@
 """The tests for the notify demo platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch
 

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -1,4 +1,5 @@
 """The tests for the notify.group platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/components/notify/test_html5.py
+++ b/tests/components/notify/test_html5.py
@@ -1,4 +1,5 @@
 """Test HTML5 notify platform."""
+# pylint: skip-file
 import json
 from unittest.mock import patch, MagicMock, mock_open
 from aiohttp.hdrs import AUTHORIZATION

--- a/tests/components/persistent_notification/test_init.py
+++ b/tests/components/persistent_notification/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the persistent notification component."""
+# pylint: skip-file
 from homeassistant.setup import setup_component
 import homeassistant.components.persistent_notification as pn
 

--- a/tests/components/recorder/models_original.py
+++ b/tests/components/recorder/models_original.py
@@ -3,6 +3,7 @@
 This file contains the original models definitions before schema tracking was
 implemented. It is used to test the schema migration logic.
 """
+# pylint: skip-file
 
 import json
 from datetime import datetime

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -1,4 +1,5 @@
 """Test data purging."""
+# pylint: skip-file
 import json
 from datetime import datetime, timedelta
 import unittest

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -1,4 +1,5 @@
 """Test util methods."""
+# pylint: skip-file
 from unittest.mock import patch, MagicMock
 
 import pytest

--- a/tests/components/scene/test_litejet.py
+++ b/tests/components/scene/test_litejet.py
@@ -1,4 +1,5 @@
 """The tests for the litejet component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest import mock

--- a/tests/components/sensor/test_canary.py
+++ b/tests/components/sensor/test_canary.py
@@ -1,4 +1,5 @@
 """The tests for the Canary sensor platform."""
+# pylint: skip-file
 import copy
 import unittest
 from unittest.mock import Mock

--- a/tests/components/sensor/test_command_line.py
+++ b/tests/components/sensor/test_command_line.py
@@ -1,4 +1,5 @@
 """The tests for the Command line sensor platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.helpers.template import Template

--- a/tests/components/sensor/test_darksky.py
+++ b/tests/components/sensor/test_darksky.py
@@ -1,4 +1,5 @@
 """The tests for the Dark Sky platform."""
+# pylint: skip-file
 import re
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -4,6 +4,7 @@ Tests setup of the DSMR component and ensure incoming telegrams cause
 Entity to be updated with new values.
 
 """
+# pylint: skip-file
 
 import asyncio
 from decimal import Decimal

--- a/tests/components/sensor/test_dte_energy_bridge.py
+++ b/tests/components/sensor/test_dte_energy_bridge.py
@@ -1,4 +1,5 @@
 """The tests for the DTE Energy Bridge."""
+# pylint: skip-file
 
 import unittest
 

--- a/tests/components/sensor/test_dyson.py
+++ b/tests/components/sensor/test_dyson.py
@@ -1,4 +1,5 @@
 """Test the Dyson sensor(s) component."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 

--- a/tests/components/sensor/test_efergy.py
+++ b/tests/components/sensor/test_efergy.py
@@ -1,4 +1,5 @@
 """The tests for Efergy sensor platform."""
+# pylint: skip-file
 import unittest
 
 import requests_mock

--- a/tests/components/sensor/test_fido.py
+++ b/tests/components/sensor/test_fido.py
@@ -1,4 +1,5 @@
 """The test for the fido sensor platform."""
+# pylint: skip-file
 import asyncio
 import logging
 import sys

--- a/tests/components/sensor/test_file.py
+++ b/tests/components/sensor/test_file.py
@@ -1,4 +1,5 @@
 """The tests for local file sensor platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import Mock, patch
 

--- a/tests/components/sensor/test_filesize.py
+++ b/tests/components/sensor/test_filesize.py
@@ -1,4 +1,5 @@
 """The tests for the filesize sensor."""
+# pylint: skip-file
 import unittest
 import os
 

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -1,4 +1,5 @@
 """The test for the data filter sensor platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.components.sensor.filter import (

--- a/tests/components/sensor/test_folder.py
+++ b/tests/components/sensor/test_folder.py
@@ -1,4 +1,5 @@
 """The tests for the folder sensor."""
+# pylint: skip-file
 import unittest
 import os
 

--- a/tests/components/sensor/test_geo_rss_events.py
+++ b/tests/components/sensor/test_geo_rss_events.py
@@ -1,4 +1,5 @@
 """The test for the geo rss events sensor platform."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 import feedparser

--- a/tests/components/sensor/test_history_stats.py
+++ b/tests/components/sensor/test_history_stats.py
@@ -1,4 +1,5 @@
 """The test for the History Statistics sensor platform."""
+# pylint: skip-file
 # pylint: disable=protected-access
 from datetime import timedelta
 import unittest

--- a/tests/components/sensor/test_hydroquebec.py
+++ b/tests/components/sensor/test_hydroquebec.py
@@ -1,4 +1,5 @@
 """The test for the hydroquebec sensor platform."""
+# pylint: skip-file
 import asyncio
 import logging
 import sys

--- a/tests/components/sensor/test_imap_email_content.py
+++ b/tests/components/sensor/test_imap_email_content.py
@@ -1,4 +1,5 @@
 """The tests for the IMAP email content sensor platform."""
+# pylint: skip-file
 from collections import deque
 import email
 from email.mime.multipart import MIMEMultipart

--- a/tests/components/sensor/test_melissa.py
+++ b/tests/components/sensor/test_melissa.py
@@ -1,4 +1,5 @@
 """Test for Melissa climate component."""
+# pylint: skip-file
 import unittest
 import json
 from unittest.mock import Mock

--- a/tests/components/sensor/test_mfi.py
+++ b/tests/components/sensor/test_mfi.py
@@ -1,4 +1,5 @@
 """The tests for the mFi sensor platform."""
+# pylint: skip-file
 import unittest
 import unittest.mock as mock
 

--- a/tests/components/sensor/test_min_max.py
+++ b/tests/components/sensor/test_min_max.py
@@ -1,4 +1,5 @@
 """The test for the min/max sensor platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/sensor/test_moldindicator.py
+++ b/tests/components/sensor/test_moldindicator.py
@@ -1,4 +1,5 @@
 """The tests for the MoldIndicator sensor."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/sensor/test_moon.py
+++ b/tests/components/sensor/test_moon.py
@@ -1,4 +1,5 @@
 """The test for the moon sensor platform."""
+# pylint: skip-file
 import unittest
 from datetime import datetime
 from unittest.mock import patch

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT sensor platform."""
+# pylint: skip-file
 import unittest
 
 from datetime import timedelta, datetime

--- a/tests/components/sensor/test_mqtt_room.py
+++ b/tests/components/sensor/test_mqtt_room.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT room presence sensor."""
+# pylint: skip-file
 import json
 import datetime
 import unittest

--- a/tests/components/sensor/test_radarr.py
+++ b/tests/components/sensor/test_radarr.py
@@ -1,4 +1,5 @@
 """The tests for the Radarr platform."""
+# pylint: skip-file
 import unittest
 
 import pytest

--- a/tests/components/sensor/test_random.py
+++ b/tests/components/sensor/test_random.py
@@ -1,4 +1,5 @@
 """The test for the random number sensor platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/sensor/test_rest.py
+++ b/tests/components/sensor/test_rest.py
@@ -1,4 +1,5 @@
 """The tests for the REST sensor platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch, Mock
 

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx sensor platform."""
+# pylint: skip-file
 import unittest
 
 import pytest

--- a/tests/components/sensor/test_simulated.py
+++ b/tests/components/sensor/test_simulated.py
@@ -1,4 +1,5 @@
 """The tests for the simulated sensor."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.components.sensor.simulated import (

--- a/tests/components/sensor/test_sonarr.py
+++ b/tests/components/sensor/test_sonarr.py
@@ -1,4 +1,5 @@
 """The tests for the Sonarr platform."""
+# pylint: skip-file
 import unittest
 import time
 from datetime import datetime

--- a/tests/components/sensor/test_statistics.py
+++ b/tests/components/sensor/test_statistics.py
@@ -1,4 +1,5 @@
 """The test for the statistics sensor platform."""
+# pylint: skip-file
 import unittest
 import statistics
 

--- a/tests/components/sensor/test_tcp.py
+++ b/tests/components/sensor/test_tcp.py
@@ -1,4 +1,5 @@
 """The tests for the TCP sensor platform."""
+# pylint: skip-file
 import socket
 import unittest
 from copy import copy

--- a/tests/components/sensor/test_uk_transport.py
+++ b/tests/components/sensor/test_uk_transport.py
@@ -1,4 +1,5 @@
 """The tests for the uk_transport platform."""
+# pylint: skip-file
 import re
 
 import requests_mock

--- a/tests/components/sensor/test_uptime.py
+++ b/tests/components/sensor/test_uptime.py
@@ -1,4 +1,5 @@
 """The tests for the uptime sensor platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch
 from datetime import timedelta

--- a/tests/components/sensor/test_version.py
+++ b/tests/components/sensor/test_version.py
@@ -1,4 +1,5 @@
 """The test for the version sensor platform."""
+# pylint: skip-file
 import asyncio
 import unittest
 from unittest.mock import patch

--- a/tests/components/sensor/test_vultr.py
+++ b/tests/components/sensor/test_vultr.py
@@ -1,4 +1,5 @@
 """The tests for the Vultr sensor platform."""
+# pylint: skip-file
 import json
 import unittest
 from unittest.mock import patch

--- a/tests/components/sensor/test_worldclock.py
+++ b/tests/components/sensor/test_worldclock.py
@@ -1,4 +1,5 @@
 """The test for the World clock sensor platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/sensor/test_zwave.py
+++ b/tests/components/sensor/test_zwave.py
@@ -1,4 +1,5 @@
 """Test Z-Wave sensor."""
+# pylint: skip-file
 from homeassistant.components.sensor import zwave
 from homeassistant.components.zwave import const
 import homeassistant.const

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -1,4 +1,5 @@
 """The tests for the Flux switch platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch
 

--- a/tests/components/switch/test_litejet.py
+++ b/tests/components/switch/test_litejet.py
@@ -1,4 +1,5 @@
 """The tests for the litejet component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest import mock

--- a/tests/components/switch/test_mfi.py
+++ b/tests/components/switch/test_mfi.py
@@ -1,4 +1,5 @@
 """The tests for the mFi switch platform."""
+# pylint: skip-file
 import unittest
 import unittest.mock as mock
 

--- a/tests/components/switch/test_mochad.py
+++ b/tests/components/switch/test_mochad.py
@@ -1,4 +1,5 @@
 """The tests for the mochad switch platform."""
+# pylint: skip-file
 import unittest
 import unittest.mock as mock
 

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT switch platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/switch/test_rest.py
+++ b/tests/components/switch/test_rest.py
@@ -1,4 +1,5 @@
 """The tests for the REST switch platform."""
+# pylint: skip-file
 import asyncio
 
 import aiohttp

--- a/tests/components/switch/test_rflink.py
+++ b/tests/components/switch/test_rflink.py
@@ -4,6 +4,7 @@ Test setup of rflink switch component/platform. State tracking and
 control of Rflink switch devices.
 
 """
+# pylint: skip-file
 
 import asyncio
 

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx switch platform."""
+# pylint: skip-file
 import unittest
 
 import pytest

--- a/tests/components/switch/test_vultr.py
+++ b/tests/components/switch/test_vultr.py
@@ -1,4 +1,5 @@
 """Test the Vultr switch platform."""
+# pylint: skip-file
 import json
 import unittest
 from unittest.mock import patch

--- a/tests/components/switch/test_wake_on_lan.py
+++ b/tests/components/switch/test_wake_on_lan.py
@@ -1,4 +1,5 @@
 """The tests for the wake on lan switch platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch
 

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -1,4 +1,5 @@
 """The tests for the Alert component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 from copy import deepcopy
 import unittest

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -1,4 +1,5 @@
 """The tests for the Home Assistant API component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import json

--- a/tests/components/test_canary.py
+++ b/tests/components/test_canary.py
@@ -1,4 +1,5 @@
 """The tests for the Canary component."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch, MagicMock, PropertyMock
 

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -1,4 +1,5 @@
 """The tests for the Conversation component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 

--- a/tests/components/test_demo.py
+++ b/tests/components/test_demo.py
@@ -1,4 +1,5 @@
 """The tests for the Demo component."""
+# pylint: skip-file
 import asyncio
 import json
 import os

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -1,4 +1,5 @@
 """The tests for the discovery component."""
+# pylint: skip-file
 import asyncio
 import os
 from unittest.mock import patch, MagicMock

--- a/tests/components/test_duckdns.py
+++ b/tests/components/test_duckdns.py
@@ -1,4 +1,5 @@
 """Test the DuckDNS component."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 

--- a/tests/components/test_dyson.py
+++ b/tests/components/test_dyson.py
@@ -1,4 +1,5 @@
 """Test the parent Dyson component."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 

--- a/tests/components/test_ffmpeg.py
+++ b/tests/components/test_ffmpeg.py
@@ -1,4 +1,5 @@
 """The tests for Home Assistant ffmpeg."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, MagicMock
 

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -1,4 +1,5 @@
 """The tests for Home Assistant frontend."""
+# pylint: skip-file
 import asyncio
 import re
 from unittest.mock import patch

--- a/tests/components/test_google.py
+++ b/tests/components/test_google.py
@@ -1,4 +1,5 @@
 """The tests for the Google Calendar component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest.mock import patch

--- a/tests/components/test_google_domains.py
+++ b/tests/components/test_google_domains.py
@@ -1,4 +1,5 @@
 """Test the Google Domains component."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 

--- a/tests/components/test_graphite.py
+++ b/tests/components/test_graphite.py
@@ -1,4 +1,5 @@
 """The tests for the Graphite component."""
+# pylint: skip-file
 import socket
 import unittest
 from unittest import mock

--- a/tests/components/test_hue.py
+++ b/tests/components/test_hue.py
@@ -1,4 +1,5 @@
 """Generic Philips Hue component tests."""
+# pylint: skip-file
 import asyncio
 import logging
 import unittest

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -1,4 +1,5 @@
 """The tests for the InfluxDB component."""
+# pylint: skip-file
 import datetime
 import unittest
 from unittest import mock

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -1,4 +1,5 @@
 """The tests for Core components."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import unittest

--- a/tests/components/test_input_boolean.py
+++ b/tests/components/test_input_boolean.py
@@ -1,4 +1,5 @@
 """The tests for the input_boolean component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import unittest

--- a/tests/components/test_input_number.py
+++ b/tests/components/test_input_number.py
@@ -1,4 +1,5 @@
 """The tests for the Input number component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import unittest

--- a/tests/components/test_input_select.py
+++ b/tests/components/test_input_select.py
@@ -1,4 +1,5 @@
 """The tests for the Input select component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import unittest

--- a/tests/components/test_input_text.py
+++ b/tests/components/test_input_text.py
@@ -1,4 +1,5 @@
 """The tests for the Input text component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import unittest

--- a/tests/components/test_litejet.py
+++ b/tests/components/test_litejet.py
@@ -1,4 +1,5 @@
 """The tests for the litejet component."""
+# pylint: skip-file
 import logging
 import unittest
 

--- a/tests/components/test_logentries.py
+++ b/tests/components/test_logentries.py
@@ -1,4 +1,5 @@
 """The tests for the Logentries component."""
+# pylint: skip-file
 
 import unittest
 from unittest import mock

--- a/tests/components/test_microsoft_face.py
+++ b/tests/components/test_microsoft_face.py
@@ -1,4 +1,5 @@
 """The tests for the microsoft face platform."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 

--- a/tests/components/test_mqtt_eventstream.py
+++ b/tests/components/test_mqtt_eventstream.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT eventstream component."""
+# pylint: skip-file
 import json
 from unittest.mock import ANY, patch
 

--- a/tests/components/test_mqtt_statestream.py
+++ b/tests/components/test_mqtt_statestream.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT statestream component."""
+# pylint: skip-file
 from unittest.mock import ANY, call, patch
 
 from homeassistant.setup import setup_component

--- a/tests/components/test_namecheapdns.py
+++ b/tests/components/test_namecheapdns.py
@@ -1,4 +1,5 @@
 """Test the NamecheapDNS component."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 

--- a/tests/components/test_no_ip.py
+++ b/tests/components/test_no_ip.py
@@ -1,4 +1,5 @@
 """Test the NO-IP component."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 

--- a/tests/components/test_panel_custom.py
+++ b/tests/components/test_panel_custom.py
@@ -1,4 +1,5 @@
 """The tests for the panel_custom component."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import Mock, patch
 

--- a/tests/components/test_pilight.py
+++ b/tests/components/test_pilight.py
@@ -1,4 +1,5 @@
 """The tests for the pilight component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest.mock import patch

--- a/tests/components/test_plant.py
+++ b/tests/components/test_plant.py
@@ -1,4 +1,5 @@
 """Unit tests for platform/plant.py."""
+# pylint: skip-file
 import asyncio
 import unittest
 import pytest

--- a/tests/components/test_proximity.py
+++ b/tests/components/test_proximity.py
@@ -1,4 +1,5 @@
 """The tests for the Proximity component."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.components import proximity

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -1,4 +1,5 @@
 """Test the python_script component."""
+# pylint: skip-file
 import asyncio
 import logging
 from unittest.mock import patch, mock_open

--- a/tests/components/test_rest_command.py
+++ b/tests/components/test_rest_command.py
@@ -1,4 +1,5 @@
 """The tests for the rest command platform."""
+# pylint: skip-file
 import asyncio
 
 import aiohttp

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -1,4 +1,5 @@
 """Common functions for Rflink component tests and generic platform tests."""
+# pylint: skip-file
 
 import asyncio
 from unittest.mock import Mock

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import unittest
 

--- a/tests/components/test_rss_feed_template.py
+++ b/tests/components/test_rss_feed_template.py
@@ -1,4 +1,5 @@
 """The tests for the rss_feed_api component."""
+# pylint: skip-file
 import asyncio
 from xml.etree import ElementTree
 

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -1,4 +1,5 @@
 """The tests for the Script component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import unittest
 from unittest.mock import patch

--- a/tests/components/test_shell_command.py
+++ b/tests/components/test_shell_command.py
@@ -1,4 +1,5 @@
 """The tests for the Shell command component."""
+# pylint: skip-file
 import asyncio
 import os
 import tempfile

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -1,4 +1,5 @@
 """Test shopping list component."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 

--- a/tests/components/test_sleepiq.py
+++ b/tests/components/test_sleepiq.py
@@ -1,4 +1,5 @@
 """The tests for the SleepIQ component."""
+# pylint: skip-file
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -1,4 +1,5 @@
 """Test the Snips component."""
+# pylint: skip-file
 import asyncio
 import json
 import logging

--- a/tests/components/test_spc.py
+++ b/tests/components/test_spc.py
@@ -1,4 +1,5 @@
 """Tests for Vanderbilt SPC component."""
+# pylint: skip-file
 import asyncio
 
 import pytest

--- a/tests/components/test_splunk.py
+++ b/tests/components/test_splunk.py
@@ -1,4 +1,5 @@
 """The tests for the Splunk component."""
+# pylint: skip-file
 import json
 import unittest
 from unittest import mock

--- a/tests/components/test_statsd.py
+++ b/tests/components/test_statsd.py
@@ -1,4 +1,5 @@
 """The tests for the StatsD feeder."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -1,4 +1,5 @@
 """The tests for the Updater component."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 from unittest.mock import patch, Mock

--- a/tests/components/test_upnp.py
+++ b/tests/components/test_upnp.py
@@ -1,4 +1,5 @@
 """Test the UPNP component."""
+# pylint: skip-file
 import asyncio
 from collections import OrderedDict
 from unittest.mock import patch, MagicMock

--- a/tests/components/test_wake_on_lan.py
+++ b/tests/components/test_wake_on_lan.py
@@ -1,4 +1,5 @@
 """Tests for Wake On LAN component."""
+# pylint: skip-file
 import asyncio
 from unittest import mock
 

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -1,4 +1,5 @@
 """Tests for the Home Assistant Websocket API."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 

--- a/tests/components/test_zone.py
+++ b/tests/components/test_zone.py
@@ -1,4 +1,5 @@
 """Test zone component."""
+# pylint: skip-file
 import unittest
 
 from homeassistant import setup

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the timer component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import unittest

--- a/tests/components/tts/test_google.py
+++ b/tests/components/tts/test_google.py
@@ -1,4 +1,5 @@
 """The tests for the Google speech platform."""
+# pylint: skip-file
 import asyncio
 import os
 import shutil

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the TTS component."""
+# pylint: skip-file
 import ctypes
 import os
 import shutil

--- a/tests/components/tts/test_marytts.py
+++ b/tests/components/tts/test_marytts.py
@@ -1,4 +1,5 @@
 """The tests for the MaryTTS speech platform."""
+# pylint: skip-file
 import asyncio
 import os
 import shutil

--- a/tests/components/tts/test_voicerss.py
+++ b/tests/components/tts/test_voicerss.py
@@ -1,4 +1,5 @@
 """The tests for the VoiceRSS speech platform."""
+# pylint: skip-file
 import asyncio
 import os
 import shutil

--- a/tests/components/tts/test_yandextts.py
+++ b/tests/components/tts/test_yandextts.py
@@ -1,4 +1,5 @@
 """The tests for the Yandex SpeechKit speech platform."""
+# pylint: skip-file
 import asyncio
 import os
 import shutil

--- a/tests/components/vacuum/test_dyson.py
+++ b/tests/components/vacuum/test_dyson.py
@@ -1,4 +1,5 @@
 """Test the Dyson 360 eye robot vacuum component."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 

--- a/tests/components/vacuum/test_mqtt.py
+++ b/tests/components/vacuum/test_mqtt.py
@@ -1,4 +1,5 @@
 """The tests for the Demo vacuum platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.components import vacuum

--- a/tests/components/vacuum/test_xiaomi_miio.py
+++ b/tests/components/vacuum/test_xiaomi_miio.py
@@ -1,4 +1,5 @@
 """The tests for the Xiaomi vacuum platform."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta, time
 from unittest import mock

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Z-Wave init."""
+# pylint: skip-file
 import asyncio
 from collections import OrderedDict
 from datetime import datetime

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -1,4 +1,5 @@
 """Test Z-Wave node entity."""
+# pylint: skip-file
 import asyncio
 import unittest
 from unittest.mock import patch, MagicMock

--- a/tests/components/zwave/test_workaround.py
+++ b/tests/components/zwave/test_workaround.py
@@ -1,4 +1,5 @@
 """Test Z-Wave workarounds."""
+# pylint: skip-file
 from homeassistant.components.zwave import const, workaround
 from tests.mock.zwave import MockNode, MockValue
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Setup some common test helper things."""
+# pylint: skip-file
 import asyncio
 import functools
 import logging

--- a/tests/helpers/test_aiohttp_client.py
+++ b/tests/helpers/test_aiohttp_client.py
@@ -1,4 +1,5 @@
 """Test the aiohttp client helper."""
+# pylint: skip-file
 import asyncio
 import unittest
 

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1,4 +1,5 @@
 """Test the condition helper."""
+# pylint: skip-file
 from unittest.mock import patch
 
 from homeassistant.helpers import condition

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -1,4 +1,5 @@
 """Test deprecation helpers."""
+# pylint: skip-file
 from homeassistant.helpers.deprecation import (
     deprecated_substitute, get_deprecated)
 

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -1,4 +1,5 @@
 """Test discovery helpers."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 

--- a/tests/helpers/test_dispatcher.py
+++ b/tests/helpers/test_dispatcher.py
@@ -1,4 +1,5 @@
 """Test dispatcher helpers."""
+# pylint: skip-file
 import asyncio
 
 from homeassistant.core import callback

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1,4 +1,5 @@
 """Test the entity helper."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 from unittest.mock import MagicMock, patch

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -1,4 +1,5 @@
 """The tests for the Entity component helper."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 from collections import OrderedDict

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1,4 +1,5 @@
 """Tests for the EntityPlatform helper."""
+# pylint: skip-file
 import asyncio
 import logging
 import unittest

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1,4 +1,5 @@
 """Tests for the Entity Registry."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, mock_open
 

--- a/tests/helpers/test_entity_values.py
+++ b/tests/helpers/test_entity_values.py
@@ -1,4 +1,5 @@
 """Test the entity values helper."""
+# pylint: skip-file
 from collections import OrderedDict
 from homeassistant.helpers.entity_values import EntityValues as EV
 

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1,4 +1,5 @@
 """Test event helpers."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import unittest

--- a/tests/helpers/test_init.py
+++ b/tests/helpers/test_init.py
@@ -1,4 +1,5 @@
 """Test component helpers."""
+# pylint: skip-file
 # pylint: disable=protected-access
 from collections import OrderedDict
 import unittest

--- a/tests/helpers/test_location.py
+++ b/tests/helpers/test_location.py
@@ -1,4 +1,5 @@
 """Tests Home Assistant location helpers."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -1,4 +1,5 @@
 """The tests for the Restore component."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 from unittest.mock import patch, MagicMock

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1,4 +1,5 @@
 """The tests for the Script component."""
+# pylint: skip-file
 # pylint: disable=protected-access
 from datetime import timedelta
 from unittest import mock

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1,4 +1,5 @@
 """Test service helpers."""
+# pylint: skip-file
 import asyncio
 from copy import deepcopy
 import unittest

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1,4 +1,5 @@
 """Test Home Assistant template helper methods."""
+# pylint: skip-file
 import asyncio
 from datetime import datetime
 import unittest

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,4 +1,5 @@
 """Test the bootstrapping."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import os

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1,4 +1,5 @@
 """Test the config manager."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import MagicMock, patch, mock_open
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 """Test to verify that Home Assistant core works."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import logging

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,4 +1,5 @@
 """Test to verify that we can load components."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import unittest

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,4 +1,5 @@
 """Test Home Assistant remote methods and classes."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import unittest
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,4 +1,5 @@
 """Test component/platform setup."""
+# pylint: skip-file
 # pylint: disable=protected-access
 import asyncio
 import os

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -1,4 +1,5 @@
 """Aiohttp test utils."""
+# pylint: skip-file
 import asyncio
 from contextlib import contextmanager
 import json as _json

--- a/tests/test_util/test_aiohttp.py
+++ b/tests/test_util/test_aiohttp.py
@@ -1,4 +1,5 @@
 """Tests for our aiohttp mocker."""
+# pylint: skip-file
 from .aiohttp import AiohttpClientMocker
 
 import pytest

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -1,4 +1,5 @@
 """Tests for async util methods from Python source."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import MagicMock, patch
 from unittest import TestCase

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -1,4 +1,5 @@
 """Test Home Assistant color util methods."""
+# pylint: skip-file
 import unittest
 import homeassistant.util.color as color_util
 

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -1,4 +1,5 @@
 """Test homeassistant distance utility functions."""
+# pylint: skip-file
 
 import unittest
 import homeassistant.util.distance as distance_util

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -1,4 +1,5 @@
 """Test Home Assistant date util methods."""
+# pylint: skip-file
 import unittest
 from datetime import datetime, timedelta
 

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -1,4 +1,5 @@
 """Test Home Assistant util methods."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch, MagicMock
 from datetime import datetime, timedelta

--- a/tests/util/test_location.py
+++ b/tests/util/test_location.py
@@ -1,4 +1,5 @@
 """Test Home Assistant location util methods."""
+# pylint: skip-file
 from unittest import TestCase
 from unittest.mock import patch
 

--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -1,4 +1,5 @@
 """Test Home Assistant logging util methods."""
+# pylint: skip-file
 import asyncio
 import logging
 import threading

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -1,4 +1,5 @@
 """Test Home Assistant package util methods."""
+# pylint: skip-file
 import asyncio
 import logging
 import os

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -1,4 +1,5 @@
 """Test Home Assistant yaml loader."""
+# pylint: skip-file
 import io
 import os
 import unittest

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
      -r{toxinidir}/requirements_test.txt
      -c{toxinidir}/homeassistant/package_constraints.txt
 commands =
-     pylint homeassistant
+     pylint homeassistant tests
 
 [testenv:lint]
 basepython = {env:PYTHON3_PATH:python3}


### PR DESCRIPTION
## Description:
This PR enables pylint for our tests directory. A good portion of our tests currently don't pass pylint, so for now they've been blacklisted so we can turn on pylint for the rest of them.

The failing tests were modified with the following bash script:
```bash
sed -i '0,/"""$/s//"""\n# pylint: skip-file/' $(pylint --msg-template='{path}' tests 2>/dev/null | grep '^tests' | uniq)
```

### Notes
We should also be braced for incoming PRs introducing lint failures unless they're rebased/merged on dev.