### PR TITLE
Allow use of date_string in service call

### DIFF
--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -1,21 +1,26 @@
 # Describes the format for available calendar services
 
-todoist:
-  new_task:
-    description: Create a new task and add it to a project.
-    fields:
-      content: 
-        description: The name of the task (Required).
-        example: Pick up the mail
-      project:
-        description: The name of the project this task should belong to. Defaults to Inbox (Optional).
-        example: Errands
-      labels:
-        description: Any labels that you want to apply to this task, separated by a comma (Optional).
-        example: Chores,Deliveries
-      priority:
-        description: The priority of this task, from 1 (normal) to 4 (urgent) (Optional).
-        example: 2
-      due_date:
-        description: The day this task is due, in format YYYY-MM-DD (Optional).
-        example: "2018-04-01"
+todoist_new_task:
+  description: Create a new task and add it to a project.
+  fields:
+    content:
+      description: The name of the task (Required).
+      example: Pick up the mail
+    project:
+      description: The name of the project this task should belong to. Defaults to Inbox (Optional).
+      example: Errands
+    labels:
+      description: Any labels that you want to apply to this task, separated by a comma (Optional).
+      example: Chores,Deliveries
+    priority:
+      description: The priority of this task, from 1 (normal) to 4 (urgent) (Optional).
+      example: 2
+    date_string:
+      description: The day this task is due, in natural language (Optional).
+      example: "tomorrow"
+    date_lang:
+      description: The langurage of date_string (Optional).
+      example: "en"
+    due_date:
+      description: The day this task is due, in format YYYY-MM-DD (Optional).
+      example: "2018-04-01"

--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -4,23 +4,23 @@ todoist_new_task:
   description: Create a new task and add it to a project.
   fields:
     content:
-      description: The name of the task (Required).
+      description: The name of the task.
       example: Pick up the mail
     project:
-      description: The name of the project this task should belong to. Defaults to Inbox (Optional).
+      description: The name of the project this task should belong to. Defaults to Inbox.
       example: Errands
     labels:
-      description: Any labels that you want to apply to this task, separated by a comma (Optional).
+      description: Any labels that you want to apply to this task, separated by a comma.
       example: Chores,Deliveries
     priority:
-      description: The priority of this task, from 1 (normal) to 4 (urgent) (Optional).
+      description: The priority of this task, from 1 (normal) to 4 (urgent).
       example: 2
-    date_string:
-      description: The day this task is due, in natural language (Optional).
+    due_date_string:
+      description: The day this task is due, in natural language.
       example: "tomorrow"
-    date_lang:
-      description: The langurage of date_string (Optional).
+    due_date_lang:
+      description: The language of due_date_string.
       example: "en"
     due_date:
-      description: The day this task is due, in format YYYY-MM-DD (Optional).
+      description: The day this task is due, in format YYYY-MM-DD.
       example: "2018-04-01"

--- a/homeassistant/components/calendar/todoist.py
+++ b/homeassistant/components/calendar/todoist.py
@@ -42,9 +42,13 @@ DESCRIPTION = 'description'
 # Calendar Platform: Used in the '_get_date()' method
 DATETIME = 'dateTime'
 # Service Call: When is this task due (in natural language)?
-DATE_STRING = 'date_string'
-# Service Call: The language of DATE_STRING
-DATE_LANG = 'date_lang'
+DUE_DATE_STRING = 'due_date_string'
+# Service Call: The language of DUE_DATE_STRING
+DUE_DATE_LANG = 'due_date_lang'
+# Service Call: The available options of DUE_DATE_LANG
+DUE_DATE_VALID_LANGS = ['en', 'da', 'pl', 'zh', 'ko', 'de',
+                        'pt', 'ja', 'it', 'fr', 'sv', 'ru',
+                        'es', 'nl']
 # Attribute: When is this task due?
 # Service Call: When is this task due?
 DUE_DATE = 'due_date'
@@ -87,9 +91,11 @@ NEW_TASK_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(PROJECT_NAME, default='inbox'): vol.All(cv.string, vol.Lower),
     vol.Optional(LABELS): cv.ensure_list_csv,
     vol.Optional(PRIORITY): vol.All(vol.Coerce(int), vol.Range(min=1, max=4)),
-    vol.Optional(DATE_STRING): cv.string,
-    vol.Optional(DATE_LANG): vol.All(cv.string, vol.Length(min=2, max=2)),
-    vol.Optional(DUE_DATE): cv.string
+
+    vol.Exclusive(DUE_DATE_STRING, 'due_date'): cv.string,
+    vol.Optional(DUE_DATE_LANG):
+        vol.All(cv.string, vol.In(DUE_DATE_VALID_LANGS)),
+    vol.Exclusive(DUE_DATE, 'due_date'): cv.string,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -192,16 +198,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if PRIORITY in call.data:
             item.update(priority=call.data[PRIORITY])
 
-        if DATE_STRING in call.data:
-            item.update(date_string=call.data[DATE_STRING])
+        if DUE_DATE_STRING in call.data:
+            item.update(date_string=call.data[DUE_DATE_STRING])
 
-        if DATE_LANG in call.data:
-            item.update(date_lang=call.data[DATE_LANG])
+        if DUE_DATE_LANG in call.data:
+            item.update(date_lang=call.data[DUE_DATE_LANG])
 
         if DUE_DATE in call.data:
-            # Make sure only DUE_DATE is set
-            item.update(date_string='')
-
             due_date = dt.parse_datetime(call.data[DUE_DATE])
             if due_date is None:
                 due = dt.parse_date(call.data[DUE_DATE])

--- a/homeassistant/components/calendar/todoist.py
+++ b/homeassistant/components/calendar/todoist.py
@@ -41,6 +41,10 @@ CONTENT = 'content'
 DESCRIPTION = 'description'
 # Calendar Platform: Used in the '_get_date()' method
 DATETIME = 'dateTime'
+# Service Call: When is this task due (in natural language)?
+DATE_STRING = 'date_string'
+# Service Call: The language of DATE_STRING
+DATE_LANG = 'date_lang'
 # Attribute: When is this task due?
 # Service Call: When is this task due?
 DUE_DATE = 'due_date'
@@ -83,7 +87,9 @@ NEW_TASK_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(PROJECT_NAME, default='inbox'): vol.All(cv.string, vol.Lower),
     vol.Optional(LABELS): cv.ensure_list_csv,
     vol.Optional(PRIORITY): vol.All(vol.Coerce(int), vol.Range(min=1, max=4)),
-    vol.Optional(DUE_DATE): cv.string,
+    vol.Optional(DATE_STRING): cv.string,
+    vol.Optional(DATE_LANG): vol.All(cv.string, vol.Length(min=2, max=2)),
+    vol.Optional(DUE_DATE): cv.string
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -186,7 +192,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if PRIORITY in call.data:
             item.update(priority=call.data[PRIORITY])
 
+        if DATE_STRING in call.data:
+            item.update(date_string=call.data[DATE_STRING])
+
+        if DATE_LANG in call.data:
+            item.update(date_lang=call.data[DATE_LANG])
+
         if DUE_DATE in call.data:
+            # Make sure only DUE_DATE is set
+            item.update(date_string='')
+
             due_date = dt.parse_datetime(call.data[DUE_DATE])
             if due_date is None:
                 due = dt.parse_date(call.data[DUE_DATE])


### PR DESCRIPTION
## Description:
In the original implementation of the Todoist calendar component it was not possible to allow Todoist natural language for due dates. This PR adds this capability.

Also fixes the `services.yaml` for the service call

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4923

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
