### PR TITLE
asyncio.ensure_future Python 3.5

### DIFF
--- a/homeassistant/components/spc.py
+++ b/homeassistant/components/spc.py
@@ -189,12 +189,7 @@ class SpcWebGateway:
 
     def start_listener(self, async_callback, *args):
         """Start the websocket listener."""
-        try:
-            from asyncio import ensure_future
-        except ImportError:
-            from asyncio import async as ensure_future
-
-        ensure_future(self._ws_listen(async_callback, *args))
+        asyncio.ensure_future(self._ws_listen(async_callback, *args))
 
     def _build_url(self, resource):
         return urljoin(self._api_url, "spc/{}".format(resource))

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -5,14 +5,7 @@ import logging
 from asyncio import coroutines
 from asyncio.futures import Future
 
-try:
-    # pylint: disable=ungrouped-imports
-    from asyncio import ensure_future
-except ImportError:
-    # Python 3.4.3 and earlier has this as async
-    # pylint: disable=unused-import
-    from asyncio import async
-    ensure_future = async
+from asyncio import ensure_future
 
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Description:

In Python 3.5 we now have [`asyncio.ensure_future`](https://docs.python.org/3.6/library/asyncio-task.html#asyncio.ensure_future).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
