### PR TITLE
Removed the google home warning from emulated_hue

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -158,10 +158,6 @@ class Config(object):
                 "Listen port not specified, defaulting to %s",
                 self.listen_port)
 
-        if self.type == TYPE_GOOGLE and self.listen_port != 80:
-            _LOGGER.warning("When targeting Google Home, listening port has "
-                            "to be port 80")
-
         # Get whether or not UPNP binds to multicast address (239.255.255.250)
         # or to the unicast address (host_ip_addr)
         self.upnp_bind_multicast = conf.get(

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -112,17 +112,3 @@ def test_config_alexa_entity_id_to_number():
 
     entity_id = conf.number_to_entity_id('light.test')
     assert entity_id == 'light.test'
-
-
-def test_warning_config_google_home_listen_port():
-    """Test we warn when non-default port is used for Google Home."""
-    with patch.object(_LOGGER, 'warning') as mock_warn:
-        Config(None, {
-            'type': 'google_home',
-            'host_ip': '123.123.123.123',
-            'listen_port': 8300
-        })
-
-        assert mock_warn.called
-        assert mock_warn.mock_calls[0][1][0] == \
-            "When targeting Google Home, listening port has to be port 80"

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -3,7 +3,7 @@ import json
 
 from unittest.mock import patch, Mock, mock_open
 
-from homeassistant.components.emulated_hue import Config, _LOGGER
+from homeassistant.components.emulated_hue import Config
 
 
 def test_config_google_home_entity_id_to_number():


### PR DESCRIPTION
## Description:

I've removed the warning that says: "When targeting google home you must use port 80" or something similar because, frankly, it's the most annoying thing that every time I reboot I have to see it, and it's completely pointless for the following reasons:

1 - It is **abundantly** clear in the docs that this is the case
2 - According to the docs, 'new' google_home users can't use emulated_hue anyway.
3 - 'Old' google_home users have surely got their settings right by now
4 - According to the docs the 'alexa' type is deprecated, which means that EVERYONE who is running an alexa device is getting this warning on every restart,
5 - I know I could just ignore the warning, but it's annoying and as per the reaons above, completely pointless.

Ta