### PR TITLE
Add Switzerland

### DIFF
--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -44,7 +44,7 @@ DEFAULT_NAME = 'Workday Sensor'
 ALLOWED_DAYS = WEEKDAYS + ['holiday']
 CONF_OFFSET = 'days_offset'
 DEFAULT_OFFSET = 0
- 
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COUNTRY): vol.In(ALL_COUNTRIES),
     vol.Optional(CONF_EXCLUDES, default=DEFAULT_EXCLUDES):

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -30,8 +30,8 @@ ALL_COUNTRIES = ['Australia', 'AU', 'Austria', 'AT', 'Belgium', 'BE', 'Canada',
                  'Norway', 'NO', 'Polish', 'PL', 'Portugal', 'PT',
                  'PortugalExt', 'PTE', 'Scotland', 'Slovenia', 'SI',
                  'Slovakia', 'SK', 'South Africa', 'ZA', 'Spain', 'ES',
-                 'Sweden', 'SE', 'UnitedKingdom', 'UK', 'UnitedStates', 'US',
-                 'Wales']
+                 'Sweden', 'SE', 'Switzerland', 'CH', 'UnitedKingdom', 'UK',
+                 'UnitedStates', 'US', 'Wales']
 CONF_COUNTRY = 'country'
 CONF_PROVINCE = 'province'
 CONF_WORKDAYS = 'workdays'
@@ -44,15 +44,15 @@ DEFAULT_NAME = 'Workday Sensor'
 ALLOWED_DAYS = WEEKDAYS + ['holiday']
 CONF_OFFSET = 'days_offset'
 DEFAULT_OFFSET = 0
-
+ 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COUNTRY): vol.In(ALL_COUNTRIES),
-    vol.Optional(CONF_PROVINCE): cv.string,
+    vol.Optional(CONF_EXCLUDES, default=DEFAULT_EXCLUDES):
+        vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_OFFSET, default=DEFAULT_OFFSET): vol.Coerce(int),
+    vol.Optional(CONF_PROVINCE): cv.string,
     vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):
-        vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
-    vol.Optional(CONF_EXCLUDES, default=DEFAULT_EXCLUDES):
         vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
 })
 
@@ -74,14 +74,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if province:
         # 'state' and 'prov' are not interchangeable, so need to make
         # sure we use the right one
-        if (hasattr(obj_holidays, "PROVINCES") and
+        if (hasattr(obj_holidays, 'PROVINCES') and
                 province in obj_holidays.PROVINCES):
-            obj_holidays = getattr(holidays, country)(prov=province,
-                                                      years=year)
-        elif (hasattr(obj_holidays, "STATES") and
+            obj_holidays = getattr(holidays, country)(
+                prov=province, years=year)
+        elif (hasattr(obj_holidays, 'STATES') and
               province in obj_holidays.STATES):
-            obj_holidays = getattr(holidays, country)(state=province,
-                                                      years=year)
+            obj_holidays = getattr(holidays, country)(
+                state=province, years=year)
         else:
             _LOGGER.error("There is no province/state %s in country %s",
                           province, country)


### PR DESCRIPTION
## Description:
Add Switzerland.

**Related issue (if applicable):** fixes [48891](https://community.home-assistant.io/t/workday-sensor-switzerland-ch-not-a-valid-option/48891)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5084

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: workday
    country: CH
    province: BE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
