### PR TITLE
Avoid breaking change for BMW ConnectedDrive sensors in #12591

### DIFF
--- a/homeassistant/components/binary_sensor/bmw_connected_drive.py
+++ b/homeassistant/components/binary_sensor/bmw_connected_drive.py
@@ -15,8 +15,8 @@ DEPENDENCIES = ['bmw_connected_drive']
 _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPES = {
-    'all_lids_closed': ['Doors', 'opening'],
-    'all_windows_closed': ['Windows', 'opening'],
+    'lids': ['Doors', 'opening'],
+    'windows': ['Windows', 'opening'],
     'door_lock_state': ['Door lock state', 'safety']
 }
 
@@ -45,7 +45,8 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
         self._account = account
         self._vehicle = vehicle
         self._attribute = attribute
-        self._name = sensor_name
+        self._name = '{} {}'.format(self._vehicle.modelName, self._attribute)
+        self._sensor_name = sensor_name
         self._device_class = device_class
         self._state = None
 
@@ -77,10 +78,10 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
             'car': self._vehicle.modelName
         }
 
-        if self._attribute == 'all_lids_closed':
+        if self._attribute == 'lids':
             for lid in vehicle_state.lids:
                 result[lid.name] = lid.state.value
-        elif self._attribute == 'all_windows_closed':
+        elif self._attribute == 'windows':
             for window in vehicle_state.windows:
                 result[window.name] = window.state.value
         elif self._attribute == 'door_lock_state':
@@ -93,10 +94,10 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
         vehicle_state = self._vehicle.state
 
         # device class opening: On means open, Off means closed
-        if self._attribute == 'all_lids_closed':
+        if self._attribute == 'lids':
             _LOGGER.debug("Status of lid: %s", vehicle_state.all_lids_closed)
             self._state = not vehicle_state.all_lids_closed
-        if self._attribute == 'all_windows_closed':
+        if self._attribute == 'windows':
             self._state = not vehicle_state.all_windows_closed
         # device class safety: On means unsafe, Off means safe
         if self._attribute == 'door_lock_state':

--- a/homeassistant/components/lock/bmw_connected_drive.py
+++ b/homeassistant/components/lock/bmw_connected_drive.py
@@ -37,7 +37,8 @@ class BMWLock(LockDevice):
         self._account = account
         self._vehicle = vehicle
         self._attribute = attribute
-        self._name = sensor_name
+        self._name = '{} {}'.format(self._vehicle.modelName, self._attribute)
+        self._sensor_name = sensor_name
         self._state = None
 
     @property

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -51,7 +51,8 @@ class BMWConnectedDriveSensor(Entity):
         self._attribute = attribute
         self._state = None
         self._unit_of_measurement = None
-        self._name = sensor_name
+        self._name = '{} {}'.format(self._vehicle.modelName, self._attribute)
+        self._sensor_name = sensor_name
         self._icon = icon
 
     @property


### PR DESCRIPTION
## Description:
With PR #12591 an unnecessary breaking change was introduced for the existing BMW ConnectedDrive sensors. As discussed with @MartinHjelmare this PR avoids that breaking change.

Once this PR is merged I will remove the breaking change description in #12591.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
