### PR TITLE
Add group.light as HomeKit light accessory

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -119,7 +119,7 @@ def get_accessory(hass, state, aid, config):
         return TYPES['Thermostat'](hass, state.entity_id,
                                    state.name, support_auto, aid=aid)
 
-    elif state.domain == 'light':
+    elif state.domain == 'light' or state.domain 'group.light':
         return TYPES['Light'](hass, state.entity_id, state.name, aid=aid)
 
     elif state.domain == 'switch' or state.domain == 'remote' \

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -119,7 +119,7 @@ def get_accessory(hass, state, aid, config):
         return TYPES['Thermostat'](hass, state.entity_id,
                                    state.name, support_auto, aid=aid)
 
-    elif state.domain == 'light' or state.domain 'group.light':
+    elif state.domain == 'light' or state.domain == 'group.light':
         return TYPES['Light'](hass, state.entity_id, state.name, aid=aid)
 
     elif state.domain == 'switch' or state.domain == 'remote' \


### PR DESCRIPTION
## Description:
This should add homekit support to the recently introduced [light group](https://www.home-assistant.io/components/light.group/). Tested locally, but I haven't set up a dev environment and performed tox tests etc. Hopefully the patch is simple enough to go through anyway?

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)