### PR TITLE
Add watt to mysensors switch attributes

### DIFF
--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -73,6 +73,12 @@ class MySensorsSwitch(mysensors.MySensorsEntity, SwitchDevice):
         return self.gateway.optimistic
 
     @property
+    def current_power_w(self):
+        """Return the current power usage in W."""
+        set_req = self.gateway.const.SetReq
+        return self._values.get(set_req.V_WATT)
+
+    @property
     def is_on(self):
         """Return True if switch is on."""
         return self._values.get(self.value_type) == STATE_ON


### PR DESCRIPTION
## Description:
* Report current power in attributes of mysensors switch entities if V_WATT is reported for the device.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**