### PR TITLE
fix: icloud lost phone service

### DIFF
--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -430,7 +430,8 @@ class Icloud(DeviceScanner):
         self.api.authenticate()
 
         for device in self.api.devices:
-            if devicename is None or device == self.devices[devicename]:
+            if (devicename is None or
+                    str(device) == str(self.devices[devicename])):
                 device.play_sound()
 
     def update_icloud(self, devicename=None):


### PR DESCRIPTION
## Description:
Fixes the `device_tracker.icloud_lost_iphone` service.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
