### PR TITLE
Adding check for empty discovery info in alarm control panel Egardia.

### DIFF
--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -33,6 +33,8 @@ STATES = {
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Egardia platform."""
+    if discovery_info is None:
+        return
     device = EgardiaAlarm(
         discovery_info['name'],
         hass.data[EGARDIA_DEVICE],


### PR DESCRIPTION
## Description:
Issue https://github.com/home-assistant/home-assistant/issues/12877 identified a bug where we did not check for empty discovery info. Adding this in in this PR.

**Related issue (if applicable):** fixes #12877 

## Example entry for `configuration.yaml` (if applicable):
```yaml
egardia:
  host:
  username:
  password:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
