### PR TITLE
Plex unavailable client cleanup

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -200,14 +200,15 @@ def setup_plexserver(
             client.set_availability(client.machine_identifier
                                     in available_client_ids)
 
-            if config.get(CONF_REMOVE_UNAVAILABLE_CLIENTS) \
-                    and not client.available:
-                interval = config.get(CONF_CLIENT_REMOVE_INTERVAL)
-                diff = dt.now() - client.marked_unavailable
-                if diff.total_seconds() >= interval.total_seconds():
-                    hass.helpers.event.async_call_later(0,
-                                                        client.async_remove())
-                    removed_clients.append(client.machine_identifier)
+            if not config.get(CONF_REMOVE_UNAVAILABLE_CLIENTS) \
+                    or client.available:
+                continue
+
+            if (dt.now() - client.marked_unavailable).total_seconds() >= \
+                    (config.get(CONF_CLIENT_REMOVE_INTERVAL)).total_seconds():
+                hass.helpers.event.async_call_later(0,
+                                                    client.async_remove())
+                removed_clients.append(client.machine_identifier)
 
         while removed_clients:
             clientid = removed_clients.pop()

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -51,7 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     cv.boolean,
     vol.Optional(CONF_REMOVE_UNAVAILABLE_CLIENTS, default=True):
     cv.boolean,
-    vol.Optional(CONF_CLIENT_REMOVE_INTERVAL, default=timedelta(seconds=10)):
+    vol.Optional(CONF_CLIENT_REMOVE_INTERVAL, default=timedelta(seconds=600)):
         vol.All(cv.time_period, cv.positive_timedelta),
 })
 

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -51,6 +51,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     cv.boolean,
     vol.Optional(CONF_REMOVE_UNAVAILABLE_CLIENTS, default=True):
     cv.boolean,
+    vol.Optional(CONF_CLIENT_REMOVE_INTERVAL, default=timedelta(seconds=600)):
+        vol.All(cv.time_period, cv.positive_timedelta),
 })
 
 PLEX_DATA = "plex"
@@ -200,9 +202,9 @@ def setup_plexserver(
 
             if config.get(CONF_REMOVE_UNAVAILABLE_CLIENTS) \
                     and not client.available:
-                interval = 10
+                interval = config.get(CONF_CLIENT_REMOVE_INTERVAL)
                 diff = dt.now() - client.marked_unavailable
-                if diff.total_seconds() >= interval:
+                if diff.total_seconds() >= interval.total_seconds():
                     hass.helpers.event.async_call_later(0,
                                                         client.async_remove())
                     removed_clients.append(client.machine_identifier)

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -535,7 +535,7 @@ class PlexClient(MediaPlayerDevice):
 
     @property
     def marked_unavailable(self):
-        """Return time device was marked unavailable"""
+        """Return time device was marked unavailable."""
         return self._marked_unavailable
 
     @property

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -8,7 +8,6 @@ import json
 import logging
 
 from datetime import timedelta
-from homeassistant.util import dt as dt_util
 
 import requests
 import voluptuous as vol
@@ -24,6 +23,8 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.util.json import load_json, save_json
+from homeassistant.util import dt as dt_util
+
 
 REQUIREMENTS = ['plexapi==3.0.6']
 
@@ -440,7 +441,7 @@ class PlexClient(MediaPlayerDevice):
         if not available:
             self._clear_media_details()
             if self._marked_unavailable is None:
-                self._marked_unavailable = dt.now()
+                self._marked_unavailable = dt_util.utcnow()
         else:
             self._marked_unavailable = None
 

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -420,7 +420,8 @@ class PlexClient(MediaPlayerDevice):
         """Set the device as available/unavailable noting time."""
         if not available:
             self._clear_media_details()
-            self._marked_unavailable = dt.now()
+            if self._marked_unavailable is None:
+                self._marked_unavailable = dt.now()
         else:
             self._marked_unavailable = None
 

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -8,6 +8,7 @@ import json
 import logging
 
 from datetime import timedelta
+from datetime import datetime as dt
 
 import requests
 import voluptuous as vol
@@ -266,6 +267,7 @@ class PlexClient(MediaPlayerDevice):
         self._app_name = ''
         self._device = None
         self._available = False
+        self._marked_unavailable = None
         self._device_protocol_capabilities = None
         self._is_player_active = False
         self._is_player_available = False
@@ -418,6 +420,10 @@ class PlexClient(MediaPlayerDevice):
         """Set the device as available/unavailable noting time."""
         if not available:
             self._clear_media_details()
+            self._marked_unavailable = dt.now()
+        else:
+            self._marked_unavailable = None
+
         self._available = available
 
     def _set_player_state(self):
@@ -505,6 +511,11 @@ class PlexClient(MediaPlayerDevice):
     def device(self):
         """Return the device, if any."""
         return self._device
+
+    @property
+    def marked_unavailable(self):
+        """Return time device was marked unavailable"""
+        return self._marked_unavailable
 
     @property
     def session(self):

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -8,7 +8,7 @@ import json
 import logging
 
 from datetime import timedelta
-from datetime import datetime as dt
+from homeassistant.util import dt as dt_util
 
 import requests
 import voluptuous as vol
@@ -204,7 +204,7 @@ def setup_plexserver(
                     or client.available:
                 continue
 
-            if (dt.now() - client.marked_unavailable) >= \
+            if (dt_util.utcnow() - client.marked_unavailable) >= \
                     (config.get(CONF_CLIENT_REMOVE_INTERVAL)):
                 hass.add_job(client.async_remove())
                 clients_to_remove.append(client.machine_identifier)

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -236,6 +236,7 @@ def setup_plexserver(
     update_sessions()
     update_devices()
 
+
 def request_configuration(host, hass, config, add_devices_callback):
     """Request configuration steps from the user."""
     configurator = hass.components.configurator


### PR DESCRIPTION
Supersedes: https://github.com/home-assistant/home-assistant/pull/12823
Fixes: https://github.com/home-assistant/home-assistant/issues/10074

Adds two options
- CONF_REMOVE_UNAVAILABLE_CLIENTS: Default True
- CONF_CLIENT_REMOVE_INTERVAL: Default 10min

Docs: https://github.com/home-assistant/home-assistant.github.io/pull/4907