### PR TITLE
Lagute LW-12 Wifi LED control

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -441,6 +441,7 @@ omit =
     homeassistant/components/light/lifx_legacy.py
     homeassistant/components/light/lifx.py
     homeassistant/components/light/limitlessled.py
+    homeassistant/components/light/lw12wifi.py
     homeassistant/components/light/mystrom.py
     homeassistant/components/light/nanoleaf_aurora.py
     homeassistant/components/light/osramlightify.py

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -125,6 +125,11 @@ class LW12WiFi(Light):
         """Return True if unable to access real state of the entity."""
         return True
 
+    @property
+    def shoud_poll(self) -> bool:
+        """Return False to not poll the state of this entity."""
+        return False
+
     def turn_on(self, **kwargs):
         """Instruct the light to turn on."""
         import lw12

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -25,7 +25,6 @@ light:
     rgb: [255, 255, 255]
 """
 
-import asyncio
 import logging
 import time
 
@@ -154,7 +153,7 @@ class LW12WiFi(Light):
 
     @property
     def assumed_state(self) -> bool:
-        """Return False if unable to access real state of the entity."""
+        """Return True if unable to access real state of the entity."""
         return True
 
     def turn_on(self, **kwargs):

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -71,6 +71,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup LW-12 WiFi LED Controller platform."""
+    import lw12
+
     # Assign configuration variables.
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
@@ -80,32 +82,28 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     effect = config.get(CONF_EFFECT)
     transition = config.get(CONF_TRANSITION)
     # Add devices
-    add_devices([LW12WiFi(name, host, port, rgb, brightness, effect,
+    lw12_light = lw12.LW12Controller(host, port)
+    add_devices([LW12WiFi(name, lw12_light, rgb, brightness, effect,
                           transition)])
 
 
 class LW12WiFi(Light):
     """LW-12 WiFi LED Controller."""
 
-    def __init__(self, name, host, port, rgb_color, brightness, effect,
+    def __init__(self, name, lw12_light, rgb_color, brightness, effect,
                  transition):
         """Initialisation of LW-12 WiFi LED Controller.
 
         Args:
             name: Friendly name for this platform to use.
-            host: Hostname or IP address of the device.
-            port: Port (Default: 5000) to connect to.
+            lw12_light: Instance of the LW12 controller.
             rgb_color: Initial color to set after the light turned on.
             brightness: Brightness of the LEDs to set.
             effect: If not None, turn on the lights with the selected effect.
             transition: Speed of the effects.
         """
-        import lw12
-
-        self._light = lw12.LW12Controller(host, port)
+        self._light = lw12_light
         self._name = name
-        self._host = host
-        self._port = port
         self._rgb_color = rgb_color
         self._brightness = brightness
         self._state = None

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -12,10 +12,6 @@ light:
     port: 5000
     # (Optional) Friendly name
     name: LW-12 FC
-    # (Optional) Effect to use as default (Default=None).
-    # For a full list of supported effects see:
-    # https://github.com/jaypikay/python-lw12/blob/v0.9.2/lw12.py#L54
-    effect: "Gradient Cyan"
 """
 
 import logging

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -16,13 +16,6 @@ light:
     # For a full list of supported effects see:
     # https://github.com/jaypikay/python-lw12/blob/v0.9.2/lw12.py#L54
     effect: "Gradient Cyan"
-    # (Optional) Transition speed for effects (Value: 0-255)
-    transition: 10
-    # (Optional) LED Brightness (Value: 0-255)
-    brightness: 10
-    # (Optional) RGB value array as standard color to set.
-    # This option is is ignored when effect is set.
-    rgb: [255, 255, 255]
 """
 
 import logging
@@ -36,7 +29,7 @@ from homeassistant.components.light import (
     SUPPORT_COLOR, SUPPORT_TRANSITION
 )
 from homeassistant.const import (
-    CONF_BRIGHTNESS, CONF_EFFECT, CONF_HOST, CONF_NAME, CONF_PORT, CONF_RGB
+    CONF_HOST, CONF_NAME, CONF_PORT
 )
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
@@ -46,25 +39,14 @@ REQUIREMENTS = ['lw12==0.9.2']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_TRANSITION = 'transition'
 
 DEFAULT_NAME = 'LW-12 FC'
 DEFAULT_PORT = 5000
-DEFAULT_RGB = [255, 255, 255]
-DEFAULT_BRIGHTNESS = 255
-DEFAULT_EFFECT = None
-DEFAULT_TRANSITION = 128
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_RGB, default=DEFAULT_RGB):
-        vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte))),
-    vol.Optional(CONF_BRIGHTNESS, default=DEFAULT_BRIGHTNESS):
-        vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_TRANSITION, default=DEFAULT_TRANSITION):
-        vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
 })
 
 
@@ -76,38 +58,24 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
-    rgb = config.get(CONF_RGB)
-    brightness = config.get(CONF_BRIGHTNESS)
-    effect = config.get(CONF_EFFECT)
-    transition = config.get(CONF_TRANSITION)
     # Add devices
     lw12_light = lw12.LW12Controller(host, port)
-    add_devices([LW12WiFi(name, lw12_light, rgb, brightness, effect,
-                          transition)])
+    add_devices([LW12WiFi(name, lw12_light)])
 
 
 class LW12WiFi(Light):
     """LW-12 WiFi LED Controller."""
 
-    def __init__(self, name, lw12_light, rgb_color, brightness, effect,
-                 transition):
+    def __init__(self, name, lw12_light):
         """Initialisation of LW-12 WiFi LED Controller.
 
         Args:
             name: Friendly name for this platform to use.
             lw12_light: Instance of the LW12 controller.
-            rgb_color: Initial color to set after the light turned on.
-            brightness: Brightness of the LEDs to set.
-            effect: If not None, turn on the lights with the selected effect.
-            transition: Speed of the effects.
         """
         self._light = lw12_light
         self._name = name
-        self._rgb_color = rgb_color
-        self._brightness = brightness
         self._state = None
-        self._effect = effect
-        self._transition_speed = transition
         # Setup feature list
         self._supported_features = SUPPORT_BRIGHTNESS | SUPPORT_EFFECT \
             | SUPPORT_COLOR | SUPPORT_TRANSITION

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -26,6 +26,7 @@ from homeassistant.components.light import (
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PORT
 )
+from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
@@ -138,8 +139,8 @@ class LW12WiFi(Light):
             if self._effect.replace(' ', '_').upper() in lw12.LW12_EFFECT:
                 kwargs['effect'] = self._effect
             else:
-                # Unknown effect: changing to no selected effect.
                 self._effect = None
+                raise HomeAssistantError("Unknown effect selected.")
         if ATTR_HS_COLOR in kwargs:
             self._rgb_color = color_util.color_hs_to_RGB(
                 *kwargs.get(ATTR_HS_COLOR))

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -1,17 +1,8 @@
 """
 Support for Lagute LW-12 WiFi LED Controller.
 
-Configuration example:
-
-light:
-  - platform: lw12wifi
-    # Host name or IP of LW-12 LED stripe to control
-    host: 192.168.0.1
-    # (Optional) Some firmware versions of the LW-12 controller listen
-    # on different ports.
-    port: 5000
-    # (Optional) Friendly name
-    name: LW-12 FC
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.lw12wifi/
 """
 
 import logging

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -26,7 +26,6 @@ from homeassistant.components.light import (
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PORT
 )
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
@@ -148,12 +147,14 @@ class LW12WiFi(Light):
         if ATTR_EFFECT in kwargs:
             self._effect = kwargs[ATTR_EFFECT].replace(' ', '_').upper()
             # Check if a known and supported effect was selected.
-            if self._effect not in [eff.name for eff in lw12.LW12_EFFECT]:
+            if self._effect in [eff.name for eff in lw12.LW12_EFFECT]:
+                # Selected effect is supported and will be applied.
+                self._light.set_effect(lw12.LW12_EFFECT[self._effect])
+            else:
                 # Unknown effect was set, recover by disabling the effect
-                # mode and raise an error.
+                # mode and log an error.
+                _LOGGER.error("Unknown effect selected: %s", self._effect)
                 self._effect = None
-                raise HomeAssistantError("Unknown effect selected.")
-            self._light.set_effect(lw12.LW12_EFFECT[self._effect])
         if ATTR_TRANSITION in kwargs:
             transition_speed = int(kwargs[ATTR_TRANSITION])
             self._light.set_light_option(lw12.LW12_LIGHT.FLASH,

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -76,6 +76,9 @@ class LW12WiFi(Light):
         self._light = lw12_light
         self._name = name
         self._state = None
+        self._effect = None
+        self._rgb_color = [255, 255, 255]
+        self._brightness = 255
         # Setup feature list
         self._supported_features = SUPPORT_BRIGHTNESS | SUPPORT_EFFECT \
             | SUPPORT_COLOR | SUPPORT_TRANSITION
@@ -150,15 +153,10 @@ class LW12WiFi(Light):
         if ATTR_EFFECT in kwargs:
             self._effect = kwargs.get(ATTR_EFFECT).replace(' ', '_').upper()
             self._light.set_effect(lw12.LW12_EFFECT[self._effect])
-            # Sending UDP messages too quickly after the previous message
-            # the new command is ignored. Adding a short wait time.
-            time.sleep(.25)
-            self._light.set_light_option(lw12.LW12_LIGHT.FLASH,
-                                         self._transition_speed)
         if ATTR_TRANSITION in kwargs:
-            self._transition_speed = int(kwargs[ATTR_TRANSITION])
+            transition_speed = int(kwargs[ATTR_TRANSITION])
             self._light.set_light_option(lw12.LW12_LIGHT.FLASH,
-                                         self._transition_speed)
+                                         transition_speed)
         self._state = True
 
     def turn_off(self, **kwargs):

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -124,14 +124,6 @@ class LW12WiFi(Light):
         return self._brightness
 
     @property
-    def rgb_color(self):
-        """Read back the color of the light.
-
-        Returns [r, g, b] list with values in range of 0-255.
-        """
-        return self._rgb_color
-
-    @property
     def hs_color(self):
         """Read back the hue-saturation of the light."""
         return color_util.color_RGB_to_hs(*self._rgb_color)

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -1,0 +1,187 @@
+"""
+Support for Lagute LW-12 WiFi LED Controller.
+"""
+
+import asyncio
+from enum import Enum
+import logging
+import socket
+import time
+
+import voluptuous as vol
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, ATTR_EFFECT, ATTR_RGB_COLOR, ATTR_TRANSITION, DOMAIN,
+    Light, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
+    SUPPORT_RGB_COLOR, SUPPORT_TRANSITION
+)
+from homeassistant.const import (
+    CONF_BRIGHTNESS, CONF_EFFECT, CONF_HOST, CONF_NAME, CONF_PORT, CONF_RGB
+)
+import homeassistant.helpers.config_validation as cv
+
+
+REQUIREMENTS = ['lw12==0.9.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_TRANSITION = 'transition'
+
+DEFAULT_NAME = 'LW-12 FC'
+DEFAULT_PORT = 5000
+DEFAULT_RGB = [255, 255, 255]
+DEFAULT_BRIGHTNESS = 255
+DEFAULT_EFFECT = None
+DEFAULT_TRANSITION = 128
+
+DOMAIN = 'lw12wifi'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_RGB, default=DEFAULT_RGB):
+    vol.All(list, vol.Length(min=3, max=3),
+            [vol.All(vol.Coerce(int), vol.Range(min=0, max=255))]),
+    vol.Optional(CONF_BRIGHTNESS, default=DEFAULT_BRIGHTNESS):
+    vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_TRANSITION, default=DEFAULT_TRANSITION):
+    vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup LW-12 WiFi LED Controller platform."""
+    import lw12
+
+    # Assign configuration variables.
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    rgb = config.get(CONF_RGB)
+    brightness = config.get(CONF_BRIGHTNESS)
+    effect = config.get(CONF_EFFECT)
+    transition = config.get(CONF_TRANSITION)
+    # Add devices
+    add_devices([LW12WiFi(name, host, port, rgb, brightness, effect,
+                          transition)])
+
+
+class LW12WiFi(Light):
+    """LW-12 WiFi LED Controller."""
+
+    def __init__(self, name, host, port, rgb_color, brightness, effect,
+                 transition):
+        import lw12
+
+        self._light = lw12.LW12Controller(host, port)
+        self._name = name
+        self._host = host
+        self._port = port
+        self._rgb_color = rgb_color
+        self._brightness = brightness
+        self._state = None
+        self._effect = effect
+        self._transition_speed = transition
+        # Setup feature list
+        self._supported_features = SUPPORT_BRIGHTNESS
+        self._supported_features |= SUPPORT_EFFECT
+        self._supported_features |= SUPPORT_FLASH
+        self._supported_features |= SUPPORT_RGB_COLOR
+        self._supported_features |= SUPPORT_TRANSITION
+
+    @property
+    def name(self):
+        """Return the display name of the controlled light."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """Return the brightness of the light."""
+        return self._brightness
+
+    @property
+    def rgb_color(self):
+        """Read back the color of the light.
+
+        Returns [r, g, b] list with values in range of 0-255.
+        """
+        return self._rgb_color
+
+    @property
+    def effect(self):
+        """Return current light effect."""
+        try:
+            return self._effect.replace('_', ' ').title()
+        except AttributeError:
+            return None
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._state
+
+    @property
+    def supported_features(self):
+        return self._supported_features
+
+    @property
+    def effect_list(self):
+        """Return a list of available effects.
+
+        Use the Enum element name for display.
+        """
+        import lw12
+        return [effect.name.replace('_', ' ').title()
+                for effect in lw12.LW12_EFFECT]
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return False if unable to access real state of the entity."""
+        return True
+
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """Instruct the light to turn on."""
+        _LOGGER.debug('async_turn_on: {}'.format(kwargs))
+        import lw12
+        self._light.light_on()
+        if self._effect:
+            _LOGGER.debug('Resume effect: {}'.format(self._effect))
+            # Effect is set as default: enable effect.
+            kwargs['effect'] = self._effect
+
+        if ATTR_RGB_COLOR in kwargs:
+            rgb = kwargs.get(ATTR_RGB_COLOR)
+            self._rgb_color = rgb
+            self._light.set_color(rgb[0], rgb[1], rgb[2])
+            # Sending UDP messages to quickly after the previous message
+            # the new command is ignored. Adding a short wait time.
+            time.sleep(.25)
+            brightness = int(self._brightness / 255 * 100)
+            self._light.set_light_option(lw12.LW12_LIGHT.BRIGHTNESS,
+                                         brightness)
+            self._effect = None
+        if ATTR_BRIGHTNESS in kwargs:
+            self._brightness = kwargs.get(ATTR_BRIGHTNESS)
+            brightness = int(self._brightness / 255 * 100)
+            self._light.set_light_option(lw12.LW12_LIGHT.BRIGHTNESS,
+                                         brightness)
+        if ATTR_EFFECT in kwargs:
+            self._effect = kwargs.get(ATTR_EFFECT).replace(' ', '_').upper()
+            self._light.set_effect(lw12.LW12_EFFECT[self._effect])
+            # Sending UDP messages to quickly after the previous message
+            # the new command is ignored. Adding a short wait time.
+            time.sleep(.25)
+            self._light.set_light_option(lw12.LW12_LIGHT.FLASH,
+                                         self._transition_speed)
+        if ATTR_TRANSITION in kwargs:
+            self._transition_speed = int(kwargs[ATTR_TRANSITION])
+            self._light.set_light_option(lw12.LW12_LIGHT.FLASH,
+                                         self._transition_speed)
+        self._state = True
+
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
+        self._light.light_off()
+        self._state = False

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -135,12 +135,6 @@ class LW12WiFi(Light):
         """Instruct the light to turn on."""
         import lw12
         self._light.light_on()
-        if self._effect is not None:
-            if self._effect.replace(' ', '_').upper() in lw12.LW12_EFFECT:
-                kwargs['effect'] = self._effect
-            else:
-                self._effect = None
-                raise HomeAssistantError("Unknown effect selected.")
         if ATTR_HS_COLOR in kwargs:
             self._rgb_color = color_util.color_hs_to_RGB(
                 *kwargs.get(ATTR_HS_COLOR))
@@ -153,6 +147,12 @@ class LW12WiFi(Light):
                                          brightness)
         if ATTR_EFFECT in kwargs:
             self._effect = kwargs.get(ATTR_EFFECT).replace(' ', '_').upper()
+            # Check if a known and supported effect was selected.
+            if self._effect not in [eff.name for eff in lw12.LW12_EFFECT]:
+                # Unknown effect was set, recover by disabling the effect
+                # mode and raise an error.
+                self._effect = None
+                raise HomeAssistantError("Unknown effect selected.")
             self._light.set_effect(lw12.LW12_EFFECT[self._effect])
         if ATTR_TRANSITION in kwargs:
             transition_speed = int(kwargs[ATTR_TRANSITION])

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -90,6 +90,17 @@ class LW12WiFi(Light):
 
     def __init__(self, name, host, port, rgb_color, brightness, effect,
                  transition):
+        """Initialisation of LW-12 WiFi LED Controller.
+
+        Args:
+            name: Friendly name for this platform to use.
+            host: Hostname or IP address of the device.
+            port: Port (Default: 5000) to connect to.
+            rgb_color: Initial color to set after the light turned on.
+            brightness: Brightness of the LEDs to set.
+            effect: If not None, turn on the lights with the selected effect.
+            transition: Speed of the effects.
+        """
         import lw12
 
         self._light = lw12.LW12Controller(host, port)
@@ -139,6 +150,7 @@ class LW12WiFi(Light):
 
     @property
     def supported_features(self):
+        """Return a list of supported features."""
         return self._supported_features
 
     @property
@@ -198,5 +210,6 @@ class LW12WiFi(Light):
         self._state = True
 
     def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
         self._light.light_off()
         self._state = False

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -137,7 +137,7 @@ class LW12WiFi(Light):
         self._light.light_on()
         if ATTR_HS_COLOR in kwargs:
             self._rgb_color = color_util.color_hs_to_RGB(
-                *kwargs.get(ATTR_HS_COLOR))
+                *kwargs[ATTR_HS_COLOR])
             self._light.set_color(*self._rgb_color)
             self._effect = None
         if ATTR_BRIGHTNESS in kwargs:
@@ -146,7 +146,7 @@ class LW12WiFi(Light):
             self._light.set_light_option(lw12.LW12_LIGHT.BRIGHTNESS,
                                          brightness)
         if ATTR_EFFECT in kwargs:
-            self._effect = kwargs.get(ATTR_EFFECT).replace(' ', '_').upper()
+            self._effect = kwargs[ATTR_EFFECT].replace(' ', '_').upper()
             # Check if a known and supported effect was selected.
             if self._effect not in [eff.name for eff in lw12.LW12_EFFECT]:
                 # Unknown effect was set, recover by disabling the effect

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -1,5 +1,28 @@
 """
 Support for Lagute LW-12 WiFi LED Controller.
+
+Configuration example:
+
+light:
+  - platform: lw12wifi
+    # Host name or IP of LW-12 LED stripe to control
+    host: 192.168.0.1
+    # (Optional) Some firmware versions of the LW-12 controller listen
+    # on different ports.
+    port: 5000
+    # (Optional) Friendly name
+    name: LW-12 FC
+    # (Optional) Effect to use as default (Default=None).
+    # For a full list of supported effects see:
+    # https://github.com/jaypikay/python-lw12/blob/v0.9.2/lw12.py#L54
+    effect: "Gradient Cyan"
+    # (Optional) Transition speed for effects (Value: 0-255)
+    transition: 10
+    # (Optional) LED Brightness (Value: 0-255)
+    brightness: 10
+    # (Optional) RGB value array as standard color to set.
+    # This option is is ignored when effect is set.
+    rgb: [255, 255, 255]
 """
 
 import asyncio

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -26,15 +26,13 @@ light:
 """
 
 import asyncio
-from enum import Enum
 import logging
-import socket
 import time
 
 import voluptuous as vol
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_EFFECT, ATTR_RGB_COLOR, ATTR_TRANSITION, DOMAIN,
+    ATTR_BRIGHTNESS, ATTR_EFFECT, ATTR_RGB_COLOR, ATTR_TRANSITION,
     Light, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
     SUPPORT_RGB_COLOR, SUPPORT_TRANSITION
 )
@@ -63,20 +61,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_RGB, default=DEFAULT_RGB):
-    vol.All(list, vol.Length(min=3, max=3),
-            [vol.All(vol.Coerce(int), vol.Range(min=0, max=255))]),
+        vol.All(list, vol.Length(min=3, max=3),
+                [vol.All(vol.Coerce(int), vol.Range(min=0, max=255))]),
     vol.Optional(CONF_BRIGHTNESS, default=DEFAULT_BRIGHTNESS):
-    vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+        vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_TRANSITION, default=DEFAULT_TRANSITION):
-    vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+        vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
 })
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup LW-12 WiFi LED Controller platform."""
-    import lw12
-
     # Assign configuration variables.
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
@@ -109,7 +105,6 @@ class LW12WiFi(Light):
         # Setup feature list
         self._supported_features = SUPPORT_BRIGHTNESS
         self._supported_features |= SUPPORT_EFFECT
-        self._supported_features |= SUPPORT_FLASH
         self._supported_features |= SUPPORT_RGB_COLOR
         self._supported_features |= SUPPORT_TRANSITION
 
@@ -134,10 +129,9 @@ class LW12WiFi(Light):
     @property
     def effect(self):
         """Return current light effect."""
-        try:
-            return self._effect.replace('_', ' ').title()
-        except AttributeError:
+        if self._effect is None:
             return None
+        return self._effect.replace('_', ' ').title()
 
     @property
     def is_on(self):
@@ -163,14 +157,11 @@ class LW12WiFi(Light):
         """Return False if unable to access real state of the entity."""
         return True
 
-    @asyncio.coroutine
-    def async_turn_on(self, **kwargs):
+    def turn_on(self, **kwargs):
         """Instruct the light to turn on."""
-        _LOGGER.debug('async_turn_on: {}'.format(kwargs))
         import lw12
         self._light.light_on()
-        if self._effect:
-            _LOGGER.debug('Resume effect: {}'.format(self._effect))
+        if self._effect is not None:
             # Effect is set as default: enable effect.
             kwargs['effect'] = self._effect
 
@@ -204,7 +195,6 @@ class LW12WiFi(Light):
                                          self._transition_speed)
         self._state = True
 
-    @asyncio.coroutine
-    def async_turn_off(self, **kwargs):
+    def turn_off(self, **kwargs):
         self._light.light_off()
         self._state = False

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -182,7 +182,7 @@ class LW12WiFi(Light):
             if self._effect.replace(' ', '_').upper() in lw12.LW12_EFFECT:
                 kwargs['effect'] = self._effect
             else:
-                # Unknown effect, changing to no selected effect.
+                # Unknown effect: changing to no selected effect.
                 self._effect = None
         if ATTR_HS_COLOR in kwargs:
             self._rgb_color = color_util.color_hs_to_RGB(

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -15,7 +15,6 @@ light:
 """
 
 import logging
-import time
 
 import voluptuous as vol
 

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -183,7 +183,7 @@ class LW12WiFi(Light):
         if ATTR_EFFECT in kwargs:
             self._effect = kwargs.get(ATTR_EFFECT).replace(' ', '_').upper()
             self._light.set_effect(lw12.LW12_EFFECT[self._effect])
-            # Sending UDP messages to quickly after the previous message
+            # Sending UDP messages too quickly after the previous message
             # the new command is ignored. Adding a short wait time.
             time.sleep(.25)
             self._light.set_light_option(lw12.LW12_LIGHT.FLASH,

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -110,10 +110,8 @@ class LW12WiFi(Light):
         self._effect = effect
         self._transition_speed = transition
         # Setup feature list
-        self._supported_features = SUPPORT_BRIGHTNESS
-        self._supported_features |= SUPPORT_EFFECT
-        self._supported_features |= SUPPORT_COLOR
-        self._supported_features |= SUPPORT_TRANSITION
+        self._supported_features = SUPPORT_BRIGHTNESS | SUPPORT_EFFECT \
+            | SUPPORT_COLOR | SUPPORT_TRANSITION
 
     @property
     def name(self):

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -55,8 +55,6 @@ DEFAULT_BRIGHTNESS = 255
 DEFAULT_EFFECT = None
 DEFAULT_TRANSITION = 128
 
-DOMAIN = 'lw12wifi'
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -161,8 +161,11 @@ class LW12WiFi(Light):
         import lw12
         self._light.light_on()
         if self._effect is not None:
-            # Effect is set as default: enable effect.
-            kwargs['effect'] = self._effect
+            if self._effect.replace(' ', '_').upper() in lw12.LW12_EFFECT:
+                kwargs['effect'] = self._effect
+            else:
+                # Unknown effect, changing to no selected effect.
+                self._effect = None
 
         if ATTR_RGB_COLOR in kwargs:
             rgb = kwargs.get(ATTR_RGB_COLOR)

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -59,8 +59,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_RGB, default=DEFAULT_RGB):
-        vol.All(list, vol.Length(min=3, max=3),
-                [vol.All(vol.Coerce(int), vol.Range(min=0, max=255))]),
+        vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte))),
     vol.Optional(CONF_BRIGHTNESS, default=DEFAULT_BRIGHTNESS):
         vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -508,6 +508,9 @@ locationsharinglib==1.2.2
 # homeassistant.components.sensor.luftdaten
 luftdaten==0.1.3
 
+# homeassistant.components.light.lw12wifi
+lw12==0.9.2
+
 # homeassistant.components.sensor.lyft
 lyft_rides==0.2
 


### PR DESCRIPTION
## Description:
New platform added to support the Lagute LW-12 WiFi LED Controller. The controller is stateless and communicates via UDP. To handle the controller itself the python module [python-lw12](https://github.com/jaypikay/python-lw12) is required and automatically installed by the `REQUIREMENTS`.

The platform supports 29 effects, brightness, rgb color and transition speed settings.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5264

## Example entry for `configuration.yaml`:
```yaml
light:
  - platform: lw12wifi
    # Host name or IP of LW-12 LED stripe to control
    host: 192.168.0.1
    # (Optional) Some firmware versions of the LW-12 controller listen
    # on different ports.
    port: 5000
    # (Optional) Friendly name
    name: LW-12 FC
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable.
  - [x] New dependencies are only imported inside functions that use them.
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
