### PR TITLE
have climate.ephember support operation_mode

### DIFF
--- a/homeassistant/components/climate/ephember.py
+++ b/homeassistant/components/climate/ephember.py
@@ -113,7 +113,7 @@ class EphEmberThermostat(ClimateDevice):
         return [STATE_AUTO]
 
     def set_operation_mode(self, operation_mode):
-        """Set operation mode"""
+        """Set operation mode."""
         return
 
     @property

--- a/homeassistant/components/climate/ephember.py
+++ b/homeassistant/components/climate/ephember.py
@@ -9,8 +9,8 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.components.climate import (
-    ClimateDevice, PLATFORM_SCHEMA, STATE_HEAT, STATE_AUTO, SUPPORT_AUX_HEAT,
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE)
+    ClimateDevice, PLATFORM_SCHEMA, STATE_HEAT, STATE_IDLE, STATE_AUTO,
+    SUPPORT_AUX_HEAT, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE)
 from homeassistant.const import (
     TEMP_CELSIUS, CONF_USERNAME, CONF_PASSWORD, ATTR_TEMPERATURE)
 import homeassistant.helpers.config_validation as cv
@@ -58,6 +58,13 @@ class EphEmberThermostat(ClimateDevice):
         self._hot_water = zone['isHotWater']
 
     @property
+    def state(self):
+        """Return the current state."""
+        if self._zone['isCurrentlyActive']:
+            return STATE_HEAT
+        return STATE_IDLE
+
+    @property
     def supported_features(self):
         """Return the list of supported features."""
         if self._hot_water:
@@ -98,14 +105,12 @@ class EphEmberThermostat(ClimateDevice):
     @property
     def current_operation(self):
         """Return current operation ie. heat, cool, idle."""
-        if self._zone['isCurrentlyActive']:
-            return STATE_HEAT
         return STATE_AUTO
 
     @property
     def operation_list(self):
         """List of available operation modes."""
-        return [STATE_HEAT, STATE_AUTO]
+        return [STATE_AUTO]
 
     def set_operation_mode(self, operation_mode):
         """Set operation mode"""

--- a/homeassistant/components/climate/ephember.py
+++ b/homeassistant/components/climate/ephember.py
@@ -9,8 +9,8 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.components.climate import (
-    ClimateDevice, PLATFORM_SCHEMA, STATE_HEAT, STATE_IDLE, SUPPORT_AUX_HEAT,
-    SUPPORT_TARGET_TEMPERATURE)
+    ClimateDevice, PLATFORM_SCHEMA, STATE_HEAT, STATE_AUTO, SUPPORT_AUX_HEAT,
+    SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE)
 from homeassistant.const import (
     TEMP_CELSIUS, CONF_USERNAME, CONF_PASSWORD, ATTR_TEMPERATURE)
 import homeassistant.helpers.config_validation as cv
@@ -61,9 +61,11 @@ class EphEmberThermostat(ClimateDevice):
     def supported_features(self):
         """Return the list of supported features."""
         if self._hot_water:
-            return SUPPORT_AUX_HEAT
+            return SUPPORT_AUX_HEAT | SUPPORT_OPERATION_MODE
 
-        return SUPPORT_TARGET_TEMPERATURE | SUPPORT_AUX_HEAT
+        return (SUPPORT_TARGET_TEMPERATURE |
+                SUPPORT_AUX_HEAT |
+                SUPPORT_OPERATION_MODE)
 
     @property
     def name(self):
@@ -98,7 +100,17 @@ class EphEmberThermostat(ClimateDevice):
         """Return current operation ie. heat, cool, idle."""
         if self._zone['isCurrentlyActive']:
             return STATE_HEAT
-        return STATE_IDLE
+        return STATE_AUTO
+
+    @property
+    def operation_list(self):
+        """List of available operation modes."""
+        return [STATE_HEAT, STATE_AUTO]
+
+    def set_operation_mode(self, operation_mode):
+        """Set operation mode.
+        Changing modes currently not supported"""
+        return
 
     @property
     def is_aux_heat_on(self):

--- a/homeassistant/components/climate/ephember.py
+++ b/homeassistant/components/climate/ephember.py
@@ -108,8 +108,7 @@ class EphEmberThermostat(ClimateDevice):
         return [STATE_HEAT, STATE_AUTO]
 
     def set_operation_mode(self, operation_mode):
-        """Set operation mode.
-        Changing modes currently not supported"""
+        """Set operation mode"""
         return
 
     @property


### PR DESCRIPTION
## Description:
Adds operation_mode support to climate.ephember so that it can work with google assistant 
 Not directly related but discussed in #13158

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
