### PR TITLE
Log invalid templates in script delays

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -3,7 +3,6 @@
 import logging
 from itertools import islice
 from typing import Optional, Sequence
-from datetime import timedelta
 
 import voluptuous as vol
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -107,7 +107,7 @@ class Script():
                 except (TemplateError, vol.Invalid) as ex:
                     _LOGGER.error("Error rendering '%s' delay template: %s",
                                   self.name, ex)
-                    delay = timedelta(seconds=1)
+                    break
 
                 unsub = async_track_point_in_utc_time(
                     self.hass, async_script_delay,

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -232,7 +232,8 @@ class TestScriptHelper(unittest.TestCase):
 
         script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'event': event},
-            {'delay': '{{ delay }}'},
+            {'delay': '{{ invalid_delay }}'},
+            {'delay': {'seconds': 5}},
             {'event': event}]))
 
         with mock.patch.object(script, '_LOGGER') as mock_logger:
@@ -240,17 +241,8 @@ class TestScriptHelper(unittest.TestCase):
             self.hass.block_till_done()
             assert mock_logger.error.called
 
-        assert script_obj.is_running
-        assert script_obj.can_cancel
-        assert script_obj.last_action == event
-        assert len(events) == 1
-
-        future = dt_util.utcnow() + timedelta(seconds=2)
-        fire_time_changed(self.hass, future)
-        self.hass.block_till_done()
-
         assert not script_obj.is_running
-        assert len(events) == 2
+        assert len(events) == 1
 
     def test_cancel_while_delay(self):
         """Test the cancelling while the delay is present."""

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -218,6 +218,40 @@ class TestScriptHelper(unittest.TestCase):
         assert not script_obj.is_running
         assert len(events) == 2
 
+    def test_delay_invalid_template(self):
+        """Test the delay as a template that fails."""
+        event = 'test_event'
+        events = []
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
+            {'event': event},
+            {'delay': '{{ delay }}'},
+            {'event': event}]))
+
+        with mock.patch.object(script, '_LOGGER') as mock_logger:
+            script_obj.run()
+            self.hass.block_till_done()
+            assert mock_logger.error.called
+
+        assert script_obj.is_running
+        assert script_obj.can_cancel
+        assert script_obj.last_action == event
+        assert len(events) == 1
+
+        future = dt_util.utcnow() + timedelta(seconds=2)
+        fire_time_changed(self.hass, future)
+        self.hass.block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 2
+
     def test_cancel_while_delay(self):
         """Test the cancelling while the delay is present."""
         event = 'test_event'


### PR DESCRIPTION
## Description:

This PR makes the script `delay:` survive invalid templates. We used to log two tracebacks and break the script so it never completed.

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  delay_template:
    sequence:
      - delay: '{{ unknown.attribute }}'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
