### PR TITLE
Add support for Canary Flex

### DIFF
--- a/homeassistant/components/canary.py
+++ b/homeassistant/components/canary.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_TIMEOUT
 from homeassistant.helpers import discovery
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['py-canary==0.4.1']
+REQUIREMENTS = ['py-canary==0.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/canary.py
+++ b/homeassistant/components/sensor/canary.py
@@ -8,6 +8,7 @@ https://home-assistant.io/components/sensor.canary/
 from homeassistant.components.canary import DATA_CANARY
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.icon import icon_for_battery_level
 
 DEPENDENCIES = ['canary']
 
@@ -84,6 +85,9 @@ class CanarySensor(Entity):
     @property
     def icon(self):
         """Icon for the sensor."""
+        if self.state is not None and self._sensor_type[0] == "battery":
+            return icon_for_battery_level(battery_level=self.state)
+
         return self._sensor_type[2]
 
     @property

--- a/homeassistant/components/sensor/canary.py
+++ b/homeassistant/components/sensor/canary.py
@@ -17,9 +17,11 @@ ATTR_AIR_QUALITY = "air_quality"
 # Sensor types are defined like so:
 # sensor type name, unit_of_measurement, icon
 SENSOR_TYPES = [
-    ["temperature", TEMP_CELSIUS, "mdi:thermometer"],
-    ["humidity", "%", "mdi:water-percent"],
-    ["air_quality", None, "mdi:weather-windy"],
+    ["temperature", TEMP_CELSIUS, "mdi:thermometer", ["Canary"]],
+    ["humidity", "%", "mdi:water-percent", ["Canary"]],
+    ["air_quality", None, "mdi:weather-windy", ["Canary"]],
+    ["wifi_signal_strength", "dBm", "mdi:wifi", ["Canary Flex"]],
+    ["battery", "%", "mdi:battery-50", ["Canary Flex"]],
 ]
 
 STATE_AIR_QUALITY_NORMAL = "normal"
@@ -35,9 +37,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for location in data.locations:
         for device in location.devices:
             if device.is_online:
+                device_type = device.device_type
                 for sensor_type in SENSOR_TYPES:
-                    devices.append(CanarySensor(data, sensor_type, location,
-                                                device))
+                    if device_type.get("name") in sensor_type[3]:
+                        devices.append(CanarySensor(data, sensor_type,
+                                                    location, device))
 
     add_devices(devices, True)
 
@@ -113,6 +117,10 @@ class CanarySensor(Entity):
             canary_sensor_type = SensorType.TEMPERATURE
         elif self._sensor_type[0] == "humidity":
             canary_sensor_type = SensorType.HUMIDITY
+        elif self._sensor_type[0] == "wifi":
+            canary_sensor_type = SensorType.WIFI
+        elif self._sensor_type[0] == "battery":
+            canary_sensor_type = SensorType.BATTERY
 
         value = self._data.get_reading(self._device_id, canary_sensor_type)
 

--- a/homeassistant/components/sensor/canary.py
+++ b/homeassistant/components/sensor/canary.py
@@ -20,7 +20,7 @@ SENSOR_TYPES = [
     ["temperature", TEMP_CELSIUS, "mdi:thermometer", ["Canary"]],
     ["humidity", "%", "mdi:water-percent", ["Canary"]],
     ["air_quality", None, "mdi:weather-windy", ["Canary"]],
-    ["wifi_signal_strength", "dBm", "mdi:wifi", ["Canary Flex"]],
+    ["wifi", "dBm", "mdi:wifi", ["Canary Flex"]],
     ["battery", "%", "mdi:battery-50", ["Canary Flex"]],
 ]
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -623,7 +623,7 @@ pwmled==1.2.1
 py-august==0.4.0
 
 # homeassistant.components.canary
-py-canary==0.4.1
+py-canary==0.5.0
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==3.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -127,7 +127,7 @@ prometheus_client==0.1.0
 pushbullet.py==0.11.0
 
 # homeassistant.components.canary
-py-canary==0.4.1
+py-canary==0.5.0
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/tests/components/sensor/test_canary.py
+++ b/tests/components/sensor/test_canary.py
@@ -40,9 +40,9 @@ class TestCanarySensorSetup(unittest.TestCase):
 
     def test_setup_sensors(self):
         """Test the sensor setup."""
-        online_device_at_home = mock_device(20, "Dining Room", True)
-        offline_device_at_home = mock_device(21, "Front Yard", False)
-        online_device_at_work = mock_device(22, "Office", True)
+        online_device_at_home = mock_device(20, "Dining Room", True, "Canary")
+        offline_device_at_home = mock_device(21, "Front Yard", False, "Canary")
+        online_device_at_work = mock_device(22, "Office", True, "Canary")
 
         self.hass.data[DATA_CANARY] = Mock()
         self.hass.data[DATA_CANARY].locations = [
@@ -57,7 +57,7 @@ class TestCanarySensorSetup(unittest.TestCase):
 
     def test_temperature_sensor(self):
         """Test temperature sensor with fahrenheit."""
-        device = mock_device(10, "Family Room")
+        device = mock_device(10, "Family Room", "Canary")
         location = mock_location("Home", False)
 
         data = Mock()
@@ -72,7 +72,7 @@ class TestCanarySensorSetup(unittest.TestCase):
 
     def test_temperature_sensor_with_none_sensor_value(self):
         """Test temperature sensor with fahrenheit."""
-        device = mock_device(10, "Family Room")
+        device = mock_device(10, "Family Room", "Canary")
         location = mock_location("Home", False)
 
         data = Mock()
@@ -85,7 +85,7 @@ class TestCanarySensorSetup(unittest.TestCase):
 
     def test_humidity_sensor(self):
         """Test humidity sensor."""
-        device = mock_device(10, "Family Room")
+        device = mock_device(10, "Family Room", "Canary")
         location = mock_location("Home")
 
         data = Mock()
@@ -100,7 +100,7 @@ class TestCanarySensorSetup(unittest.TestCase):
 
     def test_air_quality_sensor_with_very_abnormal_reading(self):
         """Test air quality sensor."""
-        device = mock_device(10, "Family Room")
+        device = mock_device(10, "Family Room", "Canary")
         location = mock_location("Home")
 
         data = Mock()
@@ -118,7 +118,7 @@ class TestCanarySensorSetup(unittest.TestCase):
 
     def test_air_quality_sensor_with_abnormal_reading(self):
         """Test air quality sensor."""
-        device = mock_device(10, "Family Room")
+        device = mock_device(10, "Family Room", "Canary")
         location = mock_location("Home")
 
         data = Mock()
@@ -136,7 +136,7 @@ class TestCanarySensorSetup(unittest.TestCase):
 
     def test_air_quality_sensor_with_normal_reading(self):
         """Test air quality sensor."""
-        device = mock_device(10, "Family Room")
+        device = mock_device(10, "Family Room", "Canary")
         location = mock_location("Home")
 
         data = Mock()
@@ -154,7 +154,7 @@ class TestCanarySensorSetup(unittest.TestCase):
 
     def test_air_quality_sensor_with_none_sensor_value(self):
         """Test air quality sensor."""
-        device = mock_device(10, "Family Room")
+        device = mock_device(10, "Family Room", "Canary")
         location = mock_location("Home")
 
         data = Mock()
@@ -165,3 +165,33 @@ class TestCanarySensorSetup(unittest.TestCase):
 
         self.assertEqual(None, sensor.state)
         self.assertEqual(None, sensor.device_state_attributes)
+
+    def test_battery_sensor(self):
+        """Test battery sensor."""
+        device = mock_device(10, "Family Room", "Canary Flex")
+        location = mock_location("Home")
+
+        data = Mock()
+        data.get_reading.return_value = 50.4567
+
+        sensor = CanarySensor(data, SENSOR_TYPES[4], location, device)
+        sensor.update()
+
+        self.assertEqual("Home Family Room Battery", sensor.name)
+        self.assertEqual("%", sensor.unit_of_measurement)
+        self.assertEqual(50.46, sensor.state)
+
+    def test_wifi_signal_strength_sensor(self):
+        """Test battery sensor."""
+        device = mock_device(10, "Family Room", "Canary Flex")
+        location = mock_location("Home")
+
+        data = Mock()
+        data.get_reading.return_value = -57
+
+        sensor = CanarySensor(data, SENSOR_TYPES[3], location, device)
+        sensor.update()
+
+        self.assertEqual("Home Family Room Wifi Signal Strength", sensor.name)
+        self.assertEqual("dBm", sensor.unit_of_measurement)
+        self.assertEqual(-57, sensor.state)

--- a/tests/components/sensor/test_canary.py
+++ b/tests/components/sensor/test_canary.py
@@ -181,7 +181,7 @@ class TestCanarySensorSetup(unittest.TestCase):
         self.assertEqual("%", sensor.unit_of_measurement)
         self.assertEqual(50.46, sensor.state)
 
-    def test_wifi_signal_strength_sensor(self):
+    def test_wifi_sensor(self):
         """Test battery sensor."""
         device = mock_device(10, "Family Room", "Canary Flex")
         location = mock_location("Home")
@@ -192,6 +192,6 @@ class TestCanarySensorSetup(unittest.TestCase):
         sensor = CanarySensor(data, SENSOR_TYPES[3], location, device)
         sensor.update()
 
-        self.assertEqual("Home Family Room Wifi Signal Strength", sensor.name)
+        self.assertEqual("Home Family Room Wifi", sensor.name)
         self.assertEqual("dBm", sensor.unit_of_measurement)
         self.assertEqual(-57, sensor.state)

--- a/tests/components/sensor/test_canary.py
+++ b/tests/components/sensor/test_canary.py
@@ -69,6 +69,7 @@ class TestCanarySensorSetup(unittest.TestCase):
         self.assertEqual("Home Family Room Temperature", sensor.name)
         self.assertEqual("°C", sensor.unit_of_measurement)
         self.assertEqual(21.12, sensor.state)
+        self.assertEqual("mdi:thermometer", sensor.icon)
 
     def test_temperature_sensor_with_none_sensor_value(self):
         """Test temperature sensor with fahrenheit."""
@@ -97,6 +98,7 @@ class TestCanarySensorSetup(unittest.TestCase):
         self.assertEqual("Home Family Room Humidity", sensor.name)
         self.assertEqual("%", sensor.unit_of_measurement)
         self.assertEqual(50.46, sensor.state)
+        self.assertEqual("mdi:water-percent", sensor.icon)
 
     def test_air_quality_sensor_with_very_abnormal_reading(self):
         """Test air quality sensor."""
@@ -112,6 +114,7 @@ class TestCanarySensorSetup(unittest.TestCase):
         self.assertEqual("Home Family Room Air Quality", sensor.name)
         self.assertEqual(None, sensor.unit_of_measurement)
         self.assertEqual(0.4, sensor.state)
+        self.assertEqual("mdi:weather-windy", sensor.icon)
 
         air_quality = sensor.device_state_attributes[ATTR_AIR_QUALITY]
         self.assertEqual(STATE_AIR_QUALITY_VERY_ABNORMAL, air_quality)
@@ -130,6 +133,7 @@ class TestCanarySensorSetup(unittest.TestCase):
         self.assertEqual("Home Family Room Air Quality", sensor.name)
         self.assertEqual(None, sensor.unit_of_measurement)
         self.assertEqual(0.59, sensor.state)
+        self.assertEqual("mdi:weather-windy", sensor.icon)
 
         air_quality = sensor.device_state_attributes[ATTR_AIR_QUALITY]
         self.assertEqual(STATE_AIR_QUALITY_ABNORMAL, air_quality)
@@ -148,6 +152,7 @@ class TestCanarySensorSetup(unittest.TestCase):
         self.assertEqual("Home Family Room Air Quality", sensor.name)
         self.assertEqual(None, sensor.unit_of_measurement)
         self.assertEqual(1.0, sensor.state)
+        self.assertEqual("mdi:weather-windy", sensor.icon)
 
         air_quality = sensor.device_state_attributes[ATTR_AIR_QUALITY]
         self.assertEqual(STATE_AIR_QUALITY_NORMAL, air_quality)
@@ -172,14 +177,15 @@ class TestCanarySensorSetup(unittest.TestCase):
         location = mock_location("Home")
 
         data = Mock()
-        data.get_reading.return_value = 50.4567
+        data.get_reading.return_value = 70.4567
 
         sensor = CanarySensor(data, SENSOR_TYPES[4], location, device)
         sensor.update()
 
         self.assertEqual("Home Family Room Battery", sensor.name)
         self.assertEqual("%", sensor.unit_of_measurement)
-        self.assertEqual(50.46, sensor.state)
+        self.assertEqual(70.46, sensor.state)
+        self.assertEqual("mdi:battery-70", sensor.icon)
 
     def test_wifi_sensor(self):
         """Test battery sensor."""
@@ -195,3 +201,4 @@ class TestCanarySensorSetup(unittest.TestCase):
         self.assertEqual("Home Family Room Wifi", sensor.name)
         self.assertEqual("dBm", sensor.unit_of_measurement)
         self.assertEqual(-57, sensor.state)
+        self.assertEqual("mdi:wifi", sensor.icon)

--- a/tests/components/test_canary.py
+++ b/tests/components/test_canary.py
@@ -8,12 +8,16 @@ from tests.common import (
     get_test_home_assistant)
 
 
-def mock_device(device_id, name, is_online=True):
+def mock_device(device_id, name, is_online=True, device_type_name=None):
     """Mock Canary Device class."""
     device = MagicMock()
     type(device).device_id = PropertyMock(return_value=device_id)
     type(device).name = PropertyMock(return_value=name)
     type(device).is_online = PropertyMock(return_value=is_online)
+    type(device).device_type = PropertyMock(return_value={
+        "id": 1,
+        "name": device_type_name,
+    })
     return device
 
 


### PR DESCRIPTION
## Description:
If device type is Canary Flex, we'll add wifi and battery sensors. If device type is Canary, we'll add temperature, humidity and air quality sensor

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54