### PR TITLE
Fix typo

### DIFF
--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -215,7 +215,7 @@ class Hyperion(Light):
                 pass
 
             led_color = response['info']['activeLedColor']
-            if not led_color or led_color[0]['RGB value'] == [0, 0, 0]:
+            if not led_color or led_color[0]['RGB Value'] == [0, 0, 0]:
                 # Get the active effect
                 if response['info'].get('activeEffects'):
                     self._rgb_color = [175, 0, 255]
@@ -234,8 +234,7 @@ class Hyperion(Light):
                     self._effect = None
             else:
                 # Get the RGB color
-                self._rgb_color =\
-                    response['info']['activeLedColor'][0]['RGB Value']
+                self._rgb_color = led_color[0]['RGB Value']
                 self._brightness = max(self._rgb_color)
                 self._rgb_mem = [int(round(float(x)*255/self._brightness))
                                  for x in self._rgb_color]


### PR DESCRIPTION
## Description:
The hyperion changes for NodeMCU introduced a typo. A lower case `v` has been used while it should have been an upper case `V`, like in the else branch.

Related issue (if applicable): fixes #13118 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
