### PR TITLE
Fix history API

### DIFF
--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import unittest
 from unittest.mock import patch, sentinel
 
-from homeassistant.setup import setup_component
+from homeassistant.setup import setup_component, async_setup_component
 import homeassistant.core as ha
 import homeassistant.util.dt as dt_util
 from homeassistant.components import history, recorder
@@ -481,3 +481,13 @@ class TestComponentHistory(unittest.TestCase):
             set_state(therm, 22, attributes={'current_temperature': 21,
                                              'hidden': True})
         return zero, four, states
+
+
+async def test_fetch_period_api(hass, test_client):
+    """Test the fetch period view for history."""
+    await hass.async_add_job(init_recorder_component, hass)
+    await async_setup_component(hass, 'history', {})
+    client = await test_client(hass.http.app)
+    response = await client.get(
+        '/api/history/period/{}'.format(dt_util.utcnow().isoformat()))
+    assert response.status == 200


### PR DESCRIPTION
## Description:
I introduced stricter JSON serialization in #13029. Looks like we did not cover all HTTP views that generate JSON in tests. This fixes that and fixes the broken history API.

Reported by @NovapaX 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
