### PR TITLE
Do not include unavailable entities in Google Assistant SYNC

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -94,8 +94,15 @@ class _GoogleEntity:
 
         https://developers.google.com/actions/smarthome/create-app#actiondevicessync
         """
-        traits = self.traits()
         state = self.state
+
+        # When a state is unavailable, the attributes that describe
+        # capabilities will be stripped. For example, a light entity will miss
+        # the min/max mireds. Therefore they will be excluded from a sync.
+        if state.state == STATE_UNAVAILABLE:
+            return None
+
+        traits = self.traits()
 
         # Found no supported traits for this entity
         if not traits:

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -52,6 +52,7 @@ class DemoLight(Light):
         self._white = white
         self._effect_list = effect_list
         self._effect = effect
+        self._available = True
 
     @property
     def should_poll(self) -> bool:
@@ -73,7 +74,7 @@ class DemoLight(Light):
         """Return availability."""
         # This demo light is always available, but well-behaving components
         # should implement this to inform Home Assistant accordingly.
-        return True
+        return self._available
 
     @property
     def brightness(self) -> int:

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -259,3 +259,31 @@ def test_serialize_input_boolean():
         'type': 'action.devices.types.SWITCH',
         'willReportState': False,
     }
+
+
+async def test_unavailable_state_doesnt_sync(hass):
+    """Test that an unavailable entity does not sync over."""
+    light = DemoLight(
+        None, 'Demo Light',
+        state=False,
+        hs_color=(180, 75),
+    )
+    light.hass = hass
+    light.entity_id = 'light.demo_light'
+    light._available = False
+    await light.async_update_ha_state()
+
+    result = await sh.async_handle_message(hass, BASIC_CONFIG, {
+        "requestId": REQ_ID,
+        "inputs": [{
+            "intent": "action.devices.SYNC"
+        }]
+    })
+
+    assert result == {
+        'requestId': REQ_ID,
+        'payload': {
+            'agentUserId': 'test-agent',
+            'devices': []
+        }
+    }


### PR DESCRIPTION
## Description:
When an entity is unavailable, the attributes that describe the supported features are dropped. For example, a light entity will still contain supported_features but it will not contain the 'min_mireds' and 'max_mireds'. This will make it impossible for Google Assistant to describe the functionalities and thus we should exclude these entities from Google Assistant SYNC requests.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
