### PR TITLE
Upgrade keyring to 12.0.0 and keyrings.alt to 3.0

### DIFF
--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -5,7 +5,7 @@ import os
 
 from homeassistant.util.yaml import _SECRET_NAMESPACE
 
-REQUIREMENTS = ['keyring==11.0.0', 'keyrings.alt==2.3']
+REQUIREMENTS = ['keyring==12.0.0', 'keyrings.alt==3.0']
 
 
 def run(args):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -430,10 +430,10 @@ jsonrpc-async==0.6
 jsonrpc-websocket==0.6
 
 # homeassistant.scripts.keyring
-keyring==11.0.0
+keyring==12.0.0
 
 # homeassistant.scripts.keyring
-keyrings.alt==2.3
+keyrings.alt==3.0
 
 # homeassistant.components.device_tracker.owntracks
 # homeassistant.components.device_tracker.owntracks_http


### PR DESCRIPTION
## Description:
### keyring

Changelog: https://github.com/jaraco/keyring/blob/master/CHANGES.rst#1200

### keyrings.alt

Changelog: https://github.com/jaraco/keyrings.alt/blob/master/CHANGES.rst#30

```bash
$ hass --script keyring --help
INFO:homeassistant.util.package:Attempting install of keyring==12.0.0
INFO:homeassistant.util.package:Attempting install of keyrings.alt==3.0
usage: hass [-h] [--script {keyring}] {get,set,del,info} [name]

Modify Home Assistant secrets in the default keyring. Use the secrets in
configuration files with: !secret <name>

positional arguments:
  {get,set,del,info}  Get, set or delete a secret
  name                Name of the secret

optional arguments:
  -h, --help          show this help message and exit
  --script {keyring}
```

## Checklist:
  - [x] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
