### PR TITLE
Enable setting a median manually for the band-pass (outlier) filter

### DIFF
--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -21,6 +21,7 @@ from homeassistant.util.decorator import Registry
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change
 import homeassistant.util.dt as dt_util
+import math
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ CONF_FILTER_NAME = 'filter'
 CONF_FILTER_WINDOW_SIZE = 'window_size'
 CONF_FILTER_PRECISION = 'precision'
 CONF_FILTER_RADIUS = 'radius'
+CONF_FILTER_MEDIAN = 'median'
 CONF_FILTER_TIME_CONSTANT = 'time_constant'
 CONF_TIME_SMA_TYPE = 'type'
 
@@ -44,6 +46,7 @@ DEFAULT_WINDOW_SIZE = 1
 DEFAULT_PRECISION = 2
 DEFAULT_FILTER_RADIUS = 2.0
 DEFAULT_FILTER_TIME_CONSTANT = 10
+NO_MANUAL_MEDIAN = math.inf
 
 NAME_TEMPLATE = "{} filter"
 ICON = 'mdi:chart-line-variant'
@@ -60,6 +63,8 @@ FILTER_OUTLIER_SCHEMA = FILTER_SCHEMA.extend({
                  default=DEFAULT_WINDOW_SIZE): vol.Coerce(int),
     vol.Optional(CONF_FILTER_RADIUS,
                  default=DEFAULT_FILTER_RADIUS): vol.Coerce(float),
+    vol.Optional(CONF_FILTER_MEDIAN,
+                 default=NO_MANUAL_MEDIAN): vol.Coerce(float),
 })
 
 FILTER_LOWPASS_SCHEMA = FILTER_SCHEMA.extend({
@@ -244,21 +249,29 @@ class OutlierFilter(Filter):
 
     Args:
         radius (float): band radius
+        median (float): band center
+            (defaults to NO_MANUAL_MEDIAN for automatic computation)
     """
 
-    def __init__(self, window_size, precision, entity, radius):
+    def __init__(self, window_size, precision, entity, radius,
+                 median=NO_MANUAL_MEDIAN):
         """Initialize Filter."""
         super().__init__(FILTER_NAME_OUTLIER, window_size, precision, entity)
         self._radius = radius
+        self._manual_median_enabled = (median == NO_MANUAL_MEDIAN)
+        self._manual_median = median
         self._stats_internal = Counter()
 
     def _filter_state(self, new_state):
         """Implement the outlier filter."""
         new_state = float(new_state)
 
-        if (self.states and
-                abs(new_state - statistics.median(self.states))
-                > self._radius):
+        diff = 0
+        if (self._manual_median_enabled):
+            diff = abs(new_state - self._manual_median)
+        elif (self.states):
+            diff = abs(new_state - statistics.median(self.states))
+        if (diff > self._radius):
 
             self._stats_internal['erasures'] += 1
 

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -266,19 +266,19 @@ class OutlierFilter(Filter):
         """Implement the outlier filter."""
         new_state = float(new_state)
 
-        diff = 0
-        if (self._manual_median_enabled):
-            diff = abs(new_state - self._manual_median)
-        elif (self.states):
-            diff = abs(new_state - statistics.median(self.states))
-        if (diff > self._radius):
-
-            self._stats_internal['erasures'] += 1
-
-            _LOGGER.debug("Outlier nr. %s in %s: %s",
-                          self._stats_internal['erasures'],
-                          self._entity, new_state)
-            return self.states[-1]
+        if(self.states):
+            if (self._manual_median_enabled):
+                diff = abs(new_state - self._manual_median)
+            else:
+                diff = abs(new_state - statistics.median(self.states))
+            if (diff > self._radius):
+    
+                self._stats_internal['erasures'] += 1
+    
+                _LOGGER.debug("Outlier nr. %s in %s: %s",
+                              self._stats_internal['erasures'],
+                              self._entity, new_state)
+                return self.states[-1]
         return new_state
 
 

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -272,9 +272,9 @@ class OutlierFilter(Filter):
             else:
                 diff = abs(new_state - statistics.median(self.states))
             if (diff > self._radius):
-    
+
                 self._stats_internal['erasures'] += 1
-    
+
                 _LOGGER.debug("Outlier nr. %s in %s: %s",
                               self._stats_internal['erasures'],
                               self._entity, new_state)

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -8,6 +8,7 @@ import logging
 import statistics
 from collections import deque, Counter
 from numbers import Number
+import math
 
 import voluptuous as vol
 
@@ -21,7 +22,6 @@ from homeassistant.util.decorator import Registry
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change
 import homeassistant.util.dt as dt_util
-import math
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -266,7 +266,7 @@ class OutlierFilter(Filter):
         new_state = float(new_state)
 
         if self.states:
-            if self._manual_median == NO_MANUAL_MEDIAN:
+            if self._manual_median != NO_MANUAL_MEDIAN:
                 diff = abs(new_state - self._manual_median)
             else:
                 diff = abs(new_state - statistics.median(self.states))

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -258,7 +258,6 @@ class OutlierFilter(Filter):
         """Initialize Filter."""
         super().__init__(FILTER_NAME_OUTLIER, window_size, precision, entity)
         self._radius = radius
-        self._manual_median_enabled = (median == NO_MANUAL_MEDIAN)
         self._manual_median = median
         self._stats_internal = Counter()
 
@@ -266,12 +265,12 @@ class OutlierFilter(Filter):
         """Implement the outlier filter."""
         new_state = float(new_state)
 
-        if(self.states):
-            if (self._manual_median_enabled):
+        if self.states:
+            if self._manual_median == NO_MANUAL_MEDIAN:
                 diff = abs(new_state - self._manual_median)
             else:
                 diff = abs(new_state - statistics.median(self.states))
-            if (diff > self._radius):
+            if diff > self._radius:
 
                 self._stats_internal['erasures'] += 1
 

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -72,6 +72,17 @@ class TestFilterSensor(unittest.TestCase):
             filtered = filt.filter_state(state)
         self.assertEqual(22, filtered)
 
+    def test_outlier_median(self):
+        """Test if outlier filter with manual median works."""
+        filt = OutlierFilter(window_size=10,
+                             precision=2,
+                             entity=None,
+                             radius=4.0,
+                             median=0)
+        for state in self.values:
+            filtered = filt.filter_state(state)
+        self.assertEqual(0, filtered)
+
     def test_lowpass(self):
         """Test if lowpass filter works."""
         filt = LowPassFilter(window_size=10,


### PR DESCRIPTION
## Description:
Automatic computation of the median for the outlier filter lead to issues. This is an attempt at fixing it.
Also user can clearly define a band for passing values this way.

**Related issue:** fixes #13363 (but is not only meant as fix for this)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4984

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: filter
    name: "filtered realistic humidity"
    entity_id: sensor.realistic_humidity
    filters:
      - filter: outlier
        window_size: 4
        radius: 4.0
        median: 50.0
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
