### PR TITLE
Catch if Hue bridge goes unavailable

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -181,6 +181,7 @@ class HueBridge(object):
         self.allow_in_emulated_hue = allow_in_emulated_hue
         self.allow_hue_groups = allow_hue_groups
 
+        self.available = True
         self.bridge = None
         self.lights = {}
         self.lightgroups = {}


### PR DESCRIPTION
## Description:
Mark all Hue lights as unavailable when the bridge goes offline.

**Related issue (if applicable):** #12935

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

