### PR TITLE
Construct version pinned

### DIFF
--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_MAC, CONF_DEVICES, TEMP_CELSIUS, ATTR_TEMPERATURE, PRECISION_HALVES)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-eq3bt==0.1.9']
+REQUIREMENTS = ['python-eq3bt==0.1.9', 'construct==2.9.41']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -49,7 +49,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
          'zhimi.humidifier.ca1']),
 })
 
-REQUIREMENTS = ['python-miio==0.3.9']
+REQUIREMENTS = ['python-miio==0.3.9', 'construct==2.9.41']
 
 ATTR_MODEL = 'model'
 

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -41,7 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
          'philips.light.candle2']),
 })
 
-REQUIREMENTS = ['python-miio==0.3.9']
+REQUIREMENTS = ['python-miio==0.3.9', 'construct==2.9.41']
 
 # The light does not accept cct values < 1
 CCT_MIN = 1

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -22,7 +22,7 @@ from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.dt import utcnow
 
-REQUIREMENTS = ['python-miio==0.3.9']
+REQUIREMENTS = ['python-miio==0.3.9', 'construct==2.9.41']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/eddystone_temperature.py
+++ b/homeassistant/components/sensor/eddystone_temperature.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_NAME, TEMP_CELSIUS, STATE_UNKNOWN, EVENT_HOMEASSISTANT_STOP,
     EVENT_HOMEASSISTANT_START)
 
-REQUIREMENTS = ['beacontools[scan]==1.2.1']
+REQUIREMENTS = ['beacontools[scan]==1.2.1', 'construct==2.9.41']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/xiaomi_miio.py
+++ b/homeassistant/components/sensor/xiaomi_miio.py
@@ -25,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-REQUIREMENTS = ['python-miio==0.3.9']
+REQUIREMENTS = ['python-miio==0.3.9', 'construct==2.9.41']
 
 ATTR_POWER = 'power'
 ATTR_CHARGING = 'charging'

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -37,7 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
          'chuangmi.plug.v2']),
 })
 
-REQUIREMENTS = ['python-miio==0.3.9']
+REQUIREMENTS = ['python-miio==0.3.9', 'construct==2.9.41']
 
 ATTR_POWER = 'power'
 ATTR_TEMPERATURE = 'temperature'

--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_TOKEN, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-miio==0.3.9']
+REQUIREMENTS = ['python-miio==0.3.9', 'construct==2.9.41']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -189,6 +189,16 @@ colorlog==3.1.2
 # homeassistant.components.binary_sensor.concord232
 concord232==0.15
 
+# homeassistant.components.climate.eq3btsmart
+# homeassistant.components.fan.xiaomi_miio
+# homeassistant.components.light.xiaomi_miio
+# homeassistant.components.remote.xiaomi_miio
+# homeassistant.components.sensor.eddystone_temperature
+# homeassistant.components.sensor.xiaomi_miio
+# homeassistant.components.switch.xiaomi_miio
+# homeassistant.components.vacuum.xiaomi_miio
+construct==2.9.41
+
 # homeassistant.scripts.credstash
 # credstash==1.14.0
 


### PR DESCRIPTION
This is part of #13511. The construct version must be pinned because of an unstable API. The relaxed requirement of the eddystone_temperature sensor (beacontools) overrules the strict requirement of python-miio. All components are construct==2.9.41 compatible. 