### PR TITLE
Add support for deCONZ daylight sensor

### DIFF
--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -16,6 +16,7 @@ from homeassistant.util import slugify
 DEPENDENCIES = ['deconz']
 
 ATTR_CURRENT = 'current'
+ATTR_DAYLIGHT = 'daylight'
 ATTR_EVENT_ID = 'event_id'
 
 
@@ -61,7 +62,8 @@ class DeconzSensor(Entity):
         """
         if reason['state'] or \
            'reachable' in reason['attr'] or \
-           'battery' in reason['attr']:
+           'battery' in reason['attr'] or \
+           'daylight' in reason['attr']:
             self.async_schedule_update_ha_state()
 
     @property
@@ -113,6 +115,8 @@ class DeconzSensor(Entity):
         if self.unit_of_measurement == 'Watts':
             attr[ATTR_CURRENT] = self._sensor.current
             attr[ATTR_VOLTAGE] = self._sensor.voltage
+        if self._sensor.sensor_class == 'daylight':
+            attr[ATTR_DAYLIGHT] = self._sensor.daylight
         return attr
 
 

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -62,8 +62,7 @@ class DeconzSensor(Entity):
         """
         if reason['state'] or \
            'reachable' in reason['attr'] or \
-           'battery' in reason['attr'] or \
-           'daylight' in reason['attr']:
+           'battery' in reason['attr']:
             self.async_schedule_update_ha_state()
 
     @property


### PR DESCRIPTION
## Description: 
Adds support for the daylight sensor built into the deCONZ software. Bumping pydeconz to 34 is required to support this feature.

**Related issue (if applicable):** N/A.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5028

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54