### PR TITLE
Add services for bmw_connected_drive

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -104,9 +104,6 @@ def setup(hass, config):
     return True
 
 
-
-
-
 class BMWConnectedDriveAccount(object):
     """Representation of a BMW vehicle."""
 

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -126,7 +126,7 @@ class BMWConnectedDriveAccount(object):
 
         The different types of services are defined in the _SERVICE_MAP.
         """
-        for service in _SERVICE_MAP.keys():
+        for service in _SERVICE_MAP:
             _LOGGER.debug('Registering service %s', service)
             self._hass.services.register(
                 DOMAIN, service,

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -69,6 +69,7 @@ def setup(hass, config: dict):
 
 def setup_account(account_config: dict, hass, name: str) \
         -> 'BMWConnectedDriveAccount':
+    """Set up a new BMWConnectedDriveAccount based on the config."""
     username = account_config[CONF_USERNAME]
     password = account_config[CONF_PASSWORD]
     region = account_config[CONF_REGION]

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -68,14 +68,13 @@ def setup(hass, config):
             This must be a member function as we need access to the bimmer
             object here.
             """
-            from bimmer_connected.remote_services import ExecutionState
             vin = call.data[ATTR_VIN]
             _LOGGER.debug('Triggering service %s of vehicle %s',
                           call.service, vin)
             vehicle = bimmer.account.get_vehicle(vin)
             function_name = _SERVICE_MAP[call.service]
             function_call = getattr(vehicle.remote_services, function_name)
-            result = function_call()
+            function_call()
 
         # register the services
         for service in _SERVICE_MAP:

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -93,6 +93,9 @@ def setup_account(account_config: dict, hass, name: str) \
         """
         vin = call.data[ATTR_VIN]
         vehicle = cd_account.account.get_vehicle(vin)
+        if not vehicle:
+            _LOGGER.error('Could not find a vehicle for VIN "%s"!', vin)
+            return
         function_name = _SERVICE_MAP[call.service]
         function_call = getattr(vehicle.remote_services, function_name)
         function_call()

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -45,8 +45,6 @@ UPDATE_INTERVAL = 5  # in minutes
 
 _SERVICE_MAP = {
     'light_flash': 'trigger_remote_light_flash',
-    'door_lock': 'trigger_remote_door_lock',
-    'door_unlock': 'trigger_remote_door_unlock',
     'sound_horn': 'trigger_remote_horn',
     'activate_air_conditioning': 'trigger_remote_air_conditioning',
 }

--- a/homeassistant/components/bmw_connected_drive/services.yaml
+++ b/homeassistant/components/bmw_connected_drive/services.yaml
@@ -34,3 +34,9 @@ activate_air_conditioning:
       description: >
         The vehicle identification number (VIN) of the vehicle, 17 characters
       example: WBANXXXXXX1234567
+
+update_state:
+  description: >
+    Fetch the last state of the vehicles of all your accounts from the BMW
+    server. This does *not* trigger an update from the vehicle, it just gets
+    the data from the BMW servers. This service does not require any attributes.

--- a/homeassistant/components/bmw_connected_drive/services.yaml
+++ b/homeassistant/components/bmw_connected_drive/services.yaml
@@ -1,0 +1,53 @@
+# Describes the format for available services for bmw_connected_drive
+
+light_flash:
+  description: >
+    Flash the lights of the vehicle. The vehicle is identified via the vin
+    (see below).
+  fields:
+    vin:
+      description: >
+        The vehicle identification number (VIN) of the vehicle, 17 characters
+      example: WBANXXXXXX1234567
+
+door_lock:
+  description: >
+    Lock the doors of the vehicle. The vehicle is identified via the vin
+    (see below).
+  fields:
+    vin:
+      description: >
+        The vehicle identification number (VIN) of the vehicle, 17 characters
+      example: WBANXXXXXX1234567
+
+door_unlock:
+  description: >
+    Unlock the doors of the vehicle. The vehicle is identified via the vin
+    (see below).
+  fields:
+    vin:
+      description: >
+        The vehicle identification number (VIN) of the vehicle, 17 characters
+      example: WBANXXXXXX1234567
+
+sound_horn:
+  description: >
+    Sound the horn of the vehicle. The vehicle is identified via the vin
+    (see below).
+  fields:
+    vin:
+      description: >
+        The vehicle identification number (VIN) of the vehicle, 17 characters
+      example: WBANXXXXXX1234567
+
+activate_air_conditioning:
+  description: >
+    Start the air conditioning of the vehicle. What exactly is started here
+    depends on the type of vehicle. It might range from just ventilation over
+    auxilary heating to real air conditioning. The vehicle is identified via
+    the vin (see below).
+  fields:
+    vin:
+      description: >
+        The vehicle identification number (VIN) of the vehicle, 17 characters
+      example: WBANXXXXXX1234567

--- a/homeassistant/components/bmw_connected_drive/services.yaml
+++ b/homeassistant/components/bmw_connected_drive/services.yaml
@@ -1,28 +1,11 @@
 # Describes the format for available services for bmw_connected_drive
+#
+# The services related to locking/unlocking are implemented in the lock
+# component to avoid redundancy.
 
 light_flash:
   description: >
     Flash the lights of the vehicle. The vehicle is identified via the vin
-    (see below).
-  fields:
-    vin:
-      description: >
-        The vehicle identification number (VIN) of the vehicle, 17 characters
-      example: WBANXXXXXX1234567
-
-door_lock:
-  description: >
-    Lock the doors of the vehicle. The vehicle is identified via the vin
-    (see below).
-  fields:
-    vin:
-      description: >
-        The vehicle identification number (VIN) of the vehicle, 17 characters
-      example: WBANXXXXXX1234567
-
-door_unlock:
-  description: >
-    Unlock the doors of the vehicle. The vehicle is identified via the vin
     (see below).
   fields:
     vin:

--- a/homeassistant/components/device_tracker/bmw_connected_drive.py
+++ b/homeassistant/components/device_tracker/bmw_connected_drive.py
@@ -48,8 +48,11 @@ class BMWDeviceTracker(object):
             return
 
         _LOGGER.debug('Updating %s', dev_id)
-
+        attrs = {
+            'vin': self.vehicle.vin,
+        }
         self._see(
             dev_id=dev_id, host_name=self.vehicle.name,
-            gps=self.vehicle.state.gps_position, icon='mdi:car'
+            gps=self.vehicle.state.gps_position, attributes=attrs,
+            icon='mdi:car'
         )


### PR DESCRIPTION
## Description:
Added services to bmw_connected_drive so that the Remote Services of the vehicle can also be triggered from Home Assistant.

* Added vin to attributes of tracker, so that the users can see the VIN of the vehicle
* I had to move the component to new package, so that I can add the services.yaml
* Added service description in services.yaml

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5055

## Example entry for `configuration.yaml` (if applicable):
no changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
