### PR TITLE
Improve Google Assistant support for climate operation modes

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -19,8 +19,6 @@ DEFAULT_EXPOSE_BY_DEFAULT = True
 DEFAULT_EXPOSED_DOMAINS = [
     'switch', 'light', 'group', 'media_player', 'fan', 'cover', 'climate'
 ]
-CLIMATE_MODE_HEATCOOL = 'heatcool'
-CLIMATE_SUPPORTED_MODES = {'heat', 'cool', 'off', 'on', CLIMATE_MODE_HEATCOOL}
 
 PREFIX_TYPES = 'action.devices.types.'
 TYPE_LIGHT = PREFIX_TYPES + 'LIGHT'

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -46,6 +46,21 @@ COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE = (
 COMMAND_THERMOSTAT_SET_MODE = PREFIX_COMMANDS + 'ThermostatSetMode'
 
 
+GOOGLE_TEMP_UNITS = {
+    TEMP_FAHRENHEIT: 'F',
+    TEMP_CELSIUS: 'C',
+}
+
+GOOGLE_THERMOSTAT_MODES = {
+    climate.STATE_HEAT: 'heat',
+    climate.STATE_COOL: 'cool',
+    climate.STATE_AUTO: 'heatcool',
+    climate.STATE_ECO: 'heatcool',
+    climate.STATE_IDLE: 'off',
+    climate.STATE_FAN_ONLY: 'off',
+    climate.STATE_DRY: 'off',
+}
+
 TRAITS = []
 
 
@@ -53,14 +68,6 @@ def register_trait(trait):
     """Decorator to register a trait."""
     TRAITS.append(trait)
     return trait
-
-
-def _google_temp_unit(state):
-    """Return Google temperature unit."""
-    if (state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) ==
-            TEMP_FAHRENHEIT):
-        return 'F'
-    return 'C'
 
 
 class _Trait:
@@ -395,15 +402,6 @@ class TemperatureSettingTrait(_Trait):
         COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE,
         COMMAND_THERMOSTAT_SET_MODE,
     ]
-    # We do not support "on" as we are unable to know how to restore
-    # the last mode.
-    hass_to_google = {
-        climate.STATE_HEAT: 'heat',
-        climate.STATE_COOL: 'cool',
-        climate.STATE_OFF: 'off',
-        climate.STATE_AUTO: 'heatcool',
-    }
-    google_to_hass = {value: key for key, value in hass_to_google.items()}
 
     @staticmethod
     def supported(domain, features):
@@ -415,15 +413,18 @@ class TemperatureSettingTrait(_Trait):
 
     def sync_attributes(self):
         """Return temperature point and modes attributes for a sync request."""
+        unit = self.state.attributes[ATTR_UNIT_OF_MEASUREMENT]
         modes = []
-        for mode in self.state.attributes.get(climate.ATTR_OPERATION_LIST, []):
-            google_mode = self.hass_to_google.get(mode)
-            if google_mode is not None:
+        # We do not support "on" as we are unable to know how to restore
+        # the last mode.
+        for mode in self.state.attributes.get(climate.ATTR_OPERATION_LIST):
+            google_mode = GOOGLE_THERMOSTAT_MODES.get(mode)
+            if google_mode is not None and google_mode not in modes:
                 modes.append(google_mode)
 
         return {
             'availableThermostatModes': ','.join(modes),
-            'thermostatTemperatureUnit': _google_temp_unit(self.state),
+            'thermostatTemperatureUnit': GOOGLE_TEMP_UNITS[unit],
         }
 
     def query_attributes(self):
@@ -432,8 +433,8 @@ class TemperatureSettingTrait(_Trait):
         response = {}
 
         operation = attrs.get(climate.ATTR_OPERATION_MODE)
-        if operation is not None and operation in self.hass_to_google:
-            response['thermostatMode'] = self.hass_to_google[operation]
+        if operation is not None and operation in GOOGLE_THERMOSTAT_MODES:
+            response['thermostatMode'] = GOOGLE_THERMOSTAT_MODES[operation]
 
         unit = self.state.attributes[ATTR_UNIT_OF_MEASUREMENT]
 
@@ -514,9 +515,16 @@ class TemperatureSettingTrait(_Trait):
                 }, blocking=True)
 
         elif command == COMMAND_THERMOSTAT_SET_MODE:
+            mode = params['thermostatMode']
+            # Work around a pylint false positive due to
+            #  https://github.com/PyCQA/pylint/issues/1830
+            # pylint: disable=stop-iteration-return
+            operation = next(
+                (k for k, v in GOOGLE_THERMOSTAT_MODES.items() if v == mode),
+                None
+            )
             await hass.services.async_call(
                 climate.DOMAIN, climate.SERVICE_SET_OPERATION_MODE, {
                     ATTR_ENTITY_ID: self.state.entity_id,
-                    climate.ATTR_OPERATION_MODE:
-                        self.google_to_hass[params['thermostatMode']],
+                    climate.ATTR_OPERATION_MODE: operation,
                 }, blocking=True)

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -507,7 +507,7 @@ async def test_temperature_setting_climate_range(hass):
             climate.ATTR_CURRENT_HUMIDITY: 25,
             climate.ATTR_OPERATION_MODE: climate.STATE_AUTO,
             climate.ATTR_OPERATION_LIST: [
-                climate.STATE_OFF,
+                climate.STATE_IDLE,
                 climate.STATE_COOL,
                 climate.STATE_HEAT,
                 climate.STATE_AUTO,
@@ -557,6 +557,17 @@ async def test_temperature_setting_climate_range(hass):
         climate.ATTR_OPERATION_MODE: climate.STATE_AUTO,
     }
 
+    calls = async_mock_service(
+        hass, climate.DOMAIN, climate.SERVICE_SET_OPERATION_MODE)
+    await trt.execute(hass, trait.COMMAND_THERMOSTAT_SET_MODE, {
+        'thermostatMode': 'off',
+    })
+    assert len(calls) == 1
+    assert calls[0].data == {
+        ATTR_ENTITY_ID: 'climate.bla',
+        climate.ATTR_OPERATION_MODE: climate.STATE_IDLE,
+    }
+
     with pytest.raises(helpers.SmartHomeError) as err:
         await trt.execute(
             hass, trait.COMMAND_THERMOSTAT_TEMPERATURE_SETPOINT, {
@@ -575,7 +586,7 @@ async def test_temperature_setting_climate_setpoint(hass):
         'climate.bla', climate.STATE_AUTO, {
             climate.ATTR_OPERATION_MODE: climate.STATE_COOL,
             climate.ATTR_OPERATION_LIST: [
-                climate.STATE_OFF,
+                climate.STATE_IDLE,
                 climate.STATE_COOL,
             ],
             climate.ATTR_MIN_TEMP: 10,


### PR DESCRIPTION
## Description:

Corrects `climate.STATE_OFF` to `climate.STATE_IDLE`, adds some missing states, and refactors the mapping code between Google and HA modes to match the Alexa component.

## Example entry for `configuration.yaml` (if applicable):
```yaml
google_assistant:
  exposed_domains:
    - climate
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.