### PR TITLE
Add MQTT Sensor unique_id

### DIFF
--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -43,7 +43,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
     vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
     # Integrations shouldn't never expose unique_id through configuration
-    # this here is an exception because of automatic MQTT discovery.
+    # this here is an exception because MQTT is a msg transport, not a protocol
     vol.Optional(CONF_UNIQUE_ID): cv.string,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 import json
 from datetime import timedelta
+from typing import Optional
 
 import voluptuous as vol
 
@@ -28,6 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_EXPIRE_AFTER = 'expire_after'
 CONF_JSON_ATTRS = 'json_attributes'
+CONF_UNIQUE_ID = 'unique_id'
 
 DEFAULT_NAME = 'MQTT Sensor'
 DEFAULT_FORCE_UPDATE = False
@@ -40,6 +42,9 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_JSON_ATTRS, default=[]): cv.ensure_list_csv,
     vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
     vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
+    # Integrations shouldn't never expose unique_id through configuration
+    # this here is an exception because of automatic MQTT discovery.
+    vol.Optional(CONF_UNIQUE_ID): cv.string,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
@@ -63,6 +68,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_ICON),
         value_template,
         config.get(CONF_JSON_ATTRS),
+        config.get(CONF_UNIQUE_ID),
         config.get(CONF_AVAILABILITY_TOPIC),
         config.get(CONF_PAYLOAD_AVAILABLE),
         config.get(CONF_PAYLOAD_NOT_AVAILABLE),
@@ -74,7 +80,8 @@ class MqttSensor(MqttAvailability, Entity):
 
     def __init__(self, name, state_topic, qos, unit_of_measurement,
                  force_update, expire_after, icon, value_template,
-                 json_attributes, availability_topic, payload_available,
+                 json_attributes, unique_id: Optional[str],
+                 availability_topic, payload_available,
                  payload_not_available):
         """Initialize the sensor."""
         super().__init__(availability_topic, qos, payload_available,
@@ -90,6 +97,7 @@ class MqttSensor(MqttAvailability, Entity):
         self._icon = icon
         self._expiration_trigger = None
         self._json_attributes = set(json_attributes)
+        self._unique_id = unique_id
         self._attributes = None
 
     @asyncio.coroutine
@@ -173,6 +181,11 @@ class MqttSensor(MqttAvailability, Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return self._attributes
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
 
     @property
     def icon(self):

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -329,3 +329,24 @@ class TestSensorMQTT(unittest.TestCase):
         self.assertEqual('100',
                          state.attributes.get('val'))
         self.assertEqual('100', state.state)
+
+    def test_unique_id(self):
+        """Test unique id option only creates one sensor per unique_id."""
+        assert setup_component(self.hass, sensor.DOMAIN, {
+            sensor.DOMAIN: [{
+                'platform': 'mqtt',
+                'name': 'Test 1',
+                'state_topic': 'test-topic',
+                'unique_id': 'TOTALLY_UNIQUE'
+            }, {
+                'platform': 'mqtt',
+                'name': 'Test 2',
+                'state_topic': 'test-topic',
+                'unique_id': 'TOTALLY_UNIQUE'
+            }]
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', 'payload')
+        self.hass.block_till_done()
+
+        assert len(self.hass.states.all()) == 1


### PR DESCRIPTION
## Description:

Add `unique_id` capabilities to MQTT Sensors. Some sensors (like the ds18b20) have serial numbers that are burnt into the chip at production time. When coupled with MQTT discovery (and [esphomelib](https://github.com/OttoWinter/esphomelib) 🤓) this could allow those sensors to be added to the entity registry.

Very much an RFC and I have a couple of open questions about this:

* Should we limit this to the sensor component? I mean over the last week I've tried to think of any other device that exposes truly unique ids, and all of them were sensors.
* We should make very clear that we then expect truly unique ids in the documentation. Up until now, the meaning of `unique_id` has not really been exposed to users, only to developers. This is the main reason I'm not sure about this.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5131

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: mqtt
    name: Test 1
    state_topic: "test-topic-1"
    unique_id: "TOTALLY_UNIQUE"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

