### PR TITLE
Upgrade slacker to 0.9.65

### DIFF
--- a/homeassistant/components/notify/slack.py
+++ b/homeassistant/components/notify/slack.py
@@ -17,7 +17,7 @@ from homeassistant.components.notify import (
     BaseNotificationService)
 from homeassistant.const import (CONF_API_KEY, CONF_USERNAME, CONF_ICON)
 
-REQUIREMENTS = ['slacker==0.9.60']
+REQUIREMENTS = ['slacker==0.9.65']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1136,7 +1136,7 @@ simplisafe-python==1.0.5
 skybellpy==0.1.1
 
 # homeassistant.components.notify.slack
-slacker==0.9.60
+slacker==0.9.65
 
 # homeassistant.components.notify.xmpp
 sleekxmpp==1.3.2


### PR DESCRIPTION
## Description:
- Add chat.getPermalink method
- Add retry support

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name : slack
    platform: slack
    api_key: !secret slack_api
    default_channel: '#ha'
```

Tested with the following content for Service data:

```json
{"message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
