### PR TITLE
Upgrade aiohue and fix race condition

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.helpers import discovery, aiohttp_client
 from homeassistant import config_entries
 from homeassistant.util.json import save_json
 
-REQUIREMENTS = ['aiohue==1.2.0']
+REQUIREMENTS = ['aiohue==1.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -145,7 +145,6 @@ async def async_setup_bridge(
     bridge = HueBridge(host, hass, filename, username, allow_unreachable,
                        allow_hue_groups)
     await bridge.async_setup()
-    hass.data[DOMAIN][host] = bridge
 
 
 def _find_username_from_config(hass, filename):
@@ -208,6 +207,8 @@ class HueBridge(object):
             _LOGGER.exception("Unknown error connecting with Hue bridge at %s",
                               self.host)
             return
+
+        self.hass.data[DOMAIN][self.host] = self
 
         # If we came here and configuring this host, mark as done
         if self.config_request_id:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -74,7 +74,7 @@ aiodns==1.1.1
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.2.0
+aiohue==1.3.0
 
 # homeassistant.components.sensor.imap
 aioimaplib==0.7.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -35,7 +35,7 @@ aioautomatic==0.6.5
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.2.0
+aiohue==1.3.0
 
 # homeassistant.components.notify.apns
 apns2==0.3.0

--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -66,6 +66,7 @@ async def test_only_create_no_username(hass):
 
 async def test_configurator_callback(hass, mock_request):
     """."""
+    hass.data[hue.DOMAIN] = {}
     with patch('aiohue.Bridge.create_user',
                side_effect=aiohue.LinkButtonNotPressed):
         await MockBridge(hass).async_setup()

--- a/tests/components/hue/test_setup.py
+++ b/tests/components/hue/test_setup.py
@@ -18,7 +18,6 @@ async def test_setup_with_multiple_hosts(hass, mock_bridge):
     assert len(mock_bridge.mock_calls) == 2
     hosts = sorted(mock_call[1][0] for mock_call in mock_bridge.mock_calls)
     assert hosts == ['127.0.0.1', '192.168.1.10']
-    assert len(hass.data[hue.DOMAIN]) == 2
 
 
 async def test_bridge_discovered(hass, mock_bridge):
@@ -33,7 +32,6 @@ async def test_bridge_discovered(hass, mock_bridge):
 
     assert len(mock_bridge.mock_calls) == 1
     assert mock_bridge.mock_calls[0][1][0] == '192.168.1.10'
-    assert len(hass.data[hue.DOMAIN]) == 1
 
 
 async def test_bridge_configure_and_discovered(hass, mock_bridge):
@@ -48,7 +46,7 @@ async def test_bridge_configure_and_discovered(hass, mock_bridge):
 
     assert len(mock_bridge.mock_calls) == 1
     assert mock_bridge.mock_calls[0][1][0] == '192.168.1.10'
-    assert len(hass.data[hue.DOMAIN]) == 1
+    hass.data[hue.DOMAIN] = {'192.168.1.10': {}}
 
     mock_bridge.reset_mock()
 
@@ -59,7 +57,6 @@ async def test_bridge_configure_and_discovered(hass, mock_bridge):
     await hass.async_block_till_done()
 
     assert len(mock_bridge.mock_calls) == 0
-    assert len(hass.data[hue.DOMAIN]) == 1
 
 
 async def test_setup_no_host(hass, aioclient_mock):
@@ -71,4 +68,3 @@ async def test_setup_no_host(hass, aioclient_mock):
     assert result
 
     assert len(aioclient_mock.mock_calls) == 1
-    assert len(hass.data[hue.DOMAIN]) == 0


### PR DESCRIPTION
## Description:
Upgrade aiohue to 1.3. In 1.3, any request that fails will now raise the appropriate exception.

Also made sure we store reference to bridge before calling setup

**Related issue (if applicable):** fixes #13454

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
