### PR TITLE
Support parsing mqtt nested json payload into attributes

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -284,6 +284,9 @@ fitbit==0.3.0
 # homeassistant.components.sensor.fixer
 fixerio==0.1.1
 
+# homeassistant.components.sensor.mqtt
+flatten_json==0.1.6
+
 # homeassistant.components.light.flux_led
 flux_led==0.21
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -62,6 +62,9 @@ evohomeclient==0.2.5
 # homeassistant.components.sensor.geo_rss_events
 feedparser==5.2.1
 
+# homeassistant.components.sensor.mqtt
+flatten_json==0.1.6
+
 # homeassistant.components.tts.google
 gTTS-token==1.1.1
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -47,6 +47,7 @@ TEST_REQUIREMENTS = (
     'ephem',
     'evohomeclient',
     'feedparser',
+    'flatten_json',
     'gTTS-token',
     'HAP-python',
     'ha-ffmpeg',


### PR DESCRIPTION
## Description:
Often mqtt messages with json payloads are far too long to be directly set as status.
This PR uses flatten_json to intuitively handle parsing long nested json payloads into attributes.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4911

For example to use the following payload:

`drachenhorst/dafang2/status {"Uptime":" 15:42:25 up 15 days, 20:12,  0 users,  load average: 3.32, 3.44, 3.48", "RTSP-Server":"running", "IR-Cut":"off", "Wifi":{"SSID":"MyNet", "Bitrate":"72.2 Mb/s", "SignalLevel":"64%", "Linkquality":"96%", "NoiseLevel":"0%"}, "LEDs":{"Blue":"off", "Yellow":"on", "Infrared":"off"}}`

Can easily achieved by:

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: mqtt
    state_topic: "dafang/status"
    value_template: '{{ value_json["RTSP-Server"] }}'
    name: "DaFang"
    json_attributes:
      - RTSP-Server
      - Uptime
      - IR-Cut
      - Wifi.SSID
      - Wifi.Bitrate
      - Wifi.SignalLevel
      - Wifi.Linkquality
      - Wifi.NoiseLevel
      - LEDs.Blue
      - LEDs.Yellow
      - LEDs.Infrared
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54