### PR TITLE
Support setting the icon when configuring MQTT entity

### DIFF
--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -17,7 +17,7 @@ from homeassistant.components.mqtt import (
     CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS, MqttAvailability)
 from homeassistant.const import (
     CONF_FORCE_UPDATE, CONF_NAME, CONF_VALUE_TEMPLATE, STATE_UNKNOWN,
-    CONF_UNIT_OF_MEASUREMENT)
+    CONF_UNIT_OF_MEASUREMENT, CONF_ICON)
 from homeassistant.helpers.entity import Entity
 import homeassistant.components.mqtt as mqtt
 import homeassistant.helpers.config_validation as cv
@@ -36,6 +36,7 @@ DEPENDENCIES = ['mqtt']
 PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+    vol.Optional(CONF_ICON): cv.icon,
     vol.Optional(CONF_JSON_ATTRS, default=[]): cv.ensure_list_csv,
     vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
     vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
@@ -59,6 +60,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_UNIT_OF_MEASUREMENT),
         config.get(CONF_FORCE_UPDATE),
         config.get(CONF_EXPIRE_AFTER),
+        config.get(CONF_ICON),
         value_template,
         config.get(CONF_JSON_ATTRS),
         config.get(CONF_AVAILABILITY_TOPIC),
@@ -71,7 +73,7 @@ class MqttSensor(MqttAvailability, Entity):
     """Representation of a sensor that can be updated using MQTT."""
 
     def __init__(self, name, state_topic, qos, unit_of_measurement,
-                 force_update, expire_after, value_template,
+                 force_update, expire_after, icon, value_template,
                  json_attributes, availability_topic, payload_available,
                  payload_not_available):
         """Initialize the sensor."""
@@ -85,6 +87,7 @@ class MqttSensor(MqttAvailability, Entity):
         self._force_update = force_update
         self._template = value_template
         self._expire_after = expire_after
+        self._icon = icon
         self._expiration_trigger = None
         self._json_attributes = set(json_attributes)
         self._attributes = None
@@ -170,3 +173,8 @@ class MqttSensor(MqttAvailability, Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return self._attributes
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._icon

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -17,7 +17,7 @@ from homeassistant.components.mqtt import (
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_OFF,
-    CONF_PAYLOAD_ON)
+    CONF_PAYLOAD_ON, CONF_ICON)
 import homeassistant.components.mqtt as mqtt
 import homeassistant.helpers.config_validation as cv
 
@@ -32,6 +32,7 @@ DEFAULT_OPTIMISTIC = False
 
 PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_ICON): cv.icon,
     vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
     vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
     vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
@@ -50,6 +51,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     async_add_devices([MqttSwitch(
         config.get(CONF_NAME),
+        config.get(CONF_ICON),
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_COMMAND_TOPIC),
         config.get(CONF_AVAILABILITY_TOPIC),
@@ -67,7 +69,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class MqttSwitch(MqttAvailability, SwitchDevice):
     """Representation of a switch that can be toggled using MQTT."""
 
-    def __init__(self, name, state_topic, command_topic, availability_topic,
+    def __init__(self, name, icon,
+                 state_topic, command_topic, availability_topic,
                  qos, retain, payload_on, payload_off, optimistic,
                  payload_available, payload_not_available, value_template):
         """Initialize the MQTT switch."""
@@ -75,6 +78,7 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
                          payload_not_available)
         self._state = False
         self._name = name
+        self._icon = icon
         self._state_topic = state_topic
         self._command_topic = command_topic
         self._qos = qos
@@ -129,6 +133,11 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
     def assumed_state(self):
         """Return true if we do optimistic updates."""
         return self._optimistic
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._icon
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):


### PR DESCRIPTION
## Description:
Support configuration of entity icon (e.g. 'mdi:speedometer' ) for sensors and switches when using MQTT discovery

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4969

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
