### PR TITLE
Avoid Sonos error when joining with self

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -886,7 +886,8 @@ class SonosDevice(MediaPlayerDevice):
             self.soco.unjoin()
 
         for slave in slaves:
-            slave.soco.join(self.soco)
+            if slave.unique_id != self.unique_id:
+                slave.soco.join(self.soco)
 
     @soco_error()
     def unjoin(self):


### PR DESCRIPTION
## Description:

This fixes an error that could happen if we attempted to add an entity as its own slave.

```
2018-03-13 23:50:22 ERROR (SyncWorker_19) [homeassistant.components.media_player.sonos] Error on join with UPnP Error 402 received: Invalid Args from 10.0.2.14
```

**Related issue (if applicable):** [reported in forum](https://community.home-assistant.io/t/sonos-does-not-work-properly-since-0-65/46695/22)


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [ ] <s>New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).</s>
  - [ ] <s>New dependencies are only imported inside functions that use them ([example][ex-import]).</s>
  - [ ] <s>New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.</s>
  - [ ] <s>New files were added to `.coveragerc`.</s>

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54