### PR TITLE
Cleanup Sonos platform setup

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -54,7 +54,6 @@ DATA_SONOS = 'sonos'
 SOURCE_LINEIN = 'Line-in'
 SOURCE_TV = 'TV'
 
-CONF_ADVERTISE_ADDR = 'advertise_addr'
 CONF_INTERFACE_ADDR = 'interface_addr'
 
 # Service call validation schemas
@@ -73,7 +72,6 @@ ATTR_IS_COORDINATOR = 'is_coordinator'
 UPNP_ERRORS_TO_IGNORE = ['701', '711']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_ADVERTISE_ADDR): cv.string,
     vol.Optional(CONF_INTERFACE_ADDR): cv.string,
     vol.Optional(CONF_HOSTS): vol.All(cv.ensure_list, [cv.string]),
 })
@@ -141,10 +139,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if DATA_SONOS not in hass.data:
         hass.data[DATA_SONOS] = SonosData()
 
-    advertise_addr = config.get(CONF_ADVERTISE_ADDR, None)
-    if advertise_addr:
-        soco.config.EVENT_ADVERTISE_IP = advertise_addr
-
+    players = []
     if discovery_info:
         player = soco.SoCo(discovery_info.get('host'))
 
@@ -152,25 +147,24 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if player.uid in hass.data[DATA_SONOS].uids:
             return
 
-        if player.is_visible:
-            hass.data[DATA_SONOS].uids.add(player.uid)
-            add_devices([SonosDevice(player)])
+        # If invisible, such as a stereo slave
+        if not player.is_visible:
+            return
+
+        players.append(player)
     else:
-        players = None
-        hosts = config.get(CONF_HOSTS, None)
+        hosts = config.get(CONF_HOSTS)
         if hosts:
             # Support retro compatibility with comma separated list of hosts
             # from config
             hosts = hosts[0] if len(hosts) == 1 else hosts
             hosts = hosts.split(',') if isinstance(hosts, str) else hosts
-            players = []
             for host in hosts:
                 try:
                     players.append(soco.SoCo(socket.gethostbyname(host)))
                 except OSError:
                     _LOGGER.warning("Failed to initialize '%s'", host)
-
-        if not players:
+        else:
             players = soco.discover(
                 interface_addr=config.get(CONF_INTERFACE_ADDR))
 
@@ -178,9 +172,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             _LOGGER.warning("No Sonos speakers found")
             return
 
-        hass.data[DATA_SONOS].uids.update([p.uid for p in players])
-        add_devices([SonosDevice(p) for p in players])
-        _LOGGER.debug("Added %s Sonos speakers", len(players))
+    hass.data[DATA_SONOS].uids.update([p.uid for p in players])
+    add_devices([SonosDevice(p) for p in players])
+    _LOGGER.debug("Added %s Sonos speakers", len(players))
 
     def service_handle(service):
         """Handle for services."""

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -172,8 +172,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             _LOGGER.warning("No Sonos speakers found")
             return
 
-    hass.data[DATA_SONOS].uids.update([p.uid for p in players])
-    add_devices([SonosDevice(p) for p in players])
+    hass.data[DATA_SONOS].uids.update(p.uid for p in players)
+    add_devices(SonosDevice(p) for p in players)
     _LOGGER.debug("Added %s Sonos speakers", len(players))
 
     def service_handle(service):

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -9,8 +9,7 @@ from soco import alarms
 
 from homeassistant.setup import setup_component
 from homeassistant.components.media_player import sonos, DOMAIN
-from homeassistant.components.media_player.sonos import CONF_INTERFACE_ADDR, \
-    CONF_ADVERTISE_ADDR
+from homeassistant.components.media_player.sonos import CONF_INTERFACE_ADDR
 from homeassistant.const import CONF_HOSTS, CONF_PLATFORM
 
 from tests.common import get_test_home_assistant
@@ -184,27 +183,6 @@ class TestSonosMediaPlayer(unittest.TestCase):
 
         self.assertEqual(len(self.hass.data[sonos.DATA_SONOS].devices), 1)
         self.assertEqual(discover_mock.call_count, 1)
-
-    @mock.patch('soco.SoCo', new=SoCoMock)
-    @mock.patch('socket.create_connection', side_effect=socket.error())
-    @mock.patch('soco.discover')
-    def test_ensure_setup_config_advertise_addr(self, discover_mock,
-                                                *args):
-        """Test an advertise address config'd by the HASS config file."""
-        discover_mock.return_value = {SoCoMock('192.0.2.1')}
-
-        config = {
-            DOMAIN: {
-                CONF_PLATFORM: 'sonos',
-                CONF_ADVERTISE_ADDR: '192.0.1.1',
-            }
-        }
-
-        assert setup_component(self.hass, DOMAIN, config)
-
-        self.assertEqual(len(self.hass.data[sonos.DATA_SONOS].devices), 1)
-        self.assertEqual(discover_mock.call_count, 1)
-        self.assertEqual(soco.config.EVENT_ADVERTISE_IP, '192.0.1.1')
 
     @mock.patch('soco.SoCo', new=SoCoMock)
     @mock.patch('socket.create_connection', side_effect=socket.error())

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -161,7 +161,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
             'host': '192.0.2.1'
         })
 
-        devices = self.hass.data[sonos.DATA_SONOS].devices
+        devices = list(self.hass.data[sonos.DATA_SONOS].devices)
         self.assertEqual(len(devices), 1)
         self.assertEqual(devices[0].name, 'Kitchen')
 
@@ -241,7 +241,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     def test_ensure_setup_sonos_discovery(self, *args):
         """Test a single device using the autodiscovery provided by Sonos."""
         sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass))
-        devices = self.hass.data[sonos.DATA_SONOS].devices
+        devices = list(self.hass.data[sonos.DATA_SONOS].devices)
         self.assertEqual(len(devices), 1)
         self.assertEqual(devices[0].name, 'Kitchen')
 
@@ -253,7 +253,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass), {
             'host': '192.0.2.1'
         })
-        device = self.hass.data[sonos.DATA_SONOS].devices[-1]
+        device = list(self.hass.data[sonos.DATA_SONOS].devices)[-1]
         device.hass = self.hass
 
         device.set_sleep_timer(30)
@@ -267,7 +267,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass), {
             'host': '192.0.2.1'
         })
-        device = self.hass.data[sonos.DATA_SONOS].devices[-1]
+        device = list(self.hass.data[sonos.DATA_SONOS].devices)[-1]
         device.hass = self.hass
 
         device.set_sleep_timer(None)
@@ -281,7 +281,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass), {
             'host': '192.0.2.1'
         })
-        device = self.hass.data[sonos.DATA_SONOS].devices[-1]
+        device = list(self.hass.data[sonos.DATA_SONOS].devices)[-1]
         device.hass = self.hass
         alarm1 = alarms.Alarm(soco_mock)
         alarm1.configure_mock(_alarm_id="1", start_time=None, enabled=False,
@@ -311,7 +311,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass), {
             'host': '192.0.2.1'
         })
-        device = self.hass.data[sonos.DATA_SONOS].devices[-1]
+        device = list(self.hass.data[sonos.DATA_SONOS].devices)[-1]
         device.hass = self.hass
 
         snapshotMock.return_value = True
@@ -329,7 +329,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         sonos.setup_platform(self.hass, {}, add_devices_factory(self.hass), {
             'host': '192.0.2.1'
         })
-        device = self.hass.data[sonos.DATA_SONOS].devices[-1]
+        device = list(self.hass.data[sonos.DATA_SONOS].devices)[-1]
         device.hass = self.hass
 
         restoreMock.return_value = True


### PR DESCRIPTION
## Description:

Reorganize Sonos setup to only call `add_devices` in one place. Also remove the unused (and undocumented) `advertise_addr` configuration.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
