### PR TITLE
Fix Sonos radio stations with ampersand

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -798,7 +798,9 @@ class SonosDevice(MediaPlayerDevice):
                 src = fav.pop()
                 uri = src.reference.get_uri()
                 if _is_radio_uri(uri):
-                    self.soco.play_uri(uri, title=source)
+                    # SoCo 0.14 fails to XML escape the title parameter
+                    from xml.sax.saxutils import escape
+                    self.soco.play_uri(uri, title=escape(source))
                 else:
                     self.soco.clear_queue()
                     self.soco.add_to_queue(src.reference)


### PR DESCRIPTION
## Description:

This fixes playing of radio stations with an ampersand in their title.

Also submitted upstream in SoCo/SoCO#605 so this can hopefully be removed with SoCo 0.15.

**Related issue (if applicable):** [reported in the forum](https://community.home-assistant.io/t/sonos-does-not-work-properly-since-0-65/46695/28)

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54