### PR TITLE
Tradfri v5 - unique_id's and color_temp support on rgb bulbs

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -250,7 +250,7 @@ class TradfriLight(Light):
             elif temp < self.min_mireds:
                 temp = self.min_mireds
 
-            if brightness is not None:
+            if brightness is None:
                 params[ATTR_TRANSITION_TIME] = transition_time
             await self._api(
                 self._light_control.set_color_temp(temp,

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -232,7 +232,7 @@ class TradfriLight(Light):
         """RGB colour of the light."""
         if self._light_data.xy_color:
             dimmer = self._light_data.dimmer
-            xyb = denormalize_xy(*self._light_data.xy_color) + dimmer
+            xyb = denormalize_xy(*self._light_data.xy_color) + tuple(dimmer)
             return color_util.color_xy_brightness_to_RGB(*xyb)
 
     @asyncio.coroutine

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -219,9 +219,7 @@ class TradfriLight(Light):
         await self._api(self._light_control.set_state(False))
 
     async def async_turn_on(self, **kwargs):
-        """
-        Instruct the light to turn on.
-        """
+        """Instruct the light to turn on."""
         params = {}
         if ATTR_TRANSITION in kwargs:
             params[ATTR_TRANSITION_TIME] = int(kwargs[ATTR_TRANSITION]) * 10

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -224,7 +224,8 @@ class TradfriLight(Light):
     @property
     def xy_color(self):
         """XY colour of the light."""
-        return denormalize_xy(*self._light_data.xy_color)
+        if self._light_data.xy_color:
+            return denormalize_xy(*self._light_data.xy_color)
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -28,6 +28,16 @@ TRADFRI_LIGHT_MANAGER = 'Tradfri Light Manager'
 SUPPORTED_FEATURES = (SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION)
 
 
+def normalize_xy(x, y, brightness=None):
+    """Normalise XY to Tradfri scaling."""
+    return (int(x*65535+0.5), int(y*65535+0.5))
+
+
+def denormalize_xy(x, y, brightness=None):
+    """Denormalise XY from Tradfri scaling."""
+    return (int(x/65535-0.5), int(y/65535-0.5))
+
+
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the IKEA Tradfri Light platform."""
@@ -213,17 +223,13 @@ class TradfriLight(Light):
 
     @property
     def xy_color(self):
-        """XY color of the light."""
-        return self._light_data.xy_color
+        """XY colour of the light."""
+        return denormalize_xy(*self._light_data.xy_color)
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):
         """Instruct the light to turn off."""
         yield from self._api(self._light_control.set_state(False))
-
-    def normalize_xy(x, y):
-        """Normalise XY to Tradfri scaling."""
-        return (int(x*65535+0.5), int(y*65535+0.5))
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -209,12 +209,12 @@ class TradfriLight(Light):
     @property
     def hs_color(self):
         """HS color of the light."""
-        hsbxy = self._light_data.hsb_xy_color
-        hue = hsbxy[0] / (65535 / 360)
-        sat = hsbxy[1] / (65279 / 100)
-        if self._light_control.can_set_color \
-                and hue is not None and sat is not None:
-            return hue, sat
+        if self._light_control.can_set_color:
+            hsbxy = self._light_data.hsb_xy_color
+            hue = hsbxy[0] / (65535 / 360)
+            sat = hsbxy[1] / (65279 / 100)
+            if hue is not None and sat is not None:
+                return hue, sat
 
     async def async_turn_off(self, **kwargs):
         """Instruct the light to turn off."""

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -280,9 +280,15 @@ class TradfriLight(Light):
         self._name = light.name
         self._features = SUPPORTED_FEATURES
 
-        if self._light_control.can_set_mireds:
+        if 'WS' in light.device_info.model_number:
+            self.can_set_temp = True
+
+        if 'CWS' in light.device_info.model_number:
+            self.can_set_color = True
+
+        if self.can_set_temp:
             self._features |= SUPPORT_COLOR_TEMP
-        if self._light_control.can_set_color:
+        if self.can_set_color:
             self._features |= SUPPORT_COLOR
 
     @callback

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -232,8 +232,8 @@ class TradfriLight(Light):
         if brightness is not None:
             if brightness > 254:
                 brightness = 254
-            elif brightness < 1:
-                brightness = 1
+            elif brightness < 0:
+                brightness = 0
 
         if ATTR_HS_COLOR in kwargs and self._light_control.can_set_color:
             params[ATTR_BRIGHTNESS] = brightness

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -212,7 +212,10 @@ class TradfriLight(Light):
         hsbxy = self._light_data.hsb_xy_color
         hue = hsbxy[0]
         sat = hsbxy[1]
-        return hue, sat
+        if hue is not None and sat is not None:
+            return hue, sat
+        else:
+            return
 
     async def async_turn_off(self, **kwargs):
         """Instruct the light to turn off."""

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -35,7 +35,7 @@ def normalize_xy(argx, argy, brightness=None):
 
 def denormalize_xy(argx, argy, brightness=None):
     """Denormalise XY from Tradfri scaling."""
-    return (int(argx/65535-0.5), int(argy/65535-0.5))
+    return (argx/65535-0.5, argy/65535-0.5)
 
 
 @asyncio.coroutine
@@ -226,6 +226,14 @@ class TradfriLight(Light):
         """XY colour of the light."""
         if self._light_data.xy_color:
             return denormalize_xy(*self._light_data.xy_color)
+
+    @property
+    def rgb_color(self):
+        """RGB colour of the light."""
+        if self._light_data.xy_color:
+            dimmer = self._light_data.dimmer
+            xyb = denormalize_xy(*self._light_data.xy_color).append(dimmer)
+            return color_util.color_xy_brightness_to_RGB(*xyb)
 
     @asyncio.coroutine
     def async_turn_off(self, **kwargs):

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -221,6 +221,10 @@ class TradfriLight(Light):
         """Instruct the light to turn off."""
         yield from self._api(self._light_control.set_state(False))
 
+    def normalize_xy(x, y):
+        """Normalise XY to Tradfri scaling."""
+        return (int(x*65535+0.5), int(y*65535+0.5))
+
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Instruct the light to turn on."""
@@ -234,18 +238,17 @@ class TradfriLight(Light):
             if brightness is not None:
                 params.pop(ATTR_TRANSITION_TIME, None)
             yield from self._api(
-                self._light_control.set_xy_color(*kwargs[ATTR_XY_COLOR],
+                self._light_control.set_xy_color(*normalize_xy(
+                                                    *kwargs[ATTR_XY_COLOR]),
                                                  **params))
-
-        if ATTR_RGB_COLOR in kwargs:
+        elif ATTR_RGB_COLOR in kwargs:
             if brightness is not None:
                 params.pop(ATTR_TRANSITION_TIME, None)
             xy = color_util.color_RGB_to_xy(*kwargs[ATTR_RGB_COLOR])
             yield from self._api(
-                self._light_control.set_xy_color(xy[0], xy[1],
+                self._light_control.set_xy_color(*normalize_xy(xy[0], xy[1]),
                                                  **params))
-
-        if ATTR_COLOR_TEMP in kwargs:
+        elif ATTR_COLOR_TEMP in kwargs:
             if brightness is not None:
                 params.pop(ATTR_TRANSITION_TIME, None)
             yield from self._api(

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -281,15 +281,9 @@ class TradfriLight(Light):
         self._features = SUPPORTED_FEATURES
 
         if 'WS' in light.device_info.model_number:
-            self.can_set_temp = True
-
-        if 'CWS' in light.device_info.model_number:
-            self.can_set_color = True
-
-        if self.can_set_temp:
-            self._features |= SUPPORT_COLOR_TEMP
-        if self.can_set_color:
             self._features |= SUPPORT_COLOR
+        if 'CWS' in light.device_info.model_number:
+            self._features |= SUPPORT_COLOR_TEMP
 
     @callback
     def _observe_update(self, tradfri_device):

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -230,8 +230,6 @@ class TradfriLight(Light):
 
         brightness = kwargs.get(ATTR_BRIGHTNESS)
 
-        action = False
-
         if ATTR_XY_COLOR in kwargs:
             if brightness is not None:
                 params.pop(ATTR_TRANSITION_TIME, None)
@@ -244,7 +242,7 @@ class TradfriLight(Light):
                 params.pop(ATTR_TRANSITION_TIME, None)
             xy = color_util.color_RGB_to_xy(*kwargs[ATTR_RGB_COLOR])
             yield from self._api(
-                self._light_control.set_xy_color(xy[0], xy[1]
+                self._light_control.set_xy_color(xy[0], xy[1],
                                                  **params))
 
         if ATTR_COLOR_TEMP in kwargs:

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -230,7 +230,7 @@ class TradfriLight(Light):
             if brightness == 255:
                 brightness = 254
 
-        if ATTR_HS_COLOR in kwargs and self._light_data.hex_color is not None:
+        if ATTR_HS_COLOR in kwargs:
             params[ATTR_BRIGHTNESS] = brightness
             await self._api(
                 self._light_control.set_hsb(*kwargs[ATTR_HS_COLOR], **params))

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -249,8 +249,6 @@ class TradfriLight(Light):
             elif temp < self.min_mireds:
                 temp = self.min_mireds
 
-            if brightness is not None:
-                params.pop(ATTR_TRANSITION_TIME, None)
             await self._api(
                 self._light_control.set_color_temp(temp,
                                                    **params))

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -226,6 +226,10 @@ class TradfriLight(Light):
 
         brightness = kwargs.get(ATTR_BRIGHTNESS)
 
+        if brightness is not None:
+            if brightness == 255:
+                brightness = 254
+
         if ATTR_HS_COLOR in kwargs and self._light_data.hex_color is not None:
             params[ATTR_BRIGHTNESS] = brightness
             await self._api(
@@ -240,9 +244,6 @@ class TradfriLight(Light):
                                                    **params))
 
         if brightness is not None:
-            if brightness == 255:
-                brightness = 254
-
             await self._api(
                 self._light_control.set_dimmer(brightness,
                                                **params))

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -160,12 +160,12 @@ class TradfriLight(Light):
     @property
     def min_mireds(self):
         """Return the coldest color_temp that this light supports."""
-        return 250
+        return self._light_control.min_mireds
 
     @property
     def max_mireds(self):
         """Return the warmest color_temp that this light supports."""
-        return 454
+        return self._light_control.max_mireds
 
     async def async_added_to_hass(self):
         """Start thread when added to hass."""
@@ -212,7 +212,8 @@ class TradfriLight(Light):
         hsbxy = self._light_data.hsb_xy_color
         hue = hsbxy[0]
         sat = hsbxy[1]
-        if hue is not None and sat is not None:
+        if self._light_control.can_set_color \
+                and hue is not None and sat is not None:
             return hue, sat
         else:
             return
@@ -239,7 +240,7 @@ class TradfriLight(Light):
                 self._light_control.set_hsb(*kwargs[ATTR_HS_COLOR], **params))
             return
 
-        elif ATTR_COLOR_TEMP in kwargs:
+        if ATTR_COLOR_TEMP in kwargs:
             if brightness is not None:
                 params.pop(ATTR_TRANSITION_TIME, None)
             await self._api(
@@ -283,9 +284,9 @@ class TradfriLight(Light):
         self._name = light.name
         self._features = SUPPORTED_FEATURES
 
-        if 'CWS' in light.device_info.model_number:
+        if light.light_control.can_set_color:
             self._features |= SUPPORT_COLOR
-        if 'WS' in light.device_info.model_number:
+        if light.light_control.can_set_temp:
             self._features |= SUPPORT_COLOR_TEMP
 
     @callback

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -228,10 +228,11 @@ class TradfriLight(Light):
 
         brightness = kwargs.get(ATTR_BRIGHTNESS)
 
-        # Ensure brightness isn't higher than the gateway accepts.
         if brightness is not None:
-            if brightness == 255:
+            if brightness > 254:
                 brightness = 254
+            elif brightness < 1:
+                brightness = 1
 
         if ATTR_HS_COLOR in kwargs and self._light_control.can_set_color:
             params[ATTR_BRIGHTNESS] = brightness

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -223,8 +223,9 @@ class TradfriLight(Light):
     async def async_turn_on(self, **kwargs):
         """Instruct the light to turn on."""
         params = {}
+        transition_time = None
         if ATTR_TRANSITION in kwargs:
-            params[ATTR_TRANSITION_TIME] = int(kwargs[ATTR_TRANSITION]) * 10
+            transition_time = int(kwargs[ATTR_TRANSITION]) * 10
 
         brightness = kwargs.get(ATTR_BRIGHTNESS)
 
@@ -249,11 +250,14 @@ class TradfriLight(Light):
             elif temp < self.min_mireds:
                 temp = self.min_mireds
 
+            if brightness is not None:
+                params[ATTR_TRANSITION_TIME] = transition_time
             await self._api(
                 self._light_control.set_color_temp(temp,
                                                    **params))
 
         if brightness is not None:
+            params[ATTR_TRANSITION_TIME] = transition_time
             await self._api(
                 self._light_control.set_dimmer(brightness,
                                                **params))

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -160,12 +160,12 @@ class TradfriLight(Light):
     @property
     def min_mireds(self):
         """Return the coldest color_temp that this light supports."""
-        return self._light_control.min_mireds
+        return 250
 
     @property
     def max_mireds(self):
         """Return the warmest color_temp that this light supports."""
-        return self._light_control.max_mireds
+        return 454
 
     async def async_added_to_hass(self):
         """Start thread when added to hass."""
@@ -203,7 +203,7 @@ class TradfriLight(Light):
 
     @property
     def color_temp(self):
-        """Return the CT color value in mireds."""
+        """Return the color temp value in mireds."""
         return self._light_data.color_temp
 
     @property

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -283,9 +283,9 @@ class TradfriLight(Light):
         self._name = light.name
         self._features = SUPPORTED_FEATURES
 
-        if 'WS' in light.device_info.model_number:
-            self._features |= SUPPORT_COLOR
         if 'CWS' in light.device_info.model_number:
+            self._features |= SUPPORT_COLOR
+        if 'WS' in light.device_info.model_number:
             self._features |= SUPPORT_COLOR_TEMP
 
     @callback

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -242,10 +242,16 @@ class TradfriLight(Light):
             return
 
         if ATTR_COLOR_TEMP in kwargs and self._light_control.can_set_temp:
+            temp = kwargs[ATTR_COLOR_TEMP]
+            if temp > self.max_mireds:
+                temp = self.max_mireds
+            elif temp < self.min_mireds:
+                temp = self.min_mireds
+
             if brightness is not None:
                 params.pop(ATTR_TRANSITION_TIME, None)
             await self._api(
-                self._light_control.set_color_temp(kwargs[ATTR_COLOR_TEMP],
+                self._light_control.set_color_temp(temp,
                                                    **params))
 
         if brightness is not None:

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -28,14 +28,14 @@ TRADFRI_LIGHT_MANAGER = 'Tradfri Light Manager'
 SUPPORTED_FEATURES = (SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION)
 
 
-def normalize_xy(x, y, brightness=None):
+def normalize_xy(argx, argy, brightness=None):
     """Normalise XY to Tradfri scaling."""
-    return (int(x*65535+0.5), int(y*65535+0.5))
+    return (int(argx*65535+0.5), int(argy*65535+0.5))
 
 
-def denormalize_xy(x, y, brightness=None):
+def denormalize_xy(argx, argy, brightness=None):
     """Denormalise XY from Tradfri scaling."""
-    return (int(x/65535-0.5), int(y/65535-0.5))
+    return (int(argx/65535-0.5), int(argy/65535-0.5))
 
 
 @asyncio.coroutine
@@ -245,14 +245,14 @@ class TradfriLight(Light):
                 params.pop(ATTR_TRANSITION_TIME, None)
             yield from self._api(
                 self._light_control.set_xy_color(*normalize_xy(
-                                                    *kwargs[ATTR_XY_COLOR]),
-                                                 **params))
+                    *kwargs[ATTR_XY_COLOR]), **params))
         elif ATTR_RGB_COLOR in kwargs:
             if brightness is not None:
                 params.pop(ATTR_TRANSITION_TIME, None)
-            xy = color_util.color_RGB_to_xy(*kwargs[ATTR_RGB_COLOR])
+            argxy = color_util.color_RGB_to_xy(*kwargs[ATTR_RGB_COLOR])
             yield from self._api(
-                self._light_control.set_xy_color(*normalize_xy(xy[0], xy[1]),
+                self._light_control.set_xy_color(*normalize_xy(argxy[0],
+                                                               argxy[1]),
                                                  **params))
         elif ATTR_COLOR_TEMP in kwargs:
             if brightness is not None:

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -231,8 +231,8 @@ class TradfriLight(Light):
     def rgb_color(self):
         """RGB colour of the light."""
         if self._light_data.xy_color:
-            dimmer = self._light_data.dimmer
-            xyb = denormalize_xy(*self._light_data.xy_color) + tuple(dimmer)
+            dimmer = self._light_data.dimmer,
+            xyb = denormalize_xy(*self._light_data.xy_color) + dimmer
             return color_util.color_xy_brightness_to_RGB(*xyb)
 
     @asyncio.coroutine

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -232,7 +232,7 @@ class TradfriLight(Light):
         """RGB colour of the light."""
         if self._light_data.xy_color:
             dimmer = self._light_data.dimmer
-            xyb = denormalize_xy(*self._light_data.xy_color).append(dimmer)
+            xyb = denormalize_xy(*self._light_data.xy_color) + dimmer
             return color_util.color_xy_brightness_to_RGB(*xyb)
 
     @asyncio.coroutine

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -226,7 +226,7 @@ class TradfriLight(Light):
     def rgb_color(self):
         """RGB colour of the light."""
         if self._light_data.xy_color and self._light_control.can_set_color:
-            dimmer = self._light_data.dimmer,
+            dimmer = self._light_data.dimmer
             xyb = denormalize_xy(*self._light_data.xy_color) + dimmer
             return color_util.color_xy_brightness_to_RGB(*xyb)
 

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -30,12 +30,12 @@ SUPPORTED_FEATURES = (SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION)
 
 def normalize_xy(argx, argy, brightness=None):
     """Normalise XY to Tradfri scaling."""
-    return (int(argx*65535+0.5), int(argy*65535+0.5))
+    return (int(argx*65535+0.56), int(argy*65535+0.56))
 
 
 def denormalize_xy(argx, argy, brightness=None):
     """Denormalise XY from Tradfri scaling."""
-    return (argx/65535-0.5, argy/65535-0.5)
+    return (argx/65535-0.56, argy/65535-0.56)
 
 
 @asyncio.coroutine
@@ -224,7 +224,7 @@ class TradfriLight(Light):
     @property
     def xy_color(self):
         """XY colour of the light."""
-        if self._light_data.xy_color:
+        if self._light_data.xy_color and self._light_control.can_set_color:
             return denormalize_xy(*self._light_data.xy_color)
 
     @property

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -276,8 +276,8 @@ class TradfriLight(Light):
             # (It can set temp, but we need to set with hsb)
             if self._light_control.can_set_color:
                 params[ATTR_BRIGHTNESS] = brightness
-                temp_K = color_util.color_temperature_mired_to_kelvin(temp)
-                hs_color = color_util.color_temperature_to_hs(temp_K)
+                temp_k = color_util.color_temperature_mired_to_kelvin(temp)
+                hs_color = color_util.color_temperature_to_hs(temp_k)
                 hue = int(hs_color[0] * (65535 / 360))
                 sat = int(hs_color[1] * (65279 / 100))
                 await self._api(

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -230,7 +230,7 @@ class TradfriLight(Light):
     @property
     def rgb_color(self):
         """RGB colour of the light."""
-        if self._light_data.xy_color:
+        if self._light_data.xy_color and self._light_control.can_set_color:
             dimmer = self._light_data.dimmer,
             xyb = denormalize_xy(*self._light_data.xy_color) + dimmer
             return color_util.color_xy_brightness_to_RGB(*xyb)

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.components.discovery import SERVICE_IKEA_TRADFRI
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['pytradfri[async]==5.4.1']
+REQUIREMENTS = ['pytradfri[async]==5.4.2']
 
 DOMAIN = 'tradfri'
 GATEWAY_IDENTITY = 'homeassistant'

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.components.discovery import SERVICE_IKEA_TRADFRI
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['pytradfri[async]==5.4.2']
+REQUIREMENTS = ['pytradfri[async]==5.4.0']
 
 DOMAIN = 'tradfri'
 GATEWAY_IDENTITY = 'homeassistant'

--- a/homeassistant/components/tradfri.py
+++ b/homeassistant/components/tradfri.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.components.discovery import SERVICE_IKEA_TRADFRI
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['pytradfri[async]==5.4.0']
+REQUIREMENTS = ['pytradfri[async]==5.4.1']
 
 DOMAIN = 'tradfri'
 GATEWAY_IDENTITY = 'homeassistant'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1022,7 +1022,7 @@ pytouchline==0.7
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-pytradfri[async]==5.4.0
+pytradfri[async]==5.4.1
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1022,7 +1022,7 @@ pytouchline==0.7
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-pytradfri[async]==5.4.1
+pytradfri[async]==5.4.2
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ pip>=8.0.3
 jinja2>=2.10
 voluptuous==0.11.1
 typing>=3,<4
-aiohttp==3.1.1
+aiohttp==3.0.9
 async_timeout==2.0.1
 astral==1.6
 certifi>=2017.4.17
@@ -74,7 +74,7 @@ aiodns==1.1.1
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.3.0
+aiohue==1.2.0
 
 # homeassistant.components.sensor.imap
 aioimaplib==0.7.13
@@ -137,7 +137,7 @@ beautifulsoup4==4.6.0
 bellows==0.5.1
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.5.0
+bimmer_connected==0.4.1
 
 # homeassistant.components.blink
 blinkpy==0.6.0
@@ -356,7 +356,7 @@ hipnotify==1.0.8
 holidays==0.9.4
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180326.0
+home-assistant-frontend==20180316.0
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.8
@@ -430,10 +430,10 @@ jsonrpc-async==0.6
 jsonrpc-websocket==0.6
 
 # homeassistant.scripts.keyring
-keyring==12.0.0
+keyring==11.0.0
 
 # homeassistant.scripts.keyring
-keyrings.alt==3.0
+keyrings.alt==2.3
 
 # homeassistant.components.device_tracker.owntracks
 # homeassistant.components.device_tracker.owntracks_http
@@ -685,7 +685,7 @@ pybbox==0.0.5-alpha
 pychannels==1.0.0
 
 # homeassistant.components.media_player.cast
-pychromecast==2.1.0
+pychromecast==2.0.0
 
 # homeassistant.components.media_player.cmus
 pycmus==0.1.0
@@ -804,7 +804,7 @@ pylutron==0.1.0
 pymailgunner==1.4
 
 # homeassistant.components.media_player.mediaroom
-pymediaroom==0.6
+pymediaroom==0.5
 
 # homeassistant.components.media_player.xiaomi_tv
 pymitv==1.0.0
@@ -860,7 +860,7 @@ pyowm==2.8.0
 pypollencom==1.1.1
 
 # homeassistant.components.qwikswitch
-pyqwikswitch==0.5
+pyqwikswitch==0.4
 
 # homeassistant.components.rainbird
 pyrainbird==0.1.3
@@ -948,14 +948,14 @@ python-juicenet==0.0.5
 # homeassistant.components.sensor.xiaomi_miio
 # homeassistant.components.switch.xiaomi_miio
 # homeassistant.components.vacuum.xiaomi_miio
-python-miio==0.3.9
+python-miio==0.3.8
 
 # homeassistant.components.media_player.mpd
 python-mpd2==0.5.5
 
 # homeassistant.components.light.mystrom
 # homeassistant.components.switch.mystrom
-python-mystrom==0.4.2
+python-mystrom==0.3.8
 
 # homeassistant.components.nest
 python-nest==3.7.0
@@ -976,7 +976,7 @@ python-roku==3.1.5
 python-sochain-api==0.0.2
 
 # homeassistant.components.media_player.songpal
-python-songpal==0.0.7
+python-songpal==0.0.6
 
 # homeassistant.components.sensor.synologydsm
 python-synology==0.1.0
@@ -1006,7 +1006,8 @@ python_opendata_transport==0.0.3
 python_openzwave==0.4.3
 
 # homeassistant.components.egardia
-pythonegardia==1.0.39
+# homeassistant.components.alarm_control_panel.egardia
+pythonegardia==1.0.38
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3
@@ -1021,7 +1022,7 @@ pytouchline==0.7
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-pytradfri[async]==5.4.2
+pytradfri[async]==5.4.0
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13
@@ -1048,13 +1049,13 @@ pywebpush==1.6.0
 pywemo==0.4.25
 
 # homeassistant.components.camera.xeoma
-pyxeoma==1.4.0
+pyxeoma==1.3
 
 # homeassistant.components.zabbix
 pyzabbix==0.7.4
 
 # homeassistant.components.sensor.qnap
-qnapstats==0.2.5
+qnapstats==0.2.4
 
 # homeassistant.components.switch.rachio
 rachiopy==0.1.2
@@ -1136,7 +1137,7 @@ simplisafe-python==1.0.5
 skybellpy==0.1.1
 
 # homeassistant.components.notify.slack
-slacker==0.9.65
+slacker==0.9.60
 
 # homeassistant.components.notify.xmpp
 sleekxmpp==1.3.2
@@ -1218,7 +1219,7 @@ todoist-python==7.0.17
 toonlib==1.0.2
 
 # homeassistant.components.alarm_control_panel.totalconnect
-total_connect_client==0.17
+total_connect_client==0.16
 
 # homeassistant.components.sensor.transmission
 # homeassistant.components.switch.transmission
@@ -1307,7 +1308,7 @@ yahooweather==0.10
 yeelight==0.4.0
 
 # homeassistant.components.light.yeelightsunflower
-yeelightsunflower==0.0.10
+yeelightsunflower==0.0.8
 
 # homeassistant.components.media_extractor
 youtube_dl==2018.03.10


### PR DESCRIPTION
## This PR depends on #11187 getting merged first. (it's currently based on that branch.) Once that is merged I'll change the target-branch to dev.

## Description:
### unique_ids for lights and light groups:
These are based on the gateway_id and the group/light id. The group/light id's can change when users re-pair their devices, or when users reset their gateway to factory defaults.
This is the best we can currently get on this platform.
Unfortunately tradfri doesn't expose the serial numbers on their API (while they do for thier Homekit integration)

### setting color temperature on a color/rgb bulb:
Unfortunately the CWS (color white spectrum) bulbs don't react to setting their color_temperature value. So we need to convert the color_temperature to hs(b) and set that with set_hsb.
This solves a feature regression compared to the previous platform/library version.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass*