### PR TITLE
Tado: don't reference unset hass var

### DIFF
--- a/homeassistant/components/device_tracker/tado.py
+++ b/homeassistant/components/device_tracker/tado.py
@@ -100,7 +100,7 @@ class TadoDeviceScanner(DeviceScanner):
         last_results = []
 
         try:
-            with async_timeout.timeout(10, loop=self.hass.loop):
+            with async_timeout.timeout(10):
                 # Format the URL here, so we can log the template URL if
                 # anything goes wrong without exposing username and password.
                 url = self.tadoapiurl.format(


### PR DESCRIPTION
## Description:
Tado was referencing a non existing hass variable.

**Related issue (if applicable):** fixes #13179

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
