### PR TITLE
Improve MQTT failed connection error message

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -515,16 +515,20 @@ class MQTT(object):
         This method is a coroutine.
         """
         result = None  # type: int
-        result = await self.hass.async_add_job(
-            self._mqttc.connect, self.broker, self.port, self.keepalive)
+        try:
+            result = await self.hass.async_add_job(
+                self._mqttc.connect, self.broker, self.port, self.keepalive)
+        except OSError as err:
+            _LOGGER.error('Failed to connect due to exception: %s', err)
+            return False
 
         if result != 0:
             import paho.mqtt.client as mqtt
             _LOGGER.error('Failed to connect: %s', mqtt.error_string(result))
-        else:
-            self._mqttc.loop_start()
+            return False
 
-        return not result
+        self._mqttc.loop_start()
+        return True
 
     @callback
     def async_disconnect(self):


### PR DESCRIPTION
## Description:

We were relying on paho-mqtt's `client#connect` to report failed connecting through the return value. That can (against at least my intuition) solely be relied upon, sometimes we also receive other socket errors like `ConnectionRefusedError` in #13136.

This PR catches all `OSError` (and therefore also `socket.error`) in general and reports the issue gracefully. Additionally, the error message is a bit different because from my experience having two error log statements with the same text can be really confusing when debugging errors.

**Related issue (if applicable):** fixes #13136

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt:
  broker: something
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
