### PR TITLE
Allow for overriding the DoorBird push notification URL in configuration

### DIFF
--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -22,6 +22,7 @@ DOMAIN = 'doorbird'
 API_URL = '/api/{}'.format(DOMAIN)
 
 CONF_DOORBELL_EVENTS = 'doorbell_events'
+CONF_CUSTOM_URL = 'push_to_host'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -29,6 +30,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_DOORBELL_EVENTS): cv.boolean,
+        vol.Optional(CONF_CUSTOM_URL): cv.string,
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -61,9 +63,17 @@ def setup(hass, config):
         # Provide an endpoint for the device to call to trigger events
         hass.http.register_view(DoorbirdRequestView())
 
+        # Get the URL of this server
+        hass_url = hass.config.api.base_url
+
+        # Override it if another is specified in the component configuration
+        if config[DOMAIN].get(CONF_CUSTOM_URL):
+            hass_url = config[DOMAIN].get(CONF_CUSTOM_URL)
+            _LOGGER.info("DoorBird will connect to this instance via %s",
+                         hass_url)
+
         # This will make HA the only service that gets doorbell events
-        url = '{}{}/{}'.format(
-            hass.config.api.base_url, API_URL, SENSOR_DOORBELL)
+        url = '{}{}/{}'.format(hass_url, API_URL, SENSOR_DOORBELL)
         device.reset_notifications()
         device.subscribe_notification(SENSOR_DOORBELL, url)
 

--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -22,7 +22,7 @@ DOMAIN = 'doorbird'
 API_URL = '/api/{}'.format(DOMAIN)
 
 CONF_DOORBELL_EVENTS = 'doorbell_events'
-CONF_CUSTOM_URL = 'push_to_host'
+CONF_CUSTOM_URL = 'hass_url_override'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({


### PR DESCRIPTION
## Description:

Useful in situations such as those described by users in [this thread](https://community.home-assistant.io/t/doorbird-integration/5564/67).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
doorbird:
  host: 192.168.2.16
  username: abcdef0001
  password: **********
  hass_url_override: https://example.com:8123
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
