### PR TITLE
Add send sticker service to telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -63,6 +63,7 @@ DOMAIN = 'telegram_bot'
 
 SERVICE_SEND_MESSAGE = 'send_message'
 SERVICE_SEND_PHOTO = 'send_photo'
+SERVICE_SEND_STICKER = 'send_sticker'
 SERVICE_SEND_VIDEO = 'send_video'
 SERVICE_SEND_DOCUMENT = 'send_document'
 SERVICE_SEND_LOCATION = 'send_location'
@@ -154,6 +155,7 @@ SERVICE_SCHEMA_DELETE_MESSAGE = vol.Schema({
 SERVICE_MAP = {
     SERVICE_SEND_MESSAGE: SERVICE_SCHEMA_SEND_MESSAGE,
     SERVICE_SEND_PHOTO: SERVICE_SCHEMA_SEND_FILE,
+    SERVICE_SEND_STICKER: SERVICE_SCHEMA_SEND_FILE,
     SERVICE_SEND_VIDEO: SERVICE_SCHEMA_SEND_FILE,
     SERVICE_SEND_DOCUMENT: SERVICE_SCHEMA_SEND_FILE,
     SERVICE_SEND_LOCATION: SERVICE_SCHEMA_SEND_LOCATION,
@@ -167,10 +169,10 @@ SERVICE_MAP = {
 
 def load_data(hass, url=None, filepath=None, username=None, password=None,
               authentication=None, num_retries=5):
-    """Load photo/document into ByteIO/File container from a source."""
+    """Load data into ByteIO/File container from a source."""
     try:
         if url is not None:
-            # Load photo from URL
+            # Load data from URL
             params = {"timeout": 15}
             if username is not None and password is not None:
                 if authentication == HTTP_DIGEST_AUTHENTICATION:
@@ -192,7 +194,7 @@ def load_data(hass, url=None, filepath=None, username=None, password=None,
                     _LOGGER.warning("Empty data (retry #%s) in %s)",
                                     retry_num + 1, url)
                 retry_num += 1
-            _LOGGER.warning("Can't load photo in %s after %s retries",
+            _LOGGER.warning("Can't load data in %s after %s retries",
                             url, retry_num)
         elif filepath is not None:
             if hass.config.is_allowed_path(filepath):
@@ -200,10 +202,10 @@ def load_data(hass, url=None, filepath=None, username=None, password=None,
 
             _LOGGER.warning("'%s' are not secure to load data from!", filepath)
         else:
-            _LOGGER.warning("Can't load photo. No photo found in params!")
+            _LOGGER.warning("Can't load data. No data found in params!")
 
     except (OSError, TypeError) as error:
-        _LOGGER.error("Can't load photo into ByteIO: %s", error)
+        _LOGGER.error("Can't load data into ByteIO: %s", error)
 
     return None
 
@@ -274,9 +276,8 @@ def async_setup(hass, config):
         if msgtype == SERVICE_SEND_MESSAGE:
             yield from hass.async_add_job(
                 partial(notify_service.send_message, **kwargs))
-        elif (msgtype == SERVICE_SEND_PHOTO or
-              msgtype == SERVICE_SEND_VIDEO or
-              msgtype == SERVICE_SEND_DOCUMENT):
+        elif msgtype in [SERVICE_SEND_PHOTO, SERVICE_SEND_STICKER,
+                         SERVICE_SEND_VIDEO, SERVICE_SEND_DOCUMENT]:
             yield from hass.async_add_job(
                 partial(notify_service.send_file, msgtype, **kwargs))
         elif msgtype == SERVICE_SEND_LOCATION:
@@ -524,11 +525,12 @@ class TelegramNotificationService:
                        text=message, show_alert=show_alert, **params)
 
     def send_file(self, file_type=SERVICE_SEND_PHOTO, target=None, **kwargs):
-        """Send a photo, video, or document."""
+        """Send a photo, sticker, video, or document."""
         params = self._get_msg_kwargs(kwargs)
         caption = kwargs.get(ATTR_CAPTION)
         func_send = {
             SERVICE_SEND_PHOTO: self.bot.sendPhoto,
+            SERVICE_SEND_STICKER: self.bot.sendSticker,
             SERVICE_SEND_VIDEO: self.bot.sendVideo,
             SERVICE_SEND_DOCUMENT: self.bot.sendDocument
         }.get(file_type)

--- a/homeassistant/components/telegram_bot/services.yaml
+++ b/homeassistant/components/telegram_bot/services.yaml
@@ -37,9 +37,37 @@ send_photo:
     file:
       description: Local path to an image.
       example: '/path/to/the/image.png'
+    username:
+      description: Username for a URL which require HTTP basic authentication.
+      example: myuser
+    password:
+      description: Password for a URL which require HTTP basic authentication.
+      example: myuser_pwd
+    target:
+      description: An array of pre-authorized chat_ids to send the document to. If not present, first allowed chat_id is the default.
+      example: '[12345, 67890] or 12345'
+    disable_notification:
+      description: Sends the message silently. iOS users and Web users will not receive a notification, Android users will receive a notification with no sound.
+      example: true
+    keyboard:
+      description: List of rows of commands, comma-separated, to make a custom keyboard.
+      example: '["/command1, /command2", "/command3"]'
+    inline_keyboard:
+      description: List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.
+      example: '["/button1, /button2", "/button3"] or [[["Text button1", "/button1"], ["Text button2", "/button2"]], [["Text button3", "/button3"]]]'
+
+send_sticker:
+  description: Send a sticker.
+  fields:
+    url:
+      description: Remote path to an webp sticker.
+      example: 'http://example.org/path/to/the/sticker.webp'
+    file:
+      description: Local path to an webp sticker.
+      example: '/path/to/the/sticker.webp'
     caption:
-      description: The title of the image.
-      example: 'My image'
+      description: The title of the sticker.
+      example: 'My sticker'
     username:
       description: Username for a URL which require HTTP basic authentication.
       example: myuser

--- a/homeassistant/components/telegram_bot/services.yaml
+++ b/homeassistant/components/telegram_bot/services.yaml
@@ -37,6 +37,9 @@ send_photo:
     file:
       description: Local path to an image.
       example: '/path/to/the/image.png'
+    caption:
+      description: The title of the image.
+      example: 'My image'
     username:
       description: Username for a URL which require HTTP basic authentication.
       example: myuser
@@ -65,9 +68,6 @@ send_sticker:
     file:
       description: Local path to an webp sticker.
       example: '/path/to/the/sticker.webp'
-    caption:
-      description: The title of the sticker.
-      example: 'My sticker'
     username:
       description: Username for a URL which require HTTP basic authentication.
       example: myuser


### PR DESCRIPTION
## Description:

Allows sending webp stickers. The size of the sticker must be less than 512x512 px. I used https://www.gstatic.com/webp/gallery3/2_webp_a.webp for testing.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/4996