### PR TITLE
Make mysensors updates and platform setup async

### DIFF
--- a/homeassistant/components/binary_sensor/mysensors.py
+++ b/homeassistant/components/binary_sensor/mysensors.py
@@ -21,11 +21,12 @@ SENSORS = {
 }
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the MySensors platform for binary sensors."""
+async def async_setup_platform(
+        hass, config, async_add_devices, discovery_info=None):
+    """Set up the mysensors platform for binary sensors."""
     mysensors.setup_mysensors_platform(
         hass, DOMAIN, discovery_info, MySensorsBinarySensor,
-        add_devices=add_devices)
+        async_add_devices=async_add_devices)
 
 
 class MySensorsBinarySensor(mysensors.MySensorsEntity, BinarySensorDevice):

--- a/homeassistant/components/climate/mysensors.py
+++ b/homeassistant/components/climate/mysensors.py
@@ -31,10 +31,12 @@ SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_HIGH |
                  SUPPORT_OPERATION_MODE)
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the MySensors climate."""
+async def async_setup_platform(
+        hass, config, async_add_devices, discovery_info=None):
+    """Set up the mysensors climate."""
     mysensors.setup_mysensors_platform(
-        hass, DOMAIN, discovery_info, MySensorsHVAC, add_devices=add_devices)
+        hass, DOMAIN, discovery_info, MySensorsHVAC,
+        async_add_devices=async_add_devices)
 
 
 class MySensorsHVAC(mysensors.MySensorsEntity, ClimateDevice):
@@ -163,8 +165,8 @@ class MySensorsHVAC(mysensors.MySensorsEntity, ClimateDevice):
             self._values[self.value_type] = operation_mode
             self.schedule_update_ha_state()
 
-    def update(self):
+    async def async_update(self):
         """Update the controller with the latest value from a sensor."""
-        super().update()
+        await super().async_update()
         self._values[self.value_type] = DICT_MYS_TO_HA[
             self._values[self.value_type]]

--- a/homeassistant/components/cover/mysensors.py
+++ b/homeassistant/components/cover/mysensors.py
@@ -9,10 +9,12 @@ from homeassistant.components.cover import ATTR_POSITION, DOMAIN, CoverDevice
 from homeassistant.const import STATE_OFF, STATE_ON
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the MySensors platform for covers."""
+async def async_setup_platform(
+        hass, config, async_add_devices, discovery_info=None):
+    """Set up the mysensors platform for covers."""
     mysensors.setup_mysensors_platform(
-        hass, DOMAIN, discovery_info, MySensorsCover, add_devices=add_devices)
+        hass, DOMAIN, discovery_info, MySensorsCover,
+        async_add_devices=async_add_devices)
 
 
 class MySensorsCover(mysensors.MySensorsEntity, CoverDevice):

--- a/homeassistant/components/device_tracker/mysensors.py
+++ b/homeassistant/components/device_tracker/mysensors.py
@@ -6,15 +6,15 @@ https://home-assistant.io/components/device_tracker.mysensors/
 """
 from homeassistant.components import mysensors
 from homeassistant.components.device_tracker import DOMAIN
-from homeassistant.helpers.dispatcher import dispatcher_connect
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util import slugify
 
 
-def setup_scanner(hass, config, see, discovery_info=None):
+async def async_setup_scanner(hass, config, async_see, discovery_info=None):
     """Set up the MySensors device scanner."""
     new_devices = mysensors.setup_mysensors_platform(
         hass, DOMAIN, discovery_info, MySensorsDeviceScanner,
-        device_args=(see, ))
+        device_args=(async_see, ))
     if not new_devices:
         return False
 
@@ -22,9 +22,9 @@ def setup_scanner(hass, config, see, discovery_info=None):
         dev_id = (
             id(device.gateway), device.node_id, device.child_id,
             device.value_type)
-        dispatcher_connect(
+        async_dispatcher_connect(
             hass, mysensors.SIGNAL_CALLBACK.format(*dev_id),
-            device.update_callback)
+            device.async_update_callback)
 
     return True
 
@@ -32,20 +32,20 @@ def setup_scanner(hass, config, see, discovery_info=None):
 class MySensorsDeviceScanner(mysensors.MySensorsDevice):
     """Represent a MySensors scanner."""
 
-    def __init__(self, see, *args):
+    def __init__(self, async_see, *args):
         """Set up instance."""
         super().__init__(*args)
-        self.see = see
+        self.async_see = async_see
 
-    def update_callback(self):
+    async def async_update_callback(self):
         """Update the device."""
-        self.update()
+        await self.async_update()
         node = self.gateway.sensors[self.node_id]
         child = node.children[self.child_id]
         position = child.values[self.value_type]
         latitude, longitude, _ = position.split(',')
 
-        self.see(
+        await self.async_see(
             dev_id=slugify(self.name),
             host_name=self.name,
             gps=(latitude, longitude),

--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -15,8 +15,9 @@ import homeassistant.util.color as color_util
 SUPPORT_MYSENSORS_RGBW = SUPPORT_COLOR | SUPPORT_WHITE_VALUE
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the MySensors platform for lights."""
+async def async_setup_platform(
+        hass, config, async_add_devices, discovery_info=None):
+    """Set up the mysensors platform for lights."""
     device_class_map = {
         'S_DIMMER': MySensorsLightDimmer,
         'S_RGB_LIGHT': MySensorsLightRGB,
@@ -24,7 +25,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     }
     mysensors.setup_mysensors_platform(
         hass, DOMAIN, discovery_info, device_class_map,
-        add_devices=add_devices)
+        async_add_devices=async_add_devices)
 
 
 class MySensorsLight(mysensors.MySensorsEntity, Light):
@@ -140,12 +141,12 @@ class MySensorsLight(mysensors.MySensorsEntity, Light):
             self._values[value_type] = STATE_OFF
             self.schedule_update_ha_state()
 
-    def _update_light(self):
+    def _async_update_light(self):
         """Update the controller with values from light child."""
         value_type = self.gateway.const.SetReq.V_LIGHT
         self._state = self._values[value_type] == STATE_ON
 
-    def _update_dimmer(self):
+    def _async_update_dimmer(self):
         """Update the controller with values from dimmer child."""
         value_type = self.gateway.const.SetReq.V_DIMMER
         if value_type in self._values:
@@ -153,7 +154,7 @@ class MySensorsLight(mysensors.MySensorsEntity, Light):
             if self._brightness == 0:
                 self._state = False
 
-    def _update_rgb_or_w(self):
+    def _async_update_rgb_or_w(self):
         """Update the controller with values from RGB or RGBW child."""
         value = self._values[self.value_type]
         color_list = rgb_hex_to_rgb_list(value)
@@ -177,11 +178,11 @@ class MySensorsLightDimmer(MySensorsLight):
         if self.gateway.optimistic:
             self.schedule_update_ha_state()
 
-    def update(self):
+    async def async_update(self):
         """Update the controller with the latest value from a sensor."""
-        super().update()
-        self._update_light()
-        self._update_dimmer()
+        await super().async_update()
+        self._async_update_light()
+        self._async_update_dimmer()
 
 
 class MySensorsLightRGB(MySensorsLight):
@@ -203,12 +204,12 @@ class MySensorsLightRGB(MySensorsLight):
         if self.gateway.optimistic:
             self.schedule_update_ha_state()
 
-    def update(self):
+    async def async_update(self):
         """Update the controller with the latest value from a sensor."""
-        super().update()
-        self._update_light()
-        self._update_dimmer()
-        self._update_rgb_or_w()
+        await super().async_update()
+        self._async_update_light()
+        self._async_update_dimmer()
+        self._async_update_rgb_or_w()
 
 
 class MySensorsLightRGBW(MySensorsLightRGB):

--- a/homeassistant/components/notify/mysensors.py
+++ b/homeassistant/components/notify/mysensors.py
@@ -9,12 +9,12 @@ from homeassistant.components.notify import (
     ATTR_TARGET, DOMAIN, BaseNotificationService)
 
 
-def get_service(hass, config, discovery_info=None):
+async def async_get_service(hass, config, discovery_info=None):
     """Get the MySensors notification service."""
     new_devices = mysensors.setup_mysensors_platform(
         hass, DOMAIN, discovery_info, MySensorsNotificationDevice)
     if not new_devices:
-        return
+        return None
     return MySensorsNotificationService(hass)
 
 

--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -34,10 +34,12 @@ SENSORS = {
 }
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+async def async_setup_platform(
+        hass, config, async_add_devices, discovery_info=None):
     """Set up the MySensors platform for sensors."""
     mysensors.setup_mysensors_platform(
-        hass, DOMAIN, discovery_info, MySensorsSensor, add_devices=add_devices)
+        hass, DOMAIN, discovery_info, MySensorsSensor,
+        async_add_devices=async_add_devices)
 
 
 class MySensorsSensor(mysensors.MySensorsEntity):

--- a/homeassistant/components/switch/mysensors.py
+++ b/homeassistant/components/switch/mysensors.py
@@ -20,7 +20,8 @@ SEND_IR_CODE_SERVICE_SCHEMA = vol.Schema({
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+async def async_setup_platform(
+        hass, config, async_add_devices, discovery_info=None):
     """Set up the mysensors platform for switches."""
     device_class_map = {
         'S_DOOR': MySensorsSwitch,
@@ -39,7 +40,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     }
     mysensors.setup_mysensors_platform(
         hass, DOMAIN, discovery_info, device_class_map,
-        add_devices=add_devices)
+        async_add_devices=async_add_devices)
 
     def send_ir_code_service(service):
         """Set IR code as device state attribute."""
@@ -59,9 +60,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         for device in _devices:
             device.turn_on(**kwargs)
 
-    hass.services.register(DOMAIN, SERVICE_SEND_IR_CODE,
-                           send_ir_code_service,
-                           schema=SEND_IR_CODE_SERVICE_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_SEND_IR_CODE, send_ir_code_service,
+        schema=SEND_IR_CODE_SERVICE_SCHEMA)
 
 
 class MySensorsSwitch(mysensors.MySensorsEntity, SwitchDevice):
@@ -143,7 +144,7 @@ class MySensorsIRSwitch(MySensorsSwitch):
             self._values[set_req.V_LIGHT] = STATE_OFF
             self.schedule_update_ha_state()
 
-    def update(self):
+    async def async_update(self):
         """Update the controller with the latest value from a sensor."""
-        super().update()
+        await super().async_update()
         self._ir_code = self._values.get(self.value_type)


### PR DESCRIPTION
## Description:
* Use async updates but keep methods that interact with mysensors gateway thread, eg turn_on and turn_off, non async. The update methods can easily be converted to async as they are only interacting with dictionaries.
* Use Python 3.5 async syntax.
* A full async conversion will follow later.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**