### PR TITLE
Include all config flow translations with backend translations

### DIFF
--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -4,6 +4,7 @@ import logging
 from typing import Optional  # NOQA
 from os import path
 
+from homeassistant import config_entries
 from homeassistant.loader import get_component, bind_hass
 from homeassistant.util.json import load_json
 
@@ -89,7 +90,7 @@ async def async_get_component_resources(hass, language):
     translation_cache = hass.data[TRANSLATION_STRING_CACHE][language]
 
     # Get the set of components
-    components = hass.config.components
+    components = hass.config.components | set(config_entries.FLOWS)
 
     # Calculate the missing components
     missing_components = components - set(translation_cache)

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -1,9 +1,21 @@
 """Test the translation helper."""
 # pylint: disable=protected-access
 from os import path
+from unittest.mock import patch
 
+import pytest
+
+from homeassistant import config_entries
 import homeassistant.helpers.translation as translation
 from homeassistant.setup import async_setup_component
+
+
+@pytest.fixture
+def mock_config_flows():
+    """Mock the config flows."""
+    flows = []
+    with patch.object(config_entries, 'FLOWS', flows):
+        yield flows
 
 
 def test_flatten():
@@ -71,7 +83,7 @@ def test_load_translations_files(hass):
     }
 
 
-async def test_get_translations(hass):
+async def test_get_translations(hass, mock_config_flows):
     """Test the get translations helper."""
     translations = await translation.async_get_translations(hass, 'en')
     assert translations == {}
@@ -105,4 +117,18 @@ async def test_get_translations(hass):
     assert translations == {
         'component.switch.state.string1': 'Value 1',
         'component.switch.state.string2': 'Value 2',
+    }
+
+
+async def test_get_translations_loads_config_flows(hass, mock_config_flows):
+    """Test the get translations helper loads config flow translations."""
+    mock_config_flows.append('component1')
+
+    with patch.object(translation, 'component_translation_file',
+                      return_value='bla.json'), \
+            patch.object(translation, 'load_translations_files', return_value={
+                'component1': {'hello': 'world'}}):
+        translations = await translation.async_get_translations(hass, 'en')
+    assert translations == {
+        'component.component1.hello': 'world'
     }


### PR DESCRIPTION
## Description:
When loading the backend translations, include all translations of components that have a config flow.

Idea by @armills 

This is a temporary fix for https://github.com/home-assistant/home-assistant-polymer/issues/1019

We should come up with a better fix in the future.

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant-polymer/issues/1019

## Example entry for `configuration.yaml` (if applicable):
```yaml
config:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
