### PR TITLE
Improve detection of entity names in templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -73,11 +73,13 @@ def extract_entities(template, variables=None):
             extraction_final.append(result[0])
 
         if variables and result[1] in variables and \
-           isinstance(variables[result[1]], str):
+           isinstance(variables[result[1]], str) and \
+           valid_entity_id(variables[result[1]]):
             extraction_final.append(variables[result[1]])
 
-    unique_valid = [e for e in set(extraction_final) if valid_entity_id(e)]
-    return unique_valid or MATCH_ALL
+    if extraction_final:
+        return list(set(extraction_final))
+    return MATCH_ALL
 
 
 class Template(object):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -13,7 +13,7 @@ from jinja2.sandbox import ImmutableSandboxedEnvironment
 from homeassistant.const import (
     ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_UNIT_OF_MEASUREMENT, MATCH_ALL,
     STATE_UNKNOWN)
-from homeassistant.core import State
+from homeassistant.core import State, valid_entity_id
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import location as loc_helper
 from homeassistant.loader import bind_hass, get_component
@@ -76,9 +76,8 @@ def extract_entities(template, variables=None):
            isinstance(variables[result[1]], str):
             extraction_final.append(variables[result[1]])
 
-    if extraction_final:
-        return list(set(extraction_final))
-    return MATCH_ALL
+    unique_valid = [e for e in set(extraction_final) if valid_entity_id(e)]
+    return unique_valid or MATCH_ALL
 
 
 class Template(object):

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -836,6 +836,12 @@ is_state_attr('device_tracker.phone_2', 'battery', 40)
                 "{{ is_state(trigger.entity_id, 'off') }}",
                 {'trigger': {'entity_id': 'input_boolean.switch'}}))
 
+        self.assertEqual(
+            MATCH_ALL,
+            template.extract_entities(
+                "{{ is_state('media_player.' ~ where , 'playing') }}",
+                {'where': 'livingroom'}))
+
 
 @asyncio.coroutine
 def test_state_with_unit(hass):


### PR DESCRIPTION
## Description:

This PR adds filtering of extracted entity names, fixing an issue where variables with invalid IDs made the algorithm not fall back to MATCH_ALL.

**Related issue (if applicable):** fixes #13398

## Example entry for `configuration.yaml` (if applicable):
```yaml
      - wait_template: >-
          {{ is_state('media_player.' ~ where, 'playing') }}
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
