### PR TITLE
Handle devices not running DHCP on ubus

### DIFF
--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -103,6 +103,9 @@ class UbusDeviceScanner(DeviceScanner):
         """Return the name of the given device or None if we don't know."""
         if self.mac2name is None:
             self._generate_mac2name()
+        if self.mac2name is None:
+            # Generation of mac2name dictionary failed
+            return None
         name = self.mac2name.get(device.upper(), None)
         return name
 


### PR DESCRIPTION
## Description:
If OpenWRT isn't running a DHCP server then neither of the implementations of `_generate_mac2name` will set `self.mac2name`. This change fixes an unhandled exception in that case.

I considered updating the implementations of `_generate_mac2name` to always set `self.mac2name` to an empty dictionary. I decided against this as it would then mean that any transient failure in `_generate_mac2name` would be cached as an empty `mac2name` dictionary.

**Related issue (if applicable):** fixes #13578

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** No documentation changes required.

## Example entry for `configuration.yaml` (if applicable):
No configuration changes required

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
