### PR TITLE
Tibber use appNickname as name

### DIFF
--- a/homeassistant/components/sensor/tibber.py
+++ b/homeassistant/components/sensor/tibber.py
@@ -61,7 +61,8 @@ class TibberSensor(Entity):
         self._state = None
         self._device_state_attributes = {}
         self._unit_of_measurement = self._tibber_home.price_unit
-        self._name = 'Electricity price {}'.format(tibber_home.address1)
+        self._name = 'Electricity price {}'.format(tibber_home.info['viewer']
+                                                   ['home']['appNickname'])
 
     async def async_update(self):
         """Get the latest data and updates the states."""


### PR DESCRIPTION
## Description:
Tibber is showing the same name if there are multiple meters in the same address.
It should use appNickname as when setting meter up in Tibber we need to put in meter nickname.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


Edit by Daniel: Release note, breaking change:
The name and the entity id for the Tibber sensor will now be the same as the nickname from the app. Default nick name is the address. So if you have not changed the nickname in the app, everything should be as before.