### PR TITLE
Bugfix Thermostat Fahrenheit support

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -186,9 +186,6 @@ class HomeKit():
 
         for state in self._hass.states.all():
             self.add_bridge_accessory(state)
-        for entity_id in self._config:
-            _LOGGER.warning('The entity "%s" was not setup when HomeKit '
-                            'was started', entity_id)
         self.bridge.set_broker(self.driver)
 
         if not self.bridge.paired:

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -5,8 +5,9 @@ import voluptuous as vol
 
 from homeassistant.core import split_entity_id
 from homeassistant.const import (
-    ATTR_CODE)
+    ATTR_CODE, TEMP_CELSIUS)
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util.temperature as temp_util
 from .const import HOMEKIT_NOTIFY_ID
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,3 +45,21 @@ def show_setup_message(bridge, hass):
 def dismiss_setup_message(hass):
     """Dismiss persistent notification and remove QR code."""
     hass.components.persistent_notification.dismiss(HOMEKIT_NOTIFY_ID)
+
+
+def convert_to_float(state):
+    """Return float of state, catch errors."""
+    try:
+        return float(state)
+    except (ValueError, TypeError):
+        return None
+
+
+def temperature_to_homekit(temperature, unit):
+    """Convert temperature to Celsius for HomeKit."""
+    return round(temp_util.convert(temperature, unit, TEMP_CELSIUS), 1)
+
+
+def temperature_to_states(temperature, unit):
+    """Convert temperature back form Celsius to Home Assistant unit."""
+    return round(temp_util.convert(temperature, TEMP_CELSIUS, unit), 1)

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -61,5 +61,5 @@ def temperature_to_homekit(temperature, unit):
 
 
 def temperature_to_states(temperature, unit):
-    """Convert temperature back form Celsius to Home Assistant unit."""
+    """Convert temperature back from Celsius to Home Assistant unit."""
     return round(temp_util.convert(temperature, TEMP_CELSIUS, unit), 1)

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -16,6 +16,20 @@ _LOGGER = logging.getLogger(__name__)
 CONFIG = {}
 
 
+def test_get_accessory_invalid_aid(caplog):
+    """Test with unsupported component."""
+    assert get_accessory(None, State('light.demo', 'on'),
+                         aid=None, config=None) is None
+    assert caplog.records[0].levelname == 'WARNING'
+    assert 'invalid aid' in caplog.records[0].msg
+
+
+def test_not_supported():
+    """Test if none is returned if entity isn't supported."""
+    assert get_accessory(None, State('demo.demo', 'on'), aid=2, config=None) \
+        is None
+
+
 class TestGetAccessories(unittest.TestCase):
     """Methods to test the get_accessory method."""
 

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -3,30 +3,11 @@ import unittest
 
 from homeassistant.components.homekit.const import PROP_CELSIUS
 from homeassistant.components.homekit.type_sensors import (
-    TemperatureSensor, HumiditySensor, calc_temperature, calc_humidity)
+    TemperatureSensor, HumiditySensor)
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
 from tests.common import get_test_home_assistant
-
-
-def test_calc_temperature():
-    """Test if temperature in Celsius is calculated correctly."""
-    assert calc_temperature(STATE_UNKNOWN) is None
-    assert calc_temperature('test') is None
-
-    assert calc_temperature('20') == 20
-    assert calc_temperature('20.12', TEMP_CELSIUS) == 20.12
-    assert calc_temperature('75.2', TEMP_FAHRENHEIT) == 24
-
-
-def test_calc_humidity():
-    """Test if humidity is a integer."""
-    assert calc_humidity(STATE_UNKNOWN) is None
-    assert calc_humidity('test') is None
-
-    assert calc_humidity('20') == 20
-    assert calc_humidity('75.2') == 75.2
 
 
 class TestHomekitSensors(unittest.TestCase):

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -7,13 +7,15 @@ from homeassistant.core import callback
 from homeassistant.components.homekit.accessories import HomeBridge
 from homeassistant.components.homekit.const import HOMEKIT_NOTIFY_ID
 from homeassistant.components.homekit.util import (
-    show_setup_message, dismiss_setup_message, ATTR_CODE)
+    show_setup_message, dismiss_setup_message, convert_to_float,
+    temperature_to_homekit, temperature_to_states, ATTR_CODE)
 from homeassistant.components.homekit.util import validate_entity_config \
     as vec
 from homeassistant.components.persistent_notification import (
     SERVICE_CREATE, SERVICE_DISMISS, ATTR_NOTIFICATION_ID)
 from homeassistant.const import (
-    EVENT_CALL_SERVICE, ATTR_DOMAIN, ATTR_SERVICE, ATTR_SERVICE_DATA)
+    EVENT_CALL_SERVICE, ATTR_DOMAIN, ATTR_SERVICE, ATTR_SERVICE_DATA,
+    TEMP_CELSIUS, TEMP_FAHRENHEIT, STATE_UNKNOWN)
 
 from tests.common import get_test_home_assistant
 
@@ -81,3 +83,20 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(
             data[ATTR_SERVICE_DATA].get(ATTR_NOTIFICATION_ID, None),
             HOMEKIT_NOTIFY_ID)
+
+    def test_convert_to_float(self):
+        """Test convert_to_float method."""
+        self.assertEqual(convert_to_float(12), 12)
+        self.assertEqual(convert_to_float(12.4), 12.4)
+        self.assertIsNone(convert_to_float(STATE_UNKNOWN))
+        self.assertIsNone(convert_to_float(None))
+
+    def test_temperature_to_homekit(self):
+        """Test temperature conversion from HA to HomeKit."""
+        self.assertEqual(temperature_to_homekit(20.46, TEMP_CELSIUS), 20.5)
+        self.assertEqual(temperature_to_homekit(92.1, TEMP_FAHRENHEIT), 33.4)
+
+    def test_temperature_to_states(self):
+        """Test temperature conversion from HomeKit to HA."""
+        self.assertEqual(temperature_to_states(20, TEMP_CELSIUS), 20.0)
+        self.assertEqual(temperature_to_states(20.2, TEMP_FAHRENHEIT), 68.4)


### PR DESCRIPTION
## Description:
Fixes unit missing unit conversion from Fahrenheit to Celsius (from HomeKit).

**Related issue (if applicable):** fixes #13463 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
