### PR TITLE
Use the first, not the last volume controller when multiple are available

### DIFF
--- a/homeassistant/components/media_player/songpal.py
+++ b/homeassistant/components/media_player/songpal.py
@@ -154,7 +154,7 @@ class SongpalDevice(MediaPlayerDevice):
                 _LOGGER.warning("Got %s volume controls, using the first one",
                                 volumes)
 
-            volume = volumes.pop(0)
+            volume = volumes[0]
             _LOGGER.debug("Current volume: %s", volume)
 
             self._volume_max = volume.maxVolume

--- a/homeassistant/components/media_player/songpal.py
+++ b/homeassistant/components/media_player/songpal.py
@@ -154,7 +154,7 @@ class SongpalDevice(MediaPlayerDevice):
                 _LOGGER.warning("Got %s volume controls, using the first one",
                                 volumes)
 
-            volume = volumes.pop()
+            volume = volumes.pop(0)
             _LOGGER.debug("Current volume: %s", volume)
 
             self._volume_max = volume.maxVolume


### PR DESCRIPTION
## Description:
Uses the first volume controller (instead of the last) when multiple zones/controllers are available in songpal platform (as indicated by the logger warning).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
