### PR TITLE
Hue: Convert XY to HS color if HS not present

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -244,20 +244,20 @@ class HueLight(Light):
 
         source = self.light.action if self.is_group else self.light.state
 
-        if mode == 'hs':
-            hue = source['hue']
-            sat = source['sat']
-        else:
-            # mode == xy
-            hue = source.get('hue')
-            sat = source.get('sat')
+        hue = source.get('hue')
+        sat = source.get('sat')
 
-            # Sometimes color mode xy will not include valid hue/sat values.
-            # Reported as issue 13434
-            if hue is None or sat is None:
-                hue, sat = color.color_xy_to_hs(*source.get('xy'))
+        # Sometimes the state will not include valid hue/sat values.
+        # Reported as issue 13434
+        if hue is not None and sat is not None:
+            return hue / 65535 * 360, sat / 255 * 100
 
-        return hue / 65535 * 360, sat / 255 * 100
+        if 'xy' not in source:
+            return None
+
+        return color.color_xy_to_hs(*source['xy'])
+
+
 
     @property
     def color_temp(self):

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -257,8 +257,6 @@ class HueLight(Light):
 
         return color.color_xy_to_hs(*source['xy'])
 
-
-
     @property
     def color_temp(self):
         """Return the CT color value."""

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -679,5 +679,4 @@ def test_hs_color():
         is_group=False,
     )
 
-    hue, sat = color.color_xy_to_hs(0.4, 0.5)
-    assert light.hs_color == (hue / 65535 * 360, sat / 255 * 100)
+    assert light.hs_color == color.color_xy_to_hs(0.4, 0.5)

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -11,6 +11,7 @@ import pytest
 
 from homeassistant.components import hue
 import homeassistant.components.light.hue as hue_light
+from homeassistant.util import color
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,7 +81,7 @@ LIGHT_1_ON = {
         "ct": 467,
         "alert": "none",
         "effect": "none",
-        "colormode": "xy",
+        "colormode": "hs",
         "reachable": True
     },
     "type": "Extended color light",
@@ -623,3 +624,60 @@ def test_available():
     )
 
     assert light.available is True
+
+
+def test_hs_color():
+    """Test hs_color property."""
+    light = hue_light.HueLight(
+        light=Mock(state={
+            'colormode': 'ct',
+            'hue': 1234,
+            'sat': 123,
+        }),
+        request_bridge_update=None,
+        bridge=Mock(),
+        is_group=False,
+    )
+
+    assert light.hs_color is None
+
+    light = hue_light.HueLight(
+        light=Mock(state={
+            'colormode': 'hs',
+            'hue': 1234,
+            'sat': 123,
+        }),
+        request_bridge_update=None,
+        bridge=Mock(),
+        is_group=False,
+    )
+
+    assert light.hs_color == (1234 / 65535 * 360, 123 / 255 * 100)
+
+    light = hue_light.HueLight(
+        light=Mock(state={
+            'colormode': 'xy',
+            'hue': 1234,
+            'sat': 123,
+        }),
+        request_bridge_update=None,
+        bridge=Mock(),
+        is_group=False,
+    )
+
+    assert light.hs_color == (1234 / 65535 * 360, 123 / 255 * 100)
+
+    light = hue_light.HueLight(
+        light=Mock(state={
+            'colormode': 'xy',
+            'hue': None,
+            'sat': 123,
+            'xy': [0.4, 0.5]
+        }),
+        request_bridge_update=None,
+        bridge=Mock(),
+        is_group=False,
+    )
+
+    hue, sat = color.color_xy_to_hs(0.4, 0.5)
+    assert light.hs_color == (hue / 65535 * 360, sat / 255 * 100)

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -81,7 +81,7 @@ LIGHT_1_ON = {
         "ct": 467,
         "alert": "none",
         "effect": "none",
-        "colormode": "hs",
+        "colormode": "xy",
         "reachable": True
     },
     "type": "Extended color light",


### PR DESCRIPTION
## Description:
In #13434 we got a report of the Hue/Sat color not being available in the light state and getting an exception trying to divide None by 365 inside the `hs_color` property for Hue lights.

I am not 100% sure in which color mode this can happen. Hue has 3 color modes and so I made the code more robust. 

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/13434

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
