### PR TITLE
Add additional receiver for Onkyo zone 2

### DIFF
--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -64,9 +64,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             if config.get(CONF_ZONE2):
                 _LOGGER.debug("Setting up zone 2")
                 hosts.append(OnkyoDevice(eiscp.eISCP(host),
-                             config.get(CONF_SOURCES),
-                             name=config.get(CONF_NAME) + " Zone 2",
-                             zone=2))
+                                         config.get(CONF_SOURCES),
+                                         name=config.get(CONF_NAME) +
+                                         " Zone 2", zone=2))
         except OSError:
             _LOGGER.error("Unable to connect to receiver at %s", host)
     else:

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -110,9 +110,9 @@ class OnkyoDevice(MediaPlayerDevice):
 
     def update(self):
         """Get the latest details from the device."""
-        if self._zone is 1:
+        if self._zone == 1:
             status = self.command('system-power query')
-        elif self._zone is 2:
+        elif self._zone == 2:
             status = self.command('zone2.power=query')
 
         if not status:
@@ -123,11 +123,11 @@ class OnkyoDevice(MediaPlayerDevice):
             self._pwstate = STATE_OFF
             return
 
-        if self._zone is 1:
+        if self._zone == 1:
             volume_raw = self.command('volume query')
             mute_raw = self.command('audio-muting query')
             current_source_raw = self.command('input-selector query')
-        elif self._zone is 2:
+        elif self._zone == 2:
             volume_raw = self.command('zone2.volume=query')
             mute_raw = self.command('zone2.muting=query')
             current_source_raw = self.command('zone2.selector=query')
@@ -194,26 +194,26 @@ class OnkyoDevice(MediaPlayerDevice):
 
     def turn_off(self):
         """Turn off media player."""
-        if self._zone is 1:
+        if self._zone == 1:
             self.command('system-power standby')
-        elif self._zone is 2:
+        elif self._zone == 2:
             self.command('zone2.power=standby')
 
     def set_volume_level(self, volume):
         """Set volume level, input is range 0..1. Onkyo ranges from 1-80."""
-        if self._zone is 1:
+        if self._zone == 1:
             self.command('volume {}'.format(int(volume*80)))
-        elif self._zone is 2:
+        elif self._zone == 2:
             self.command('zone2.volume={}'.format(int(volume*80)))
 
     def mute_volume(self, mute):
         """Mute (true) or unmute (false) media player."""
-        if self._zone is 1:
+        if self._zone == 1:
             if mute:
                 self.command('audio-muting on')
             else:
                 self.command('audio-muting off')
-        elif self._zone is 2:
+        elif self._zone == 2:
             if mute:
                 self.command('zone2.muting=on')
             else:
@@ -221,9 +221,9 @@ class OnkyoDevice(MediaPlayerDevice):
 
     def turn_on(self):
         """Turn the media player on."""
-        if self._zone is 1:
+        if self._zone == 1:
             self.command('system-power on')
-        elif self._zone is 2:
+        elif self._zone == 2:
             self.command('zone2.power=on')
 
     def select_source(self, source):
@@ -231,7 +231,7 @@ class OnkyoDevice(MediaPlayerDevice):
         if source in self._source_list:
             source = self._reverse_mapping[source]
 
-        if self._zone is 1:
+        if self._zone == 1:
             self.command('input-selector {}'.format(source))
-        elif self._zone is 2:
+        elif self._zone == 2:
             self.command('zone2.selector={}'.format(source))

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -108,7 +108,7 @@ class OnkyoDevice(MediaPlayerDevice):
         return result
 
     def update(self):
-        """Get the latest details from the device."""
+        """Get the latest state from the device."""
         status = self.command('system-power query')
 
         if not status:
@@ -160,12 +160,12 @@ class OnkyoDevice(MediaPlayerDevice):
 
     @property
     def is_volume_muted(self):
-        """Boolean if volume is currently muted."""
+        """Return boolean indicating mute status."""
         return self._muted
 
     @property
     def supported_features(self):
-        """Flag media player features that are supported."""
+        """Return media player features that are supported."""
         return SUPPORT_ONKYO
 
     @property
@@ -179,7 +179,7 @@ class OnkyoDevice(MediaPlayerDevice):
         return self._source_list
 
     def turn_off(self):
-        """Turn off media player."""
+        """Turn the media player off."""
         self.command('system-power standby')
 
     def set_volume_level(self, volume):
@@ -205,10 +205,10 @@ class OnkyoDevice(MediaPlayerDevice):
 
 
 class OnkyoDeviceZone2(OnkyoDevice):
-    """Representation of an Onkyo devices zone 2."""
+    """Representation of an Onkyo device's zone 2."""
 
     def update(self):
-        """Get the latest details from the device."""
+        """Get the latest state from the device."""
         status = self.command('zone2.power=query')
 
         if not status:
@@ -244,7 +244,7 @@ class OnkyoDeviceZone2(OnkyoDevice):
         self._volume = volume_raw[1] / 80.0
 
     def turn_off(self):
-        """Turn off media player."""
+        """Turn the media player off."""
         self.command('zone2.power=standby')
 
     def set_volume_level(self, volume):


### PR DESCRIPTION
## Description:

Adds a media player to control Zone 2 on an Onkyo receiver.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5058

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: Onkyo
    host: 192.168.1.50
    zone2: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

