### PR TITLE
Matrix Chatbot

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -522,7 +522,6 @@ omit =
     homeassistant/components/notify/lannouncer.py
     homeassistant/components/notify/llamalab_automate.py
     homeassistant/components/notify/mastodon.py
-    homeassistant/components/notify/matrix.py
     homeassistant/components/notify/message_bird.py
     homeassistant/components/notify/mycroft.py
     homeassistant/components/notify/nfandroidtv.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -166,6 +166,9 @@ omit =
     homeassistant/components/mailgun.py
     homeassistant/components/*/mailgun.py
 
+    homeassistant/components/matrix.py
+    homeassistant/components/*/matrix.py
+
     homeassistant/components/maxcube.py
     homeassistant/components/*/maxcube.py
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -94,6 +94,8 @@ homeassistant/components/*/hive.py @Rendili @KJonline
 homeassistant/components/homekit/* @cdce8p
 homeassistant/components/knx.py @Julius2342
 homeassistant/components/*/knx.py @Julius2342
+homeassistant/components/matrix.py @tinloaf
+homeassistant/components/*/matrix.py @tinloaf
 homeassistant/components/qwikswitch.py @kellerza
 homeassistant/components/*/qwikswitch.py @kellerza
 homeassistant/components/*/rfxtrx.py @danielhiversen

--- a/homeassistant/components/matrix.py
+++ b/homeassistant/components/matrix.py
@@ -134,14 +134,14 @@ class MatrixBot(object):
             try:
                 if room_id in joined_rooms:
                     room = joined_rooms[room_id]
-                    _LOGGER.debug("Already in room {}".format(room_id))
+                    _LOGGER.debug("Already in room %s", room_id)
                 else:
                     room = self._client.join_room(room_id)
-                    _LOGGER.debug("Joined room {}".format(room_id))
+                    _LOGGER.debug("Joined room %s", room_id)
 
                 room.add_listener(room_message_cb, "m.room.message")
             except MatrixRequestError as ex:
-                _LOGGER.error("Could not join room {}: {}".format(room_id, ex))
+                _LOGGER.error("Could not join room %s: %s", room_id, ex)
 
     def _get_auth_tokens(self):
         """

--- a/homeassistant/components/matrix.py
+++ b/homeassistant/components/matrix.py
@@ -16,7 +16,7 @@ from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
                                  CONF_VERIFY_SSL, CONF_NAME)
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['matrix-client==0.0.6']
+REQUIREMENTS = ['matrix-client==0.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -146,13 +146,18 @@ class MatrixBot(object):
 
     def _setup(self):
         """Log in, join rooms etc."""
+        def handle_matrix_exception(exception):
+            """Handle exceptions raised inside the Matrix SDK."""
+            _LOGGER.error("Matrix exception:\n %s", str(exception))
+
         # Login, this will raise a MatrixRequestError if login is unsuccessful
         self._client = self._login()
 
         # Join rooms in which we listen for commands and start listening
         self._join_rooms()
 
-        self._client.start_listener_thread()
+        self._client.start_listener_thread(
+            exception_handler=handle_matrix_exception)
 
         self._setup_done = True
 

--- a/homeassistant/components/matrix.py
+++ b/homeassistant/components/matrix.py
@@ -107,7 +107,7 @@ class MatrixBot(object):
         self._client.start_listener_thread()
 
     def _join_rooms(self):
-        """ Join the rooms that we listen for commands in. """
+        """Join the rooms that we listen for commands in."""
         from matrix_client.client import MatrixRequestError
 
         def room_message_cb(room, event):

--- a/homeassistant/components/matrix.py
+++ b/homeassistant/components/matrix.py
@@ -1,0 +1,259 @@
+"""
+The matrix bot component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/matrix/
+"""
+import logging
+import os
+from urllib.parse import urlparse
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.notify import (ATTR_TARGET, ATTR_MESSAGE)
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL
+from homeassistant.util.json import load_json, save_json
+
+REQUIREMENTS = ['matrix-client==0.0.6']
+
+_LOGGER = logging.getLogger(__name__)
+
+SESSION_FILE = 'matrix.conf'
+
+CONF_HOMESERVER = 'homeserver'
+CONF_LISTENING_ROOMS = 'listening_rooms'
+CONF_COMMANDS = 'commands'
+
+EVENT_MATRIX_COMMAND = 'matrix_command'
+
+DOMAIN = 'matrix'
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_HOMESERVER): cv.url,
+    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_LISTENING_ROOMS, default=[]): vol.All(cv.ensure_list,
+                                                            [cv.string]),
+    vol.Optional(CONF_COMMANDS, default=[]): vol.All(cv.ensure_list,
+                                                     [cv.string]),
+})
+
+SERVICE_SEND_MESSAGE = 'send_message'
+
+SERVICE_SCHEMA_SEND_MESSAGE = vol.Schema({
+    vol.Required(ATTR_MESSAGE): cv.string,
+    vol.Required(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
+})
+
+
+def setup(hass, config):
+    """Set up the Matrix bot component."""
+    if not config[DOMAIN]:
+        return False
+
+    config = config[DOMAIN][0]
+
+    bot = MatrixBot(
+        hass,
+        os.path.join(hass.config.path(), SESSION_FILE),
+        config.get(CONF_HOMESERVER),
+        config.get(CONF_VERIFY_SSL),
+        config.get(CONF_USERNAME),
+        config.get(CONF_PASSWORD),
+        config.get(CONF_LISTENING_ROOMS, []),
+        config.get(CONF_COMMANDS, []))
+    hass.data[DOMAIN] = bot
+
+    def send_message_handler(service):
+        """Handle the send_message service."""
+        bot.handle_send_message(service)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_SEND_MESSAGE, send_message_handler,
+        schema=SERVICE_SCHEMA_SEND_MESSAGE)
+
+    return True
+
+
+class MatrixBot(object):
+    """The Matrix Bot."""
+
+    def __init__(self, hass, config_file, homeserver, verify_ssl,
+                 username, password, listening_rooms, commands):
+        """Set up the client."""
+        self.hass = hass
+
+        self._session_filepath = config_file
+        self._auth_tokens = self._get_auth_tokens()
+
+        self._homeserver = homeserver
+        self._verify_tls = verify_ssl
+        self._username = username
+        self._password = password
+
+        self._mx_id = "{user}@{homeserver}".format(
+            user=username, homeserver=urlparse(homeserver).netloc)
+
+        self._listening_rooms = listening_rooms
+        self._commands = set(commands)
+
+        # Login, this will raise a MatrixRequestError if login is unsuccessful
+        self._client = self._login()
+
+        # Join rooms in which we listen for commands and start listening
+        self._join_rooms()
+        self._client.start_listener_thread()
+
+    def _join_rooms(self):
+        """ Join the rooms that we listen for commands in. """
+        from matrix_client.client import MatrixRequestError
+
+        def room_message_cb(room, event):
+            """Handle a message sent to a room."""
+            if (event['content']['msgtype'] == "m.text" and
+                    event['content']['body'][0] == "!"):
+                pieces = event['content']['body'].split(' ')
+                cmd = pieces[0][1:]
+                if cmd not in self._commands:
+                    return
+
+                event_data = {
+                    'command': cmd,
+                    'sender': event['sender'],
+                    'room': room.room_id,
+                    'args': pieces[1:]
+                }
+
+                self.hass.bus.fire(EVENT_MATRIX_COMMAND, event_data)
+
+        joined_rooms = self._client.get_rooms()
+
+        for room_id in self._listening_rooms:
+            try:
+                if room_id in joined_rooms:
+                    room = joined_rooms[room_id]
+                    _LOGGER.debug("Already in room {}".format(room_id))
+                else:
+                    room = self._client.join_room(room_id)
+                    _LOGGER.debug("Joined room {}".format(room_id))
+
+                room.add_listener(room_message_cb, "m.room.message")
+            except MatrixRequestError as ex:
+                _LOGGER.error("Could not join room {}: {}".format(room_id, ex))
+
+    def _get_auth_tokens(self):
+        """
+        Read sorted authentication tokens from disk.
+
+        Returns the auth_tokens dictionary.
+        """
+        if not os.path.exists(self._session_filepath):
+            return {}
+
+        try:
+            data = load_json(self._session_filepath)
+
+            auth_tokens = {}
+            for mx_id, token in data.items():
+                auth_tokens[mx_id] = token
+
+            return auth_tokens
+
+        except (OSError, IOError, PermissionError) as ex:
+            _LOGGER.warning(
+                "Loading authentication tokens from file '%s' failed: %s",
+                self._session_filepath, str(ex))
+            return {}
+
+    def _store_auth_token(self, token):
+        """Store authentication token to session and persistent storage."""
+        self._auth_tokens[self._mx_id] = token
+
+        save_json(self._session_filepath, self._auth_tokens)
+
+    def _login(self):
+        """Login to the matrix homeserver and return the client instance."""
+        from matrix_client.client import MatrixRequestError
+
+        # Attempt to generate a valid client using either of the two possible
+        # login methods:
+        client = None
+
+        # If we have an authentication token
+        if self._mx_id in self._auth_tokens:
+            try:
+                client = self._login_by_token()
+                _LOGGER.debug("Logged in using stored token.")
+
+            except MatrixRequestError as ex:
+                _LOGGER.warning(
+                    "Login by token failed, falling back to password. "
+                    "login_by_token raised: (%d) %s",
+                    ex.code, ex.content)
+
+        # If we still don't have a client try password.
+        if not client:
+            try:
+                client = self._login_by_password()
+                _LOGGER.debug("Logged in using password.")
+
+            except MatrixRequestError as ex:
+                _LOGGER.error(
+                    "Login failed, both token and username/password invalid "
+                    "login_by_password raised: (%d) %s",
+                    ex.code, ex.content)
+
+                # re-raise the error so the constructor can catch it.
+                raise
+
+        return client
+
+    def _login_by_token(self):
+        """Login using authentication token and return the client."""
+        from matrix_client.client import MatrixClient
+
+        return MatrixClient(
+            base_url=self._homeserver,
+            token=self._auth_tokens[self._mx_id],
+            user_id=self._username,
+            valid_cert_check=self._verify_tls)
+
+    def _login_by_password(self):
+        """Login using password authentication and return the client."""
+        from matrix_client.client import MatrixClient
+
+        _client = MatrixClient(
+            base_url=self._homeserver,
+            valid_cert_check=self._verify_tls)
+
+        _client.login_with_password(self._username, self._password)
+
+        self._store_auth_token(_client.token)
+
+        return _client
+
+    def _send_message(self, message, target_rooms):
+        """Send the message to the matrix server."""
+        from matrix_client.client import MatrixRequestError
+
+        rooms = self._client.get_rooms()
+        for target_room in target_rooms:
+            try:
+                if target_room in rooms:
+                    room = rooms[target_room]
+                else:
+                    room = self._client.join_room(target_room)
+
+                _LOGGER.debug(room.send_text(message))
+
+            except MatrixRequestError as ex:
+                _LOGGER.error(
+                    "Unable to deliver message to room '%s': (%d): %s",
+                    target_room, ex.code, ex.content)
+
+    def handle_send_message(self, service):
+        """Handle the send_message service."""
+        self._send_message(service.data[ATTR_MESSAGE],
+                           service.data[ATTR_TARGET])

--- a/homeassistant/components/notify/matrix.py
+++ b/homeassistant/components/notify/matrix.py
@@ -5,181 +5,48 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.matrix/
 """
 import logging
-import os
-from urllib.parse import urlparse
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (ATTR_TARGET, PLATFORM_SCHEMA,
-                                             BaseNotificationService)
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL
-from homeassistant.util.json import load_json, save_json
+                                             BaseNotificationService,
+                                             ATTR_MESSAGE)
 
 REQUIREMENTS = ['matrix-client==0.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 
-SESSION_FILE = 'matrix.conf'
-
-CONF_HOMESERVER = 'homeserver'
 CONF_DEFAULT_ROOM = 'default_room'
 
+DOMAIN = 'matrix'
+DEPENDENCIES = [DOMAIN]
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOMESERVER): cv.url,
-    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_DEFAULT_ROOM): cv.string,
 })
 
 
 def get_service(hass, config, discovery_info=None):
     """Get the Matrix notification service."""
-    from matrix_client.client import MatrixRequestError
-
-    try:
-        return MatrixNotificationService(
-            os.path.join(hass.config.path(), SESSION_FILE),
-            config.get(CONF_HOMESERVER),
-            config.get(CONF_DEFAULT_ROOM),
-            config.get(CONF_VERIFY_SSL),
-            config.get(CONF_USERNAME),
-            config.get(CONF_PASSWORD))
-
-    except MatrixRequestError:
-        return None
+    return MatrixNotificationService(config.get(CONF_DEFAULT_ROOM))
 
 
 class MatrixNotificationService(BaseNotificationService):
     """Send Notifications to a Matrix Room."""
 
-    def __init__(self, config_file, homeserver, default_room, verify_ssl,
-                 username, password):
-        """Set up the client."""
-        self.session_filepath = config_file
-        self.auth_tokens = self.get_auth_tokens()
+    def __init__(self, default_room):
+        """Set up the notification service."""
+        self._default_room = default_room
 
-        self.homeserver = homeserver
-        self.default_room = default_room
-        self.verify_tls = verify_ssl
-        self.username = username
-        self.password = password
-
-        self.mx_id = "{user}@{homeserver}".format(
-            user=username, homeserver=urlparse(homeserver).netloc)
-
-        # Login, this will raise a MatrixRequestError if login is unsuccessful
-        self.client = self.login()
-
-    def get_auth_tokens(self):
-        """
-        Read sorted authentication tokens from disk.
-
-        Returns the auth_tokens dictionary.
-        """
-        if not os.path.exists(self.session_filepath):
-            return {}
-
-        try:
-            data = load_json(self.session_filepath)
-
-            auth_tokens = {}
-            for mx_id, token in data.items():
-                auth_tokens[mx_id] = token
-
-            return auth_tokens
-
-        except (OSError, IOError, PermissionError) as ex:
-            _LOGGER.warning(
-                "Loading authentication tokens from file '%s' failed: %s",
-                self.session_filepath, str(ex))
-            return {}
-
-    def store_auth_token(self, token):
-        """Store authentication token to session and persistent storage."""
-        self.auth_tokens[self.mx_id] = token
-
-        save_json(self.session_filepath, self.auth_tokens)
-
-    def login(self):
-        """Login to the matrix homeserver and return the client instance."""
-        from matrix_client.client import MatrixRequestError
-
-        # Attempt to generate a valid client using either of the two possible
-        # login methods:
-        client = None
-
-        # If we have an authentication token
-        if self.mx_id in self.auth_tokens:
-            try:
-                client = self.login_by_token()
-                _LOGGER.debug("Logged in using stored token.")
-
-            except MatrixRequestError as ex:
-                _LOGGER.warning(
-                    "Login by token failed, falling back to password. "
-                    "login_by_token raised: (%d) %s",
-                    ex.code, ex.content)
-
-        # If we still don't have a client try password.
-        if not client:
-            try:
-                client = self.login_by_password()
-                _LOGGER.debug("Logged in using password.")
-
-            except MatrixRequestError as ex:
-                _LOGGER.error(
-                    "Login failed, both token and username/password invalid "
-                    "login_by_password raised: (%d) %s",
-                    ex.code, ex.content)
-
-                # re-raise the error so the constructor can catch it.
-                raise
-
-        return client
-
-    def login_by_token(self):
-        """Login using authentication token and return the client."""
-        from matrix_client.client import MatrixClient
-
-        return MatrixClient(
-            base_url=self.homeserver,
-            token=self.auth_tokens[self.mx_id],
-            user_id=self.username,
-            valid_cert_check=self.verify_tls)
-
-    def login_by_password(self):
-        """Login using password authentication and return the client."""
-        from matrix_client.client import MatrixClient
-
-        _client = MatrixClient(
-            base_url=self.homeserver,
-            valid_cert_check=self.verify_tls)
-
-        _client.login_with_password(self.username, self.password)
-
-        self.store_auth_token(_client.token)
-
-        return _client
-
-    def send_message(self, message, **kwargs):
+    def send_message(self, message="", **kwargs):
         """Send the message to the matrix server."""
-        from matrix_client.client import MatrixRequestError
+        target_rooms = kwargs.get(ATTR_TARGET) or [self._default_room]
 
-        target_rooms = kwargs.get(ATTR_TARGET) or [self.default_room]
+        service_data = {
+            ATTR_TARGET: target_rooms,
+            ATTR_MESSAGE: message
+        }
 
-        rooms = self.client.get_rooms()
-        for target_room in target_rooms:
-            try:
-                if target_room in rooms:
-                    room = rooms[target_room]
-                else:
-                    room = self.client.join_room(target_room)
-
-                _LOGGER.debug(room.send_text(message))
-
-            except MatrixRequestError as ex:
-                _LOGGER.error(
-                    "Unable to deliver message to room '%s': (%d): %s",
-                    target_room, ex.code, ex.content)
+        return self.hass.services.call(
+            DOMAIN, 'send_message', service_data=service_data)

--- a/homeassistant/components/notify/matrix.py
+++ b/homeassistant/components/notify/matrix.py
@@ -13,8 +13,6 @@ from homeassistant.components.notify import (ATTR_TARGET, PLATFORM_SCHEMA,
                                              BaseNotificationService,
                                              ATTR_MESSAGE)
 
-REQUIREMENTS = ['matrix-client==0.0.6']
-
 _LOGGER = logging.getLogger(__name__)
 
 CONF_DEFAULT_ROOM = 'default_room'

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -75,28 +75,6 @@ def has_at_least_one_key_value(*items: list) -> Callable:
     return validate
 
 
-def validate_if(premise: Callable, conclusion: Callable) -> Callable:
-    """Validate that if the premise validates the conclusion also validates."""
-    def validate(obj: Dict) -> Dict:
-        """Validate a validate_if."""
-        try:
-            premise(obj)
-        except vol.Invalid:
-            # Ex falso quodlibet!
-            return obj
-
-        # The premise has validated, the conclusion must validate, too!
-        try:
-            conclusion(obj)
-        except vol.Invalid:
-            raise vol.Invalid("If {} is valid, so must be {}!".format(
-                str(premise), str(conclusion)))
-
-        return obj
-
-    return validate
-
-
 def boolean(value: Any) -> bool:
     """Validate and coerce a boolean value."""
     if isinstance(value, str):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -98,8 +98,7 @@ def isdevice(value):
 
 def matches_regex(regex):
     """Validate that the value is a string that matches a regex."""
-    if isinstance(regex, str):
-        regex = re.compile(regex)
+    regex = re.compile(regex)
 
     def validator(value: Any) -> str:
         """Validate that value matches the given regex."""
@@ -119,7 +118,10 @@ def is_regex(value):
     try:
         r = re.compile(value)
         return r
-    except Exception:
+    except TypeError:
+        raise vol.Invalid("value {} is of the wrong type for a regular "
+                          "expression".format(value))
+    except re.error:
         raise vol.Invalid("value {} is not a valid regular expression".format(
             value))
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -96,6 +96,24 @@ def isdevice(value):
         raise vol.Invalid('No device at {} found'.format(value))
 
 
+def matches_regex(regex):
+    """Validate that the value is a string that matches a regex."""
+    if isinstance(regex, str):
+        regex = re.compile(regex)
+
+    def validator(value: Any) -> str:
+        """Validate that value matches the given regex."""
+        if not isinstance(value, str):
+            raise vol.Invalid('not a string value: {}'.format(value))
+
+        if not regex.match(value):
+            raise vol.Invalid('value {} does not match regular expression {}'
+                              .format(regex.pattern, value))
+
+        return value
+    return validator
+
+
 def isfile(value: Any) -> str:
     """Validate that the value is an existing file."""
     if value is None:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -75,6 +75,28 @@ def has_at_least_one_key_value(*items: list) -> Callable:
     return validate
 
 
+def validate_if(premise: Callable, conclusion: Callable) -> Callable:
+    """Validate that if the premise validates the conclusion also validates."""
+    def validate(obj: Dict) -> Dict:
+        """Validate a ValidateIf."""
+        try:
+            premise(obj)
+        except vol.Invalid:
+            # Ex falso quodlibet!
+            return obj
+
+        # The premise has validated, the conclusion must validate, too!
+        try:
+            conclusion(obj)
+        except vol.Invalid:
+            raise vol.Invalid("If {} is valid, so must {} be!".format(
+                str(premise), str(conclusion)))
+
+        return obj
+
+    return validate
+
+
 def boolean(value: Any) -> bool:
     """Validate and coerce a boolean value."""
     if isinstance(value, str):
@@ -112,6 +134,16 @@ def matches_regex(regex):
 
         return value
     return validator
+
+
+def is_regex(value):
+    """Validate that a string is a valid regular expression."""
+    try:
+        r = re.compile(value)
+        return r
+    except Exception:
+        raise vol.Invalid("value {} is not a valid regular expression".format(
+            value))
 
 
 def isfile(value: Any) -> str:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -78,7 +78,7 @@ def has_at_least_one_key_value(*items: list) -> Callable:
 def validate_if(premise: Callable, conclusion: Callable) -> Callable:
     """Validate that if the premise validates the conclusion also validates."""
     def validate(obj: Dict) -> Dict:
-        """Validate a ValidateIf."""
+        """Validate a validate_if."""
         try:
             premise(obj)
         except vol.Invalid:
@@ -89,7 +89,7 @@ def validate_if(premise: Callable, conclusion: Callable) -> Callable:
         try:
             conclusion(obj)
         except vol.Invalid:
-            raise vol.Invalid("If {} is valid, so must {} be!".format(
+            raise vol.Invalid("If {} is valid, so must be {}!".format(
                 str(premise), str(conclusion)))
 
         return obj

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -509,8 +509,7 @@ luftdaten==0.1.3
 lyft_rides==0.2
 
 # homeassistant.components.matrix
-# homeassistant.components.notify.matrix
-matrix-client==0.0.6
+matrix-client==0.1.0
 
 # homeassistant.components.maxcube
 maxcube-api==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -508,6 +508,7 @@ luftdaten==0.1.3
 # homeassistant.components.sensor.lyft
 lyft_rides==0.2
 
+# homeassistant.components.matrix
 # homeassistant.components.notify.matrix
 matrix-client==0.0.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -509,7 +509,7 @@ luftdaten==0.1.3
 lyft_rides==0.2
 
 # homeassistant.components.matrix
-matrix-client==0.1.0
+matrix-client==0.2.0
 
 # homeassistant.components.maxcube
 maxcube-api==0.1.0

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -568,7 +568,7 @@ def test_socket_timeout():  # pylint: disable=invalid-name
 
 
 def test_matches_regex():
-    """Test regex validator."""
+    """Test matches_regex validator."""
     schema = vol.Schema(cv.matches_regex('.*uiae.*'))
 
     with pytest.raises(vol.Invalid):
@@ -579,3 +579,47 @@ def test_matches_regex():
 
     test_str = "This is a test including uiae."
     assert(schema(test_str) == test_str)
+
+
+def test_is_regex():
+    """Test the is_regex validator."""
+    schema = vol.Schema(cv.is_regex)
+
+    with pytest.raises(vol.Invalid):
+        schema("(")
+
+    with pytest.raises(vol.Invalid):
+        schema({"a dict": "is not a regex"})
+
+    valid_re = ".*"
+    schema(valid_re)
+
+
+def test_validate_if():
+    """Test the validate_if validator."""
+    premise = vol.Schema({
+        vol.Required("premise"): cv.string
+    }, extra=vol.ALLOW_EXTRA)
+    conclusion = vol.Schema({
+        vol.Required("conclusion"): cv.positive_int
+    }, extra=vol.ALLOW_EXTRA)
+
+    schema = vol.Schema(cv.validate_if(premise, conclusion))
+
+    with pytest.raises(vol.Invalid):
+        schema({"premise": "but no conclusion"})
+
+    schema({"conclusion": 5})  # Only a conclusion
+
+    with pytest.raises(vol.Invalid):
+        schema({
+            "premise": "this is a string",
+            "conclusion": "this is not a positive integer"
+        })
+
+    schema({
+        "premise": "this is a string",
+        "conclusion": 42
+    })
+
+    schema({})

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -593,33 +593,3 @@ def test_is_regex():
 
     valid_re = ".*"
     schema(valid_re)
-
-
-def test_validate_if():
-    """Test the validate_if validator."""
-    premise = vol.Schema({
-        vol.Required("premise"): cv.string
-    }, extra=vol.ALLOW_EXTRA)
-    conclusion = vol.Schema({
-        vol.Required("conclusion"): cv.positive_int
-    }, extra=vol.ALLOW_EXTRA)
-
-    schema = vol.Schema(cv.validate_if(premise, conclusion))
-
-    with pytest.raises(vol.Invalid):
-        schema({"premise": "but no conclusion"})
-
-    schema({"conclusion": 5})  # Only a conclusion
-
-    with pytest.raises(vol.Invalid):
-        schema({
-            "premise": "this is a string",
-            "conclusion": "this is not a positive integer"
-        })
-
-    schema({
-        "premise": "this is a string",
-        "conclusion": 42
-    })
-
-    schema({})

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -565,3 +565,17 @@ def test_socket_timeout():  # pylint: disable=invalid-name
     assert _GLOBAL_DEFAULT_TIMEOUT == schema(None)
 
     assert schema(1) == 1.0
+
+
+def test_matches_regex():
+    """Test regex validator."""
+    schema = vol.Schema(cv.matches_regex('.*uiae.*'))
+
+    with pytest.raises(vol.Invalid):
+        schema(1.0)
+
+    with pytest.raises(vol.Invalid):
+        schema("  nrtd   ")
+
+    test_str = "This is a test including uiae."
+    assert(schema(test_str) == test_str)


### PR DESCRIPTION
## Description:

This adds a (rudimentary version of) a Matrix chatbot. Like the Telegram chatbot, it is able to fire events for incoming messages, which can be reacted to using automations. Since it probably doesn't make a lot of sense two have two pieces of code that interface with matrix, I also incorporated the Matrix notification platform into this component (which makes this a breaking change).

*Edit*: Credit where credit is due: Large parts of the component have been taken from the original notify platform by @mweinelt and @Cadair !

Some thoughts:
* With the old Matrix notification platform, it was not only possible to have several instances of the Matrix notification platform (that's still possible…), but also to use different Matrix accounts for them. That's not possible with the current implementation, however I don't see why this would be a useful feature.
* The Telegram chatbot is called `telegram_bot` instead of just `telegram`, presumably because there is an (independent) `telegram` notify platform. I still think it's better to name the component `matrix` than `matrix_bot`, even if it does similar things.

**Breaking Change Notice:** The Matrix notification platform now depends on the the new Matrix component. Please see the documentation for how to configure the Matrix component.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5019

## Example entry for `configuration.yaml` (if applicable):
```yaml
matrix:
  homeserver: https://matrix.org
  username: "@myusername:matrix.org"
  password: supersecurepassword
  listening_rooms:
    - "#testroom:matrix.org"
  commands:
    - word: "test"
      name: test
    - expression: "My name is (?P<name>.*)"
      name: introduction

notify:
  - name: matrix_notify
    platform: matrix
    default_room: "#testroom:matrix.org"

automation:
  - alias: 'Test'
    trigger:
      platform: event
      event_type: matrix_command
    action:
      service: notify.matrix_notify
      data:
        message: 'Test received'
```

This configuration…
* sets up the Matrix component, listening in room "#testroom:matrix.org" for two things:
  * The magic word "!test"
  * Any message matching "My name is <arbitrary string>" 
* offers a notification service under `notify.matrix_notify` (which is also being used in the automation below)
* Sends "Test received" to the room if somebody writes "!test" or "My name is <arbitrary string>" into the room.
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New files were added to `.coveragerc`.
