### PR TITLE
Report swap in MiB

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -42,8 +42,8 @@ SENSOR_TYPES = {
     'process': ['Process', ' ', 'mdi:memory'],
     'processor_use': ['Processor use', '%', 'mdi:memory'],
     'since_last_boot': ['Since last boot', '', 'mdi:clock'],
-    'swap_free': ['Swap free', 'GiB', 'mdi:harddisk'],
-    'swap_use': ['Swap use', 'GiB', 'mdi:harddisk'],
+    'swap_free': ['Swap free', 'MiB', 'mdi:harddisk'],
+    'swap_use': ['Swap use', 'MiB', 'mdi:harddisk'],
     'swap_use_percent': ['Swap use (percent)', '%', 'mdi:harddisk'],
 }
 
@@ -135,9 +135,9 @@ class SystemMonitorSensor(Entity):
         elif self.type == 'swap_use_percent':
             self._state = psutil.swap_memory().percent
         elif self.type == 'swap_use':
-            self._state = round(psutil.swap_memory().used / 1024**3, 1)
+            self._state = round(psutil.swap_memory().used / 1024**2, 1)
         elif self.type == 'swap_free':
-            self._state = round(psutil.swap_memory().free / 1024**3, 1)
+            self._state = round(psutil.swap_memory().free / 1024**2, 1)
         elif self.type == 'processor_use':
             self._state = round(psutil.cpu_percent(interval=None))
         elif self.type == 'process':


### PR DESCRIPTION
## Description:

It makes sense to report swap and memory in the same unit and MiB is more appropriate considering Home Assistant may be running on lower end hardware (Raspberry Pi for example) where 100MiB resolution is not adequate.

### Breaking changes

Used and available swap space reported by the system monitor component is now measured in MiB instead of GiB.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: memory_use
      - type: memory_free
      - type: swap_use
      - type: swap_free
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - ~[ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
