### PR TITLE
Cleanup homematicip_cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/homematicip_cloud/
 
 import logging
 from socket import timeout
+
 import voluptuous as vol
 
 from homeassistant.core import callback

--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -5,9 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/homematicip_cloud/
 """
 
-import asyncio
 import logging
-
 from socket import timeout
 import voluptuous as vol
 
@@ -117,8 +115,7 @@ class HomematicipGenericDevice(Entity):
         self._home = home
         self._device = device
 
-    @asyncio.coroutine
-    def async_added_to_hass(self):
+    async def async_added_to_hass(self):
         """Register callbacks."""
         async_dispatcher_connect(
             self.hass, EVENT_DEVICE_CHANGED, self._device_changed)

--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -2,13 +2,15 @@
 Support for HomematicIP components.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/homematicip/
+https://home-assistant.io/components/homematicip_cloud/
 """
 
+import asyncio
 import logging
-from socket import timeout
 
+from socket import timeout
 import voluptuous as vol
+
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (dispatcher_send,
@@ -49,12 +51,14 @@ ATTR_FIRMWARE_STATE = 'firmware_state'
 ATTR_LOW_BATTERY = 'low_battery'
 ATTR_SABOTAGE = 'sabotage'
 ATTR_RSSI = 'rssi'
+ATTR_TYPE = 'type'
 
 
 def setup(hass, config):
     """Set up the HomematicIP component."""
     # pylint: disable=import-error, no-name-in-module
     from homematicip.home import Home
+
     hass.data.setdefault(DOMAIN, {})
     homes = hass.data[DOMAIN]
     accesspoints = config.get(DOMAIN, [])
@@ -100,19 +104,22 @@ def setup(hass, config):
         _LOGGER.info('HUB name: %s, id: %s', home.label, home.id)
 
         for component in ['sensor']:
-            load_platform(hass, component, DOMAIN,
-                          {'homeid': home.id}, config)
+            load_platform(hass, component, DOMAIN, {'homeid': home.id}, config)
+
     return True
 
 
 class HomematicipGenericDevice(Entity):
     """Representation of an HomematicIP generic device."""
 
-    def __init__(self, hass, home, device, signal=None):
+    def __init__(self, home, device):
         """Initialize the generic device."""
-        self.hass = hass
         self._home = home
         self._device = device
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
         async_dispatcher_connect(
             self.hass, EVENT_DEVICE_CHANGED, self._device_changed)
 
@@ -162,6 +169,7 @@ class HomematicipGenericDevice(Entity):
             ATTR_FIRMWARE_STATE: self._device.updateState.lower(),
             ATTR_LOW_BATTERY: self._device.lowBat,
             ATTR_RSSI: self._device.rssiDeviceValue,
+            ATTR_TYPE: self._device.modelType
         }
 
     @property

--- a/homeassistant/components/sensor/homematicip_cloud.py
+++ b/homeassistant/components/sensor/homematicip_cloud.py
@@ -2,14 +2,15 @@
 Support for HomematicIP sensors.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/homematicip/
+https://home-assistant.io/components/homematicip_cloud/
 """
 
+import asyncio
 import logging
 
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.dispatcher import dispatcher_connect
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.components.homematicip_cloud import (
     HomematicipGenericDevice, DOMAIN, EVENT_HOME_CHANGED,
     ATTR_HOME_LABEL, ATTR_HOME_ID, ATTR_LOW_BATTERY, ATTR_RSSI)
@@ -38,41 +39,44 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         HeatingThermostat, TemperatureHumiditySensorWithoutDisplay,
         TemperatureHumiditySensorDisplay)
 
-    _LOGGER.info('Setting up HomeMaticIP accespoint & generic devices')
     homeid = discovery_info['homeid']
     home = hass.data[DOMAIN][homeid]
-    devices = [HomematicipAccesspoint(hass, home)]
-    if home.devices is None:
-        return
+    devices = [HomematicipAccesspoint(home)]
+
     for device in home.devices:
-        devices.append(HomematicipDeviceStatus(hass, home, device))
+        devices.append(HomematicipDeviceStatus(home, device))
         if isinstance(device, HeatingThermostat):
-            devices.append(HomematicipHeatingThermostat(hass, home, device))
+            devices.append(HomematicipHeatingThermostat(home, device))
         if isinstance(device, TemperatureHumiditySensorWithoutDisplay):
-            devices.append(HomematicipSensorThermometer(hass, home, device))
-            devices.append(HomematicipSensorHumidity(hass, home, device))
+            devices.append(HomematicipSensorThermometer(home, device))
+            devices.append(HomematicipSensorHumidity(home, device))
         if isinstance(device, TemperatureHumiditySensorDisplay):
-            devices.append(HomematicipSensorThermometer(hass, home, device))
-            devices.append(HomematicipSensorHumidity(hass, home, device))
-    add_devices(devices)
+            devices.append(HomematicipSensorThermometer(home, device))
+            devices.append(HomematicipSensorHumidity(home, device))
+
+    if home.devices:
+        add_devices(devices)
 
 
 class HomematicipAccesspoint(Entity):
     """Representation of an HomeMaticIP access point."""
 
-    def __init__(self, hass, home):
+    def __init__(self, home):
         """Initialize the access point sensor."""
-        self.hass = hass
         self._home = home
-        dispatcher_connect(
-            self.hass, EVENT_HOME_CHANGED, self._home_changed)
         _LOGGER.debug('Setting up access point %s', home.label)
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register callbacks."""
+        async_dispatcher_connect(
+            self.hass, EVENT_HOME_CHANGED, self._home_changed)
 
     @callback
     def _home_changed(self, deviceid):
         """Handle device state changes."""
         if deviceid is None or deviceid == self._home.id:
-            _LOGGER.debug('Event access point %s', self._home.label)
+            _LOGGER.debug('Event home %s', self._home.label)
             self.async_schedule_update_ha_state()
 
     @property
@@ -109,9 +113,9 @@ class HomematicipAccesspoint(Entity):
 class HomematicipDeviceStatus(HomematicipGenericDevice):
     """Representation of an HomematicIP device status."""
 
-    def __init__(self, hass, home, device, signal=None):
+    def __init__(self, home, device):
         """Initialize the device."""
-        super().__init__(hass, home, device)
+        super().__init__(home, device)
         _LOGGER.debug('Setting up sensor device status: %s', device.label)
 
     @property
@@ -147,9 +151,9 @@ class HomematicipDeviceStatus(HomematicipGenericDevice):
 class HomematicipHeatingThermostat(HomematicipGenericDevice):
     """MomematicIP heating thermostat representation."""
 
-    def __init__(self, hass, home, device):
+    def __init__(self, home, device):
         """"Initialize heating thermostat."""
-        super().__init__(hass, home, device)
+        super().__init__(home, device)
         _LOGGER.debug('Setting up heating thermostat device: %s', device.label)
 
     @property
@@ -185,11 +189,10 @@ class HomematicipHeatingThermostat(HomematicipGenericDevice):
 class HomematicipSensorHumidity(HomematicipGenericDevice):
     """MomematicIP thermometer device."""
 
-    def __init__(self, hass, home, device):
+    def __init__(self, home, device):
         """"Initialize the thermometer device."""
-        super().__init__(hass, home, device)
-        _LOGGER.debug('Setting up humidity device: %s',
-                      device.label)
+        super().__init__(home, device)
+        _LOGGER.debug('Setting up humidity device: %s', device.label)
 
     @property
     def name(self):
@@ -223,9 +226,9 @@ class HomematicipSensorHumidity(HomematicipGenericDevice):
 class HomematicipSensorThermometer(HomematicipGenericDevice):
     """MomematicIP thermometer device."""
 
-    def __init__(self, hass, home, device):
+    def __init__(self, home, device):
         """"Initialize the thermometer device."""
-        super().__init__(hass, home, device)
+        super().__init__(home, device)
         _LOGGER.debug('Setting up thermometer device: %s', device.label)
 
     @property

--- a/homeassistant/components/sensor/homematicip_cloud.py
+++ b/homeassistant/components/sensor/homematicip_cloud.py
@@ -2,7 +2,7 @@
 Support for HomematicIP sensors.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/homematicip_cloud/
+https://home-assistant.io/components/homematicip/
 """
 
 import logging

--- a/homeassistant/components/sensor/homematicip_cloud.py
+++ b/homeassistant/components/sensor/homematicip_cloud.py
@@ -2,7 +2,7 @@
 Support for HomematicIP sensors.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/homematicip_cloud/
+https://home-assistant.io/components/sensor.homematicip_cloud/
 """
 
 import logging

--- a/homeassistant/components/sensor/homematicip_cloud.py
+++ b/homeassistant/components/sensor/homematicip_cloud.py
@@ -5,7 +5,6 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/homematicip_cloud/
 """
 
-import asyncio
 import logging
 
 from homeassistant.core import callback
@@ -66,8 +65,7 @@ class HomematicipAccesspoint(Entity):
         self._home = home
         _LOGGER.debug('Setting up access point %s', home.label)
 
-    @asyncio.coroutine
-    def async_added_to_hass(self):
+    async def async_added_to_hass(self):
         """Register callbacks."""
         async_dispatcher_connect(
             self.hass, EVENT_HOME_CHANGED, self._home_changed)

--- a/homeassistant/components/sensor/homematicip_cloud.py
+++ b/homeassistant/components/sensor/homematicip_cloud.py
@@ -2,7 +2,7 @@
 Support for HomematicIP sensors.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/homematicip/
+https://home-assistant.io/components/homematicip_cloud/
 """
 
 import logging


### PR DESCRIPTION
## Description:
Cleanup of the initial PR

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
