### PR TITLE
upcloud: Provide unique ID for server entities

### DIFF
--- a/homeassistant/components/upcloud.py
+++ b/homeassistant/components/upcloud.py
@@ -117,6 +117,11 @@ class UpCloudServerEntity(Entity):
         self.data = None
 
     @property
+    def unique_id(self) -> str:
+        """Return unique ID for the entity."""
+        return self.uuid
+
+    @property
     def name(self):
         """Return the name of the component."""
         try:


### PR DESCRIPTION
## Description:

Provide unique ID for UpCloud server entities.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
