### PR TITLE
Added Stride notification component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -517,6 +517,7 @@ omit =
     homeassistant/components/notify/sendgrid.py
     homeassistant/components/notify/simplepush.py
     homeassistant/components/notify/slack.py
+    homeassistant/components/notify/stride.py
     homeassistant/components/notify/smtp.py
     homeassistant/components/notify/synology_chat.py
     homeassistant/components/notify/syslog.py

--- a/homeassistant/components/notify/stride.py
+++ b/homeassistant/components/notify/stride.py
@@ -1,0 +1,103 @@
+"""
+Stride platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.stride/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.notify import (
+    ATTR_TARGET, ATTR_DATA, PLATFORM_SCHEMA, BaseNotificationService)
+from homeassistant.const import CONF_TOKEN, CONF_HOST, CONF_ROOM
+
+REQUIREMENTS = ['pystride==0.1.7']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_PANEL = 'panel'
+CONF_CLOUDID = 'cloudid'
+
+DEFAULT_PANEL = None
+
+VALID_PANELS = {'info', 'note', 'tip', 'warning', None}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_CLOUDID): cv.string,
+    vol.Required(CONF_ROOM): cv.string,
+    vol.Required(CONF_TOKEN): cv.string,
+    vol.Optional(CONF_PANEL, default=DEFAULT_PANEL): vol.In(VALID_PANELS),
+})
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the Stride notification service."""
+    return StrideNotificationService(
+        config[CONF_TOKEN], config[CONF_ROOM], config[CONF_PANEL],
+        config[CONF_CLOUDID])
+
+
+class StrideNotificationService(BaseNotificationService):
+    """Implement the notification service for Stride."""
+
+    def __init__(self, token, default_room, default_panel,# default_notify,
+                 cloudid):
+        """Initialize the service."""
+        self._token = token
+        self._default_room = default_room
+        self._default_panel = default_panel
+        self._cloudid = cloudid
+
+        from stride import Stride
+        self._stride = Stride(self._cloudid, access_token=self._token)
+
+    def send_message(self, message="", **kwargs):
+        """Send a message."""
+        panel = self._default_panel
+
+        if kwargs.get(ATTR_DATA) is not None:
+            data = kwargs.get(ATTR_DATA)
+            if ((data.get(CONF_PANEL) is not None)
+                    and (data.get(CONF_PANEL) in VALID_PANELS)):
+                panel = data.get(CONF_PANEL)
+        
+        message_text = {
+                    'type': 'paragraph', 
+                    'content': 
+                    [{
+                        'type': 'text', 
+                        'text': message
+                    }]
+                }
+        panel_text = message_text
+        if panel is not None:
+            panel_text = {
+                    'type': 'panel', 
+                    'attrs': 
+                    {
+                        'panelType': panel
+                    },
+                    'content': 
+                    [
+                        message_text,
+                    ]
+                }
+
+        message_doc = {
+                    'body': 
+                    {
+                        'version': 1,
+                        'type': 'doc',
+                        'content': 
+                        [
+                            panel_text,
+                        ]
+                    }
+                }
+
+        targets = kwargs.get(ATTR_TARGET, [self._default_room])
+
+        for target in targets:
+            self._stride.message_room(target, message_doc)

--- a/homeassistant/components/notify/stride.py
+++ b/homeassistant/components/notify/stride.py
@@ -63,38 +63,38 @@ class StrideNotificationService(BaseNotificationService):
                 panel = data.get(CONF_PANEL)
 
         message_text = {
-                    'type': 'paragraph',
-                    'content':
-                    [{
-                        'type': 'text',
-                        'text': message
-                    }]
+            'type': 'paragraph',
+            'content': [
+                {
+                    'type': 'text',
+                    'text': message
                 }
+            ]
+            }
         panel_text = message_text
         if panel is not None:
             panel_text = {
-                    'type': 'panel',
-                    'attrs':
+                'type': 'panel',
+                'attrs':
                     {
                         'panelType': panel
                     },
-                    'content':
+                'content':
                     [
                         message_text,
                     ]
                 }
 
         message_doc = {
-                    'body':
-                    {
-                        'version': 1,
-                        'type': 'doc',
-                        'content':
-                        [
-                            panel_text,
-                        ]
-                    }
+            'body': {
+                'version': 1,
+                'type': 'doc',
+                'content':
+                [
+                    panel_text,
+                ]
                 }
+            }
 
         targets = kwargs.get(ATTR_TARGET, [self._default_room])
 

--- a/homeassistant/components/notify/stride.py
+++ b/homeassistant/components/notify/stride.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
     ATTR_TARGET, ATTR_DATA, PLATFORM_SCHEMA, BaseNotificationService)
-from homeassistant.const import CONF_TOKEN, CONF_HOST, CONF_ROOM
+from homeassistant.const import CONF_TOKEN, CONF_ROOM
 
 REQUIREMENTS = ['pystride==0.1.7']
 
@@ -42,8 +42,7 @@ def get_service(hass, config, discovery_info=None):
 class StrideNotificationService(BaseNotificationService):
     """Implement the notification service for Stride."""
 
-    def __init__(self, token, default_room, default_panel,# default_notify,
-                 cloudid):
+    def __init__(self, token, default_room, default_panel, cloudid):
         """Initialize the service."""
         self._token = token
         self._default_room = default_room
@@ -62,7 +61,7 @@ class StrideNotificationService(BaseNotificationService):
             if ((data.get(CONF_PANEL) is not None)
                     and (data.get(CONF_PANEL) in VALID_PANELS)):
                 panel = data.get(CONF_PANEL)
-        
+ 
         message_text = {
                     'type': 'paragraph',
                     'content':

--- a/homeassistant/components/notify/stride.py
+++ b/homeassistant/components/notify/stride.py
@@ -64,33 +64,33 @@ class StrideNotificationService(BaseNotificationService):
                 panel = data.get(CONF_PANEL)
         
         message_text = {
-                    'type': 'paragraph', 
-                    'content': 
+                    'type': 'paragraph',
+                    'content':
                     [{
-                        'type': 'text', 
+                        'type': 'text',
                         'text': message
                     }]
                 }
         panel_text = message_text
         if panel is not None:
             panel_text = {
-                    'type': 'panel', 
-                    'attrs': 
+                    'type': 'panel',
+                    'attrs':
                     {
                         'panelType': panel
                     },
-                    'content': 
+                    'content':
                     [
                         message_text,
                     ]
                 }
 
         message_doc = {
-                    'body': 
+                    'body':
                     {
                         'version': 1,
                         'type': 'doc',
-                        'content': 
+                        'content':
                         [
                             panel_text,
                         ]

--- a/homeassistant/components/notify/stride.py
+++ b/homeassistant/components/notify/stride.py
@@ -61,7 +61,7 @@ class StrideNotificationService(BaseNotificationService):
             if ((data.get(CONF_PANEL) is not None)
                     and (data.get(CONF_PANEL) in VALID_PANELS)):
                 panel = data.get(CONF_PANEL)
- 
+
         message_text = {
                     'type': 'paragraph',
                     'content':

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -888,6 +888,9 @@ pysma==0.2
 # homeassistant.components.switch.snmp
 pysnmp==4.4.4
 
+# homeassistant.components.notify.stride
+pystride==0.1.7
+
 # homeassistant.components.media_player.liveboxplaytv
 pyteleloisirs==3.3
 


### PR DESCRIPTION
## Description:
Unfortunately did not manage to get around to this before Atlassian started migrating HipChat customers to Stride. Since they have done so, at least for us, I've finally whipped up this minimal support for Stride (doesn't support all the bells and whistles, but works fine for the purpose of posting notifications). We've been using it for a couple of days without issue. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4921

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: stride
    platform: stride
    cloudid: CLOUD-ID
    token: TOKEN
    room: ROOM-ID
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.