### PR TITLE
Update HAP-python to 1.1.8

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -28,7 +28,7 @@ from .util import (
 TYPES = Registry()
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['HAP-python==1.1.7']
+REQUIREMENTS = ['HAP-python==1.1.8']
 
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -8,8 +8,8 @@ from homeassistant.helpers.event import async_track_state_change
 
 from .const import (
     ACCESSORY_MODEL, ACCESSORY_NAME, BRIDGE_MODEL, BRIDGE_NAME,
-    MANUFACTURER, SERV_ACCESSORY_INFO, SERV_BRIDGING_STATE,
-    CHAR_MANUFACTURER, CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER)
+    MANUFACTURER, SERV_ACCESSORY_INFO, CHAR_MANUFACTURER, CHAR_MODEL,
+    CHAR_NAME, CHAR_SERIAL_NUMBER)
 from .util import (
     show_setup_message, dismiss_setup_message)
 
@@ -37,15 +37,6 @@ def set_accessory_info(acc, name, model, manufacturer=MANUFACTURER,
     service.get_characteristic(CHAR_MODEL).set_value(model)
     service.get_characteristic(CHAR_MANUFACTURER).set_value(manufacturer)
     service.get_characteristic(CHAR_SERIAL_NUMBER).set_value(serial_number)
-
-
-def override_properties(char, properties=None, valid_values=None):
-    """Override characteristic property values and valid values."""
-    if properties:
-        char.properties.update(properties)
-
-    if valid_values:
-        char.properties['ValidValues'].update(valid_values)
 
 
 class HomeAccessory(Accessory):
@@ -83,7 +74,6 @@ class HomeBridge(Bridge):
 
     def _set_services(self):
         add_preload_service(self, SERV_ACCESSORY_INFO)
-        add_preload_service(self, SERV_BRIDGING_STATE)
 
     def setup_message(self):
         """Prevent print of pyhap setup message to terminal."""

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -34,7 +34,6 @@ CATEGORY_WINDOW_COVERING = 'WINDOW_COVERING'
 
 # #### Services ####
 SERV_ACCESSORY_INFO = 'AccessoryInformation'
-SERV_BRIDGING_STATE = 'BridgingState'
 SERV_HUMIDITY_SENSOR = 'HumiditySensor'
 # CurrentRelativeHumidity | StatusActive, StatusFault, StatusTampered,
 # StatusLowBattery, Name
@@ -47,9 +46,7 @@ SERV_WINDOW_COVERING = 'WindowCovering'
 
 
 # #### Characteristics ####
-CHAR_ACC_IDENTIFIER = 'AccessoryIdentifier'
 CHAR_BRIGHTNESS = 'Brightness'  # Int | [0, 100]
-CHAR_CATEGORY = 'Category'
 CHAR_COOLING_THRESHOLD_TEMPERATURE = 'CoolingThresholdTemperature'
 CHAR_CURRENT_HEATING_COOLING = 'CurrentHeatingCoolingState'
 CHAR_CURRENT_POSITION = 'CurrentPosition'
@@ -58,13 +55,11 @@ CHAR_CURRENT_SECURITY_STATE = 'SecuritySystemCurrentState'
 CHAR_CURRENT_TEMPERATURE = 'CurrentTemperature'
 CHAR_HEATING_THRESHOLD_TEMPERATURE = 'HeatingThresholdTemperature'
 CHAR_HUE = 'Hue'  # arcdegress | [0, 360]
-CHAR_LINK_QUALITY = 'LinkQuality'
 CHAR_MANUFACTURER = 'Manufacturer'
 CHAR_MODEL = 'Model'
 CHAR_NAME = 'Name'
 CHAR_ON = 'On'  # boolean
 CHAR_POSITION_STATE = 'PositionState'
-CHAR_REACHABLE = 'Reachable'
 CHAR_SATURATION = 'Saturation'  # percent
 CHAR_SERIAL_NUMBER = 'SerialNumber'
 CHAR_TARGET_HEATING_COOLING = 'TargetHeatingCoolingState'

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -152,4 +152,5 @@ class Light(HomeAccessory):
                 self.char_hue.set_value(hue, should_callback=False)
                 self.char_saturation.set_value(saturation,
                                                should_callback=False)
+                self._hue, self._saturation = (hue, saturation)
             self._flag[RGB_COLOR] = False

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -5,8 +5,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
 
 from . import TYPES
-from .accessories import (
-    HomeAccessory, add_preload_service, override_properties)
+from .accessories import HomeAccessory, add_preload_service
 from .const import (
     CATEGORY_SENSOR, SERV_HUMIDITY_SENSOR, SERV_TEMPERATURE_SENSOR,
     CHAR_CURRENT_HUMIDITY, CHAR_CURRENT_TEMPERATURE, PROP_CELSIUS)
@@ -32,7 +31,7 @@ class TemperatureSensor(HomeAccessory):
 
         serv_temp = add_preload_service(self, SERV_TEMPERATURE_SENSOR)
         self.char_temp = serv_temp.get_characteristic(CHAR_CURRENT_TEMPERATURE)
-        override_properties(self.char_temp, PROP_CELSIUS)
+        self.char_temp.override_properties(properties=PROP_CELSIUS)
         self.char_temp.value = 0
         self.unit = None
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -22,7 +22,7 @@ attrs==17.4.0
 DoorBirdPy==0.1.3
 
 # homeassistant.components.homekit
-HAP-python==1.1.7
+HAP-python==1.1.8
 
 # homeassistant.components.notify.mastodon
 Mastodon.py==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -19,7 +19,7 @@ requests_mock==1.4
 
 
 # homeassistant.components.homekit
-HAP-python==1.1.7
+HAP-python==1.1.8
 
 # homeassistant.components.notify.html5
 PyJWT==1.6.0


### PR DESCRIPTION
~~Do not merge yet, in case hotfixes to `0.66.0` are necessary.~~

## Changelog (partial):
 - The service `BridgingState` is not supported anymore
 - `override_properties` is now part of `HAP-python`
 - `char.get_value` is no longer supported


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**