### PR TITLE
Throttle Arlo API calls

### DIFF
--- a/homeassistant/components/arlo.py
+++ b/homeassistant/components/arlo.py
@@ -5,11 +5,13 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/arlo/
 """
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 from requests.exceptions import HTTPError, ConnectTimeout
 
 from homeassistant.helpers import config_validation as cv
+from homeassistant.util import Throttle
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
 REQUIREMENTS = ['pyarlo==0.1.2']
@@ -45,6 +47,7 @@ def setup(hass, config):
         arlo = PyArlo(username, password, preload=False)
         if not arlo.is_connected:
             return False
+        arlo.update = Throttle(timedelta(seconds=10))(arlo.update)
         hass.data[DATA_ARLO] = arlo
     except (ConnectTimeout, HTTPError) as ex:
         _LOGGER.error("Unable to connect to Netgear Arlo: %s", str(ex))


### PR DESCRIPTION
Currently, we are hammering the Arlo api with every component making a call. This results in frequent warnings such as 
```
2017-11-15 08:35:03 WARNING (MainThread) [homeassistant.setup] Setup of alarm_control_panel is taking over 10 seconds.
2017-11-15 08:35:03 WARNING (MainThread) [homeassistant.setup] Setup of camera is taking over 10 seconds.
2017-11-15 08:35:05 WARNING (MainThread) [homeassistant.components.alarm_control_panel] Setup of platform arlo is taking over 10 seconds.
2017-11-15 08:35:05 WARNING (MainThread) [homeassistant.components.camera] Setup of platform arlo is taking over 10 seconds.
```

Thanks Paulus for the fix!!

**Related issue (if applicable):** 
https://community.home-assistant.io/t/insteon-hub-pro-help/31276/8
https://community.home-assistant.io/t/hassio-io-10-second-warnings/23714/11

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**