### PR TITLE
[WIP] CalDav: Add option to define time offset per calendar (previously only by event)

### DIFF
--- a/homeassistant/components/calendar/google.py
+++ b/homeassistant/components/calendar/google.py
@@ -8,11 +8,11 @@ https://home-assistant.io/components/binary_sensor.google_calendar/
 import logging
 from datetime import timedelta
 
-from homeassistant.components.calendar import CalendarEventDevice
+from homeassistant.components.calendar import (
+    CONF_SEARCH, CalendarEventDevice)
 from homeassistant.components.google import (
     CONF_CAL_ID, CONF_ENTITIES, CONF_TRACK, TOKEN_FILE,
-    CONF_IGNORE_AVAILABILITY, CONF_SEARCH,
-    GoogleCalendarService)
+    CONF_IGNORE_AVAILABILITY, GoogleCalendarService)
 from homeassistant.util import Throttle, dt
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/google.py
+++ b/homeassistant/components/google.py
@@ -17,6 +17,8 @@ import voluptuous as vol
 from voluptuous.error import Error as VoluptuousError
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.components.calendar import (
+    CONF_OFFSET, CONF_SEARCH, CONF_DEVICE_ID, CONF_NAME)
 from homeassistant.setup import setup_component
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import generate_entity_id
@@ -38,16 +40,11 @@ CONF_CLIENT_SECRET = 'client_secret'
 CONF_TRACK_NEW = 'track_new_calendar'
 
 CONF_CAL_ID = 'cal_id'
-CONF_DEVICE_ID = 'device_id'
-CONF_NAME = 'name'
 CONF_ENTITIES = 'entities'
 CONF_TRACK = 'track'
-CONF_SEARCH = 'search'
-CONF_OFFSET = 'offset'
 CONF_IGNORE_AVAILABILITY = 'ignore_availability'
 
 DEFAULT_CONF_TRACK_NEW = True
-DEFAULT_CONF_OFFSET = '!!'
 
 NOTIFICATION_ID = 'google_calendar_notification'
 NOTIFICATION_TITLE = 'Google Calendar Setup'


### PR DESCRIPTION
## Description:
Currently, a time offset can be defined per event, which needs to be specified in the event title. This PR adds the ability to define a default offset per calendar, thus allowing offsets also on external calendar feeds over which the user does not have control.

If an offset is specified for an event, this takes priority over the default value for the calendar.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5578

## Example entry for `configuration.yaml` (if applicable):
In this example, the offset_reached attribute would activate 15 minutes before any event in the calendar
```yaml
calendar:
  - platform: caldav
    url: !secret caldav
    username: !secret username
    password: !secret password
    custom_calendars:
       - name: 'Lecture'
         calendar: 'Uni'
         search: 'Lecture'
         daysforward: 2
         include_all_day: false
         cal_offset:
                hours: -1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
