### PR TITLE
Try to fix caldav

### DIFF
--- a/homeassistant/components/calendar/caldav.py
+++ b/homeassistant/components/calendar/caldav.py
@@ -194,7 +194,7 @@ class WebDavCalendarData(object):
     @staticmethod
     def is_over(vevent):
         """Return if the event is over."""
-        return dt.now() > WebDavCalendarData.to_datetime(
+        return dt.now() >= WebDavCalendarData.to_datetime(
             WebDavCalendarData.get_end_date(vevent)
         )
 

--- a/homeassistant/components/calendar/caldav.py
+++ b/homeassistant/components/calendar/caldav.py
@@ -194,7 +194,9 @@ class WebDavCalendarData(object):
     @staticmethod
     def is_over(vevent):
         """Return if the event is over."""
-        return dt.now() > WebDavCalendarData.get_end_date(vevent)
+        return dt.now() > WebDavCalendarData.to_datetime(
+            WebDavCalendarData.get_end_date(vevent)
+        )
 
     @staticmethod
     def get_hass_date(obj):
@@ -230,4 +232,4 @@ class WebDavCalendarData(object):
         else:
             enddate = obj.dtstart.value + timedelta(days=1)
 
-        return WebDavCalendarData.to_datetime(enddate)
+        return enddate

--- a/tests/components/calendar/test_caldav.py
+++ b/tests/components/calendar/test_caldav.py
@@ -105,6 +105,20 @@ LOCATION:Hamburg
 DESCRIPTION:What a day
 END:VEVENT
 END:VCALENDAR
+""",
+    """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Global Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:7
+DTSTART;TZID=America/Los_Angeles:20171127T083000
+DTSTAMP:20180301T020053Z
+DTEND;TZID=America/Los_Angeles:20171127T093000
+SUMMARY:Enjoy the sun
+LOCATION:San Francisco
+DESCRIPTION:Sunny day
+END:VEVENT
+END:VCALENDAR
 """
 
 ]
@@ -225,7 +239,7 @@ class TestComponentsWebDavCalendar(unittest.TestCase):
                               },
                               _add_device)
 
-    @patch('homeassistant.util.dt.now', return_value=_local_datetime(17, 30))
+    @patch('homeassistant.util.dt.now', return_value=_local_datetime(17, 45))
     def test_ongoing_event(self, mock_now):
         """Test that the ongoing event is returned."""
         cal = caldav.WebDavCalendarEventDevice(self.hass,
@@ -242,6 +256,44 @@ class TestComponentsWebDavCalendar(unittest.TestCase):
             "end_time": "2017-11-27 18:00:00",
             "location": "Hamburg",
             "description": "Surprisingly rainy"
+        })
+
+    @patch('homeassistant.util.dt.now', return_value=_local_datetime(17, 30))
+    def test_just_ended_event(self, mock_now):
+        """Test that the next ongoing event is returned."""
+        cal = caldav.WebDavCalendarEventDevice(self.hass,
+                                               DEVICE_DATA,
+                                               self.calendar)
+
+        self.assertEqual(cal.name, DEVICE_DATA["name"])
+        self.assertEqual(cal.state, STATE_ON)
+        self.assertEqual(cal.device_state_attributes, {
+            "message": "This is a normal event",
+            "all_day": False,
+            "offset_reached": False,
+            "start_time": "2017-11-27 17:00:00",
+            "end_time": "2017-11-27 18:00:00",
+            "location": "Hamburg",
+            "description": "Surprisingly rainy"
+        })
+
+    @patch('homeassistant.util.dt.now', return_value=_local_datetime(17, 00))
+    def test_ongoing_event_different_tz(self, mock_now):
+        """Test that the ongoing event with another timezone is returned."""
+        cal = caldav.WebDavCalendarEventDevice(self.hass,
+                                               DEVICE_DATA,
+                                               self.calendar)
+
+        self.assertEqual(cal.name, DEVICE_DATA["name"])
+        self.assertEqual(cal.state, STATE_ON)
+        self.assertEqual(cal.device_state_attributes, {
+            "message": "Enjoy the sun",
+            "all_day": False,
+            "offset_reached": False,
+            "start_time": "2017-11-27 16:30:00",
+            "description": "Sunny day",
+            "end_time": "2017-11-27 17:30:00",
+            "location": "San Francisco"
         })
 
     @patch('homeassistant.util.dt.now', return_value=_local_datetime(8, 30))


### PR DESCRIPTION
## Description:
* fixes a bug apparently introduced when the type of the `end` attribute was changed to be forced to `datetime`
* fixes the method that determine if an event is over. HA consider a event as ended when the end-time is reached. The caldav component was considering an event as ended once the end-time was over. This PR change the caldav behavior to match HA's
* add a test with different timezones
* add a test when the date is the exact endtime of an event

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/12802
I must admit I couldn't reproduce the issue. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
