### PR TITLE
Yeelight: Control the power mode by an additional turn_on parameter

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -79,6 +79,8 @@ EFFECT_COLORLOOP = "colorloop"
 EFFECT_RANDOM = "random"
 EFFECT_WHITE = "white"
 
+ATTR_MODE = "mode"
+
 COLOR_GROUP = "Color descriptors"
 
 LIGHT_PROFILES_FILE = "light_profiles.csv"
@@ -118,6 +120,7 @@ LIGHT_TURN_ON_SCHEMA = vol.Schema({
     ATTR_WHITE_VALUE: vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
     ATTR_FLASH: vol.In([FLASH_SHORT, FLASH_LONG]),
     ATTR_EFFECT: cv.string,
+    ATTR_MODE: vol.All(vol.Coerce(int), vol.Clamp(min=0, max=5)),
 })
 
 LIGHT_TURN_OFF_SCHEMA = vol.Schema({
@@ -151,12 +154,13 @@ def is_on(hass, entity_id=None):
 def turn_on(hass, entity_id=None, transition=None, brightness=None,
             brightness_pct=None, rgb_color=None, xy_color=None,
             color_temp=None, kelvin=None, white_value=None,
-            profile=None, flash=None, effect=None, color_name=None):
+            profile=None, flash=None, effect=None, color_name=None,
+            mode=None):
     """Turn all or specified light on."""
     hass.add_job(
         async_turn_on, hass, entity_id, transition, brightness, brightness_pct,
         rgb_color, xy_color, color_temp, kelvin, white_value,
-        profile, flash, effect, color_name)
+        profile, flash, effect, color_name, mode)
 
 
 @callback
@@ -164,7 +168,8 @@ def turn_on(hass, entity_id=None, transition=None, brightness=None,
 def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
                   brightness_pct=None, rgb_color=None, xy_color=None,
                   color_temp=None, kelvin=None, white_value=None,
-                  profile=None, flash=None, effect=None, color_name=None):
+                  profile=None, flash=None, effect=None, color_name=None,
+                  mode=None):
     """Turn all or specified light on."""
     data = {
         key: value for key, value in [
@@ -181,6 +186,7 @@ def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
             (ATTR_FLASH, flash),
             (ATTR_EFFECT, effect),
             (ATTR_COLOR_NAME, color_name),
+            (ATTR_MODE, mode),
         ] if value is not None
     }
 

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -46,6 +46,9 @@ turn_on:
       values:
         - colorloop
         - random
+    mode:
+      description: Operation mode for the light. Valid modes are 0 (Last), 1 (Normal), 2 (RGB), 3 (HSV), 4 (Color flow) and 5 (Moonlight).
+      example: 5
 
 turn_off:
   description: Turn a light off.

--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -38,6 +38,8 @@ CONF_MODE_MUSIC = 'use_music_mode'
 
 DOMAIN = 'yeelight'
 
+ATTR_MODE = 'mode'
+
 DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_TRANSITION, default=DEFAULT_TRANSITION): cv.positive_int,
@@ -417,6 +419,7 @@ class YeelightLight(Light):
     def turn_on(self, **kwargs) -> None:
         """Turn the bulb on."""
         import yeelight
+        mode = yeelight.enums.PowerMode(kwargs.get(ATTR_MODE, 0))
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         colortemp = kwargs.get(ATTR_COLOR_TEMP)
         rgb = kwargs.get(ATTR_RGB_COLOR)
@@ -429,7 +432,7 @@ class YeelightLight(Light):
             duration = int(kwargs.get(ATTR_TRANSITION) * 1000)  # kwarg in s
 
         try:
-            self._bulb.turn_on(duration=duration)
+            self._bulb.turn_on(duration=duration, power_mode=mode)
         except yeelight.BulbException as ex:
             _LOGGER.error("Unable to turn the bulb on: %s", ex)
             return


### PR DESCRIPTION
This feature provides the support for the moonlight mode of the Yeelight Ceiling Lamp.

```
light.turn_on {'mode': 5}
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** TBD.

