### PR TITLE
Added gogogate2 cover

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -357,6 +357,7 @@ omit =
     homeassistant/components/climate/touchline.py
     homeassistant/components/climate/venstar.py
     homeassistant/components/cover/garadget.py
+    homeassistant/components/cover/gogogate2.py
     homeassistant/components/cover/homematic.py
     homeassistant/components/cover/knx.py
     homeassistant/components/cover/myq.py

--- a/homeassistant/components/cover/gogogate2.py
+++ b/homeassistant/components/cover/gogogate2.py
@@ -10,8 +10,8 @@ import voluptuous as vol
 
 from homeassistant.components.cover import CoverDevice
 from homeassistant.const import (
-    CONF_USERNAME, CONF_PASSWORD, STATE_CLOSED, STATE_OPEN, STATE_UNAVAILABLE,
-    CONF_IP_ADDRESS, CONF_API_KEY)
+    CONF_USERNAME, CONF_PASSWORD, STATE_CLOSED, STATE_UNAVAILABLE,
+    CONF_IP_ADDRESS, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pygogogate2==0.0.2']
@@ -47,7 +47,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             raise ValueError(
                 "Username or Password is incorrect or no devices found")
 
-        add_devices(MyGogogate2Device(mygogogate2, door, name) for door in devices)
+        add_devices(MyGogogate2Device(
+            mygogogate2, door, name) for door in devices)
         return
 
     except (TypeError, KeyError, NameError, ValueError) as ex:

--- a/homeassistant/components/cover/gogogate2.py
+++ b/homeassistant/components/cover/gogogate2.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.components.cover import CoverDevice
 from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD, STATE_CLOSED, STATE_UNKNOWN,
-    CONF_IP_ADDRESS, CONF_NAME)
+    CONF_IP_ADDRESS, CONF_NAME, SUPPORT_OPEN, SUPPORT_CLOSE)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pygogogate2==0.0.3']
@@ -97,7 +97,7 @@ class MyGogogate2Device(CoverDevice):
     def available(self):
         """Could the device be accessed during the last update call."""
         return self.available
-    
+
     def close_cover(self, **kwargs):
         """Issue close command to cover."""
         self.mygogogate2.close_device(self.device_id)

--- a/homeassistant/components/cover/gogogate2.py
+++ b/homeassistant/components/cover/gogogate2.py
@@ -1,0 +1,99 @@
+"""
+Support for Gogogate2 Garage Doors.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/cover.gogogate2/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.cover import CoverDevice
+from homeassistant.const import (
+    CONF_USERNAME, CONF_PASSWORD, STATE_CLOSED, CONF_IP_ADDRESS, CONF_API_KEY)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pygogogate2==0.0.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'gogogate2'
+
+NOTIFICATION_ID = 'gogogate2_notification'
+NOTIFICATION_TITLE = 'Gogogate2 Cover Setup'
+
+COVER_SCHEMA = vol.Schema({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Required(CONF_IP_ADDRESS): cv.string,
+    vol.Optional(CONF_API_KEY): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Gogogate2 component."""
+    from pygogogate2 import Gogogate2API as pygogogate2
+
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    ip_address = config.get(CONF_IP_ADDRESS)
+    api_key = config.get(CONF_API_KEY)
+    mygogogate2 = pygogogate2(username, password, ip_address, api_key)
+
+    try:
+        devices = mygogogate2.get_devices()
+        if devices == False:
+            raise ValueError("Username or Password is incorrect or no devices found")
+
+        add_devices(MyGogogate2Device(mygogogate2, door) for door in devices)
+        return True
+
+    except (TypeError, KeyError, NameError, ValueError) as ex:
+        _LOGGER.error("%s", ex)
+        hass.components.persistent_notification.create(
+            'Error: {}<br />'
+            'You will need to restart hass after fixing.'
+            ''.format(ex),
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID)
+        return False
+
+
+class MyGogogate2Device(CoverDevice):
+    """Representation of a Gogogate2 cover."""
+
+    def __init__(self, mygogogate2, device):
+        """Initialize with API object, device id."""
+        self.mygogogate2 = mygogogate2
+        self.device_id = device['door']
+        self._name = device['name']
+        self._status = STATE_CLOSED
+
+    @property
+    def should_poll(self):
+        """Poll for state."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the garage door if any."""
+        return self._name if self._name else DEFAULT_NAME
+
+    @property
+    def is_closed(self):
+        """Return true if cover is closed, else False."""
+        return self._status == STATE_CLOSED
+
+    def close_cover(self, **kwargs):
+        """Issue close command to cover."""
+        self.mygogogate2.close_device(self.device_id)
+        self.schedule_update_ha_state(True)
+
+    def open_cover(self, **kwargs):
+        """Issue open command to cover."""
+        self.mygogogate2.open_device(self.device_id)
+        self.schedule_update_ha_state(True)
+
+    def update(self):
+        """Update status of cover."""
+        self._status = self.mygogogate2.get_status(self.device_id)

--- a/homeassistant/components/cover/gogogate2.py
+++ b/homeassistant/components/cover/gogogate2.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_IP_ADDRESS, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pygogogate2==0.0.2']
+REQUIREMENTS = ['pygogogate2==0.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/cover/gogogate2.py
+++ b/homeassistant/components/cover/gogogate2.py
@@ -42,8 +42,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     try:
         devices = mygogogate2.get_devices()
-        if devices == False:
-            raise ValueError("Username or Password is incorrect or no devices found")
+        if devices is False:
+            raise ValueError(
+                "Username or Password is incorrect or no devices found")
 
         add_devices(MyGogogate2Device(mygogogate2, door) for door in devices)
         return True

--- a/homeassistant/components/cover/gogogate2.py
+++ b/homeassistant/components/cover/gogogate2.py
@@ -118,4 +118,3 @@ class MyGogogate2Device(CoverDevice):
             _LOGGER.error("%s", ex)
             self._status = STATE_UNKNOWN
             self.available = False
- 

--- a/homeassistant/components/cover/gogogate2.py
+++ b/homeassistant/components/cover/gogogate2.py
@@ -8,10 +8,11 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.cover import CoverDevice
+from homeassistant.components.cover import (
+    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE)
 from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD, STATE_CLOSED, STATE_UNKNOWN,
-    CONF_IP_ADDRESS, CONF_NAME, SUPPORT_OPEN, SUPPORT_CLOSE)
+    CONF_IP_ADDRESS, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pygogogate2==0.0.3']

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -742,6 +742,9 @@ pyflexit==0.3
 # homeassistant.components.ifttt
 pyfttt==0.3
 
+# homeassistant.components.cover.gogogate2
+pygogogate2==0.0.2
+
 # homeassistant.components.remote.harmony
 pyharmony==1.0.20
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -743,7 +743,7 @@ pyflexit==0.3
 pyfttt==0.3
 
 # homeassistant.components.cover.gogogate2
-pygogogate2==0.0.2
+pygogogate2==0.0.3
 
 # homeassistant.components.remote.harmony
 pyharmony==1.0.20


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5023

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  - platform: gogogate2
    username: email@email.com
    password: password
    ip_address: 192.168.1.200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
