### PR TITLE
Change Hass.io icon to home-assistant

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -156,7 +156,7 @@ def async_setup(hass, config):
 
     if 'frontend' in hass.config.components:
         yield from hass.components.frontend.async_register_built_in_panel(
-            'hassio', 'Hass.io', 'mdi:access-point-network')
+            'hassio', 'Hass.io', 'mdi:home-assistant')
 
     if 'http' in config:
         yield from hassio.update_hass_api(config['http'])


### PR DESCRIPTION
## Description:
we also use this icon in the docs for Hass.io
![icon](https://user-images.githubusercontent.com/11984118/37443063-130c4b7e-280a-11e8-9c70-d4b49273c483.png)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**