### PR TITLE
Add support for tracking devices on Netgear access points

### DIFF
--- a/homeassistant/components/device_tracker/netgear.py
+++ b/homeassistant/components/device_tracker/netgear.py
@@ -12,11 +12,14 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
-    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT)
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT,
+    CONF_DEVICES, CONF_EXCLUDE)
 
-REQUIREMENTS = ['pynetgear==0.3.3']
+REQUIREMENTS = ['pynetgear==0.3.4']
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_APS = 'accesspoints'
 
 DEFAULT_HOST = 'routerlogin.net'
 DEFAULT_USER = 'admin'
@@ -26,7 +29,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_USERNAME, default=DEFAULT_USER): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_DEVICES, default=[]):
+        vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_EXCLUDE, default=[]):
+        vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_APS, default=[]):
+        vol.All(cv.ensure_list, [cv.string]),
 })
 
 
@@ -37,8 +46,12 @@ def get_scanner(hass, config):
     username = info.get(CONF_USERNAME)
     password = info.get(CONF_PASSWORD)
     port = info.get(CONF_PORT)
+    devices = info.get(CONF_DEVICES)
+    excluded_devices = info.get(CONF_EXCLUDE)
+    accesspoints = info.get(CONF_APS)
 
-    scanner = NetgearDeviceScanner(host, username, password, port)
+    scanner = NetgearDeviceScanner(host, username, password, port,
+                                   devices, excluded_devices, accesspoints)
 
     return scanner if scanner.success_init else None
 
@@ -46,16 +59,21 @@ def get_scanner(hass, config):
 class NetgearDeviceScanner(DeviceScanner):
     """Queries a Netgear wireless router using the SOAP-API."""
 
-    def __init__(self, host, username, password, port):
+    def __init__(self, host, username, password, port, devices,
+                 excluded_devices, accesspoints):
         """Initialize the scanner."""
         import pynetgear
+
+        self.tracked_devices = devices
+        self.excluded_devices = excluded_devices
+        self.tracked_accesspoints = accesspoints
 
         self.last_results = []
         self._api = pynetgear.Netgear(password, host, username, port)
 
         _LOGGER.info("Logging in")
 
-        results = self._api.get_attached_devices()
+        results = self.get_attached_devices()
 
         self.success_init = results is not None
 
@@ -68,15 +86,50 @@ class NetgearDeviceScanner(DeviceScanner):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
 
-        return (device.mac for device in self.last_results)
+        devices = []
+
+        for dev in self.last_results:
+            tracked = (not self.tracked_devices or
+                       dev.mac in self.tracked_devices or
+                       dev.name in self.tracked_devices)
+            tracked = tracked and (not self.excluded_devices or not(
+                dev.mac in self.excluded_devices or
+                dev.name in self.excluded_devices))
+            if tracked:
+                devices.append(dev.mac)
+                if (self.tracked_accesspoints and
+                        dev.conn_ap_mac in self.tracked_accesspoints):
+                    devices.append(dev.mac + "_" + dev.conn_ap_mac)
+
+        return devices
 
     def get_device_name(self, device):
-        """Return the name of the given device or None if we don't know."""
-        try:
-            return next(result.name for result in self.last_results
-                        if result.mac == device)
-        except StopIteration:
-            return None
+        """Return the name of the given device or the MAC if we don't know."""
+        parts = device.split("_")
+        mac = parts[0]
+        ap_mac = None
+        if len(parts) > 1:
+            ap_mac = parts[1]
+
+        name = None
+        for dev in self.last_results:
+            if dev.mac == mac:
+                name = dev.name
+                break
+
+        if not name or name == "--":
+            name = mac
+
+        if ap_mac:
+            ap_name = "Router"
+            for dev in self.last_results:
+                if dev.mac == ap_mac:
+                    ap_name = dev.name
+                    break
+
+            return name + " on " + ap_name
+
+        return name
 
     def _update_info(self):
         """Retrieve latest information from the Netgear router.
@@ -88,9 +141,21 @@ class NetgearDeviceScanner(DeviceScanner):
 
         _LOGGER.info("Scanning")
 
-        results = self._api.get_attached_devices()
+        results = self.get_attached_devices()
 
         if results is None:
             _LOGGER.warning("Error scanning devices")
 
         self.last_results = results or []
+
+    def get_attached_devices(self):
+        """
+        List attached devices with pynetgear.
+
+        The v2 method takes more time and is more heavy on the router
+        so we only use it if we need connected AP info.
+        """
+        if self.tracked_accesspoints:
+            return self._api.get_attached_devices_2()
+
+        return self._api.get_attached_devices()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -869,7 +869,7 @@ pymysensors==0.11.1
 pynello==1.5.1
 
 # homeassistant.components.device_tracker.netgear
-pynetgear==0.3.4
+pynetgear==0.4.0
 
 # homeassistant.components.switch.netio
 pynetio==0.1.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -869,7 +869,7 @@ pymysensors==0.11.1
 pynello==1.5.1
 
 # homeassistant.components.device_tracker.netgear
-pynetgear==0.3.3
+pynetgear==0.3.4
 
 # homeassistant.components.switch.netio
 pynetio==0.1.6


### PR DESCRIPTION
## Description:

It also allows the use of SSL parameter. Autodetection of the URL has also been added.

Cf doc PR for more infos.

This is waiting on balloob/pynetgear#30, balloob/pynetgear#32, balloob/pynetgear#33 and balloob/pynetgear#35 to be merged.
In the meantime you can test with `pip install git+https://github.com/MatMaul/pynetgear.git@hass-orbi`.

Tested with Orbi.

**Pull request in home-assistant.github.io:** home-assistant/home-assistant.github.io#4958

## Example entry for `configuration.yaml`:
```yaml
device_tracker:
  - platform: netgear
    password: YOUR_ADMIN_PASSWORD
    devices:
      - MY-LAPTOP
      - 00:1A:2B:3C:44:55
    exclude:
      - MY-SERVER
    accesspoints:
      - 3C:44:55:00:1A:2B
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable.
  - [x] New dependencies are only imported inside functions that use them.
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`: nothing since omitted file
