### PR TITLE
Disable Monkey Patch for 3.6.3+

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -335,7 +335,8 @@ def main() -> int:
     """Start Home Assistant."""
     validate_python()
 
-    if os.environ.get('HASS_NO_MONKEY') != '1':
+    monkey_patch_needed = sys.version_info[:3] < (3, 6, 3)
+    if monkey_patch_needed and os.environ.get('HASS_NO_MONKEY') != '1':
         if sys.version_info[:2] >= (3, 6):
             monkey_patch.disable_c_asyncio()
         monkey_patch.patch_weakref_tasks()


### PR DESCRIPTION
## Description:

Follow-up on #13142; The monkey patch is not needed anymore for Python 3.6.3+ (including beta 3.7)

To recap: First there was a weakref bug (https://bugs.python.org/issue26617) that was fixed in 3.5.3, 3.6.0 and 3.7.0a1.

Even after that bug got fixed users still reported segfaults so monkey patches were re-enabled and another issue (https://bugs.python.org/issue31061) report was created. The changeset of that was merged into 3.6.3 and beta 3.7.0

This PR disables the monkey patches for Python 3.6.3+, where they are not needed anymore. This could potentially make asyncio futures a whole bunch quicker.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
