### PR TITLE
[WIP] Enable pylint for tests v2

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,5 @@
 """Test the helper method for writing tests."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 import functools as ft

--- a/tests/common.py
+++ b/tests/common.py
@@ -80,7 +80,6 @@ def get_test_home_assistant():
 
     def run_loop():
         """Run event loop."""
-        # pylint: disable=protected-access
         loop._thread_ident = threading.get_ident()
         loop.run_forever()
         stop_event.set()
@@ -105,7 +104,6 @@ def get_test_home_assistant():
     return hass
 
 
-# pylint: disable=protected-access
 @asyncio.coroutine
 def async_test_home_assistant(loop):
     """Return a Home Assistant object pointing at test config dir."""
@@ -180,7 +178,7 @@ def async_mock_service(hass, domain, service, schema=None):
     calls = []
 
     @asyncio.coroutine
-    def mock_service_log(call):  # pylint: disable=unnecessary-lambda
+    def mock_service_log(call):
         """Mock service call."""
         calls.append(call)
 
@@ -306,7 +304,6 @@ def mock_registry(hass, mock_entries=None):
 class MockModule(object):
     """Representation of a fake module."""
 
-    # pylint: disable=invalid-name
     def __init__(self, domain=None, dependencies=None, setup=None,
                  requirements=None, config_schema=None, platform_schema=None,
                  async_setup=None, async_setup_entry=None,
@@ -342,7 +339,6 @@ class MockModule(object):
 class MockPlatform(object):
     """Provide a fake platform."""
 
-    # pylint: disable=invalid-name
     def __init__(self, setup_platform=None, dependencies=None,
                  platform_schema=None, async_setup_platform=None):
         """Initialize the platform."""

--- a/tests/components/alarm_control_panel/test_manual.py
+++ b/tests/components/alarm_control_panel/test_manual.py
@@ -21,11 +21,11 @@ CODE = 'HELLO_CODE'
 class TestAlarmControlPanelManual(unittest.TestCase):
     """Test the manual alarm module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/alarm_control_panel/test_manual_mqtt.py
+++ b/tests/components/alarm_control_panel/test_manual_mqtt.py
@@ -20,12 +20,12 @@ CODE = 'HELLO_CODE'
 class TestAlarmControlPanelManualMqtt(unittest.TestCase):
     """Test the manual_mqtt alarm module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/alarm_control_panel/test_mqtt.py
+++ b/tests/components/alarm_control_panel/test_mqtt.py
@@ -18,14 +18,12 @@ CODE = 'HELLO_CODE'
 class TestAlarmControlPanelMQTT(unittest.TestCase):
     """Test the manual alarm module."""
 
-    # pylint: disable=invalid-name
-
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down stuff we started."""
         self.hass.stop()
 

--- a/tests/components/alarm_control_panel/test_spc.py
+++ b/tests/components/alarm_control_panel/test_spc.py
@@ -1,4 +1,5 @@
 """Tests for Vanderbilt SPC alarm control panel platform."""
+# pylint: skip-file
 import asyncio
 
 import pytest

--- a/tests/components/alexa/test_flash_briefings.py
+++ b/tests/components/alexa/test_flash_briefings.py
@@ -1,4 +1,5 @@
 """The tests for the Alexa component."""
+# pylint: skip-file
 import asyncio
 import datetime
 

--- a/tests/components/alexa/test_flash_briefings.py
+++ b/tests/components/alexa/test_flash_briefings.py
@@ -1,5 +1,4 @@
 """The tests for the Alexa component."""
-# pylint: disable=protected-access
 import asyncio
 import datetime
 
@@ -14,7 +13,6 @@ SESSION_ID = "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000"
 APPLICATION_ID = "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
 REQUEST_ID = "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000"
 
-# pylint: disable=invalid-name
 calls = []
 
 NPR_NEWS_MP3_URL = "https://pd.npr.org/anon.npr-mp3/npr/news/newscast.mp3"

--- a/tests/components/alexa/test_intent.py
+++ b/tests/components/alexa/test_intent.py
@@ -1,4 +1,5 @@
 """The tests for the Alexa component."""
+# pylint: skip-file
 import asyncio
 import json
 

--- a/tests/components/alexa/test_intent.py
+++ b/tests/components/alexa/test_intent.py
@@ -1,5 +1,4 @@
 """The tests for the Alexa component."""
-# pylint: disable=protected-access
 import asyncio
 import json
 
@@ -16,7 +15,6 @@ REQUEST_ID = "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000"
 AUTHORITY_ID = "amzn1.er-authority.000000-d0ed-0000-ad00-000000d00ebe.ZODIAC"
 BUILTIN_AUTH_ID = "amzn1.er-authority.000000-d0ed-0000-ad00-000000d00ebe.TEST"
 
-# pylint: disable=invalid-name
 calls = []
 
 NPR_NEWS_MP3_URL = "https://pd.npr.org/anon.npr-mp3/npr/news/newscast.mp3"

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -8,7 +8,6 @@ import homeassistant.components.automation as automation
 from tests.common import get_test_home_assistant, mock_component
 
 
-# pylint: disable=invalid-name
 class TestAutomationEvent(unittest.TestCase):
     """Test the event automation."""
 

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the automation component."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 import unittest

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -17,7 +17,6 @@ from tests.common import (
     mock_service, async_mock_service, mock_restore_cache)
 
 
-# pylint: disable=invalid-name
 class TestAutomation(unittest.TestCase):
     """Test the event automation."""
 

--- a/tests/components/automation/test_litejet.py
+++ b/tests/components/automation/test_litejet.py
@@ -1,4 +1,5 @@
 """The tests for the litejet component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest import mock

--- a/tests/components/automation/test_mqtt.py
+++ b/tests/components/automation/test_mqtt.py
@@ -9,7 +9,6 @@ from tests.common import (
     mock_component)
 
 
-# pylint: disable=invalid-name
 class TestAutomationMQTT(unittest.TestCase):
     """Test the event automation."""
 

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -1,4 +1,5 @@
 """The tests for numeric state automation."""
+# pylint: skip-file
 from datetime import timedelta
 import unittest
 from unittest.mock import patch

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -13,7 +13,6 @@ from tests.common import (
     assert_setup_component)
 
 
-# pylint: disable=invalid-name
 class TestAutomationNumericState(unittest.TestCase):
     """Test the event automation."""
 
@@ -30,7 +29,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
         self.hass.services.register('test', 'automation', record_call)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -1,4 +1,5 @@
 """The test for state automation."""
+# pylint: skip-file
 from datetime import timedelta
 
 import unittest

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -14,7 +14,6 @@ from tests.common import (
     mock_component)
 
 
-# pylint: disable=invalid-name
 class TestAutomationState(unittest.TestCase):
     """Test the event automation."""
 

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -14,7 +14,6 @@ from tests.common import (
     fire_time_changed, get_test_home_assistant, mock_component)
 
 
-# pylint: disable=invalid-name
 class TestAutomationSun(unittest.TestCase):
     """Test the sun automation."""
 

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -1,4 +1,5 @@
 """The tests for the Template automation."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.core import callback

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -9,7 +9,6 @@ from tests.common import (
     get_test_home_assistant, assert_setup_component, mock_component)
 
 
-# pylint: disable=invalid-name
 class TestAutomationTemplate(unittest.TestCase):
     """Test the event automation."""
 

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -13,7 +13,6 @@ from tests.common import (
     mock_component)
 
 
-# pylint: disable=invalid-name
 class TestAutomationTime(unittest.TestCase):
     """Test the event automation."""
 

--- a/tests/components/automation/test_zone.py
+++ b/tests/components/automation/test_zone.py
@@ -8,7 +8,6 @@ from homeassistant.components import automation, zone
 from tests.common import get_test_home_assistant, mock_component
 
 
-# pylint: disable=invalid-name
 class TestAutomationZone(unittest.TestCase):
     """Test the event automation."""
 

--- a/tests/components/binary_sensor/test_aurora.py
+++ b/tests/components/binary_sensor/test_aurora.py
@@ -20,7 +20,7 @@ class TestAuroraSensorSetUp(unittest.TestCase):
         self.hass.config.longitude = self.lon
         self.entities = []
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -15,12 +15,12 @@ from tests.common import mock_component, mock_mqtt_component
 class TestSensorMQTT(unittest.TestCase):
     """Test the MQTT sensor."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/binary_sensor/test_nx584.py
+++ b/tests/components/binary_sensor/test_nx584.py
@@ -1,4 +1,5 @@
 """The tests for the nx584 sensor platform."""
+# pylint: skip-file
 import requests
 import unittest
 from unittest import mock

--- a/tests/components/binary_sensor/test_sleepiq.py
+++ b/tests/components/binary_sensor/test_sleepiq.py
@@ -31,7 +31,7 @@ class TestSleepIQBinarySensorSetup(unittest.TestCase):
             'password': self.password,
         }
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/binary_sensor/test_spc.py
+++ b/tests/components/binary_sensor/test_spc.py
@@ -1,4 +1,5 @@
 """Tests for Vanderbilt SPC binary sensor platform."""
+# pylint: skip-file
 import asyncio
 
 import pytest

--- a/tests/components/binary_sensor/test_tcp.py
+++ b/tests/components/binary_sensor/test_tcp.py
@@ -1,4 +1,5 @@
 """The tests for the TCP binary sensor platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch, Mock
 

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -20,7 +20,6 @@ class TestBinarySensorTemplate(unittest.TestCase):
     """Test for Binary sensor template platform."""
 
     hass = None
-    # pylint: disable=invalid-name
 
     def setup_method(self, method):
         """Setup things to be run when tests are started."""
@@ -175,7 +174,6 @@ class TestBinarySensorTemplate(unittest.TestCase):
         run_callback_threadsafe(self.hass.loop, vs.async_check_state).result()
         self.assertFalse(vs.is_on)
 
-        # pylint: disable=protected-access
         vs._template = template_hlpr.Template("{{ 2 > 1 }}", self.hass)
 
         run_callback_threadsafe(self.hass.loop, vs.async_check_state).result()

--- a/tests/components/binary_sensor/test_threshold.py
+++ b/tests/components/binary_sensor/test_threshold.py
@@ -1,4 +1,5 @@
 """The test for the threshold sensor platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/binary_sensor/test_trend.py
+++ b/tests/components/binary_sensor/test_trend.py
@@ -273,8 +273,7 @@ class TestTrendBinarySensor:
         state = self.hass.states.get('binary_sensor.test_trend_sensor')
         assert state.state == 'off'
 
-    def test_invalid_name_does_not_create(self): \
-            # pylint: disable=invalid-name
+    def test_invalid_name_does_not_create(self):
         """Test invalid name."""
         with assert_setup_component(0):
             assert setup.setup_component(self.hass, 'binary_sensor', {
@@ -290,8 +289,7 @@ class TestTrendBinarySensor:
             })
         assert self.hass.states.all() == []
 
-    def test_invalid_sensor_does_not_create(self): \
-            # pylint: disable=invalid-name
+    def test_invalid_sensor_does_not_create(self):
         """Test invalid sensor."""
         with assert_setup_component(0):
             assert setup.setup_component(self.hass, 'binary_sensor', {

--- a/tests/components/binary_sensor/test_vultr.py
+++ b/tests/components/binary_sensor/test_vultr.py
@@ -1,4 +1,5 @@
 """Test the Vultr binary sensor platform."""
+# pylint: skip-file
 import json
 import unittest
 from unittest.mock import patch

--- a/tests/components/calendar/test_caldav.py
+++ b/tests/components/calendar/test_caldav.py
@@ -1,4 +1,5 @@
 """The tests for the webdav calendar component."""
+# pylint: skip-file
 import datetime
 import logging
 import unittest

--- a/tests/components/calendar/test_caldav.py
+++ b/tests/components/calendar/test_caldav.py
@@ -1,5 +1,4 @@
 """The tests for the webdav calendar component."""
-# pylint: disable=protected-access
 import datetime
 import logging
 import unittest
@@ -145,13 +144,11 @@ class TestComponentsWebDavCalendar(unittest.TestCase):
 
     hass = None  # HomeAssistant
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.calendar = _mock_calendar("Private")
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/calendar/test_google.py
+++ b/tests/components/calendar/test_google.py
@@ -1,5 +1,4 @@
 """The tests for the google calendar component."""
-# pylint: disable=protected-access
 import logging
 import unittest
 from unittest.mock import patch
@@ -23,7 +22,6 @@ class TestComponentsGoogleCalendar(unittest.TestCase):
 
     hass = None  # HomeAssistant
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
@@ -32,7 +30,6 @@ class TestComponentsGoogleCalendar(unittest.TestCase):
         # This keeps UTC-6 all year round
         dt_util.set_default_time_zone(dt_util.get_time_zone('America/Regina'))
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         dt_util.set_default_time_zone(dt_util.get_time_zone('UTC'))

--- a/tests/components/calendar/test_google.py
+++ b/tests/components/calendar/test_google.py
@@ -1,4 +1,5 @@
 """The tests for the google calendar component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest.mock import patch

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -1,4 +1,5 @@
 """The tests for local file camera component."""
+# pylint: skip-file
 import asyncio
 from unittest import mock
 

--- a/tests/components/camera/test_uvc.py
+++ b/tests/components/camera/test_uvc.py
@@ -1,4 +1,5 @@
 """The tests for UVC camera module."""
+# pylint: skip-file
 import socket
 import unittest
 from unittest import mock

--- a/tests/components/climate/test_demo.py
+++ b/tests/components/climate/test_demo.py
@@ -18,7 +18,7 @@ ENTITY_HEATPUMP = 'climate.heatpump'
 class TestDemoClimate(unittest.TestCase):
     """Test the demo climate hvac."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.units = METRIC_SYSTEM
@@ -27,7 +27,7 @@ class TestDemoClimate(unittest.TestCase):
                 'platform': 'demo',
             }}))
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -1,4 +1,5 @@
 """The tests for the generic_thermostat."""
+# pylint: skip-file
 import asyncio
 import datetime
 import unittest

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -41,11 +41,11 @@ HOT_TOLERANCE = 0.5
 class TestSetupClimateGenericThermostat(unittest.TestCase):
     """Test the Generic thermostat with custom config."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 
@@ -78,7 +78,7 @@ class TestGenericThermostatHeaterSwitching(unittest.TestCase):
     Different toggle type devices are tested.
     """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.units = METRIC_SYSTEM
@@ -86,7 +86,7 @@ class TestGenericThermostatHeaterSwitching(unittest.TestCase):
             comps.async_setup(self.hass, {}), self.hass.loop
         ).result())
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 
@@ -151,7 +151,7 @@ class TestGenericThermostatHeaterSwitching(unittest.TestCase):
 class TestClimateGenericThermostat(unittest.TestCase):
     """Test the Generic thermostat."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.units = METRIC_SYSTEM
@@ -165,7 +165,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
             'away_temp': 16
         }})
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 
@@ -390,7 +390,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
 class TestClimateGenericThermostatACMode(unittest.TestCase):
     """Test the Generic thermostat."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.temperature_unit = TEMP_CELSIUS
@@ -405,7 +405,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
             'ac_mode': True
         }})
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 
@@ -555,7 +555,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
 class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
     """Test the Generic Thermostat."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.temperature_unit = TEMP_CELSIUS
@@ -570,7 +570,7 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
             'min_cycle_duration': datetime.timedelta(minutes=10)
         }})
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 
@@ -649,7 +649,7 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
 class TestClimateGenericThermostatMinCycle(unittest.TestCase):
     """Test the Generic thermostat."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.temperature_unit = TEMP_CELSIUS
@@ -663,7 +663,7 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
             'min_cycle_duration': datetime.timedelta(minutes=10)
         }})
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 
@@ -742,7 +742,7 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
 class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
     """Test the Generic Thermostat."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.temperature_unit = TEMP_CELSIUS
@@ -758,7 +758,7 @@ class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
             'keep_alive': datetime.timedelta(minutes=10)
         }})
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 
@@ -835,7 +835,7 @@ class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
 class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
     """Test the Generic Thermostat."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.temperature_unit = TEMP_CELSIUS
@@ -850,7 +850,7 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
             'keep_alive': datetime.timedelta(minutes=10)
         }})
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 
@@ -998,12 +998,12 @@ def test_no_restore_state(hass):
 class TestClimateGenericThermostatRestoreState(unittest.TestCase):
     """Test generic thermostat when restore state from HA startup."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.config.temperature_unit = TEMP_CELSIUS
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/climate/test_honeywell.py
+++ b/tests/components/climate/test_honeywell.py
@@ -1,4 +1,5 @@
 """The test the Honeywell thermostat module."""
+# pylint: skip-file
 import socket
 import unittest
 from unittest import mock

--- a/tests/components/climate/test_melissa.py
+++ b/tests/components/climate/test_melissa.py
@@ -21,7 +21,7 @@ from tests.common import get_test_home_assistant, load_fixture
 class TestMelissa(unittest.TestCase):
     """Tests for Melissa climate."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Set up test variables."""
         self.hass = get_test_home_assistant()
         self._serial = '12345678'
@@ -61,7 +61,7 @@ class TestMelissa(unittest.TestCase):
             self.api, device['serial_number'], device)
         self.thermostat.update()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Teardown this test class. Stop hass."""
         self.hass.stop()
 

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -1,4 +1,5 @@
 """The tests for the mqtt climate component."""
+# pylint: skip-file
 import unittest
 import copy
 

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -34,13 +34,13 @@ DEFAULT_CONFIG = {
 class TestMQTTClimate(unittest.TestCase):
     """Test the mqtt climate hvac."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
         self.hass.config.units = METRIC_SYSTEM
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/climate/test_nuheat.py
+++ b/tests/components/climate/test_nuheat.py
@@ -20,9 +20,7 @@ SCHEDULE_TEMPORARY_HOLD = 2
 class TestNuHeat(unittest.TestCase):
     """Tests for NuHeat climate."""
 
-    # pylint: disable=protected-access, no-self-use
-
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Set up test variables."""
         serial_number = "12345"
         temperature_unit = "F"
@@ -53,7 +51,7 @@ class TestNuHeat(unittest.TestCase):
         self.thermostat = nuheat.NuHeatThermostat(
             self.api, serial_number, temperature_unit)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop hass."""
         self.hass.stop()
 

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -1,4 +1,5 @@
 """Tests for the HTTP API for the cloud component."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, MagicMock
 

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -1,4 +1,5 @@
 """Test config entries API."""
+# pylint: skip-file
 
 import asyncio
 from collections import OrderedDict

--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -1,4 +1,5 @@
 """Test hassbian config."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the counter component."""
-# pylint: disable=protected-access
 import asyncio
 import unittest
 import logging
@@ -19,12 +18,10 @@ _LOGGER = logging.getLogger(__name__)
 class TestCounter(unittest.TestCase):
     """Test the counter component."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/cover/test_demo.py
+++ b/tests/components/cover/test_demo.py
@@ -13,14 +13,14 @@ ENTITY_COVER = 'cover.living_room_window'
 class TestCoverDemo(unittest.TestCase):
     """Test the Demo cover."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.assertTrue(setup_component(self.hass, cover.DOMAIN, {'cover': {
             'platform': 'demo',
         }}))
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -14,12 +14,12 @@ from tests.common import (
 class TestCoverMQTT(unittest.TestCase):
     """Test the MQTT cover."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/cover/test_template.py
+++ b/tests/components/cover/test_template.py
@@ -18,7 +18,6 @@ class TestTemplateCover(unittest.TestCase):
 
     hass = None
     calls = None
-    # pylint: disable=invalid-name
 
     def setup_method(self, method):
         """Initialize services when tests are started."""

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -1,4 +1,5 @@
 """The tests for the ASUSWRT device tracker platform."""
+# pylint: skip-file
 import os
 from datetime import timedelta
 import unittest

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -159,8 +159,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         scanner.last_results = WAKE_DEVICES
         self.assertEqual(list(WAKE_DEVICES), scanner.scan_devices())
 
-    def test_password_or_pub_key_required(self): \
-            # pylint: disable=invalid-name
+    def test_password_or_pub_key_required(self):
         """Test creating an AsusWRT scanner without a pass or pubkey."""
         with assert_setup_component(0, DOMAIN):
             assert setup_component(
@@ -174,8 +173,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
     @mock.patch(
         'homeassistant.components.device_tracker.asuswrt.AsusWrtDeviceScanner',
         return_value=mock.MagicMock())
-    def test_get_scanner_with_password_no_pubkey(self, asuswrt_mock): \
-            # pylint: disable=invalid-name
+    def test_get_scanner_with_password_no_pubkey(self, asuswrt_mock):
         """Test creating an AsusWRT scanner with a password and no pubkey."""
         conf_dict = {
             DOMAIN: {
@@ -204,8 +202,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
     @mock.patch(
         'homeassistant.components.device_tracker.asuswrt.AsusWrtDeviceScanner',
         return_value=mock.MagicMock())
-    def test_get_scanner_with_pubkey_no_password(self, asuswrt_mock): \
-            # pylint: disable=invalid-name
+    def test_get_scanner_with_pubkey_no_password(self, asuswrt_mock):
         """Test creating an AsusWRT scanner with a pubkey and no password."""
         conf_dict = {
             device_tracker.DOMAIN: {
@@ -283,8 +280,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
                       password='fake_pass', port=22)
         )
 
-    def test_ssh_login_without_password_or_pubkey(self): \
-            # pylint: disable=invalid-name
+    def test_ssh_login_without_password_or_pubkey(self):
         """Test that login is not called without password or pub_key."""
         ssh = mock.MagicMock()
         ssh_mock = mock.patch('pexpect.pxssh.pxssh', return_value=ssh)
@@ -354,8 +350,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
             mock.call(b'#')
         )
 
-    def test_telnet_login_without_password(self): \
-            # pylint: disable=invalid-name
+    def test_telnet_login_without_password(self):
         """Test that login is not called without password or pub_key."""
         telnet = mock.MagicMock()
         telnet_mock = mock.patch('telnetlib.Telnet', return_value=telnet)

--- a/tests/components/device_tracker/test_automatic.py
+++ b/tests/components/device_tracker/test_automatic.py
@@ -1,4 +1,5 @@
 """Test the automatic device tracker platform."""
+# pylint: skip-file
 import asyncio
 from datetime import datetime
 import logging

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the device tracker component."""
+# pylint: skip-file
 import asyncio
 import json
 import logging

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the device tracker component."""
-# pylint: disable=protected-access
 import asyncio
 import json
 import logging
@@ -39,13 +38,11 @@ class TestComponentsDeviceTracker(unittest.TestCase):
     hass = None  # HomeAssistant
     yaml_devices = None  # type: str
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.yaml_devices = self.hass.config.path(device_tracker.YAML_DEVICES)
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         if os.path.isfile(self.yaml_devices):
@@ -65,7 +62,6 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
         self.assertFalse(device_tracker.is_on(self.hass, entity_id))
 
-    # pylint: disable=no-self-use
     def test_reading_broken_yaml_config(self):
         """Test when known devices contains invalid data."""
         files = {'empty.yaml': '',
@@ -114,7 +110,6 @@ class TestComponentsDeviceTracker(unittest.TestCase):
         self.assertEqual(device.vendor, config.vendor)
         self.assertEqual(device.icon, config.icon)
 
-    # pylint: disable=invalid-name
     @patch('homeassistant.components.device_tracker._LOGGER.warning')
     def test_track_with_duplicate_mac_dev_id(self, mock_warning):
         """Test adding duplicate MACs or device IDs to DeviceTracker."""
@@ -466,7 +461,6 @@ class TestComponentsDeviceTracker(unittest.TestCase):
             'vendor': 'unknown',
         }
 
-    # pylint: disable=invalid-name
     def test_not_write_duplicate_yaml_keys(self):
         """Test that the device tracker will not generate invalid YAML."""
         with assert_setup_component(1, device_tracker.DOMAIN):
@@ -482,7 +476,6 @@ class TestComponentsDeviceTracker(unittest.TestCase):
                                             timedelta(seconds=0))
         assert len(config) == 2
 
-    # pylint: disable=invalid-name
     def test_not_allow_invalid_dev_id(self):
         """Test that the device tracker will not allow invalid dev ids."""
         with assert_setup_component(1, device_tracker.DOMAIN):

--- a/tests/components/device_tracker/test_locative.py
+++ b/tests/components/device_tracker/test_locative.py
@@ -1,4 +1,5 @@
 """The tests the for Locative device tracker platform."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 

--- a/tests/components/device_tracker/test_meraki.py
+++ b/tests/components/device_tracker/test_meraki.py
@@ -1,4 +1,5 @@
 """The tests the for Meraki device tracker."""
+# pylint: skip-file
 import asyncio
 import json
 

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -18,12 +18,12 @@ _LOGGER = logging.getLogger(__name__)
 class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
     """Test MQTT device tracker platform."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
         try:
@@ -31,8 +31,7 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
         except FileNotFoundError:
             pass
 
-    def test_ensure_device_tracker_platform_validation(self): \
-            # pylint: disable=invalid-name
+    def test_ensure_device_tracker_platform_validation(self):
         """Test if platform validation was done."""
         @asyncio.coroutine
         def mock_setup_scanner(hass, config, see, discovery_info=None):

--- a/tests/components/device_tracker/test_mqtt_json.py
+++ b/tests/components/device_tracker/test_mqtt_json.py
@@ -28,12 +28,12 @@ LOCATION_MESSAGE_INCOMPLETE = {
 class TestComponentsDeviceTrackerJSONMQTT(unittest.TestCase):
     """Test JSON MQTT device tracker platform."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
         try:
@@ -41,8 +41,7 @@ class TestComponentsDeviceTrackerJSONMQTT(unittest.TestCase):
         except FileNotFoundError:
             pass
 
-    def test_ensure_device_tracker_platform_validation(self): \
-            # pylint: disable=invalid-name
+    def test_ensure_device_tracker_platform_validation(self):
         """Test if platform validation was done."""
         @asyncio.coroutine
         def mock_setup_scanner(hass, config, see, discovery_info=None):

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -1,4 +1,5 @@
 """The tests for the Owntracks device tracker."""
+# pylint: skip-file
 import asyncio
 import json
 import unittest

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -325,7 +325,6 @@ class BaseMQTT(unittest.TestCase):
 class TestDeviceTrackerOwnTracks(BaseMQTT):
     """Test the OwnTrack sensor."""
 
-    # pylint: disable=invalid-name
     def setup_method(self, _):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
@@ -396,7 +395,7 @@ class TestDeviceTrackerOwnTracks(BaseMQTT):
         state = self.hass.states.get(dev_id)
         self.assertEqual(state.attributes.get('gps_accuracy'), accuracy)
 
-    def test_location_invalid_devid(self):  # pylint: disable=invalid-name
+    def test_location_invalid_devid(self):
         """Test the update of a location."""
         self.send_message('owntracks/paulus/nexus-5x', LOCATION_MESSAGE)
         state = self.hass.states.get('device_tracker.paulus_nexus5x')
@@ -1312,8 +1311,6 @@ def mock_cipher():
 
 class TestDeviceTrackerOwnTrackConfigs(BaseMQTT):
     """Test the OwnTrack sensor."""
-
-    # pylint: disable=invalid-name
 
     def setup_method(self, method):
         """Setup things to be run when tests are started."""

--- a/tests/components/device_tracker/test_tomato.py
+++ b/tests/components/device_tracker/test_tomato.py
@@ -1,4 +1,5 @@
 """The tests for the Tomato device tracker platform."""
+# pylint: skip-file
 from unittest import mock
 import pytest
 import requests

--- a/tests/components/device_tracker/test_tplink.py
+++ b/tests/components/device_tracker/test_tplink.py
@@ -1,4 +1,5 @@
 """The tests for the tplink device tracker platform."""
+# pylint: skip-file
 
 import os
 import unittest

--- a/tests/components/device_tracker/test_tplink.py
+++ b/tests/components/device_tracker/test_tplink.py
@@ -15,11 +15,11 @@ from tests.common import get_test_home_assistant
 class TestTplink4DeviceScanner(unittest.TestCase):
     """Tests for the Tplink4DeviceScanner class."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
         try:

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -1,4 +1,5 @@
 """The tests for the Unifi WAP device tracker platform."""
+# pylint: skip-file
 from unittest import mock
 from pyunifi.controller import APIError
 import homeassistant.util.dt as dt_util

--- a/tests/components/device_tracker/test_unifi_direct.py
+++ b/tests/components/device_tracker/test_unifi_direct.py
@@ -45,8 +45,7 @@ class TestComponentsDeviceTrackerUnifiDirect(unittest.TestCase):
 
     @mock.patch(scanner_path,
                 return_value=mock.MagicMock())
-    def test_get_scanner(self, unifi_mock):  \
-            # pylint: disable=invalid-name
+    def test_get_scanner(self, unifi_mock):
         """Test creating an Unifi direct scanner with a password."""
         conf_dict = {
             DOMAIN: {
@@ -136,7 +135,7 @@ class TestComponentsDeviceTrackerUnifiDirect(unittest.TestCase):
         scanner = get_scanner(self.hass, conf_dict)
         # mock_sendline.side_effect = AssertionError("Test")
         mock_prompt.side_effect = AssertionError("Test")
-        devices = scanner._get_update()  # pylint: disable=protected-access
+        devices = scanner._get_update()
         self.assertTrue(devices is None)
 
     def test_good_response_parses(self):

--- a/tests/components/device_tracker/test_upc_connect.py
+++ b/tests/components/device_tracker/test_upc_connect.py
@@ -1,4 +1,5 @@
 """The tests for the UPC ConnextBox device tracker platform."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 import logging

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -1,4 +1,5 @@
 """The tests for the emulated Hue component."""
+# pylint: skip-file
 import asyncio
 import json
 from unittest.mock import patch

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -342,7 +342,6 @@ def test_put_light_state_fan(hass_hue, hue_client):
     assert living_room_fan.attributes[fan.ATTR_SPEED] == fan.SPEED_MEDIUM
 
 
-# pylint: disable=invalid-name
 @asyncio.coroutine
 def test_put_with_form_urlencoded_content_type(hass_hue, hue_client):
     """Test the form with urlencoded content."""
@@ -419,7 +418,6 @@ def test_proper_put_state_request(hue_client):
     assert result.status == 400
 
 
-# pylint: disable=invalid-name
 async def perform_put_test_on_ceiling_lights(hass_hue, hue_client,
                                              content_type='application/json'):
     """Test the setting of a light."""

--- a/tests/components/fan/test_dyson.py
+++ b/tests/components/fan/test_dyson.py
@@ -1,4 +1,5 @@
 """Test the Dyson fan component."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 

--- a/tests/components/fan/test_dyson.py
+++ b/tests/components/fan/test_dyson.py
@@ -64,11 +64,11 @@ def _get_device_on():
 class DysonTest(unittest.TestCase):
     """Dyson Sensor component test class."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/fan/test_mqtt.py
+++ b/tests/components/fan/test_mqtt.py
@@ -12,12 +12,12 @@ from tests.common import (
 class TestMqttFan(unittest.TestCase):
     """Test the MQTT fan platform."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """"Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -1,5 +1,4 @@
 """The tests for the Google Assistant component."""
-# pylint: disable=protected-access
 import asyncio
 import json
 

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Group components."""
-# pylint: disable=protected-access
 import asyncio
 from collections import OrderedDict
 import unittest
@@ -17,12 +16,10 @@ from tests.common import get_test_home_assistant, assert_setup_component
 class TestComponentsGroup(unittest.TestCase):
     """Test Group component."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
@@ -430,7 +427,6 @@ def test_service_group_services(hass):
     assert hass.services.has_service('group', group.SERVICE_REMOVE)
 
 
-# pylint: disable=invalid-name
 @asyncio.coroutine
 def test_service_group_set_group_remove_group(hass):
     """Check if service are available."""

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Hass.io."""
+# pylint: skip-file
 import os
 from unittest.mock import patch, Mock
 

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -1,4 +1,5 @@
 """The tests for the hassio component."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, Mock, MagicMock
 

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -36,7 +36,6 @@ def test_sensor_temperature_celsius():
     assert len(mock_type.mock_calls) == 1
 
 
-# pylint: disable=invalid-name
 def test_sensor_temperature_fahrenheit():
     """Test temperature sensor with Fahrenheit as unit."""
     mock_type = MagicMock()

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -5,7 +5,6 @@ from unittest.mock import call, patch, ANY
 
 import voluptuous as vol
 
-# pylint: disable=unused-import
 from pyhap.accessory_driver import AccessoryDriver  # noqa F401
 
 from homeassistant import setup

--- a/tests/components/http/__init__.py
+++ b/tests/components/http/__init__.py
@@ -1,4 +1,5 @@
 """Tests for the HTTP component."""
+# pylint: skip-file
 from ipaddress import ip_address
 
 from aiohttp import web

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -1,5 +1,4 @@
 """The tests for the Home Assistant HTTP component."""
-# pylint: disable=protected-access
 from ipaddress import ip_network
 from unittest.mock import patch
 

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -1,5 +1,4 @@
 """The tests for the Home Assistant HTTP component."""
-# pylint: disable=protected-access
 from unittest.mock import patch, mock_open
 
 from aiohttp import web

--- a/tests/components/http/test_data_validator.py
+++ b/tests/components/http/test_data_validator.py
@@ -1,4 +1,5 @@
 """Test data validator decorator."""
+# pylint: skip-file
 from unittest.mock import Mock
 
 from aiohttp import web

--- a/tests/components/image_processing/test_openalpr_local.py
+++ b/tests/components/image_processing/test_openalpr_local.py
@@ -1,4 +1,5 @@
 """The tests for the openalpr local platform."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch, PropertyMock, MagicMock
 

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -1,5 +1,4 @@
 """The tests for the demo light component."""
-# pylint: disable=protected-access
 import unittest
 
 from homeassistant.setup import setup_component
@@ -13,7 +12,6 @@ ENTITY_LIGHT = 'light.bed_light'
 class TestDemoLight(unittest.TestCase):
     """Test the demo light."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
@@ -21,7 +19,6 @@ class TestDemoLight(unittest.TestCase):
             'platform': 'demo',
         }}))
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -1,4 +1,5 @@
 """Philips Hue lights platform tests."""
+# pylint: skip-file
 
 import logging
 import unittest

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -18,7 +18,7 @@ HUE_LIGHT_NS = 'homeassistant.components.light.hue.'
 class TestSetup(unittest.TestCase):
     """Test the Hue light platform."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.skip_teardown_stop = False
@@ -450,7 +450,7 @@ class TestSetup(unittest.TestCase):
 class TestHueLight(unittest.TestCase):
     """Test the HueLight class."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.skip_teardown_stop = False

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Light component."""
-# pylint: disable=protected-access
 import unittest
 import os
 
@@ -18,12 +17,10 @@ from tests.common import (
 class TestLight(unittest.TestCase):
     """Test the light module."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/light/test_litejet.py
+++ b/tests/components/light/test_litejet.py
@@ -1,4 +1,5 @@
 """The tests for the litejet component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest import mock

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -153,14 +153,12 @@ from tests.common import (
 class TestLightMQTT(unittest.TestCase):
     """Test the MQTT light."""
 
-    # pylint: disable=invalid-name
-
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 
@@ -175,8 +173,7 @@ class TestLightMQTT(unittest.TestCase):
             })
         self.assertIsNone(self.hass.states.get('light.test'))
 
-    def test_no_color_brightness_color_temp_white_xy_if_no_topics(self): \
-            # pylint: disable=invalid-name
+    def test_no_color_brightness_color_temp_white_xy_if_no_topics(self):
         """Test if there is no color and brightness if no topic."""
         with assert_setup_component(1, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -207,8 +204,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertIsNone(state.attributes.get('white_value'))
         self.assertIsNone(state.attributes.get('xy_color'))
 
-    def test_controlling_state_via_topic(self): \
-            # pylint: disable=invalid-name
+    def test_controlling_state_via_topic(self):
         """Test the controlling of the state via topic."""
         config = {light.DOMAIN: {
             'platform': 'mqtt',
@@ -408,8 +404,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual(255,
                          light_state.attributes['white_value'])
 
-    def test_controlling_state_via_topic_with_templates(self): \
-            # pylint: disable=invalid-name
+    def test_controlling_state_via_topic_with_templates(self):
         """Test the setting og the state with a template."""
         config = {light.DOMAIN: {
             'platform': 'mqtt',
@@ -464,8 +459,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual(75, state.attributes.get('white_value'))
         self.assertEqual([0.123, 0.123], state.attributes.get('xy_color'))
 
-    def test_sending_mqtt_commands_and_optimistic(self): \
-            # pylint: disable=invalid-name
+    def test_sending_mqtt_commands_and_optimistic(self):
         """Test the sending of command in optimistic mode."""
         config = {light.DOMAIN: {
             'platform': 'mqtt',

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -104,17 +104,16 @@ from tests.common import (
 class TestLightMQTTJSON(unittest.TestCase):
     """Test the MQTT JSON light."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def test_fail_setup_if_no_command_topic(self): \
-            # pylint: disable=invalid-name
+    def test_fail_setup_if_no_command_topic(self):
         """Test if setup fails with no command topic."""
         with assert_setup_component(0, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -125,8 +124,7 @@ class TestLightMQTTJSON(unittest.TestCase):
             })
         self.assertIsNone(self.hass.states.get('light.test'))
 
-    def test_no_color_brightness_color_temp_white_val_if_no_topics(self): \
-            # pylint: disable=invalid-name
+    def test_no_color_brightness_color_temp_white_val_if_no_topics(self):
         """Test for no RGB, brightness, color temp, effect, white val or XY."""
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
@@ -159,8 +157,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertIsNone(state.attributes.get('white_value'))
         self.assertIsNone(state.attributes.get('xy_color'))
 
-    def test_controlling_state_via_topic(self): \
-            # pylint: disable=invalid-name
+    def test_controlling_state_via_topic(self):
         """Test the controlling of the state via topic."""
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
@@ -268,8 +265,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         light_state = self.hass.states.get('light.test')
         self.assertEqual(155, light_state.attributes.get('white_value'))
 
-    def test_sending_mqtt_commands_and_optimistic(self): \
-            # pylint: disable=invalid-name
+    def test_sending_mqtt_commands_and_optimistic(self):
         """Test the sending of command in optimistic mode."""
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
@@ -335,8 +331,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertEqual('colorloop', state.attributes['effect'])
         self.assertEqual(170, state.attributes['white_value'])
 
-    def test_flash_short_and_long(self): \
-            # pylint: disable=invalid-name
+    def test_flash_short_and_long(self):
         """Test for flash length being sent when included."""
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
@@ -469,8 +464,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertEqual(STATE_ON, state.state)
         self.assertEqual(255, state.attributes.get('brightness'))
 
-    def test_invalid_color_brightness_and_white_values(self): \
-            # pylint: disable=invalid-name
+    def test_invalid_color_brightness_and_white_values(self):
         """Test that invalid color/brightness/white values are ignored."""
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {

--- a/tests/components/light/test_mqtt_template.py
+++ b/tests/components/light/test_mqtt_template.py
@@ -40,17 +40,16 @@ from tests.common import (
 class TestLightMQTTTemplate(unittest.TestCase):
     """Test the MQTT Template light."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def test_setup_fails(self): \
-            # pylint: disable=invalid-name
+    def test_setup_fails(self):
         """Test that setup fails with missing required configuration items."""
         with assert_setup_component(0, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -61,8 +60,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
             })
         self.assertIsNone(self.hass.states.get('light.test'))
 
-    def test_state_change_via_topic(self): \
-            # pylint: disable=invalid-name
+    def test_state_change_via_topic(self):
         """Test state change via topic."""
         with assert_setup_component(1, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -101,8 +99,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.assertIsNone(state.attributes.get('color_temp'))
         self.assertIsNone(state.attributes.get('white_value'))
 
-    def test_state_brightness_color_effect_temp_white_change_via_topic(self): \
-            # pylint: disable=invalid-name
+    def test_state_brightness_color_effect_temp_white_change_via_topic(self):
         """Test state, bri, color, effect, color temp, white val change."""
         with assert_setup_component(1, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -203,8 +200,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         light_state = self.hass.states.get('light.test')
         self.assertEqual('rainbow', light_state.attributes.get('effect'))
 
-    def test_optimistic(self): \
-            # pylint: disable=invalid-name
+    def test_optimistic(self):
         """Test optimistic mode."""
         with assert_setup_component(1, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -272,8 +268,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.assertEqual(200, state.attributes['color_temp'])
         self.assertEqual(139, state.attributes['white_value'])
 
-    def test_flash(self): \
-            # pylint: disable=invalid-name
+    def test_flash(self):
         """Test flash."""
         with assert_setup_component(1, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -336,8 +331,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.mock_publish.async_publish.assert_called_once_with(
             'test_light_rgb/set', 'off,4', 0, False)
 
-    def test_invalid_values(self): \
-            # pylint: disable=invalid-name
+    def test_invalid_values(self):
         """Test that invalid values are ignored."""
         with assert_setup_component(1, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -4,6 +4,7 @@ Test setup of rflink lights component/platform. State tracking and
 control of Rflink switch devices.
 
 """
+# pylint: skip-file
 
 import asyncio
 

--- a/tests/components/light/test_rfxtrx.py
+++ b/tests/components/light/test_rfxtrx.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx light platform."""
+# pylint: skip-file
 import unittest
 
 import pytest

--- a/tests/components/light/test_template.py
+++ b/tests/components/light/test_template.py
@@ -17,7 +17,6 @@ class TestTemplateLight:
 
     hass = None
     calls = None
-    # pylint: disable=invalid-name
 
     def setup_method(self, method):
         """Setup things to be run when tests are started."""

--- a/tests/components/light/test_zwave.py
+++ b/tests/components/light/test_zwave.py
@@ -1,4 +1,5 @@
 """Test Z-Wave lights."""
+# pylint: skip-file
 from unittest.mock import patch, MagicMock
 
 import homeassistant.components.zwave

--- a/tests/components/lock/test_demo.py
+++ b/tests/components/lock/test_demo.py
@@ -14,7 +14,7 @@ KITCHEN = 'lock.kitchen_door'
 class TestLockDemo(unittest.TestCase):
     """Test the demo lock."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.assertTrue(setup_component(self.hass, lock.DOMAIN, {
@@ -23,7 +23,7 @@ class TestLockDemo(unittest.TestCase):
             }
         }))
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/lock/test_mqtt.py
+++ b/tests/components/lock/test_mqtt.py
@@ -12,12 +12,12 @@ from tests.common import (
 class TestLockMQTT(unittest.TestCase):
     """Test the MQTT lock."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/lock/test_zwave.py
+++ b/tests/components/lock/test_zwave.py
@@ -1,4 +1,5 @@
 """Test Z-Wave locks."""
+# pylint: skip-file
 import asyncio
 
 from unittest.mock import patch, MagicMock

--- a/tests/components/media_player/test_async_helpers.py
+++ b/tests/components/media_player/test_async_helpers.py
@@ -122,7 +122,7 @@ class SyncMediaPlayer(mp.MediaPlayerDevice):
 class TestAsyncMediaPlayer(unittest.TestCase):
     """Test the media_player module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.player = AsyncMediaPlayer(self.hass)
@@ -175,7 +175,7 @@ class TestAsyncMediaPlayer(unittest.TestCase):
 class TestSyncMediaPlayer(unittest.TestCase):
     """Test the media_player module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.player = SyncMediaPlayer(self.hass)

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -1,5 +1,4 @@
 """The tests for the Cast Media player platform."""
-# pylint: disable=protected-access
 import asyncio
 from typing import Optional
 from unittest.mock import patch, MagicMock, Mock
@@ -22,7 +21,6 @@ def cast_mock():
         yield
 
 
-# pylint: disable=invalid-name
 FakeUUID = UUID('57355bce-9364-4aa6-ac1e-eb849dccf9e2')
 
 

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -1,4 +1,5 @@
 """The tests for the Demo Media player platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch
 import asyncio

--- a/tests/components/media_player/test_demo.py
+++ b/tests/components/media_player/test_demo.py
@@ -24,7 +24,7 @@ entity_id = 'media_player.walkman'
 class TestDemoMediaPlayer(unittest.TestCase):
     """Test the media_player module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 

--- a/tests/components/media_player/test_monoprice.py
+++ b/tests/components/media_player/test_monoprice.py
@@ -1,4 +1,5 @@
 """The tests for Monoprice Media player platform."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 import voluptuous as vol

--- a/tests/components/media_player/test_samsungtv.py
+++ b/tests/components/media_player/test_samsungtv.py
@@ -1,4 +1,5 @@
 """Tests for samsungtv Components."""
+# pylint: skip-file
 import unittest
 from subprocess import CalledProcessError
 

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -1,4 +1,5 @@
 """The tests for the Demo Media player platform."""
+# pylint: skip-file
 import datetime
 import socket
 import unittest

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -134,7 +134,6 @@ def add_devices_factory(hass):
 class TestSonosMediaPlayer(unittest.TestCase):
     """Test the media_player module."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
@@ -147,7 +146,6 @@ class TestSonosMediaPlayer(unittest.TestCase):
         self.real_available = sonos.SonosDevice.available
         sonos.SonosDevice.available = monkey_available
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         # Monkey patches

--- a/tests/components/media_player/test_soundtouch.py
+++ b/tests/components/media_player/test_soundtouch.py
@@ -1,4 +1,5 @@
 """Test the Soundtouch component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest import mock

--- a/tests/components/media_player/test_soundtouch.py
+++ b/tests/components/media_player/test_soundtouch.py
@@ -147,12 +147,12 @@ def default_component():
 class TestSoundtouchMediaPlayer(unittest.TestCase):
     """Bose Soundtouch test class."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         logging.disable(logging.CRITICAL)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         logging.disable(logging.NOTSET)
         self.hass.stop()

--- a/tests/components/media_player/test_universal.py
+++ b/tests/components/media_player/test_universal.py
@@ -157,7 +157,7 @@ class MockMediaPlayer(media_player.MediaPlayerDevice):
 class TestMediaPlayer(unittest.TestCase):
     """Test the media_player module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
@@ -208,7 +208,7 @@ class TestMediaPlayer(unittest.TestCase):
             }
         }
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/media_player/test_webostv.py
+++ b/tests/components/media_player/test_webostv.py
@@ -1,4 +1,5 @@
 """The tests for the LG webOS media player platform."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT component."""
+# pylint: skip-file
 import asyncio
 import unittest
 from unittest import mock

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -40,17 +40,16 @@ def async_mock_mqtt_client(hass, config=None):
 mock_mqtt_client = threadsafe_coroutine_factory(async_mock_mqtt_client)
 
 
-# pylint: disable=invalid-name
 class TestMQTTComponent(unittest.TestCase):
     """Test the MQTT component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         mock_mqtt_component(self.hass)
         self.calls = []
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 
@@ -137,17 +136,16 @@ class TestMQTTComponent(unittest.TestCase):
         self.assertRaises(vol.Invalid, mqtt.valid_subscribe_topic, 'bad\0one')
 
 
-# pylint: disable=invalid-name
 class TestMQTTCallbacks(unittest.TestCase):
     """Test the MQTT callbacks."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         mock_mqtt_client(self.hass)
         self.calls = []
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/notify/test_apns.py
+++ b/tests/components/notify/test_apns.py
@@ -1,4 +1,5 @@
 """The tests for the APNS component."""
+# pylint: skip-file
 import io
 import unittest
 from unittest.mock import Mock, patch, mock_open

--- a/tests/components/notify/test_apns.py
+++ b/tests/components/notify/test_apns.py
@@ -27,11 +27,11 @@ CONFIG = {
 class TestApns(unittest.TestCase):
     """Test the APNS component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/notify/test_command_line.py
+++ b/tests/components/notify/test_command_line.py
@@ -12,11 +12,11 @@ from tests.common import assert_setup_component, get_test_home_assistant
 class TestCommandLine(unittest.TestCase):
     """Test the command line notifications."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -19,7 +19,7 @@ CONFIG = {
 class TestNotifyDemo(unittest.TestCase):
     """Test the demo notify."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.events = []
@@ -32,7 +32,7 @@ class TestNotifyDemo(unittest.TestCase):
 
         self.hass.bus.listen(demo.EVENT_NOTIFY, record_event)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """"Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/notify/test_file.py
+++ b/tests/components/notify/test_file.py
@@ -15,11 +15,11 @@ from tests.common import assert_setup_component, get_test_home_assistant
 class TestNotifyFile(unittest.TestCase):
     """Test the file notify."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """"Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -1,4 +1,5 @@
 """The tests for the notify.group platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -13,7 +13,7 @@ from tests.common import assert_setup_component, get_test_home_assistant
 class TestNotifyGroup(unittest.TestCase):
     """Test the notify.group platform."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.events = []
@@ -52,7 +52,7 @@ class TestNotifyGroup(unittest.TestCase):
 
         assert self.service is not None
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """"Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/notify/test_pushbullet.py
+++ b/tests/components/notify/test_pushbullet.py
@@ -19,7 +19,7 @@ class TestPushBullet(unittest.TestCase):
         """Initialize values for this test case class."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that we started."""
         self.hass.stop()
 

--- a/tests/components/notify/test_smtp.py
+++ b/tests/components/notify/test_smtp.py
@@ -18,7 +18,7 @@ class MockSMTP(smtp.MailNotificationService):
 class TestNotifySmtp(unittest.TestCase):
     """Test the smtp notify."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mailer = MockSMTP('localhost', 25, 5, 'test@test.com', 1,
@@ -26,7 +26,7 @@ class TestNotifySmtp(unittest.TestCase):
                                ['recip1@example.com', 'testrecip@test.com'],
                                'HomeAssistant', 0)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """"Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/recorder/models_original.py
+++ b/tests/components/recorder/models_original.py
@@ -3,6 +3,7 @@
 This file contains the original models definitions before schema tracking was
 implemented. It is used to test the schema migration logic.
 """
+# pylint: skip-file
 
 import json
 from datetime import datetime

--- a/tests/components/recorder/models_original.py
+++ b/tests/components/recorder/models_original.py
@@ -17,7 +17,6 @@ from homeassistant.core import Event, EventOrigin, State, split_entity_id
 from homeassistant.remote import JSONEncoder
 
 # SQLAlchemy Schema
-# pylint: disable=invalid-name
 Base = declarative_base()
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Recorder component."""
-# pylint: disable=protected-access
 import unittest
 from unittest.mock import patch
 
@@ -18,13 +17,13 @@ from tests.common import get_test_home_assistant, init_recorder_component
 class TestRecorder(unittest.TestCase):
     """Test the recorder module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         init_recorder_component(self.hass)
         self.hass.start()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 
@@ -127,7 +126,6 @@ def _add_events(hass, events):
         return [ev.to_native() for ev in session.query(Events)]
 
 
-# pylint: disable=redefined-outer-name,invalid-name
 def test_saving_state_include_domains(hass_recorder):
     """Test saving and restoring a state."""
     hass = hass_recorder({'include': {'domains': 'test2'}})

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -1,5 +1,4 @@
 """The tests for the Recorder component."""
-# pylint: disable=protected-access
 import asyncio
 from unittest.mock import patch, call
 

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -15,7 +15,7 @@ ENGINE = None
 SESSION = None
 
 
-def setUpModule():  # pylint: disable=invalid-name
+def setUpModule():
     """Set up a database to use."""
     global ENGINE
     global SESSION
@@ -26,7 +26,7 @@ def setUpModule():  # pylint: disable=invalid-name
     SESSION = scoped_session(session_factory)
 
 
-def tearDownModule():  # pylint: disable=invalid-name
+def tearDownModule():
     """Close database."""
     global ENGINE
     global SESSION
@@ -39,7 +39,6 @@ def tearDownModule():  # pylint: disable=invalid-name
 class TestEvents(unittest.TestCase):
     """Test Events model."""
 
-    # pylint: disable=no-self-use
     def test_from_event(self):
         """Test converting event to db event."""
         event = ha.Event('test_event', {
@@ -50,8 +49,6 @@ class TestEvents(unittest.TestCase):
 
 class TestStates(unittest.TestCase):
     """Test States model."""
-
-    # pylint: disable=no-self-use
 
     def test_from_event(self):
         """Test converting event to db state."""
@@ -82,14 +79,14 @@ class TestStates(unittest.TestCase):
 class TestRecorderRuns(unittest.TestCase):
     """Test recorder run model."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Set up recorder runs."""
         self.session = session = SESSION()
         session.query(Events).delete()
         session.query(States).delete()
         session.query(RecorderRuns).delete()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Clean up."""
         self.session.rollback()
 

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -15,13 +15,13 @@ from tests.common import get_test_home_assistant, init_recorder_component
 class TestRecorderPurge(unittest.TestCase):
     """Base class for common recorder tests."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         init_recorder_component(self.hass)
         self.hass.start()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/remote/test_demo.py
+++ b/tests/components/remote/test_demo.py
@@ -1,5 +1,4 @@
 """The tests for the demo remote component."""
-# pylint: disable=protected-access
 import unittest
 
 from homeassistant.setup import setup_component
@@ -13,7 +12,6 @@ ENTITY_ID = 'remote.remote_one'
 class TestDemoRemote(unittest.TestCase):
     """Test the demo remote."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
@@ -21,7 +19,6 @@ class TestDemoRemote(unittest.TestCase):
             'platform': 'demo',
         }}))
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()

--- a/tests/components/remote/test_init.py
+++ b/tests/components/remote/test_init.py
@@ -1,6 +1,4 @@
 """The tests for the Remote component, adapted from Light Test."""
-# pylint: disable=protected-access
-
 import unittest
 
 from homeassistant.setup import setup_component
@@ -17,12 +15,10 @@ SERVICE_SEND_COMMAND = 'send_command'
 class TestRemote(unittest.TestCase):
     """Test the remote module."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/remote/test_kira.py
+++ b/tests/components/remote/test_kira.py
@@ -21,7 +21,6 @@ DISCOVERY_INFO = {
 class TestKiraSensor(unittest.TestCase):
     """Tests the Kira Sensor platform."""
 
-    # pylint: disable=invalid-name
     DEVICES = []
 
     def add_devices(self, devices):

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -13,7 +13,7 @@ from tests.common import get_test_home_assistant
 class TestScene(unittest.TestCase):
     """Test the scene component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         test_light = loader.get_component('light.test')
@@ -33,7 +33,7 @@ class TestScene(unittest.TestCase):
         self.assertFalse(self.light_1.is_on)
         self.assertFalse(self.light_2.is_on)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/scene/test_litejet.py
+++ b/tests/components/scene/test_litejet.py
@@ -1,4 +1,5 @@
 """The tests for the litejet component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest import mock

--- a/tests/components/sensor/test_command_line.py
+++ b/tests/components/sensor/test_command_line.py
@@ -1,4 +1,5 @@
 """The tests for the Command line sensor platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.helpers.template import Template

--- a/tests/components/sensor/test_darksky.py
+++ b/tests/components/sensor/test_darksky.py
@@ -1,4 +1,5 @@
 """The tests for the Dark Sky platform."""
+# pylint: skip-file
 import re
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/components/sensor/test_darksky.py
+++ b/tests/components/sensor/test_darksky.py
@@ -40,7 +40,7 @@ class TestDarkSkySetup(unittest.TestCase):
         self.lon = self.hass.config.longitude = -122.423
         self.entities = []
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -4,6 +4,7 @@ Tests setup of the DSMR component and ensure incoming telegrams cause
 Entity to be updated with new values.
 
 """
+# pylint: skip-file
 
 import asyncio
 from decimal import Decimal

--- a/tests/components/sensor/test_dyson.py
+++ b/tests/components/sensor/test_dyson.py
@@ -1,4 +1,5 @@
 """Test the Dyson sensor(s) component."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 

--- a/tests/components/sensor/test_dyson.py
+++ b/tests/components/sensor/test_dyson.py
@@ -51,11 +51,11 @@ def _get_with_standby_monitoring():
 class DysonTest(unittest.TestCase):
     """Dyson Sensor component test class."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/sensor/test_efergy.py
+++ b/tests/components/sensor/test_efergy.py
@@ -1,4 +1,5 @@
 """The tests for Efergy sensor platform."""
+# pylint: skip-file
 import unittest
 
 import requests_mock

--- a/tests/components/sensor/test_efergy.py
+++ b/tests/components/sensor/test_efergy.py
@@ -73,7 +73,7 @@ class TestEfergySensor(unittest.TestCase):
         self.hass = get_test_home_assistant()
         self.config = ONE_SENSOR_CONFIG
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/sensor/test_fido.py
+++ b/tests/components/sensor/test_fido.py
@@ -1,4 +1,5 @@
 """The test for the fido sensor platform."""
+# pylint: skip-file
 import asyncio
 import logging
 import sys

--- a/tests/components/sensor/test_geo_rss_events.py
+++ b/tests/components/sensor/test_geo_rss_events.py
@@ -1,4 +1,5 @@
 """The test for the geo rss events sensor platform."""
+# pylint: skip-file
 import unittest
 from unittest import mock
 import feedparser

--- a/tests/components/sensor/test_history_stats.py
+++ b/tests/components/sensor/test_history_stats.py
@@ -1,5 +1,4 @@
 """The test for the History Statistics sensor platform."""
-# pylint: disable=protected-access
 from datetime import timedelta
 import unittest
 from unittest.mock import patch

--- a/tests/components/sensor/test_hydroquebec.py
+++ b/tests/components/sensor/test_hydroquebec.py
@@ -1,4 +1,5 @@
 """The test for the hydroquebec sensor platform."""
+# pylint: skip-file
 import asyncio
 import logging
 import sys

--- a/tests/components/sensor/test_imap_email_content.py
+++ b/tests/components/sensor/test_imap_email_content.py
@@ -1,4 +1,5 @@
 """The tests for the IMAP email content sensor platform."""
+# pylint: skip-file
 from collections import deque
 import email
 from email.mime.multipart import MIMEMultipart

--- a/tests/components/sensor/test_kira.py
+++ b/tests/components/sensor/test_kira.py
@@ -19,7 +19,6 @@ DISCOVERY_INFO = {
 class TestKiraSensor(unittest.TestCase):
     """Tests the Kira Sensor platform."""
 
-    # pylint: disable=invalid-name
     DEVICES = []
 
     def add_devices(self, devices):
@@ -38,7 +37,6 @@ class TestKiraSensor(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    # pylint: disable=protected-access
     def test_kira_sensor_callback(self):
         """Ensure Kira sensor properly updates its attributes from callback."""
         kira.setup_platform(self.hass, TEST_CONFIG, self.add_devices,

--- a/tests/components/sensor/test_melissa.py
+++ b/tests/components/sensor/test_melissa.py
@@ -1,4 +1,5 @@
 """Test for Melissa climate component."""
+# pylint: skip-file
 import unittest
 import json
 from unittest.mock import Mock

--- a/tests/components/sensor/test_melissa.py
+++ b/tests/components/sensor/test_melissa.py
@@ -14,7 +14,7 @@ from tests.common import get_test_home_assistant, load_fixture
 class TestMelissa(unittest.TestCase):
     """Tests for Melissa climate."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Set up test variables."""
         self.hass = get_test_home_assistant()
         self._serial = '12345678'
@@ -33,7 +33,7 @@ class TestMelissa(unittest.TestCase):
         self.temp = MelissaTemperatureSensor(device, self.api)
         self.hum = MelissaHumiditySensor(device, self.api)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Teardown this test class. Stop hass."""
         self.hass.stop()
 

--- a/tests/components/sensor/test_moldindicator.py
+++ b/tests/components/sensor/test_moldindicator.py
@@ -1,4 +1,5 @@
 """The tests for the MoldIndicator sensor."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/sensor/test_moon.py
+++ b/tests/components/sensor/test_moon.py
@@ -1,4 +1,5 @@
 """The test for the moon sensor platform."""
+# pylint: skip-file
 import unittest
 from datetime import datetime
 from unittest.mock import patch

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT sensor platform."""
+# pylint: skip-file
 import unittest
 
 from datetime import timedelta, datetime

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -17,12 +17,12 @@ from tests.common import get_test_home_assistant, mock_component
 class TestSensorMQTT(unittest.TestCase):
     """Test the MQTT sensor."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/sensor/test_openhardwaremonitor.py
+++ b/tests/components/sensor/test_openhardwaremonitor.py
@@ -19,7 +19,7 @@ class TestOpenHardwareMonitorSetup(unittest.TestCase):
             }
         }
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/sensor/test_pilight.py
+++ b/tests/components/sensor/test_pilight.py
@@ -18,7 +18,6 @@ def fire_pilight_message(protocol, data):
     HASS.bus.fire(pilight.EVENT, message)
 
 
-# pylint: disable=invalid-name
 def setup_function():
     """Initialize a Home Assistant server."""
     global HASS
@@ -27,7 +26,6 @@ def setup_function():
     mock_component(HASS, 'pilight')
 
 
-# pylint: disable=invalid-name
 def teardown_function():
     """Stop the Home Assistant server."""
     HASS.stop()

--- a/tests/components/sensor/test_radarr.py
+++ b/tests/components/sensor/test_radarr.py
@@ -1,4 +1,5 @@
 """The tests for the Radarr platform."""
+# pylint: skip-file
 import unittest
 
 import pytest

--- a/tests/components/sensor/test_radarr.py
+++ b/tests/components/sensor/test_radarr.py
@@ -191,7 +191,6 @@ def mocked_requests_get(*args, **kwargs):
 class TestRadarrSetup(unittest.TestCase):
     """Test the Radarr platform."""
 
-    # pylint: disable=invalid-name
     DEVICES = []
 
     def add_devices(self, devices, update):
@@ -205,7 +204,7 @@ class TestRadarrSetup(unittest.TestCase):
         self.hass = get_test_home_assistant()
         self.hass.config.time_zone = 'America/Los_Angeles'
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/sensor/test_rfxtrx.py
+++ b/tests/components/sensor/test_rfxtrx.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx sensor platform."""
+# pylint: skip-file
 import unittest
 
 import pytest

--- a/tests/components/sensor/test_season.py
+++ b/tests/components/sensor/test_season.py
@@ -1,5 +1,4 @@
 """The tests for the Season sensor platform."""
-# pylint: disable=protected-access
 import unittest
 from datetime import datetime
 
@@ -52,7 +51,6 @@ HEMISPHERE_EMPTY = {
 }
 
 
-# pylint: disable=invalid-name
 class TestSeason(unittest.TestCase):
     """Test the season platform."""
 

--- a/tests/components/sensor/test_sleepiq.py
+++ b/tests/components/sensor/test_sleepiq.py
@@ -31,7 +31,7 @@ class TestSleepIQSensorSetup(unittest.TestCase):
             'password': self.password,
         }
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/sensor/test_sonarr.py
+++ b/tests/components/sensor/test_sonarr.py
@@ -1,4 +1,5 @@
 """The tests for the Sonarr platform."""
+# pylint: skip-file
 import unittest
 import time
 from datetime import datetime

--- a/tests/components/sensor/test_sonarr.py
+++ b/tests/components/sensor/test_sonarr.py
@@ -577,7 +577,6 @@ def mocked_requests_get(*args, **kwargs):
 class TestSonarrSetup(unittest.TestCase):
     """Test the Sonarr platform."""
 
-    # pylint: disable=invalid-name
     DEVICES = []
 
     def add_devices(self, devices, update):
@@ -591,7 +590,7 @@ class TestSonarrSetup(unittest.TestCase):
         self.hass = get_test_home_assistant()
         self.hass.config.time_zone = 'America/Los_Angeles'
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/sensor/test_statistics.py
+++ b/tests/components/sensor/test_statistics.py
@@ -1,4 +1,5 @@
 """The test for the statistics sensor platform."""
+# pylint: skip-file
 import unittest
 import statistics
 

--- a/tests/components/sensor/test_tcp.py
+++ b/tests/components/sensor/test_tcp.py
@@ -1,4 +1,5 @@
 """The tests for the TCP sensor platform."""
+# pylint: skip-file
 import socket
 import unittest
 from copy import copy

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -8,7 +8,6 @@ class TestTemplateSensor:
     """Test the Template sensor."""
 
     hass = None
-    # pylint: disable=invalid-name
 
     def setup_method(self, method):
         """Setup things to be run when tests are started."""

--- a/tests/components/sensor/test_time_date.py
+++ b/tests/components/sensor/test_time_date.py
@@ -11,7 +11,6 @@ from tests.common import get_test_home_assistant
 class TestTimeDateSensor(unittest.TestCase):
     """Tests the Kira Sensor platform."""
 
-    # pylint: disable=invalid-name
     DEVICES = []
 
     def add_devices(self, devices):
@@ -29,7 +28,6 @@ class TestTimeDateSensor(unittest.TestCase):
         dt_util.set_default_time_zone(self.DEFAULT_TIME_ZONE)
         self.hass.stop()
 
-    # pylint: disable=protected-access
     def test_intervals(self):
         """Test timing intervals of sensors."""
         device = time_date.TimeDateSensor(self.hass, 'time')

--- a/tests/components/sensor/test_uk_transport.py
+++ b/tests/components/sensor/test_uk_transport.py
@@ -1,4 +1,5 @@
 """The tests for the uk_transport platform."""
+# pylint: skip-file
 import re
 
 import requests_mock

--- a/tests/components/sensor/test_vultr.py
+++ b/tests/components/sensor/test_vultr.py
@@ -1,4 +1,5 @@
 """The tests for the Vultr sensor platform."""
+# pylint: skip-file
 import json
 import unittest
 from unittest.mock import patch

--- a/tests/components/sensor/test_worldclock.py
+++ b/tests/components/sensor/test_worldclock.py
@@ -1,4 +1,5 @@
 """The test for the World clock sensor platform."""
+# pylint: skip-file
 import unittest
 
 from homeassistant.setup import setup_component

--- a/tests/components/sensor/test_wsdot.py
+++ b/tests/components/sensor/test_wsdot.py
@@ -38,7 +38,7 @@ class TestWSDOT(unittest.TestCase):
         }
         self.entities = []
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/sensor/test_yahoo_finance.py
+++ b/tests/components/sensor/test_yahoo_finance.py
@@ -17,7 +17,6 @@ VALID_CONFIG = {
 }
 
 
-# pylint: disable=invalid-name
 class TestYahooFinanceSetup(unittest.TestCase):
     """Test the Yahoo Finance platform."""
 

--- a/tests/components/sensor/test_yweather.py
+++ b/tests/components/sensor/test_yweather.py
@@ -56,18 +56,18 @@ BAD_CONF_DATA = {
 }
 
 
-def _yql_queryMock(yql):  # pylint: disable=invalid-name
+def _yql_queryMock(yql):
     """Mock yahoo query language query."""
     return ('{"query": {"count": 1, "created": "2017-11-17T13:40:47Z", '
             '"lang": "en-US", "results": {"place": {"woeid": "23511632"}}}}')
 
 
-def get_woeidMock(lat, lon):  # pylint: disable=invalid-name
+def get_woeidMock(lat, lon):
     """Mock get woeid Where On Earth Identifiers."""
     return '23511632'
 
 
-def get_woeidNoneMock(lat, lon):  # pylint: disable=invalid-name
+def get_woeidNoneMock(lat, lon):
     """Mock get woeid Where On Earth Identifiers."""
     return None
 
@@ -81,46 +81,45 @@ class YahooWeatherMock():
         self.temp_unit = temp_unit
         self._data = json.loads(load_fixture('yahooweather.json'))
 
-    # pylint: disable=no-self-use
-    def updateWeather(self):  # pylint: disable=invalid-name
+    def updateWeather(self):
         """Return sample values."""
         return True
 
     @property
-    def RawData(self):  # pylint: disable=invalid-name
+    def RawData(self):
         """Raw Data."""
         if self.woeid == '12345':
             return json.loads('[]')
         return self._data
 
     @property
-    def Units(self):  # pylint: disable=invalid-name
+    def Units(self):
         """Return dict with units."""
         return self._data['query']['results']['channel']['units']
 
     @property
-    def Now(self):  # pylint: disable=invalid-name
+    def Now(self):
         """Current weather data."""
         if self.woeid == '111':
             raise ValueError
         return self._data['query']['results']['channel']['item']['condition']
 
     @property
-    def Atmosphere(self):  # pylint: disable=invalid-name
+    def Atmosphere(self):
         """Atmosphere weather data."""
         return self._data['query']['results']['channel']['atmosphere']
 
     @property
-    def Wind(self):  # pylint: disable=invalid-name
+    def Wind(self):
         """Wind weather data."""
         return self._data['query']['results']['channel']['wind']
 
     @property
-    def Forecast(self):  # pylint: disable=invalid-name
+    def Forecast(self):
         """Forecast data 0-5 Days."""
         return self._data['query']['results']['channel']['item']['forecast']
 
-    def getWeatherImage(self, code):  # pylint: disable=invalid-name
+    def getWeatherImage(self, code):
         """Create a link to weather image from yahoo code."""
         return "https://l.yimg.com/a/i/us/we/52/{}.gif".format(code)
 

--- a/tests/components/sensor/test_zwave.py
+++ b/tests/components/sensor/test_zwave.py
@@ -1,4 +1,5 @@
 """Test Z-Wave sensor."""
+# pylint: skip-file
 from homeassistant.components.sensor import zwave
 from homeassistant.components.zwave import const
 import homeassistant.const

--- a/tests/components/switch/test_command_line.py
+++ b/tests/components/switch/test_command_line.py
@@ -12,7 +12,6 @@ import homeassistant.components.switch.command_line as command_line
 from tests.common import get_test_home_assistant
 
 
-# pylint: disable=invalid-name
 class TestCommandSwitch(unittest.TestCase):
     """Test the command switch."""
 

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -1,4 +1,5 @@
 """The tests for the Flux switch platform."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch
 

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -157,7 +157,6 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 119)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.591, 0.395])
 
-    # pylint: disable=invalid-name
     def test_flux_after_sunrise_before_sunset(self):
         """Test the flux switch after sunrise and before sunset."""
         platform = loader.get_component('light.test')
@@ -204,7 +203,6 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 180)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.431, 0.38])
 
-    # pylint: disable=invalid-name
     def test_flux_after_sunset_before_stop(self):
         """Test the flux switch after sunset and before stop."""
         platform = loader.get_component('light.test')
@@ -252,7 +250,6 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 153)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.496, 0.397])
 
-    # pylint: disable=invalid-name
     def test_flux_after_stop_before_sunrise(self):
         """Test the flux switch after stop and before sunrise."""
         platform = loader.get_component('light.test')
@@ -299,7 +296,6 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 119)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.591, 0.395])
 
-    # pylint: disable=invalid-name
     def test_flux_with_custom_start_stop_times(self):
         """Test the flux with custom start and stop times."""
         platform = loader.get_component('light.test')
@@ -398,7 +394,6 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 119)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.591, 0.395])
 
-    # pylint: disable=invalid-name
     def test_flux_after_sunrise_before_sunset_stop_next_day(self):
         """
         Test the flux switch after sunrise and before sunset.
@@ -450,7 +445,6 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 180)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.431, 0.38])
 
-    # pylint: disable=invalid-name
     def test_flux_after_sunset_before_midnight_stop_next_day(self):
         """Test the flux switch after sunset and before stop.
 
@@ -501,7 +495,6 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 126)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.574, 0.401])
 
-    # pylint: disable=invalid-name
     def test_flux_after_sunset_after_midnight_stop_next_day(self):
         """Test the flux switch after sunset and before stop.
 
@@ -552,7 +545,6 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 122)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.586, 0.397])
 
-    # pylint: disable=invalid-name
     def test_flux_after_stop_before_sunrise_stop_next_day(self):
         """Test the flux switch after stop and before sunrise.
 
@@ -603,7 +595,6 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 119)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.591, 0.395])
 
-    # pylint: disable=invalid-name
     def test_flux_with_custom_colortemps(self):
         """Test the flux with custom start and stop colortemps."""
         platform = loader.get_component('light.test')
@@ -653,7 +644,6 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 167)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.461, 0.389])
 
-    # pylint: disable=invalid-name
     def test_flux_with_custom_brightness(self):
         """Test the flux with custom start and stop colortemps."""
         platform = loader.get_component('light.test')

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Switch component."""
-# pylint: disable=protected-access
 import unittest
 
 from homeassistant.setup import setup_component
@@ -13,7 +12,6 @@ from tests.common import get_test_home_assistant
 class TestSwitch(unittest.TestCase):
     """Test the switch module."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
@@ -23,7 +21,6 @@ class TestSwitch(unittest.TestCase):
         self.switch_1, self.switch_2, self.switch_3 = \
             platform.DEVICES
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/switch/test_litejet.py
+++ b/tests/components/switch/test_litejet.py
@@ -1,4 +1,5 @@
 """The tests for the litejet component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest import mock

--- a/tests/components/switch/test_mfi.py
+++ b/tests/components/switch/test_mfi.py
@@ -1,4 +1,5 @@
 """The tests for the mFi switch platform."""
+# pylint: skip-file
 import unittest
 import unittest.mock as mock
 

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -12,12 +12,12 @@ from tests.common import (
 class TestSwitchMQTT(unittest.TestCase):
     """Test the MQTT switch."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """"Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/switch/test_rflink.py
+++ b/tests/components/switch/test_rflink.py
@@ -4,6 +4,7 @@ Test setup of rflink switch component/platform. State tracking and
 control of Rflink switch devices.
 
 """
+# pylint: skip-file
 
 import asyncio
 

--- a/tests/components/switch/test_rfxtrx.py
+++ b/tests/components/switch/test_rfxtrx.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx switch platform."""
+# pylint: skip-file
 import unittest
 
 import pytest

--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -13,7 +13,6 @@ class TestTemplateSwitch:
 
     hass = None
     calls = None
-    # pylint: disable=invalid-name
 
     def setup_method(self, method):
         """Setup things to be run when tests are started."""

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -1,4 +1,5 @@
 """The tests for the Alert component."""
+# pylint: skip-file
 from copy import deepcopy
 import unittest
 

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -1,5 +1,4 @@
 """The tests for the Alert component."""
-# pylint: disable=protected-access
 from copy import deepcopy
 import unittest
 
@@ -31,7 +30,6 @@ TEST_NOACK = [NAME, NAME, DONE_MESSAGE, "sensor.test",
 ENTITY_ID = alert.ENTITY_ID_FORMAT.format(NAME)
 
 
-# pylint: disable=invalid-name
 class TestAlert(unittest.TestCase):
     """Test the alert module."""
 

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -1,5 +1,4 @@
 """The tests for the Home Assistant API component."""
-# pylint: disable=protected-access
 import asyncio
 import json
 
@@ -69,7 +68,6 @@ def test_api_state_change(hass, mock_api_client):
     assert hass.states.get("test.test").state == "debug_state_change2"
 
 
-# pylint: disable=invalid-name
 @asyncio.coroutine
 def test_api_state_change_of_non_existing_entity(hass, mock_api_client):
     """Test if changing a state of a non existing entity is possible."""
@@ -85,7 +83,6 @@ def test_api_state_change_of_non_existing_entity(hass, mock_api_client):
         new_state
 
 
-# pylint: disable=invalid-name
 @asyncio.coroutine
 def test_api_state_change_with_bad_data(hass, mock_api_client):
     """Test if API sends appropriate error if we omit state."""
@@ -96,7 +93,6 @@ def test_api_state_change_with_bad_data(hass, mock_api_client):
     assert resp.status == 400
 
 
-# pylint: disable=invalid-name
 @asyncio.coroutine
 def test_api_state_change_to_zero_value(hass, mock_api_client):
     """Test if changing a state to a zero value is possible."""
@@ -113,7 +109,6 @@ def test_api_state_change_to_zero_value(hass, mock_api_client):
     assert resp.status == 200
 
 
-# pylint: disable=invalid-name
 @asyncio.coroutine
 def test_api_state_change_push(hass, mock_api_client):
     """Test if we can push a change the state of an entity."""
@@ -141,7 +136,6 @@ def test_api_state_change_push(hass, mock_api_client):
     assert len(events) == 1
 
 
-# pylint: disable=invalid-name
 @asyncio.coroutine
 def test_api_fire_event_with_no_data(hass, mock_api_client):
     """Test if the API allows us to fire an event."""
@@ -161,7 +155,6 @@ def test_api_fire_event_with_no_data(hass, mock_api_client):
     assert len(test_value) == 1
 
 
-# pylint: disable=invalid-name
 @asyncio.coroutine
 def test_api_fire_event_with_data(hass, mock_api_client):
     """Test if the API allows us to fire an event."""
@@ -187,7 +180,6 @@ def test_api_fire_event_with_data(hass, mock_api_client):
     assert len(test_value) == 1
 
 
-# pylint: disable=invalid-name
 @asyncio.coroutine
 def test_api_fire_event_with_invalid_json(hass, mock_api_client):
     """Test if the API allows us to fire an event."""

--- a/tests/components/test_canary.py
+++ b/tests/components/test_canary.py
@@ -41,7 +41,7 @@ class TestCanary(unittest.TestCase):
         """Initialize values for this test case class."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_configurator.py
+++ b/tests/components/test_configurator.py
@@ -1,5 +1,4 @@
 """The tests for the Configurator component."""
-# pylint: disable=protected-access
 import unittest
 
 import homeassistant.components.configurator as configurator
@@ -11,12 +10,10 @@ from tests.common import get_test_home_assistant
 class TestConfigurator(unittest.TestCase):
     """Test the Configurator component."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -1,4 +1,5 @@
 """The tests for the Conversation component."""
+# pylint: skip-file
 import asyncio
 
 import pytest

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -1,5 +1,4 @@
 """The tests for the Conversation component."""
-# pylint: disable=protected-access
 import asyncio
 
 import pytest

--- a/tests/components/test_datadog.py
+++ b/tests/components/test_datadog.py
@@ -19,11 +19,11 @@ from tests.common import (assert_setup_component, get_test_home_assistant,
 class TestDatadog(unittest.TestCase):
     """Test the Datadog component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_demo.py
+++ b/tests/components/test_demo.py
@@ -1,4 +1,5 @@
 """The tests for the Demo component."""
+# pylint: skip-file
 import asyncio
 import json
 import os

--- a/tests/components/test_device_sun_light_trigger.py
+++ b/tests/components/test_device_sun_light_trigger.py
@@ -1,5 +1,4 @@
 """The tests device sun light trigger component."""
-# pylint: disable=protected-access
 from datetime import datetime
 import unittest
 from unittest.mock import patch
@@ -17,7 +16,7 @@ from tests.common import get_test_home_assistant, fire_time_changed
 class TestDeviceSunLightTrigger(unittest.TestCase):
     """Test the device sun light trigger module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
@@ -56,7 +55,7 @@ class TestDeviceSunLightTrigger(unittest.TestCase):
             light.DOMAIN: {CONF_PLATFORM: 'test'}
         }))
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 
@@ -79,8 +78,7 @@ class TestDeviceSunLightTrigger(unittest.TestCase):
 
         self.assertTrue(light.is_on(self.hass))
 
-    def test_lights_turn_off_when_everyone_leaves(self): \
-            # pylint: disable=invalid-name
+    def test_lights_turn_off_when_everyone_leaves(self):
         """Test lights turn off when everyone leaves the house."""
         light.turn_on(self.hass)
 
@@ -97,8 +95,7 @@ class TestDeviceSunLightTrigger(unittest.TestCase):
 
         self.assertFalse(light.is_on(self.hass))
 
-    def test_lights_turn_on_when_coming_home_after_sun_set(self): \
-            # pylint: disable=invalid-name
+    def test_lights_turn_on_when_coming_home_after_sun_set(self):
         """Test lights turn on when coming home after sun set."""
         test_time = datetime(2017, 4, 5, 3, 2, 3, tzinfo=dt_util.UTC)
         with patch('homeassistant.util.dt.utcnow', return_value=test_time):

--- a/tests/components/test_dialogflow.py
+++ b/tests/components/test_dialogflow.py
@@ -1,5 +1,4 @@
 """The tests for the Dialogflow component."""
-# pylint: disable=protected-access
 import json
 import unittest
 
@@ -34,12 +33,10 @@ MAX_RESPONSE_TIME = 5  # https://dialogflow.com/docs/fulfillment
 # allow the test to finish
 REQUEST_TIMEOUT = 15
 
-# pylint: disable=invalid-name
 hass = None
 calls = []
 
 
-# pylint: disable=invalid-name
 def setUpModule():
     """Initialize a Home Assistant server for testing this module."""
     global hass
@@ -110,7 +107,6 @@ def setUpModule():
     hass.start()
 
 
-# pylint: disable=invalid-name
 def tearDownModule():
     """Stop the Home Assistant server."""
     hass.stop()

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -1,4 +1,5 @@
 """The tests for the discovery component."""
+# pylint: skip-file
 import asyncio
 import os
 from unittest.mock import patch, MagicMock

--- a/tests/components/test_dyson.py
+++ b/tests/components/test_dyson.py
@@ -35,11 +35,11 @@ def _get_dyson_account_device_error():
 class DysonTest(unittest.TestCase):
     """Dyson parent component test class."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_google.py
+++ b/tests/components/test_google.py
@@ -1,4 +1,5 @@
 """The tests for the Google Calendar component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest.mock import patch

--- a/tests/components/test_google.py
+++ b/tests/components/test_google.py
@@ -13,11 +13,11 @@ _LOGGER = logging.getLogger(__name__)
 class TestGoogle(unittest.TestCase):
     """Test the Google component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_graphite.py
+++ b/tests/components/test_graphite.py
@@ -1,4 +1,5 @@
 """The tests for the Graphite component."""
+# pylint: skip-file
 import socket
 import unittest
 from unittest import mock

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -1,5 +1,4 @@
 """The tests the History component."""
-# pylint: disable=protected-access,invalid-name
 from datetime import timedelta
 import unittest
 from unittest.mock import patch, sentinel
@@ -16,11 +15,11 @@ from tests.common import (
 class TestComponentHistory(unittest.TestCase):
     """Test History component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 
@@ -395,8 +394,7 @@ class TestComponentHistory(unittest.TestCase):
                     history.CONF_ENTITIES: ['media_player.test']}}})
         self.check_significant_states(zero, four, states, config)
 
-    def check_significant_states(self, zero, four, states, config): \
-            # pylint: disable=no-self-use
+    def check_significant_states(self, zero, four, states, config):
         """Check if significant states are retrieved."""
         filters = history.Filters()
         exclude = config[history.DOMAIN].get(history.CONF_EXCLUDE)

--- a/tests/components/test_history_graph.py
+++ b/tests/components/test_history_graph.py
@@ -9,11 +9,11 @@ from tests.common import init_recorder_component, get_test_home_assistant
 class TestGraph(unittest.TestCase):
     """Test the Google component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_hue.py
+++ b/tests/components/test_hue.py
@@ -1,4 +1,5 @@
 """Generic Philips Hue component tests."""
+# pylint: skip-file
 import asyncio
 import logging
 import unittest

--- a/tests/components/test_hue.py
+++ b/tests/components/test_hue.py
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 class TestSetup(unittest.TestCase):
     """Test the Hue component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.skip_teardown_stop = False
@@ -199,7 +199,7 @@ class TestSetup(unittest.TestCase):
 class TestHueBridge(unittest.TestCase):
     """Test the HueBridge class."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.hass.data[hue.DOMAIN] = {}

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -1,5 +1,4 @@
 """The tests for Core components."""
-# pylint: disable=protected-access
 import asyncio
 import unittest
 from unittest.mock import patch, Mock
@@ -24,7 +23,6 @@ from tests.common import (
 class TestComponentsCore(unittest.TestCase):
     """Test homeassistant.components module."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
@@ -35,7 +33,6 @@ class TestComponentsCore(unittest.TestCase):
         self.hass.states.set('light.Bowl', STATE_ON)
         self.hass.states.set('light.Ceiling', STATE_OFF)
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -1,4 +1,5 @@
 """The tests for Core components."""
+# pylint: skip-file
 import asyncio
 import unittest
 from unittest.mock import patch, Mock

--- a/tests/components/test_input_boolean.py
+++ b/tests/components/test_input_boolean.py
@@ -1,5 +1,4 @@
 """The tests for the input_boolean component."""
-# pylint: disable=protected-access
 import asyncio
 import unittest
 import logging
@@ -20,12 +19,10 @@ _LOGGER = logging.getLogger(__name__)
 class TestInputBoolean(unittest.TestCase):
     """Test the input boolean module."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/test_input_datetime.py
+++ b/tests/components/test_input_datetime.py
@@ -1,5 +1,4 @@
 """Tests for the Input slider component."""
-# pylint: disable=protected-access
 import asyncio
 import unittest
 import datetime
@@ -15,12 +14,10 @@ from tests.common import get_test_home_assistant, mock_restore_cache
 class TestInputDatetime(unittest.TestCase):
     """Test the input datetime component."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/test_input_number.py
+++ b/tests/components/test_input_number.py
@@ -1,5 +1,4 @@
 """The tests for the Input number component."""
-# pylint: disable=protected-access
 import asyncio
 import unittest
 
@@ -14,12 +13,10 @@ from tests.common import get_test_home_assistant, mock_restore_cache
 class TestInputNumber(unittest.TestCase):
     """Test the input number component."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/test_input_select.py
+++ b/tests/components/test_input_select.py
@@ -1,5 +1,4 @@
 """The tests for the Input select component."""
-# pylint: disable=protected-access
 import asyncio
 import unittest
 
@@ -17,12 +16,10 @@ from homeassistant.const import (
 class TestInputSelect(unittest.TestCase):
     """Test the input select component."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/test_input_text.py
+++ b/tests/components/test_input_text.py
@@ -1,5 +1,4 @@
 """The tests for the Input text component."""
-# pylint: disable=protected-access
 import asyncio
 import unittest
 
@@ -13,12 +12,10 @@ from tests.common import get_test_home_assistant, mock_restore_cache
 class TestInputText(unittest.TestCase):
     """Test the input slider component."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/test_kira.py
+++ b/tests/components/test_kira.py
@@ -34,7 +34,6 @@ KIRA_CODES = """
 class TestKiraSetup(unittest.TestCase):
     """Test class for kira."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -1,5 +1,4 @@
 """The tests for the logbook component."""
-# pylint: disable=protected-access,invalid-name
 import logging
 from datetime import timedelta
 import unittest
@@ -542,8 +541,7 @@ class TestComponentLogbook(unittest.TestCase):
 
     def create_state_changed_event(self, event_time_fired, entity_id, state,
                                    attributes=None, last_changed=None,
-                                   last_updated=None): \
-            # pylint: disable=no-self-use
+                                   last_updated=None):
         """Create state changed event."""
         # Logbook only cares about state change events that
         # contain an old state but will not actually act on it.

--- a/tests/components/test_logentries.py
+++ b/tests/components/test_logentries.py
@@ -1,4 +1,5 @@
 """The tests for the Logentries component."""
+# pylint: skip-file
 
 import unittest
 from unittest import mock

--- a/tests/components/test_logentries.py
+++ b/tests/components/test_logentries.py
@@ -13,11 +13,11 @@ from tests.common import get_test_home_assistant
 class TestLogentries(unittest.TestCase):
     """Test the Logentries component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_melissa.py
+++ b/tests/components/test_melissa.py
@@ -15,12 +15,12 @@ VALID_CONFIG = {
 class TestMelissa(unittest.TestCase):
     """Test the Melissa component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Initialize the values for this test class."""
         self.hass = get_test_home_assistant()
         self.config = VALID_CONFIG
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Teardown this test class. Stop hass."""
         self.hass.stop()
 

--- a/tests/components/test_mqtt_eventstream.py
+++ b/tests/components/test_mqtt_eventstream.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT eventstream component."""
+# pylint: skip-file
 import json
 from unittest.mock import ANY, patch
 

--- a/tests/components/test_no_ip.py
+++ b/tests/components/test_no_ip.py
@@ -1,4 +1,5 @@
 """Test the NO-IP component."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 

--- a/tests/components/test_nuheat.py
+++ b/tests/components/test_nuheat.py
@@ -18,12 +18,12 @@ VALID_CONFIG = {
 class TestNuHeat(unittest.TestCase):
     """Test the NuHeat component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Initialize the values for this test class."""
         self.hass = get_test_home_assistant()
         self.config = VALID_CONFIG
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Teardown this test class. Stop hass."""
         self.hass.stop()
 

--- a/tests/components/test_pilight.py
+++ b/tests/components/test_pilight.py
@@ -1,4 +1,5 @@
 """The tests for the pilight component."""
+# pylint: skip-file
 import logging
 import unittest
 from unittest.mock import patch

--- a/tests/components/test_pilight.py
+++ b/tests/components/test_pilight.py
@@ -40,7 +40,7 @@ class PilightDaemonSim:
         """Init pilight client, ignore parameters."""
         pass
 
-    def send_code(self, call):  # pylint: disable=no-self-use
+    def send_code(self, call):
         """Called pilight.send service is called."""
         _LOGGER.error('PilightDaemonSim payload: ' + str(call))
 
@@ -55,7 +55,7 @@ class PilightDaemonSim:
             self.callback(self.test_message)
             self.called = True
 
-    def stop(self):  # pylint: disable=no-self-use
+    def stop(self):
         """Called homeassistant.stop is called."""
         _LOGGER.error('PilightDaemonSim stop')
 
@@ -69,7 +69,7 @@ class PilightDaemonSim:
 class TestPilight(unittest.TestCase):
     """Test the Pilight component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.skip_teardown_stop = False
@@ -350,7 +350,7 @@ class TestPilight(unittest.TestCase):
 class TestPilightCallrateThrottler(unittest.TestCase):
     """Test the Throttler used to throttle calls to send_code."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 

--- a/tests/components/test_plant.py
+++ b/tests/components/test_plant.py
@@ -1,4 +1,5 @@
 """Unit tests for platform/plant.py."""
+# pylint: skip-file
 import asyncio
 import unittest
 import pytest

--- a/tests/components/test_prometheus.py
+++ b/tests/components/test_prometheus.py
@@ -18,7 +18,7 @@ def prometheus_client(loop, hass, test_client):
 
 
 @asyncio.coroutine
-def test_view(prometheus_client):  # pylint: disable=redefined-outer-name
+def test_view(prometheus_client):
     """Test prometheus metrics view."""
     resp = yield from prometheus_client.get(prometheus.API_ENDPOINT)
 

--- a/tests/components/test_python_script.py
+++ b/tests/components/test_python_script.py
@@ -1,4 +1,5 @@
 """Test the python_script component."""
+# pylint: skip-file
 import asyncio
 import logging
 from unittest.mock import patch, mock_open

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -1,4 +1,5 @@
 """Common functions for Rflink component tests and generic platform tests."""
+# pylint: skip-file
 
 import asyncio
 from unittest.mock import Mock

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx component."""
+# pylint: skip-file
 import unittest
 
 import pytest

--- a/tests/components/test_rfxtrx.py
+++ b/tests/components/test_rfxtrx.py
@@ -1,5 +1,4 @@
 """The tests for the Rfxtrx component."""
-# pylint: disable=protected-access
 import unittest
 
 import pytest

--- a/tests/components/test_ring.py
+++ b/tests/components/test_ring.py
@@ -33,7 +33,7 @@ class TestRing(unittest.TestCase):
         self.cache = get_test_config_dir(ring.DEFAULT_CACHEDB)
         self.config = VALID_CONFIG
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
         self.cleanup()

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -1,4 +1,5 @@
 """The tests for the Script component."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch
 

--- a/tests/components/test_script.py
+++ b/tests/components/test_script.py
@@ -1,5 +1,4 @@
 """The tests for the Script component."""
-# pylint: disable=protected-access
 import unittest
 from unittest.mock import patch
 
@@ -16,12 +15,10 @@ ENTITY_ID = 'script.test'
 class TestScriptComponent(unittest.TestCase):
     """Test the Script component."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()

--- a/tests/components/test_shell_command.py
+++ b/tests/components/test_shell_command.py
@@ -1,4 +1,5 @@
 """The tests for the Shell command component."""
+# pylint: skip-file
 import asyncio
 import os
 import tempfile

--- a/tests/components/test_shell_command.py
+++ b/tests/components/test_shell_command.py
@@ -33,7 +33,7 @@ def mock_process_creator(error: bool = False) -> asyncio.coroutine:
 class TestShellCommand(unittest.TestCase):
     """Test the shell_command component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started.
 
         Also seems to require a child watcher attached to the loop when run
@@ -42,7 +42,7 @@ class TestShellCommand(unittest.TestCase):
         self.hass = get_test_home_assistant()
         asyncio.get_child_watcher().attach_loop(self.hass.loop)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_sleepiq.py
+++ b/tests/components/test_sleepiq.py
@@ -1,4 +1,5 @@
 """The tests for the SleepIQ component."""
+# pylint: skip-file
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/components/test_sleepiq.py
+++ b/tests/components/test_sleepiq.py
@@ -42,7 +42,7 @@ class TestSleepIQ(unittest.TestCase):
             }
         }
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -1,4 +1,5 @@
 """Test the Snips component."""
+# pylint: skip-file
 import asyncio
 import json
 import logging

--- a/tests/components/test_spc.py
+++ b/tests/components/test_spc.py
@@ -1,4 +1,5 @@
 """Tests for Vanderbilt SPC component."""
+# pylint: skip-file
 import asyncio
 
 import pytest

--- a/tests/components/test_splunk.py
+++ b/tests/components/test_splunk.py
@@ -15,11 +15,11 @@ from tests.common import get_test_home_assistant
 class TestSplunk(unittest.TestCase):
     """Test the Splunk component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_statsd.py
+++ b/tests/components/test_statsd.py
@@ -15,11 +15,11 @@ from tests.common import get_test_home_assistant
 class TestStatsd(unittest.TestCase):
     """Test the StatsD component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/test_sun.py
+++ b/tests/components/test_sun.py
@@ -1,5 +1,4 @@
 """The tests for the Sun component."""
-# pylint: disable=protected-access
 import unittest
 from unittest.mock import patch
 from datetime import timedelta, datetime
@@ -12,7 +11,6 @@ import homeassistant.components.sun as sun
 from tests.common import get_test_home_assistant
 
 
-# pylint: disable=invalid-name
 class TestSun(unittest.TestCase):
     """Test the sun module."""
 

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -1,4 +1,5 @@
 """The tests for the Updater component."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 from unittest.mock import patch, Mock

--- a/tests/components/test_upnp.py
+++ b/tests/components/test_upnp.py
@@ -1,4 +1,5 @@
 """Test the UPNP component."""
+# pylint: skip-file
 import asyncio
 from collections import OrderedDict
 from unittest.mock import patch, MagicMock

--- a/tests/components/test_vultr.py
+++ b/tests/components/test_vultr.py
@@ -27,7 +27,7 @@ class TestVultr(unittest.TestCase):
         self.hass = get_test_home_assistant()
         self.config = VALID_CONFIG
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that we started."""
         self.hass.stop()
 

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -1,4 +1,5 @@
 """Tests for the Home Assistant Websocket API."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import patch
 

--- a/tests/components/test_zone.py
+++ b/tests/components/test_zone.py
@@ -1,4 +1,5 @@
 """Test zone component."""
+# pylint: skip-file
 import unittest
 
 from homeassistant import setup

--- a/tests/components/test_zone.py
+++ b/tests/components/test_zone.py
@@ -10,11 +10,11 @@ from tests.common import get_test_home_assistant
 class TestComponentZone(unittest.TestCase):
     """Test the zone component."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the timer component."""
-# pylint: disable=protected-access
 import asyncio
 import unittest
 import logging
@@ -23,12 +22,10 @@ _LOGGER = logging.getLogger(__name__)
 class TestTimer(unittest.TestCase):
     """Test the timer component."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/components/vacuum/test_demo.py
+++ b/tests/components/vacuum/test_demo.py
@@ -26,13 +26,13 @@ ENTITY_VACUUM_NONE = '{}.{}'.format(DOMAIN, DEMO_VACUUM_NONE).lower()
 class TestVacuumDemo(unittest.TestCase):
     """Test the Demo vacuum."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.assertTrue(setup_component(
             self.hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: 'demo'}}))
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/vacuum/test_dyson.py
+++ b/tests/components/vacuum/test_dyson.py
@@ -66,11 +66,11 @@ def _get_vacuum_device_unknown_state():
 class DysonTest(unittest.TestCase):
     """Dyson 360 eye robot vacuum component test class."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 

--- a/tests/components/vacuum/test_mqtt.py
+++ b/tests/components/vacuum/test_mqtt.py
@@ -16,7 +16,7 @@ from tests.common import (
 class TestVacuumMQTT(unittest.TestCase):
     """MQTT vacuum component test class."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.mock_publish = mock_mqtt_component(self.hass)
@@ -43,7 +43,7 @@ class TestVacuumMQTT(unittest.TestCase):
             mqtt.CONF_FAN_SPEED_LIST: ['min', 'medium', 'high', 'max'],
         }
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/components/weather/test_yweather.py
+++ b/tests/components/weather/test_yweather.py
@@ -14,13 +14,13 @@ from tests.common import (get_test_home_assistant, load_fixture,
                           MockDependency)
 
 
-def _yql_queryMock(yql):  # pylint: disable=invalid-name
+def _yql_queryMock(yql):
     """Mock yahoo query language query."""
     return ('{"query": {"count": 1, "created": "2017-11-17T13:40:47Z", '
             '"lang": "en-US", "results": {"place": {"woeid": "23511632"}}}}')
 
 
-def get_woeidMock(lat, lon):  # pylint: disable=invalid-name
+def get_woeidMock(lat, lon):
     """Mock get woeid Where On Earth Identifiers."""
     return '23511632'
 
@@ -34,37 +34,36 @@ class YahooWeatherMock():
         self.temp_unit = temp_unit
         self._data = json.loads(load_fixture('yahooweather.json'))
 
-    # pylint: disable=no-self-use
-    def updateWeather(self):  # pylint: disable=invalid-name
+    def updateWeather(self):
         """Return sample values."""
         return True
 
     @property
-    def RawData(self):  # pylint: disable=invalid-name
+    def RawData(self):
         """Raw Data."""
         if self.woeid == '12345':
             return json.loads('[]')
         return self._data
 
     @property
-    def Now(self):  # pylint: disable=invalid-name
+    def Now(self):
         """Current weather data."""
         if self.woeid == '111':
             raise ValueError
         return self._data['query']['results']['channel']['item']['condition']
 
     @property
-    def Atmosphere(self):  # pylint: disable=invalid-name
+    def Atmosphere(self):
         """Atmosphere weather data."""
         return self._data['query']['results']['channel']['atmosphere']
 
     @property
-    def Wind(self):  # pylint: disable=invalid-name
+    def Wind(self):
         """Wind weather data."""
         return self._data['query']['results']['channel']['wind']
 
     @property
-    def Forecast(self):  # pylint: disable=invalid-name
+    def Forecast(self):
         """Forecast data 0-5 Days."""
         if self.woeid == '123123':
             raise ValueError

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Z-Wave init."""
+# pylint: skip-file
 import asyncio
 from collections import OrderedDict
 from datetime import datetime

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -477,7 +477,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         }}
         self.device_config = {self.entity_id: {}}
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
 
@@ -790,7 +790,7 @@ class TestZWaveServices(unittest.TestCase):
         self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
         self.hass.block_till_done()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop everything that was started."""
         self.hass.services.call('zwave', 'stop_network', {})
         self.hass.block_till_done()

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -1,4 +1,5 @@
 """Test Z-Wave node entity."""
+# pylint: skip-file
 import asyncio
 import unittest
 from unittest.mock import patch, MagicMock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Setup some common test helper things."""
+# pylint: skip-file
 import asyncio
 import functools
 import logging

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -502,7 +502,6 @@ def test_deprecated(caplog):
     )
 
     deprecated_schema({'venus': True})
-    # pylint: disable=len-as-condition
     assert len(caplog.records) == 0
 
     deprecated_schema({'mars': True})
@@ -572,7 +571,7 @@ def test_enum():
         schema('value3')
 
 
-def test_socket_timeout():  # pylint: disable=invalid-name
+def test_socket_timeout():
     """Test socket timeout validator."""
     schema = vol.Schema(cv.socket_timeout)
 

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -1,4 +1,5 @@
 """Test deprecation helpers."""
+# pylint: skip-file
 from homeassistant.helpers.deprecation import (
     deprecated_substitute, get_deprecated)
 

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1,4 +1,5 @@
 """Test the entity helper."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import MagicMock, patch
 

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1,5 +1,4 @@
 """Test the entity helper."""
-# pylint: disable=protected-access
 import asyncio
 from unittest.mock import MagicMock, patch
 

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -1,5 +1,4 @@
 """The tests for the Entity component helper."""
-# pylint: disable=protected-access
 import asyncio
 from collections import OrderedDict
 import logging
@@ -28,11 +27,11 @@ DOMAIN = "test_domain"
 class TestHelpersEntityComponent(unittest.TestCase):
     """Test homeassistant.helpers.entity_component module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Initialize a test Home Assistant instance."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Clean up the test Home Assistant instance."""
         self.hass.stop()
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1,4 +1,5 @@
 """Tests for the EntityPlatform helper."""
+# pylint: skip-file
 import asyncio
 import logging
 import unittest

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -25,11 +25,11 @@ PLATFORM = 'test_platform'
 class TestHelpersEntityPlatform(unittest.TestCase):
     """Test homeassistant.helpers.entity_component module."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Initialize a test Home Assistant instance."""
         self.hass = get_test_home_assistant()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Clean up the test Home Assistant instance."""
         self.hass.stop()
 

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1,4 +1,5 @@
 """Test event helpers."""
+# pylint: skip-file
 import asyncio
 import unittest
 from datetime import datetime, timedelta

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1,5 +1,4 @@
 """Test event helpers."""
-# pylint: disable=protected-access
 import asyncio
 import unittest
 from datetime import datetime, timedelta
@@ -35,12 +34,10 @@ from unittest.mock import patch
 class TestEventHelpers(unittest.TestCase):
     """Test the Home Assistant event helpers."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/helpers/test_init.py
+++ b/tests/helpers/test_init.py
@@ -1,5 +1,4 @@
 """Test component helpers."""
-# pylint: disable=protected-access
 from collections import OrderedDict
 import unittest
 
@@ -11,12 +10,10 @@ from tests.common import get_test_home_assistant
 class TestHelpers(unittest.TestCase):
     """Tests homeassistant.helpers module."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Init needed objects."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -1,4 +1,5 @@
 """The tests for the Restore component."""
+# pylint: skip-file
 import asyncio
 from datetime import timedelta
 from unittest.mock import patch, MagicMock

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -132,7 +132,6 @@ def test_cache_timeout(hass):
 
 def _add_data_in_last_run(hass, entities):
     """Add test data in the last recorder_run."""
-    # pylint: disable=protected-access
     t_now = dt_util.utcnow() - timedelta(minutes=10)
     t_min_1 = t_now - timedelta(minutes=20)
     t_min_2 = t_now - timedelta(minutes=30)

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1,4 +1,5 @@
 """The tests for the Script component."""
+# pylint: skip-file
 from datetime import timedelta
 from unittest import mock
 import unittest

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1,5 +1,4 @@
 """The tests for the Script component."""
-# pylint: disable=protected-access
 from datetime import timedelta
 from unittest import mock
 import unittest
@@ -19,12 +18,10 @@ ENTITY_ID = 'script.test'
 class TestScriptHelper(unittest.TestCase):
     """Test the Script component."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -18,12 +18,12 @@ from tests.common import get_test_home_assistant, mock_service
 class TestServiceHelpers(unittest.TestCase):
     """Test the Home Assistant service helpers."""
 
-    def setUp(self):     # pylint: disable=invalid-name
+    def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.calls = mock_service(self.hass, 'test_domain', 'test_service')
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop down everything that was started."""
         self.hass.stop()
 

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -52,13 +52,13 @@ def test_async_track_states(hass):
 class TestStateHelpers(unittest.TestCase):
     """Test the Home Assistant event helpers."""
 
-    def setUp(self):     # pylint: disable=invalid-name
+    def setUp(self):
         """Run when tests are started."""
         self.hass = get_test_home_assistant()
         run_coroutine_threadsafe(core_components.async_setup(
             self.hass, {}), self.hass.loop).result()
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Stop when tests are finished."""
         self.hass.stop()
 

--- a/tests/helpers/test_sun.py
+++ b/tests/helpers/test_sun.py
@@ -1,5 +1,4 @@
 """The tests for the Sun helpers."""
-# pylint: disable=protected-access
 import unittest
 from unittest.mock import patch
 from datetime import timedelta, datetime
@@ -10,7 +9,6 @@ import homeassistant.helpers.sun as sun
 from tests.common import get_test_home_assistant
 
 
-# pylint: disable=invalid-name
 class TestSun(unittest.TestCase):
     """Test the sun helpers."""
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1,4 +1,5 @@
 """Test Home Assistant template helper methods."""
+# pylint: skip-file
 import asyncio
 from datetime import datetime
 import unittest

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -25,7 +25,6 @@ from tests.common import get_test_home_assistant
 class TestHelpersTemplate(unittest.TestCase):
     """Test the Template."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup the tests."""
         self.hass = get_test_home_assistant()
@@ -33,7 +32,6 @@ class TestHelpersTemplate(unittest.TestCase):
                                             LENGTH_METERS, VOLUME_LITERS,
                                             MASS_GRAMS)
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop down stuff we started."""
         self.hass.stop()

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -1,5 +1,4 @@
 """Test the translation helper."""
-# pylint: disable=protected-access
 from os import path
 
 import homeassistant.helpers.translation as translation

--- a/tests/pylintrc
+++ b/tests/pylintrc
@@ -1,0 +1,63 @@
+[MASTER]
+reports=no
+
+# Reasons disabled:
+# locally-disabled - it spams too much
+# duplicate-code - unavoidable
+# cyclic-import - doesn't test if both import on load
+# abstract-class-little-used - prevents from setting right foundation
+# abstract-class-not-used - is flaky, should not show up but does
+# unused-argument - generic callbacks and setup methods create a lot of warnings
+# global-statement - used for the on-demand requirement installation
+# redefined-variable-type - this is Python, we're duck typing!
+# too-many-* - are not enforced for the sake of readability
+# too-few-* - same as too-many-*
+# abstract-method - with intro of async there are always methods missing
+# inconsistent-return-statements - doesn't handle raise
+
+# Reasons disabled for tests/
+# invalid-name - tests can have long names
+# redefined-outer-name - test fixtures
+# attribute-defined-outside-init - would only break tests anyway
+# unnecessary-lambda - Too verbose for tests and good for readability
+# no-self-use - Not good for unittest.TestCase
+# not-an-iterable - coroutine bug https://github.com/PyCQA/pylint/issues/996
+# unsubscriptable-object - MagicMock#mock_calls[]
+# unused-import - Fixtures + handled by flake8 anyway
+
+generated-members=botocore.errorfactory
+
+disable=
+  abstract-class-little-used,
+  abstract-class-not-used,
+  abstract-method,
+  cyclic-import,
+  duplicate-code,
+  global-statement,
+  inconsistent-return-statements,
+  locally-disabled,
+  not-context-manager,
+  redefined-variable-type,
+  too-few-public-methods,
+  too-many-arguments,
+  too-many-branches,
+  too-many-instance-attributes,
+  too-many-lines,
+  too-many-locals,
+  too-many-public-methods,
+  too-many-return-statements,
+  too-many-statements,
+  unused-argument,
+  invalid-name,
+  redefined-outer-name,
+  protected-access,
+  len-as-condition,
+  attribute-defined-outside-init,
+  unnecessary-lambda,
+  no-self-use,
+  not-an-iterable,
+  unsubscriptable-object,
+  unused-import
+
+[EXCEPTIONS]
+overgeneral-exceptions=Exception,HomeAssistantError

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -1,7 +1,7 @@
 """Test check_config script."""
 import asyncio
 import logging
-import os  # noqa: F401 pylint: disable=unused-import
+import os  # noqa: F401
 import unittest
 from unittest.mock import patch
 
@@ -31,7 +31,6 @@ def normalize_yaml_files(check_dict):
             for key in sorted(check_dict['yaml_files'].keys())]
 
 
-# pylint: disable=unsubscriptable-object
 class TestCheckConfig(unittest.TestCase):
     """Tests for the homeassistant.scripts.check_config module."""
 
@@ -47,9 +46,8 @@ class TestCheckConfig(unittest.TestCase):
             asyncio.set_event_loop(asyncio.new_event_loop())
 
         # Will allow seeing full diff
-        self.maxDiff = None  # pylint: disable=invalid-name
+        self.maxDiff = None
 
-    # pylint: disable=no-self-use,invalid-name
     @patch('os.path.isfile', return_value=True)
     def test_config_platform_valid(self, isfile_patch):
         """Test a valid platform setup."""
@@ -172,8 +170,7 @@ class TestCheckConfig(unittest.TestCase):
                 '.../configuration.yaml', '.../secrets.yaml']
 
     @patch('os.path.isfile', return_value=True)
-    def test_package_invalid(self, isfile_patch): \
-            # pylint: disable=no-self-use,invalid-name
+    def test_package_invalid(self, isfile_patch):
         """Test a valid platform setup."""
         files = {
             YAML_CONFIG_FILE: BASE_CONFIG + (
@@ -194,8 +191,7 @@ class TestCheckConfig(unittest.TestCase):
             assert res['secrets'] == {}
             assert len(res['yaml_files']) == 1
 
-    def test_bootstrap_error(self): \
-            # pylint: disable=no-self-use,invalid-name
+    def test_bootstrap_error(self):
         """Test a valid platform setup."""
         files = {
             YAML_CONFIG_FILE: BASE_CONFIG + 'automation: !include no.yaml',

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,4 +1,5 @@
 """Test the bootstrapping."""
+# pylint: skip-file
 import asyncio
 import os
 from unittest.mock import Mock, patch

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,5 +1,4 @@
 """Test the bootstrapping."""
-# pylint: disable=protected-access
 import asyncio
 import os
 from unittest.mock import Mock, patch

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,4 @@
 """Test config utils."""
-# pylint: disable=protected-access
 import asyncio
 import os
 import unittest
@@ -51,12 +50,10 @@ def create_file(path):
 class TestConfig(unittest.TestCase):
     """Test the configutils."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Initialize a test Home Assistant instance."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Clean up."""
         dt_util.DEFAULT_TIME_ZONE = ORIG_TIMEZONE
@@ -84,7 +81,6 @@ class TestConfig(unittest.TestCase):
 
         self.hass.stop()
 
-    # pylint: disable=no-self-use
     def test_create_default_config(self):
         """Test creation of default config."""
         config_util.create_default_config(CONFIG_DIR, False)
@@ -208,7 +204,6 @@ class TestConfig(unittest.TestCase):
                 os.path.join(CONFIG_DIR, 'non_existing_dir/'), False))
         self.assertTrue(mock_print.called)
 
-    # pylint: disable=no-self-use
     def test_core_config_schema(self):
         """Test core config schema."""
         for value in (
@@ -545,7 +540,6 @@ class TestConfig(unittest.TestCase):
         ).result() == 'hello'
 
 
-# pylint: disable=redefined-outer-name
 @pytest.fixture
 def merge_log_err(hass):
     """Patch _merge_log_error from packages."""

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1,4 +1,5 @@
 """Test the config manager."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import MagicMock, patch, mock_open
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,4 @@
 """Test to verify that Home Assistant core works."""
-# pylint: disable=protected-access
 import asyncio
 import logging
 import os
@@ -116,12 +115,10 @@ def test_stage_shutdown():
 class TestHomeAssistant(unittest.TestCase):
     """Test the Home Assistant core classes."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
@@ -272,13 +269,11 @@ class TestEvent(unittest.TestCase):
 class TestEventBus(unittest.TestCase):
     """Test EventBus methods."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         self.bus = self.hass.bus
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop down stuff we started."""
         self.hass.stop()
@@ -476,7 +471,6 @@ class TestState(unittest.TestCase):
 class TestStateMachine(unittest.TestCase):
     """Test State machine methods."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
@@ -484,7 +478,6 @@ class TestStateMachine(unittest.TestCase):
         self.states.set("light.Bowl", "on")
         self.states.set("switch.AC", "off")
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop down stuff we started."""
         self.hass.stop()
@@ -603,7 +596,6 @@ class TestServiceCall(unittest.TestCase):
 class TestServiceRegistry(unittest.TestCase):
     """Test ServicerRegistry methods."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.hass = get_test_home_assistant()
@@ -624,7 +616,6 @@ class TestServiceRegistry(unittest.TestCase):
 
         self.hass.bus.listen(EVENT_SERVICE_REGISTERED, mock_event_register)
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop down stuff we started."""
         self.hass.stop()
@@ -758,7 +749,6 @@ class TestServiceRegistry(unittest.TestCase):
 class TestConfig(unittest.TestCase):
     """Test configuration methods."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup things to be run when tests are started."""
         self.config = ha.Config()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 """Test to verify that Home Assistant core works."""
+# pylint: skip-file
 import asyncio
 import logging
 import os

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,4 +1,5 @@
 """Test to verify that we can load components."""
+# pylint: skip-file
 import asyncio
 import unittest
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,5 +1,4 @@
 """Test to verify that we can load components."""
-# pylint: disable=protected-access
 import asyncio
 import unittest
 
@@ -15,12 +14,10 @@ from tests.common import (
 class TestLoader(unittest.TestCase):
     """Test the loader module."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Setup tests."""
         self.hass = get_test_home_assistant()
 
-    # pylint: disable=invalid-name
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,5 +1,4 @@
 """Test Home Assistant remote methods and classes."""
-# pylint: disable=protected-access
 import unittest
 
 from homeassistant import remote, setup, core as ha
@@ -26,7 +25,6 @@ def _url(path=''):
     return HTTP_BASE_URL + path
 
 
-# pylint: disable=invalid-name
 def setUpModule():
     """Initialization of a Home Assistant server instance."""
     global hass, master_api
@@ -48,7 +46,6 @@ def setUpModule():
     master_api = remote.API('127.0.0.1', API_PASSWORD, MASTER_PORT)
 
 
-# pylint: disable=invalid-name
 def tearDownModule():
     """Stop the Home Assistant server."""
     hass.stop()

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -14,7 +14,6 @@ class TestRequirements:
     hass = None
     backup_cache = None
 
-    # pylint: disable=invalid-name, no-self-use
     def setup_method(self, method):
         """Setup the test."""
         self.hass = get_test_home_assistant()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,5 +1,4 @@
 """Test component/platform setup."""
-# pylint: disable=protected-access
 import asyncio
 import os
 from unittest import mock
@@ -32,7 +31,6 @@ class TestSetup:
     hass = None
     backup_cache = None
 
-    # pylint: disable=invalid-name, no-self-use
     def setup_method(self, method):
         """Setup the test."""
         self.hass = get_test_home_assistant()

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -1,4 +1,5 @@
 """Aiohttp test utils."""
+# pylint: skip-file
 import asyncio
 from contextlib import contextmanager
 import json as _json

--- a/tests/test_util/test_aiohttp.py
+++ b/tests/test_util/test_aiohttp.py
@@ -1,4 +1,5 @@
 """Tests for our aiohttp mocker."""
+# pylint: skip-file
 from .aiohttp import AiohttpClientMocker
 
 import pytest

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -1,4 +1,5 @@
 """Tests for async util methods from Python source."""
+# pylint: skip-file
 import asyncio
 from unittest.mock import MagicMock, patch
 from unittest import TestCase

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -1,4 +1,5 @@
 """Test Home Assistant color util methods."""
+# pylint: skip-file
 import unittest
 import homeassistant.util.color as color_util
 

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -9,7 +9,6 @@ import voluptuous as vol
 class TestColorUtil(unittest.TestCase):
     """Test color util methods."""
 
-    # pylint: disable=invalid-name
     def test_color_RGB_to_xy(self):
         """Test color_RGB_to_xy."""
         self.assertEqual((0, 0, 0), color_util.color_RGB_to_xy(0, 0, 0))

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -1,4 +1,5 @@
 """Test Home Assistant util methods."""
+# pylint: skip-file
 import unittest
 from unittest.mock import patch, MagicMock
 from datetime import datetime, timedelta

--- a/tests/util/test_location.py
+++ b/tests/util/test_location.py
@@ -1,4 +1,5 @@
 """Test Home Assistant location util methods."""
+# pylint: skip-file
 from unittest import TestCase
 from unittest.mock import patch
 

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -1,4 +1,5 @@
 """Test Home Assistant package util methods."""
+# pylint: skip-file
 import asyncio
 import logging
 import os

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -1,4 +1,5 @@
 """Test Home Assistant yaml loader."""
+# pylint: skip-file
 import io
 import os
 import unittest

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -24,8 +24,6 @@ def mock_credstash():
 class TestYaml(unittest.TestCase):
     """Test util.yaml loader."""
 
-    # pylint: disable=no-self-use, invalid-name
-
     def test_simple_list(self):
         """Test simple list."""
         conf = "config:\n  - simple\n  - list"
@@ -289,7 +287,6 @@ class FakeKeyring():
         """Store keyring dictionary."""
         self._secrets = secrets_dict
 
-    # pylint: disable=protected-access
     def get_password(self, domain, name):
         """Retrieve password."""
         assert domain == yaml._SECRET_NAMESPACE
@@ -298,8 +295,6 @@ class FakeKeyring():
 
 class TestSecrets(unittest.TestCase):
     """Test the secrets parameter in the yaml utility."""
-
-    # pylint: disable=protected-access,invalid-name
 
     def setUp(self):
         """Create & load secrets file."""

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
      -c{toxinidir}/homeassistant/package_constraints.txt
 commands =
      pylint homeassistant
+     pylint tests --rcfile tests/pylintrc
 
 [testenv:lint]
 basepython = {env:PYTHON3_PATH:python3}


### PR DESCRIPTION
## Description:

See #13101; I've accidentally made the changes on my dev branch and don't really want to deal with reverts/merge conflicts with that PR, so I made this into a separate PR

- [x] Disable specific pylint lints for `tests/` (I think creating a separate `tests/pylintrc` is the correct way here)
- [x] Remove existing `# pylint: disable=*` where appropriate
- [x] Skip test files that don't pass (using the excellent script by @armills in #13101 👍)
- [x] Update tox.ini
- [ ] Update lazytox
- [ ] Benchmark pylint travis slowdown.
- [ ] Fix merge conflicts (if any)
- [ ] Warn other PRs about conflicts

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
