### PR TITLE
Use 0/1 for raspberry pi cover GPIO writes rather than true/false

### DIFF
--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -87,7 +87,7 @@ class RPiGPIOCover(CoverDevice):
         self._invert_relay = invert_relay
         rpi_gpio.setup_output(self._relay_pin)
         rpi_gpio.setup_input(self._state_pin, self._state_pull_mode)
-        rpi_gpio.write_output(self._relay_pin, not self._invert_relay)
+        rpi_gpio.write_output(self._relay_pin, 0 if self._invert_relay else 1)
 
     @property
     def name(self):

--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -105,9 +105,9 @@ class RPiGPIOCover(CoverDevice):
 
     def _trigger(self):
         """Trigger the cover."""
-        rpi_gpio.write_output(self._relay_pin, self._invert_relay)
+        rpi_gpio.write_output(self._relay_pin, 1 if self._invert_relay else 0)
         sleep(self._relay_time)
-        rpi_gpio.write_output(self._relay_pin, not self._invert_relay)
+        rpi_gpio.write_output(self._relay_pin, 0 if self._invert_relay else 1)
 
     def close_cover(self, **kwargs):
         """Close the cover."""


### PR DESCRIPTION
## Description:

Raspberry pi GPIO pins don't appear to respond to true/false writes and I have found that for this reason the raspberry pi GPIO cover doesn't appear to work. Other HA code that writes to the RPi GPIO pins is written differently, for example, in `\components\switch\rpio_gpio.py` the following code is used:

```
    def turn_on(self, **kwargs):
        """Turn the device on."""
        rpi_gpio.write_output(self._port, 0 if self._invert_logic else 1)
        self._state = True
        self.schedule_update_ha_state()
```

This code works. Hence this PR uses 0/1 in the raspberry pi GPIO cover, instead of true/false.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
