### PR TITLE
Add arguments with effects

### DIFF
--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -153,8 +153,12 @@ class Hyperion(Light):
 
         if ATTR_EFFECT in kwargs:
             self._skip_update = True
-            mess = kwargs[ATTR_EFFECT].split('||')
-            self._effect = mess[0]
+            mess = kwargs[ATTR_EFFECT]
+            if isinstance(kwargs[ATTR_EFFECT], dict):
+                self._effect = mess['name']
+                mess.pop('name')
+            else:
+                self._effect = mess[ATTR_EFFECT]
             if self._effect == 'HDMI':
                 self.json_request({'command': 'clearall'})
                 self._icon = 'mdi:video-input-hdmi'
@@ -166,13 +170,10 @@ class Hyperion(Light):
                     'priority': self._priority,
                     'effect': {'name': self._effect}
                 }
-                if len(mess) > 1:
+                if isinstance(mess, dict):
                     json_mess['effect']['args'] = {}
-                    for i in range(1, len(mess)):
-                        arg = mess[i].split('=')
-                        if len(arg) == 2:
-                            json_mess['effect']['args'][arg[0]] =\
-                                json.loads(arg[1])
+                    for key in mess:
+                        json_mess['effect']['args'][key] = mess[key]
                 self.json_request(json_mess)
                 self._icon = 'mdi:lava-lamp'
                 self._rgb_color = [175, 0, 255]

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/light.hyperion/
 import json
 import logging
 import socket
-from ast import literal_eval
 
 import voluptuous as vol
 
@@ -173,7 +172,7 @@ class Hyperion(Light):
                         arg = mess[i].split('=')
                         if len(arg) == 2:
                             json_mess['effect']['args'][arg[0]] =\
-                                literal_eval(arg[1])
+                                json.loads(arg[1])
                 self.json_request(json_mess)
                 self._icon = 'mdi:lava-lamp'
                 self._rgb_color = [175, 0, 255]

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -153,18 +153,26 @@ class Hyperion(Light):
 
         if ATTR_EFFECT in kwargs:
             self._skip_update = True
-            self._effect = kwargs[ATTR_EFFECT]
+            mess = kwargs[ATTR_EFFECT].split('||')
+            self._effect = mess[0]
             if self._effect == 'HDMI':
                 self.json_request({'command': 'clearall'})
                 self._icon = 'mdi:video-input-hdmi'
                 self._brightness = 255
                 self._rgb_color = [125, 125, 125]
             else:
-                self.json_request({
+                json_mess = {
                     'command': 'effect',
                     'priority': self._priority,
                     'effect': {'name': self._effect}
-                })
+                }
+                if len(mess)>1:
+                    json_mess['effect']['args'] = {}
+                    for i in range(1,len(mess)):
+                        arg = mess[i].split('=')
+                        if len(arg)==2:
+                            json_mess['effect']['args'][arg[0]] = eval(arg[1])
+                self.json_request(json_mess)
                 self._icon = 'mdi:lava-lamp'
                 self._rgb_color = [175, 0, 255]
             return

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/light.hyperion/
 import json
 import logging
 import socket
+from ast import literal_eval
 
 import voluptuous as vol
 
@@ -171,7 +172,8 @@ class Hyperion(Light):
                     for i in range(1, len(mess)):
                         arg = mess[i].split('=')
                         if len(arg) == 2:
-                            json_mess['effect']['args'][arg[0]] = eval(arg[1])
+                            json_mess['effect']['args'][arg[0]] =\
+                                literal_eval(arg[1])
                 self.json_request(json_mess)
                 self._icon = 'mdi:lava-lamp'
                 self._rgb_color = [175, 0, 255]

--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -166,11 +166,11 @@ class Hyperion(Light):
                     'priority': self._priority,
                     'effect': {'name': self._effect}
                 }
-                if len(mess)>1:
+                if len(mess) > 1:
                     json_mess['effect']['args'] = {}
-                    for i in range(1,len(mess)):
+                    for i in range(1, len(mess)):
                         arg = mess[i].split('=')
-                        if len(arg)==2:
+                        if len(arg) == 2:
                             json_mess['effect']['args'][arg[0]] = eval(arg[1])
                 self.json_request(json_mess)
                 self._icon = 'mdi:lava-lamp'


### PR DESCRIPTION
## Description:

Hyperion: Add posibility for arguments with effects.
If the turn on service is called with the effect parameter, now effect arguments of hyperion can be used in the call following this syntax:
- service: light.turn_on
   data:
       entity_id: "light.tv_light"
       effect: "EFFECT_NAME||ARGUMENT1=VALUE1||ARGUMENT2=VALUE2"

so first the name of the effect, then a seperation sign "||" then the name of the first argument followed by the value of this argument seperated with an "=" sign. A unlimeted amount of argumets can follow each with a "||" between arguments and a "=" between the argument and its value.

For instance two working effects for Hyperion including arguments would be:
effect: "Cinema brighten lights||color-start=[ 0, 0, 0 ]||color-end=[ 255, 136, 0 ]||fade-time=60.0"
or 
effect: "Knight rider||speed=1.0||fadeFactor=0.7||color=[0,255,0]"


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation :** home-assistant/home-assistant.github.io#5037

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
