### PR TITLE
Adding range filter

### DIFF
--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -355,7 +355,7 @@ class BandPassFilter(Filter):
     """
 
     def __init__(self, window_size, precision, entity,
-                 lower_bound=math.inf, upper_bound=-math.inf):
+                 lower_bound, upper_bound):
         """Initialize Filter."""
         super().__init__(FILTER_NAME_OUTLIER, window_size, precision, entity)
         self._lower_bound = lower_bound
@@ -363,7 +363,7 @@ class BandPassFilter(Filter):
         self._stats_internal = Counter()
 
     def _filter_state(self, new_state):
-        """Implement the outlier filter."""
+        """Implement the band-pass filter."""
         new_state = float(new_state)
 
         if new_state > self._upper_bound:

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -11,7 +11,6 @@ from numbers import Number
 from functools import partial
 from copy import copy
 from datetime import timedelta
-import math
 
 import voluptuous as vol
 
@@ -55,8 +54,6 @@ DEFAULT_WINDOW_SIZE = 1
 DEFAULT_PRECISION = 2
 DEFAULT_FILTER_RADIUS = 2.0
 DEFAULT_FILTER_TIME_CONSTANT = 10
-DEFAULT_LOWER_BOUND = -math.inf
-DEFAULT_UPPER_BOUND = math.inf
 
 NAME_TEMPLATE = "{} filter"
 ICON = 'mdi:chart-line-variant'
@@ -85,10 +82,8 @@ FILTER_LOWPASS_SCHEMA = FILTER_SCHEMA.extend({
 
 FILTER_RANGE_SCHEMA = FILTER_SCHEMA.extend({
     vol.Required(CONF_FILTER_NAME): FILTER_NAME_RANGE,
-    vol.Optional(CONF_FILTER_LOWER_BOUND,
-                 default=DEFAULT_LOWER_BOUND): vol.Coerce(float),
-    vol.Optional(CONF_FILTER_UPPER_BOUND,
-                 default=DEFAULT_UPPER_BOUND): vol.Coerce(float),
+    vol.Optional(CONF_FILTER_LOWER_BOUND): vol.Coerce(float),
+    vol.Optional(CONF_FILTER_UPPER_BOUND): vol.Coerce(float),
 })
 
 FILTER_TIME_SMA_SCHEMA = FILTER_SCHEMA.extend({
@@ -353,7 +348,7 @@ class RangeFilter(Filter):
     """
 
     def __init__(self, entity,
-                 lower_bound, upper_bound):
+                 lower_bound=None, upper_bound=None):
         """Initialize Filter."""
         super().__init__(FILTER_NAME_RANGE, entity=entity)
         self._lower_bound = lower_bound
@@ -362,7 +357,7 @@ class RangeFilter(Filter):
 
     def _filter_state(self, new_state):
         """Implement the range filter."""
-        if new_state.state > self._upper_bound:
+        if self._upper_bound and new_state.state > self._upper_bound:
 
             self._stats_internal['erasures_up'] += 1
 
@@ -371,7 +366,7 @@ class RangeFilter(Filter):
                           self._entity, new_state)
             new_state.state = self._upper_bound
 
-        elif new_state.state < self._lower_bound:
+        elif self._lower_bound and new_state.state < self._lower_bound:
 
             self._stats_internal['erasures_low'] += 1
 

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -85,6 +85,8 @@ FILTER_LOWPASS_SCHEMA = FILTER_SCHEMA.extend({
 
 FILTER_BANDPASS_SCHEMA = FILTER_SCHEMA.extend({
     vol.Required(CONF_FILTER_NAME): FILTER_NAME_BANDPASS,
+    vol.Optional(CONF_FILTER_WINDOW_SIZE,
+                 default=DEFAULT_WINDOW_SIZE): vol.Coerce(int),
     vol.Optional(CONF_FILTER_LOWER_BOUND,
                  default=DEFAULT_LOWER_BOUND): vol.Coerce(float),
     vol.Optional(CONF_FILTER_UPPER_BOUND,
@@ -352,7 +354,7 @@ class BandPassFilter(Filter):
         lower_bound (float): band lower bound
     """
 
-    def __init__(self, window_size=1, precision=None, entity,
+    def __init__(self, window_size, precision, entity,
                  lower_bound=math.inf, upper_bound=-math.inf):
         """Initialize Filter."""
         super().__init__(FILTER_NAME_OUTLIER, window_size, precision, entity)

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -364,25 +364,24 @@ class RangeFilter(Filter):
 
     def _filter_state(self, new_state):
         """Implement the range filter."""
-        new_state = float(new_state)
 
-        if new_state > self._upper_bound:
+        if new_state.state > self._upper_bound:
 
             self._stats_internal['erasures_up'] += 1
 
             _LOGGER.debug("Upper outlier nr. %s in %s: %s",
                           self._stats_internal['erasures_up'],
                           self._entity, new_state)
-            return self._upper_bound
+            new_state.state = self._upper_bound
 
-        if new_state < self._lower_bound:
+        elif new_state < self._lower_bound:
 
             self._stats_internal['erasures_low'] += 1
 
             _LOGGER.debug("Lower outlier nr. %s in %s: %s",
                           self._stats_internal['erasures_low'],
                           self._entity, new_state)
-            return self._lower_bound
+            new_state.state = self._upper_bound
 
         return new_state
 

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -364,7 +364,6 @@ class RangeFilter(Filter):
 
     def _filter_state(self, new_state):
         """Implement the range filter."""
-
         if new_state.state > self._upper_bound:
 
             self._stats_internal['erasures_up'] += 1

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -380,7 +380,7 @@ class RangeFilter(Filter):
             _LOGGER.debug("Lower outlier nr. %s in %s: %s",
                           self._stats_internal['erasures_low'],
                           self._entity, new_state)
-            new_state.state = self._upper_bound
+            new_state.state = self._lower_bound
 
         return new_state
 

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -348,7 +348,7 @@ class RangeFilter(Filter):
     """
 
     def __init__(self, entity,
-                 lower_bound=None, upper_bound=None):
+                 lower_bound, upper_bound):
         """Initialize Filter."""
         super().__init__(FILTER_NAME_RANGE, entity=entity)
         self._lower_bound = lower_bound

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -374,7 +374,7 @@ class RangeFilter(Filter):
                           self._entity, new_state)
             new_state.state = self._upper_bound
 
-        elif new_state < self._lower_bound:
+        elif new_state.state < self._lower_bound:
 
             self._stats_internal['erasures_low'] += 1
 

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -29,7 +29,7 @@ import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
-FILTER_NAME_BANDPASS = 'bandpass'
+FILTER_NAME_RANGE = 'range'
 FILTER_NAME_LOWPASS = 'lowpass'
 FILTER_NAME_OUTLIER = 'outlier'
 FILTER_NAME_THROTTLE = 'throttle'
@@ -83,8 +83,8 @@ FILTER_LOWPASS_SCHEMA = FILTER_SCHEMA.extend({
                  default=DEFAULT_FILTER_TIME_CONSTANT): vol.Coerce(int),
 })
 
-FILTER_BANDPASS_SCHEMA = FILTER_SCHEMA.extend({
-    vol.Required(CONF_FILTER_NAME): FILTER_NAME_BANDPASS,
+FILTER_RANGE_SCHEMA = FILTER_SCHEMA.extend({
+    vol.Required(CONF_FILTER_NAME): FILTER_NAME_RANGE,
     vol.Optional(CONF_FILTER_WINDOW_SIZE,
                  default=DEFAULT_WINDOW_SIZE): vol.Coerce(int),
     vol.Optional(CONF_FILTER_LOWER_BOUND,
@@ -117,7 +117,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                                                  FILTER_LOWPASS_SCHEMA,
                                                  FILTER_TIME_SMA_SCHEMA,
                                                  FILTER_THROTTLE_SCHEMA,
-                                                 FILTER_BANDPASS_SCHEMA)])
+                                                 FILTER_RANGE_SCHEMA)])
 })
 
 
@@ -342,11 +342,11 @@ class Filter(object):
         return new_state
 
 
-@FILTERS.register(FILTER_NAME_BANDPASS)
-class BandPassFilter(Filter):
-    """Band pass filter.
+@FILTERS.register(FILTER_NAME_RANGE)
+class RangeFilter(Filter):
+    """Range filter.
 
-    Determines if new state is in a band between upper_bound and lower_bound.
+    Determines if new state is in the range of upper_bound and lower_bound.
     If not inside, lower or upper bound is returned instead.
 
     Args:
@@ -357,13 +357,13 @@ class BandPassFilter(Filter):
     def __init__(self, window_size, precision, entity,
                  lower_bound, upper_bound):
         """Initialize Filter."""
-        super().__init__(FILTER_NAME_OUTLIER, window_size, precision, entity)
+        super().__init__(FILTER_NAME_RANGE, window_size, precision, entity)
         self._lower_bound = lower_bound
         self._upper_bound = upper_bound
         self._stats_internal = Counter()
 
     def _filter_state(self, new_state):
-        """Implement the band-pass filter."""
+        """Implement the range filter."""
         new_state = float(new_state)
 
         if new_state > self._upper_bound:

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -85,8 +85,6 @@ FILTER_LOWPASS_SCHEMA = FILTER_SCHEMA.extend({
 
 FILTER_RANGE_SCHEMA = FILTER_SCHEMA.extend({
     vol.Required(CONF_FILTER_NAME): FILTER_NAME_RANGE,
-    vol.Optional(CONF_FILTER_WINDOW_SIZE,
-                 default=DEFAULT_WINDOW_SIZE): vol.Coerce(int),
     vol.Optional(CONF_FILTER_LOWER_BOUND,
                  default=DEFAULT_LOWER_BOUND): vol.Coerce(float),
     vol.Optional(CONF_FILTER_UPPER_BOUND,
@@ -354,10 +352,10 @@ class RangeFilter(Filter):
         lower_bound (float): band lower bound
     """
 
-    def __init__(self, window_size, precision, entity,
+    def __init__(self, entity,
                  lower_bound, upper_bound):
         """Initialize Filter."""
-        super().__init__(FILTER_NAME_RANGE, window_size, precision, entity)
+        super().__init__(FILTER_NAME_RANGE, entity=entity)
         self._lower_bound = lower_bound
         self._upper_bound = upper_bound
         self._stats_internal = Counter()

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -11,6 +11,7 @@ from numbers import Number
 from functools import partial
 from copy import copy
 from datetime import timedelta
+import math
 
 import voluptuous as vol
 
@@ -28,6 +29,7 @@ import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
+FILTER_NAME_BANDPASS = 'bandpass'
 FILTER_NAME_LOWPASS = 'lowpass'
 FILTER_NAME_OUTLIER = 'outlier'
 FILTER_NAME_THROTTLE = 'throttle'
@@ -40,6 +42,8 @@ CONF_FILTER_WINDOW_SIZE = 'window_size'
 CONF_FILTER_PRECISION = 'precision'
 CONF_FILTER_RADIUS = 'radius'
 CONF_FILTER_TIME_CONSTANT = 'time_constant'
+CONF_FILTER_LOWER_BOUND = 'lower_bound'
+CONF_FILTER_UPPER_BOUND = 'upper_bound'
 CONF_TIME_SMA_TYPE = 'type'
 
 TIME_SMA_LAST = 'last'
@@ -51,6 +55,8 @@ DEFAULT_WINDOW_SIZE = 1
 DEFAULT_PRECISION = 2
 DEFAULT_FILTER_RADIUS = 2.0
 DEFAULT_FILTER_TIME_CONSTANT = 10
+DEFAULT_LOWER_BOUND = -math.inf
+DEFAULT_UPPER_BOUND = math.inf
 
 NAME_TEMPLATE = "{} filter"
 ICON = 'mdi:chart-line-variant'
@@ -77,6 +83,14 @@ FILTER_LOWPASS_SCHEMA = FILTER_SCHEMA.extend({
                  default=DEFAULT_FILTER_TIME_CONSTANT): vol.Coerce(int),
 })
 
+FILTER_BANDPASS_SCHEMA = FILTER_SCHEMA.extend({
+    vol.Required(CONF_FILTER_NAME): FILTER_NAME_BANDPASS,
+    vol.Optional(CONF_FILTER_LOWER_BOUND,
+                 default=DEFAULT_LOWER_BOUND): vol.Coerce(float),
+    vol.Optional(CONF_FILTER_UPPER_BOUND,
+                 default=DEFAULT_UPPER_BOUND): vol.Coerce(float),
+})
+
 FILTER_TIME_SMA_SCHEMA = FILTER_SCHEMA.extend({
     vol.Required(CONF_FILTER_NAME): FILTER_NAME_TIME_SMA,
     vol.Optional(CONF_TIME_SMA_TYPE,
@@ -100,7 +114,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                                         [vol.Any(FILTER_OUTLIER_SCHEMA,
                                                  FILTER_LOWPASS_SCHEMA,
                                                  FILTER_TIME_SMA_SCHEMA,
-                                                 FILTER_THROTTLE_SCHEMA)])
+                                                 FILTER_THROTTLE_SCHEMA,
+                                                 FILTER_BANDPASS_SCHEMA)])
 })
 
 
@@ -322,6 +337,51 @@ class Filter(object):
         filtered.set_precision(self.precision)
         self.states.append(copy(filtered))
         new_state.state = filtered.state
+        return new_state
+
+
+@FILTERS.register(FILTER_NAME_BANDPASS)
+class BandPassFilter(Filter):
+    """Band pass filter.
+
+    Determines if new state is in a band between upper_bound and lower_bound.
+    If not inside, lower or upper bound is returned instead.
+
+    Args:
+        upper_bound (float): band upper bound
+        lower_bound (float): band lower bound
+    """
+
+    def __init__(self, window_size=1, precision=None, entity,
+                 lower_bound=math.inf, upper_bound=-math.inf):
+        """Initialize Filter."""
+        super().__init__(FILTER_NAME_OUTLIER, window_size, precision, entity)
+        self._lower_bound = lower_bound
+        self._upper_bound = upper_bound
+        self._stats_internal = Counter()
+
+    def _filter_state(self, new_state):
+        """Implement the outlier filter."""
+        new_state = float(new_state)
+
+        if new_state > self._upper_bound:
+
+            self._stats_internal['erasures_up'] += 1
+
+            _LOGGER.debug("Upper outlier nr. %s in %s: %s",
+                          self._stats_internal['erasures_up'],
+                          self._entity, new_state)
+            return self._upper_bound
+
+        if new_state < self._lower_bound:
+
+            self._stats_internal['erasures_low'] += 1
+
+            _LOGGER.debug("Lower outlier nr. %s in %s: %s",
+                          self._stats_internal['erasures_low'],
+                          self._entity, new_state)
+            return self._lower_bound
+
         return new_state
 
 

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -137,9 +137,9 @@ class TestFilterSensor(unittest.TestCase):
         lower = 10
         upper = 20
         filt = RangeFilter(1, None,
-                              entity=None,
-                              lower_bound=lower,
-                              upper_bound=upper)
+                           entity=None,
+                           lower_bound=lower,
+                           upper_bound=upper)
         for state in self.values:
             filtered = filt.filter_state(state)
             if state < lower:

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -131,6 +131,22 @@ class TestFilterSensor(unittest.TestCase):
             filtered = filt.filter_state(state)
         self.assertEqual(18.05, filtered.state)
 
+    def test_bandpass(self):
+        """Test if bandpass filter works."""
+        lower = 10
+        upper = 20
+        filt = LowPassFilter(entity=None,
+                             lower_bound=lower,
+                             upper_bound=upper)
+        for state in self.values:
+            filtered = filt.filter_state(state)
+            if state < lower:
+                self.assertEqual(lower, filtered)
+            elif state > upper:
+                self.assertEqual(upper, filtered)
+            else:
+                self.assertEqual(state, filtered)
+
     def test_throttle(self):
         """Test if lowpass filter works."""
         filt = ThrottleFilter(window_size=3,

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -136,8 +136,7 @@ class TestFilterSensor(unittest.TestCase):
         """Test if range filter works."""
         lower = 10
         upper = 20
-        filt = RangeFilter(1, None,
-                           entity=None,
+        filt = RangeFilter(entity=None,
                            lower_bound=lower,
                            upper_bound=upper)
         for unf_state in self.values:

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -4,7 +4,8 @@ import unittest
 from unittest.mock import patch
 
 from homeassistant.components.sensor.filter import (
-    LowPassFilter, OutlierFilter, ThrottleFilter, TimeSMAFilter)
+    LowPassFilter, OutlierFilter, ThrottleFilter, TimeSMAFilter,
+    BandPassFilter)
 import homeassistant.util.dt as dt_util
 from homeassistant.setup import setup_component
 import homeassistant.core as ha
@@ -135,9 +136,10 @@ class TestFilterSensor(unittest.TestCase):
         """Test if bandpass filter works."""
         lower = 10
         upper = 20
-        filt = LowPassFilter(entity=None,
-                             lower_bound=lower,
-                             upper_bound=upper)
+        filt = BandPassFilter(1, None,
+                              entity=None,
+                              lower_bound=lower,
+                              upper_bound=upper)
         for state in self.values:
             filtered = filt.filter_state(state)
             if state < lower:

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -141,14 +141,14 @@ class TestFilterSensor(unittest.TestCase):
                            lower_bound=lower,
                            upper_bound=upper)
         for unf_state in self.values:
-            prev = float(unf_state.state)
+            unf = float(unf_state.state)
             filtered = filt.filter_state(unf_state)
-            if prev < lower:
+            if unf < lower:
                 self.assertEqual(lower, filtered.state)
-            elif prev > upper:
+            elif unf > upper:
                 self.assertEqual(upper, filtered.state)
             else:
-                self.assertEqual(prev, filtered.state)
+                self.assertEqual(unf, filtered.state)
 
     def test_throttle(self):
         """Test if lowpass filter works."""

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -141,7 +141,7 @@ class TestFilterSensor(unittest.TestCase):
                            lower_bound=lower,
                            upper_bound=upper)
         for unf_state in self.values:
-            prev = unf_state.state
+            prev = float(unf_state.state)
             filtered = filt.filter_state(unf_state)
             if prev < lower:
                 self.assertEqual(lower, filtered.state)

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -140,14 +140,14 @@ class TestFilterSensor(unittest.TestCase):
                            entity=None,
                            lower_bound=lower,
                            upper_bound=upper)
-        for state in self.values:
-            filtered = filt.filter_state(state)
-            if state < lower:
-                self.assertEqual(lower, filtered)
-            elif state > upper:
-                self.assertEqual(upper, filtered)
+        for unf_state in self.values:
+            filtered = filt.filter_state(unf_state)
+            if unf_state.state < lower:
+                self.assertEqual(lower, filtered.state)
+            elif unf_state.state > upper:
+                self.assertEqual(upper, filtered.state)
             else:
-                self.assertEqual(state, filtered)
+                self.assertEqual(unf_state.state, filtered.state)
 
     def test_throttle(self):
         """Test if lowpass filter works."""

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -141,13 +141,14 @@ class TestFilterSensor(unittest.TestCase):
                            lower_bound=lower,
                            upper_bound=upper)
         for unf_state in self.values:
+            prev = unf_state.state
             filtered = filt.filter_state(unf_state)
-            if unf_state.state < lower:
+            if prev < lower:
                 self.assertEqual(lower, filtered.state)
-            elif unf_state.state > upper:
+            elif prev > upper:
                 self.assertEqual(upper, filtered.state)
             else:
-                self.assertEqual(unf_state.state, filtered.state)
+                self.assertEqual(prev, filtered.state)
 
     def test_throttle(self):
         """Test if lowpass filter works."""

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from homeassistant.components.sensor.filter import (
     LowPassFilter, OutlierFilter, ThrottleFilter, TimeSMAFilter,
-    BandPassFilter)
+    RangeFilter)
 import homeassistant.util.dt as dt_util
 from homeassistant.setup import setup_component
 import homeassistant.core as ha
@@ -132,11 +132,11 @@ class TestFilterSensor(unittest.TestCase):
             filtered = filt.filter_state(state)
         self.assertEqual(18.05, filtered.state)
 
-    def test_bandpass(self):
-        """Test if bandpass filter works."""
+    def test_range(self):
+        """Test if range filter works."""
         lower = 10
         upper = 20
-        filt = BandPassFilter(1, None,
+        filt = RangeFilter(1, None,
                               entity=None,
                               lower_bound=lower,
                               upper_bound=upper)


### PR DESCRIPTION
## Description:
As there were issues with the outlier filter this adds a range filter on its own. It only allows values in a given range to pass.

**Related issue (if applicable):** additional way to solve #13363

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4985

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: filter
    name: "filtered realistic humidity"
    entity_id: sensor.realistic_humidity
    filters:
      - filter: range
        lower_bound: -30.0
        upper_bound: 50
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
