### PR TITLE
Updated samsungtv to work on osx

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -128,7 +128,11 @@ class SamsungTVDevice(MediaPlayerDevice):
         if sys.platform == 'win32':
             _ping_cmd = ['ping', '-n 1', '-w', '1000', self._config['host']]
         else:
-            _ping_cmd = ['ping', '-n', '-q', '-c1', '-W1',
+            if sys.platform == 'darwin':
+                _ping_location = '/sbin/ping'
+            else:
+                _ping_location = '/bin/ping'
+            _ping_cmd = [_ping_location, '-n', '-q', '-c1', '-W1',
                          self._config['host']]
 
         ping = subprocess.Popen(


### PR DESCRIPTION
## Description:
The default path for ping is set to /sbin/ping on osx,
/bin/ping on other *nix.
Had to specify this for the command to work properly

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


