### PR TITLE
Updates default Pilight port number

### DIFF
--- a/homeassistant/components/pilight.py
+++ b/homeassistant/components/pilight.py
@@ -26,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_SEND_DELAY = 'send_delay'
 
 DEFAULT_HOST = '127.0.0.1'
-DEFAULT_PORT = 5000
+DEFAULT_PORT = 5001
 DEFAULT_SEND_DELAY = 0.0
 DOMAIN = 'pilight'
 

--- a/tests/components/test_pilight.py
+++ b/tests/components/test_pilight.py
@@ -81,7 +81,7 @@ class TestPilight(unittest.TestCase):
 
     @patch('homeassistant.components.pilight._LOGGER.error')
     def test_connection_failed_error(self, mock_error):
-        """Try to connect at 127.0.0.1:5000 with socket error."""
+        """Try to connect at 127.0.0.1:5001 with socket error."""
         with assert_setup_component(4):
             with patch('pilight.pilight.Client',
                        side_effect=socket.error) as mock_client:
@@ -93,7 +93,7 @@ class TestPilight(unittest.TestCase):
 
     @patch('homeassistant.components.pilight._LOGGER.error')
     def test_connection_timeout_error(self, mock_error):
-        """Try to connect at 127.0.0.1:5000 with socket timeout."""
+        """Try to connect at 127.0.0.1:5001 with socket timeout."""
         with assert_setup_component(4):
             with patch('pilight.pilight.Client',
                        side_effect=socket.timeout) as mock_client:


### PR DESCRIPTION
## Description:

A PR on the documentation was opened by @ettiennegous, which, I think, should also be reflected/corrected in the codebase.

> Based on the Pilight docs targeted the default port is 5001.
> As started here https://manual.pilight.org/development/api.html and in the original Home Assistant doc

*Note*: This might be a breaking change since people relying on the default (with a custom port) might be left with a non-working component.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4976

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
