### PR TITLE
Ignore unsupported Sonos favorites

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -426,7 +426,17 @@ class SonosDevice(MediaPlayerDevice):
         self._play_mode = self.soco.play_mode
         self._night_sound = self.soco.night_mode
         self._speech_enhance = self.soco.dialog_mode
-        self._favorites = self.soco.music_library.get_sonos_favorites()
+
+        self._favorites = []
+        for fav in self.soco.music_library.get_sonos_favorites():
+            # SoCo 0.14 raises a generic Exception on invalid xml in favorites.
+            # Filter those out now so our list is safe to use.
+            try:
+                if fav.reference.get_uri():
+                    self._favorites.append(fav)
+            # pylint: disable=broad-except
+            except Exception:
+                _LOGGER.debug("Ignoring invalid favorite '%s'", fav.title)
 
     def _subscribe_to_player_events(self):
         """Add event subscriptions."""


### PR DESCRIPTION
## Description:

This filters out Sonos favorites that the current SoCo library is unable to handle. 

**Related issue (if applicable):** [reported in forum](https://community.home-assistant.io/t/sonos-does-not-work-properly-since-0-65/46695/14)

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).</s>
  - [ ] <s>New dependencies are only imported inside functions that use them ([example][ex-import]).</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54