### PR TITLE
Google assistant sync

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -37,6 +37,7 @@ CONF_FILTER = 'filter'
 CONF_GOOGLE_ACTIONS = 'google_actions'
 CONF_RELAYER = 'relayer'
 CONF_USER_POOL_ID = 'user_pool_id'
+CONF_GOOGLE_ACTIONS_SYNC_URL = 'google_actions_sync_url'
 
 DEFAULT_MODE = 'production'
 DEPENDENCIES = ['http']
@@ -75,6 +76,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_USER_POOL_ID): str,
         vol.Optional(CONF_REGION): str,
         vol.Optional(CONF_RELAYER): str,
+        vol.Optional(CONF_GOOGLE_ACTIONS_SYNC_URL): str,
         vol.Optional(CONF_ALEXA): ALEXA_SCHEMA,
         vol.Optional(CONF_GOOGLE_ACTIONS): GACTIONS_SCHEMA,
     }),
@@ -110,7 +112,7 @@ class Cloud:
 
     def __init__(self, hass, mode, alexa, google_actions,
                  cognito_client_id=None, user_pool_id=None, region=None,
-                 relayer=None):
+                 relayer=None, google_actions_sync_url=None):
         """Create an instance of Cloud."""
         self.hass = hass
         self.mode = mode
@@ -128,6 +130,7 @@ class Cloud:
             self.user_pool_id = user_pool_id
             self.region = region
             self.relayer = relayer
+            self.google_actions_sync_url = google_actions_sync_url
 
         else:
             info = SERVERS[mode]
@@ -136,6 +139,7 @@ class Cloud:
             self.user_pool_id = info['user_pool_id']
             self.region = info['region']
             self.relayer = info['relayer']
+            self.google_actions_sync_url = info['google_actions_sync_url']
 
     @property
     def is_logged_in(self):

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -9,7 +9,8 @@ SERVERS = {
         'user_pool_id': 'us-east-1_87ll5WOP8',
         'region': 'us-east-1',
         'relayer': 'wss://cloud.hass.io:8000/websocket',
-        'google_actions_sync_url': '',
+        'google_actions_sync_url': ('https://24ab3v80xd.execute-api.us-east-1.'
+                                    'amazonaws.com/prod/smart_home_sync'),
     }
 }
 

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -8,7 +8,8 @@ SERVERS = {
         'cognito_client_id': '60i2uvhvbiref2mftj7rgcrt9u',
         'user_pool_id': 'us-east-1_87ll5WOP8',
         'region': 'us-east-1',
-        'relayer': 'wss://cloud.hass.io:8000/websocket'
+        'relayer': 'wss://cloud.hass.io:8000/websocket',
+        'google_actions_sync_url': '',
     }
 }
 

--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -16,8 +16,7 @@ from .const import DOMAIN, REQUEST_TIMEOUT
 _LOGGER = logging.getLogger(__name__)
 
 
-@asyncio.coroutine
-def async_setup(hass):
+async def async_setup(hass):
     """Initialize the HTTP API."""
     hass.http.register_view(GoogleActionsSyncView)
     hass.http.register_view(CloudLoginView)
@@ -39,12 +38,11 @@ _CLOUD_ERRORS = {
 
 def _handle_cloud_errors(handler):
     """Handle auth errors."""
-    @asyncio.coroutine
     @wraps(handler)
-    def error_handler(view, request, *args, **kwargs):
+    async def error_handler(view, request, *args, **kwargs):
         """Handle exceptions that raise from the wrapped request handler."""
         try:
-            result = yield from handler(view, request, *args, **kwargs)
+            result = await handler(view, request, *args, **kwargs)
             return result
 
         except (auth_api.CloudError, asyncio.TimeoutError) as err:
@@ -65,18 +63,17 @@ class GoogleActionsSyncView(HomeAssistantView):
     name = 'api:cloud:google_actions/sync'
 
     @_handle_cloud_errors
-    @asyncio.coroutine
-    def post(self, request):
+    async def post(self, request):
         """Trigger a Google Actions sync."""
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
         websession = hass.helpers.aiohttp_client.async_get_clientsession()
 
         with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
-            yield from hass.async_add_job(auth_api.check_token, cloud)
+            await hass.async_add_job(auth_api.check_token, cloud)
 
         with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
-            req = yield from websession.post(
+            req = await websession.post(
                 cloud.google_actions_sync_url, headers={
                     'authorization': cloud.id_token
                 })
@@ -95,19 +92,18 @@ class CloudLoginView(HomeAssistantView):
         vol.Required('email'): str,
         vol.Required('password'): str,
     }))
-    @asyncio.coroutine
-    def post(self, request, data):
+    async def post(self, request, data):
         """Handle login request."""
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
 
         with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
-            yield from hass.async_add_job(auth_api.login, cloud, data['email'],
-                                          data['password'])
+            await hass.async_add_job(auth_api.login, cloud, data['email'],
+                                     data['password'])
 
         hass.async_add_job(cloud.iot.connect)
         # Allow cloud to start connecting.
-        yield from asyncio.sleep(0, loop=hass.loop)
+        await asyncio.sleep(0, loop=hass.loop)
         return self.json(_account_data(cloud))
 
 
@@ -118,14 +114,13 @@ class CloudLogoutView(HomeAssistantView):
     name = 'api:cloud:logout'
 
     @_handle_cloud_errors
-    @asyncio.coroutine
-    def post(self, request):
+    async def post(self, request):
         """Handle logout request."""
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
 
         with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
-            yield from cloud.logout()
+            await cloud.logout()
 
         return self.json_message('ok')
 
@@ -136,8 +131,7 @@ class CloudAccountView(HomeAssistantView):
     url = '/api/cloud/account'
     name = 'api:cloud:account'
 
-    @asyncio.coroutine
-    def get(self, request):
+    async def get(self, request):
         """Get account info."""
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
@@ -159,14 +153,13 @@ class CloudRegisterView(HomeAssistantView):
         vol.Required('email'): str,
         vol.Required('password'): vol.All(str, vol.Length(min=6)),
     }))
-    @asyncio.coroutine
-    def post(self, request, data):
+    async def post(self, request, data):
         """Handle registration request."""
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
 
         with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
-            yield from hass.async_add_job(
+            await hass.async_add_job(
                 auth_api.register, cloud, data['email'], data['password'])
 
         return self.json_message('ok')
@@ -182,14 +175,13 @@ class CloudResendConfirmView(HomeAssistantView):
     @RequestDataValidator(vol.Schema({
         vol.Required('email'): str,
     }))
-    @asyncio.coroutine
-    def post(self, request, data):
+    async def post(self, request, data):
         """Handle resending confirm email code request."""
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
 
         with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
-            yield from hass.async_add_job(
+            await hass.async_add_job(
                 auth_api.resend_email_confirm, cloud, data['email'])
 
         return self.json_message('ok')
@@ -205,14 +197,13 @@ class CloudForgotPasswordView(HomeAssistantView):
     @RequestDataValidator(vol.Schema({
         vol.Required('email'): str,
     }))
-    @asyncio.coroutine
-    def post(self, request, data):
+    async def post(self, request, data):
         """Handle forgot password request."""
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
 
         with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
-            yield from hass.async_add_job(
+            await hass.async_add_job(
                 auth_api.forgot_password, cloud, data['email'])
 
         return self.json_message('ok')

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -11,6 +11,9 @@ from homeassistant.components.cloud import DOMAIN, auth_api, iot
 from tests.common import mock_coro
 
 
+GOOGLE_ACTIONS_SYNC_URL = 'https://api-test.hass.io/google_actions_sync'
+
+
 @pytest.fixture
 def cloud_client(hass, aiohttp_client):
     """Fixture that can fetch from the cloud client."""
@@ -23,6 +26,7 @@ def cloud_client(hass, aiohttp_client):
                 'user_pool_id': 'user_pool_id',
                 'region': 'region',
                 'relayer': 'relayer',
+                'google_actions_sync_url': GOOGLE_ACTIONS_SYNC_URL,
             }
         }))
     hass.data['cloud']._decode_claims = \
@@ -36,6 +40,21 @@ def mock_cognito():
     """Mock warrant."""
     with patch('homeassistant.components.cloud.auth_api._cognito') as mock_cog:
         yield mock_cog()
+
+
+async def test_google_actions_sync(mock_cognito, cloud_client, aioclient_mock):
+    """Test logging out."""
+    aioclient_mock.post(GOOGLE_ACTIONS_SYNC_URL)
+    req = await cloud_client.post('/api/cloud/google_actions/sync')
+    assert req.status == 200
+
+
+async def test_google_actions_sync_fails(mock_cognito, cloud_client,
+                                         aioclient_mock):
+    """Test logging out."""
+    aioclient_mock.post(GOOGLE_ACTIONS_SYNC_URL, status=403)
+    req = await cloud_client.post('/api/cloud/google_actions/sync')
+    assert req.status == 403
 
 
 @asyncio.coroutine

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -43,7 +43,7 @@ def mock_cognito():
 
 
 async def test_google_actions_sync(mock_cognito, cloud_client, aioclient_mock):
-    """Test logging out."""
+    """Test syncing Google Actions."""
     aioclient_mock.post(GOOGLE_ACTIONS_SYNC_URL)
     req = await cloud_client.post('/api/cloud/google_actions/sync')
     assert req.status == 200
@@ -51,7 +51,7 @@ async def test_google_actions_sync(mock_cognito, cloud_client, aioclient_mock):
 
 async def test_google_actions_sync_fails(mock_cognito, cloud_client,
                                          aioclient_mock):
-    """Test logging out."""
+    """Test syncing Google Actions gone bad."""
     aioclient_mock.post(GOOGLE_ACTIONS_SYNC_URL, status=403)
     req = await cloud_client.post('/api/cloud/google_actions/sync')
     assert req.status == 403

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -29,6 +29,7 @@ def test_constructor_loads_info_from_constant():
             'user_pool_id': 'test-user_pool_id',
             'region': 'test-region',
             'relayer': 'test-relayer',
+            'google_actions_sync_url': 'test-google_actions_sync_url',
         }
     }), patch('homeassistant.components.cloud.Cloud._fetch_jwt_keyset',
               return_value=mock_coro(True)):
@@ -43,6 +44,7 @@ def test_constructor_loads_info_from_constant():
     assert cl.user_pool_id == 'test-user_pool_id'
     assert cl.region == 'test-region'
     assert cl.relayer == 'test-relayer'
+    assert cl.google_actions_sync_url == 'test-google_actions_sync_url'
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:
Add an API method to trigger a Sync with Google Actions for Home Assistant Cloud users. Will allow us to add a button to trigger a sync in the Cloud config panel.

## Example entry for `configuration.yaml` (if applicable):
```yaml
cloud:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
