### PR TITLE
Make Telnet Switch value template optional

### DIFF
--- a/homeassistant/components/switch/telnet.py
+++ b/homeassistant/components/switch/telnet.py
@@ -25,7 +25,7 @@ SWITCH_SCHEMA = vol.Schema({
     vol.Required(CONF_COMMAND_OFF): cv.string,
     vol.Required(CONF_COMMAND_ON): cv.string,
     vol.Required(CONF_RESOURCE): cv.string,
-    vol.Required(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     vol.Optional(CONF_COMMAND_STATE): cv.string,
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,


### PR DESCRIPTION
## Description:

When no status command is defined a value template does nothing so should not have to be provided.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5007

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: telnet
    switches:
      tv_power:
        resource: "192.168.x.x"
        command_on: "ka 00 01"
        command_off: "ka 00 00"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
