### PR TITLE
Fixing Egardia 'home armed' state not shown correctly.

### DIFF
--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -19,7 +19,7 @@ from homeassistant.components.egardia import (
     REPORT_SERVER_CODES_IGNORE, CONF_REPORT_SERVER_CODES,
     CONF_REPORT_SERVER_ENABLED, CONF_REPORT_SERVER_PORT
     )
-REQUIREMENTS = ['pythonegardia==1.0.39']
+DEPENDENCIES = ['egardia']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/alarm_control_panel/egardia.py
+++ b/homeassistant/components/alarm_control_panel/egardia.py
@@ -12,13 +12,14 @@ import requests
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.const import (
     STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_ARMED_AWAY, STATE_ALARM_TRIGGERED)
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_TRIGGERED,
+    STATE_ALARM_ARMED_NIGHT)
 from homeassistant.components.egardia import (
     EGARDIA_DEVICE, EGARDIA_SERVER,
     REPORT_SERVER_CODES_IGNORE, CONF_REPORT_SERVER_CODES,
     CONF_REPORT_SERVER_ENABLED, CONF_REPORT_SERVER_PORT
     )
-REQUIREMENTS = ['pythonegardia==1.0.38']
+REQUIREMENTS = ['pythonegardia==1.0.39']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +28,8 @@ STATES = {
     'DAY HOME': STATE_ALARM_ARMED_HOME,
     'DISARM': STATE_ALARM_DISARMED,
     'ARMHOME': STATE_ALARM_ARMED_HOME,
+    'HOME': STATE_ALARM_ARMED_HOME,
+    'NIGHT HOME': STATE_ALARM_ARMED_NIGHT,
     'TRIGGERED': STATE_ALARM_TRIGGERED
 }
 

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -12,7 +12,7 @@ from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.components.egardia import (
     EGARDIA_DEVICE, ATTR_DISCOVER_DEVICES)
 _LOGGER = logging.getLogger(__name__)
-
+DEPENDENCIES = ['egardia']
 EGARDIA_TYPE_TO_DEVICE_CLASS = {'IR Sensor': 'motion',
                                 'Door Contact': 'opening',
                                 'IR': 'motion'}

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_PORT, CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_NAME,
     EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pythonegardia==1.0.38']
+REQUIREMENTS = ['pythonegardia==1.0.39']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1006,8 +1006,10 @@ python_opendata_transport==0.0.3
 python_openzwave==0.4.3
 
 # homeassistant.components.egardia
-# homeassistant.components.alarm_control_panel.egardia
 pythonegardia==1.0.38
+
+# homeassistant.components.alarm_control_panel.egardia
+pythonegardia==1.0.39
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1006,8 +1006,6 @@ python_opendata_transport==0.0.3
 python_openzwave==0.4.3
 
 # homeassistant.components.egardia
-pythonegardia==1.0.38
-
 # homeassistant.components.alarm_control_panel.egardia
 pythonegardia==1.0.39
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1006,7 +1006,6 @@ python_opendata_transport==0.0.3
 python_openzwave==0.4.3
 
 # homeassistant.components.egardia
-# homeassistant.components.alarm_control_panel.egardia
 pythonegardia==1.0.39
 
 # homeassistant.components.sensor.whois


### PR DESCRIPTION
## Description:
Fixing Python-egardia bug jeroenterheerdt/python-egardia#17: Home armed state was not showing correctly in Home Assistant. This PR replaces #13309 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
