### PR TITLE
Add timeout / debounce (for brightness and others)

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -1,19 +1,62 @@
 """Extend the basic Accessory and Bridge functions."""
+from datetime import timedelta
+from functools import wraps
+from inspect import getmodule
 import logging
 
 from pyhap.accessory import Accessory, Bridge, Category
 from pyhap.accessory_driver import AccessoryDriver
 
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.core import callback
+from homeassistant.helpers.event import (
+    async_track_state_change, track_point_in_utc_time)
+from homeassistant.util import dt as dt_util
 
 from .const import (
-    ACCESSORY_MODEL, ACCESSORY_NAME, BRIDGE_MODEL, BRIDGE_NAME,
-    MANUFACTURER, SERV_ACCESSORY_INFO, CHAR_MANUFACTURER, CHAR_MODEL,
-    CHAR_NAME, CHAR_SERIAL_NUMBER)
+    DEBOUNCE_TIMEOUT, ACCESSORY_MODEL, ACCESSORY_NAME, BRIDGE_MODEL,
+    BRIDGE_NAME, MANUFACTURER, SERV_ACCESSORY_INFO, CHAR_MANUFACTURER,
+    CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER)
 from .util import (
     show_setup_message, dismiss_setup_message)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def debounce(func):
+    """Decorator function. Debounce callbacks form HomeKit."""
+    @callback
+    def call_later_listener(*args):
+        """Callback listener called from call_later."""
+        # pylint: disable=unsubscriptable-object
+        nonlocal lastargs, remove_listener
+        hass = lastargs[0]
+        hass.async_add_job(func, *lastargs[1:])
+        lastargs = remove_listener = None
+
+    @wraps(func)
+    def wrapper(*args):
+        """Wrapper starts async timer.
+
+        The accessory must have 'self.hass' and 'self.entity_id' as attributes.
+        """
+        # pylint: disable=not-callable
+        hass = args[0].hass
+        nonlocal lastargs, remove_listener
+        if remove_listener:
+            remove_listener()
+            lastargs = remove_listener = None
+        lastargs = (hass, *args)
+        remove_listener = track_point_in_utc_time(
+            hass, call_later_listener,
+            dt_util.utcnow() + timedelta(seconds=DEBOUNCE_TIMEOUT))
+        logger.debug('%s: Start %s timeout', args[0].entity_id,
+                     func.__name__.replace('set_', ''))
+
+    remove_listener = None
+    lastargs = None
+    name = getmodule(func).__name__
+    logger = logging.getLogger(name)
+    return wrapper
 
 
 def add_preload_service(acc, service, chars=None):

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -29,8 +29,8 @@ def debounce(func):
         """Callback listener called from call_later."""
         # pylint: disable=unsubscriptable-object
         nonlocal lastargs, remove_listener
-        hass = lastargs[0]
-        hass.async_add_job(func, *lastargs[1:])
+        hass = lastargs['hass']
+        hass.async_add_job(func, *lastargs['args'])
         lastargs = remove_listener = None
 
     @wraps(func)
@@ -45,7 +45,7 @@ def debounce(func):
         if remove_listener:
             remove_listener()
             lastargs = remove_listener = None
-        lastargs = (hass, *args)
+        lastargs = {'hass': hass, 'args': [*args]}
         remove_listener = track_point_in_utc_time(
             hass, call_later_listener,
             dt_util.utcnow() + timedelta(seconds=DEBOUNCE_TIMEOUT))

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -1,5 +1,6 @@
 """Constants used be the HomeKit component."""
 # #### MISC ####
+DEBOUNCE_TIMEOUT = 0.5
 DOMAIN = 'homekit'
 HOMEKIT_FILE = '.homekit.state'
 HOMEKIT_NOTIFY_ID = 4663548

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -7,7 +7,7 @@ from homeassistant.components.light import (
 from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_ON, STATE_OFF
 
 from . import TYPES
-from .accessories import HomeAccessory, add_preload_service
+from .accessories import HomeAccessory, add_preload_service, debounce
 from .const import (
     CATEGORY_LIGHT, SERV_LIGHTBULB, CHAR_COLOR_TEMPERATURE,
     CHAR_BRIGHTNESS, CHAR_HUE, CHAR_ON, CHAR_SATURATION)
@@ -94,6 +94,7 @@ class Light(HomeAccessory):
         elif value == 0:
             self.hass.components.light.turn_off(self.entity_id)
 
+    @debounce
     def set_brightness(self, value):
         """Set brightness if call came from HomeKit."""
         _LOGGER.debug('%s: Set brightness to %d', self.entity_id, value)

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -10,7 +10,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, STATE_OFF, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
 from . import TYPES
-from .accessories import HomeAccessory, add_preload_service
+from .accessories import HomeAccessory, add_preload_service, debounce
 from .const import (
     CATEGORY_THERMOSTAT, SERV_THERMOSTAT, CHAR_CURRENT_HEATING_COOLING,
     CHAR_TARGET_HEATING_COOLING, CHAR_CURRENT_TEMPERATURE,
@@ -105,6 +105,7 @@ class Thermostat(HomeAccessory):
             self.hass.components.climate.set_operation_mode(
                 operation_mode=hass_value, entity_id=self.entity_id)
 
+    @debounce
     def set_cooling_threshold(self, value):
         """Set cooling threshold temp to value if call came from HomeKit."""
         _LOGGER.debug('%s: Set cooling threshold temperature to %.2f°C',
@@ -118,6 +119,7 @@ class Thermostat(HomeAccessory):
             entity_id=self.entity_id, target_temp_high=value,
             target_temp_low=low)
 
+    @debounce
     def set_heating_threshold(self, value):
         """Set heating threshold temp to value if call came from HomeKit."""
         _LOGGER.debug('%s: Set heating threshold temperature to %.2f°C',
@@ -132,6 +134,7 @@ class Thermostat(HomeAccessory):
             entity_id=self.entity_id, target_temp_high=high,
             target_temp_low=value)
 
+    @debounce
     def set_target_temperature(self, value):
         """Set target temperature to value if call came from HomeKit."""
         _LOGGER.debug('%s: Set target temperature to %.2f°C',

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -19,6 +19,12 @@ import homeassistant.util.dt as dt_util
 from tests.common import get_test_home_assistant
 
 
+def patch_debounce():
+    """Return patch for debounce method."""
+    return patch('homeassistant.components.homekit.accessories.debounce',
+                 lambda f: lambda *args, **kwargs: f(*args, **kwargs))
+
+
 class TestAccessories(unittest.TestCase):
     """Test pyhap adapter methods."""
 

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -2,20 +2,60 @@
 
 This includes tests for all mock object types.
 """
+from datetime import datetime, timedelta
 import unittest
 from unittest.mock import call, patch, Mock
 
 from homeassistant.components.homekit.accessories import (
     add_preload_service, set_accessory_info,
-    HomeAccessory, HomeBridge, HomeDriver)
+    debounce, HomeAccessory, HomeBridge, HomeDriver)
 from homeassistant.components.homekit.const import (
     ACCESSORY_MODEL, ACCESSORY_NAME, BRIDGE_MODEL, BRIDGE_NAME,
     SERV_ACCESSORY_INFO, CHAR_MANUFACTURER, CHAR_MODEL,
     CHAR_NAME, CHAR_SERIAL_NUMBER)
+from homeassistant.const import ATTR_NOW, EVENT_TIME_CHANGED
+import homeassistant.util.dt as dt_util
+
+from tests.common import get_test_home_assistant
 
 
 class TestAccessories(unittest.TestCase):
     """Test pyhap adapter methods."""
+
+    def test_debounce(self):
+        """Test add_timeout decorator function."""
+        def demo_func(*args):
+            nonlocal arguments, counter
+            counter += 1
+            arguments = args
+
+        arguments = None
+        counter = 0
+        hass = get_test_home_assistant()
+        mock = Mock(hass=hass)
+
+        debounce_demo = debounce(demo_func)
+        self.assertEqual(debounce_demo.__name__, 'demo_func')
+        now = datetime(2018, 1, 1, 20, 0, 0, tzinfo=dt_util.UTC)
+
+        with patch('homeassistant.util.dt.utcnow', return_value=now):
+            debounce_demo(mock, 'value')
+        hass.bus.fire(
+            EVENT_TIME_CHANGED, {ATTR_NOW: now + timedelta(seconds=3)})
+        hass.block_till_done()
+        assert counter == 1
+        assert len(arguments) == 2
+
+        with patch('homeassistant.util.dt.utcnow', return_value=now):
+            debounce_demo(mock, 'value')
+            debounce_demo(mock, 'value')
+
+        hass.bus.fire(
+            EVENT_TIME_CHANGED, {ATTR_NOW: now + timedelta(seconds=3)})
+        hass.block_till_done()
+        assert counter == 2
+
+        hass.stop()
 
     def test_add_preload_service(self):
         """Test add_preload_service without additional characteristics."""

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_PORT, EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 
 from tests.common import get_test_home_assistant
+from tests.components.homekit.test_accessories import patch_debounce
 
 IP_ADDRESS = '127.0.0.1'
 PATH_HOMEKIT = 'homeassistant.components.homekit'
@@ -21,6 +22,17 @@ PATH_HOMEKIT = 'homeassistant.components.homekit'
 
 class TestHomeKit(unittest.TestCase):
     """Test setup of HomeKit component and HomeKit class."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup debounce patcher."""
+        cls.patcher = patch_debounce()
+        cls.patcher.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Stop debounce patcher."""
+        cls.patcher.stop()
 
     def setUp(self):
         """Setup things to be run when tests are started."""

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -1,8 +1,8 @@
 """Test different accessory types: Lights."""
 import unittest
+from unittest.mock import patch
 
 from homeassistant.core import callback
-from homeassistant.components.homekit.type_lights import Light
 from homeassistant.components.light import (
     DOMAIN, ATTR_BRIGHTNESS, ATTR_BRIGHTNESS_PCT, ATTR_COLOR_TEMP,
     ATTR_HS_COLOR, SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_COLOR)
@@ -12,6 +12,10 @@ from homeassistant.const import (
     SERVICE_TURN_OFF, STATE_ON, STATE_OFF, STATE_UNKNOWN)
 
 from tests.common import get_test_home_assistant
+
+patch('homeassistant.components.homekit.accessories.debounce',
+      lambda f: lambda *args, **kwargs: f(*args, **kwargs)).start()
+from homeassistant.components.homekit.type_lights import Light  # noqa: E402
 
 
 class TestHomekitLights(unittest.TestCase):

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -1,17 +1,22 @@
 """Test different accessory types: Thermostats."""
 import unittest
+from unittest.mock import patch
 
 from homeassistant.core import callback
 from homeassistant.components.climate import (
     ATTR_CURRENT_TEMPERATURE, ATTR_TEMPERATURE,
     ATTR_TARGET_TEMP_LOW, ATTR_TARGET_TEMP_HIGH, ATTR_OPERATION_MODE,
     ATTR_OPERATION_LIST, STATE_COOL, STATE_HEAT, STATE_AUTO)
-from homeassistant.components.homekit.type_thermostats import Thermostat
 from homeassistant.const import (
     ATTR_SERVICE, EVENT_CALL_SERVICE, ATTR_SERVICE_DATA,
     ATTR_UNIT_OF_MEASUREMENT, STATE_OFF, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
 from tests.common import get_test_home_assistant
+
+patch('homeassistant.components.homekit.accessories.debounce',
+      lambda f: lambda *args, **kwargs: f(*args, **kwargs)).start()
+from homeassistant.components.homekit.type_thermostats import (  # noqa: E402
+    Thermostat)
 
 
 class TestHomekitThermostats(unittest.TestCase):


### PR DESCRIPTION
## Description:
This PR fixes an issue, where for continuous characteristics slowly changing the value in the `Home` app caused multiple service calls, instead of just one. ~~Since this timeout feature introduces latency, I decided to add a configuration parameter for it, so users can decide how long the timeout should be (float, between 0 and 5s).~~ The Timeout is set to 0.5s.

In addition I did some style cleanup.


**Related issue:** fixes #13493
**Discussion belove:** #12819

~~**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5050~~

## Example entry for `configuration.yaml` (if applicable):
```yaml
homekit:
  timeout: 2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
  - [x] ~~Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~~

---

cc: @maxclaey @DaveOke