### PR TITLE
Fix mysensors light turn on hs color

### DIFF
--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -107,7 +107,11 @@ class MySensorsLight(mysensors.MySensorsEntity, Light):
         rgb = color_util.color_hs_to_RGB(*self._hs)
         white = self._white
         hex_color = self._values.get(self.value_type)
-        new_rgb = color_util.color_hs_to_RGB(*kwargs.get(ATTR_HS_COLOR))
+        hs_color = kwargs.get(ATTR_HS_COLOR)
+        if hs_color is not None:
+            new_rgb = color_util.color_hs_to_RGB(*hs_color)
+        else:
+            new_rgb = None
         new_white = kwargs.get(ATTR_WHITE_VALUE)
 
         if new_rgb is None and new_white is None:


### PR DESCRIPTION
## Description:
The internal method called in the mysensors light platform for rgb light doesn't always have a keyword argument for hs color.

**Related issue (if applicable):**
https://github.com/home-assistant/home-assistant/pull/11288

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**