### PR TITLE
Fix pytest 3.4.0 cache gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ Icon
 *.iml
 
 # pytest
-.cache
+.pytest_cache
 
 # GITHUB Proposed Python stuff:
 *.py[cod]


### PR DESCRIPTION
## Description:

In #13169 pytest was upgraded to 3.4.2, but with that upgrade pytest also changed the pytest cache directory to `.pytest_cache`: https://github.com/pytest-dev/pytest/blob/master/CHANGELOG.rst

> The default cache directory has been renamed from .cache to .pytest_cache after community feedback that the name .cache did not make it clear that it was used by pytest.

Missed that when scrolling through the logs, sorry about that!

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**