### PR TITLE
Fix 'dict' object has no attribute 'strftime'

### DIFF
--- a/homeassistant/components/calendar/todoist.py
+++ b/homeassistant/components/calendar/todoist.py
@@ -496,6 +496,10 @@ class TodoistProjectData(object):
             # We had no valid tasks
             return True
 
+        # Make sure the task collection is reset to prevent an
+        # infinite collection repeating the same tasks
+        self.all_project_tasks = []
+
         # Organize the best tasks (so users can see all the tasks
         # they have, organized)
         while project_tasks:

--- a/homeassistant/components/calendar/todoist.py
+++ b/homeassistant/components/calendar/todoist.py
@@ -498,7 +498,7 @@ class TodoistProjectData(object):
 
         # Make sure the task collection is reset to prevent an
         # infinite collection repeating the same tasks
-        self.all_project_tasks = []
+        self.all_project_tasks.clear()
 
         # Organize the best tasks (so users can see all the tasks
         # they have, organized)


### PR DESCRIPTION
## Description:
Currently the Todoist component has an issue that is causing the following error:
'dict' object has no attribute 'strftime'

Turns out this was caused by two problems:
1. The `all_project_tasks` variable not being emptied before refilling it with Todoist tasks. This was causing the list to grow forever.

2. When the `update` gets triggerd, all the old values in `all_project_tasks` would have been converted to `dict` instead of `datetime`, on which of course it's not possible to call `strftime`.

Solved this by making sure the old tasks are purged before adding the latest state from Todoist.

**Related issue (if applicable):** fixes #9563

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54