### PR TITLE
Add extra check for ESSID field in case there's a wired connection

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -98,7 +98,8 @@ class UnifiScanner(DeviceScanner):
         # Filter clients to provided SSID list
         if self._ssid_filter:
             clients = [client for client in clients
-                       if client['essid'] in self._ssid_filter]
+                       if 'essid' in client and
+                       client['essid'] in self._ssid_filter]
 
         self._clients = {
             client['mac']: client


### PR DESCRIPTION
## Description:
Unifi controller also manages non-wireless connections for which an `essid` field is not present. This will skip these hosts when an ssid filter is present.

**Related issue:** fixes #13366 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Entry for `configuration.yaml` :
```yaml
device_tracker:
  - platform: unifi
    username: admin
    password: xxx
    host: 192.168.1.10
    verify_ssl: false
    detection_time: 120
    ssid_filter:
      - 'xxx'
    new-device-defaults:
      track_new_devices: False
      hide_if_away: False
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
