### PR TITLE
Add mastodon

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -508,6 +508,7 @@ omit =
     homeassistant/components/notify/kodi.py
     homeassistant/components/notify/lannouncer.py
     homeassistant/components/notify/llamalab_automate.py
+    homeassistant/components/notify/mastodon.py
     homeassistant/components/notify/matrix.py
     homeassistant/components/notify/message_bird.py
     homeassistant/components/notify/mycroft.py
@@ -523,8 +524,8 @@ omit =
     homeassistant/components/notify/sendgrid.py
     homeassistant/components/notify/simplepush.py
     homeassistant/components/notify/slack.py
-    homeassistant/components/notify/stride.py
     homeassistant/components/notify/smtp.py
+    homeassistant/components/notify/stride.py
     homeassistant/components/notify/synology_chat.py
     homeassistant/components/notify/syslog.py
     homeassistant/components/notify/telegram.py

--- a/homeassistant/components/notify/mastodon.py
+++ b/homeassistant/components/notify/mastodon.py
@@ -1,0 +1,70 @@
+"""
+Mastodon platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.mastodon/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.notify import (
+    PLATFORM_SCHEMA, BaseNotificationService)
+from homeassistant.const import CONF_ACCESS_TOKEN
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['Mastodon.py==1.2.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_BASE_URL = 'base_url'
+CONF_CLIENT_ID = 'client_id'
+CONF_CLIENT_SECRET = 'client_secret'
+
+DEFAULT_URL = 'https://mastodon.social'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ACCESS_TOKEN): cv.string,
+    vol.Required(CONF_CLIENT_ID): cv.string,
+    vol.Required(CONF_CLIENT_SECRET): cv.string,
+    vol.Optional(CONF_BASE_URL, default=DEFAULT_URL): cv.string,
+})
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the Mastodon notification service."""
+    from mastodon import Mastodon
+    from mastodon.Mastodon import MastodonUnauthorizedError
+
+    client_id = config.get(CONF_CLIENT_ID)
+    client_secret = config.get(CONF_CLIENT_SECRET)
+    access_token = config.get(CONF_ACCESS_TOKEN)
+    base_url = config.get(CONF_BASE_URL)
+
+    try:
+        mastodon = Mastodon(
+            client_id=client_id, client_secret=client_secret,
+            access_token=access_token, api_base_url=base_url)
+        mastodon.account_verify_credentials()
+    except MastodonUnauthorizedError:
+        _LOGGER.warning("Authentication failed")
+        return None
+
+    return MastodonNotificationService(mastodon)
+
+
+class MastodonNotificationService(BaseNotificationService):
+    """Implement the notification service for Mastodon."""
+
+    def __init__(self, api):
+        """Initialize the service."""
+        self._api = api
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to a user."""
+        from mastodon.Mastodon import MastodonAPIError
+
+        try:
+            self._api.toot(message)
+        except MastodonAPIError:
+            _LOGGER.error("Unable to send message")

--- a/homeassistant/components/notify/mastodon.py
+++ b/homeassistant/components/notify/mastodon.py
@@ -33,38 +33,41 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def get_service(hass, config, discovery_info=None):
     """Get the Mastodon notification service."""
-    from mastodon import Mastodon
-    from mastodon.Mastodon import MastodonUnauthorizedError
-
     client_id = config.get(CONF_CLIENT_ID)
     client_secret = config.get(CONF_CLIENT_SECRET)
     access_token = config.get(CONF_ACCESS_TOKEN)
     base_url = config.get(CONF_BASE_URL)
 
-    try:
-        mastodon = Mastodon(
-            client_id=client_id, client_secret=client_secret,
-            access_token=access_token, api_base_url=base_url)
-        mastodon.account_verify_credentials()
-    except MastodonUnauthorizedError:
-        _LOGGER.warning("Authentication failed")
-        return None
-
-    return MastodonNotificationService(mastodon)
+    return MastodonNotificationService(
+        client_id, client_secret, access_token, base_url)
 
 
 class MastodonNotificationService(BaseNotificationService):
     """Implement the notification service for Mastodon."""
 
-    def __init__(self, api):
+    def __init__(self, client_id, client_secret, access_token, base_url):
         """Initialize the service."""
-        self._api = api
+        from mastodon import Mastodon
+        from mastodon.Mastodon import MastodonUnauthorizedError
+
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._access_token = access_token
+        self._base_url = base_url
+
+        try:
+            self._mastodon = Mastodon(
+                client_id=self._client_id, client_secret=self._client_secret,
+                access_token=self._access_token, api_base_url=self._base_url)
+            self._mastodon.account_verify_credentials()
+        except MastodonUnauthorizedError:
+            _LOGGER.error("Authentication failed")
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
         from mastodon.Mastodon import MastodonAPIError
 
         try:
-            self._api.toot(message)
+            self._mastodon.toot(message)
         except MastodonAPIError:
             _LOGGER.error("Unable to send message")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -24,6 +24,9 @@ DoorBirdPy==0.1.3
 # homeassistant.components.homekit
 HAP-python==1.1.7
 
+# homeassistant.components.notify.mastodon
+Mastodon.py==1.2.2
+
 # homeassistant.components.isy994
 PyISY==1.1.0
 


### PR DESCRIPTION
## Description:
This notification platform uses [Mastodon](https://joinmastodon.org/) to deliver messages.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5010

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: mastodon
    name: mastodon
    access_token: !secret mastodon_access_token
    client_id: !secret mastodon_client_id
    client_secret: !secret mastodon_client_secret
```
Service data:

```json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"
}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
