### PR TITLE
zha: catch the exception from bellows if a device isn't available.

### DIFF
--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -119,13 +119,25 @@ class Light(zha.Entity, light.Light):
             self.async_schedule_update_ha_state()
             return
 
-        await self._endpoint.on_off.on()
+        import bellows
+        try:
+            await self._endpoint.on_off.on()
+        except bellows.zigbee.exceptions.DeliveryError as ex:
+            _LOGGER.error("Unable to turn the light on: %s", ex)
+            return
+
         self._state = 1
         self.async_schedule_update_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
-        await self._endpoint.on_off.off()
+        import bellows
+        try:
+            await self._endpoint.on_off.off()
+        except bellows.zigbee.exceptions.DeliveryError as ex:
+            _LOGGER.error("Unable to turn the light off: %s", ex)
+            return
+
         self._state = 0
         self.async_schedule_update_ha_state()
 

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -5,7 +5,6 @@ For more details on this platform, please refer to the documentation
 at https://home-assistant.io/components/light.zha/
 """
 import logging
-from zigpy.exceptions import DeliveryError
 from homeassistant.components import light, zha
 from homeassistant.util.color import color_RGB_to_xy
 from homeassistant.const import STATE_UNKNOWN
@@ -118,7 +117,7 @@ class Light(zha.Entity, light.Light):
             self._state = 1
             self.async_schedule_update_ha_state()
             return
-
+        from zigpy.exceptions import DeliveryError
         try:
             await self._endpoint.on_off.on()
         except DeliveryError as ex:
@@ -130,6 +129,7 @@ class Light(zha.Entity, light.Light):
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
+        from zigpy.exceptions import DeliveryError
         try:
             await self._endpoint.on_off.off()
         except DeliveryError as ex:

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -5,7 +5,7 @@ For more details on this platform, please refer to the documentation
 at https://home-assistant.io/components/light.zha/
 """
 import logging
-
+from zigpy.exceptions import DeliveryError
 from homeassistant.components import light, zha
 from homeassistant.util.color import color_RGB_to_xy
 from homeassistant.const import STATE_UNKNOWN
@@ -119,10 +119,9 @@ class Light(zha.Entity, light.Light):
             self.async_schedule_update_ha_state()
             return
 
-        import bellows
         try:
             await self._endpoint.on_off.on()
-        except bellows.zigbee.exceptions.DeliveryError as ex:
+        except DeliveryError as ex:
             _LOGGER.error("Unable to turn the light on: %s", ex)
             return
 
@@ -131,10 +130,9 @@ class Light(zha.Entity, light.Light):
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
-        import bellows
         try:
             await self._endpoint.on_off.off()
-        except bellows.zigbee.exceptions.DeliveryError as ex:
+        except DeliveryError as ex:
             _LOGGER.error("Unable to turn the light off: %s", ex)
             return
 

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -57,12 +57,24 @@ class Switch(zha.Entity, SwitchDevice):
 
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        await self._endpoint.on_off.on()
+        import bellows
+        try:
+            await self._endpoint.on_off.on()
+        except bellows.zigbee.exceptions.DeliveryError as ex:
+            _LOGGER.error("Unable to turn the switch on: %s", ex)
+            return
+
         self._state = 1
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
-        await self._endpoint.on_off.off()
+        import bellows
+        try:
+            await self._endpoint.on_off.off()
+        except bellows.zigbee.exceptions.DeliveryError as ex:
+            _LOGGER.error("Unable to turn the switch off: %s", ex)
+            return
+
         self._state = 0
 
     async def async_update(self):

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -5,7 +5,7 @@ For more details on this platform, please refer to the documentation
 at https://home-assistant.io/components/switch.zha/
 """
 import logging
-from zigpy.exceptions import DeliveryError
+
 from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.components import zha
 
@@ -57,6 +57,7 @@ class Switch(zha.Entity, SwitchDevice):
 
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
+        from zigpy.exceptions import DeliveryError
         try:
             await self._endpoint.on_off.on()
         except DeliveryError as ex:
@@ -67,6 +68,7 @@ class Switch(zha.Entity, SwitchDevice):
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
+        from zigpy.exceptions import DeliveryError
         try:
             await self._endpoint.on_off.off()
         except DeliveryError as ex:

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -5,7 +5,7 @@ For more details on this platform, please refer to the documentation
 at https://home-assistant.io/components/switch.zha/
 """
 import logging
-
+from zigpy.exceptions import DeliveryError
 from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.components import zha
 
@@ -57,10 +57,9 @@ class Switch(zha.Entity, SwitchDevice):
 
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        import bellows
         try:
             await self._endpoint.on_off.on()
-        except bellows.zigbee.exceptions.DeliveryError as ex:
+        except DeliveryError as ex:
             _LOGGER.error("Unable to turn the switch on: %s", ex)
             return
 
@@ -68,10 +67,9 @@ class Switch(zha.Entity, SwitchDevice):
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
-        import bellows
         try:
             await self._endpoint.on_off.off()
-        except bellows.zigbee.exceptions.DeliveryError as ex:
+        except DeliveryError as ex:
             _LOGGER.error("Unable to turn the switch off: %s", ex)
             return
 


### PR DESCRIPTION
## Description:

If a zha device isn't available (ie someone used the wall switch to turn it off) the complete on/off stops.
This fix catches the bellows exception.

**Related issue (if applicable):** fixes #11751

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

Currently no tests exist at all for zha.