### PR TITLE
Fix freegeoip

### DIFF
--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -10,7 +10,7 @@ from typing import Any, Optional, Tuple, Dict
 import requests
 
 ELEVATION_URL = 'http://maps.googleapis.com/maps/api/elevation/json'
-FREEGEO_API = 'https://freegeoip.io/json/'
+FREEGEO_API = 'https://freegeoip.net/json/'
 IP_API = 'http://ip-api.com/json'
 
 # Constants from https://github.com/maurycyp/vincenty


### PR DESCRIPTION
## Description:

On freegeoip.io is the ssl certificate invalid. Freegeoip.net is opensource: https://github.com/fiorix/freegeoip