### PR TITLE
Fix FLUX_LED error when no color is set 

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -204,7 +204,7 @@ class FluxLight(Light):
             self._bulb.turnOn()
 
         hs_color = kwargs.get(ATTR_HS_COLOR)
-        
+
         if hs_color is not None:
             rgb = color_util.color_hs_to_RGB(*hs_color)
         elif hs_color is None:

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -204,7 +204,12 @@ class FluxLight(Light):
             self._bulb.turnOn()
 
         hs_color = kwargs.get(ATTR_HS_COLOR)
-        rgb = color_util.color_hs_to_RGB(*hs_color)
+        
+        if hs_color is not None:
+            rgb = color_util.color_hs_to_RGB(*hs_color)
+        elif hs_color is None:
+            rgb = None
+
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         effect = kwargs.get(ATTR_EFFECT)
 

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -205,9 +205,9 @@ class FluxLight(Light):
 
         hs_color = kwargs.get(ATTR_HS_COLOR)
 
-        if hs_color is not None:
+        if hs_color:
             rgb = color_util.color_hs_to_RGB(*hs_color)
-        elif hs_color is None:
+        else:
             rgb = None
 
         brightness = kwargs.get(ATTR_BRIGHTNESS)


### PR DESCRIPTION
## Description:
As is, an error gets thrown when turn_on is called without an HS value. By adding an if statement, we only try to set RGB if an HS value is applied.

**Related issue (if applicable):** fixes #13519

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
