### PR TITLE
Add pincode fallback

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -191,6 +191,7 @@ class HomeKit():
         if not self.bridge.paired:
             show_setup_message(self.bridge, self._hass)
 
+        _LOGGER.info('Pincode: %s', self.bridge.pincode.decode())
         _LOGGER.debug('Driver start')
         self.driver.start()
 

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -191,7 +191,6 @@ class HomeKit():
         if not self.bridge.paired:
             show_setup_message(self.bridge, self._hass)
 
-        _LOGGER.info('Pincode: %s', self.bridge.pincode.decode())
         _LOGGER.debug('Driver start')
         self.driver.start()
 

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -36,6 +36,7 @@ def validate_entity_config(values):
 def show_setup_message(bridge, hass):
     """Display persistent notification with setup information."""
     pin = bridge.pincode.decode()
+    _LOGGER.info('Pincode: %s', pin)
     message = 'To setup Home Assistant in the Home App, enter the ' \
               'following code:\n### {}'.format(pin)
     hass.components.persistent_notification.create(


### PR DESCRIPTION
## Description:
Added fallback solution to find the pincode for HomeKit.

**Related issue:** fixes #13566

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5067

## Example entry for `configuration.yaml` (if applicable):
```yaml
logger:
  logs:
    homeassistant.components.homekit: info
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
