### PR TITLE
Added Epson projector support

### DIFF
--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -8,10 +8,7 @@ import asyncio
 import logging
 
 import aiohttp
-from epson_projector.const import (
-    BACK, BUSY, CMODE, CMODE_LIST, CMODE_LIST_SET, DEFAULT_SOURCES,
-    EPSON_CODES, FAST, INV_SOURCES, MUTE, PAUSE, PLAY, POWER, SOURCE,
-    SOURCE_LIST, TURN_OFF, TURN_ON, VOL_DOWN, VOL_UP, VOLUME)
+
 from homeassistant.components.media_player import (
     DOMAIN, MEDIA_PLAYER_SCHEMA, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
     SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF,
@@ -77,6 +74,7 @@ async def async_setup_platform(
 
     async def async_service_handler(service):
         """Handle for services."""
+        from epson_projector.const import (CMODE_LIST_SET)
         entity_ids = service.data.get(ATTR_ENTITY_ID)
         if entity_ids:
             devices = [device for device in hass.data[DATA_EPSON]
@@ -103,6 +101,7 @@ class EpsonProjector(MediaPlayerDevice):
         self._hass = hass
         self._name = name
         import epson_projector as epson
+        from epson_projector.const import DEFAULT_SOURCES
         self._projector = epson.Projector(
             host,
             websession=self._websession(False),
@@ -121,6 +120,10 @@ class EpsonProjector(MediaPlayerDevice):
 
     async def update(self):
         """Update state of device."""
+        from epson_projector.const import (
+            EPSON_CODES, POWER,
+            CMODE, CMODE_LIST, SOURCE, VOLUME,
+            BUSY, SOURCE_LIST)
         is_turned_on = await self._projector.get_property(POWER)
         _LOGGER.debug("Is turned on %s", is_turned_on)
         if is_turned_on and is_turned_on == EPSON_CODES[POWER]:
@@ -156,10 +159,12 @@ class EpsonProjector(MediaPlayerDevice):
 
     async def async_turn_on(self):
         """Turn on epson."""
+        from epson_projector.const import TURN_ON
         return await self._projector.send_command(TURN_ON)
 
     async def async_turn_off(self):
         """Turn off epson."""
+        from epson_projector.const import TURN_OFF
         return await self._projector.send_command(TURN_OFF)
 
     @property
@@ -184,42 +189,51 @@ class EpsonProjector(MediaPlayerDevice):
 
     async def select_cmode(self, cmode):
         """Set color mode in Epson."""
+        from epson_projector.const import (CMODE_LIST_SET)
         if cmode in CMODE_LIST_SET:
             return await self._projector.send_command(CMODE_LIST_SET[cmode])
 
     async def async_select_source(self, source):
         """Select input source."""
         _LOGGER.debug("select source")
+        from epson_projector.const import INV_SOURCES
         selected_source = INV_SOURCES[source]
         return await self._projector.send_command(selected_source)
 
     async def async_mute_volume(self, mute):
         """Mute (true) or unmute (false) sound."""
+        from epson_projector.const import MUTE
         return await self._projector.send_command(MUTE)
 
     async def async_volume_up(self):
         """Increase volume."""
         _LOGGER.debug("volume up")
+        from epson_projector.const import VOL_UP
         return await self._projector.send_command(VOL_UP)
 
     async def async_volume_down(self):
         """Decrease volume."""
+        from epson_projector.const import VOL_DOWN
         return await self._projector.send_command(VOL_DOWN)
 
     async def async_media_play(self):
         """Play media via Epson."""
+        from epson_projector.const import PLAY
         return await self._projector.send_command(PLAY)
 
     async def async_media_pause(self):
         """Pause media via Epson."""
+        from epson_projector.const import PAUSE
         return await self._projector.send_command(PAUSE)
 
     async def async_media_next_track(self):
         """Skip to next."""
+        from epson_projector.const import FAST
         return await self._projector.send_command(FAST)
 
     async def async_media_previous_track(self):
         """Skip to previous."""
+        from epson_projector.const import BACK
         return await self._projector.send_command(BACK)
 
     @property

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -262,12 +262,12 @@ class EpsonProjector(MediaPlayerDevice):
 
     @asyncio.coroutine
     def async_media_play(self):
-        """Play."""
+        """Play media via Epson."""
         return self.sendCommand("PLAY")
 
     @asyncio.coroutine
     def async_media_pause(self):
-        """Play."""
+        """Pause media via Epson."""
         return self.sendCommand("PAUSE")
 
     @asyncio.coroutine

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -1,5 +1,5 @@
 """
-Support for showing text in the frontend.
+Support for Epson projector
 
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/cookbook/python_component_basic_state/

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -8,7 +8,6 @@ import asyncio
 import logging
 
 import aiohttp
-import epson_projector as epson
 from epson_projector.const import (
     BACK, BUSY, CMODE, CMODE_LIST, CMODE_LIST_SET, DEFAULT_SOURCES,
     EPSON_CODES, FAST, INV_SOURCES, MUTE, PAUSE, PLAY, POWER, SOURCE,
@@ -103,6 +102,7 @@ class EpsonProjector(MediaPlayerDevice):
         """Initialize entity to control Epson projector."""
         self._hass = hass
         self._name = name
+        import epson_projector as epson
         self._projector = epson.Projector(
             host,
             websession=self._websession(False),

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -38,6 +38,18 @@ KEY_COMMANDS = {
     "CMODE_DYNAMIC": [('CMODE', '06')],
     "CMODE_3DDYNAMIC": [('CMODE', '18')],
     "CMODE_3DCINEMA": [('CMODE', '17')],
+    "CMODE_3DTHX": [('CMODE', '19')],
+    "CMODE_BWCINEMA": [('CMODE', '20')],
+    "CMODE_ARGB": [('CMODE', '21')],
+    "CMODE_DCINEMA": [('CMODE', '22')],
+    "CMODE_THX": [('CMODE', '13')],
+    "CMODE_GAME": [('CMODE', '0D')],
+    "CMODE_STAGE": [('CMODE', '16')],
+    "CMODE_AUTOCOLOR": [('CMODE', 'C1')],
+    "CMODE_XV": [('CMODE', '0B')],
+    "CMODE_THEATRE": [('CMODE', '05')],
+    "CMODE_THEATREBLACK": [('CMODE', '09')],
+    "CMODE_THEATREBLACK2": [('CMODE', '0A')],
     "VOL_UP": [('KEY', '56')],
     "VOL_DOWN": [('KEY', '57')],
     "MUTE": [('KEY', 'D8')],
@@ -91,7 +103,19 @@ CMODE_LIST = {
     '0C': 'Bright Cinema/Living',
     '06': 'Dynamic',
     '17': '3D Cinema',
-    '18': '3D Dynamic'
+    '18': '3D Dynamic',
+    '19': '3D THX',
+    '20': 'B&W Cinema',
+    '21': 'Adobe RGB',
+    '22': 'Digital Cinema',
+    '13': 'THX',
+    '0D': 'Game',
+    '16': 'Stage',
+    'C1': 'AutoColor',
+    '0B': 'x.v. color',
+    '05': 'Theatre',
+    '09': 'Theatre Black 1/HD',
+    '0A': 'Theatre Black 2/Silver Screen'
 }
 
 CMODE_LIST_SET = {
@@ -102,6 +126,18 @@ CMODE_LIST_SET = {
     '3ddynamic': 'CMODE_3DDYNAMIC',
     '3dcinema': 'CMODE_3DCINEMA',
     'auto': 'CMODE_AUTO',
+    '3dthx': 'CMODE_3DTHX',
+    'bwcinema': 'CMODE_BWCINEMA',
+    'adobe rgb': 'CMODE_ARGB',
+    'digital cinema': 'CMODE_DCINEMA',
+    'thx': 'CMODE_THX',
+    'game': 'CMODE_GAME',
+    'stage': 'CMODE_STAGE',
+    'autocolor': 'CMODE_AUTOCOLOR',
+    'xv': 'CMODE_XV',
+    'theatre': 'CMODE_THEATRE',
+    'theatre black': 'CMODE_THEATREBLACK',
+    'theatre black 2': 'CMODE_THEATREBLACK2'
 }
 
 DATA_EPSON = 'epson'
@@ -216,10 +252,10 @@ class EpsonProjector(MediaPlayerDevice):
         if isTurnedOn and isTurnedOn == EPSON_CODES['ON']:
             self._state = STATE_ON
             cmode = yield from self.getProperty('CMODE')
-            if cmode:
+            if cmode and cmode in CMODE_LIST:
                 self._cmode = CMODE_LIST[cmode]
             source = yield from self.getProperty('SOURCE')
-            if source:
+            if source and souce in SOURCE_LIST:
                 self._source = SOURCE_LIST[source]
             volume = yield from self.getProperty('VOLUME')
             if volume:

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -153,7 +153,7 @@ class EpsonProjector(MediaPlayerDevice):
         self._port = port
         self._cmode = None
         self._source_list = list(DEFAULT_SOURCES.values())
-        self._KEY_COMMANDS = key_commands
+        self.key_commands = key_commands
         self._encryption = encryption
         self._state = STATE_UNKNOWN
         http_protocol = 'https' if self._encryption else 'http'
@@ -223,12 +223,12 @@ class EpsonProjector(MediaPlayerDevice):
     @asyncio.coroutine
     def async_turn_on(self):
         """Turn on epson."""
-        return self.sendCommand('TURN_ON')
+        return self.send_command('TURN_ON')
 
     @asyncio.coroutine
     def async_turn_off(self):
         """Turn off epson."""
-        return self.sendCommand('TURN_OFF')
+        return self.send_command('TURN_OFF')
 
     @property
     def source_list(self):
@@ -244,56 +244,56 @@ class EpsonProjector(MediaPlayerDevice):
     def select_cmode(self, cmode):
         """Set color mode in Epson."""
         if cmode in CMODE_LIST_SET:
-            return self.sendCommand(CMODE_LIST_SET[cmode])
+            return self.send_command(CMODE_LIST_SET[cmode])
 
     @asyncio.coroutine
     def async_select_source(self, source):
         """Select input source."""
         _LOGGER.debug("select source")
         selected_source = INV_SOURCES[source]
-        return self.sendCommand(selected_source)
+        return self.send_command(selected_source)
 
     @asyncio.coroutine
     def async_mute_volume(self, mute):
         """Mute (true) or unmute (false) sound and video input."""
-        return self.sendCommand("MUTE")
+        return self.send_command("MUTE")
 
     @asyncio.coroutine
     def async_volume_up(self):
         """Increase volume."""
         _LOGGER.debug("volume up")
-        return self.sendCommand("VOL_UP")
+        return self.send_command("VOL_UP")
 
     @asyncio.coroutine
     def async_volume_down(self):
         """Decrease volume."""
-        return self.sendCommand("VOL_DOWN")
+        return self.send_command("VOL_DOWN")
 
     @asyncio.coroutine
     def async_media_play(self):
         """Play media via Epson."""
-        return self.sendCommand("PLAY")
+        return self.send_command("PLAY")
 
     @asyncio.coroutine
     def async_media_pause(self):
         """Pause media via Epson."""
-        return self.sendCommand("PAUSE")
+        return self.send_command("PAUSE")
 
     @asyncio.coroutine
     def async_media_next_track(self):
         """Skip to next."""
-        return self.sendCommand("FAST")
+        return self.send_command("FAST")
 
     @asyncio.coroutine
     def async_media_previous_track(self):
         """Skip to previous."""
-        return self.sendCommand("BACK")
+        return self.send_command("BACK")
 
     @asyncio.coroutine
-    def sendCommand(self, command):
+    def send_command(self, command):
         """Send command to Epson."""
         _LOGGER.debug("COMMAND %s", command)
-        params = self._KEY_COMMANDS[command]
+        params = self.key_commands[command]
         try:
             url = '{url}{type}'.format(url=self._http_url, type='directsend')
             response = yield from self.websession_action.get(

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -8,137 +8,25 @@ import asyncio
 import logging
 
 import aiohttp
-import async_timeout
-import voluptuous as vol
-
+import epson_projector as epson
+from epson_projector.const import (
+    BACK, BUSY, CMODE, CMODE_LIST, CMODE_LIST_SET, DEFAULT_SOURCES,
+    EPSON_CODES, FAST, INV_SOURCES, MUTE, PAUSE, PLAY, POWER, SOURCE,
+    SOURCE_LIST, TURN_OFF, TURN_ON, VOL_DOWN, VOL_UP, VOLUME)
 from homeassistant.components.media_player import (
     DOMAIN, MEDIA_PLAYER_SCHEMA, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
     SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
     MediaPlayerDevice)
 from homeassistant.const import (
-    ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_PORT, CONF_SSL,
-    CONTENT_TYPE_JSON, HTTP_OK, STATE_OFF, STATE_ON)
+    ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_PORT, CONF_SSL, STATE_OFF,
+    STATE_ON)
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 
-KEY_COMMANDS = {
-    "TURN_ON": [('KEY', '3B')],
-    "TURN_OFF": [('KEY', '3B'), ('KEY', '3B')],
-    "HDMILINK": [('jsoncallback', 'HDMILINK?')],
-    "PWR": [('jsoncallback', 'PWR?')],
-    "SOURCE": [('jsoncallback', 'SOURCE?')],
-    "CMODE": [('jsoncallback', 'CMODE?')],
-    "VOLUME": [('jsoncallback', 'VOL?')],
-    "CMODE_AUTO": [('CMODE', '00')],
-    "CMODE_CINEMA": [('CMODE', '15')],
-    "CMODE_NATURAL": [('CMODE', '07')],
-    "CMODE_BRIGHT": [('CMODE', '0C')],
-    "CMODE_DYNAMIC": [('CMODE', '06')],
-    "CMODE_3DDYNAMIC": [('CMODE', '18')],
-    "CMODE_3DCINEMA": [('CMODE', '17')],
-    "CMODE_3DTHX": [('CMODE', '19')],
-    "CMODE_BWCINEMA": [('CMODE', '20')],
-    "CMODE_ARGB": [('CMODE', '21')],
-    "CMODE_DCINEMA": [('CMODE', '22')],
-    "CMODE_THX": [('CMODE', '13')],
-    "CMODE_GAME": [('CMODE', '0D')],
-    "CMODE_STAGE": [('CMODE', '16')],
-    "CMODE_AUTOCOLOR": [('CMODE', 'C1')],
-    "CMODE_XV": [('CMODE', '0B')],
-    "CMODE_THEATRE": [('CMODE', '05')],
-    "CMODE_THEATREBLACK": [('CMODE', '09')],
-    "CMODE_THEATREBLACK2": [('CMODE', '0A')],
-    "VOL_UP": [('KEY', '56')],
-    "VOL_DOWN": [('KEY', '57')],
-    "MUTE": [('KEY', 'D8')],
-    "HDMI1": [('KEY', '4D')],
-    "HDMI2": [('KEY', '40')],
-    "PC": [('KEY', '44')],
-    "VIDEO": [('KEY', '46')],
-    "USB": [('KEY', '85')],
-    "LAN": [('KEY', '53')],
-    "WFD": [('KEY', '56')],
-    "PLAY": [('KEY', 'D1')],
-    "PAUSE": [('KEY', 'D3')],
-    "STOP": [('KEY', 'D2')],
-    "BACK": [('KEY', 'D4')],
-    "FAST": [('KEY', 'D5')],
-}
-
-TIMEOUT_TIMES = {
-    'TURN_ON': 40,
-    'TURN_OFF': 10,
-    'SOURCE': 5,
-    'ALL': 3
-}
-
-DEFAULT_SOURCES = {
-    'HDMI1': 'HDMI1',
-    'HDMI2': 'HDMI2',
-    'PC': 'PC',
-    'VIDEO': 'VIDEO',
-    'USB': 'USB',
-    'LAN': 'LAN',
-    'WFD': 'WiFi Direct'
-}
-
-SOURCE_LIST = {
-    '30': 'HDMI1',
-    '10': 'PC',
-    '40': 'VIDEO',
-    '52': 'USB',
-    '53': 'LAN',
-    '56': 'WDF',
-    'A0': 'HDMI2'
-}
-
-INV_SOURCES = {v: k for k, v in DEFAULT_SOURCES.items()}
-
-CMODE_LIST = {
-    '00': 'Auto',
-    '15': 'Cinema',
-    '07': 'Natural',
-    '0C': 'Bright Cinema/Living',
-    '06': 'Dynamic',
-    '17': '3D Cinema',
-    '18': '3D Dynamic',
-    '19': '3D THX',
-    '20': 'B&W Cinema',
-    '21': 'Adobe RGB',
-    '22': 'Digital Cinema',
-    '13': 'THX',
-    '0D': 'Game',
-    '16': 'Stage',
-    'C1': 'AutoColor',
-    '0B': 'x.v. color',
-    '05': 'Theatre',
-    '09': 'Theatre Black 1/HD',
-    '0A': 'Theatre Black 2/Silver Screen'
-}
-
-CMODE_LIST_SET = {
-    'cinema': 'CMODE_CINEMA',
-    'natural': 'CMODE_NATURAL',
-    'bright cinema': 'CMODE_BRIGHT',
-    'dynamic': 'CMODE_DYNAMIC',
-    '3ddynamic': 'CMODE_3DDYNAMIC',
-    '3dcinema': 'CMODE_3DCINEMA',
-    'auto': 'CMODE_AUTO',
-    '3dthx': 'CMODE_3DTHX',
-    'bwcinema': 'CMODE_BWCINEMA',
-    'adobe rgb': 'CMODE_ARGB',
-    'digital cinema': 'CMODE_DCINEMA',
-    'thx': 'CMODE_THX',
-    'game': 'CMODE_GAME',
-    'stage': 'CMODE_STAGE',
-    'autocolor': 'CMODE_AUTOCOLOR',
-    'xv': 'CMODE_XV',
-    'theatre': 'CMODE_THEATRE',
-    'theatre black': 'CMODE_THEATREBLACK',
-    'theatre black 2': 'CMODE_THEATREBLACK2'
-}
+REQUIREMENTS = ['epson-projector==0.1.1']
 
 DATA_EPSON = 'epson'
 DEFAULT_NAME = 'EPSON Projector'
@@ -149,15 +37,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=80): cv.port,
     vol.Optional(CONF_SSL, default=False): cv.boolean
 })
+
 ATTR_CMODE = 'cmode'
 SUPPORT_CMODE = 33001
-ACCEPT_ENCODING = "gzip, deflate"
-ACCEPT_HEADER = CONTENT_TYPE_JSON
-EPSON_ERROR_CODE = 'ERR'
-EPSON_CODES = {
-    'ON': '01'
-}
-TIMEOUT = 15
+
 SUPPORT_EPSON = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE |\
             SUPPORT_CMODE | SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_STEP | \
             SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
@@ -170,8 +53,11 @@ EPSON_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
 _LOGGER = logging.getLogger(__name__)
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(
+        hass,
+        config,
+        async_add_devices,
+        discovery_info=None):
     """Set up the Epson media player platform."""
     if DATA_EPSON not in hass.data:
         hass.data[DATA_EPSON] = []
@@ -181,8 +67,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     try:
         epson = EpsonProjector(
             hass, name, host,
-            config.get(CONF_PORT), config.get(CONF_SSL), KEY_COMMANDS)
-        epson.update()
+            config.get(CONF_PORT), config.get(CONF_SSL))
+        await epson.update()
     except (aiohttp.client_exceptions.ClientConnectorError,
             asyncio.TimeoutError):
         raise PlatformNotReady
@@ -190,8 +76,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         hass.data[DATA_EPSON].append(epson)
         async_add_devices([epson], update_before_add=True)
 
-    @asyncio.coroutine
-    def async_service_handler(service):
+    async def async_service_handler(service):
         """Handle for services."""
         entity_ids = service.data.get(ATTR_ENTITY_ID)
         if entity_ids:
@@ -203,8 +88,8 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
             if service.service == ATTR_CMODE:
                 cmode = service.data.get(ATTR_CMODE).lower()
                 if cmode in CMODE_LIST_SET:
-                    yield from device.select_cmode(cmode)
-            yield from device.update()
+                    await device.select_cmode(cmode)
+            await device.update()
     hass.services.async_register(
         DOMAIN, ATTR_CMODE, async_service_handler,
         schema=EPSON_SCHEMA)
@@ -214,82 +99,45 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class EpsonProjector(MediaPlayerDevice):
     """Representation of Epson Projector Device."""
 
-    def __init__(self, hass, name, host, port, encryption, key_commands):
+    def __init__(self, hass, name, host, port, encryption):
         """Initialize entity to control Epson projector."""
         self._hass = hass
         self._name = name
-        self._host = host
-        self._port = port
+        self._projector = epson.Projector(
+            host,
+            websession=self._websession(False),
+            port=port)
+
         self._cmode = None
         self._source_list = list(DEFAULT_SOURCES.values())
         self._source = None
         self._volume = None
-        self.key_commands = key_commands
-        self._encryption = encryption
-        self._state = None
-        http_protocol = 'https' if self._encryption else 'http'
-        self._http_url = '{http_protocol}://{host}:{port}/cgi-bin/'.format(
-            http_protocol=http_protocol,
-            host=self._host,
-            port=self._port)
-        referer = "{http_protocol}://{host}:{port}/cgi-bin/webconf".format(
-            http_protocol=http_protocol,
-            host=self._host,
-            port=self._port)
-        self._headers = {
-            "Accept-Encoding": ACCEPT_ENCODING,
-            "Accept": CONTENT_TYPE_JSON,
-            "Referer": referer
-        }
-        self.websession = async_create_clientsession(
-            hass,
-            verify_ssl=False)
 
-    @asyncio.coroutine
-    def update(self):
+        self._state = None
+
+    def _websession(self, verify_ssl):
+        """Return a websession."""
+        return async_get_clientsession(self._hass, verify_ssl)
+
+    async def update(self):
         """Update state of device."""
-        is_turned_on = yield from self.get_property('PWR')
-        if is_turned_on and is_turned_on == EPSON_CODES['ON']:
+        is_turned_on = await self._projector.get_property(POWER)
+        _LOGGER.debug("Is turned on %s", is_turned_on)
+        if is_turned_on and is_turned_on == EPSON_CODES[POWER]:
             self._state = STATE_ON
-            cmode = yield from self.get_property('CMODE')
+            cmode = await self._projector.get_property(CMODE)
             if cmode and cmode in CMODE_LIST:
                 self._cmode = CMODE_LIST[cmode]
-            source = yield from self.get_property('SOURCE')
+            source = await self._projector.get_property(SOURCE)
             if source and source in SOURCE_LIST:
                 self._source = SOURCE_LIST[source]
-            volume = yield from self.get_property('VOLUME')
+            volume = await self._projector.get_property(VOLUME)
             if volume:
                 self._volume = volume
+        elif is_turned_on == BUSY:
+            self._state = STATE_ON
         else:
             self._state = STATE_OFF
-
-    @asyncio.coroutine
-    def get_property(self, command):
-        """Get property state from device."""
-        try:
-            if command in TIMEOUT_TIMES:
-                timeout = TIMEOUT_TIMES[command]
-            else:
-                timeout = TIMEOUT_TIMES['ALL']
-            with async_timeout.timeout(timeout):
-                response = yield from self.websession.get(
-                    url='{url}{type}'.format(
-                        url=self._http_url,
-                        type='json_query'),
-                    params=KEY_COMMANDS[command],
-                    headers=self._headers)
-                if response.status != HTTP_OK:
-                    _LOGGER.warning(
-                        "Error message %d from Epson.", response.status)
-                    return False
-                resp = yield from response.json()
-                reply_code = resp['projector']['feature']['reply']
-                return reply_code
-        except (asyncio.TimeoutError, aiohttp.ClientError):
-            _LOGGER.error("Error getting info")
-            self._state = STATE_OFF
-            return False
-        return True
 
     @property
     def name(self):
@@ -306,15 +154,13 @@ class EpsonProjector(MediaPlayerDevice):
         """Flag media player features that are supported."""
         return SUPPORT_EPSON
 
-    @asyncio.coroutine
-    def async_turn_on(self):
+    async def async_turn_on(self):
         """Turn on epson."""
-        return self.send_command('TURN_ON')
+        return await self._projector.send_command(TURN_ON)
 
-    @asyncio.coroutine
-    def async_turn_off(self):
+    async def async_turn_off(self):
         """Turn off epson."""
-        return self.send_command('TURN_OFF')
+        return await self._projector.send_command(TURN_OFF)
 
     @property
     def source_list(self):
@@ -336,79 +182,45 @@ class EpsonProjector(MediaPlayerDevice):
         """Return the volume level of the media player (0..1)."""
         return self._volume
 
-    @asyncio.coroutine
-    def select_cmode(self, cmode):
+    async def select_cmode(self, cmode):
         """Set color mode in Epson."""
         if cmode in CMODE_LIST_SET:
-            return self.send_command(CMODE_LIST_SET[cmode])
+            return await self._projector.send_command(CMODE_LIST_SET[cmode])
 
-    @asyncio.coroutine
-    def async_select_source(self, source):
+    async def async_select_source(self, source):
         """Select input source."""
         _LOGGER.debug("select source")
         selected_source = INV_SOURCES[source]
-        return self.send_command(selected_source)
+        return await self._projector.send_command(selected_source)
 
-    @asyncio.coroutine
-    def async_mute_volume(self, mute):
+    async def async_mute_volume(self, mute):
         """Mute (true) or unmute (false) sound."""
-        return self.send_command("MUTE")
+        return await self._projector.send_command(MUTE)
 
-    @asyncio.coroutine
-    def async_volume_up(self):
+    async def async_volume_up(self):
         """Increase volume."""
         _LOGGER.debug("volume up")
-        return self.send_command("VOL_UP")
+        return await self._projector.send_command(VOL_UP)
 
-    @asyncio.coroutine
-    def async_volume_down(self):
+    async def async_volume_down(self):
         """Decrease volume."""
-        return self.send_command("VOL_DOWN")
+        return await self._projector.send_command(VOL_DOWN)
 
-    @asyncio.coroutine
-    def async_media_play(self):
+    async def async_media_play(self):
         """Play media via Epson."""
-        return self.send_command("PLAY")
+        return await self._projector.send_command(PLAY)
 
-    @asyncio.coroutine
-    def async_media_pause(self):
+    async def async_media_pause(self):
         """Pause media via Epson."""
-        return self.send_command("PAUSE")
+        return await self._projector.send_command(PAUSE)
 
-    @asyncio.coroutine
-    def async_media_next_track(self):
+    async def async_media_next_track(self):
         """Skip to next."""
-        return self.send_command("FAST")
+        return await self._projector.send_command(FAST)
 
-    @asyncio.coroutine
-    def async_media_previous_track(self):
+    async def async_media_previous_track(self):
         """Skip to previous."""
-        return self.send_command("BACK")
-
-    @asyncio.coroutine
-    def send_command(self, command):
-        """Send command to Epson."""
-        _LOGGER.debug("COMMAND %s", command)
-        params = self.key_commands[command]
-        try:
-            if command in TIMEOUT_TIMES:
-                timeout = TIMEOUT_TIMES[command]
-            else:
-                timeout = TIMEOUT_TIMES['ALL']
-            with async_timeout.timeout(timeout):
-                url = '{url}{type}'.format(
-                    url=self._http_url,
-                    type='directsend')
-                response = yield from self.websession.get(
-                    url,
-                    params=params,
-                    headers=self._headers)
-            if response.status != HTTP_OK:
-                return None
-            return True
-        except (asyncio.TimeoutError, aiohttp.ClientError):
-            _LOGGER.error("Error sending command")
-        return None
+        return await self._projector.send_command(BACK)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -19,8 +19,7 @@ from homeassistant.components.media_player import (
     MediaPlayerDevice)
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_PORT, CONF_SSL, STATE_OFF,
-    STATE_ON, STATE_PLAYING, STATE_UNKNOWN)
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
+    STATE_ON, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
 KEY_COMMANDS = {

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -5,7 +5,6 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/media_player.epson/
 """
 import asyncio
-from datetime import timedelta
 import logging
 
 import aiohttp

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -255,7 +255,7 @@ class EpsonProjector(MediaPlayerDevice):
             if cmode and cmode in CMODE_LIST:
                 self._cmode = CMODE_LIST[cmode]
             source = yield from self.get_property('SOURCE')
-            if source and souce in SOURCE_LIST:
+            if source and source in SOURCE_LIST:
                 self._source = SOURCE_LIST[source]
             volume = yield from self.get_property('VOLUME')
             if volume:

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -1,83 +1,78 @@
 """
-Support for Epson projector
+Support for Epson projector.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/
-
+https://home-assistant.io/components/media_player.epson/
 """
-import logging
-from datetime import timedelta
-
-import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
-import async_timeout
 import asyncio
+from datetime import timedelta
+import logging
+
 import aiohttp
+import async_timeout
+import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    PLATFORM_SCHEMA, MediaPlayerDevice, SUPPORT_TURN_ON, SUPPORT_TURN_OFF,SUPPORT_SELECT_SOURCE, MEDIA_PLAYER_SCHEMA, DOMAIN,
-    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP, SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK
-)
-
-""" ,SUPPORT_PLAY, SUPPORT_PAUSE, SUPPORT_STOP"""
-
+    DOMAIN, MEDIA_PLAYER_SCHEMA, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
+    SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
+    MediaPlayerDevice)
+from homeassistant.const import (
+    ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_PORT, CONF_SSL, STATE_OFF,
+    STATE_ON, STATE_PLAYING, STATE_UNKNOWN)
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
-from homeassistant.const import (ATTR_ENTITY_ID, CONF_HOST,CONF_NAME,CONF_PORT,CONF_SSL, STATE_ON, STATE_OFF, STATE_UNKNOWN, STATE_PLAYING)
-
-import homeassistant.util as util
-
-DEPENDENCIES = []
+import homeassistant.helpers.config_validation as cv
 
 KEY_COMMANDS = {
-    "TURN_ON" : [('KEY', '3B')],
+    "TURN_ON": [('KEY', '3B')],
     "TURN_OFF": [('KEY', '3B'), ('KEY', '3B')],
-    "HDMILINK" : [('jsoncallback', 'HDMILINK?')],
-    "CMODE" : [('jsoncallback', 'CMODE?')],
-    "CMODE_CINEMA" : [('CMODE', '15')],
-    "CMODE_NATURAL" : [('CMODE', '07')],
-    "CMODE_BRIGHT" : [('CMODE', '0C')],
-    "CMODE_DYNAMIC" : [('CMODE', '06S')],
-    "VOL_UP" : [('KEY', '56')],
-    "VOL_DOWN" : [('KEY', '57')],
-    "MUTE" : [('KEY', '3E')],
-    "HDMI1" : [('KEY', '4D')],
-    "HDMI2" : [('KEY', '40')],
-    "PC" : [('KEY', '44')],
-    "VIDEO" : [('KEY', '46')],
-    "USB" : [('KEY', '85')],
-    "LAN" : [('KEY', '53')],
-    "WFD" : [('KEY', '56')],
-    "PLAY" : [('KEY', 'D1')],
-    "PAUSE" : [('KEY', 'D3')],
-    "STOP" : [('KEY', 'D2')],
-    "BACK" : [('KEY', 'D4')],
-    "FAST" : [('KEY', 'D5')],
+    "HDMILINK": [('jsoncallback', 'HDMILINK?')],
+    "CMODE": [('jsoncallback', 'CMODE?')],
+    "CMODE_CINEMA": [('CMODE', '15')],
+    "CMODE_NATURAL": [('CMODE', '07')],
+    "CMODE_BRIGHT": [('CMODE', '0C')],
+    "CMODE_DYNAMIC": [('CMODE', '06S')],
+    "VOL_UP": [('KEY', '56')],
+    "VOL_DOWN": [('KEY', '57')],
+    "MUTE": [('KEY', '3E')],
+    "HDMI1": [('KEY', '4D')],
+    "HDMI2": [('KEY', '40')],
+    "PC": [('KEY', '44')],
+    "VIDEO": [('KEY', '46')],
+    "USB": [('KEY', '85')],
+    "LAN": [('KEY', '53')],
+    "WFD": [('KEY', '56')],
+    "PLAY": [('KEY', 'D1')],
+    "PAUSE": [('KEY', 'D3')],
+    "STOP": [('KEY', 'D2')],
+    "BACK": [('KEY', 'D4')],
+    "FAST": [('KEY', 'D5')],
 }
 
 DEFAULT_SOURCES = {
-    'HDMI1' : 'HDMI1',
-    'HDMI2' : 'HDMI2',
-    'PC'    : 'PC',
-    'VIDEO'    : 'VIDEO',
-    'USB'    : 'USB',
-    'LAN'    : 'LAN',
-    'WFD'   : 'WiFi Direct'
+    'HDMI1': 'HDMI1',
+    'HDMI2': 'HDMI2',
+    'PC': 'PC',
+    'VIDEO': 'VIDEO',
+    'USB': 'USB',
+    'LAN': 'LAN',
+    'WFD': 'WiFi Direct'
 }
 
 INV_SOURCES = {v: k for k, v in DEFAULT_SOURCES.items()}
 
 CMODE_LIST = {
-    '15' : 'Cinema',
-    '07' : 'Natural',
-    '0C' : 'Bright Cinema',
-    '06' : 'Dynamic'
+    '15': 'Cinema',
+    '07': 'Natural',
+    '0C': 'Bright Cinema',
+    '06': 'Dynamic'
 }
 
 CMODE_LIST_SET = {
     'cinema': 'CMODE_CINEMA',
-    'natural' : 'CMODE_NATURAL',
-    'bright cinema' : 'CMODE_BRIGHT',
-    'dynamic' : 'CMODE_DYNAMIC'
+    'natural': 'CMODE_NATURAL',
+    'bright cinema': 'CMODE_BRIGHT',
+    'dynamic': 'CMODE_DYNAMIC'
 }
 
 DATA_EPSON = 'epson'
@@ -87,43 +82,43 @@ MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOST) : cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME) : cv.string,
-    vol.Optional(CONF_PORT, default=80) : cv.port,
-    vol.Optional(CONF_SSL, default=False) : cv.boolean
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=80): cv.port,
+    vol.Optional(CONF_SSL, default=False): cv.boolean
 })
 ATTR_CMODE = 'cmode'
 SUPPORT_CMODE = 33001
+ACCEPT_ENCODING = "gzip, deflate"
+ACCEPT_HEADER = "application/json, text/javascript"
 
-SUPPORT_EPSON = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE | SUPPORT_CMODE | \
-                SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_STEP | \
-                 SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
-                 # SUPPORT_PLAY | SUPPORT_PAUSE | SUPPORT_STOP
+SUPPORT_EPSON = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE |\
+            SUPPORT_CMODE | SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_STEP | \
+            SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
 
-
-EPSON_SCHEMA =  MEDIA_PLAYER_SCHEMA.extend({
+EPSON_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
     vol.Required(ATTR_ENTITY_ID): cv.entity_id,
     vol.Optional(ATTR_CMODE): cv.string
 })
 
-# ATTR_TO_PROPERTY = ATTR_TO_PROPERTY.extend(ATTR_CMODE)
-
 _LOGGER = logging.getLogger(__name__)
+
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-
+    """Set up the Epson media player platform."""
     if DATA_EPSON not in hass.data:
         hass.data[DATA_EPSON] = []
 
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
-    epson = EpsonProjector(hass, name, host, config.get(CONF_PORT), config.get(CONF_SSL), KEY_COMMANDS)
+    epson = EpsonProjector(
+        hass, name, host,
+        config.get(CONF_PORT), config.get(CONF_SSL), KEY_COMMANDS)
 
     epson.update()
     hass.data[DATA_EPSON].append(epson)
     async_add_devices([epson], update_before_add=True)
-    # async_add_devices([epson])
 
     @asyncio.coroutine
     def async_service_handler(service):
@@ -145,10 +140,12 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         schema=EPSON_SCHEMA)
     return True
 
+
 class EpsonProjector(MediaPlayerDevice):
     """Representation of Epson Projector Device."""
 
     def __init__(self, hass, name, host, port, encryption, key_commands):
+        """Initialize entity to control Epson projector."""
         self._hass = hass
         self._name = name
         self._host = host
@@ -159,48 +156,46 @@ class EpsonProjector(MediaPlayerDevice):
         self._encryption = encryption
         self._state = STATE_UNKNOWN
         http_protocol = 'https' if self._encryption else 'http'
-        self._http_url = '{http_protocol}://{host}:{port}/cgi-bin/'.format(http_protocol=http_protocol, host=self._host, port=self._port)
+        self._http_url = '{http_protocol}://{host}:{port}/cgi-bin/'.format(
+            http_protocol=http_protocol,
+            host=self._host,
+            port=self._port)
+        referer = "{http_protocol}://{host}:{port}/cgi-bin/webconf".format(
+            http_protocol=http_protocol,
+            host=self._host,
+            port=self._port)
         self._headers = {
-            "Accept-Encoding" : "gzip, deflate",
-            "Accept" : "application/json, text/javascript",
-            "Referer": "{http_protocol}://{host}:{port}/cgi-bin/webconf".format(http_protocol=http_protocol,host=self._host,port=self._port)
-        };
-
-        self.websession = async_create_clientsession(hass, verify_ssl=self._encryption)
-        self.websession_action = async_create_clientsession(hass, verify_ssl=self._encryption)
-        self.update()
+            "Accept-Encoding": ACCEPT_ENCODING,
+            "Accept": ACCEPT_HEADER,
+            "Referer": referer
+        }
 
     @asyncio.coroutine
     def update(self):
         """Update state of device."""
-        # self._state = STATE_ON
-        # self._cmode = CMODE_LIST['15']
-        # return True
         try:
             with async_timeout.timeout(10, loop=self._hass.loop):
                 response = yield from self.websession.get(
-                    url='{url}{type}'.format(url=self._http_url, type='json_query' ),
+                    url='{url}{type}'.format(
+                        url=self._http_url,
+                        type='json_query'),
                     params=KEY_COMMANDS['CMODE'],
                     headers=self._headers)
             if response.status != 200:
-                    _LOGGER.warning("[%s] Error %d on Epson.", DOMAIN, response.status)
+                    _LOGGER.warning(
+                        "[%s] Error %d on Epson.", DOMAIN, response.status)
                     self._state = STATE_OFF
-            response_json = yield from response.json()
-            if (response_json['projector']['feature']['reply'] == 'ERR'):
+            resp = yield from response.json()
+            if (resp['projector']['feature']['reply'] == 'ERR'):
                 self._state = STATE_OFF
-                # self._cmode = CMODE_LIST['15']
             else:
                 self._state = STATE_ON
-                self._cmode = CMODE_LIST[response_json['projector']['feature']['reply']]
-                # if self._cmode is not None:
-                #     self._state = STATE_PLAYING
+                self._cmode = CMODE_LIST[resp['projector']['feature']['reply']]
         except (aiohttp.ClientError):
             _LOGGER.error("[%s] Error getting info", DOMAIN)
             self._state = STATE_OFF
             return False
         return True
-
-
 
     @property
     def name(self):
@@ -219,12 +214,12 @@ class EpsonProjector(MediaPlayerDevice):
 
     @asyncio.coroutine
     def async_turn_on(self):
-        """Turn on epson"""
+        """Turn on epson."""
         return self.sendCommand('TURN_ON')
 
     @asyncio.coroutine
     def async_turn_off(self):
-        """Turn off epson"""
+        """Turn off epson."""
         return self.sendCommand('TURN_OFF')
 
     @property
@@ -234,29 +229,31 @@ class EpsonProjector(MediaPlayerDevice):
 
     @property
     def cmode(self):
+        """Get CMODE/color mode from Epson."""
         return self._cmode
 
     @asyncio.coroutine
     def select_cmode(self, cmode):
+        """Set color mode in Epson."""
         if cmode in CMODE_LIST_SET:
             return self.sendCommand(CMODE_LIST_SET[cmode])
 
     @asyncio.coroutine
     def async_select_source(self, source):
         """Select input source."""
-        _LOGGER.info("select source")
+        _LOGGER.debug("select source")
         selected_source = INV_SOURCES[source]
         return self.sendCommand(selected_source)
 
     @asyncio.coroutine
     def async_mute_volume(self, mute):
-        """Mute (true) or unmute (false) projector. It also mutes video input!  """
+        """Mute (true) or unmute (false) sound and video input."""
         return self.sendCommand("MUTE")
 
     @asyncio.coroutine
     def async_volume_up(self):
         """Increase volume."""
-        _LOGGER.info("volume up")
+        _LOGGER.debug("volume up")
         return self.sendCommand("VOL_UP")
 
     @asyncio.coroutine
@@ -286,12 +283,15 @@ class EpsonProjector(MediaPlayerDevice):
 
     @asyncio.coroutine
     def sendCommand(self, command):
-        _LOGGER.info("COMMAND %s", command)
+        """Send command to Epson."""
+        _LOGGER.debug("COMMAND %s", command)
         params = self.KEY_COMMANDS[command]
         try:
             url = '{url}{type}'.format(url=self._http_url, type='directsend')
-            # with async_timeout.timeout(10, loop=self._hass.loop):
-            response = yield from self.websession_action.get(url,params=params,headers=self._headers)
+            response = yield from self.websession_action.get(
+                url,
+                params=params,
+                headers=self._headers)
             if response.status != 200:
                 return None
             return True
@@ -303,18 +303,6 @@ class EpsonProjector(MediaPlayerDevice):
     def device_state_attributes(self):
         """Return device specific state attributes."""
         attributes = {}
-
         if self._cmode is not None:
             attributes[ATTR_CMODE] = self._cmode
-
         return attributes
-
-
-#curl 'http://192.168.4.131/cgi-bin/json_query?jsoncallback=HDMILINK?%2001&_=1520179300356' -H 'Accept-Encoding: gzip, deflate'  -H 'Accept: application/json, text/javascript, */*; q=0.01' -H 'Referer: http://192.168.4.131/cgi-bin/webconf' -H 'X-Requested-With: XMLHttpRequest' -H 'Connection: keep-alive' --compressed
-# def setup(hass, config):
-#     """Setup the Hello State component. """
-#     _LOGGER.info("The 'hello state' component is ready!")
-#     text = config[DOMAIN].get(CONF_TEXT, DEFAULT_TEXT)
-#     hass.states.set('first.Hello_State', text)
-#
-#     return True

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -20,8 +20,8 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_PORT, CONF_SSL, STATE_OFF,
     STATE_ON, STATE_UNKNOWN)
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
+import homeassistant.helpers.config_validation as cv
 
 KEY_COMMANDS = {
     "TURN_ON": [('KEY', '3B')],

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -2,7 +2,8 @@
 Support for Epson projector
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/cookbook/python_component_basic_state/
+https://home-assistant.io/
+
 """
 import logging
 from datetime import timedelta

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -248,23 +248,23 @@ class EpsonProjector(MediaPlayerDevice):
     @asyncio.coroutine
     def update(self):
         """Update state of device."""
-        isTurnedOn = yield from self.getProperty('PWR')
-        if isTurnedOn and isTurnedOn == EPSON_CODES['ON']:
+        is_turned_on = yield from self.get_property('PWR')
+        if is_turned_on and is_turned_on == EPSON_CODES['ON']:
             self._state = STATE_ON
-            cmode = yield from self.getProperty('CMODE')
+            cmode = yield from self.get_property('CMODE')
             if cmode and cmode in CMODE_LIST:
                 self._cmode = CMODE_LIST[cmode]
-            source = yield from self.getProperty('SOURCE')
+            source = yield from self.get_property('SOURCE')
             if source and souce in SOURCE_LIST:
                 self._source = SOURCE_LIST[source]
-            volume = yield from self.getProperty('VOLUME')
+            volume = yield from self.get_property('VOLUME')
             if volume:
                 self._volume = volume
         else:
             self._state = STATE_OFF
 
     @asyncio.coroutine
-    def getProperty(self, command):
+    def get_property(self, command):
         """Get property state from device."""
         try:
             if command in TIMEOUT_TIMES:

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -1,0 +1,226 @@
+"""
+Support for showing text in the frontend.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/cookbook/python_component_basic_state/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+import async_timeout
+import asyncio
+import aiohttp
+
+from homeassistant.components.media_player import (
+    PLATFORM_SCHEMA, MediaPlayerDevice, SUPPORT_TURN_ON, SUPPORT_TURN_OFF,SUPPORT_SELECT_SOURCE, MEDIA_PLAYER_SCHEMA, DOMAIN
+)
+
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.const import (ATTR_ENTITY_ID, CONF_HOST,CONF_NAME,CONF_PORT,CONF_SSL, STATE_ON, STATE_OFF, STATE_UNKNOWN)
+
+import homeassistant.util as util
+
+DEPENDENCIES = []
+
+KEY_COMMANDS = {
+    "TURN_ON" : [('KEY', '3B')],
+    "TURN_OFF": [('KEY', '3B'), ('KEY', '3B')],
+    "HDMILINK" : [('jsoncallback', 'HDMILINK?')],
+    "CMODE" : [('jsoncallback', 'CMODE?')]
+}
+
+DEFAULT_SOURCES = {
+    'hdmi1' : 'HDMI1',
+    'hdmi2' : 'HDMI2',
+    'pc'    : 'PC'
+}
+
+CMODE_LIST = {
+    '15' : 'Cinema',
+    '07' : 'Natural',
+    '0C' : 'Bright Cinema',
+    '06' : 'Dynamic'
+}
+
+DATA_EPSON = 'epson'
+DEFAULT_NAME = 'EPSON Projector'
+ATTR_MASTER = 'master'
+# ATTR_CMODE = 'cmode'
+
+MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST) : cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME) : cv.string,
+    vol.Optional(CONF_PORT, default=80) : cv.port,
+    vol.Optional(CONF_SSL, default=False) : cv.boolean
+})
+ATTR_CMODE = 'cmode'
+SUPPORT_CMODE = 33001
+
+SUPPORT_EPSON = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE | SUPPORT_CMODE
+
+
+EPSON_SCHEMA =  MEDIA_PLAYER_SCHEMA.extend({
+    vol.Optional(ATTR_MASTER): cv.entity_id,
+    vol.Optional(ATTR_CMODE): cv.boolean,
+})
+
+# ATTR_TO_PROPERTY = ATTR_TO_PROPERTY.extend(ATTR_CMODE)
+
+_LOGGER = logging.getLogger(__name__)
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+
+    known_devices = hass.data.get(DATA_EPSON)
+    if known_devices is None:
+        hass.data[DATA_EPSON] = known_devices = set()
+
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+    epson = EpsonProjector(hass, name, host, config.get(CONF_PORT), config.get(CONF_SSL), KEY_COMMANDS)
+
+    epson.update()
+    known_devices.add(host)
+    async_add_devices([epson])
+
+    @asyncio.coroutine
+    def async_service_handler(service):
+        """Handle for services."""
+        entity_ids = service.data.get('entity_id')
+        if entity_ids:
+            devices = [device for device in hass.data[DATA_EPSON].devices
+                       if device.entity_id in entity_ids]
+        else:
+            devices = hass.data[DATA_EPSON].devices
+        for device in devices:
+            yield from device.update()
+    hass.services.async_register(
+        DOMAIN, ATTR_CMODE, async_service_handler,
+        schema=EPSON_SCHEMA)
+    return True
+
+class EpsonProjector(MediaPlayerDevice):
+    """Representation of Epson Projector Device."""
+
+    def __init__(self, hass, name, host, port, encryption, key_commands):
+        self._hass = hass
+        self._name = name
+        self._host = host
+        self._port = port
+        self._source_list = list(DEFAULT_SOURCES.values())
+        self.KEY_COMMANDS = key_commands
+        self._encryption = encryption
+        self._state = STATE_UNKNOWN
+        http_protocol = 'https' if self._encryption else 'http'
+        self._http_url = '{http_protocol}://{host}:{port}/cgi-bin/'.format(http_protocol=http_protocol, host=self._host, port=self._port)
+        self._headers = {
+            "Accept-Encoding" : "gzip, deflate",
+            "Accept" : "application/json, text/javascript",
+            "Referer": "{http_protocol}://{host}:{port}/cgi-bin/webconf".format(http_protocol=http_protocol,host=self._host,port=self._port)
+        };
+
+        self.websession = async_create_clientsession(hass, verify_ssl=self._encryption)
+        self.websession_action = async_create_clientsession(hass, verify_ssl=self._encryption)
+        self.update()
+
+    @asyncio.coroutine
+    def update(self):
+        """Update state of device."""
+        self._state = STATE_ON
+        self._cmode = CMODE_LIST['15']
+        return True
+        try:
+            with async_timeout.timeout(10, loop=self._hass.loop):
+                response = yield from self.websession.get(
+                    url='{url}{type}'.format(url=self._http_url, type='json_query' ),
+                    params=KEY_COMMANDS['CMODE'],
+                    headers=self._headers)
+            if response.status != 200:
+                    _LOGGER.warning("[%s] Error %d on Epson.", DOMAIN, response.status)
+                    self._state = STATE_OFF
+            response_json = yield from response.json()
+            if (response_json['projector']['feature']['reply'] == 'ERR'):
+                self._state = STATE_OFF
+            else:
+                self._state = STATE_ON
+                self._cmode = CMODE_LIST[response_json['projector']['feature']['reply']]
+        except (aiohttp.ClientError):
+            _LOGGER.error("[%s] Error getting info", DOMAIN)
+            self._state = STATE_OFF
+            return False
+        return True
+
+
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_EPSON
+
+    @property
+    def effect_list(self):
+        """Return the list of supported effects."""
+        return [
+            'COLOR', 'BLACK'
+        ]
+
+    def async_turn_on(self):
+        """Turn on epson"""
+        return self.sendCommand('TURN_ON')
+
+    def async_turn_off(self):
+        """Turn off epson"""
+        return self.sendCommand('TURN_OFF')
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+        return self._source_list
+
+    @property
+    def cmode(self):
+        self._cmode
+
+
+    def select_source(self, source):
+        """Select input source."""
+        _LOGGER.info('change source')
+
+    @asyncio.coroutine
+    def sendCommand(self, command):
+        _LOGGER.info('haha')
+        params = self.KEY_COMMANDS[command]
+        try:
+            url = '{url}{type}'.format(url=self._http_url, type='directsend')
+            # with async_timeout.timeout(10, loop=self._hass.loop):
+            response = yield from self.websession_action.get(url,params=params,headers=self._headers)
+            if response.status != 200:
+                return None
+            return True
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            _LOGGER.error("[%s] Error getting info", DOMAIN)
+        return None
+
+#curl 'http://192.168.4.131/cgi-bin/json_query?jsoncallback=HDMILINK?%2001&_=1520179300356' -H 'Accept-Encoding: gzip, deflate'  -H 'Accept: application/json, text/javascript, */*; q=0.01' -H 'Referer: http://192.168.4.131/cgi-bin/webconf' -H 'X-Requested-With: XMLHttpRequest' -H 'Connection: keep-alive' --compressed
+# def setup(hass, config):
+#     """Setup the Hello State component. """
+#     _LOGGER.info("The 'hello state' component is ready!")
+#     text = config[DOMAIN].get(CONF_TEXT, DEFAULT_TEXT)
+#     hass.states.set('first.Hello_State', text)
+#
+#     return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -28,7 +28,7 @@ Adafruit-SHT31==1.0.2
 DoorBirdPy==0.1.3
 
 # homeassistant.components.homekit
-HAP-python==2.2.2
+HAP-python==2.1.0
 
 # homeassistant.components.notify.mastodon
 Mastodon.py==1.2.2
@@ -46,7 +46,7 @@ PyMVGLive==1.1.4
 PyMata==2.14
 
 # homeassistant.components.xiaomi_aqara
-PyXiaomiGateway==0.9.5
+PyXiaomiGateway==0.9.3
 
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.1
@@ -61,7 +61,7 @@ SoCo==0.14
 TravisPy==0.3.5
 
 # homeassistant.components.notify.twitter
-TwitterAPI==2.5.4
+TwitterAPI==2.5.0
 
 # homeassistant.components.sensor.waze_travel_time
 WazeRouteCalculator==0.5
@@ -86,7 +86,7 @@ aiodns==1.1.1
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.5.0
+aiohue==1.3.0
 
 # homeassistant.components.sensor.imap
 aioimaplib==0.7.13
@@ -161,7 +161,7 @@ blinkstick==1.1.8
 # blinkt==0.1.0
 
 # homeassistant.components.sensor.bitcoin
-blockchain==1.4.4
+blockchain==1.4.0
 
 # homeassistant.components.light.decora
 # bluepy==1.1.4
@@ -199,7 +199,7 @@ ciscosparkapi==0.4.2
 coinbase==2.1.0
 
 # homeassistant.components.sensor.coinmarketcap
-coinmarketcap==5.0.3
+coinmarketcap==4.2.1
 
 # homeassistant.scripts.check_config
 colorlog==3.1.4
@@ -246,10 +246,10 @@ defusedxml==0.5.0
 deluge-client==1.4.0
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.7.2
+denonavr==0.6.1
 
 # homeassistant.components.media_player.directv
-directpy==0.5
+directpy==0.2
 
 # homeassistant.components.sensor.discogs
 discogs_client==2.2.1
@@ -344,7 +344,7 @@ gTTS-token==1.1.1
 gearbest_parser==1.0.5
 
 # homeassistant.components.sensor.gitter
-gitterpy==0.1.7
+gitterpy==0.1.6
 
 # homeassistant.components.notify.gntp
 gntp==1.0.3
@@ -368,7 +368,7 @@ gstreamer-player==1.1.0
 ha-ffmpeg==1.9
 
 # homeassistant.components.media_player.philips_js
-ha-philipsjs==0.0.4
+ha-philipsjs==0.0.3
 
 # homeassistant.components.sensor.geo_rss_events
 haversine==0.4.5
@@ -389,13 +389,13 @@ hipnotify==1.0.8
 holidays==0.9.5
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180603.0
+home-assistant-frontend==20180526.4
 
 # homeassistant.components.homekit_controller
 # homekit==0.6
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.9.4
+homematicip==0.9.2.4
 
 # homeassistant.components.camera.onvif
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a
@@ -430,9 +430,6 @@ https://github.com/soldag/pyflic/archive/0.4.zip#pyflic==0.4
 # homeassistant.components.media_player.lg_netcast
 https://github.com/wokar/pylgnetcast/archive/v0.2.0.zip#pylgnetcast==0.2.0
 
-# homeassistant.components.hydrawise
-hydrawiser==0.1.1
-
 # homeassistant.components.sensor.bh1750
 # homeassistant.components.sensor.bme280
 # homeassistant.components.sensor.htu21d
@@ -454,9 +451,6 @@ insteonlocal==0.53
 # homeassistant.components.insteon_plm
 insteonplm==0.9.2
 
-# homeassistant.components.sensor.iperf3
-iperf3==0.1.10
-
 # homeassistant.components.verisure
 jsonpath==0.75
 
@@ -468,7 +462,7 @@ jsonrpc-async==0.6
 jsonrpc-websocket==0.6
 
 # homeassistant.scripts.keyring
-keyring==12.2.1
+keyring==12.2.0
 
 # homeassistant.scripts.keyring
 keyrings.alt==3.1
@@ -477,7 +471,7 @@ keyrings.alt==3.1
 konnected==0.1.2
 
 # homeassistant.components.eufy
-lakeside==0.7
+lakeside==0.6
 
 # homeassistant.components.device_tracker.owntracks
 # homeassistant.components.device_tracker.owntracks_http
@@ -505,7 +499,7 @@ lightify==1.0.6.1
 limitlessled==1.1.0
 
 # homeassistant.components.linode
-linode-api==4.1.9b1
+linode-api==4.1.4b2
 
 # homeassistant.components.media_player.liveboxplaytv
 liveboxplaytv==2.0.2
@@ -515,13 +509,10 @@ liveboxplaytv==2.0.2
 lmnotify==0.0.4
 
 # homeassistant.components.device_tracker.google_maps
-locationsharinglib==2.0.7
+locationsharinglib==2.0.2
 
 # homeassistant.components.sensor.luftdaten
-luftdaten==0.2.0
-
-# homeassistant.components.light.lw12wifi
-lw12==0.9.2
+luftdaten==0.1.3
 
 # homeassistant.components.sensor.lyft
 lyft_rides==0.2
@@ -566,9 +557,6 @@ nad_receiver==0.0.9
 
 # homeassistant.components.light.nanoleaf_aurora
 nanoleaf==0.4.1
-
-# homeassistant.components.sensor.netdata
-netdata==0.1.2
 
 # homeassistant.components.discovery
 netdisco==1.4.1
@@ -633,9 +621,6 @@ pifacedigitalio==3.0.5
 # homeassistant.components.light.piglow
 piglow==1.2.4
 
-# homeassistant.components.sensor.pi_hole
-pihole==0.1.2
-
 # homeassistant.components.pilight
 pilight==0.1.1
 
@@ -657,7 +642,7 @@ pmsensor==0.4
 pocketcasts==0.1
 
 # homeassistant.components.sensor.postnl
-postnl_api==1.0.2
+postnl_api==1.0.1
 
 # homeassistant.components.climate.proliphix
 proliphix==0.4.1
@@ -712,9 +697,6 @@ pyTibber==0.4.1
 # homeassistant.components.switch.dlink
 pyW215==0.6.0
 
-# homeassistant.components.cover.ryobi_gdo
-py_ryobi_gdo==0.0.10
-
 # homeassistant.components.ads
 pyads==2.2.6
 
@@ -734,7 +716,7 @@ pyasn1-modules==0.1.5
 pyasn1==0.3.7
 
 # homeassistant.components.apple_tv
-pyatv==0.3.10
+pyatv==0.3.9
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox
@@ -776,9 +758,6 @@ pydispatcher==2.0.5
 
 # homeassistant.components.android_ip_webcam
 pydroid-ipcam==0.8
-
-# homeassistant.components.sensor.ebox
-pyebox==1.1.4
 
 # homeassistant.components.climate.econet
 pyeconet==0.0.5
@@ -826,7 +805,7 @@ pyhik==0.1.8
 pyhiveapi==0.2.14
 
 # homeassistant.components.homematic
-pyhomematic==0.1.43
+pyhomematic==0.1.42
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==2.2.2
@@ -836,9 +815,6 @@ pyialarm==0.2
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.9.1
-
-# homeassistant.components.weather.ipma
-pyipma==1.1.3
 
 # homeassistant.components.sensor.irish_rail_transport
 pyirishrail==0.0.2
@@ -940,7 +916,7 @@ pypollencom==1.1.2
 pyqwikswitch==0.8
 
 # homeassistant.components.rainbird
-pyrainbird==0.1.6
+pyrainbird==0.1.3
 
 # homeassistant.components.sabnzbd
 pysabnzbd==1.0.1
@@ -1039,7 +1015,7 @@ python-mpd2==1.0.0
 python-mystrom==0.4.2
 
 # homeassistant.components.nest
-python-nest==4.0.1
+python-nest==3.7.0
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1
@@ -1077,11 +1053,14 @@ python-velbus==2.0.11
 # homeassistant.components.media_player.vlc
 python-vlc==1.1.2
 
+# homeassistant.components.sensor.domain_expiry
+python-whois==0.6.9
+
 # homeassistant.components.wink
 python-wink==1.7.3
 
 # homeassistant.components.sensor.swiss_public_transport
-python_opendata_transport==0.1.0
+python_opendata_transport==0.0.3
 
 # homeassistant.components.zwave
 python_openzwave==0.4.3
@@ -1114,7 +1093,7 @@ pyupnp-async==0.1.0.2
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.2.43
+pyvera==0.2.42
 
 # homeassistant.components.switch.vesync
 pyvesync==0.1.1
@@ -1153,10 +1132,10 @@ raincloudy==0.0.4
 # raspihats==2.2.3
 
 # homeassistant.components.rainmachine
-regenmaschine==0.4.2
+regenmaschine==0.4.1
 
 # homeassistant.components.python_script
-restrictedpython==4.0b4
+restrictedpython==4.0b3
 
 # homeassistant.components.rflink
 rflink==0.0.37
@@ -1208,7 +1187,7 @@ sense_energy==0.3.1
 sharp_aquos_rc==0.3.2
 
 # homeassistant.components.sensor.shodan
-shodan==1.8.1
+shodan==1.7.7
 
 # homeassistant.components.notify.simplepush
 simplepush==1.1.4
@@ -1249,7 +1228,7 @@ socialbladeclient==0.2
 somecomfort==0.5.2
 
 # homeassistant.components.sensor.speedtest
-speedtest-cli==2.0.2
+speedtest-cli==2.0.0
 
 # homeassistant.components.sensor.spotcrime
 spotcrime==1.0.3
@@ -1257,7 +1236,7 @@ spotcrime==1.0.3
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator
 # homeassistant.components.sensor.sql
-sqlalchemy==1.2.8
+sqlalchemy==1.2.7
 
 # homeassistant.components.statsd
 statsd==3.2.1
@@ -1305,7 +1284,7 @@ todoist-python==7.0.17
 toonlib==1.0.2
 
 # homeassistant.components.alarm_control_panel.totalconnect
-total_connect_client==0.18
+total_connect_client==0.17
 
 # homeassistant.components.sensor.transmission
 # homeassistant.components.switch.transmission
@@ -1403,7 +1382,7 @@ yeelight==0.4.0
 yeelightsunflower==0.0.10
 
 # homeassistant.components.media_extractor
-youtube_dl==2018.06.02
+youtube_dl==2018.05.09
 
 # homeassistant.components.light.zengge
 zengge==0.2
@@ -1415,7 +1394,7 @@ zeroconf==0.20.0
 ziggo-mediabox-xl==1.0.0
 
 # homeassistant.components.zha
-zigpy-xbee==0.1.1
+zigpy-xbee==0.1.0
 
 # homeassistant.components.zha
 zigpy==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -19,7 +19,7 @@ requests_mock==1.5
 
 
 # homeassistant.components.homekit
-HAP-python==2.2.2
+HAP-python==2.1.0
 
 # homeassistant.components.notify.html5
 PyJWT==1.6.0
@@ -35,7 +35,7 @@ aioautomatic==0.6.5
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.5.0
+aiohue==1.3.0
 
 # homeassistant.components.notify.apns
 apns2==0.3.0
@@ -44,7 +44,7 @@ apns2==0.3.0
 caldav==0.5.0
 
 # homeassistant.components.sensor.coinmarketcap
-coinmarketcap==5.0.3
+coinmarketcap==4.2.1
 
 # homeassistant.components.device_tracker.upc_connect
 defusedxml==0.5.0
@@ -81,7 +81,7 @@ hbmqtt==0.9.2
 holidays==0.9.5
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180603.0
+home-assistant-frontend==20180526.4
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
@@ -168,7 +168,7 @@ pyupnp-async==0.1.0.2
 pywebpush==1.6.0
 
 # homeassistant.components.python_script
-restrictedpython==4.0b4
+restrictedpython==4.0b3
 
 # homeassistant.components.rflink
 rflink==0.0.37
@@ -188,7 +188,7 @@ somecomfort==0.5.2
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator
 # homeassistant.components.sensor.sql
-sqlalchemy==1.2.8
+sqlalchemy==1.2.7
 
 # homeassistant.components.statsd
 statsd==3.2.1


### PR DESCRIPTION
## Description:

Hello,
I created epson projector support.
It is based on Android app (packet sniffing) from epson.
Tested with Epson EH-TW5350


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5005

I can make documentation if you will to add this module to home assistant.

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: epson
  host: 192.168.1.2
  name: Epson Projector
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
