### PR TITLE
Mediaroom async

### DIFF
--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -197,29 +197,23 @@ class MediaroomDevice(MediaPlayerDevice):
     async def async_turn_on(self):
         """Turn on the receiver."""
         from pymediaroom import PyMediaroomError
-
         try:
             self.set_state(await self.stb.turn_on())
+            if self._optimistic:
+                self._state = STATE_PLAYING
         except PyMediaroomError:
             self._available = False
-
-        if self._optimistic:
-            self._state = STATE_PLAYING
         self.async_schedule_update_ha_state()
 
     async def async_turn_off(self):
         """Turn off the receiver."""
         from pymediaroom import PyMediaroomError
-        if self._optimistic:
-            return
-
         try:
             self.set_state(await self.stb.turn_off())
+            if self._optimistic:
+                self._state = STATE_STANDBY
         except PyMediaroomError:
             self._available = False
-
-        if self._optimistic:
-            self._state = STATE_STANDBY
         self.async_schedule_update_ha_state()
 
     async def async_media_play(self):
@@ -285,7 +279,7 @@ class MediaroomDevice(MediaPlayerDevice):
             await self.stb.send_cmd('VolUp')
         except PyMediaroomError:
             self._available = False
-            self.async_schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     async def async_volume_down(self):
         """Send volume up command."""
@@ -294,7 +288,7 @@ class MediaroomDevice(MediaPlayerDevice):
             await self.stb.send_cmd('VolDown')
         except PyMediaroomError:
             self._available = False
-            self.async_schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     async def async_mute_volume(self, mute):
         """Send mute command."""
@@ -303,4 +297,4 @@ class MediaroomDevice(MediaPlayerDevice):
             await self.stb.send_cmd('Mute')
         except PyMediaroomError:
             self._available = False
-            self.async_schedule_update_ha_state()
+        self.async_schedule_update_ha_state()

--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -77,7 +77,7 @@ async def async_setup_platform(hass, config, async_add_devices,
         )
         async_add_devices([new_stb])
 
-    if not config.get(CONF_OPTIMISTIC):
+    if not config[CONF_OPTIMISTIC]:
         from pymediaroom import install_mediaroom_protocol
 
         await install_mediaroom_protocol(responses_callback=callback_notify)
@@ -120,7 +120,7 @@ class MediaroomDevice(MediaPlayerDevice):
         if device_id:
             self._unique_id = device_id
         else:
-            self._unique_id = self.stb.device_id
+            self._unique_id = None 
 
     @property
     def should_poll(self):

--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pymediaroom==0.5']
+REQUIREMENTS = ['pymediaroom==0.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -156,7 +156,8 @@ class MediaroomDevice(MediaPlayerDevice):
                 return
 
             await self.stb.send_cmd(int(media_id))
-            self._state = STATE_PLAYING
+            if self._optimistic:
+                self._state = STATE_PLAYING
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
         self.schedule_update_ha_state()
@@ -221,7 +222,8 @@ class MediaroomDevice(MediaPlayerDevice):
         try:
             _LOGGER.debug("media_play()")
             await self.stb.send_cmd('PlayPause')
-            self._state = STATE_PLAYING
+            if self._optimistic:
+                self._state = STATE_PLAYING
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
         self.schedule_update_ha_state()
@@ -231,7 +233,8 @@ class MediaroomDevice(MediaPlayerDevice):
         from pymediaroom import PyMediaroomError
         try:
             await self.stb.send_cmd('PlayPause')
-            self._state = STATE_PAUSED
+            if self._optimistic:
+                self._state = STATE_PAUSED
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
         self.schedule_update_ha_state()
@@ -241,7 +244,8 @@ class MediaroomDevice(MediaPlayerDevice):
         from pymediaroom import PyMediaroomError
         try:
             await self.stb.send_cmd('Stop')
-            self._state = STATE_PAUSED
+            if self._optimistic:
+                self._state = STATE_PAUSED
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
         self.schedule_update_ha_state()
@@ -251,7 +255,8 @@ class MediaroomDevice(MediaPlayerDevice):
         from pymediaroom import PyMediaroomError
         try:
             await self.stb.send_cmd('ProgDown')
-            self._state = STATE_PLAYING
+            if self._optimistic:
+                self._state = STATE_PLAYING
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
         self.schedule_update_ha_state()
@@ -261,7 +266,8 @@ class MediaroomDevice(MediaPlayerDevice):
         from pymediaroom import PyMediaroomError
         try:
             await self.stb.send_cmd('ProgUp')
-            self._state = STATE_PLAYING
+            if self._optimistic:
+                self._state = STATE_PLAYING
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
         self.schedule_update_ha_state()

--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -28,9 +28,7 @@ REQUIREMENTS = ['pymediaroom==0.6']
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "mediaroom"
-NOTIFICATION_TITLE = 'Mediaroom Media Player Setup'
-NOTIFICATION_ID = 'mediaroom_notification'
+PLATFORM = "mediaroom"
 DEFAULT_NAME = 'Mediaroom STB'
 DEFAULT_TIMEOUT = 9
 DATA_MEDIAROOM = "mediaroom_known_stb"
@@ -123,7 +121,7 @@ class MediaroomDevice(MediaPlayerDevice):
         self._channel = None
         self._optimistic = optimistic
         self._state = STATE_PLAYING if optimistic else STATE_STANDBY
-        self._name = '{}_{}'.format(DOMAIN, device_id)
+        self._name = '{} {}'.format(PLATFORM, device_id)
         if device_id:
             self._unique_id = device_id
         else:
@@ -140,7 +138,7 @@ class MediaroomDevice(MediaPlayerDevice):
             """Process STB state from NOTIFY message."""
             self.set_state(self.stb.notify_callback(notify))
             _LOGGER.debug("STB(%s) is [%s]", self.host, self._state)
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
         async_dispatcher_connect(self.hass, SIGNAL_STB_NOTIFY,
                                  notify_received)
@@ -163,7 +161,7 @@ class MediaroomDevice(MediaPlayerDevice):
                 self._state = STATE_PLAYING
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     @property
     def unique_id(self):
@@ -205,7 +203,7 @@ class MediaroomDevice(MediaPlayerDevice):
             self.set_state(await self.stb.turn_on())
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     async def async_turn_off(self):
         """Turn off the receiver."""
@@ -217,7 +215,7 @@ class MediaroomDevice(MediaPlayerDevice):
             self.set_state(await self.stb.turn_off())
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     async def async_media_play(self):
         """Send play command."""
@@ -229,7 +227,7 @@ class MediaroomDevice(MediaPlayerDevice):
                 self._state = STATE_PLAYING
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     async def async_media_pause(self):
         """Send pause command."""
@@ -240,7 +238,7 @@ class MediaroomDevice(MediaPlayerDevice):
                 self._state = STATE_PAUSED
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     async def async_media_stop(self):
         """Send stop command."""
@@ -251,7 +249,7 @@ class MediaroomDevice(MediaPlayerDevice):
                 self._state = STATE_PAUSED
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     async def async_media_previous_track(self):
         """Send Program Down command."""
@@ -262,7 +260,7 @@ class MediaroomDevice(MediaPlayerDevice):
                 self._state = STATE_PLAYING
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     async def async_media_next_track(self):
         """Send Program Up command."""
@@ -273,7 +271,7 @@ class MediaroomDevice(MediaPlayerDevice):
                 self._state = STATE_PLAYING
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     async def async_volume_up(self):
         """Send volume up command."""
@@ -282,7 +280,7 @@ class MediaroomDevice(MediaPlayerDevice):
             await self.stb.send_cmd('VolUp')
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
     async def async_volume_down(self):
         """Send volume up command."""
@@ -291,7 +289,7 @@ class MediaroomDevice(MediaPlayerDevice):
             await self.stb.send_cmd('VolDown')
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
     async def async_mute_volume(self, mute):
         """Send mute command."""
@@ -300,4 +298,4 @@ class MediaroomDevice(MediaPlayerDevice):
             await self.stb.send_cmd('Mute')
         except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()

--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -120,7 +120,7 @@ class MediaroomDevice(MediaPlayerDevice):
         if device_id:
             self._unique_id = device_id
         else:
-            self._unique_id = None 
+            self._unique_id = None
 
     @property
     def should_poll(self):

--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -9,23 +9,23 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    MEDIA_TYPE_CHANNEL, SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA,
-    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_STOP, PLATFORM_SCHEMA,
-    SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK, SUPPORT_PLAY,
-    SUPPORT_VOLUME_STEP, SUPPORT_VOLUME_MUTE,
-    MediaPlayerDevice)
-from homeassistant.helpers.dispatcher import (dispatcher_send,
-                                              async_dispatcher_connect)
+    MEDIA_TYPE_CHANNEL, SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA, SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON, SUPPORT_STOP, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
+    SUPPORT_PREVIOUS_TRACK, SUPPORT_PLAY, SUPPORT_VOLUME_STEP,
+    SUPPORT_VOLUME_MUTE, MediaPlayerDevice,
+)
+from homeassistant.helpers.dispatcher import (
+    dispatcher_send, async_dispatcher_connect
+)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_OPTIMISTIC, CONF_TIMEOUT,
-    STATE_PAUSED, STATE_PLAYING, STATE_STANDBY,
-    STATE_ON, STATE_OFF, STATE_UNAVAILABLE,
-    EVENT_HOMEASSISTANT_STOP)
+    CONF_HOST, CONF_NAME, CONF_OPTIMISTIC,
+    CONF_TIMEOUT, STATE_PAUSED, STATE_PLAYING, STATE_STANDBY, STATE_ON,
+    STATE_UNAVAILABLE
+)
 import homeassistant.helpers.config_validation as cv
+
 REQUIREMENTS = ['pymediaroom==0.5']
-
 _LOGGER = logging.getLogger(__name__)
-
 DOMAIN = "mediaroom"
 NOTIFICATION_TITLE = 'Mediaroom Media Player Setup'
 NOTIFICATION_ID = 'mediaroom_notification'
@@ -33,78 +33,81 @@ DEFAULT_NAME = 'Mediaroom STB'
 DEFAULT_TIMEOUT = 9
 DATA_MEDIAROOM = "mediaroom_known_stb"
 SIGNAL_STB_NOTIFY = 'stb_discovered'
+SUPPORT_MEDIAROOM = SUPPORT_PAUSE | SUPPORT_TURN_ON | SUPPORT_TURN_OFF \
+    | SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | SUPPORT_PLAY_MEDIA \
+    | SUPPORT_STOP | SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK \
+    | SUPPORT_PLAY
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+    }
+)
 
-SUPPORT_MEDIAROOM = SUPPORT_PAUSE | SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
-    SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | \
-    SUPPORT_PLAY_MEDIA | SUPPORT_STOP | SUPPORT_NEXT_TRACK | \
-    SUPPORT_PREVIOUS_TRACK | SUPPORT_PLAY
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_HOST): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
-    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-})
-
-async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
     """Set up the Mediaroom platform."""
     known_hosts = hass.data.get(DATA_MEDIAROOM)
     if known_hosts is None:
         known_hosts = hass.data[DATA_MEDIAROOM] = []
-
     host = config.get(CONF_HOST, None)
     if host:
-        async_add_devices([MediaroomDevice( 
-                                            host=host, 
-                                            device_id=None, 
-                                            optimistic=config.get(CONF_OPTIMISTIC), 
-                                            timeout=config.get(CONF_TIMEOUT)
-                                            )])
+        async_add_devices(
+            [
+                MediaroomDevice(
+                    host=host,
+                    device_id=None,
+                    optimistic=config.get(CONF_OPTIMISTIC),
+                    timeout=config.get(CONF_TIMEOUT),
+                )
+            ]
+        )
         hass.data[DATA_MEDIAROOM].append(host)
-
     _LOGGER.debug("Trying to discover Mediaroom STB")
-    
+
     def callback_notify(notify):
+        """Process NOTIFY message from STB."""
         if notify.ip_address in hass.data[DATA_MEDIAROOM]:
             dispatcher_send(hass, SIGNAL_STB_NOTIFY, notify)
             return
-        
+
         _LOGGER.debug("Discovered new stb %s", notify.ip_address)
-
         hass.data[DATA_MEDIAROOM].append(notify.ip_address)
-        
         new_stb = MediaroomDevice(
-                    host=notify.ip_address,
-                    device_id=notify.device_uuid,
-                    optimistic=False
-                    )
-
+            host=notify.ip_address, device_id=notify.device_uuid,
+            optimistic=False
+        )
         async_add_devices([new_stb])
 
     from pymediaroom import installMediaroomProtocol
-    mr_protocol = await installMediaroomProtocol(
-                            responses_callback=callback_notify)
+
+    await installMediaroomProtocol(responses_callback=callback_notify)
     _LOGGER.debug("Auto discovery installed")
+
 
 class MediaroomDevice(MediaPlayerDevice):
     """Representation of a Mediaroom set-up-box on the network."""
 
-    def __init__(self, host, device_id, optimistic=False, timeout=DEFAULT_TIMEOUT):
+    def __init__(self, host, device_id, optimistic=False,
+                 timeout=DEFAULT_TIMEOUT):
         """Initialize the device."""
         from pymediaroom import Remote
 
         self.host = host
         self.stb = Remote(host)
-        _LOGGER.info(
-            "Found STB at %s%s", host,
-            " - I'm optimistic" if optimistic else "")
+        _LOGGER.info("Found STB at %s%s", host,
+                     " - I'm optimistic" if optimistic else "")
         self._is_standby = not optimistic
+        self._channel = None
         self._current = None
         self._optimistic = optimistic
         self._state = STATE_STANDBY
         self._name = '{}_{}'.format(DOMAIN, device_id)
         if device_id:
-            self._unique_id = device_id 
+            self._unique_id = device_id
         else:
             self._unique_id = self.stb.get_device_id()
 
@@ -115,44 +118,44 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_added_to_hass(self):
         """Retrieve latest state."""
-        from pymediaroom import installMediaroomProtocol 
-        
         def async_notify_received(notify):
+            """Process STB state from NOTIFY message."""
             _LOGGER.debug(notify)
-
             if notify.ip_address != self.host:
                 return
 
             if notify.tune:
-                self._state = STATE_PLAYING 
+                self._state = STATE_PLAYING
+                self._channel = self.stb.resolv(notify.tune['@src'])
             else:
                 self._state = STATE_STANDBY
-            _LOGGER.debug(
-                    "STB(%s) is [%s]",
-                    self.host, self._state)
+            _LOGGER.debug("STB(%s) is [%s]", self.host, self._state)
+            self.schedule_update_ha_state()
 
         async_dispatcher_connect(self.hass, SIGNAL_STB_NOTIFY,
                                  async_notify_received)
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Play media."""
-        from pymediaroom import PyMediaroomError 
-        
+        from pymediaroom import PyMediaroomError
+
         try:
-            _LOGGER.debug(
-                "STB(%s) Play media: %s (%s)",
-                self.stb.stb_ip, media_id, media_type)
+            _LOGGER.debug("STB(%s) Play media: %s (%s)", self.stb.stb_ip,
+                          media_id, media_type)
             if media_type != MEDIA_TYPE_CHANNEL:
                 _LOGGER.error('invalid media type')
                 return
+
             if media_id.isdigit():
                 media_id = int(media_id)
             else:
                 return
+
             await self.stb.send_cmd(media_id)
             self._state = STATE_PLAYING
-        except PyMediaroomError as e:
+        except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
+        self.schedule_update_ha_state()
 
     @property
     def unique_id(self):
@@ -164,7 +167,6 @@ class MediaroomDevice(MediaPlayerDevice):
         """Return the name of the device."""
         return self._name
 
-    # MediaPlayerDevice properties and methods
     @property
     def state(self):
         """Return the state of the device."""
@@ -180,100 +182,115 @@ class MediaroomDevice(MediaPlayerDevice):
         """Return the content type of current playing media."""
         return MEDIA_TYPE_CHANNEL
 
+    @property
+    def media_channel(self):
+        """Channel currently playing."""
+        return self._channel
+
     async def async_turn_on(self):
         """Turn on the receiver."""
-        from pymediaroom import PyMediaroomError 
-        
+        from pymediaroom import PyMediaroomError
+
         try:
             await self.stb.send_cmd('Power')
             self._state = STATE_ON
-        except PyMediaroomError as e:
+        except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
+        self.schedule_update_ha_state()
 
     async def async_turn_off(self):
         """Turn off the receiver."""
-        from pymediaroom import PyMediaroomError 
-        
+        from pymediaroom import PyMediaroomError
+
         try:
             await self.stb.send_cmd('Power')
             self._state = STATE_STANDBY
-        except PyMediaroomError as e:
+        except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
+        self.schedule_update_ha_state()
 
     async def async_media_play(self):
         """Send play command."""
-        from pymediaroom import PyMediaroomError 
-        
+        from pymediaroom import PyMediaroomError
+
         try:
             _LOGGER.debug("media_play()")
             await self.stb.send_cmd('PlayPause')
             self._state = STATE_PLAYING
-        except PyMediaroomError as e:
+        except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
+        self.schedule_update_ha_state()
 
     async def async_media_pause(self):
         """Send pause command."""
-        from pymediaroom import PyMediaroomError 
-        
+        from pymediaroom import PyMediaroomError
+
         try:
             await self.stb.send_cmd('PlayPause')
             self._state = STATE_PAUSED
-        except PyMediaroomError as e:
+        except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
+        self.schedule_update_ha_state()
 
     async def async_media_stop(self):
         """Send stop command."""
-        from pymediaroom import PyMediaroomError 
-        
+        from pymediaroom import PyMediaroomError
+
         try:
             await self.stb.send_cmd('Stop')
             self._state = STATE_PAUSED
-        except PyMediaroomError as e:
+        except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
+        self.schedule_update_ha_state()
 
     async def async_media_previous_track(self):
         """Send Program Down command."""
-        from pymediaroom import PyMediaroomError 
-        
+        from pymediaroom import PyMediaroomError
+
         try:
             await self.stb.send_cmd('ProgDown')
             self._state = STATE_PLAYING
-        except PyMediaroomError as e:
+        except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
+        self.schedule_update_ha_state()
 
     async def async_media_next_track(self):
         """Send Program Up command."""
-        from pymediaroom import PyMediaroomError 
-        
+        from pymediaroom import PyMediaroomError
+
         try:
             await self.stb.send_cmd('ProgUp')
             self._state = STATE_PLAYING
-        except PyMediaroomError as e:
+        except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
+        self.schedule_update_ha_state()
 
     async def async_volume_up(self):
         """Send volume up command."""
-        from pymediaroom import PyMediaroomError 
-        
+        from pymediaroom import PyMediaroomError
+
         try:
             await self.stb.send_cmd('VolUp')
-        except PyMediaroomError as e:
+        except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
+            self.schedule_update_ha_state()
 
     async def async_volume_down(self):
         """Send volume up command."""
-        from pymediaroom import PyMediaroomError 
-        
+        from pymediaroom import PyMediaroomError
+
         try:
             await self.stb.send_cmd('VolDown')
-        except PyMediaroomError as e:
+        except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
+            self.schedule_update_ha_state()
 
     async def async_mute_volume(self, mute):
         """Send mute command."""
-        from pymediaroom import PyMediaroomError 
-        
+        from pymediaroom import PyMediaroomError
+
         try:
             await self.stb.send_cmd('Mute')
-        except PyMediaroomError as e:
+        except PyMediaroomError:
             self._state = STATE_UNAVAILABLE
+            self.schedule_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -801,7 +801,7 @@ pylutron==0.1.0
 pymailgunner==1.4
 
 # homeassistant.components.media_player.mediaroom
-pymediaroom==0.5
+pymediaroom==0.6
 
 # homeassistant.components.media_player.xiaomi_tv
 pymitv==1.0.0


### PR DESCRIPTION
## Description:

The mediaroom platform has been ported to asyncio (together with the supporting pymediaroom library)

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: mediaroom
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.