### PR TITLE
Add regex functions as templating helpers

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -517,7 +517,7 @@ def forgiving_float(value):
 
 
 def regex_match(value, find='', ignorecase=False):
-    """Match value using regex"""
+    """Match value using regex."""
     if not isinstance(value, str):
         value = str(value)
     flags = re.I if ignorecase else 0
@@ -525,7 +525,7 @@ def regex_match(value, find='', ignorecase=False):
 
 
 def regex_replace(value='', find='', replace='', ignorecase=False):
-    """Replace using regex"""
+    """Replace using regex."""
     if not isinstance(value, str):
         value = str(value)
     flags = re.I if ignorecase else 0
@@ -534,7 +534,7 @@ def regex_replace(value='', find='', replace='', ignorecase=False):
 
 
 def regex_search(value, find='', ignorecase=False):
-    """Search using regex"""
+    """Search using regex."""
     if not isinstance(value, str):
         value = str(value)
     flags = re.I if ignorecase else 0
@@ -542,7 +542,7 @@ def regex_search(value, find='', ignorecase=False):
 
 
 def regex_findall_index(value, find='', index=0, ignorecase=False):
-    """Find all matches using regex and then pick specific match index"""
+    """Find all matches using regex and then pick specific match index."""
     if not isinstance(value, str):
         value = str(value)
     flags = re.I if ignorecase else 0

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -515,12 +515,14 @@ def forgiving_float(value):
     except (ValueError, TypeError):
         return value
 
+
 def regex_match(value, find='', ignorecase=False):
     """Match value using regex"""
     if not isinstance(value, str):
         value = str(value)
     flags = re.I if ignorecase else 0
     return bool(re.match(find, value, flags))
+
 
 def regex_replace(value='', find='', replace='', ignorecase=False):
     """Replace using regex"""
@@ -530,12 +532,14 @@ def regex_replace(value='', find='', replace='', ignorecase=False):
     regex = re.compile(find, flags)
     return regex.sub(replace, value)
 
+
 def regex_search(value, find='', ignorecase=False):
     """Search using regex"""
     if not isinstance(value, str):
         value = str(value)
     flags = re.I if ignorecase else 0
     return bool(re.search(find, value, flags))
+
 
 def regex_findall_index(value, find='', index=0, ignorecase=False):
     """Find all matches using regex and then pick specific match index"""

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -515,6 +515,35 @@ def forgiving_float(value):
     except (ValueError, TypeError):
         return value
 
+def regex_match(value, find='', ignorecase=False):
+    """Match value using regex"""
+    if not isinstance(value, str):
+        value = str(value)
+    flags = re.I if ignorecase else 0
+    return bool(re.match(find, value, flags))
+
+def regex_replace(value='', find='', replace='', ignorecase=False):
+    """Replace using regex"""
+    if not isinstance(value, str):
+        value = str(value)
+    flags = re.I if ignorecase else 0
+    regex = re.compile(find, flags)
+    return regex.sub(replace, value)
+
+def regex_search(value, find='', ignorecase=False):
+    """Search using regex"""
+    if not isinstance(value, str):
+        value = str(value)
+    flags = re.I if ignorecase else 0
+    return bool(re.search(find, value, flags))
+
+def regex_findall_index(value, find='', index=0, ignorecase=False):
+    """Find all matches using regex and then pick specific match index"""
+    if not isinstance(value, str):
+        value = str(value)
+    flags = re.I if ignorecase else 0
+    return re.findall(find, value, flags)[index]
+
 
 @contextfilter
 def random_every_time(context, values):
@@ -545,6 +574,10 @@ ENV.filters['is_defined'] = fail_when_undefined
 ENV.filters['max'] = max
 ENV.filters['min'] = min
 ENV.filters['random'] = random_every_time
+ENV.filters['regex_match'] = regex_match
+ENV.filters['regex_replace'] = regex_replace
+ENV.filters['regex_search'] = regex_search
+ENV.filters['regex_findall_index'] = regex_findall_index
 ENV.globals['log'] = logarithm
 ENV.globals['float'] = forgiving_float
 ENV.globals['now'] = dt_util.now

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -441,6 +441,59 @@ class TestHelpersTemplate(unittest.TestCase):
                 template.Template('{{ utcnow().isoformat() }}',
                                   self.hass).render())
 
+    def test_regex_match(self):
+        """Test regex_match method."""
+        tpl = template.Template("""
+{{ '123-456-7890' | regex_match('(\d{3})-(\d{3})-(\d{4})') }}
+                """, self.hass)
+        self.assertEqual('True', tpl.render())
+
+        tpl = template.Template("""
+{{ 'home assistant test' | regex_match('Home', True) }}
+                """, self.hass)
+        self.assertEqual('True', tpl.render())
+
+        tpl = template.Template("""
+        {{ 'Another home assistant test' | regex_match('home') }}
+                        """, self.hass)
+        self.assertEqual('False', tpl.render())
+
+    def test_regex_search(self):
+        """Test regex_search method."""
+        tpl = template.Template("""
+{{ '123-456-7890' | regex_search('(\d{3})-(\d{3})-(\d{4})') }}
+                """, self.hass)
+        self.assertEqual('True', tpl.render())
+
+        tpl = template.Template("""
+{{ 'home assistant test' | regex_search('Home', True) }}
+                """, self.hass)
+        self.assertEqual('True', tpl.render())
+
+        tpl = template.Template("""
+        {{ 'Another home assistant test' | regex_search('home') }}
+                        """, self.hass)
+        self.assertEqual('True', tpl.render())
+
+    def test_regex_replace(self):
+        """Test regex_replace method."""
+        tpl = template.Template("""
+{{ 'Hello World' | regex_replace('(Hello\s)',) }}
+                """, self.hass)
+        self.assertEqual('World', tpl.render())
+
+    def test_regex_findall_index(self):
+        """Test regex_findall_index method."""
+        tpl = template.Template("""
+{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 0) }}
+                """, self.hass)
+        self.assertEqual('JFK', tpl.render())
+
+        tpl = template.Template("""
+{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 1) }}
+                """, self.hass)
+        self.assertEqual('LHR', tpl.render())
+
     def test_distance_function_with_1_state(self):
         """Test distance function with 1 state."""
         self.hass.states.set('test.object', 'happy', {


### PR DESCRIPTION
## Description:
This PR adds python regex functions as template helpers so that they can be used in template sensors and automations - these are not available in Jinja

**Related issue (if applicable):** 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5085

## Example entry for `configuration.yaml` (if applicable):

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
