### PR TITLE
Upgrade broadlink to 0.8

### DIFF
--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -19,9 +19,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = [
-    'https://github.com/balloob/python-broadlink/archive/'
-    '3580ff2eaccd267846f14246d6ede6e30671f7c6.zip#broadlink==0.5.1']
+REQUIREMENTS = ['broadlink==0.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -22,9 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 from homeassistant.util.dt import utcnow
 
-REQUIREMENTS = [
-    'https://github.com/balloob/python-broadlink/archive/'
-    '3580ff2eaccd267846f14246d6ede6e30671f7c6.zip#broadlink==0.5.1']
+REQUIREMENTS = ['broadlink==0.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -166,6 +166,10 @@ boto3==1.4.7
 # homeassistant.scripts.credstash
 botocore==1.7.34
 
+# homeassistant.components.sensor.broadlink
+# homeassistant.components.switch.broadlink
+broadlink==0.8
+
 # homeassistant.components.sensor.buienradar
 # homeassistant.components.weather.buienradar
 buienradar==0.91
@@ -372,10 +376,6 @@ httplib2==0.10.3
 
 # homeassistant.components.media_player.braviatv
 https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
-
-# homeassistant.components.sensor.broadlink
-# homeassistant.components.switch.broadlink
-https://github.com/balloob/python-broadlink/archive/3580ff2eaccd267846f14246d6ede6e30671f7c6.zip#broadlink==0.5.1
 
 # homeassistant.components.media_player.spotify
 https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f86c90aa26b2.zip#spotipy==2.4.4


### PR DESCRIPTION
## Description:
[changelog](https://github.com/mjg59/python-broadlink/compare/b8cf8d073e409fafef50ad0fb5435cb23d016bb2...9286d9a1d9d133d9897becf3898025d822a7d841)

Highlight: Drop pycrypto in favor of pycryptodome

I did not test this locally. Any broadlink user that can test this? @Danielhiversen ?

I know that the pycryptodome change works, as that is what is currently shipping. However I don't know about the other changes.

**Related issue (if applicable):** #12715 
