### PR TITLE
Use "lx" instead of "lux" in deconz

### DIFF
--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -92,7 +92,10 @@ class DeconzSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this sensor."""
-        return self._sensor.sensor_unit
+        if self._sensor.sensor_unit.lower() == 'lux':
+            return 'lx'
+        else:
+            return self._sensor.sensor_unit
 
     @property
     def available(self):

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -94,8 +94,7 @@ class DeconzSensor(Entity):
         """Return the unit of measurement of this sensor."""
         if self._sensor.sensor_unit.lower() == 'lux':
             return 'lx'
-        else:
-            return self._sensor.sensor_unit
+        return self._sensor.sensor_unit
 
     @property
     def available(self):


### PR DESCRIPTION
## Description:
Other components use "lx". We should use the same for every component.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
