### PR TITLE
Channel up and down for webostv

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -357,8 +357,8 @@ class LgWebOSDevice(MediaPlayerDevice):
 
     def media_next_track(self):
         """Send next track command."""
-        self._client.fast_forward()
+        self._client.channel_up()
 
     def media_previous_track(self):
         """Send the previous track command."""
-        self._client.rewind()
+        self._client.channel_down()


### PR DESCRIPTION
This enable using the next and previous buttons on the media player interface to switch channels up and down, which is the desired default behaviour for a television.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [] Tests have been added to verify that the new code works. 