### PR TITLE
Switched to async/await. Bumped pyxeoma version

### DIFF
--- a/homeassistant/components/camera/xeoma.py
+++ b/homeassistant/components/camera/xeoma.py
@@ -4,7 +4,6 @@ Support for Xeoma Cameras.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.xeoma/
 """
-import asyncio
 import logging
 
 import voluptuous as vol
@@ -14,7 +13,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME)
 from homeassistant.helpers import config_validation as cv
 
-REQUIREMENTS = ['pyxeoma==1.3']
+REQUIREMENTS = ['pyxeoma==1.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,8 +40,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
     """Discover and setup Xeoma Cameras."""
     from pyxeoma.xeoma import Xeoma, XeomaError
 
@@ -53,8 +52,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     xeoma = Xeoma(host, login, password)
 
     try:
-        yield from xeoma.async_test_connection()
-        discovered_image_names = yield from xeoma.async_get_image_names()
+        await xeoma.async_test_connection()
+        discovered_image_names = await xeoma.async_get_image_names()
         discovered_cameras = [
             {
                 CONF_IMAGE_NAME: image_name,
@@ -103,12 +102,11 @@ class XeomaCamera(Camera):
         self._password = password
         self._last_image = None
 
-    @asyncio.coroutine
-    def async_camera_image(self):
+    async def async_camera_image(self):
         """Return a still image response from the camera."""
         from pyxeoma.xeoma import XeomaError
         try:
-            image = yield from self._xeoma.async_get_camera_image(
+            image = await self._xeoma.async_get_camera_image(
                 self._image, self._username, self._password)
             self._last_image = image
         except XeomaError as err:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1048,7 +1048,7 @@ pywebpush==1.6.0
 pywemo==0.4.25
 
 # homeassistant.components.camera.xeoma
-pyxeoma==1.3
+pyxeoma==1.4.0
 
 # homeassistant.components.zabbix
 pyzabbix==0.7.4


### PR DESCRIPTION
## Description:
Switched to async/await syntax and bumped pyxeoma version to incorporate PR from @loredous.

https://github.com/jeradM/pyxeoma/pull/2

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
