### PR TITLE
Fix encoding errors in mikrotik device tracker

### DIFF
--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -73,7 +73,8 @@ class MikrotikScanner(DeviceScanner):
                 self.host,
                 self.username,
                 self.password,
-                port=int(self.port)
+                port=int(self.port),
+                encoding='utf-8'
             )
 
             try:


### PR DESCRIPTION
## Description:
This PR fixes a bug where devices and/or networks with non-ascii characters crash the mikrotik device tracker.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** no influence on docs

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: mikrotik
    host: 10.10.10.10
    username: homeassistant
    password: badpassword
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
