### PR TITLE
Fixing Egardia 'home armed' state not shown correctly.

### DIFF
--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -12,21 +12,26 @@ import requests
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.const import (
     STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_ARMED_AWAY, STATE_ALARM_TRIGGERED)
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_TRIGGERED,
+    STATE_ALARM_ARMED_NIGHT)
 from homeassistant.components.egardia import (
     EGARDIA_DEVICE, EGARDIA_SERVER,
     REPORT_SERVER_CODES_IGNORE, CONF_REPORT_SERVER_CODES,
     CONF_REPORT_SERVER_ENABLED, CONF_REPORT_SERVER_PORT
     )
-REQUIREMENTS = ['pythonegardia==1.0.38']
+REQUIREMENTS = ['pythonegardia==1.0.39']
 
 _LOGGER = logging.getLogger(__name__)
 
+# Some states are mapped twice since different Egardia
+# versions return different state names.
 STATES = {
     'ARM': STATE_ALARM_ARMED_AWAY,
     'DAY HOME': STATE_ALARM_ARMED_HOME,
     'DISARM': STATE_ALARM_DISARMED,
     'ARMHOME': STATE_ALARM_ARMED_HOME,
+    'HOME': STATE_ALARM_ARMED_HOME,
+    'NIGHT HOME': STATE_ALARM_ARMED_NIGHT,
     'TRIGGERED': STATE_ALARM_TRIGGERED
 }
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1001,7 +1001,7 @@ python_openzwave==0.4.3
 
 # homeassistant.components.egardia
 # homeassistant.components.alarm_control_panel.egardia
-pythonegardia==1.0.38
+pythonegardia==1.0.39
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -18,17 +18,11 @@ attrs==17.4.0
 # homeassistant.components.bbb_gpio
 # Adafruit_BBIO==1.0.0
 
-# homeassistant.components.doorbird
-DoorBirdPy==0.1.2
-
-# homeassistant.components.homekit
-HAP-python==1.1.7
-
 # homeassistant.components.isy994
-PyISY==1.1.0
+PyISY==1.0.7
 
 # homeassistant.components.notify.html5
-PyJWT==1.6.0
+PyJWT==1.5.0
 
 # homeassistant.components.sensor.mvglive
 PyMVGLive==1.1.4
@@ -36,87 +30,55 @@ PyMVGLive==1.1.4
 # homeassistant.components.arduino
 PyMata==2.14
 
-# homeassistant.components.xiaomi_aqara
-PyXiaomiGateway==0.8.3
-
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.1
 
-# homeassistant.components.remember_the_milk
-RtmAPI==0.7.0
-
 # homeassistant.components.media_player.sonos
-SoCo==0.14
-
-# homeassistant.components.sensor.travisci
-TravisPy==0.3.5
+SoCo==0.12
 
 # homeassistant.components.notify.twitter
-TwitterAPI==2.5.0
-
-# homeassistant.components.notify.yessssms
-YesssSMS==0.1.1b3
-
-# homeassistant.components.abode
-abodepy==0.12.2
-
-# homeassistant.components.media_player.frontier_silicon
-afsapi==0.0.3
+TwitterAPI==2.4.5
 
 # homeassistant.components.device_tracker.automatic
-aioautomatic==0.6.5
+aioautomatic==0.4.0
 
 # homeassistant.components.sensor.dnsip
 aiodns==1.1.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
-aiohttp_cors==0.7.0
-
-# homeassistant.components.hue
-aiohue==1.2.0
-
-# homeassistant.components.sensor.imap
-aioimaplib==0.7.13
+aiohttp_cors==0.5.3
 
 # homeassistant.components.light.lifx
-aiolifx==0.6.1
+aiolifx==0.5.0
 
 # homeassistant.components.light.lifx
-aiolifx_effects==0.1.2
+aiolifx_effects==0.1.0
 
 # homeassistant.components.scene.hunterdouglas_powerview
-aiopvapi==1.5.4
+aiopvapi==1.4
 
 # homeassistant.components.alarmdecoder
-alarmdecoder==1.13.2
+alarmdecoder==0.12.1.0
 
-# homeassistant.components.sensor.alpha_vantage
-alpha_vantage==1.9.0
-
-# homeassistant.components.amcrest
-amcrest==1.2.1
+# homeassistant.components.camera.amcrest
+# homeassistant.components.sensor.amcrest
+amcrest==1.2.0
 
 # homeassistant.components.media_player.anthemav
 anthemav==1.1.8
 
 # homeassistant.components.apcupsd
-apcaccess==0.0.13
+apcaccess==0.0.10
 
 # homeassistant.components.notify.apns
-apns2==0.3.0
-
-# homeassistant.components.asterisk_mbox
-asterisk_mbox==0.4.0
+apns2==0.1.1
 
 # homeassistant.components.light.avion
-# avion==0.7
+# avion==0.6
 
 # homeassistant.components.axis
-axis==14
-
-# homeassistant.components.tts.baidu
-baidu-aip==1.6.6
+axis==8
 
 # homeassistant.components.sensor.modem_callerid
 basicmodem==0.7
@@ -125,19 +87,14 @@ basicmodem==0.7
 batinfo==0.4.2
 
 # homeassistant.components.sensor.eddystone_temperature
-# beacontools[scan]==1.2.1
+# beacontools[scan]==1.0.1
 
 # homeassistant.components.device_tracker.linksys_ap
-# homeassistant.components.sensor.geizhals
 # homeassistant.components.sensor.scrape
-# homeassistant.components.sensor.sytadin
 beautifulsoup4==4.6.0
 
 # homeassistant.components.zha
-bellows==0.5.1
-
-# homeassistant.components.bmw_connected_drive
-bimmer_connected==0.4.1
+bellows==0.2.7
 
 # homeassistant.components.blink
 blinkpy==0.6.0
@@ -149,48 +106,33 @@ blinkstick==1.1.8
 # blinkt==0.1.0
 
 # homeassistant.components.sensor.bitcoin
-blockchain==1.4.0
-
-# homeassistant.components.light.decora
-# bluepy==1.1.4
-
-# homeassistant.components.sensor.bme680
-# bme680==1.0.4
+blockchain==1.3.3
 
 # homeassistant.components.notify.aws_lambda
 # homeassistant.components.notify.aws_sns
 # homeassistant.components.notify.aws_sqs
 # homeassistant.components.tts.amazon_polly
-boto3==1.4.7
+boto3==1.4.3
 
-# homeassistant.scripts.credstash
-botocore==1.7.34
+# homeassistant.components.sensor.broadlink
+# homeassistant.components.switch.broadlink
+broadlink==0.3
 
 # homeassistant.components.sensor.buienradar
-# homeassistant.components.weather.buienradar
-buienradar==0.91
-
-# homeassistant.components.calendar.caldav
-caldav==0.5.0
+buienradar==0.6
 
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2
 
-# homeassistant.components.coinbase
-coinbase==2.1.0
-
 # homeassistant.components.sensor.coinmarketcap
-coinmarketcap==4.2.1
+coinmarketcap==3.0.1
 
 # homeassistant.scripts.check_config
-colorlog==3.1.2
+colorlog>2.1,<3
 
 # homeassistant.components.alarm_control_panel.concord232
 # homeassistant.components.binary_sensor.concord232
-concord232==0.15
-
-# homeassistant.scripts.credstash
-# credstash==1.14.0
+concord232==0.14
 
 # homeassistant.components.sensor.crimereports
 crimereports==1.0.0
@@ -205,30 +147,17 @@ datapoint==0.4.3
 # homeassistant.components.light.decora
 # decora==0.6
 
-# homeassistant.components.light.decora_wifi
-# decora_wifi==1.3
-
-# homeassistant.components.device_tracker.upc_connect
-defusedxml==0.5.0
-
-# homeassistant.components.sensor.deluge
-# homeassistant.components.switch.deluge
-deluge-client==1.0.5
-
 # homeassistant.components.media_player.denonavr
-denonavr==0.6.1
+denonavr==0.5.1
 
 # homeassistant.components.media_player.directv
-directpy==0.2
-
-# homeassistant.components.sensor.discogs
-discogs_client==2.2.1
+directpy==0.1
 
 # homeassistant.components.notify.discord
-discord.py==0.16.12
+discord.py==0.16.0
 
 # homeassistant.components.updater
-distro==1.2.0
+distro==1.0.4
 
 # homeassistant.components.switch.digitalloggers
 dlipower==0.7.165
@@ -240,7 +169,7 @@ dnspython3==1.15.0
 dovado==0.4.1
 
 # homeassistant.components.sensor.dsmr
-dsmr_parser==0.11
+dsmr_parser==0.8
 
 # homeassistant.components.dweet
 # homeassistant.components.sensor.dweet
@@ -250,13 +179,10 @@ dweepy==0.3.0
 eliqonline==1.0.13
 
 # homeassistant.components.enocean
-enocean==0.40
+enocean==0.31
 
 # homeassistant.components.sensor.envirophat
 # envirophat==0.0.6
-
-# homeassistant.components.sensor.season
-ephem==3.7.6.0
 
 # homeassistant.components.keyboard_remote
 # evdev==0.6.1
@@ -266,40 +192,42 @@ evohomeclient==0.2.5
 
 # homeassistant.components.image_processing.dlib_face_detect
 # homeassistant.components.image_processing.dlib_face_identify
-# face_recognition==1.0.0
+# face_recognition==0.1.14
 
 # homeassistant.components.sensor.fastdotcom
-fastdotcom==0.0.3
+fastdotcom==0.0.1
 
 # homeassistant.components.sensor.fedex
-fedexdeliverymanager==1.0.6
+fedexdeliverymanager==1.0.3
 
 # homeassistant.components.feedreader
-# homeassistant.components.sensor.geo_rss_events
 feedparser==5.2.1
 
 # homeassistant.components.sensor.fitbit
-fitbit==0.3.0
+fitbit==0.2.3
 
 # homeassistant.components.sensor.fixer
 fixerio==0.1.1
 
 # homeassistant.components.light.flux_led
-flux_led==0.21
-
-# homeassistant.components.sensor.foobot
-foobot_async==0.3.0
+flux_led==0.19
 
 # homeassistant.components.notify.free_mobile
-freesms==0.1.2
+freesms==0.1.1
 
 # homeassistant.components.device_tracker.fritz
 # homeassistant.components.sensor.fritzbox_callmonitor
 # homeassistant.components.sensor.fritzbox_netmonitor
-# fritzconnection==0.6.5
+# fritzconnection==0.6.3
 
 # homeassistant.components.switch.fritzdect
-fritzhome==1.0.4
+fritzhome==1.0.2
+
+# homeassistant.components.media_player.frontier_silicon
+fsapi==0.0.7
+
+# homeassistant.components.conversation
+fuzzywuzzy==0.15.0
 
 # homeassistant.components.tts.google
 gTTS-token==1.1.1
@@ -307,41 +235,32 @@ gTTS-token==1.1.1
 # homeassistant.components.device_tracker.bluetooth_le_tracker
 # gattlib==0.20150805
 
-# homeassistant.components.sensor.gearbest
-gearbest_parser==1.0.5
-
 # homeassistant.components.sensor.gitter
-gitterpy==0.1.6
+gitterpy==0.1.5
 
 # homeassistant.components.notify.gntp
 gntp==1.0.3
 
 # homeassistant.components.google
-google-api-python-client==1.6.4
+google-api-python-client==1.6.2
 
 # homeassistant.components.sensor.google_travel_time
-googlemaps==2.5.1
+googlemaps==2.4.6
 
 # homeassistant.components.sensor.gpsd
 gps3==0.33.3
-
-# homeassistant.components.light.greenwave
-greenwavereality==0.5.1
 
 # homeassistant.components.media_player.gstreamer
 gstreamer-player==1.1.0
 
 # homeassistant.components.ffmpeg
-ha-ffmpeg==1.9
+ha-ffmpeg==1.5
 
 # homeassistant.components.media_player.philips_js
-ha-philipsjs==0.0.2
-
-# homeassistant.components.sensor.geo_rss_events
-haversine==0.4.5
+ha-philipsjs==0.0.1
 
 # homeassistant.components.mqtt.server
-hbmqtt==0.9.1
+hbmqtt==0.8
 
 # homeassistant.components.climate.heatmiser
 heatmiserV3==0.9.1
@@ -349,48 +268,50 @@ heatmiserV3==0.9.1
 # homeassistant.components.switch.hikvisioncam
 hikvision==0.4
 
-# homeassistant.components.notify.hipchat
-hipnotify==1.0.8
-
 # homeassistant.components.binary_sensor.workday
-holidays==0.9.4
-
-# homeassistant.components.frontend
-home-assistant-frontend==20180316.0
+holidays==0.8.1
 
 # homeassistant.components.camera.onvif
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a
 
-# homeassistant.components.remember_the_milk
-httplib2==0.10.3
+# homeassistant.components.switch.dlink
+https://github.com/LinuxChristian/pyW215/archive/v0.4.zip#pyW215==0.4
 
 # homeassistant.components.sensor.dht
-# https://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.2
+# https://github.com/adafruit/Adafruit_Python_DHT/archive/da8cddf7fb629c1ef4f046ca44f42523c9cf2d11.zip#Adafruit_DHT==1.3.0
 
 # homeassistant.components.media_player.braviatv
 https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
-
-# homeassistant.components.sensor.broadlink
-# homeassistant.components.switch.broadlink
-https://github.com/balloob/python-broadlink/archive/3580ff2eaccd267846f14246d6ede6e30671f7c6.zip#broadlink==0.5.1
 
 # homeassistant.components.media_player.spotify
 https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f86c90aa26b2.zip#spotipy==2.4.4
 
 # homeassistant.components.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/v0.9.2.1.zip#lnetatmo==0.9.2.1
+https://github.com/jabesq/netatmo-api-python/archive/v0.9.2.zip#lnetatmo==0.9.2
 
 # homeassistant.components.neato
-https://github.com/jabesq/pybotvac/archive/v0.0.5.zip#pybotvac==0.0.5
+https://github.com/jabesq/pybotvac/archive/v0.0.3.zip#pybotvac==0.0.3
+
+# homeassistant.components.sensor.sabnzbd
+https://github.com/jamespcole/home-assistant-nzb-clients/archive/616cad59154092599278661af17e2a9f2cf5e2a9.zip#python-sabnzbd==0.1
 
 # homeassistant.components.switch.anel_pwrctrl
 https://github.com/mweinelt/anel-pwrctrl/archive/ed26e8830e28a2bfa4260a9002db23ce3e7e63d7.zip#anel_pwrctrl==0.0.1
+
+# homeassistant.components.switch.edimax
+https://github.com/rkabadi/pyedimax/archive/365301ce3ff26129a7910c501ead09ea625f3700.zip#pyedimax==0.1
 
 # homeassistant.components.sensor.gtfs
 https://github.com/robbiet480/pygtfs/archive/00546724e4bbcb3053110d844ca44e2246267dd8.zip#pygtfs==0.1.3
 
 # homeassistant.components.binary_sensor.flic
 https://github.com/soldag/pyflic/archive/0.4.zip#pyflic==0.4
+
+# homeassistant.components.light.osramlightify
+https://github.com/tfriedel/python-lightify/archive/1bb1db0e7bd5b14304d7bb267e2398cd5160df46.zip#lightify==1.0.5
+
+# homeassistant.components.tado
+https://github.com/wmalgadey/PyTado/archive/0.2.1.zip#PyTado==0.2.1
 
 # homeassistant.components.media_player.lg_netcast
 https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
@@ -400,21 +321,15 @@ https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 # homeassistant.components.sensor.htu21d
 # i2csense==0.0.4
 
-# homeassistant.components.light.iglo
-iglo==1.2.7
-
-# homeassistant.components.ihc
-ihcsdk==2.2.0
-
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
-influxdb==5.0.0
+influxdb==3.0.0
 
 # homeassistant.components.insteon_local
-insteonlocal==0.53
+insteonlocal==0.52
 
 # homeassistant.components.insteon_plm
-insteonplm==0.8.2
+insteonplm==0.7.4
 
 # homeassistant.components.verisure
 jsonpath==0.75
@@ -424,63 +339,43 @@ jsonpath==0.75
 jsonrpc-async==0.6
 
 # homeassistant.components.media_player.kodi
-jsonrpc-websocket==0.6
+jsonrpc-websocket==0.5
 
 # homeassistant.scripts.keyring
-keyring==11.0.0
+keyring>=9.3,<10.0
 
-# homeassistant.scripts.keyring
-keyrings.alt==2.3
+# homeassistant.components.knx
+knxip==0.3.3
 
 # homeassistant.components.device_tracker.owntracks
-# homeassistant.components.device_tracker.owntracks_http
-libnacl==1.6.1
+libnacl==1.5.1
 
 # homeassistant.components.dyson
-libpurecoollink==0.4.2
-
-# homeassistant.components.camera.foscam
-libpyfoscam==1.0
+libpurecoollink==0.1.5
 
 # homeassistant.components.device_tracker.mikrotik
-librouteros==1.0.5
+librouteros==1.0.2
 
 # homeassistant.components.media_player.soundtouch
-libsoundtouch==0.7.2
+libsoundtouch==0.6.2
 
 # homeassistant.components.light.lifx_legacy
 liffylights==0.9.4
 
-# homeassistant.components.light.osramlightify
-lightify==1.0.6.1
-
 # homeassistant.components.light.limitlessled
-limitlessled==1.1.0
-
-# homeassistant.components.linode
-linode-api==4.1.4b2
+limitlessled==1.0.8
 
 # homeassistant.components.media_player.liveboxplaytv
-liveboxplaytv==2.0.2
-
-# homeassistant.components.lametric
-# homeassistant.components.notify.lametric
-lmnotify==0.0.4
-
-# homeassistant.components.sensor.luftdaten
-luftdaten==0.1.3
+liveboxplaytv==1.4.9
 
 # homeassistant.components.sensor.lyft
-lyft_rides==0.2
+lyft_rides==0.1.0b0
 
 # homeassistant.components.notify.matrix
 matrix-client==0.0.6
 
 # homeassistant.components.maxcube
 maxcube-api==0.1.0
-
-# homeassistant.components.mercedesme
-mercedesmejsonpy==0.1.2
 
 # homeassistant.components.notify.message_bird
 messagebird==1.2.0
@@ -490,45 +385,29 @@ messagebird==1.2.0
 mficlient==0.3.0
 
 # homeassistant.components.sensor.miflora
-miflora==0.3.0
+miflora==0.1.16
 
 # homeassistant.components.upnp
-miniupnpc==2.0.2
-
-# homeassistant.components.sensor.mopar
-motorparts==1.0.2
+miniupnpc==1.9
 
 # homeassistant.components.tts
-mutagen==1.40.0
+mutagen==1.38
 
-# homeassistant.components.mychevy
-mychevy==0.1.1
-
-# homeassistant.components.mycroft
-mycroftapi==2.0
-
-# homeassistant.components.usps
-myusps==1.3.2
+# homeassistant.components.sensor.usps
+myusps==1.1.2
 
 # homeassistant.components.media_player.nad
 # homeassistant.components.media_player.nadtcp
-nad_receiver==0.0.9
+nad_receiver==0.0.6
 
 # homeassistant.components.discovery
-netdisco==1.3.0
+netdisco==1.0.1
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1
 
-# homeassistant.components.sensor.nederlandse_spoorwegen
-nsapi==2.7.4
-
-# homeassistant.components.nuheat
-nuheat==0.3.0
-
-# homeassistant.components.binary_sensor.trend
 # homeassistant.components.image_processing.opencv
-numpy==1.14.2
+numpy==1.13.0
 
 # homeassistant.components.google
 oauth2client==4.0.0
@@ -537,7 +416,7 @@ oauth2client==4.0.0
 oemthermostat==1.1
 
 # homeassistant.components.media_player.onkyo
-onkyo-eiscp==1.2.4
+onkyo-eiscp==1.1
 
 # homeassistant.components.camera.onvif
 onvif-py3==0.1.3
@@ -553,10 +432,10 @@ orvibo==1.1.1
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.3.1
+paho-mqtt==1.3.0
 
 # homeassistant.components.media_player.panasonic_viera
-panasonic_viera==0.3.1
+panasonic_viera==0.2
 
 # homeassistant.components.media_player.dunehd
 pdunehd==1.3
@@ -564,9 +443,11 @@ pdunehd==1.3
 # homeassistant.components.device_tracker.aruba
 # homeassistant.components.device_tracker.asuswrt
 # homeassistant.components.device_tracker.cisco_ios
-# homeassistant.components.device_tracker.unifi_direct
 # homeassistant.components.media_player.pandora
 pexpect==4.0.1
+
+# homeassistant.components.light.hue
+phue==0.9
 
 # homeassistant.components.rpi_pfio
 pifacecommon==4.1.2
@@ -580,15 +461,9 @@ piglow==1.2.4
 # homeassistant.components.pilight
 pilight==0.1.1
 
-# homeassistant.components.camera.proxy
-pillow==5.0.0
-
-# homeassistant.components.dominos
-pizzapi==0.0.3
-
 # homeassistant.components.media_player.plex
 # homeassistant.components.sensor.plex
-plexapi==3.0.6
+plexapi==2.0.2
 
 # homeassistant.components.sensor.mhz19
 # homeassistant.components.sensor.serial_pm
@@ -600,76 +475,51 @@ pocketcasts==0.1
 # homeassistant.components.climate.proliphix
 proliphix==0.4.1
 
-# homeassistant.components.prometheus
-prometheus_client==0.1.0
-
 # homeassistant.components.sensor.systemmonitor
-psutil==5.4.3
+psutil==5.2.2
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.2
 
 # homeassistant.components.notify.pushbullet
 # homeassistant.components.sensor.pushbullet
-pushbullet.py==0.11.0
+pushbullet.py==0.10.0
 
 # homeassistant.components.notify.pushetta
 pushetta==1.0.15
 
+# homeassistant.components.sensor.waqi
+pwaqi==3.0
+
 # homeassistant.components.light.rpi_gpio_pwm
-pwmled==1.2.1
-
-# homeassistant.components.august
-py-august==0.4.0
-
-# homeassistant.components.canary
-py-canary==0.4.1
+pwmled==1.1.1
 
 # homeassistant.components.sensor.cpuspeed
 py-cpuinfo==3.3.0
 
-# homeassistant.components.melissa
-py-melissa-climate==1.0.6
-
-# homeassistant.components.camera.synology
-py-synology==0.2.0
-
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13
 
-# homeassistant.components.light.tplink
 # homeassistant.components.switch.tplink
-pyHS100==0.3.0
+pyHS100==0.2.4.2
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.21.1
-
-# homeassistant.components.sensor.tibber
-pyTibber==0.4.0
-
-# homeassistant.components.switch.dlink
-pyW215==0.6.0
-
-# homeassistant.components.ads
-pyads==2.2.6
-
-# homeassistant.components.sensor.airvisual
-pyairvisual==1.0.0
+pyRFXtrx==0.18.0
 
 # homeassistant.components.alarm_control_panel.alarmdotcom
-pyalarmdotcom==0.3.1
+pyalarmdotcom==0.3.0
 
 # homeassistant.components.arlo
-pyarlo==0.1.2
+pyarlo==0.0.4
 
 # homeassistant.components.notify.xmpp
-pyasn1-modules==0.1.5
+pyasn1-modules==0.0.9
 
 # homeassistant.components.notify.xmpp
-pyasn1==0.3.7
+pyasn1==0.2.3
 
-# homeassistant.components.apple_tv
-pyatv==0.3.9
+# homeassistant.components.media_player.apple_tv
+pyatv==0.2.1
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox
@@ -678,11 +528,8 @@ pybbox==0.0.5-alpha
 # homeassistant.components.device_tracker.bluetooth_tracker
 # pybluez==0.22
 
-# homeassistant.components.media_player.channels
-pychannels==1.0.0
-
 # homeassistant.components.media_player.cast
-pychromecast==2.0.0
+pychromecast==0.8.1
 
 # homeassistant.components.media_player.cmus
 pycmus==0.1.0
@@ -690,18 +537,8 @@ pycmus==0.1.0
 # homeassistant.components.comfoconnect
 pycomfoconnect==0.3
 
-# homeassistant.components.tts.microsoft
-pycsspeechtts==1.0.2
-
 # homeassistant.components.sensor.cups
 # pycups==1.9.73
-
-# homeassistant.components.daikin
-# homeassistant.components.climate.daikin
-pydaikin==0.4
-
-# homeassistant.components.deconz
-pydeconz==32
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5
@@ -712,26 +549,17 @@ pydroid-ipcam==0.8
 # homeassistant.components.sensor.ebox
 pyebox==0.1.0
 
-# homeassistant.components.climate.econet
-pyeconet==0.0.5
-
-# homeassistant.components.switch.edimax
-pyedimax==0.1
-
 # homeassistant.components.eight_sleep
 pyeight==0.0.7
 
 # homeassistant.components.media_player.emby
-pyemby==1.5
+pyemby==1.3
 
 # homeassistant.components.envisalink
-pyenvisalink==2.2
-
-# homeassistant.components.climate.ephember
-pyephember==0.1.1
+pyenvisalink==2.1
 
 # homeassistant.components.sensor.fido
-pyfido==2.1.0
+pyfido==1.0.1
 
 # homeassistant.components.climate.flexit
 pyflexit==0.3
@@ -739,35 +567,29 @@ pyflexit==0.3
 # homeassistant.components.ifttt
 pyfttt==0.3
 
+# homeassistant.components.sensor.skybeacon
+pygatt==3.1.1
+
 # homeassistant.components.remote.harmony
-pyharmony==1.0.20
+pyharmony==1.0.16
 
 # homeassistant.components.binary_sensor.hikvision
-pyhik==0.1.8
-
-# homeassistant.components.hive
-pyhiveapi==0.2.11
+pyhik==0.1.2
 
 # homeassistant.components.homematic
-pyhomematic==0.1.39
+pyhomematic==0.1.28
 
 # homeassistant.components.sensor.hydroquebec
-pyhydroquebec==2.1.0
-
-# homeassistant.components.alarm_control_panel.ialarm
-pyialarm==0.2
+pyhydroquebec==1.2.0
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.9.1
-
-# homeassistant.components.sensor.irish_rail_transport
-pyirishrail==0.0.2
 
 # homeassistant.components.binary_sensor.iss
 pyiss==1.0.1
 
 # homeassistant.components.remote.itach
-pyitachip2ir==0.0.7
+pyitachip2ir==0.0.6
 
 # homeassistant.components.kira
 pykira==0.1.1
@@ -775,11 +597,8 @@ pykira==0.1.1
 # homeassistant.components.sensor.kwb
 pykwb==0.0.8
 
-# homeassistant.components.sensor.lacrosse
-pylacrosse==0.3.1
-
 # homeassistant.components.sensor.lastfm
-pylast==2.1.0
+pylast==1.8.0
 
 # homeassistant.components.media_player.webostv
 # homeassistant.components.notify.webostv
@@ -789,10 +608,10 @@ pylgtv==0.1.7
 pylitejet==0.1
 
 # homeassistant.components.sensor.loopenergy
-pyloopenergy==0.0.18
+pyloopenergy==0.0.17
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.3.0
+pylutron-caseta==0.2.6
 
 # homeassistant.components.lutron
 pylutron==0.1.0
@@ -800,32 +619,17 @@ pylutron==0.1.0
 # homeassistant.components.notify.mailgun
 pymailgunner==1.4
 
-# homeassistant.components.media_player.mediaroom
-pymediaroom==0.5
-
-# homeassistant.components.media_player.xiaomi_tv
-pymitv==1.0.0
-
 # homeassistant.components.mochad
-pymochad==0.2.0
+pymochad==0.1.1
 
 # homeassistant.components.modbus
-pymodbus==1.3.1
-
-# homeassistant.components.media_player.monoprice
-pymonoprice==0.3
-
-# homeassistant.components.media_player.yamaha_musiccast
-pymusiccast==0.1.6
+pymodbus==1.3.0rc1
 
 # homeassistant.components.cover.myq
 pymyq==0.0.8
 
 # homeassistant.components.mysensors
-pymysensors==0.11.1
-
-# homeassistant.components.lock.nello
-pynello==1.5.1
+pymysensors==0.10.0
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.3.3
@@ -834,7 +638,7 @@ pynetgear==0.3.3
 pynetio==0.1.6
 
 # homeassistant.components.lock.nuki
-pynuki==1.3.1
+pynuki==1.2.2
 
 # homeassistant.components.sensor.nut
 pynut2==2.1.2
@@ -843,33 +647,15 @@ pynut2==2.1.2
 # homeassistant.components.binary_sensor.nx584
 pynx584==0.4
 
-# homeassistant.components.iota
-pyota==2.0.4
-
-# homeassistant.components.sensor.otp
-pyotp==2.2.6
-
 # homeassistant.components.sensor.openweathermap
 # homeassistant.components.weather.openweathermap
-pyowm==2.8.0
-
-# homeassistant.components.sensor.pollen
-pypollencom==1.1.1
+pyowm==2.6.1
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.4
 
-# homeassistant.components.rainbird
-pyrainbird==0.1.3
-
-# homeassistant.components.sensor.sabnzbd
-pysabnzbd==1.0.1
-
 # homeassistant.components.climate.sensibo
-pysensibo==1.0.2
-
-# homeassistant.components.sensor.serial
-pyserial-asyncio==0.4
+pysensibo==1.0.1
 
 # homeassistant.components.switch.acer_projector
 pyserial==3.1.1
@@ -877,22 +663,12 @@ pyserial==3.1.1
 # homeassistant.components.lock.sesame
 pysesame==0.1.0
 
-# homeassistant.components.goalfeed
-pysher==0.2.0
-
 # homeassistant.components.sensor.sma
-pysma==0.2
+pysma==0.1.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
-# homeassistant.components.switch.snmp
-pysnmp==4.4.4
-
-# homeassistant.components.notify.stride
-pystride==0.1.7
-
-# homeassistant.components.media_player.liveboxplaytv
-pyteleloisirs==3.3
+pysnmp==4.3.8
 
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner
@@ -905,23 +681,19 @@ python-blockchain-api==0.0.2
 python-clementine-remote==1.0.1
 
 # homeassistant.components.digital_ocean
-python-digitalocean==1.13.2
+python-digitalocean==1.12
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.0.15
+python-ecobee-api==0.0.7
 
 # homeassistant.components.climate.eq3btsmart
-# python-eq3bt==0.1.9
+# python-eq3bt==0.1.5
 
 # homeassistant.components.sensor.etherscan
-python-etherscan-api==0.0.3
+python-etherscan-api==0.0.1
 
 # homeassistant.components.sensor.darksky
-# homeassistant.components.weather.darksky
-python-forecastio==1.4.0
-
-# homeassistant.components.gc100
-python-gc100==1.0.3a
+python-forecastio==1.3.5
 
 # homeassistant.components.sensor.hp_ilo
 python-hpilo==3.9
@@ -936,14 +708,6 @@ python-juicenet==0.0.5
 # homeassistant.components.lirc
 # python-lirc==1.2.3
 
-# homeassistant.components.fan.xiaomi_miio
-# homeassistant.components.light.xiaomi_miio
-# homeassistant.components.remote.xiaomi_miio
-# homeassistant.components.sensor.xiaomi_miio
-# homeassistant.components.switch.xiaomi_miio
-# homeassistant.components.vacuum.xiaomi_miio
-python-miio==0.3.8
-
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5
 
@@ -952,71 +716,43 @@ python-mpd2==0.5.5
 python-mystrom==0.3.8
 
 # homeassistant.components.nest
-python-nest==3.7.0
+python-nest==3.1.0
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1
 
 # homeassistant.components.notify.pushover
-python-pushover==0.3
+python-pushover==0.2
 
 # homeassistant.components.sensor.ripple
-python-ripple-api==0.0.3
+python-ripple-api==0.0.2
 
 # homeassistant.components.media_player.roku
-python-roku==3.1.5
-
-# homeassistant.components.sensor.sochain
-python-sochain-api==0.0.2
-
-# homeassistant.components.media_player.songpal
-python-songpal==0.0.6
+python-roku==3.1.3
 
 # homeassistant.components.sensor.synologydsm
 python-synology==0.1.0
 
-# homeassistant.components.tado
-python-tado==0.2.2
-
 # homeassistant.components.telegram_bot
-python-telegram-bot==10.0.1
+python-telegram-bot==6.1.0
 
 # homeassistant.components.sensor.twitch
 python-twitch==1.3.0
-
-# homeassistant.components.velbus
-python-velbus==2.0.11
 
 # homeassistant.components.media_player.vlc
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.7.3
-
-# homeassistant.components.sensor.swiss_public_transport
-python_opendata_transport==0.0.3
+python-wink==1.2.4
 
 # homeassistant.components.zwave
-python_openzwave==0.4.3
-
-# homeassistant.components.egardia
-# homeassistant.components.alarm_control_panel.egardia
-pythonegardia==1.0.39
-
-# homeassistant.components.sensor.whois
-pythonwhois==2.4.3
-
-# homeassistant.components.device_tracker.tile
-pytile==1.1.0
-
-# homeassistant.components.climate.touchline
-pytouchline==0.7
+python_openzwave==0.4.0.31
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-pytradfri[async]==4.1.0
+pytradfri==1.1
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13
@@ -1025,25 +761,13 @@ pyunifi==2.13
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.2.42
-
-# homeassistant.components.switch.vesync
-pyvesync==0.1.1
-
-# homeassistant.components.media_player.vizio
-pyvizio==0.0.2
-
-# homeassistant.components.velux
-pyvlx==0.1.3
+pyvera==0.2.33
 
 # homeassistant.components.notify.html5
-pywebpush==1.6.0
+pywebpush==1.0.5
 
 # homeassistant.components.wemo
-pywemo==0.4.25
-
-# homeassistant.components.camera.xeoma
-pyxeoma==1.3
+pywemo==0.4.19
 
 # homeassistant.components.zabbix
 pyzabbix==0.7.4
@@ -1057,81 +781,51 @@ rachiopy==0.1.2
 # homeassistant.components.climate.radiotherm
 radiotherm==1.3
 
-# homeassistant.components.raincloud
-raincloudy==0.0.4
-
 # homeassistant.components.raspihats
-# raspihats==2.2.3
-
-# homeassistant.components.switch.rainmachine
-regenmaschine==0.4.1
+# raspihats==2.2.1
 
 # homeassistant.components.python_script
-restrictedpython==4.0b2
+restrictedpython==4.0a3
 
 # homeassistant.components.rflink
 rflink==0.0.34
 
 # homeassistant.components.ring
-ring_doorbell==0.1.8
-
-# homeassistant.components.notify.rocketchat
-rocketchat-API==0.6.1
-
-# homeassistant.components.vacuum.roomba
-roombapy==1.3.1
+ring_doorbell==0.1.4
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.6
 
 # homeassistant.components.media_player.russound_rnet
-russound==0.1.9
-
-# homeassistant.components.media_player.russound_rio
-russound_rio==0.1.4
+russound==0.1.7
 
 # homeassistant.components.media_player.yamaha
-rxv==0.5.1
+rxv==0.4.0
 
 # homeassistant.components.media_player.samsungtv
-samsungctl[websocket]==0.7.1
-
-# homeassistant.components.satel_integra
-satel_integra==0.1.0
+samsungctl==0.6.0
 
 # homeassistant.components.sensor.deutsche_bahn
-schiene==0.22
+schiene==0.18
 
 # homeassistant.components.scsgate
 scsgate==0.1.0
 
 # homeassistant.components.notify.sendgrid
-sendgrid==5.3.0
+sendgrid==4.2.0
 
 # homeassistant.components.light.sensehat
 # homeassistant.components.sensor.sensehat
 sense-hat==2.2.0
 
-# homeassistant.components.sensor.sense
-sense_energy==0.3.1
-
 # homeassistant.components.media_player.aquostv
 sharp_aquos_rc==0.3.2
 
-# homeassistant.components.sensor.shodan
-shodan==1.7.7
-
-# homeassistant.components.notify.simplepush
-simplepush==1.1.4
-
 # homeassistant.components.alarm_control_panel.simplisafe
-simplisafe-python==1.0.5
-
-# homeassistant.components.skybell
-skybellpy==0.1.1
+simplisafe-python==1.0.2
 
 # homeassistant.components.notify.slack
-slacker==0.9.60
+slacker==0.9.50
 
 # homeassistant.components.notify.xmpp
 sleekxmpp==1.3.2
@@ -1139,33 +833,24 @@ sleekxmpp==1.3.2
 # homeassistant.components.sleepiq
 sleepyq==0.6
 
-# homeassistant.components.smappee
-smappy==0.2.15
-
-# homeassistant.components.raspihats
 # homeassistant.components.sensor.bh1750
 # homeassistant.components.sensor.bme280
-# homeassistant.components.sensor.bme680
 # homeassistant.components.sensor.envirophat
 # homeassistant.components.sensor.htu21d
 # smbus-cffi==0.5.1
 
 # homeassistant.components.media_player.snapcast
-snapcast==2.0.8
+snapcast==2.0.6
 
 # homeassistant.components.climate.honeywell
-somecomfort==0.5.0
+somecomfort==0.4.1
 
 # homeassistant.components.sensor.speedtest
-speedtest-cli==2.0.0
-
-# homeassistant.components.sensor.spotcrime
-spotcrime==1.0.3
+speedtest-cli==1.0.6
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator
-# homeassistant.components.sensor.sql
-sqlalchemy==1.2.5
+sqlalchemy==1.1.11
 
 # homeassistant.components.statsd
 statsd==3.2.1
@@ -1176,29 +861,18 @@ steamodd==4.21
 # homeassistant.components.camera.onvif
 suds-py3==1.3.3.0
 
-# homeassistant.components.tahoma
-tahoma-api==0.0.13
-
-# homeassistant.components.sensor.tank_utility
-tank_utility==1.4.0
-
 # homeassistant.components.binary_sensor.tapsaff
 tapsaff==0.1.3
 
 # homeassistant.components.tellstick
-tellcore-net==0.4
-
-# homeassistant.components.tellstick
+# homeassistant.components.sensor.tellstick
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.10.4
+tellduslive==0.3.4
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.3
-
-# homeassistant.components.tesla
-teslajsonpy==0.0.23
 
 # homeassistant.components.thingspeak
 thingspeak==0.4.1
@@ -1206,14 +880,8 @@ thingspeak==0.4.1
 # homeassistant.components.light.tikteck
 tikteck==0.4
 
-# homeassistant.components.calendar.todoist
-todoist-python==7.0.17
-
-# homeassistant.components.toon
-toonlib==1.0.2
-
 # homeassistant.components.alarm_control_panel.totalconnect
-total_connect_client==0.16
+total_connect_client==0.7
 
 # homeassistant.components.sensor.transmission
 # homeassistant.components.switch.transmission
@@ -1223,49 +891,28 @@ transmissionrpc==0.11
 twilio==5.7.0
 
 # homeassistant.components.sensor.uber
-uber_rides==0.6.0
-
-# homeassistant.components.upcloud
-upcloud-api==0.4.2
+uber_rides==0.4.1
 
 # homeassistant.components.sensor.ups
 upsmychoice==1.0.6
 
 # homeassistant.components.camera.uvc
-uvcclient==0.10.1
-
-# homeassistant.components.climate.venstar
-venstarcolortouch==0.6
-
-# homeassistant.components.config.config_entries
-voluptuous-serialize==1
+uvcclient==0.10.0
 
 # homeassistant.components.volvooncall
-volvooncall==0.4.0
+volvooncall==0.3.3
 
 # homeassistant.components.verisure
-vsure==1.3.7
+vsure==1.3.6
 
 # homeassistant.components.sensor.vasttrafik
 vtjp==0.1.14
 
-# homeassistant.components.vultr
-vultr==0.1.2
-
-# homeassistant.components.wake_on_lan
 # homeassistant.components.media_player.panasonic_viera
 # homeassistant.components.media_player.samsungtv
+# homeassistant.components.media_player.webostv
 # homeassistant.components.switch.wake_on_lan
-wakeonlan==1.0.0
-
-# homeassistant.components.sensor.waqi
-waqiasync==1.0.0
-
-# homeassistant.components.cloud
-warrant==0.6.1
-
-# homeassistant.components.waterfurnace
-waterfurnace==0.4.0
+wakeonlan==0.2.2
 
 # homeassistant.components.media_player.gpmdp
 websocket-client==0.37.0
@@ -1280,15 +927,9 @@ xbee-helper==0.0.7
 # homeassistant.components.sensor.xbox_live
 xboxapi==0.1.1
 
-# homeassistant.components.knx
-xknx==0.8.5
-
-# homeassistant.components.media_player.bluesound
-# homeassistant.components.sensor.startca
 # homeassistant.components.sensor.swiss_hydrological_data
 # homeassistant.components.sensor.ted5000
 # homeassistant.components.sensor.yr
-# homeassistant.components.sensor.zestimate
 xmltodict==0.11.0
 
 # homeassistant.components.sensor.yahoo_finance
@@ -1296,28 +937,16 @@ yahoo-finance==1.4.0
 
 # homeassistant.components.sensor.yweather
 # homeassistant.components.weather.yweather
-yahooweather==0.10
+yahooweather==0.8
 
 # homeassistant.components.light.yeelight
-yeelight==0.4.0
+yeelight==0.3.0
 
 # homeassistant.components.light.yeelightsunflower
 yeelightsunflower==0.0.8
-
-# homeassistant.components.media_extractor
-youtube_dl==2018.03.10
 
 # homeassistant.components.light.zengge
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.20.0
-
-# homeassistant.components.media_player.ziggo_mediabox_xl
-ziggo-mediabox-xl==1.0.0
-
-# homeassistant.components.zha
-zigpy-xbee==0.0.2
-
-# homeassistant.components.zha
-zigpy==0.0.3
+zeroconf==0.19.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -18,97 +18,70 @@ pytest==3.4.2
 requests_mock==1.4
 
 
-# homeassistant.components.homekit
-HAP-python==1.1.7
-
 # homeassistant.components.notify.html5
-PyJWT==1.6.0
+PyJWT==1.5.0
 
 # homeassistant.components.media_player.sonos
-SoCo==0.14
+SoCo==0.12
 
 # homeassistant.components.device_tracker.automatic
-aioautomatic==0.6.5
+aioautomatic==0.4.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
-aiohttp_cors==0.7.0
-
-# homeassistant.components.hue
-aiohue==1.2.0
+aiohttp_cors==0.5.3
 
 # homeassistant.components.notify.apns
-apns2==0.3.0
-
-# homeassistant.components.calendar.caldav
-caldav==0.5.0
+apns2==0.1.1
 
 # homeassistant.components.sensor.coinmarketcap
-coinmarketcap==4.2.1
-
-# homeassistant.components.device_tracker.upc_connect
-defusedxml==0.5.0
+coinmarketcap==3.0.1
 
 # homeassistant.components.sensor.dsmr
-dsmr_parser==0.11
-
-# homeassistant.components.sensor.season
-ephem==3.7.6.0
+dsmr_parser==0.8
 
 # homeassistant.components.climate.honeywell
 evohomeclient==0.2.5
 
 # homeassistant.components.feedreader
-# homeassistant.components.sensor.geo_rss_events
 feedparser==5.2.1
-
-# homeassistant.components.sensor.foobot
-foobot_async==0.3.0
 
 # homeassistant.components.tts.google
 gTTS-token==1.1.1
 
 # homeassistant.components.ffmpeg
-ha-ffmpeg==1.9
-
-# homeassistant.components.sensor.geo_rss_events
-haversine==0.4.5
+ha-ffmpeg==1.5
 
 # homeassistant.components.mqtt.server
-hbmqtt==0.9.1
+hbmqtt==0.8
 
 # homeassistant.components.binary_sensor.workday
-holidays==0.9.4
-
-# homeassistant.components.frontend
-home-assistant-frontend==20180316.0
+holidays==0.8.1
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
-influxdb==5.0.0
+influxdb==3.0.0
 
 # homeassistant.components.dyson
-libpurecoollink==0.4.2
+libpurecoollink==0.1.5
 
 # homeassistant.components.media_player.soundtouch
-libsoundtouch==0.7.2
+libsoundtouch==0.6.2
 
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi
 mficlient==0.3.0
 
-# homeassistant.components.binary_sensor.trend
 # homeassistant.components.image_processing.opencv
-numpy==1.14.2
+numpy==1.13.0
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.3.1
+paho-mqtt==1.3.0
 
 # homeassistant.components.device_tracker.aruba
 # homeassistant.components.device_tracker.asuswrt
 # homeassistant.components.device_tracker.cisco_ios
-# homeassistant.components.device_tracker.unifi_direct
 # homeassistant.components.media_player.pandora
 pexpect==4.0.1
 
@@ -119,15 +92,9 @@ pilight==0.1.1
 # homeassistant.components.sensor.serial_pm
 pmsensor==0.4
 
-# homeassistant.components.prometheus
-prometheus_client==0.1.0
-
 # homeassistant.components.notify.pushbullet
 # homeassistant.components.sensor.pushbullet
-pushbullet.py==0.11.0
-
-# homeassistant.components.canary
-py-canary==0.4.1
+pushbullet.py==0.10.0
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5
@@ -135,69 +102,52 @@ pydispatcher==2.0.5
 # homeassistant.components.litejet
 pylitejet==0.1
 
-# homeassistant.components.media_player.monoprice
-pymonoprice==0.3
-
 # homeassistant.components.alarm_control_panel.nx584
 # homeassistant.components.binary_sensor.nx584
 pynx584==0.4
 
 # homeassistant.components.sensor.darksky
-# homeassistant.components.weather.darksky
-python-forecastio==1.4.0
-
-# homeassistant.components.sensor.whois
-pythonwhois==2.4.3
+python-forecastio==1.3.5
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13
 
 # homeassistant.components.notify.html5
-pywebpush==1.6.0
+pywebpush==1.0.5
 
 # homeassistant.components.python_script
-restrictedpython==4.0b2
+restrictedpython==4.0a3
 
 # homeassistant.components.rflink
 rflink==0.0.34
 
 # homeassistant.components.ring
-ring_doorbell==0.1.8
+ring_doorbell==0.1.4
 
 # homeassistant.components.media_player.yamaha
-rxv==0.5.1
+rxv==0.4.0
 
 # homeassistant.components.sleepiq
 sleepyq==0.6
 
 # homeassistant.components.climate.honeywell
-somecomfort==0.5.0
+somecomfort==0.4.1
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator
-# homeassistant.components.sensor.sql
-sqlalchemy==1.2.5
+sqlalchemy==1.1.11
 
 # homeassistant.components.statsd
 statsd==3.2.1
 
 # homeassistant.components.camera.uvc
-uvcclient==0.10.1
+uvcclient==0.10.0
 
-# homeassistant.components.config.config_entries
-voluptuous-serialize==1
-
-# homeassistant.components.vultr
-vultr==0.1.2
-
-# homeassistant.components.wake_on_lan
 # homeassistant.components.media_player.panasonic_viera
 # homeassistant.components.media_player.samsungtv
+# homeassistant.components.media_player.webostv
 # homeassistant.components.switch.wake_on_lan
-wakeonlan==1.0.0
-
-# homeassistant.components.cloud
-warrant==0.6.1
+wakeonlan==0.2.2
 
 # homeassistant.components.sensor.yahoo_finance
 yahoo-finance==1.4.0


### PR DESCRIPTION
## Description:
Fixing Python-egardia bug https://github.com/jeroenterheerdt/python-egardia/issues/17: Home armed state was not showing correctly in Home Assistant.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
