### PR TITLE
QNAP updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -69,6 +69,7 @@ homeassistant/components/sensor/gearbest.py @HerrHofrat
 homeassistant/components/sensor/irish_rail_transport.py @ttroy50
 homeassistant/components/sensor/miflora.py @danielhiversen @ChristianKuehnel
 homeassistant/components/sensor/pollen.py @bachya
+homeassistant/components/sensor/qnap.py @colinodell
 homeassistant/components/sensor/sytadin.py @gautric
 homeassistant/components/sensor/sql.py @dgomes
 homeassistant/components/sensor/tibber.py @danielhiversen

--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['qnapstats==0.2.4']
+REQUIREMENTS = ['qnapstats==0.2.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1054,7 +1054,7 @@ pyxeoma==1.4.0
 pyzabbix==0.7.4
 
 # homeassistant.components.sensor.qnap
-qnapstats==0.2.4
+qnapstats==0.2.5
 
 # homeassistant.components.switch.rachio
 rachiopy==0.1.2


### PR DESCRIPTION
## Description:

This bumps the requirement of qnapstats from version 0.2.4 to 0.2.5.  Also adds me to `CODEOWNERS` for the qnap sensor.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] ~~New~~ Existing dependencies have been ~~added to~~ updated in the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] ~~New~~ Existing dependencies have been ~~added to~~ updated in `requirements_all.txt` ~~by running `script/gen_requirements_all.py`~~ manually.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
