### PR TITLE
Fix input_boolean Google Assistant serialize error

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -17,7 +17,16 @@ from homeassistant.core import callback
 from homeassistant.const import (
     CONF_NAME, STATE_UNAVAILABLE, ATTR_SUPPORTED_FEATURES)
 from homeassistant.components import (
-    switch, light, cover, media_player, group, fan, scene, script, climate,
+    climate,
+    cover,
+    fan,
+    group,
+    input_boolean,
+    light,
+    media_player,
+    scene,
+    script,
+    switch,
 )
 
 from . import trait
@@ -33,15 +42,16 @@ HANDLERS = Registry()
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN_TO_GOOGLE_TYPES = {
+    climate.DOMAIN: TYPE_THERMOSTAT,
+    cover.DOMAIN: TYPE_SWITCH,
+    fan.DOMAIN: TYPE_SWITCH,
     group.DOMAIN: TYPE_SWITCH,
+    input_boolean.DOMAIN: TYPE_SWITCH,
+    light.DOMAIN: TYPE_LIGHT,
+    media_player.DOMAIN: TYPE_SWITCH,
     scene.DOMAIN: TYPE_SCENE,
     script.DOMAIN: TYPE_SCENE,
     switch.DOMAIN: TYPE_SWITCH,
-    fan.DOMAIN: TYPE_SWITCH,
-    light.DOMAIN: TYPE_LIGHT,
-    cover.DOMAIN: TYPE_SWITCH,
-    media_player.DOMAIN: TYPE_SWITCH,
-    climate.DOMAIN: TYPE_THERMOSTAT,
 }
 
 

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -1,4 +1,5 @@
 """Test Google Smart Home."""
+from homeassistant.core import State
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
 from homeassistant.setup import async_setup_component
@@ -243,4 +244,18 @@ async def test_raising_error_trait(hass):
                 "errorCode": "valueOutOfRange"
             }]
         }
+    }
+
+
+def test_serialize_input_boolean():
+    """Test serializing an input boolean entity."""
+    state = State('input_boolean.bla', 'on')
+    entity = sh._GoogleEntity(None, BASIC_CONFIG, state)
+    assert entity.sync_serialize() == {
+        'id': 'input_boolean.bla',
+        'attributes': {},
+        'name': {'name': 'bla'},
+        'traits': ['action.devices.traits.OnOff'],
+        'type': 'action.devices.types.SWITCH',
+        'willReportState': False,
     }


### PR DESCRIPTION
## Description:
Fix Google Assistant serializing input booleans.

**Related issue (if applicable):** fixes #13153, fixes #13110


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
