### PR TITLE
Add FreeDNS component

### DIFF
--- a/homeassistant/components/freedns.py
+++ b/homeassistant/components/freedns.py
@@ -49,7 +49,7 @@ def async_setup(hass, config):
     result = yield from _update_freedns(
         hass, session, url, auth_token)
 
-    if not result:
+    if result is False:
         return False
 
     @asyncio.coroutine
@@ -82,7 +82,7 @@ def _update_freedns(hass, session, url, auth_token):
 
             if "has not changed" in body:
                 # IP has not changed.
-                _LOGGER.info("FreeDNS update skipped: IP has not changed.")
+                _LOGGER.debug("FreeDNS update skipped: IP has not changed.")
                 return True
 
             if "ERROR" not in body:

--- a/homeassistant/components/freedns.py
+++ b/homeassistant/components/freedns.py
@@ -49,7 +49,7 @@ def async_setup(hass, config):
     result = yield from _update_freedns(
         hass, session, url, auth_token)
 
-    if not result:
+    if result is False:
         return False
 
     @asyncio.coroutine
@@ -82,7 +82,7 @@ def _update_freedns(hass, session, url, auth_token):
 
             if "has not changed" in body:
                 # IP has not changed.
-                _LOGGER.info("FreeDNS update skipped: IP has not changed.")
+                _LOGGER.debug("FreeDNS update skipped: IP has not changed")
                 return True
 
             if "ERROR" not in body:

--- a/homeassistant/components/freedns.py
+++ b/homeassistant/components/freedns.py
@@ -1,0 +1,118 @@
+"""
+Integrate with FreeDNS Dynamic DNS service at freedns.afraid.org.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/freedns/
+"""
+import asyncio
+import base64
+from datetime import timedelta
+import logging
+
+import aiohttp
+from aiohttp.hdrs import USER_AGENT, AUTHORIZATION
+import async_timeout
+import voluptuous as vol
+import yarl
+
+from homeassistant.const import (CONF_URL, CONF_TIMEOUT, CONF_ACCESS_TOKEN)
+from homeassistant.helpers.aiohttp_client import SERVER_SOFTWARE
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'freedns'
+
+# We should set a dedicated address for the user agent.
+EMAIL = 'hello@home-assistant.io'
+
+DEFAULT_INTERVAL = timedelta(minutes=10)
+DEFAULT_TIMEOUT = 10
+
+UPDATE_URL = 'https://freedns.afraid.org/dynamic/update.php'
+HA_USER_AGENT = "{} {}".format(SERVER_SOFTWARE, EMAIL)
+
+CONF_UPDATE_INTERVAL = 'update_interval'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Exclusive(CONF_URL, DOMAIN): cv.string,
+        vol.Exclusive(CONF_ACCESS_TOKEN, DOMAIN): cv.string,
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+        vol.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_INTERVAL): vol.All(
+            cv.time_period, cv.positive_timedelta),
+
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Initialize the FreeDNS component."""
+    url = config[DOMAIN].get(CONF_URL)
+    auth_token = config[DOMAIN].get(CONF_ACCESS_TOKEN)
+    timeout = config[DOMAIN].get(CONF_TIMEOUT)
+    update_interval = config[DOMAIN].get(CONF_UPDATE_INTERVAL)
+
+    session = hass.helpers.aiohttp_client.async_get_clientsession(False)
+
+    result = yield from _update_freedns(
+        hass, session, url, auth_token, timeout)
+
+    if not result:
+        return False
+
+    @asyncio.coroutine
+    def update_domain_callback(now):
+        """Update the FreeDNS entry."""
+        yield from _update_freedns(hass, session, url, auth_token, timeout)
+
+    hass.helpers.event.async_track_time_interval(
+        update_domain_callback, update_interval)
+
+    return True
+
+
+@asyncio.coroutine
+def _update_freedns(hass, session, url, auth_token, timeout):
+    """Update FreeDNS."""
+
+    headers = {
+        USER_AGENT: HA_USER_AGENT,
+    }
+
+    params = None
+
+    if (url == None):
+        url = UPDATE_URL
+
+    if not (auth_token == None):
+        params = { }
+        params[auth_token] = ""
+
+    try:
+        with async_timeout.timeout(timeout, loop=hass.loop):
+            resp = yield from session.get(url, params=params, headers=headers)
+            body = yield from resp.text()
+
+            if "has not changed" in body:
+                # IP has not changed.
+                return True
+
+            if "ERROR" not in body:
+                _LOGGER.debug("Updating FreeDNS was successful: %s", body)
+                return True
+
+            if "Invalid update URL" in body:
+                _LOGGER.error("FreeDNS update token is invalid")
+            else:
+                _LOGGER.warning("Updating FreeDNS failed: %s => %s",
+                    resp.url, body)
+
+    except aiohttp.ClientError:
+        _LOGGER.warning("Can't connect to FreeDNS API")
+
+    except asyncio.TimeoutError:
+        _LOGGER.warning("Timeout from FreeDNS API at %s", url)
+
+    return False

--- a/homeassistant/components/freedns.py
+++ b/homeassistant/components/freedns.py
@@ -5,32 +5,24 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/freedns/
 """
 import asyncio
-import base64
 from datetime import timedelta
 import logging
 
 import aiohttp
-from aiohttp.hdrs import USER_AGENT, AUTHORIZATION
 import async_timeout
 import voluptuous as vol
-import yarl
 
-from homeassistant.const import (CONF_URL, CONF_TIMEOUT, CONF_ACCESS_TOKEN)
-from homeassistant.helpers.aiohttp_client import SERVER_SOFTWARE
+from homeassistant.const import (CONF_URL, CONF_ACCESS_TOKEN)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'freedns'
 
-# We should set a dedicated address for the user agent.
-EMAIL = 'hello@home-assistant.io'
-
 DEFAULT_INTERVAL = timedelta(minutes=10)
-DEFAULT_TIMEOUT = 10
 
+TIMEOUT = 10
 UPDATE_URL = 'https://freedns.afraid.org/dynamic/update.php'
-HA_USER_AGENT = "{} {}".format(SERVER_SOFTWARE, EMAIL)
 
 CONF_UPDATE_INTERVAL = 'update_interval'
 
@@ -38,7 +30,6 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Exclusive(CONF_URL, DOMAIN): cv.string,
         vol.Exclusive(CONF_ACCESS_TOKEN, DOMAIN): cv.string,
-        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
         vol.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_INTERVAL): vol.All(
             cv.time_period, cv.positive_timedelta),
 
@@ -51,13 +42,12 @@ def async_setup(hass, config):
     """Initialize the FreeDNS component."""
     url = config[DOMAIN].get(CONF_URL)
     auth_token = config[DOMAIN].get(CONF_ACCESS_TOKEN)
-    timeout = config[DOMAIN].get(CONF_TIMEOUT)
     update_interval = config[DOMAIN].get(CONF_UPDATE_INTERVAL)
 
-    session = hass.helpers.aiohttp_client.async_get_clientsession(False)
+    session = hass.helpers.aiohttp_client.async_get_clientsession()
 
     result = yield from _update_freedns(
-        hass, session, url, auth_token, timeout)
+        hass, session, url, auth_token)
 
     if not result:
         return False
@@ -65,7 +55,7 @@ def async_setup(hass, config):
     @asyncio.coroutine
     def update_domain_callback(now):
         """Update the FreeDNS entry."""
-        yield from _update_freedns(hass, session, url, auth_token, timeout)
+        yield from _update_freedns(hass, session, url, auth_token)
 
     hass.helpers.event.async_track_time_interval(
         update_domain_callback, update_interval)
@@ -74,29 +64,25 @@ def async_setup(hass, config):
 
 
 @asyncio.coroutine
-def _update_freedns(hass, session, url, auth_token, timeout):
+def _update_freedns(hass, session, url, auth_token):
     """Update FreeDNS."""
-
-    headers = {
-        USER_AGENT: HA_USER_AGENT,
-    }
-
     params = None
 
-    if (url == None):
+    if url is None:
         url = UPDATE_URL
 
-    if not (auth_token == None):
-        params = { }
+    if auth_token is not None:
+        params = {}
         params[auth_token] = ""
 
     try:
-        with async_timeout.timeout(timeout, loop=hass.loop):
-            resp = yield from session.get(url, params=params, headers=headers)
+        with async_timeout.timeout(TIMEOUT, loop=hass.loop):
+            resp = yield from session.get(url, params=params)
             body = yield from resp.text()
 
             if "has not changed" in body:
                 # IP has not changed.
+                _LOGGER.info("FreeDNS update skipped: IP has not changed.")
                 return True
 
             if "ERROR" not in body:
@@ -106,8 +92,7 @@ def _update_freedns(hass, session, url, auth_token, timeout):
             if "Invalid update URL" in body:
                 _LOGGER.error("FreeDNS update token is invalid")
             else:
-                _LOGGER.warning("Updating FreeDNS failed: %s => %s",
-                    resp.url, body)
+                _LOGGER.warning("Updating FreeDNS failed: %s", body)
 
     except aiohttp.ClientError:
         _LOGGER.warning("Can't connect to FreeDNS API")

--- a/tests/components/test_freedns.py
+++ b/tests/components/test_freedns.py
@@ -1,0 +1,75 @@
+"""Test the FreeDNS component."""
+import asyncio
+from datetime import timedelta
+
+import pytest
+
+from homeassistant.setup import async_setup_component
+from homeassistant.components import freedns
+from homeassistant.util.dt import utcnow
+
+from tests.common import async_fire_time_changed
+
+ACCESS_TOKEN = 'test_token'
+TIMEOUT = freedns.DEFAULT_TIMEOUT
+UPDATE_INTERVAL = freedns.DEFAULT_INTERVAL
+UPDATE_URL = freedns.UPDATE_URL
+
+@pytest.fixture
+def setup_freedns(hass, aioclient_mock):
+    """Fixture that sets up FreeDNS."""
+    params = { }
+    params[ACCESS_TOKEN] = ""
+    aioclient_mock.get(
+        UPDATE_URL, params=params, text='Successfully updated 1 domains.')
+
+    hass.loop.run_until_complete(async_setup_component(hass, freedns.DOMAIN, {
+            freedns.DOMAIN: {
+                'access_token': ACCESS_TOKEN,
+                'timeout': TIMEOUT,
+                'update_interval': UPDATE_INTERVAL,
+            }
+        }))
+
+
+@asyncio.coroutine
+def test_setup(hass, aioclient_mock):
+    """Test setup works if update passes."""
+    params = { }
+    params[ACCESS_TOKEN] = ""
+    aioclient_mock.get(
+        UPDATE_URL, params=params,
+            text='ERROR: Address 1.2.3.4 has not changed.')
+
+    result = yield from async_setup_component(hass, freedns.DOMAIN, {
+        freedns.DOMAIN: {
+            'access_token': ACCESS_TOKEN,
+            'timeout': TIMEOUT,
+            'update_interval': UPDATE_INTERVAL,
+        }
+    })
+    assert result
+    assert aioclient_mock.call_count == 1
+
+    async_fire_time_changed(hass, utcnow() + UPDATE_INTERVAL)
+    yield from hass.async_block_till_done()
+    assert aioclient_mock.call_count == 2
+
+
+@asyncio.coroutine
+def test_setup_fails_if_wrong_token(hass, aioclient_mock):
+    """Test setup fails if first update fails through wrong token."""
+    params = { }
+    params[ACCESS_TOKEN] = ""
+    aioclient_mock.get(
+        UPDATE_URL, params=params, text='ERROR: Invalid update URL (2)')
+
+    result = yield from async_setup_component(hass, freedns.DOMAIN, {
+        freedns.DOMAIN: {
+            'access_token': ACCESS_TOKEN,
+            'timeout': TIMEOUT,
+            'update_interval': UPDATE_INTERVAL,
+        }
+    })
+    assert not result
+    assert aioclient_mock.call_count == 1

--- a/tests/components/test_freedns.py
+++ b/tests/components/test_freedns.py
@@ -1,7 +1,5 @@
 """Test the FreeDNS component."""
 import asyncio
-from datetime import timedelta
-
 import pytest
 
 from homeassistant.setup import async_setup_component
@@ -11,14 +9,14 @@ from homeassistant.util.dt import utcnow
 from tests.common import async_fire_time_changed
 
 ACCESS_TOKEN = 'test_token'
-TIMEOUT = freedns.DEFAULT_TIMEOUT
 UPDATE_INTERVAL = freedns.DEFAULT_INTERVAL
 UPDATE_URL = freedns.UPDATE_URL
+
 
 @pytest.fixture
 def setup_freedns(hass, aioclient_mock):
     """Fixture that sets up FreeDNS."""
-    params = { }
+    params = {}
     params[ACCESS_TOKEN] = ""
     aioclient_mock.get(
         UPDATE_URL, params=params, text='Successfully updated 1 domains.')
@@ -26,7 +24,6 @@ def setup_freedns(hass, aioclient_mock):
     hass.loop.run_until_complete(async_setup_component(hass, freedns.DOMAIN, {
             freedns.DOMAIN: {
                 'access_token': ACCESS_TOKEN,
-                'timeout': TIMEOUT,
                 'update_interval': UPDATE_INTERVAL,
             }
         }))
@@ -35,16 +32,14 @@ def setup_freedns(hass, aioclient_mock):
 @asyncio.coroutine
 def test_setup(hass, aioclient_mock):
     """Test setup works if update passes."""
-    params = { }
+    params = {}
     params[ACCESS_TOKEN] = ""
     aioclient_mock.get(
-        UPDATE_URL, params=params,
-            text='ERROR: Address 1.2.3.4 has not changed.')
+        UPDATE_URL, params=params, text='ERROR: Address has not changed.')
 
     result = yield from async_setup_component(hass, freedns.DOMAIN, {
         freedns.DOMAIN: {
             'access_token': ACCESS_TOKEN,
-            'timeout': TIMEOUT,
             'update_interval': UPDATE_INTERVAL,
         }
     })
@@ -59,7 +54,7 @@ def test_setup(hass, aioclient_mock):
 @asyncio.coroutine
 def test_setup_fails_if_wrong_token(hass, aioclient_mock):
     """Test setup fails if first update fails through wrong token."""
-    params = { }
+    params = {}
     params[ACCESS_TOKEN] = ""
     aioclient_mock.get(
         UPDATE_URL, params=params, text='ERROR: Invalid update URL (2)')
@@ -67,7 +62,6 @@ def test_setup_fails_if_wrong_token(hass, aioclient_mock):
     result = yield from async_setup_component(hass, freedns.DOMAIN, {
         freedns.DOMAIN: {
             'access_token': ACCESS_TOKEN,
-            'timeout': TIMEOUT,
             'update_interval': UPDATE_INTERVAL,
         }
     })


### PR DESCRIPTION
## Description:
This adds ads yet another "Dynamic DNS" provider: [FreeDNS](https://freedns.afraid.org/).
It's free, community-driven and supports thousands of domains, so I guess it fits the spirit of HA.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5046

## Example entry for `configuration.yaml` (if applicable):
```yaml
freedns:
  access_token: YOUR_TOKEN
  update_interval:
    minutes: 15
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
