### PR TITLE
Support L5100-WiFi Control Panel

### DIFF
--- a/homeassistant/components/alarm_control_panel/totalconnect.py
+++ b/homeassistant/components/alarm_control_panel/totalconnect.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_CUSTOM_BYPASS)
 
 
-REQUIREMENTS = ['total_connect_client==0.16']
+REQUIREMENTS = ['total_connect_client==0.17']
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Bump requirement for total_connect_client  library from v0.16 to v0.17 in order to support the L5100-WiFi panel.

