### PR TITLE
Unflake folder watcher test

### DIFF
--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -202,8 +202,5 @@ wakeonlan==1.0.0
 # homeassistant.components.cloud
 warrant==0.6.1
 
-# homeassistant.components.folder_watcher
-watchdog==0.8.3
-
 # homeassistant.components.sensor.yahoo_finance
 yahoo-finance==1.4.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -91,7 +91,6 @@ TEST_REQUIREMENTS = (
     'yahoo-finance',
     'pythonwhois',
     'wakeonlan',
-    'watchdog',
     'vultr'
 )
 

--- a/tests/components/test_folder_watcher.py
+++ b/tests/components/test_folder_watcher.py
@@ -4,7 +4,7 @@ import os
 
 from homeassistant.components import folder_watcher
 from homeassistant.setup import async_setup_component
-from tests.common import get_test_home_assistant, MockDependency
+from tests.common import MockDependency
 
 
 async def test_invalid_path_setup(hass):

--- a/tests/components/test_folder_watcher.py
+++ b/tests/components/test_folder_watcher.py
@@ -1,46 +1,31 @@
 """The tests for the folder_watcher component."""
-import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 import os
 
 from homeassistant.components import folder_watcher
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 from tests.common import get_test_home_assistant, MockDependency
 
-CWD = os.path.join(os.path.dirname(__file__))
-FILE = 'file.txt'
+
+async def test_invalid_path_setup(hass):
+    """Test that a invalid path is not setup."""
+    assert not await async_setup_component(
+        hass, folder_watcher.DOMAIN, {
+            folder_watcher.DOMAIN: {
+                    folder_watcher.CONF_FOLDER: 'invalid_path'
+            }
+        })
 
 
-class TestFolderWatcher(unittest.TestCase):
-    """Test the file_watcher component."""
-
-    def setup_method(self, method):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.hass.config.whitelist_external_dirs = set((CWD))
-
-    def teardown_method(self, method):
-        """Stop everything that was started."""
-        self.hass.stop()
-
-    def test_invalid_path_setup(self):
-        """Test that a invalid path is not setup."""
-        config = {
-            folder_watcher.DOMAIN: [{
-                folder_watcher.CONF_FOLDER: 'invalid_path'
-                }]
-        }
-        self.assertFalse(
-            setup_component(self.hass, folder_watcher.DOMAIN, config))
-
-    def test_valid_path_setup(self):
-        """Test that a valid path is setup."""
-        config = {
-            folder_watcher.DOMAIN: [{folder_watcher.CONF_FOLDER: CWD}]
-        }
-
-        self.assertTrue(setup_component(
-            self.hass, folder_watcher.DOMAIN, config))
+async def test_valid_path_setup(hass):
+    """Test that a valid path is setup."""
+    cwd = os.path.join(os.path.dirname(__file__))
+    hass.config.whitelist_external_dirs = set((cwd))
+    with patch.object(folder_watcher, 'Watcher'):
+        assert await async_setup_component(
+            hass, folder_watcher.DOMAIN, {
+                folder_watcher.DOMAIN: {folder_watcher.CONF_FOLDER: cwd}
+            })
 
 
 @MockDependency('watchdog', 'events')


### PR DESCRIPTION
## Description:
Unflake the folder watcher test. Also makes it no longer needed to install the `watchdog` dependency to run the tests. This fix also improves the speed of our test suite and brings it down on my machine from 1.36s to 0.15s

**Related issue (if applicable):** fixes #13558

