### PR TITLE
Allow to set a desired update interval for camera_proxy_stream view

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -305,10 +305,10 @@ class Camera(Entity):
 
     @asyncio.coroutine
     def handle_async_mjpeg_stream(self, request):
-        """Generate an HTTP MJPEG stream from camera images.
+        """Serve an HTTP MJPEG stream from the camera.
+
         This method can be overridden by camera plaforms to proxy
         a direct stream from the camera.
-
         This method must be run in the event loop.
         """
         yield from self.handle_async_still_stream(request)
@@ -425,6 +425,7 @@ class CameraMjpegStream(CameraView):
 
     @asyncio.coroutine
     def handle(self, request, camera):
+        """Serve camera stream, possibly with interval."""
         if request.query.get('interval'):
             """Compose camera stream from stills."""
             interval = float(request.query.get('interval'))

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -433,8 +433,8 @@ class CameraMjpegStream(CameraView):
 
     @asyncio.coroutine
     def handle(self, request, camera):
-        """Serve camera stream."""
         if request.query.get('interval'):
+            """Compose camera stream from stills."""
             interval = float(request.query.get('interval'))
             if interval < MIN_STREAM_INTERVAL:
                 return web.Response(status=403,
@@ -443,4 +443,5 @@ class CameraMjpegStream(CameraView):
                                     .format(MIN_STREAM_INTERVAL))
             yield from camera.handle_async_still_stream(request, interval)
         else:
+            """Serve camera stream."""
             yield from camera.handle_async_mjpeg_stream(request)

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -429,7 +429,7 @@ class CameraMjpegStream(CameraView):
     async def handle(self, request, camera):
         """Serve camera stream, possibly with interval."""
         interval = request.query.get('interval')
-        if interval = None:
+        if interval is None:
             await camera.handle_async_mjpeg_stream(request)
             return
 

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -54,7 +54,7 @@ TOKEN_CHANGE_INTERVAL = timedelta(minutes=5)
 _RND = SystemRandom()
 
 FALLBACK_STREAM_INTERVAL = 1  # seconds
-MIN_STREAM_INTERVAL = 0.5 # seconds
+MIN_STREAM_INTERVAL = 0.5  # seconds
 
 CAMERA_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
@@ -428,15 +428,15 @@ class CameraMjpegStream(CameraView):
 
     async def handle(self, request, camera):
         """Serve camera stream, possibly with interval."""
-        if request.query.get('interval'):
+        interval = request.query.get('interval')
+        if interval = None:
+            await camera.handle_async_mjpeg_stream(request)
+            return
+
+        try:
             # Compose camera stream from stills
             interval = float(request.query.get('interval'))
-            if interval < MIN_STREAM_INTERVAL:
-                return web.Response(status=400,
-                                    reason="Interval must be a number \
-                                    with a minumum value of {}"
-                                    .format(MIN_STREAM_INTERVAL))
             await camera.handle_async_still_stream(request, interval)
-        else:
-            # Serve camera stream.
-            await camera.handle_async_mjpeg_stream(request)
+            return
+
+        return web.Response(status=400)

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -275,6 +275,12 @@ class Camera(Entity):
 
         last_image = None
 
+        interval = .5 # default stream framerate: 2 fps
+        min_interval = .05 # max stream framerate: 20 fps
+
+        if request.query.get('interval'):
+            interval = max(float(request.query.get('interval')), min_interval)
+
         try:
             while True:
                 img_bytes = yield from self.async_camera_image()
@@ -291,7 +297,7 @@ class Camera(Entity):
 
                     last_image = img_bytes
 
-                yield from asyncio.sleep(.5)
+                yield from asyncio.sleep(interval)
 
         except asyncio.CancelledError:
             _LOGGER.debug("Stream closed by frontend.")

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -256,7 +256,7 @@ class Camera(Entity):
         return self.hass.async_add_job(self.camera_image)
 
     async def handle_async_still_stream(self, request,
-                                  interval=DEFAULT_STREAM_INTERVAL):
+                                        interval=DEFAULT_STREAM_INTERVAL):
         """Generate an HTTP MJPEG stream from camera images.
 
         This method must be run in the event loop.

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -275,8 +275,8 @@ class Camera(Entity):
 
         last_image = None
 
-        interval = .5 # default stream framerate: 2 fps
-        min_interval = .05 # max stream framerate: 20 fps
+        interval = .5  # default stream framerate: 2 fps
+        min_interval = .05  # max stream framerate: 20 fps
 
         if request.query.get('interval'):
             interval = max(float(request.query.get('interval')), min_interval)

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -261,8 +261,8 @@ class Camera(Entity):
         This method must be run in the event loop.
         """
         if interval < MIN_STREAM_INTERVAL:
-            raise HomeAssistantError("Stream interval must be be > {}"
-                                     .format(MIN_STREAM_INTERVAL))
+            raise ValueError("Stream interval must be be > {}"
+                             .format(MIN_STREAM_INTERVAL))
 
         response = web.StreamResponse()
         response.content_type = ('multipart/x-mixed-replace; '
@@ -438,7 +438,5 @@ class CameraMjpegStream(CameraView):
             interval = float(request.query.get('interval'))
             await camera.handle_async_still_stream(request, interval)
             return
-        except (ValueError, HomeAssistantError):
+        except ValueError:
             return web.Response(status=400)
-
-        return web.Response(status=500)

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -438,5 +438,7 @@ class CameraMjpegStream(CameraView):
             interval = float(request.query.get('interval'))
             await camera.handle_async_still_stream(request, interval)
             return
+        except (ValueError, HomeAssistantError):
+            return web.Response(status=400)
 
-        return web.Response(status=400)
+        return web.Response(status=500)


### PR DESCRIPTION
## Description:

Set desired image update interval using 'interval' query parameter. defaults to (existing) 0.5 seconds. Harcoded mininum of 0.05 seconds. Selecting a shorter interval will increase disk I/O (comparing image file, but not more network traffic)
Maybe the minimum interval is too short, I don't really know, please discuss!

In the front-end this could be used like:
```
this.cameraFeedSrc = '/api/camera_proxy_stream/' + this.stateObj.entity_id +
             '?interval=10&token=' + this.stateObj.attributes.access_token;
```

note: if the 'interval' parameter is omitted it will use the default (0.5) seconds.

Main use case: convert the frontend camera card to use the camera proxy (with a long interval, or maybe even selectable) and only update the image if it is changed, instead of a new request (and image transfer) every 10 seconds.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54