### PR TITLE
Upgrade py-cpuinfo to 4.0.0

### DIFF
--- a/homeassistant/components/sensor/cpuspeed.py
+++ b/homeassistant/components/sensor/cpuspeed.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['py-cpuinfo==3.3.0']
+REQUIREMENTS = ['py-cpuinfo==4.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -648,7 +648,7 @@ py-august==0.4.0
 py-canary==0.5.0
 
 # homeassistant.components.sensor.cpuspeed
-py-cpuinfo==3.3.0
+py-cpuinfo==4.0.0
 
 # homeassistant.components.melissa
 py-melissa-climate==1.0.6


### PR DESCRIPTION
## Description:
* Broken when using Pyinstaller
* Get L1, L2, and L3 cache info from lscpu
* Byte formats are inconsistent
* Byte formatter breaks on non strings
* Fixed wrong setup of CPUID machine code and added more flags
* Get Windows CPU info with wmic
* Fails to detect winreg imported as _winreg in get_system_info
* Include if Python is 32 or 64 bit in get_system_info
* lscpu gets brand field twice
* Include Python version in output
* CPUID HZ measurement is scaled wrong
* Officially drop support for Python 2.6
* Made it only check the dmesg boot log on Linux
* Parsing Haiku sysinfo fails

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: cpuspeed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
