### PR TITLE
Upgrade TwitterAPI to 2.5.0

### DIFF
--- a/homeassistant/components/notify/twitter.py
+++ b/homeassistant/components/notify/twitter.py
@@ -19,7 +19,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_USERNAME
 from homeassistant.helpers.event import async_track_point_in_time
 
-REQUIREMENTS = ['TwitterAPI==2.4.10']
+REQUIREMENTS = ['TwitterAPI==2.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -52,7 +52,7 @@ SoCo==0.14
 TravisPy==0.3.5
 
 # homeassistant.components.notify.twitter
-TwitterAPI==2.4.10
+TwitterAPI==2.5.0
 
 # homeassistant.components.notify.yessssms
 YesssSMS==0.1.1b3


### PR DESCRIPTION
### Description:
- v2.5.0,    15 Mar 2018 -- Renamed get_rest_quota() to get_quota(), renamed TwitterRestPager to TwitterPager.

## Example entry for `configuration.yaml` (if applicable):
``` yaml
notify:
  - platform: twitter
    name: twitter
    consumer_key: !secret twitter_consumer_key
    consumer_secret: !secret twitter_consumer_secret
    access_token: !secret twitter_access_token
    access_token_secret: !secret twitter_token_secret
```

Message sent with "Call Service"

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}! Just an update of TwitterAPI for @home_assistant"
}
```

:smile: -> [:m:](https://twitter.com/fabaff/status/974995797002551296)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
