### PR TITLE
Configuration options for IFTTT alarm control panel

### DIFF
--- a/homeassistant/components/alarm_control_panel/ifttt.py
+++ b/homeassistant/components/alarm_control_panel/ifttt.py
@@ -47,7 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_EVENT_HOME, default=DEFAULT_EVENT_HOME): cv.string,
     vol.Optional(CONF_EVENT_NIGHT, default=DEFAULT_EVENT_NIGHT): cv.string,
     vol.Optional(CONF_EVENT_DISARM, default=DEFAULT_EVENT_DISARM): cv.string,
-    vol.Optional(CONF_OPTIMISTIC, default=True): cv.boolean,
+    vol.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
 })
 
 SERVICE_PUSH_ALARM_STATE = "ifttt_push_alarm_state"


### PR DESCRIPTION
## Description:

This update adds some configuration options to the IFTTT alarm control panel:
- It gives the user the possibility to define custom event names for the different IFTTT webhook calls. This can be useful when you want to control multiple security systems over IFTTT using HA.
- You can configure the component to set the state immediately after firing the IFTTT webhook call, without having to wait for an ifttt_push_alarm_state call. This can be useful for alarm systems that have no IFTTT triggers for state changes.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4970

## Example entry for `configuration.yaml` (if applicable):
```yaml
ifttt:
  key: YOUR_WEBHOOK_KEY
 
alarm_control_panel:
  - platform: ifttt
    name: YOUR_ALARM_NAME
    code: YOUR_ALARM_CODE
    event_arm_away: alarm_arm_away
    event_arm_home: alarm_arm_home
    event_arm_night: alarm_arm_night
    event_disarm: alarm_disarm
    optimistic: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)