### PR TITLE
Added support for TP-Link Archer C50 V3 BR Version

### DIFF
--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -287,7 +287,6 @@ class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
 
         Return boolean if scanning successful.
         """
-
         _LOGGER.info("Loading dhcp clients...")
 
         mac_results = []
@@ -312,6 +311,7 @@ class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
 
         self.last_results = mac_results
         return True
+
 
 class Tplink4DeviceScanner(TplinkDeviceScanner):
     """This class queries an Archer C7 router with TP-Link firmware 150427."""

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -282,27 +282,11 @@ class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
         """Get the name of the wireless device."""
         return None
 
-    def _get_auth_tokens(self):
-        """Retrieve auth tokens from the router."""
-        _LOGGER.info("Retrieving auth tokens...")
-        url = 'http://{}/'.format(self.host)
-
-        credentials = '{}:{}'.format(self.username,
-            self.password).encode('utf')
-
-        # Encode the credentials to be sent as a cookie.
-        self.credentials = base64.b64encode(credentials).decode('utf')
-
-        # Create the authorization cookie.
-        cookie = 'Authorization=Basic {}'.format(self.credentials)
-
     def _update_info(self):
         """Ensure the information from the TP-Link router is up to date.
 
         Return boolean if scanning successful.
         """
-        if (self.credentials == '') or (self.token == ''):
-            self._get_auth_tokens()
 
         _LOGGER.info("Loading dhcp clients...")
 
@@ -315,7 +299,7 @@ class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
 
         payload = '[LAN_HOST_ENTRY#0,0,0,0,0,0#0,0,0,0,0,0]0,4\r\n' + \
             'leaseTimeRemaining\r\nMACAddress\r\nhostName\r\nIPAddress\r\n'
-        
+
         page = requests.post(url, headers={
             COOKIE: cookie,
             REFERER: referer

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -258,6 +258,7 @@ class Tplink3DeviceScanner(TplinkDeviceScanner):
         self.stok = ''
         self.sysauth = ''
 
+
 class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
     """This class queries an Archer C7 router with TP-Link firmware 150427."""
 
@@ -265,9 +266,10 @@ class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
         """Initialize the scanner."""
         self.credentials = ''
         self.token = ''
-        #had to rewrite due c50 responds with colon mac instead of dash
-        self.parse_macs_c50 = re.compile('[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:' +
-                                     '[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}')
+        # I had to rewrite due c50 responds with colon mac instead of dash
+        self.parse_macs_c50 = 
+            re.compile('[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:' +
+                       '[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}')
         super(TplinkArcherC50DeviceScanner, self).__init__(config)
 
     def scan_devices(self):
@@ -285,15 +287,14 @@ class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
         _LOGGER.info("Retrieving auth tokens...")
         url = 'http://{}/'.format(self.host)
 
-        credentials = '{}:{}'.format(self.username, self.password).encode('utf')
+        credentials = '{}:{}'.format(self.username, \
+            self.password).encode('utf')
 
         # Encode the credentials to be sent as a cookie.
         self.credentials = base64.b64encode(credentials).decode('utf')
 
         # Create the authorization cookie.
         cookie = 'Authorization=Basic {}'.format(self.credentials)
-
-        response = requests.get(url, headers={COOKIE: cookie})
 
     def _update_info(self):
         """Ensure the information from the TP-Link router is up to date.
@@ -307,12 +308,13 @@ class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
 
         mac_results = []
 
-        #CHECK DHCP CLIENT LIST
+        # CHECK DHCP CLIENT LIST
         url = 'http://{}/cgi?5'.format(self.host)
         referer = 'http://{}/'.format(self.host)
         cookie = 'Authorization=Basic {}'.format(self.credentials)
 
-        payload = '[LAN_HOST_ENTRY#0,0,0,0,0,0#0,0,0,0,0,0]0,4\r\nleaseTimeRemaining\r\nMACAddress\r\nhostName\r\nIPAddress\r\n'
+        payload = '[LAN_HOST_ENTRY#0,0,0,0,0,0#0,0,0,0,0,0]0,4\r\n' +
+                  'leaseTimeRemaining\r\nMACAddress\r\nhostName\r\nIPAddress\r\n'
 
         page = requests.post(url, headers={
             COOKIE: cookie,

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -267,9 +267,9 @@ class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
         self.credentials = ''
         self.token = ''
         # I had to rewrite due c50 responds with colon mac instead of dash
-        self.parse_macs_c50 = 
-            re.compile('[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:' +
-                       '[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}')
+        self.parse_macs_c50 = re.compile('[0-9A-F]{2}:[0-9A-F]{2}:' +
+                                         '[0-9A-F]{2}:[0-9A-F]{2}:' +
+                                         '[0-9A-F]{2}:[0-9A-F]{2}')
         super(TplinkArcherC50DeviceScanner, self).__init__(config)
 
     def scan_devices(self):
@@ -287,7 +287,7 @@ class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
         _LOGGER.info("Retrieving auth tokens...")
         url = 'http://{}/'.format(self.host)
 
-        credentials = '{}:{}'.format(self.username, \
+        credentials = '{}:{}'.format(self.username,
             self.password).encode('utf')
 
         # Encode the credentials to be sent as a cookie.
@@ -304,7 +304,7 @@ class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
         if (self.credentials == '') or (self.token == ''):
             self._get_auth_tokens()
 
-        _LOGGER.info("Loading wireless clients...")
+        _LOGGER.info("Loading dhcp clients...")
 
         mac_results = []
 
@@ -313,9 +313,9 @@ class TplinkArcherC50DeviceScanner(TplinkDeviceScanner):
         referer = 'http://{}/'.format(self.host)
         cookie = 'Authorization=Basic {}'.format(self.credentials)
 
-        payload = '[LAN_HOST_ENTRY#0,0,0,0,0,0#0,0,0,0,0,0]0,4\r\n' +
-                  'leaseTimeRemaining\r\nMACAddress\r\nhostName\r\nIPAddress\r\n'
-
+        payload = '[LAN_HOST_ENTRY#0,0,0,0,0,0#0,0,0,0,0,0]0,4\r\n' + \
+            'leaseTimeRemaining\r\nMACAddress\r\nhostName\r\nIPAddress\r\n'
+        
         page = requests.post(url, headers={
             COOKIE: cookie,
             REFERER: referer


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)**
The tplink.py was not working for this model of router, I tested with my Brazilian Version, maybe it works with Europe Version or even with other other Hardware versions, not only v3.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
