### PR TITLE
Bugfix: Zwave set_config_parameter failed when config list contained int

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -472,18 +472,15 @@ def setup(hass, config):
         for value in (
                 node.get_values(class_id=const.COMMAND_CLASS_CONFIGURATION)
                 .values()):
-            _LOGGER.info("value type: %s", value.type)
             if value.index != param:
                 continue
             if value.type in [const.TYPE_LIST, const.TYPE_BOOL]:
-                _LOGGER.info("List or Bool value type")
                 value.data = str(selection)
                 _LOGGER.info("Setting config parameter %s on Node %s "
                              "with list/bool selection %s", param, node_id,
                              str(selection))
                 return
             if value.type == const.TYPE_BUTTON:
-                _LOGGER.info("Button value type")
                 network.manager.pressButton(value.value_id)
                 network.manager.releaseButton(value.value_id)
                 _LOGGER.info("Setting config parameter %s on Node %s "
@@ -491,7 +488,6 @@ def setup(hass, config):
                              selection)
 
                 return
-            _LOGGER.info("Int, Short or Long value type")
             value.data = int(selection)
             _LOGGER.info("Setting config parameter %s on Node %s "
                          "with selection %s", param, node_id,

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -472,14 +472,26 @@ def setup(hass, config):
         for value in (
                 node.get_values(class_id=const.COMMAND_CLASS_CONFIGURATION)
                 .values()):
+            _LOGGER.info("value type: %s", value.type)
             if value.index != param:
                 continue
-            if value.type in [const.TYPE_LIST, const.TYPE_BOOL, const.TYPE_BUTTON]:
+            if value.type in [const.TYPE_LIST, const.TYPE_BOOL]:
+                _LOGGER.info("List or Bool value type")
                 value.data = str(selection)
-                _LOGGER.info("Setting config list parameter %s on Node %s "
-                             "with selection %s", param, node_id,
+                _LOGGER.info("Setting config parameter %s on Node %s "
+                             "with list/bool selection %s", param, node_id,
                              str(selection))
                 return
+            if value.type == const.TYPE_BUTTON:
+                _LOGGER.info("Button value type")
+                network.manager.pressButton(value.value_id)
+                network.manager.releaseButton(value.value_id)
+                _LOGGER.info("Setting config parameter %s on Node %s "
+                             "with button selection %s", param, node_id,
+                             selection)
+
+                return
+            _LOGGER.info("Int, Short or Long value type")
             value.data = int(selection)
             _LOGGER.info("Setting config parameter %s on Node %s "
                          "with selection %s", param, node_id,

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -474,7 +474,7 @@ def setup(hass, config):
                 .values()):
             if value.index != param:
                 continue
-            if value.type in [const.TYPE_LIST, const.TYPE_BOOL]:
+            if value.type in [const.TYPE_LIST, const.TYPE_BOOL, const.TYPE_BUTTON]:
                 value.data = str(selection)
                 _LOGGER.info("Setting config list parameter %s on Node %s "
                              "with selection %s", param, node_id,

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -486,7 +486,6 @@ def setup(hass, config):
                 _LOGGER.info("Setting config parameter %s on Node %s "
                              "with button selection %s", param, node_id,
                              selection)
-
                 return
             value.data = int(selection)
             _LOGGER.info("Setting config parameter %s on Node %s "

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -475,10 +475,10 @@ def setup(hass, config):
             if value.index != param:
                 continue
             if value.type in [const.TYPE_LIST, const.TYPE_BOOL]:
-                value.data = selection
+                value.data = str(selection)
                 _LOGGER.info("Setting config list parameter %s on Node %s "
                              "with selection %s", param, node_id,
-                             selection)
+                             str(selection))
                 return
             value.data = int(selection)
             _LOGGER.info("Setting config parameter %s on Node %s "

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -328,6 +328,7 @@ TYPE_DECIMAL = "Decimal"
 TYPE_INT = "Int"
 TYPE_LIST = "List"
 TYPE_STRING = "String"
+TYPE_BUTTON = "Button"
 
 DISC_COMMAND_CLASS = "command_class"
 DISC_COMPONENT = "component"

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1014,6 +1014,12 @@ class TestZWaveServices(unittest.TestCase):
             type=const.TYPE_LIST,
             data_items=['item1', 'item2', 'item3'],
         )
+        value_list_int = MockValue(
+            index=15,
+            command_class=const.COMMAND_CLASS_CONFIGURATION,
+            type=const.TYPE_LIST,
+            data_items=['1', '2', '3'],
+        )
         value_button = MockValue(
             index=14,
             command_class=const.COMMAND_CLASS_CONFIGURATION,
@@ -1021,7 +1027,8 @@ class TestZWaveServices(unittest.TestCase):
         )
         node = MockNode(node_id=14)
         node.get_values.return_value = {12: value, 13: value_list,
-                                        14: value_button}
+                                        14: value_button,
+                                        15: value_list_int}
         self.zwave_network.nodes = {14: node}
 
         self.hass.services.call('zwave', 'set_config_parameter', {
@@ -1032,6 +1039,15 @@ class TestZWaveServices(unittest.TestCase):
         self.hass.block_till_done()
 
         assert value_list.data == 'item3'
+
+        self.hass.services.call('zwave', 'set_config_parameter', {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 15,
+            const.ATTR_CONFIG_VALUE: '3',
+        })
+        self.hass.block_till_done()
+
+        assert value_list_int.data == '3'
 
         self.hass.services.call('zwave', 'set_config_parameter', {
             const.ATTR_NODE_ID: 14,

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1043,7 +1043,7 @@ class TestZWaveServices(unittest.TestCase):
         self.hass.services.call('zwave', 'set_config_parameter', {
             const.ATTR_NODE_ID: 14,
             const.ATTR_CONFIG_PARAMETER: 15,
-            const.ATTR_CONFIG_VALUE: '3',
+            const.ATTR_CONFIG_VALUE: 3,
         })
         self.hass.block_till_done()
 

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1014,8 +1014,14 @@ class TestZWaveServices(unittest.TestCase):
             type=const.TYPE_LIST,
             data_items=['item1', 'item2', 'item3'],
         )
+        value_button = MockValue(
+            index=14,
+            command_class=const.COMMAND_CLASS_CONFIGURATION,
+            type=const.TYPE_BUTTON,
+        )
         node = MockNode(node_id=14)
-        node.get_values.return_value = {12: value, 13: value_list}
+        node.get_values.return_value = {12: value, 13: value_list,
+                                        14: value_button}
         self.zwave_network.nodes = {14: node}
 
         self.hass.services.call('zwave', 'set_config_parameter', {
@@ -1035,6 +1041,16 @@ class TestZWaveServices(unittest.TestCase):
         self.hass.block_till_done()
 
         assert value.data == 7
+
+        self.hass.services.call('zwave', 'set_config_parameter', {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 14,
+            const.ATTR_CONFIG_VALUE: True,
+        })
+        self.hass.block_till_done()
+
+        assert self.zwave_network.manager.pressButton.called
+        assert self.zwave_network.manager.releaseButton.called
 
         self.hass.services.call('zwave', 'set_config_parameter', {
             const.ATTR_NODE_ID: 14,


### PR DESCRIPTION
## Description:
The `set_config_paramter` failed for devices having an int in the configuration option list.
While debugging this, I also came accross another bug, that Button value types were not set, and generated a traceback. This is also fixed in this PR.

**Related issue (if applicable):** fixes #12419 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
