### PR TITLE
Python 3.5 async with

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -311,7 +311,7 @@ class EntityPlatform(object):
                 self.scan_interval)
             return
 
-        with (await self._process_updates):
+        async with self._process_updates:
             tasks = []
             for entity in self.entities.values():
                 if not entity.should_poll:

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -75,7 +75,7 @@ async def async_get_last_state(hass, entity_id: str):
     if _LOCK not in hass.data:
         hass.data[_LOCK] = asyncio.Lock(loop=hass.loop)
 
-    with (await hass.data[_LOCK]):
+    async with hass.data[_LOCK]:
         if DATA_RESTORE_CACHE not in hass.data:
             await hass.async_add_job(
                 _load_restore_cache, hass)


### PR DESCRIPTION
## Description:

In two places we were using `with (await ...):` for [`asyncio.Lock`](https://docs.python.org/3/library/asyncio-sync.html#asyncio.Lock). In [PEP 492](https://www.python.org/dev/peps/pep-0492) we got the [`async with`](https://www.python.org/dev/peps/pep-0492/#asynchronous-context-managers-and-async-with) syntax which is a bit cleaner.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**