### PR TITLE
Add support for controlling homekit lights and switches

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -109,7 +109,7 @@ omit =
     homeassistant/components/hive.py
     homeassistant/components/*/hive.py
 
-    homeassistant/components/homekit_controller.py
+    homeassistant/components/homekit_controller/__init__.py
     homeassistant/components/*/homekit_controller.py
 
     homeassistant/components/homematic/__init__.py
@@ -421,7 +421,6 @@ omit =
     homeassistant/components/light/decora.py
     homeassistant/components/light/flux_led.py
     homeassistant/components/light/greenwave.py
-    homeassistant/components/light/homekit_controller.py
     homeassistant/components/light/hue.py
     homeassistant/components/light/hyperion.py
     homeassistant/components/light/iglo.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -109,6 +109,9 @@ omit =
     homeassistant/components/hive.py
     homeassistant/components/*/hive.py
 
+    homeassistant/components/homekit_controller.py
+    homeassistant/components/*/homekit_controller.py
+
     homeassistant/components/homematic/__init__.py
     homeassistant/components/*/homematic.py
 
@@ -418,6 +421,7 @@ omit =
     homeassistant/components/light/decora.py
     homeassistant/components/light/flux_led.py
     homeassistant/components/light/greenwave.py
+    homeassistant/components/light/homekit_controller.py
     homeassistant/components/light/hue.py
     homeassistant/components/light/hyperion.py
     homeassistant/components/light/iglo.py

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -115,9 +115,6 @@ async def async_setup(hass, config):
     # Optional platforms enabled by config
     enabled_platforms = config[DOMAIN][CONF_ENABLE]
 
-    for service in enabled_platforms:
-        SERVICE_HANDLERS[service] = OPTIONAL_SERVICE_HANDLERS[service]
-
     async def new_service_found(service, info):
         """Handle a new service if one is found."""
         if service in ignored_platforms:
@@ -139,6 +136,9 @@ async def async_setup(hass, config):
             return
 
         comp_plat = SERVICE_HANDLERS.get(service)
+
+        if not comp_plat and service in enabled_platforms:
+            comp_plat = OPTIONAL_SERVICE_HANDLERS[service]
 
         # We do not know how to handle this service.
         if not comp_plat:

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -40,6 +40,7 @@ SERVICE_HUE = 'philips_hue'
 SERVICE_DECONZ = 'deconz'
 SERVICE_DAIKIN = 'daikin'
 SERVICE_SAMSUNG_PRINTER = 'samsung_printer'
+SERVICE_HOMEKIT = 'homekit'
 
 CONFIG_ENTRY_HANDLERS = {
     SERVICE_HUE: 'hue',
@@ -59,6 +60,7 @@ SERVICE_HANDLERS = {
     SERVICE_DECONZ: ('deconz', None),
     SERVICE_DAIKIN: ('daikin', None),
     SERVICE_SAMSUNG_PRINTER: ('sensor', 'syncthru'),
+    SERVICE_HOMEKIT: ('homekit_controller', None),
     'google_cast': ('media_player', 'cast'),
     'panasonic_viera': ('media_player', 'panasonic_viera'),
     'plex_mediaserver': ('media_player', 'plex'),

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -60,7 +60,6 @@ SERVICE_HANDLERS = {
     SERVICE_DECONZ: ('deconz', None),
     SERVICE_DAIKIN: ('daikin', None),
     SERVICE_SAMSUNG_PRINTER: ('sensor', 'syncthru'),
-    SERVICE_HOMEKIT: ('homekit_controller', None),
     'google_cast': ('media_player', 'cast'),
     'panasonic_viera': ('media_player', 'panasonic_viera'),
     'plex_mediaserver': ('media_player', 'plex'),
@@ -81,13 +80,20 @@ SERVICE_HANDLERS = {
     'songpal': ('media_player', 'songpal'),
 }
 
+OPTIONAL_SERVICE_HANDLERS = {
+    SERVICE_HOMEKIT: ('homekit_controller', None),
+}
+
 CONF_IGNORE = 'ignore'
+CONF_ENABLE = 'enable'
 
 CONFIG_SCHEMA = vol.Schema({
     vol.Required(DOMAIN): vol.Schema({
         vol.Optional(CONF_IGNORE, default=[]):
             vol.All(cv.ensure_list, [
-                vol.In(list(CONFIG_ENTRY_HANDLERS) + list(SERVICE_HANDLERS))])
+                vol.In(list(CONFIG_ENTRY_HANDLERS) + list(SERVICE_HANDLERS))]),
+        vol.Optional(CONF_ENABLE, default=[]):
+            vol.All(cv.ensure_list, [vol.In(OPTIONAL_SERVICE_HANDLERS)])
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -105,6 +111,12 @@ async def async_setup(hass, config):
 
     # Platforms ignore by config
     ignored_platforms = config[DOMAIN][CONF_IGNORE]
+
+    # Optional platforms enabled by config
+    enabled_platforms = config[DOMAIN][CONF_ENABLE]
+
+    for service in enabled_platforms:
+        SERVICE_HANDLERS[service] = OPTIONAL_SERVICE_HANDLERS[service]
 
     async def new_service_found(service, info):
         """Handle a new service if one is found."""

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -150,8 +150,7 @@ class HKDevice():
 class HomeKitEntity(Entity):
     """Representation of a Home Assistant HomeKit device."""
 
-    def __init__(self, hass, devinfo):
-        accessory = hass.data[KNOWN_ACCESSORIES][devinfo['serial']]
+    def __init__(self, accessory, devinfo):
         self._name = accessory.model
         self._securecon = accessory.securecon
         self._aid = devinfo['aid']
@@ -159,7 +158,6 @@ class HomeKitEntity(Entity):
         self._address = "homekit-{}-{}".format(devinfo['serial'], self._iid)
         self._features = 0
         self._chars = {}
-        self.update()
 
     def update(self):
         response = self._securecon.get('/accessories')

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -26,9 +26,7 @@ HOMEKIT_ACCESSORY_DISPATCH = {
 }
 
 KNOWN_ACCESSORIES = "{}-accessories".format(DOMAIN)
-
-KNOWN_DEVICES = {}
-DEVICES = []
+KNOWN_DEVICES = "{}-devices".format(DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -183,7 +181,7 @@ class HomeKitEntity(Entity):
         """Return the name of the device if any."""
         return self._name
 
-    def update_characteristics(self):
+    def update_characteristics(self, characteristics):
         raise NotImplementedError
 
 
@@ -201,8 +199,8 @@ def setup(hass, config):
         config_num = int(discovery_info['properties']['c#'])
 
         # Only register a device once, but rescan if the config has changed
-        if hkid in KNOWN_DEVICES:
-            device = KNOWN_DEVICES[hkid]
+        if hkid in hass.data[KNOWN_DEVICES]:
+            device = hass.data[KNOWN_DEVICES][hkid]
             if config_num > device.config_num and \
                device.pairing_info is not None:
                 device.accessory_setup()
@@ -210,9 +208,9 @@ def setup(hass, config):
 
         _LOGGER.debug('Discovered unique device %s', hkid)
         device = HKDevice(hass, host, port, model, hkid, config_num, config)
-        KNOWN_DEVICES[hkid] = device
-        DEVICES.append(device)
+        hass.data[KNOWN_DEVICES][hkid] = device
 
     hass.data[KNOWN_ACCESSORIES] = {}
+    hass.data[KNOWN_DEVICES] = {}
     discovery.listen(hass, SERVICE_HOMEKIT, discovery_dispatch)
     return True

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -181,6 +181,9 @@ class HomeKitEntity(Entity):
         """Return the name of the device if any."""
         return self._name
 
+    def update_characteristics(self):
+        raise NotImplementedError
+
 
 # pylint: too-many-function-args
 def setup(hass, config):

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -84,7 +84,8 @@ class HKDevice():
     def get_serial(self, accessory):
         import homekit
         for service in accessory['services']:
-            if homekit.ServicesTypes.get_short(service['type']) != 'accessory-information':
+            if homekit.ServicesTypes.get_short(service['type']) != \
+               'accessory-information':
                 continue
             for characteristic in service['characteristics']:
                 ctype = homekit.CharacteristicsTypes.get_short(
@@ -120,7 +121,7 @@ class HKDevice():
                     discovery.load_platform(self.hass, component, DOMAIN,
                                             service_info, self.config)
 
-    def device_configuration_callback(self, callback_data):
+    def device_config_callback(self, callback_data):
         """Handle initial pairing"""
         import homekit
         pairing_id = str(uuid.uuid4())
@@ -136,10 +137,11 @@ class HKDevice():
             self.configurator.notify_errors(_configurator, error_msg)
 
     def configure(self):
-        description = """Please enter the HomeKit code for your {}""".format(self.model)
+        description = "Please enter the HomeKit code for your {}".format(
+            self.model)
         self.hass.data[DOMAIN+self.hkid] = \
             self.configurator.request_config(self.model,
-                                             self.device_configuration_callback,
+                                             self.device_config_callback,
                                              description=description,
                                              submit_caption="submit",
                                              fields=[{'id': 'code',

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -47,7 +47,7 @@ def homekit_http_send(self, message_body=None):
     self.send(msg)
 
 
-def get_serial(self, accessory):
+def get_serial(accessory):
     """Obtain the serial number of a HomeKit device."""
     # pylint: disable=import-error
     import homekit

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -1,0 +1,215 @@
+"""
+Support for Homekit device discovery.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/homekit_controller/
+"""
+import http
+import json
+import logging
+import os
+import uuid
+
+from homeassistant.components.discovery import SERVICE_HOMEKIT
+from homeassistant.helpers import discovery
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['homekit==0.5']
+
+DOMAIN = 'homekit_controller'
+HOMEKIT_DIR = '.homekit'
+
+# Mapping from Homekit type to component.
+HOMEKIT_ACCESSORY_DISPATCH = {
+    'lightbulb': 'light',
+    'outlet': 'switch',
+}
+
+KNOWN_ACCESSORIES = "{}-accessories".format(DOMAIN)
+
+KNOWN_DEVICES = {}
+DEVICES = []
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def homekit_http_send(self, message_body=None):
+    """Send the currently buffered request and clear the buffer.
+
+    Appends an extra \\r\\n to the buffer.
+    A message_body may be specified, to be appended to the request.
+    """
+    self._buffer.extend((b"", b""))
+    msg = b"\r\n".join(self._buffer)
+    del self._buffer[:]
+
+    if message_body is not None:
+        msg = msg + message_body
+
+    self.send(msg)
+
+
+class HKDevice():
+    """Homekit device"""
+
+    def __init__(self, hass, host, port, model, hkid, config_num, config):
+        import homekit
+
+        _LOGGER.info("Setting up Homekit device %s", model)
+        self.hass = hass
+        self.host = host
+        self.port = port
+        self.model = model
+        self.hkid = hkid
+        self.config_num = config_num
+        self.config = config
+        self.configurator = hass.components.configurator
+
+        data_dir = os.path.join(hass.config.path(), HOMEKIT_DIR)
+        if not os.path.isdir(data_dir):
+            os.mkdir(data_dir)
+
+        self.pairing_file = os.path.join(data_dir, 'hk-{}'.format(hkid))
+        self.pairing_data = homekit.load_pairing(self.pairing_file)
+
+        # Monkey patch httpclient for increased compatibility
+        http.client.HTTPConnection._send_output = homekit_http_send
+
+        self.conn = http.client.HTTPConnection(self.host, port=self.port)
+        if self.pairing_data is not None:
+            self.accessory_setup()
+        else:
+            self.configure()
+
+    def get_serial(self, accessory):
+        import homekit
+        for service in accessory['services']:
+            if homekit.ServicesTypes.get_short(service['type']) != 'accessory-information':
+                continue
+            for characteristic in service['characteristics']:
+                ctype = homekit.CharacteristicsTypes.get_short(
+                    characteristic['type'])
+                if ctype != 'serial-number':
+                    continue
+                return characteristic['value']
+        return None
+
+    def accessory_setup(self):
+        import homekit
+        self.controllerkey, self.accessorykey = \
+            homekit.get_session_keys(self.conn, self.pairing_data)
+        self.securecon = homekit.SecureHttp(self.conn.sock,
+                                            self.accessorykey,
+                                            self.controllerkey)
+        response = self.securecon.get('/accessories')
+        data = json.loads(response.read().decode())
+        for accessory in data['accessories']:
+            serial = self.get_serial(accessory)
+            if serial in self.hass.data[KNOWN_ACCESSORIES]:
+                continue
+            self.hass.data[KNOWN_ACCESSORIES][serial] = self
+            aid = accessory['aid']
+            for service in accessory['services']:
+                service_info = {'serial': serial,
+                                'aid': aid,
+                                'iid': service['iid']}
+                devtype = homekit.ServicesTypes.get_short(service['type'])
+                _LOGGER.debug("Found %s", devtype)
+                component = HOMEKIT_ACCESSORY_DISPATCH.get(devtype, None)
+                if component is not None:
+                    discovery.load_platform(self.hass, component, DOMAIN,
+                                            service_info, self.config)
+
+    def device_configuration_callback(self, callback_data):
+        """Handle initial pairing"""
+        import homekit
+        pairing_id = str(uuid.uuid4())
+        code = callback_data.get('code').strip()
+        self.pairing_data = homekit.perform_pair_setup(
+            self.conn, code, pairing_id)
+        if self.pairing_data is not None:
+            homekit.save_pairing(self.pairing_file, self.pairing_data)
+            self.accessory_setup()
+        else:
+            error_msg = "Unable to pair, please try again"
+            _configurator = self.hass.data[DOMAIN+self.hkid]
+            self.configurator.notify_errors(_configurator, error_msg)
+
+    def configure(self):
+        description = """Please enter the HomeKit code for your {}""".format(self.model)
+        self.hass.data[DOMAIN+self.hkid] = \
+            self.configurator.request_config(self.model,
+                                             self.device_configuration_callback,
+                                             description=description,
+                                             submit_caption="submit",
+                                             fields=[{'id': 'code',
+                                                      'name': 'HomeKit code',
+                                                      'type': 'string'}])
+
+
+class HomeKitEntity(Entity):
+    """Representation of a Home Assistant HomeKit device."""
+
+    def __init__(self, hass, devinfo):
+        accessory = hass.data[KNOWN_ACCESSORIES][devinfo['serial']]
+        self._name = accessory.model
+        self._securecon = accessory.securecon
+        self._aid = devinfo['aid']
+        self._iid = devinfo['iid']
+        self._address = "homekit-{}-{}".format(devinfo['serial'], self._iid)
+        self._features = 0
+        self._chars = {}
+        self.update()
+
+    def update(self):
+        response = self._securecon.get('/accessories')
+        data = json.loads(response.read().decode())
+        for accessory in data['accessories']:
+            if accessory['aid'] != self._aid:
+                continue
+            for service in accessory['services']:
+                if service['iid'] != self._iid:
+                    continue
+                self.update_characteristics(service['characteristics'])
+                break
+
+    @property
+    def unique_id(self):
+        """Return the ID of this device."""
+        return self._address
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+
+# pylint: too-many-function-args
+def setup(hass, config):
+    """Set up for Homekit devices."""
+
+    def discovery_dispatch(service, discovery_info):
+        """Dispatcher for Homekit discovery events."""
+        # model, id
+        host = discovery_info['host']
+        port = discovery_info['port']
+        model = discovery_info['properties']['md']
+        hkid = discovery_info['properties']['id']
+        config_num = int(discovery_info['properties']['c#'])
+
+        # Only register a device once, but rescan if the config has changed
+        if hkid in KNOWN_DEVICES:
+            device = KNOWN_DEVICES[hkid]
+            if config_num > device.config_num and \
+               device.pairing_info is not None:
+                device.accessory_setup()
+            return
+
+        _LOGGER.debug('Discovered unique device %s', hkid)
+        device = HKDevice(hass, host, port, model, hkid, config_num, config)
+        KNOWN_DEVICES[hkid] = device
+        DEVICES.append(device)
+
+    hass.data[KNOWN_ACCESSORIES] = {}
+    discovery.listen(hass, SERVICE_HOMEKIT, discovery_dispatch)
+    return True

--- a/homeassistant/components/light/homekit_controller.py
+++ b/homeassistant/components/light/homekit_controller.py
@@ -28,6 +28,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class HomeKitLight(HomeKitEntity, Light):
     """Representation of a Homekit light."""
 
+    def __init__(self, *args):
+        super().__init__(*args)
+        self._on = None
+        self._brightness = None
+        self._color_tempeature = None
+        self._hue = None
+        self._saturation = None
+
     def update_characteristics(self, characteristics):
         import homekit
 

--- a/homeassistant/components/light/homekit_controller.py
+++ b/homeassistant/components/light/homekit_controller.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/light.homekit_controller/
 import json
 import logging
 
-from homeassistant.components.homekit_controller import HomeKitEntity
+from homeassistant.components.homekit_controller import (
+    HomeKitEntity, KNOWN_ACCESSORIES)
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_COLOR_TEMP, SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR, SUPPORT_COLOR_TEMP, Light)
@@ -20,7 +21,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Homekit lighting."""
     if discovery_info is not None:
-        add_devices([HomeKitLight(hass, discovery_info)])
+        accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+        add_devices([HomeKitLight(accessory, discovery_info)], True)
 
 
 class HomeKitLight(HomeKitEntity, Light):
@@ -53,16 +55,6 @@ class HomeKitLight(HomeKitEntity, Light):
                 self._saturation = characteristic['value']
 
     @property
-    def unique_id(self):
-        """Return the ID of this light."""
-        return self._address
-
-    @property
-    def name(self):
-        """Return the name of the device if any."""
-        return self._name
-
-    @property
     def is_on(self):
         """Return true if device is on."""
         return self._on
@@ -92,11 +84,6 @@ class HomeKitLight(HomeKitEntity, Light):
     def supported_features(self):
         """Flag supported features."""
         return self._features
-
-    @property
-    def assumed_state(self):
-        """We return the actual state."""
-        return False
 
     def turn_on(self, **kwargs):
         """Turn the specified light on."""

--- a/homeassistant/components/light/homekit_controller.py
+++ b/homeassistant/components/light/homekit_controller.py
@@ -29,14 +29,17 @@ class HomeKitLight(HomeKitEntity, Light):
     """Representation of a Homekit light."""
 
     def __init__(self, *args):
+        """Initialise the light."""
         super().__init__(*args)
         self._on = None
         self._brightness = None
-        self._color_tempeature = None
+        self._color_temperature = None
         self._hue = None
         self._saturation = None
 
     def update_characteristics(self, characteristics):
+        """Synchronise light state with Home Assistant."""
+        # pylint: disable=import-error
         import homekit
 
         for characteristic in characteristics:
@@ -71,7 +74,7 @@ class HomeKitLight(HomeKitEntity, Light):
     def brightness(self):
         """Return the brightness of this light between 0..255."""
         if self._features & SUPPORT_BRIGHTNESS:
-            return (self._brightness * 255 / 100)
+            return self._brightness * 255 / 100
         return None
 
     @property
@@ -95,6 +98,7 @@ class HomeKitLight(HomeKitEntity, Light):
 
     def turn_on(self, **kwargs):
         """Turn the specified light on."""
+        # pylint: disable=invalid-name
         hs = kwargs.get(ATTR_HS_COLOR)
         temperature = kwargs.get(ATTR_COLOR_TEMP)
         brightness = kwargs.get(ATTR_BRIGHTNESS)

--- a/homeassistant/components/light/homekit_controller.py
+++ b/homeassistant/components/light/homekit_controller.py
@@ -1,0 +1,136 @@
+"""
+Support for Homekit lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.homekit_controller/
+"""
+import json
+import logging
+
+from homeassistant.components.homekit_controller import HomeKitEntity
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_COLOR_TEMP, SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR, SUPPORT_COLOR_TEMP, Light)
+
+DEPENDENCIES = ['homekit_controller']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Homekit lighting."""
+    if discovery_info is not None:
+        add_devices([HomeKitLight(hass, discovery_info)])
+
+
+class HomeKitLight(HomeKitEntity, Light):
+    """Representation of a Homekit light."""
+
+    def update_characteristics(self, characteristics):
+        import homekit
+
+        for characteristic in characteristics:
+            ctype = characteristic['type']
+            ctype = homekit.CharacteristicsTypes.get_short(ctype)
+            if ctype == "on":
+                self._chars['on'] = characteristic['iid']
+                self._on = characteristic['value']
+            elif ctype == 'brightness':
+                self._chars['brightness'] = characteristic['iid']
+                self._features |= SUPPORT_BRIGHTNESS
+                self._brightness = characteristic['value']
+            elif ctype == 'color-temperature':
+                self._chars['color_temperature'] = characteristic['iid']
+                self._features |= SUPPORT_COLOR_TEMP
+                self._color_temperature = characteristic['value']
+            elif ctype == "hue":
+                self._chars['hue'] = characteristic['iid']
+                self._features |= SUPPORT_COLOR
+                self._hue = characteristic['value']
+            elif ctype == "saturation":
+                self._chars['saturation'] = characteristic['iid']
+                self._features |= SUPPORT_COLOR
+                self._saturation = characteristic['value']
+
+    @property
+    def unique_id(self):
+        """Return the ID of this light."""
+        return self._address
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._on
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        if self._features & SUPPORT_BRIGHTNESS:
+            return (self._brightness * 255 / 100)
+        return None
+
+    @property
+    def hs_color(self):
+        """Return the color property."""
+        if self._features & SUPPORT_COLOR:
+            return (self._hue, self._saturation)
+        return None
+
+    @property
+    def color_temp(self):
+        """Return the color temperature."""
+        if self._features & SUPPORT_COLOR_TEMP:
+            return self._color_temperature
+        return None
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return self._features
+
+    @property
+    def assumed_state(self):
+        """We return the actual state."""
+        return False
+
+    def turn_on(self, **kwargs):
+        """Turn the specified light on."""
+        hs = kwargs.get(ATTR_HS_COLOR)
+        temperature = kwargs.get(ATTR_COLOR_TEMP)
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+
+        characteristics = []
+        if hs is not None:
+            characteristics.append({'aid': self._aid,
+                                    'iid': self._chars['hue'],
+                                    'value': hs[0]})
+            characteristics.append({'aid': self._aid,
+                                    'iid': self._chars['saturation'],
+                                    'value': hs[1]})
+        if brightness is not None:
+            characteristics.append({'aid': self._aid,
+                                    'iid': self._chars['brightness'],
+                                    'value': int(brightness * 100 / 255)})
+
+        if temperature is not None:
+            characteristics.append({'aid': self._aid,
+                                    'iid': self._chars['color-temperature'],
+                                    'value': int(temperature)})
+        characteristics.append({'aid': self._aid,
+                                'iid': self._chars['on'],
+                                'value': True})
+        body = json.dumps({'characteristics': characteristics})
+        self._securecon.put('/characteristics', body)
+
+    def turn_off(self, **kwargs):
+        """Turn the specified light off."""
+        characteristics = [{'aid': self._aid,
+                            'iid': self._chars['on'],
+                            'value': False}]
+        body = json.dumps({'characteristics': characteristics})
+        self._securecon.put('/characteristics', body)

--- a/homeassistant/components/light/homekit_controller.py
+++ b/homeassistant/components/light/homekit_controller.py
@@ -98,19 +98,18 @@ class HomeKitLight(HomeKitEntity, Light):
 
     def turn_on(self, **kwargs):
         """Turn the specified light on."""
-        # pylint: disable=invalid-name
-        hs = kwargs.get(ATTR_HS_COLOR)
+        hs_color = kwargs.get(ATTR_HS_COLOR)
         temperature = kwargs.get(ATTR_COLOR_TEMP)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
 
         characteristics = []
-        if hs is not None:
+        if hs_color is not None:
             characteristics.append({'aid': self._aid,
                                     'iid': self._chars['hue'],
-                                    'value': hs[0]})
+                                    'value': hs_color[0]})
             characteristics.append({'aid': self._aid,
                                     'iid': self._chars['saturation'],
-                                    'value': hs[1]})
+                                    'value': hs_color[1]})
         if brightness is not None:
             characteristics.append({'aid': self._aid,
                                     'iid': self._chars['brightness'],

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -134,6 +134,7 @@ async def async_setup(hass, config):
 
 class SwitchDevice(ToggleEntity):
     """Representation of a switch."""
+
     # pylint: disable=no-self-use
     @property
     def current_power_w(self):

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -134,7 +134,6 @@ async def async_setup(hass, config):
 
 class SwitchDevice(ToggleEntity):
     """Representation of a switch."""
-
     # pylint: disable=no-self-use
     @property
     def current_power_w(self):

--- a/homeassistant/components/switch/homekit_controller.py
+++ b/homeassistant/components/switch/homekit_controller.py
@@ -25,6 +25,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 class HomeKitSwitch(HomeKitEntity, SwitchDevice):
     """Representation of a Homekit switch."""
+
     def __init__(self, *args):
         super().__init__(*args)
         self._on = None

--- a/homeassistant/components/switch/homekit_controller.py
+++ b/homeassistant/components/switch/homekit_controller.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/switch.homekit_controller/
 import json
 import logging
 
-from homeassistant.components.homekit_controller import HomeKitEntity
+from homeassistant.components.homekit_controller import (HomeKitEntity,
+                                                         KNOWN_ACCESSORIES)
 from homeassistant.components.switch import SwitchDevice
 
 DEPENDENCIES = ['homekit_controller']
@@ -17,7 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Homekit switch support."""
     if discovery_info is not None:
-        add_devices([HomeKitSwitch(hass, discovery_info)])
+        accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+        add_devices([HomeKitSwitch(accessory, discovery_info)], True)
 
 
 class HomeKitSwitch(HomeKitEntity, SwitchDevice):

--- a/homeassistant/components/switch/homekit_controller.py
+++ b/homeassistant/components/switch/homekit_controller.py
@@ -27,10 +27,13 @@ class HomeKitSwitch(HomeKitEntity, SwitchDevice):
     """Representation of a Homekit switch."""
 
     def __init__(self, *args):
+        """Initialise the switch."""
         super().__init__(*args)
         self._on = None
 
     def update_characteristics(self, characteristics):
+        """Synchronise the switch state with Home Assistant."""
+        # pylint: disable=import-error
         import homekit
 
         for characteristic in characteristics:

--- a/homeassistant/components/switch/homekit_controller.py
+++ b/homeassistant/components/switch/homekit_controller.py
@@ -15,6 +15,7 @@ DEPENDENCIES = ['homekit_controller']
 
 _LOGGER = logging.getLogger(__name__)
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Homekit switch support."""
     if discovery_info is not None:
@@ -24,6 +25,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 class HomeKitSwitch(HomeKitEntity, SwitchDevice):
     """Representation of a Homekit switch."""
+    def __init__(self, *args):
+        super().__init__(*args)
+        self._on = None
 
     def update_characteristics(self, characteristics):
         import homekit

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -381,6 +381,10 @@ holidays==0.9.4
 # homeassistant.components.frontend
 home-assistant-frontend==20180404.0
 
+# homeassistant.components.homekit_controller
+# homeassistant.components.light.homekit_controller
+homekit==0.5
+
 # homeassistant.components.homematicip_cloud
 homematicip==0.8
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -382,7 +382,6 @@ holidays==0.9.4
 home-assistant-frontend==20180404.0
 
 # homeassistant.components.homekit_controller
-# homeassistant.components.light.homekit_controller
 # homekit==0.5
 
 # homeassistant.components.homematicip_cloud

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -383,7 +383,7 @@ home-assistant-frontend==20180404.0
 
 # homeassistant.components.homekit_controller
 # homeassistant.components.light.homekit_controller
-homekit==0.5
+# homekit==0.5
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.8

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -33,6 +33,7 @@ COMMENT_REQUIREMENTS = (
     'i2csense',
     'credstash',
     'bme680',
+    'homekit',
 )
 
 TEST_REQUIREMENTS = (

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -25,7 +25,8 @@ UNKNOWN_SERVICE = 'this_service_will_never_be_supported'
 
 BASE_CONFIG = {
     discovery.DOMAIN: {
-        'ignore': []
+        'ignore': [],
+        'enable': []
     }
 }
 


### PR DESCRIPTION
## Description:
Add infrastructure for communicating with Homekit IP appliances, along with support for controlling Homekit lightbulbs

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#4966


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
