### PR TITLE
Qwikswitch refactor & sensor

### DIFF
--- a/homeassistant/components/light/qwikswitch.py
+++ b/homeassistant/components/light/qwikswitch.py
@@ -4,18 +4,34 @@ Support for Qwikswitch Relays and Dimmers.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.qwikswitch/
 """
-import logging
+from homeassistant.components.qwikswitch import (
+    QSToggleEntity, DOMAIN as QWIKSWITCH)
+from homeassistant.components.light import SUPPORT_BRIGHTNESS, Light
 
-DEPENDENCIES = ['qwikswitch']
+DEPENDENCIES = [QWIKSWITCH]
 
 
-# pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices, discovery_info=None):
+async def async_setup_platform(hass, _, add_devices, discovery_info=None):
     """Add lights from the main Qwikswitch component."""
-    if discovery_info is None:
-        logging.getLogger(__name__).error(
-            "Configure Qwikswitch Light component failed")
-        return False
+    qsusb = hass.data[QWIKSWITCH]
+    devs = [QSLight(id, qsusb) for id in discovery_info[QWIKSWITCH]]
 
-    add_devices(hass.data['qwikswitch']['light'])
-    return True
+    add_devices(devs)
+
+    for _id, dev in zip(discovery_info[QWIKSWITCH], devs):
+        hass.helpers.dispatcher.async_dispatcher_connect(
+            _id, dev.schedule_update_ha_state)  # Part of Entity/ToggleEntity
+
+
+class QSLight(QSToggleEntity, Light):
+    """Light based on a Qwikswitch relay/dimmer module."""
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light (0-255)."""
+        return self._qsusb[self._id, 1] if self._dim else None
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_BRIGHTNESS if self._dim else 0

--- a/homeassistant/components/light/qwikswitch.py
+++ b/homeassistant/components/light/qwikswitch.py
@@ -13,14 +13,12 @@ DEPENDENCIES = [QWIKSWITCH]
 
 async def async_setup_platform(hass, _, add_devices, discovery_info=None):
     """Add lights from the main Qwikswitch component."""
+    if discovery_info is None:
+        return
+
     qsusb = hass.data[QWIKSWITCH]
-    devs = [QSLight(id, qsusb) for id in discovery_info[QWIKSWITCH]]
-
+    devs = [QSLight(qsid, qsusb) for qsid in discovery_info[QWIKSWITCH]]
     add_devices(devs)
-
-    for _id, dev in zip(discovery_info[QWIKSWITCH], devs):
-        hass.helpers.dispatcher.async_dispatcher_connect(
-            _id, dev.schedule_update_ha_state)  # Part of Entity/ToggleEntity
 
 
 class QSLight(QSToggleEntity, Light):
@@ -29,7 +27,7 @@ class QSLight(QSToggleEntity, Light):
     @property
     def brightness(self):
         """Return the brightness of this light (0-255)."""
-        return self._qsusb[self._id, 1] if self._dim else None
+        return self._qsusb[self.qsid, 1] if self._dim else None
 
     @property
     def supported_features(self):

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers.entity import Entity
 from homeassistant.components.light import ATTR_BRIGHTNESS
 import homeassistant.helpers.config_validation as cv
 
@@ -39,7 +40,7 @@ CONFIG_SCHEMA = vol.Schema({
     })}, extra=vol.ALLOW_EXTRA)
 
 
-class QSToggleEntity(object):
+class QSToggleEntity(Entity):
     """Representation of a Qwikswitch Entity.
 
     Implement base QS methods. Modeled around HA ToggleEntity[1] & should only
@@ -89,8 +90,6 @@ class QSToggleEntity(object):
 
     async def async_added_to_hass(self):
         """Listen for updates from QSUSb via dispatcher."""
-        # hass and schedule_update_ha_state is part of Entity/ToggleEntity
-        # pylint: disable=no-member
         self.hass.helpers.dispatcher.async_dispatcher_connect(
             self.qsid, lambda _=None: self.async_schedule_update_ha_state())
 

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -92,7 +92,7 @@ class QSToggleEntity(object):
         # hass and schedule_update_ha_state is part of Entity/ToggleEntity
         # pylint: disable=no-member
         self.hass.helpers.dispatcher.async_dispatcher_connect(
-            self.qsid, lambda _=None: self.schedule_update_ha_state)
+            self.qsid, lambda _=None: self.async_schedule_update_ha_state)
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -9,7 +9,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, CONF_URL)
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, CONF_URL,
+    CONF_SENSORS, CONF_SWITCHES)
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.discovery import load_platform
@@ -17,7 +18,7 @@ from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyqwikswitch==0.5']
+REQUIREMENTS = ['pyqwikswitch==0.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,8 +26,6 @@ DOMAIN = 'qwikswitch'
 
 CONF_DIMMER_ADJUST = 'dimmer_adjust'
 CONF_BUTTON_EVENTS = 'button_events'
-CONF_SENSORS = 'sensors'
-CONF_SWITCHES = 'switches'
 CV_DIM_VALUE = vol.All(vol.Coerce(float), vol.Range(min=1, max=3))
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -15,7 +15,6 @@ from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.components.light import ATTR_BRIGHTNESS
-from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pyqwikswitch==0.6']
@@ -123,7 +122,7 @@ async def async_setup(hass, config):
 
     # Discover all devices in QSUSB
     if not await qsusb.update_from_devices():
-        raise PlatformNotReady
+        return False
 
     hass.data[DOMAIN] = qsusb
 

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -4,7 +4,6 @@ Support for Qwikswitch devices.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/qwikswitch/
 """
-import asyncio
 import logging
 
 import voluptuous as vol
@@ -14,9 +13,9 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.discovery import load_platform
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
-from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.light import ATTR_BRIGHTNESS
+from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pyqwikswitch==0.5']
 
@@ -26,6 +25,8 @@ DOMAIN = 'qwikswitch'
 
 CONF_DIMMER_ADJUST = 'dimmer_adjust'
 CONF_BUTTON_EVENTS = 'button_events'
+CONF_SENSORS = 'sensors'
+CONF_SWITCHES = 'switches'
 CV_DIM_VALUE = vol.All(vol.Coerce(float), vol.Range(min=1, max=3))
 
 CONFIG_SCHEMA = vol.Schema({
@@ -33,7 +34,10 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_URL, default='http://127.0.0.1:2020'):
             vol.Coerce(str),
         vol.Optional(CONF_DIMMER_ADJUST, default=1): CV_DIM_VALUE,
-        vol.Optional(CONF_BUTTON_EVENTS): vol.Coerce(str)
+        vol.Optional(CONF_BUTTON_EVENTS): cv.ensure_list_csv,
+        vol.Optional(CONF_SENSORS, default=[]): vol.Schema({cv.slug: str}),
+        vol.Optional(CONF_SWITCHES, default=[]): vol.All(
+            cv.ensure_list, [str])
     })}, extra=vol.ALLOW_EXTRA)
 
 
@@ -76,127 +80,98 @@ class QSToggleEntity(object):
         """Check if device is on (non-zero)."""
         return self._qsusb[self._id, 1] > 0
 
-    def turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs):
         """Turn the device on."""
         new = kwargs.get(ATTR_BRIGHTNESS, 255)
         self._qsusb.set_value(self._id, new)
 
-    @asyncio.coroutine
-    def async_turn_on(self, **kwargs):
-        """Turn the device on."""
-        new = kwargs.get(ATTR_BRIGHTNESS, 255)
-        self._qsusb.set_value(self._id, new)
-
-    def turn_off(self, **kwargs):  # pylint: disable=unused-argument
-        """Turn the device off."""
-        self._qsusb.set_value(self._id, 0)
-
-    @asyncio.coroutine
-    def async_turn_off(self, **kwargs):  # pylint: disable=unused-argument
+    async def async_turn_off(self, **_):
         """Turn the device off."""
         self._qsusb.set_value(self._id, 0)
 
 
-class QSSwitch(QSToggleEntity, SwitchDevice):
-    """Switch based on a Qwikswitch relay module."""
-
-    pass
-
-
-class QSLight(QSToggleEntity, Light):
-    """Light based on a Qwikswitch relay/dimmer module."""
-
-    @property
-    def brightness(self):
-        """Return the brightness of this light (0-255)."""
-        return self._qsusb[self._id, 1] if self._dim else None
-
-    @property
-    def supported_features(self):
-        """Flag supported features."""
-        return SUPPORT_BRIGHTNESS if self._dim else None
-
-
-@asyncio.coroutine
-def async_setup(hass, config):
-    """Setup qwiskswitch component."""
-    from pyqwikswitch.async import QSUsb
+async def async_setup(hass, config):
+    """Qwiskswitch component setup."""
+    from pyqwikswitch.async_ import QSUsb
     from pyqwikswitch import (
-        CMD_BUTTONS, QS_CMD, QSDATA, QS_ID, QS_NAME, QS_TYPE, QSType)
+        CMD_BUTTONS, QS_CMD, QS_ID, QS_TYPE, QSType)
 
-    hass.data[DOMAIN] = {}
-
-    # Override which cmd's in /&listen packets will fire events
+    # Add cmd's to in /&listen packets will fire events
     # By default only buttons of type [TOGGLE,SCENE EXE,LEVEL]
-    cmd_buttons = config[DOMAIN].get(CONF_BUTTON_EVENTS, ','.join(CMD_BUTTONS))
-    cmd_buttons = cmd_buttons.split(',')
+    cmd_buttons = set(CMD_BUTTONS)
+    for btn in config[DOMAIN].get(CONF_BUTTON_EVENTS, []):
+        cmd_buttons.add(btn)
 
     url = config[DOMAIN][CONF_URL]
     dimmer_adjust = config[DOMAIN][CONF_DIMMER_ADJUST]
+    sensors = config[DOMAIN]['sensors']
+    switches = config[DOMAIN]['switches']
 
-    def callback_value_changed(qsdevices, key, new): \
-            # pylint: disable=unused-argument
-        """Update entiry values based on device change."""
-        entity = hass.data[DOMAIN].get(key)
-        if entity is not None:
-            entity.schedule_update_ha_state()  # Part of Entity/ToggleEntity
+    def callback_value_changed(_qsd, key, _val):
+        """Update entity values based on device change."""
+        hass.helpers.dispatcher.async_dispatcher_send(key)
 
     session = async_get_clientsession(hass)
     qsusb = QSUsb(url=url, dim_adj=dimmer_adjust, session=session,
                   callback_value_changed=callback_value_changed)
 
-    @callback
-    def async_stop(event):  # pylint: disable=unused-argument
-        """Stop the listener queue and clean up."""
-        nonlocal qsusb
-        qsusb.stop()
-        qsusb = None
-        hass.data[DOMAIN] = {}
-        _LOGGER.info("Waiting for long poll to QSUSB to time out")
-
-    hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, async_stop)
-
     # Discover all devices in QSUSB
-    yield from qsusb.update_from_devices()
-    hass.data[DOMAIN]['switch'] = []
-    hass.data[DOMAIN]['light'] = []
+    if not await qsusb.update_from_devices():
+        raise PlatformNotReady
+
+    hass.data[DOMAIN] = qsusb
+
+    _new = {'switch': [], 'light': [], 'sensor': sensors}
     for _id, item in qsusb.devices:
-        if (item[QS_TYPE] == QSType.relay and
-                item[QSDATA][QS_NAME].lower().endswith(' switch')):
-            item[QSDATA][QS_NAME] = item[QSDATA][QS_NAME][:-7]  # Remove switch
-            new_dev = QSSwitch(_id, qsusb)
-            hass.data[DOMAIN]['switch'].append(new_dev)
+        if _id in switches:
+            if item[QS_TYPE] != QSType.relay:
+                _LOGGER.warning(
+                    "You specified a switch that is not a relay %s", _id)
+                continue
+            _new['switch'].append(_id)
         elif item[QS_TYPE] in [QSType.relay, QSType.dimmer]:
-            new_dev = QSLight(_id, qsusb)
-            hass.data[DOMAIN]['light'].append(new_dev)
+            _new['light'].append(_id)
         else:
             _LOGGER.warning("Ignored unknown QSUSB device: %s", item)
             continue
-        hass.data[DOMAIN][_id] = new_dev
 
     # Load platforms
-    for comp_name in ('switch', 'light'):
-        if hass.data[DOMAIN][comp_name]:
-            load_platform(hass, comp_name, 'qwikswitch', {}, config)
+    for comp_name in _new:
+        if _new[comp_name]:
+            load_platform(
+                hass, comp_name, DOMAIN, {DOMAIN: _new[comp_name]}, config)
 
     def callback_qs_listen(item):
         """Typically a button press or update signal."""
-        if qsusb is None:  # Shutting down
-            return
-
         # If button pressed, fire a hass event
-        if item.get(QS_CMD, '') in cmd_buttons and QS_ID in item:
-            hass.bus.async_fire('qwikswitch.button.{}'.format(item[QS_ID]))
-            return
+        if QS_ID in item:
+            if item.get(QS_CMD, '') in cmd_buttons:
+                hass.bus.async_fire(
+                    'qwikswitch.button.{}'.format(item[QS_ID]), item)
+                return
+
+            if item[QS_ID] not in qsusb.devices:
+                # Not a standard device in, component can handle packet
+                # i.e. sensors
+                hass.helpers.dispatcher.async_dispatcher_send(
+                    item[QS_ID], item)
 
         # Update all ha_objects
         hass.async_add_job(qsusb.update_from_devices)
 
     @callback
-    def async_start(event):  # pylint: disable=unused-argument
+    def async_start(_):
         """Start listening."""
         hass.async_add_job(qsusb.listen, callback_qs_listen)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_start)
+
+    @callback
+    def async_stop(_):
+        """Stop the listener queue and clean up."""
+        hass.data[DOMAIN].stop()
+        _LOGGER.info("Waiting for long poll to QSUSB to time out (max 30sec)")
+
+    hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, async_stop)
 
     return True

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -88,10 +88,14 @@ class QSToggleEntity(Entity):
         """Turn the device off."""
         self._qsusb.set_value(self.qsid, 0)
 
+    def _update(self, _packet=None):
+        """Schedule an update - match dispather_send signature."""
+        self.async_schedule_update_ha_state()
+
     async def async_added_to_hass(self):
         """Listen for updates from QSUSb via dispatcher."""
         self.hass.helpers.dispatcher.async_dispatcher_connect(
-            self.qsid, lambda _=None: self.async_schedule_update_ha_state())
+            self.qsid, self._update)
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -87,7 +87,7 @@ class QSToggleEntity(object):
         """Turn the device off."""
         self._qsusb.set_value(self.qsid, 0)
 
-    def async_added_to_hass(self):
+    async def async_added_to_hass(self):
         """Listen for updates from QSUSb via dispatcher."""
         # hass and schedule_update_ha_state is part of Entity/ToggleEntity
         # pylint: disable=no-member

--- a/homeassistant/components/sensor/qwikswitch.py
+++ b/homeassistant/components/sensor/qwikswitch.py
@@ -60,7 +60,7 @@ class QSSensor(Entity):
         """QS sensors gets packets in update_packet."""
         return False
 
-    def async_added_to_hass(self):
+    async def async_added_to_hass(self):
         """Listen for updates from QSUSb via dispatcher."""
         # Part of Entity/ToggleEntity
         self.hass.helpers.dispatcher.async_dispatcher_connect(

--- a/homeassistant/components/sensor/qwikswitch.py
+++ b/homeassistant/components/sensor/qwikswitch.py
@@ -38,7 +38,9 @@ class QSSensor(Entity):
 
     def update_packet(self, packet):
         """Receive update packet from QSUSB."""
+        _LOGGER.debug("Update %s (%s): %s", self.entity_id, self.qsid, packet)
         self._val = packet
+        self.async_schedule_update_ha_state()
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/qwikswitch.py
+++ b/homeassistant/components/sensor/qwikswitch.py
@@ -1,0 +1,63 @@
+"""
+Support for Qwikswitch Sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.qwikswitch/
+"""
+import logging
+
+from homeassistant.components.qwikswitch import DOMAIN as QWIKSWITCH
+from homeassistant.helpers.entity import Entity
+
+DEPENDENCIES = [QWIKSWITCH]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, _, add_devices, discovery_info=None):
+    """Add lights from the main Qwikswitch component."""
+    qsusb = hass.data[QWIKSWITCH]
+    _LOGGER.info("Setup qwikswitch.sensor %s, %s", qsusb, discovery_info)
+    devs = [QSSensor(name, id)
+            for name, id in discovery_info[QWIKSWITCH].items()]
+
+    add_devices(devs)
+
+    for dev in devs:
+        hass.helpers.dispatcher.async_dispatcher_connect(
+            dev.qsid, dev.update_packet)  # Part of Entity/ToggleEntity
+
+
+class QSSensor(Entity):
+    """Sensor based on a Qwikswitch relay/dimmer module."""
+
+    _val = {}
+
+    def __init__(self, sensor_name, sensor_id):
+        """Initialize the sensor."""
+        self._name = sensor_name
+        self.qsid = sensor_id
+
+    def update_packet(self, packet):
+        """Receive update packet from QSUSB."""
+        self._val = packet
+
+    @property
+    def state(self):
+        """Return the value of the sensor."""
+        return self._val.get('data', 0)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return self._val
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return None
+
+    @property
+    def poll(self):
+        """QS sensors gets packets in update_packet."""
+        return False

--- a/homeassistant/components/switch/qwikswitch.py
+++ b/homeassistant/components/switch/qwikswitch.py
@@ -13,17 +13,13 @@ DEPENDENCIES = [QWIKSWITCH]
 
 async def async_setup_platform(hass, _, add_devices, discovery_info=None):
     """Add switches from the main Qwikswitch component."""
+    if discovery_info is None:
+        return
+
     qsusb = hass.data[QWIKSWITCH]
-    devs = [QSSwitch(id, qsusb) for id in discovery_info[QWIKSWITCH]]
-
+    devs = [QSSwitch(qsid, qsusb) for qsid in discovery_info[QWIKSWITCH]]
     add_devices(devs)
-
-    for _id, dev in zip(discovery_info[QWIKSWITCH], devs):
-        hass.helpers.dispatcher.async_dispatcher_connect(
-            _id, dev.schedule_update_ha_state)
 
 
 class QSSwitch(QSToggleEntity, SwitchDevice):
     """Switch based on a Qwikswitch relay module."""
-
-    pass

--- a/homeassistant/components/switch/qwikswitch.py
+++ b/homeassistant/components/switch/qwikswitch.py
@@ -4,18 +4,26 @@ Support for Qwikswitch relays.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.qwikswitch/
 """
-import logging
+from homeassistant.components.qwikswitch import (
+    QSToggleEntity, DOMAIN as QWIKSWITCH)
+from homeassistant.components.switch import SwitchDevice
 
-DEPENDENCIES = ['qwikswitch']
+DEPENDENCIES = [QWIKSWITCH]
 
 
-# pylint: disable=unused-argument
-def setup_platform(hass, config, add_devices, discovery_info=None):
+async def async_setup_platform(hass, _, add_devices, discovery_info=None):
     """Add switches from the main Qwikswitch component."""
-    if discovery_info is None:
-        logging.getLogger(__name__).error(
-            "Configure Qwikswitch Switch component failed")
-        return False
+    qsusb = hass.data[QWIKSWITCH]
+    devs = [QSSwitch(id, qsusb) for id in discovery_info[QWIKSWITCH]]
 
-    add_devices(hass.data['qwikswitch']['switch'])
-    return True
+    add_devices(devs)
+
+    for _id, dev in zip(discovery_info[QWIKSWITCH], devs):
+        hass.helpers.dispatcher.async_dispatcher_connect(
+            _id, dev.schedule_update_ha_state)
+
+
+class QSSwitch(QSToggleEntity, SwitchDevice):
+    """Switch based on a Qwikswitch relay module."""
+
+    pass

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -860,7 +860,7 @@ pyowm==2.8.0
 pypollencom==1.1.1
 
 # homeassistant.components.qwikswitch
-pyqwikswitch==0.5
+pyqwikswitch==0.6
 
 # homeassistant.components.rainbird
 pyrainbird==0.1.3


### PR DESCRIPTION
## Description:
Refactor of qwikswicth (async/await/dispatchers/feedback from #12641) and adding first version of sensor.

As discussed [on MyBB](https://mybroadband.co.za/vb/showthread.php/932621-Home-Automation-QwikSwitch/page3) wireframe sensor support for QwikSwitch. Sensors need to implement their own logic over time in the `qsSensor` class in `components/sensors/qwikswitch/`. `binary_sensor` can be added later, but lets see how this general sensor starts....

Config changes:
* `sensors:` added. Format is dictionary of {endtity_id: qs_id}, so adding a door sensor
  ```yaml
  qwikswitch:
    sensors:
      door_sensor: '@id03'
  ```
* `cmd_buttons:` now adds to the defaults and no need to include defaults anymore (backward compatible). Can be a list or csv list
* Switches needs to be specified in the config or they will be discovered as lights. The " switch" in the name can be removed in QSUSB interface: **BREAKING CHANGE**
  ```yaml
  qwikswitch:
    switches: ['@id01', '@id02']
  ```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5045


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `lazytox`. 

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
