### PR TITLE
0.65.5

### DIFF
--- a/homeassistant/components/arlo.py
+++ b/homeassistant/components/arlo.py
@@ -5,13 +5,11 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/arlo/
 """
 import logging
-from datetime import timedelta
 
 import voluptuous as vol
 from requests.exceptions import HTTPError, ConnectTimeout
 
 from homeassistant.helpers import config_validation as cv
-from homeassistant.util import Throttle
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
 REQUIREMENTS = ['pyarlo==0.1.2']
@@ -47,7 +45,6 @@ def setup(hass, config):
         arlo = PyArlo(username, password, preload=False)
         if not arlo.is_connected:
             return False
-        arlo.update = Throttle(timedelta(seconds=10))(arlo.update)
         hass.data[DATA_ARLO] = arlo
     except (ConnectTimeout, HTTPError) as ex:
         _LOGGER.error("Unable to connect to Netgear Arlo: %s", str(ex))

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -17,7 +17,16 @@ from homeassistant.core import callback
 from homeassistant.const import (
     CONF_NAME, STATE_UNAVAILABLE, ATTR_SUPPORTED_FEATURES)
 from homeassistant.components import (
-    switch, light, cover, media_player, group, fan, scene, script, climate,
+    climate,
+    cover,
+    fan,
+    group,
+    input_boolean,
+    light,
+    media_player,
+    scene,
+    script,
+    switch,
 )
 
 from . import trait
@@ -33,15 +42,16 @@ HANDLERS = Registry()
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN_TO_GOOGLE_TYPES = {
+    climate.DOMAIN: TYPE_THERMOSTAT,
+    cover.DOMAIN: TYPE_SWITCH,
+    fan.DOMAIN: TYPE_SWITCH,
     group.DOMAIN: TYPE_SWITCH,
+    input_boolean.DOMAIN: TYPE_SWITCH,
+    light.DOMAIN: TYPE_LIGHT,
+    media_player.DOMAIN: TYPE_SWITCH,
     scene.DOMAIN: TYPE_SCENE,
     script.DOMAIN: TYPE_SCENE,
     switch.DOMAIN: TYPE_SWITCH,
-    fan.DOMAIN: TYPE_SWITCH,
-    light.DOMAIN: TYPE_LIGHT,
-    cover.DOMAIN: TYPE_SWITCH,
-    media_player.DOMAIN: TYPE_SWITCH,
-    climate.DOMAIN: TYPE_THERMOSTAT,
 }
 
 

--- a/homeassistant/components/homekit/thermostats.py
+++ b/homeassistant/components/homekit/thermostats.py
@@ -157,12 +157,12 @@ class Thermostat(HomeAccessory):
 
         # Update current temperature
         current_temp = new_state.attributes.get(ATTR_CURRENT_TEMPERATURE)
-        if current_temp is not None:
+        if isinstance(current_temp, (int, float)):
             self.char_current_temp.set_value(current_temp)
 
         # Update target temperature
         target_temp = new_state.attributes.get(ATTR_TEMPERATURE)
-        if target_temp is not None:
+        if isinstance(target_temp, (int, float)):
             if not self.temperature_flag_target_state:
                 self.char_target_temp.set_value(target_temp,
                                                 should_callback=False)

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -426,7 +426,17 @@ class SonosDevice(MediaPlayerDevice):
         self._play_mode = self.soco.play_mode
         self._night_sound = self.soco.night_mode
         self._speech_enhance = self.soco.dialog_mode
-        self._favorites = self.soco.music_library.get_sonos_favorites()
+
+        self._favorites = []
+        for fav in self.soco.music_library.get_sonos_favorites():
+            # SoCo 0.14 raises a generic Exception on invalid xml in favorites.
+            # Filter those out now so our list is safe to use.
+            try:
+                if fav.reference.get_uri():
+                    self._favorites.append(fav)
+            # pylint: disable=broad-except
+            except Exception:
+                _LOGGER.debug("Ignoring invalid favorite '%s'", fav.title)
 
     def _subscribe_to_player_events(self):
         """Add event subscriptions."""

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -896,7 +896,8 @@ class SonosDevice(MediaPlayerDevice):
             self.soco.unjoin()
 
         for slave in slaves:
-            slave.soco.join(self.soco)
+            if slave.unique_id != self.unique_id:
+                slave.soco.join(self.soco)
 
     @soco_error()
     def unjoin(self):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 65
-PATCH_VERSION = '4'
+PATCH_VERSION = '5'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -1,4 +1,5 @@
 """Test Google Smart Home."""
+from homeassistant.core import State
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
 from homeassistant.setup import async_setup_component
@@ -243,4 +244,18 @@ async def test_raising_error_trait(hass):
                 "errorCode": "valueOutOfRange"
             }]
         }
+    }
+
+
+def test_serialize_input_boolean():
+    """Test serializing an input boolean entity."""
+    state = State('input_boolean.bla', 'on')
+    entity = sh._GoogleEntity(None, BASIC_CONFIG, state)
+    assert entity.sync_serialize() == {
+        'id': 'input_boolean.bla',
+        'attributes': {},
+        'name': {'name': 'bla'},
+        'traits': ['action.devices.traits.OnOff'],
+        'type': 'action.devices.types.SWITCH',
+        'willReportState': False,
     }


### PR DESCRIPTION
- Bugfix HomeKit: Error string values for temperature ([@cdce8p] - [#13162]) ([homekit docs])
- Revert throttle Arlo api calls ([@arsaboo] - [#13174]) ([arlo docs])
- Ignore unsupported Sonos favorites ([@amelchio] - [#13195]) ([media_player.sonos docs])
- Avoid Sonos error when joining with self ([@amelchio] - [#13196]) ([media_player.sonos docs])
- Fix input_boolean Google Assistant serialize error ([@balloob] - [#13220]) ([google_assistant docs])

[#13162]: https://github.com/home-assistant/home-assistant/pull/13162
[#13174]: https://github.com/home-assistant/home-assistant/pull/13174
[#13195]: https://github.com/home-assistant/home-assistant/pull/13195
[#13196]: https://github.com/home-assistant/home-assistant/pull/13196
[#13220]: https://github.com/home-assistant/home-assistant/pull/13220
[@amelchio]: https://github.com/amelchio
[@arsaboo]: https://github.com/arsaboo
[@balloob]: https://github.com/balloob
[@cdce8p]: https://github.com/cdce8p
[arlo docs]: https://home-assistant.io/components/arlo/
[google_assistant docs]: https://home-assistant.io/components/google_assistant/
[homekit docs]: https://home-assistant.io/components/homekit/
[media_player.sonos docs]: https://home-assistant.io/components/media_player.sonos/
