### PR TITLE
Don't add falsy items to list (merge_packages)

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -554,6 +554,8 @@ def merge_packages_config(config, packages, _log_pkg_error=_log_pkg_error):
                 continue
 
             if hasattr(component, 'PLATFORM_SCHEMA'):
+                if not comp_conf:
+                    continue  # Ensure we dont add Falsy items to list
                 config[comp_name] = cv.ensure_list(config.get(comp_name))
                 config[comp_name].extend(cv.ensure_list(comp_conf))
                 continue
@@ -562,6 +564,8 @@ def merge_packages_config(config, packages, _log_pkg_error=_log_pkg_error):
                 merge_type, _ = _identify_config_schema(component)
 
                 if merge_type == 'list':
+                    if not comp_conf:
+                        continue  # Ensure we dont add Falsy items to list
                     config[comp_name] = cv.ensure_list(config.get(comp_name))
                     config[comp_name].extend(cv.ensure_list(comp_conf))
                     continue

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -592,6 +592,25 @@ def test_merge(merge_log_err):
     assert config['wake_on_lan'] is None
 
 
+def test_merge_try_falsy(merge_log_err):
+    """Ensure we dont add falsy items like empty OrderedDict() to list."""
+    packages = {
+        'pack_falsy_to_lst': {'automation': OrderedDict()},
+        'pack_list2': {'light': OrderedDict()},
+    }
+    config = {
+        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        'automation': {'do': 'something'},
+        'light': {'some': 'light'},
+    }
+    config_util.merge_packages_config(config, packages)
+
+    assert merge_log_err.call_count == 0
+    assert len(config) == 3
+    assert len(config['automation']) == 1
+    assert len(config['light']) == 1
+
+
 def test_merge_new(merge_log_err):
     """Test adding new components to outer scope."""
     packages = {


### PR DESCRIPTION
## Description:
`merge_pakages` added falsy items to list (i.e. empty OrderedDict() from load_yaml added to automation list)

**Related issue (if applicable):** fixes #13412

## FIXED Example entry for `configuration.yaml` (if applicable):

```yaml
homeassistant:
  packages:
    empty_auto:
      automation: !include empty.yaml

automation:
  - alias: "Some valid automation"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
