### PR TITLE
Fix logbook JSON serialize issue

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -139,9 +139,12 @@ class LogbookView(HomeAssistantView):
         end_day = start_day + timedelta(days=1)
         hass = request.app['hass']
 
-        events = yield from hass.async_add_job(
-            _get_events, hass, self.config, start_day, end_day)
-        response = yield from hass.async_add_job(self.json, events)
+        def json_events():
+            """Fetch events and generate JSON."""
+            return self.json(list(
+                _get_events(hass, self.config, start_day, end_day)))
+
+        response = yield from hass.async_add_job(json_events)
         return response
 
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -29,6 +29,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entityfilter import generate_filter
 from homeassistant.helpers.typing import ConfigType
 import homeassistant.util.dt as dt_util
+from homeassistant.loader import bind_hass
 
 from . import migration, purge
 from .const import DATA_INSTANCE
@@ -87,14 +88,10 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-@asyncio.coroutine
-def wait_connection_ready(hass):
-    """
-    Wait till the connection is ready.
-
-    Returns a coroutine object.
-    """
-    return (yield from hass.data[DATA_INSTANCE].async_db_ready)
+@bind_hass
+async def wait_connection_ready(hass):
+    """Wait till the connection is ready."""
+    return (await hass.data[DATA_INSTANCE].async_db_ready)
 
 
 def run_information(hass, point_in_time: Optional[datetime] = None):

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -91,7 +91,7 @@ CONFIG_SCHEMA = vol.Schema({
 @bind_hass
 async def wait_connection_ready(hass):
     """Wait till the connection is ready."""
-    return (await hass.data[DATA_INSTANCE].async_db_ready)
+    return await hass.data[DATA_INSTANCE].async_db_ready
 
 
 def run_information(hass, point_in_time: Optional[datetime] = None):

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -488,7 +488,7 @@ async def test_fetch_period_api(hass, aiohttp_client):
     await hass.async_add_job(init_recorder_component, hass)
     await async_setup_component(hass, 'history', {})
     await hass.components.recorder.wait_connection_ready()
-    await hass.async_block_till_done()
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
     client = await aiohttp_client(hass.http.app)
     response = await client.get(
         '/api/history/period/{}'.format(dt_util.utcnow().isoformat()))

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -487,6 +487,7 @@ async def test_fetch_period_api(hass, test_client):
     """Test the fetch period view for history."""
     await hass.async_add_job(init_recorder_component, hass)
     await async_setup_component(hass, 'history', {})
+    await hass.components.recorder.wait_connection_ready()
     client = await test_client(hass.http.app)
     response = await client.get(
         '/api/history/period/{}'.format(dt_util.utcnow().isoformat()))

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -483,12 +483,13 @@ class TestComponentHistory(unittest.TestCase):
         return zero, four, states
 
 
-async def test_fetch_period_api(hass, test_client):
+async def test_fetch_period_api(hass, aiohttp_client):
     """Test the fetch period view for history."""
     await hass.async_add_job(init_recorder_component, hass)
     await async_setup_component(hass, 'history', {})
     await hass.components.recorder.wait_connection_ready()
-    client = await test_client(hass.http.app)
+    await hass.async_block_till_done()
+    client = await aiohttp_client(hass.http.app)
     response = await client.get(
         '/api/history/period/{}'.format(dt_util.utcnow().isoformat()))
     assert response.status == 200

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -561,6 +561,7 @@ async def test_logbook_view(hass, aiohttp_client):
     """Test the logbook view."""
     await hass.async_add_job(init_recorder_component, hass)
     await async_setup_component(hass, 'logbook', {})
+    await hass.components.recorder.wait_connection_ready()
     client = await aiohttp_client(hass.http.app)
     response = await client.get(
         '/api/logbook/{}'.format(dt_util.utcnow().isoformat()))

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -10,7 +10,7 @@ from homeassistant.const import (
     EVENT_STATE_CHANGED, EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
     ATTR_HIDDEN, STATE_NOT_HOME, STATE_ON, STATE_OFF)
 import homeassistant.util.dt as dt_util
-from homeassistant.components import logbook
+from homeassistant.components import logbook, recorder
 from homeassistant.setup import setup_component, async_setup_component
 
 from tests.common import (
@@ -562,7 +562,7 @@ async def test_logbook_view(hass, aiohttp_client):
     await hass.async_add_job(init_recorder_component, hass)
     await async_setup_component(hass, 'logbook', {})
     await hass.components.recorder.wait_connection_ready()
-    await hass.async_block_till_done()
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
     client = await aiohttp_client(hass.http.app)
     response = await client.get(
         '/api/logbook/{}'.format(dt_util.utcnow().isoformat()))

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -562,6 +562,7 @@ async def test_logbook_view(hass, aiohttp_client):
     await hass.async_add_job(init_recorder_component, hass)
     await async_setup_component(hass, 'logbook', {})
     await hass.components.recorder.wait_connection_ready()
+    await hass.async_block_till_done()
     client = await aiohttp_client(hass.http.app)
     response = await client.get(
         '/api/logbook/{}'.format(dt_util.utcnow().isoformat()))

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     ATTR_HIDDEN, STATE_NOT_HOME, STATE_ON, STATE_OFF)
 import homeassistant.util.dt as dt_util
 from homeassistant.components import logbook
-from homeassistant.setup import setup_component
+from homeassistant.setup import setup_component, async_setup_component
 
 from tests.common import (
     init_recorder_component, get_test_home_assistant)
@@ -555,3 +555,13 @@ class TestComponentLogbook(unittest.TestCase):
             'old_state': state,
             'new_state': state,
         }, time_fired=event_time_fired)
+
+
+async def test_logbook_view(hass, aiohttp_client):
+    """Test the logbook view."""
+    await hass.async_add_job(init_recorder_component, hass)
+    await async_setup_component(hass, 'logbook', {})
+    client = await aiohttp_client(hass.http.app)
+    response = await client.get(
+        '/api/logbook/{}'.format(dt_util.utcnow().isoformat()))
+    assert response.status == 200


### PR DESCRIPTION
## Description:
I introduced stricter JSON serialization in #13029. Looks like we did not cover all HTTP views that generate JSON in tests. This fixes that and fixes the broken logbook API.

Reported by @cdce8p 

## Example entry for `configuration.yaml` (if applicable):
```yaml
logbook:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
