### PR TITLE
Fix Hue error logging

### DIFF
--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -31,9 +31,14 @@ class HueBridge(object):
         self.available = True
         self.api = None
 
+    @property
+    def host(self):
+        """Return the host of this bridge."""
+        return self.config_entry.data['host']
+
     async def async_setup(self, tries=0):
         """Set up a phue bridge based on host parameter."""
-        host = self.config_entry.data['host']
+        host = self.host
 
         try:
             self.api = await get_bridge(

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -160,7 +160,13 @@ LIGHT_RESPONSE = {
 @pytest.fixture
 def mock_bridge(hass):
     """Mock a Hue bridge."""
-    bridge = Mock(available=True, allow_groups=False, host='1.1.1.1')
+    bridge = Mock(
+        available=True,
+        allow_unreachable=False,
+        allow_groups=False,
+        api=Mock(),
+        spec=hue.HueBridge
+    )
     bridge.mock_requests = []
     # We're using a deque so we can schedule multiple responses
     # and also means that `popleft()` will blow up if we get more updates


### PR DESCRIPTION
## Description:
Hue would hit a non-existing property when trying to log an error.

Updated the mock used in the test to raise if unknown properties are used.

