### PR TITLE
Upgrade pytest to 3.4.2

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-aiohttp==0.3.0
 pytest-cov==2.5.1
 pytest-sugar==0.9.0
 pytest-timeout>=1.2.1
-pytest==3.3.1
+pytest==3.4.2
 requests_mock==1.4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,7 +11,7 @@ pydocstyle==1.1.1
 pylint==1.8.2
 pytest-aiohttp==0.3.0
 pytest-cov==2.5.1
-pytest-sugar==0.9.0
+pytest-sugar==0.9.1
 pytest-timeout>=1.2.1
 pytest==3.4.2
 requests_mock==1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -12,7 +12,7 @@ pydocstyle==1.1.1
 pylint==1.8.2
 pytest-aiohttp==0.3.0
 pytest-cov==2.5.1
-pytest-sugar==0.9.0
+pytest-sugar==0.9.1
 pytest-timeout>=1.2.1
 pytest==3.4.2
 requests_mock==1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -14,7 +14,7 @@ pytest-aiohttp==0.3.0
 pytest-cov==2.5.1
 pytest-sugar==0.9.0
 pytest-timeout>=1.2.1
-pytest==3.3.1
+pytest==3.4.2
 requests_mock==1.4
 
 


### PR DESCRIPTION
## Description:

Upgrade pytest: [Changelog](https://github.com/pytest-dev/pytest/blob/master/CHANGELOG.rst)

Includes a memory leak fix that I noticed before but never investigated:

> Fix memory leak where objects returned by fixtures were never destructed by the garbage collector.

Though I didn't notice any issues, pytest-sugar has a new version 0.9.1 that supposedly fixes pytest 3.4 compatability: https://github.com/Frozenball/pytest-sugar/blob/master/CHANGES.rst

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
