### PR TITLE
Buienradar improvements: continuous sensors and unique ID's

### DIFF
--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -161,7 +161,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     dev = []
     for sensor_type in config[CONF_MONITORED_CONDITIONS]:
-        dev.append(BrSensor(sensor_type, config.get(CONF_NAME, 'br')))
+        dev.append(BrSensor(sensor_type, config.get(CONF_NAME, 'br'),
+                            coordinates))
     async_add_devices(dev)
 
     data = BrData(hass, coordinates, timeframe, dev)
@@ -172,7 +173,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class BrSensor(Entity):
     """Representation of an Buienradar sensor."""
 
-    def __init__(self, sensor_type, client_name):
+    def __init__(self, sensor_type, client_name, coordinates):
         """Initialize the sensor."""
         from buienradar.buienradar import (PRECIPITATION_FORECAST, CONDITION)
 
@@ -185,6 +186,7 @@ class BrSensor(Entity):
         self._attribution = None
         self._measured = None
         self._stationname = None
+        self._unique_id = self.uuid(coordinates)
 
         # All continuous sensors should be forced to be updated
         self._force_update = self.type != SYMBOL and \
@@ -192,6 +194,21 @@ class BrSensor(Entity):
 
         if self.type.startswith(PRECIPITATION_FORECAST):
             self._timeframe = None
+
+    def uuid(self, coordinates):
+        """Generate a UUID using coordinates, client name and sensor type"""
+
+        from hashlib import sha1
+        from uuid import UUID
+
+        # The combination of the location, name an sensor type is unique
+        unique_str = "%2.6f%2.6f%s%s" % (coordinates[CONF_LATITUDE],
+                                         coordinates[CONF_LONGITUDE],
+                                         self.type,
+                                         self.client_name)
+
+        # Create UUID based on the hash of the unique string
+        return str(UUID(sha1(unique_str.encode()).hexdigest()[:32]))
 
     def load_data(self, data):
         """Load the sensor with relevant data."""
@@ -303,6 +320,11 @@ class BrSensor(Entity):
     def attribution(self):
         """Return the attribution."""
         return self._attribution
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -190,7 +190,7 @@ class BrSensor(Entity):
 
         # All continuous sensors should be forced to be updated
         self._force_update = self.type != SYMBOL and \
-                             not self.type.startswith(CONDITION)
+            not self.type.startswith(CONDITION)
 
         if self.type.startswith(PRECIPITATION_FORECAST):
             self._timeframe = None

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -359,8 +359,9 @@ class BrSensor(Entity):
 
     @property
     def force_update(self):
-        """Return true for continuous sensors, false for discrete sensors"""
+        """Return true for continuous sensors, false for discrete sensors."""
         return self._force_update
+
 
 class BrData(object):
     """Get the latest data and updates the states."""

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -197,7 +197,6 @@ class BrSensor(Entity):
 
     def uid(self, coordinates):
         """Generate a unique id using coordinates and sensor type."""
-
         # The combination of the location, name an sensor type is unique
         return "%2.6f%2.6f%s" % (coordinates[CONF_LATITUDE],
                                  coordinates[CONF_LONGITUDE],

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -204,7 +204,6 @@ class BrSensor(Entity):
         unique_str = "%2.6f%2.6f%s" % (coordinates[CONF_LATITUDE],
                                        coordinates[CONF_LONGITUDE],
                                        self.type)
-        _LOGGER.error(unique_str)
 
         # Create UUID based on the hash of the unique string
         return str(UUID(sha1(unique_str.encode()).hexdigest()[:32]))

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -186,7 +186,7 @@ class BrSensor(Entity):
         self._attribution = None
         self._measured = None
         self._stationname = None
-        self._unique_id = self.uuid(coordinates)
+        self._unique_id = self.uid(coordinates)
 
         # All continuous sensors should be forced to be updated
         self._force_update = self.type != SYMBOL and \
@@ -195,18 +195,13 @@ class BrSensor(Entity):
         if self.type.startswith(PRECIPITATION_FORECAST):
             self._timeframe = None
 
-    def uuid(self, coordinates):
-        """Generate a UUID using coordinates, client name and sensor type."""
-        from hashlib import sha1
-        from uuid import UUID
+    def uid(self, coordinates):
+        """Generate a unique id using coordinates and sensor type."""
 
         # The combination of the location, name an sensor type is unique
-        unique_str = "%2.6f%2.6f%s" % (coordinates[CONF_LATITUDE],
-                                       coordinates[CONF_LONGITUDE],
-                                       self.type)
-
-        # Create UUID based on the hash of the unique string
-        return str(UUID(sha1(unique_str.encode()).hexdigest()[:32]))
+        return "%2.6f%2.6f%s" % (coordinates[CONF_LATITUDE],
+                                 coordinates[CONF_LONGITUDE],
+                                 self.type)
 
     def load_data(self, data):
         """Load the sensor with relevant data."""

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -161,8 +161,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     dev = []
     for sensor_type in config[CONF_MONITORED_CONDITIONS]:
-        dev.append(BrSensor(sensor_type, config.get(CONF_NAME, 'br'),
-                            coordinates))
+        dev.append(BrSensor(sensor_type, config.get(CONF_NAME, 'br')))
     async_add_devices(dev)
 
     data = BrData(hass, coordinates, timeframe, dev)
@@ -173,7 +172,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class BrSensor(Entity):
     """Representation of an Buienradar sensor."""
 
-    def __init__(self, sensor_type, client_name, coordinates):
+    def __init__(self, sensor_type, client_name):
         """Initialize the sensor."""
         from buienradar.buienradar import (PRECIPITATION_FORECAST, CONDITION)
 
@@ -186,7 +185,6 @@ class BrSensor(Entity):
         self._attribution = None
         self._measured = None
         self._stationname = None
-        self._unique_id = self.uuid(coordinates)
 
         # All continuous sensors should be forced to be updated
         self._force_update = self.type != SYMBOL and \
@@ -194,21 +192,6 @@ class BrSensor(Entity):
 
         if self.type.startswith(PRECIPITATION_FORECAST):
             self._timeframe = None
-
-    def uuid(self, coordinates):
-        """Generate a UUID using coordinates, client name and sensor type"""
-
-        from hashlib import sha1
-        from uuid import UUID
-
-        # The combination of the location, name an sensor type is unique
-        unique_str = "%2.6f%2.6f%s%s" % (coordinates[CONF_LATITUDE],
-                                         coordinates[CONF_LONGITUDE],
-                                         self.type,
-                                         self.client_name)
-
-        # Create UUID based on the hash of the unique string
-        return str(UUID(sha1(unique_str.encode()).hexdigest()[:32]))
 
     def load_data(self, data):
         """Load the sensor with relevant data."""
@@ -320,11 +303,6 @@ class BrSensor(Entity):
     def attribution(self):
         """Return the attribution."""
         return self._attribution
-
-    @property
-    def unique_id(self):
-        """Return the unique id."""
-        return self._unique_id
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:

Adds the following to the Buienradar component:
- Continuous signals are forced to update even if state doesn't change. This is mostly applicable for irradiance as this is 0 the whole night. But without force update it's not possible to use the statistics or filter sensor. Also, the measured value is continuous, and it only adds 6 entries/hour.
- Check if the measurement time changed. If not, state didn't change either.
- Unique Id's. Herefore I choose the combination of the location and sensor type.

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
sensor:
  - platform: buienradar
    monitored_conditions:
      - symbol
      - humidity
      - temperature
      - windspeed
      - pressure
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
