### PR TITLE
Check whitelisted paths #13107

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1060,15 +1060,19 @@ class Config(object):
         """Check if the path is valid for access from outside."""
         assert path is not None
 
-        parent = pathlib.Path(path)
+        thepath = pathlib.Path(path)
         try:
-            parent = parent.resolve()  # pylint: disable=no-member
+            # The file path does not have to exist (it's parent should)
+            if thepath.exists():
+                thepath = thepath.resolve()
+            else:
+                thepath = thepath.parent.resolve()
         except (FileNotFoundError, RuntimeError, PermissionError):
             return False
 
         for whitelisted_path in self.whitelist_external_dirs:
             try:
-                parent.relative_to(whitelisted_path)
+                thepath.relative_to(whitelisted_path)
                 return True
             except ValueError:
                 pass

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -809,7 +809,8 @@ class TestConfig(unittest.TestCase):
 
             valid = [
                 test_file,
-                tmp_dir
+                tmp_dir,
+                os.path.join(tmp_dir, 'notfound321')
             ]
             for path in valid:
                 assert self.config.is_allowed_path(path)


### PR DESCRIPTION
## Description:
A follow up on #12810, which forced the path to EXIST as well.

Path.resolve(strict=False) does not require the path to exist, it will resolve as far as possible.

The oiginal code has Path.parent.resolve(strict=True), so have to enure the parent exists (and not just as far as possibe)

**Related issue (if applicable):** fixes #13107



## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
