### PR TITLE
HomeKit Bugfix: Error for string values

### DIFF
--- a/homeassistant/components/homekit/thermostats.py
+++ b/homeassistant/components/homekit/thermostats.py
@@ -157,12 +157,12 @@ class Thermostat(HomeAccessory):
 
         # Update current temperature
         current_temp = new_state.attributes.get(ATTR_CURRENT_TEMPERATURE)
-        if current_temp is not None:
+        if isinstance(current_temp, (int, float)):
             self.char_current_temp.set_value(current_temp)
 
         # Update target temperature
         target_temp = new_state.attributes.get(ATTR_TEMPERATURE)
-        if target_temp is not None:
+        if isinstance(target_temp, (int, float)):
             if not self.temperature_flag_target_state:
                 self.char_target_temp.set_value(target_temp,
                                                 should_callback=False)


### PR DESCRIPTION
## Description:
Fixed error that occurred if a `climate` device wasn't reporting a valid temperature as `int` or `float`.


**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/12868#issuecomment-372482473


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.