### PR TITLE
Tradfri - unique_id's and color_temp support for rgb-bulbs

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -258,7 +258,8 @@ class TradfriLight(Light):
                 self._light_control.set_hsb(hue, sat, **params))
             return
 
-        if ATTR_COLOR_TEMP in kwargs and self._light_control.can_set_temp:
+        if ATTR_COLOR_TEMP in kwargs and (self._light_control.can_set_temp or
+                                          self._light_control.can_set_color):
             temp = kwargs[ATTR_COLOR_TEMP]
             if temp > self.max_mireds:
                 temp = self.max_mireds
@@ -267,13 +268,13 @@ class TradfriLight(Light):
 
             if brightness is None:
                 params[ATTR_TRANSITION_TIME] = transition_time
-            # White Spectrum bulb (can set temp, but cannot set color)
+            # White Spectrum bulb
             if (self._light_control.can_set_temp and
                     not self._light_control.can_set_color):
                 await self._api(
                     self._light_control.set_color_temp(temp, **params))
-            # Color White Spsctrum (CWS) bulb
-            # (It can set temp, but we need to set with hsb)
+            # Color bulb (CWS)
+            # color_temp needs to be set with hue/saturation
             if self._light_control.can_set_color:
                 params[ATTR_BRIGHTNESS] = brightness
                 temp_k = color_util.color_temperature_mired_to_kelvin(temp)

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -276,8 +276,8 @@ class TradfriLight(Light):
             # (It can set temp, but we need to set with hsb)
             if self._light_control.can_set_color:
                 params[ATTR_BRIGHTNESS] = brightness
-                temp_K = color_util.color_temperature_mired_to_kelvin(temp)
-                hs_color = color_util.color_temperature_to_hs(temp_K)
+                temp_k = color_util.color_temperature_mired_to_kelvin(temp)
+                hs_color = color_util.color_temperature_to_hs(temp_k)
                 hue = int(hs_color[0] * (65535 / 360))
                 sat = int(hs_color[1] * (65279 / 100))
                 await self._api(


### PR DESCRIPTION
## Description:

### unique_ids for lights and light groups:

These are based on the gateway_id and the group/light id. The group/light id's can change when users re-pair their devices, or when users reset their gateway to factory defaults.
This is the best we can currently get on this platform.
Unfortunately tradfri doesn't expose the serial numbers on their API (while they do for thier Homekit integration)

There's already been some discussion about the unique_id style here: #13439 
 
## setting color temperature on a color/rgb bulb:

Unfortunately the CWS (color white spectrum) bulbs don't react to setting their color_temperature value. So we need to convert the color_temperature to hs(b) and set that with set_hsb.
This solves a feature regression compared to the previous platform/library version.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**