### PR TITLE
Fix security systems

### DIFF
--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -58,7 +58,9 @@ class SecuritySystem(HomeAccessory):
         hass_value = HOMEKIT_TO_HASS[value]
         service = STATE_TO_SERVICE[hass_value]
 
-        params = {ATTR_ENTITY_ID: self._entity_id, ATTR_CODE: self._alarm_code}
+        params = {ATTR_ENTITY_ID: self._entity_id}
+        if self._alarm_code:
+            params[ATTR_CODE] = self._alarm_code
         self._hass.services.call('alarm_control_panel', service, params)
 
     def update_state(self, entity_id=None, old_state=None, new_state=None):

--- a/tests/components/homekit/test_type_security_systems.py
+++ b/tests/components/homekit/test_type_security_systems.py
@@ -102,3 +102,19 @@ class TestHomekitSecuritySystems(unittest.TestCase):
         self.assertEqual(
             self.events[0].data[ATTR_SERVICE_DATA][ATTR_CODE], '1234')
         self.assertEqual(acc.char_target_state.value, 3)
+
+    def test_no_alarm_code(self):
+        """Test accessory if security_system doesn't require a alarm_code."""
+        acp = 'alarm_control_panel.test'
+
+        acc = SecuritySystem(self.hass, acp, 'SecuritySystem',
+                             alarm_code=None, aid=2)
+        acc.run()
+
+        # Set from HomeKit
+        acc.char_target_state.set_value(0)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE], 'alarm_arm_home')
+        self.assertNotIn(ATTR_CODE, self.events[0].data[ATTR_SERVICE_DATA])
+        self.assertEqual(acc.char_target_state.value, 0)


### PR DESCRIPTION
## Description:
Fix issue that occurred if the securtiy_system doesn't require a `alarm_code`. Added test.

**Related issue:** fixes #13492

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.