### PR TITLE
Support for HmIP-STHO-A Homematic IP Sensor 

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -68,7 +68,7 @@ HM_DEVICE_TYPES = {
         'WeatherStation', 'ThermostatWall2', 'TemperatureDiffSensor',
         'TemperatureSensor', 'CO2Sensor', 'IPSwitchPowermeter', 'HMWIOSwitch',
         'FillingLevel', 'ValveDrive', 'EcoLogic', 'IPThermostatWall',
-        'IPSmoke', 'RFSiren', 'PresenceIP'],
+        'IPSmoke', 'RFSiren', 'PresenceIP', 'IPAreaThermostat'],
     DISCOVER_CLIMATE: [
         'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2',
         'MAXWallThermostat', 'IPThermostat', 'IPThermostatWall',
@@ -85,6 +85,10 @@ HM_IGNORE_DISCOVERY_NODE = [
     'ACTUAL_TEMPERATURE',
     'ACTUAL_HUMIDITY'
 ]
+
+HM_IGNORE_DISCOVERY_NODE_EXCEPTIONS = {
+    'ACTUAL_TEMPERATURE': ['IPAreaThermostat'],
+}
 
 HM_ATTRIBUTE_SUPPORT = {
     'LOWBAT': ['battery', {0: 'High', 1: 'Low'}],
@@ -505,7 +509,8 @@ def _get_devices(hass, discovery_type, keys, interface):
 
         # Generate options for 1...n elements with 1...n parameters
         for param, channels in metadata.items():
-            if param in HM_IGNORE_DISCOVERY_NODE:
+            if param in HM_IGNORE_DISCOVERY_NODE and class_name not in \
+             HM_IGNORE_DISCOVERY_NODE_EXCEPTIONS.get(param, []):
                 continue
 
             # Add devices

--- a/homeassistant/components/sensor/homematic.py
+++ b/homeassistant/components/sensor/homematic.py
@@ -35,6 +35,7 @@ HM_STATE_HA_CAST = {
 HM_UNIT_HA_CAST = {
     'HUMIDITY': '%',
     'TEMPERATURE': '°C',
+    'ACTUAL_TEMPERATURE': '°C',
     'BRIGHTNESS': '#',
     'POWER': 'W',
     'CURRENT': 'mA',
@@ -57,6 +58,7 @@ HM_ICON_HA_CAST = {
     'WIND_SPEED': 'mdi:weather-windy',
     'HUMIDITY': 'mdi:water-percent',
     'TEMPERATURE': 'mdi:thermometer',
+    'ACTUAL_TEMPERATURE': 'mdi:thermometer',
     'LUX': 'mdi:weather-sunny',
     'BRIGHTNESS': 'mdi:invert-colors',
     'POWER': 'mdi:flash-red-eye',


### PR DESCRIPTION
## Description:

Added Support for HmIP-STHO-A Sensor. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
