### PR TITLE
More robust MJPEG parser. Fixes #13138.

### DIFF
--- a/homeassistant/components/camera/proxy.py
+++ b/homeassistant/components/camera/proxy.py
@@ -56,32 +56,21 @@ async def async_setup_platform(hass, config, async_add_devices,
     async_add_devices([ProxyCamera(hass, config)])
 
 
-async def _read_frame(req):
-    """Read a single frame from an MJPEG stream."""
-    # based on https://gist.github.com/russss/1143799
-    import cgi
-    # Read in HTTP headers:
+# This routine is adapted from the one in mjpeg.py.  They should probably
+# be merged together
+async def extract_images_from_mjpeg(req, chunk_size):
+    """Take in a MJPEG stream object, return the jpg from it."""
     stream = req.content
-    # multipart/x-mixed-replace; boundary=--frameboundary
-    _mimetype, options = cgi.parse_header(req.headers['content-type'])
-    boundary = options.get('boundary').encode('utf-8')
-    if not boundary:
-        _LOGGER.error("Malformed MJPEG missing boundary")
-        raise Exception("Can't find content-type")
-
-    line = await stream.readline()
-    # Seek ahead to the first chunk
-    while line.strip() != boundary:
-        line = await stream.readline()
-    # Read in chunk headers
-    while line.strip() != b'':
-        parts = line.split(b':')
-        if len(parts) > 1 and parts[0].lower() == b'content-length':
-            # Grab chunk length
-            length = int(parts[1].strip())
-        line = await stream.readline()
-    image = await stream.read(length)
-    return image
+    data = b''
+    while True:
+        chunk = await stream.read(chunk_size)
+        data += chunk
+        jpg_start = data.find(b'\xff\xd8')
+        jpg_end = data.find(b'\xff\xd9')
+        if jpg_start != -1 and jpg_end != -1:
+            jpg = data[jpg_start:jpg_end + 2]
+            data = data[jpg_end + 2:]
+            yield jpg
 
 
 def _resize_image(image, opts):
@@ -227,9 +216,9 @@ class ProxyCamera(Camera):
                                  'boundary=--frameboundary')
         await response.prepare(request)
 
-        def write(img_bytes):
+        async def write(img_bytes):
             """Write image to stream."""
-            response.write(bytes(
+            await response.write(bytes(
                 '--frameboundary\r\n'
                 'Content-Type: {}\r\n'
                 'Content-Length: {}\r\n\r\n'.format(
@@ -240,13 +229,10 @@ class ProxyCamera(Camera):
             req = await stream_coro
 
         try:
-            while True:
-                image = await _read_frame(req)
-                if not image:
-                    break
+            async for image in extract_images_from_mjpeg(req, 102400):
                 image = await self.hass.async_add_job(
                     _resize_image, image, self._stream_opts)
-                write(image)
+                await write(image)
         except asyncio.CancelledError:
             _LOGGER.debug("Stream closed by frontend.")
             req.close()


### PR DESCRIPTION
## Description:
This reimplements the mjpeg frame extractor using code based on the mjpeg.py extract_image_from_mjpeg() function, however it properly works in a fully asynchronous method and does not drop frames.

**Related issue (if applicable):** fixes #13138

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

