### PR TITLE
Bugfix: Zwave Print_node to logfile instead of console

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -182,10 +182,9 @@ def nice_print_node(node):
     node_dict['values'] = {value_id: _obj_to_dict(value)
                            for value_id, value in node.values.items()}
 
-    print("\n\n\n")
-    print("FOUND NODE", node.product_name)
-    pprint(node_dict)
-    print("\n\n\n")
+    _LOGGER.info("FOUND NODE %s \n"
+                 "%s \n"
+                 "\n", node.product_name, node_dict)
 
 
 def get_config_value(node, value_index, tries=5):

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -183,8 +183,7 @@ def nice_print_node(node):
                            for value_id, value in node.values.items()}
 
     _LOGGER.info("FOUND NODE %s \n"
-                 "%s \n"
-                 "\n", node.product_name, node_dict)
+                 "%s", node.product_name, node_dict)
 
 
 def get_config_value(node, value_index, tries=5):

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1063,18 +1063,17 @@ class TestZWaveServices(unittest.TestCase):
 
     def test_print_node(self):
         """Test zwave print_node_parameter service."""
-        node1 = MockNode(node_id=14)
-        node2 = MockNode(node_id=15)
-        self.zwave_network.nodes = {14: node1, 15: node2}
+        node = MockNode(node_id=14)
 
-        with patch.object(zwave, '_LOGGER') as mock_logger:
+        self.zwave_network.nodes = {14: node}
+
+        with self.assertLogs(level='INFO') as mock_logger:
             self.hass.services.call('zwave', 'print_node', {
                 const.ATTR_NODE_ID: 14
             })
             self.hass.block_till_done()
 
-            assert mock_logger.info.called
-
+            self.assertIn("FOUND NODE ", mock_logger.output[1])
 
     def test_set_wakeup(self):
         """Test zwave set_wakeup service."""
@@ -1082,7 +1081,7 @@ class TestZWaveServices(unittest.TestCase):
             index=12,
             command_class=const.COMMAND_CLASS_WAKE_UP,
         )
-        node = MockNode(node_id=14)
+        node = MockNode(node_id=14,)
         node.values = {12: value}
         node.get_values.return_value = node.values
         self.zwave_network.nodes = {14: node}

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1062,20 +1062,19 @@ class TestZWaveServices(unittest.TestCase):
             assert mock_logger.info.mock_calls[0][1][3] == 2345
 
     def test_print_node(self):
-        """Test zwave print_config_parameter service."""
+        """Test zwave print_node_parameter service."""
         node1 = MockNode(node_id=14)
         node2 = MockNode(node_id=15)
         self.zwave_network.nodes = {14: node1, 15: node2}
 
-        with patch.object(zwave, 'pprint') as mock_pprint:
+        with patch.object(zwave, '_LOGGER') as mock_logger:
             self.hass.services.call('zwave', 'print_node', {
-                const.ATTR_NODE_ID: 15,
+                const.ATTR_NODE_ID: 14
             })
             self.hass.block_till_done()
 
-            assert mock_pprint.called
-            assert len(mock_pprint.mock_calls) == 1
-            assert mock_pprint.mock_calls[0][1][0]['node_id'] == 15
+            assert mock_logger.info.called
+
 
     def test_set_wakeup(self):
         """Test zwave set_wakeup service."""

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1081,7 +1081,7 @@ class TestZWaveServices(unittest.TestCase):
             index=12,
             command_class=const.COMMAND_CLASS_WAKE_UP,
         )
-        node = MockNode(node_id=14,)
+        node = MockNode(node_id=14)
         node.values = {12: value}
         node.get_values.return_value = node.values
         self.zwave_network.nodes = {14: node}


### PR DESCRIPTION
## Description:
The output of the `print_node` service printed directly to console. In a lot of cases, this is not viewable to the user unless they access systemlogs.
This PR moves the output to homeassistant.log

**Related issue (if applicable):** fixes #10945
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
