### PR TITLE
media_content_type attribute display fix

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -60,8 +60,7 @@ DEPRECATED_TURN_OFF_ACTIONS = {
 
 # https://github.com/xbmc/xbmc/blob/master/xbmc/media/MediaType.h
 MEDIA_TYPES = {
-    'music': MEDIA_TYPE_MUSIC,
-    'audio': MEDIA_TYPE_MUSIC,
+    'music': MEDIA_TYPE_MUSIC,    
     'artist': MEDIA_TYPE_MUSIC,
     'album': MEDIA_TYPE_MUSIC,
     'song': MEDIA_TYPE_MUSIC,
@@ -74,6 +73,8 @@ MEDIA_TYPES = {
     'episode': MEDIA_TYPE_TVSHOW,
     # Type 'channel' is used for radio or tv streams from pvr
     'channel': MEDIA_TYPE_CHANNEL,
+    # Type 'audio' is used for audio media, that Kodi couldn't scroblle
+    'audio': MEDIA_TYPE_MUSIC,
 }
 
 SUPPORT_KODI = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
@@ -482,12 +483,13 @@ class KodiDevice(MediaPlayerDevice):
     @property
     def media_content_type(self):
         """Content type of current playing media."""
-        """If item type is unknown to Kodi, return type of first player instead, if any"""
+        """If item type is unknown to Kodi, 
+           return type of first player instead, if any"""
         if MEDIA_TYPES.get(self._item.get('type')) is None and self._players:            
-            content_type = MEDIA_TYPES.get(self._players[0]['type'])
+            return MEDIA_TYPES.get(self._players[0]['type'])
         else:
-            content_type = MEDIA_TYPES.get(self._item.get('type'))
-        return content_type
+            return MEDIA_TYPES.get(self._item.get('type'))
+        
 
     @property
     def media_duration(self):

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -482,9 +482,10 @@ class KodiDevice(MediaPlayerDevice):
 
     @property
     def media_content_type(self):
-        """Content type of current playing media."""
-        """If item type is unknown to Kodi,
-           return type of first player instead, if any"""
+        """Content type of current playing media.
+
+        If the media type cannot be detected, the player type is used.
+        """
         if MEDIA_TYPES.get(self._item.get('type')) is None and self._players:
             return MEDIA_TYPES.get(self._players[0]['type'])
         else:

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -488,8 +488,7 @@ class KodiDevice(MediaPlayerDevice):
         """
         if MEDIA_TYPES.get(self._item.get('type')) is None and self._players:
             return MEDIA_TYPES.get(self._players[0]['type'])
-        else:
-            return MEDIA_TYPES.get(self._item.get('type'))
+        return MEDIA_TYPES.get(self._item.get('type'))
 
     @property
     def media_duration(self):

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -60,7 +60,7 @@ DEPRECATED_TURN_OFF_ACTIONS = {
 
 # https://github.com/xbmc/xbmc/blob/master/xbmc/media/MediaType.h
 MEDIA_TYPES = {
-    'music': MEDIA_TYPE_MUSIC,    
+    'music': MEDIA_TYPE_MUSIC,
     'artist': MEDIA_TYPE_MUSIC,
     'album': MEDIA_TYPE_MUSIC,
     'song': MEDIA_TYPE_MUSIC,
@@ -483,13 +483,12 @@ class KodiDevice(MediaPlayerDevice):
     @property
     def media_content_type(self):
         """Content type of current playing media."""
-        """If item type is unknown to Kodi, 
+        """If item type is unknown to Kodi,
            return type of first player instead, if any"""
-        if MEDIA_TYPES.get(self._item.get('type')) is None and self._players:            
+        if MEDIA_TYPES.get(self._item.get('type')) is None and self._players:
             return MEDIA_TYPES.get(self._players[0]['type'])
         else:
             return MEDIA_TYPES.get(self._item.get('type'))
-        
 
     @property
     def media_duration(self):

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -481,7 +481,12 @@ class KodiDevice(MediaPlayerDevice):
     @property
     def media_content_type(self):
         """Content type of current playing media."""
-        return MEDIA_TYPES.get(self._item.get('type'))
+        """If item type is unknown to Kodi, return type of first player instead, if any"""
+        if MEDIA_TYPES.get(self._item.get('type')) is None and self._players:            
+            content_type = MEDIA_TYPES.get(self._players[0]['type'])
+        else:
+            content_type = MEDIA_TYPES.get(self._item.get('type'))
+        return content_type
 
     @property
     def media_duration(self):

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -61,6 +61,7 @@ DEPRECATED_TURN_OFF_ACTIONS = {
 # https://github.com/xbmc/xbmc/blob/master/xbmc/media/MediaType.h
 MEDIA_TYPES = {
     'music': MEDIA_TYPE_MUSIC,
+    'audio': MEDIA_TYPE_MUSIC,
     'artist': MEDIA_TYPE_MUSIC,
     'album': MEDIA_TYPE_MUSIC,
     'song': MEDIA_TYPE_MUSIC,


### PR DESCRIPTION
Kodi media_content_type attribute display fix

## Description:

When Kodi can't retrieves media info, API call to Player.GetProperties returns item "type" "unknown" for some media (If you watch smth known to IMDB, for example, item type is "movie", but for home video it would be "unknown"). This causes media_player entity not to display media_content_type attribute for certain content, so actions using this attribute do not work properly in certain cases.

This fix displays Player type, if Item type not defined in MEDIA_TYPES. 

**Related issue (if applicable):** fixes #6989 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


