### PR TITLE
Template cover: Fix current_cover_position

### DIFF
--- a/homeassistant/components/cover/template.py
+++ b/homeassistant/components/cover/template.py
@@ -234,7 +234,9 @@ class CoverTemplate(CoverDevice):
 
         None is unknown, 0 is closed, 100 is fully open.
         """
-        return self._position
+        if self._position_template or self._position_script:
+            return self._position
+        return None
 
     @property
     def current_cover_tilt_position(self):


### PR DESCRIPTION
## Description:
Makes sure that `current_cover_position` is `None` if the template cover doesn't support `set_cover_position` through `position_template` or `position_script`. That way the UI Slider won't be display, although it is unusable.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**