### PR TITLE
Adds template function state_attr to get attribute from a state

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -409,7 +409,7 @@ class TemplateMethods(object):
         return state_attr is not None and state_attr == value
 
     def state_attr(self, entity_id, name):
-        """Gets a specific attribute from a state."""
+        """Get a specific attribute from a state."""
         state_obj = self._hass.states.get(entity_id)
         if state_obj is not None:
             return state_obj.attributes.get(name)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -28,7 +28,7 @@ DATE_STR_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 _RE_NONE_ENTITIES = re.compile(r"distance\(|closest\(", re.I | re.M)
 _RE_GET_ENTITIES = re.compile(
-    r"(?:(?:states\.|(?:is_state|is_state_attr|states)"
+    r"(?:(?:states\.|(?:is_state|is_state_attr|state_attr|states)"
     r"\((?:[\ \'\"]?))([\w]+\.[\w]+)|([\w]+))", re.I | re.M
 )
 
@@ -181,6 +181,7 @@ class Template(object):
             'distance': template_methods.distance,
             'is_state': self.hass.states.is_state,
             'is_state_attr': template_methods.is_state_attr,
+            'state_attr': template_methods.state_attr,
             'states': AllStates(self.hass),
         })
 
@@ -404,9 +405,15 @@ class TemplateMethods(object):
 
     def is_state_attr(self, entity_id, name, value):
         """Test if a state is a specific attribute."""
+        state_attr = self.state_attr(entity_id, name)
+        return state_attr is not None and state_attr == value
+
+    def state_attr(self, entity_id, name):
+        """Gets a specific attribute from a state."""
         state_obj = self._hass.states.get(entity_id)
-        return state_obj is not None and \
-            state_obj.attributes.get(name) == value
+        if state_obj is not None:
+            return state_obj.attributes.get(name)
+        return None
 
     def _resolve_state(self, entity_id_or_state):
         """Return state or entity_id if given."""

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -401,7 +401,7 @@ class TestHelpersTemplate(unittest.TestCase):
         """Test state_attr method."""
         self.hass.states.set('test.object', 'available', {'mode': 'on'})
         tpl = template.Template("""
-{% if state_attr("test.object", "mode", "on") == on %}yes{% else %}no{% endif %}
+{% if state_attr("test.object", "mode") == on %}yes{% else %}no{% endif %}
                     """, self.hass)
         self.assertEqual('yes', tpl.render())
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -397,6 +397,19 @@ class TestHelpersTemplate(unittest.TestCase):
                 """, self.hass)
         self.assertEqual('False', tpl.render())
 
+    def test_state_attr(self):
+        """Test state_attr method."""
+        self.hass.states.set('test.object', 'available', {'mode': 'on'})
+        tpl = template.Template("""
+{% if state_attr("test.object", "mode", "on") == on %}yes{% else %}no{% endif %}
+                    """, self.hass)
+        self.assertEqual('yes', tpl.render())
+
+        tpl = template.Template("""
+{{ state_attr("test.noobject", "mode") == None }}
+                    """, self.hass)
+        self.assertEqual('True', tpl.render())
+
     def test_states_function(self):
         """Test using states as a function."""
         self.hass.states.set('test.object', 'available')

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -402,12 +402,12 @@ class TestHelpersTemplate(unittest.TestCase):
         self.hass.states.set('test.object', 'available', {'mode': 'on'})
         tpl = template.Template("""
 {% if state_attr("test.object", "mode") == on %}yes{% else %}no{% endif %}
-                    """, self.hass)
+                """, self.hass)
         self.assertEqual('yes', tpl.render())
 
         tpl = template.Template("""
 {{ state_attr("test.noobject", "mode") == None }}
-                    """, self.hass)
+                """, self.hass)
         self.assertEqual('True', tpl.render())
 
     def test_states_function(self):

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -401,7 +401,7 @@ class TestHelpersTemplate(unittest.TestCase):
         """Test state_attr method."""
         self.hass.states.set('test.object', 'available', {'mode': 'on'})
         tpl = template.Template("""
-{% if state_attr("test.object", "mode") == on %}yes{% else %}no{% endif %}
+{% if state_attr("test.object", "mode") == "on" %}yes{% else %}no{% endif %}
                 """, self.hass)
         self.assertEqual('yes', tpl.render())
 


### PR DESCRIPTION

## Description:
Adds state_attr so that you can use a string to get the state attributes. By enabling this you can write configs like below without iterating through all state which is one solution that is on the forums.

I do not know how to update the documentation. I'll need help with that.

I have added test to check if the right date is delivered and if it can handle non existing states.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4981

## Example entry for `configuration.yaml` (if applicable):
```yaml
intent_script:
  ActivateLightColor:
    action:
      - service: light.turn_on
        data_template:
          entity_id: light.{{ objectLocation | replace(" ","_") }}
          color_name: {{ objectColor }}
          brightness: >-
            {% if objectBrightness -%}
              {{objectBrightness}}
            {%- else -%}
              {{state_attr('light.' + objectLocation.replace(" ","_"), 'brightness')}}
            {%- endif %}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
