### PR TITLE
Add the possibility to filter on line(s) in Västtrafik Public Transport sensor

### DIFF
--- a/homeassistant/components/sensor/vasttrafik.py
+++ b/homeassistant/components/sensor/vasttrafik.py
@@ -47,7 +47,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Required(CONF_FROM): cv.string,
         vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): cv.positive_int,
         vol.Optional(CONF_HEADING): cv.string,
-        vol.Optional(CONF_LINES, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_LINES, default=[]):
+            vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_NAME): cv.string}]
 })
 

--- a/homeassistant/components/sensor/vasttrafik.py
+++ b/homeassistant/components/sensor/vasttrafik.py
@@ -127,7 +127,7 @@ class VasttrafikDepartureSensor(Entity):
                     return self._departureboard[0]['rtTime']
                 return self._departureboard[0]['time']
         # No departures of given lines found
-        _LOGGER.info(
+        _LOGGER.debug(
             "No departures from %s heading %s on line(s) %s",
             self._departure['name'],
             self._heading['name'] if self._heading else 'ANY',

--- a/homeassistant/components/sensor/vasttrafik.py
+++ b/homeassistant/components/sensor/vasttrafik.py
@@ -100,14 +100,14 @@ class VasttrafikDepartureSensor(Entity):
             return
 
         for departure in self._departureboard:
-            line = departure.get('sname', None)
+            line = departure.get('sname')
             if not self._lines or line in self._lines:
                 params = {
-                    ATTR_ACCESSIBILITY: departure.get('accessibility', None),
+                    ATTR_ACCESSIBILITY: departure.get('accessibility'),
                     ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-                    ATTR_DIRECTION: departure.get('direction', None),
-                    ATTR_LINE: departure.get('sname', None),
-                    ATTR_TRACK: departure.get('track', None),
+                    ATTR_DIRECTION: departure.get('direction'),
+                    ATTR_LINE: departure.get('sname'),
+                    ATTR_TRACK: departure.get('track'),
                     }
         return {k: v for k, v in params.items() if v}
 
@@ -121,7 +121,7 @@ class VasttrafikDepartureSensor(Entity):
                 self._heading['name'] if self._heading else 'ANY')
             return
         for departure in self._departureboard:
-            line = departure.get('sname', None)
+            line = departure.get('sname')
             if not self._lines or line in self._lines:
                 if 'rtTime' in self._departureboard[0]:
                     return self._departureboard[0]['rtTime']

--- a/homeassistant/components/sensor/vasttrafik.py
+++ b/homeassistant/components/sensor/vasttrafik.py
@@ -30,6 +30,7 @@ CONF_DELAY = 'delay'
 CONF_DEPARTURES = 'departures'
 CONF_FROM = 'from'
 CONF_HEADING = 'heading'
+CONF_LINES = 'lines'
 CONF_KEY = 'key'
 CONF_SECRET = 'secret'
 
@@ -46,6 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Required(CONF_FROM): cv.string,
         vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): cv.positive_int,
         vol.Optional(CONF_HEADING): cv.string,
+        vol.Optional(CONF_LINES, default=[]): cv.ensure_list_csv,
         vol.Optional(CONF_NAME): cv.string}]
 })
 
@@ -61,14 +63,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             VasttrafikDepartureSensor(
                 vasttrafik, planner, departure.get(CONF_NAME),
                 departure.get(CONF_FROM), departure.get(CONF_HEADING),
-                departure.get(CONF_DELAY)))
+                departure.get(CONF_LINES), departure.get(CONF_DELAY)))
     add_devices(sensors, True)
 
 
 class VasttrafikDepartureSensor(Entity):
     """Implementation of a Vasttrafik Departure Sensor."""
 
-    def __init__(self, vasttrafik, planner, name, departure, heading, delay):
+    def __init__(self, vasttrafik, planner, name, departure, heading,
+                 lines, delay):
         """Initialize the sensor."""
         self._vasttrafik = vasttrafik
         self._planner = planner
@@ -76,6 +79,7 @@ class VasttrafikDepartureSensor(Entity):
         self._departure = planner.location_name(departure)[0]
         self._heading = (planner.location_name(heading)[0]
                          if heading else None)
+        self._lines = lines if lines else None
         self._delay = timedelta(minutes=delay)
         self._departureboard = None
 
@@ -94,14 +98,17 @@ class VasttrafikDepartureSensor(Entity):
         """Return the state attributes."""
         if not self._departureboard:
             return
-        departure = self._departureboard[0]
-        params = {
-            ATTR_ACCESSIBILITY: departure.get('accessibility', None),
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-            ATTR_DIRECTION: departure.get('direction', None),
-            ATTR_LINE: departure.get('sname', None),
-            ATTR_TRACK: departure.get('track', None),
-            }
+
+        for departure in self._departureboard:
+            line = departure.get('sname', None)
+            if not self._lines or line in self._lines:
+                params = {
+                    ATTR_ACCESSIBILITY: departure.get('accessibility', None),
+                    ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+                    ATTR_DIRECTION: departure.get('direction', None),
+                    ATTR_LINE: departure.get('sname', None),
+                    ATTR_TRACK: departure.get('track', None),
+                    }
         return {k: v for k, v in params.items() if v}
 
     @property
@@ -113,9 +120,18 @@ class VasttrafikDepartureSensor(Entity):
                 self._departure['name'],
                 self._heading['name'] if self._heading else 'ANY')
             return
-        if 'rtTime' in self._departureboard[0]:
-            return self._departureboard[0]['rtTime']
-        return self._departureboard[0]['time']
+        for departure in self._departureboard:
+            line = departure.get('sname', None)
+            if not self._lines or line in self._lines:
+                if 'rtTime' in self._departureboard[0]:
+                    return self._departureboard[0]['rtTime']
+                return self._departureboard[0]['time']
+        # No departures of given lines found
+        _LOGGER.info(
+            "No departures from %s heading %s on line(s) %s",
+            self._departure['name'],
+            self._heading['name'] if self._heading else 'ANY',
+            ', '.join((str(line) for line in self._lines)))
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/sensor/vasttrafik.py
+++ b/homeassistant/components/sensor/vasttrafik.py
@@ -47,7 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Required(CONF_FROM): cv.string,
         vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): cv.positive_int,
         vol.Optional(CONF_HEADING): cv.string,
-        vol.Optional(CONF_LINES, default=[]): cv.ensure_list_csv,
+        vol.Optional(CONF_LINES, default=[]): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_NAME): cv.string}]
 })
 
@@ -109,7 +109,7 @@ class VasttrafikDepartureSensor(Entity):
                     ATTR_LINE: departure.get('sname'),
                     ATTR_TRACK: departure.get('track'),
                     }
-        return {k: v for k, v in params.items() if v}
+                return {k: v for k, v in params.items() if v}
 
     @property
     def state(self):


### PR DESCRIPTION
## Description:
Add a config entry "lines" to be able to filter departures on line(s) for the
vasttrafik sensor.

Documentation will be updated through "edit on github" when/if request merged.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: vasttrafik
    key: XXXXXXXXXXXXXXXXXXX
    secret: YYYYYYYYYYYYYYYYY
    departures:
      - name: Mot järntorget
        from: Musikvägen
        heading: Järntorget
        lines:
          - 1
          - GRÖN
        delay: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
