### PR TITLE
Added the ability to switch Tahoma Garage door relay.

### DIFF
--- a/homeassistant/components/switch/tahoma.py
+++ b/homeassistant/components/switch/tahoma.py
@@ -1,0 +1,48 @@
+"""
+Support for Tahoma Switch - those are push buttons for garage door etc.
+Those buttons are implemented as switchs that are never on. They only receive the turn_on action, perform the relay click, and stay in OFF state
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.tahoma/
+"""
+import logging
+
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.tahoma import (
+    DOMAIN as TAHOMA_DOMAIN, TahomaDevice)
+
+DEPENDENCIES = ['tahoma']
+
+_LOGGER = logging.getLogger(__name__)
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Tahoma switchs."""
+    controller = hass.data[TAHOMA_DOMAIN]['controller']
+    devices = []
+    for switch in hass.data[TAHOMA_DOMAIN]['devices']['switch']:
+        devices.append(TahomaSwitch(switch, controller))
+    add_devices(devices, True)
+	
+class TahomaSwitch(TahomaDevice, SwitchDevice):
+    """Representation a Tahoma Switch."""
+
+    @property
+    def device_class(self):
+        """Return the class of the device."""
+        if self.tahoma_device.type == 'rts:GarageDoor4TRTSComponent':
+            return 'garage'
+        return None
+
+    def turn_on(self, **kwargs):
+        """Send the on command."""
+        self.toggle()
+		
+    def toggle(self, **kwargs):
+        """Click the switch."""
+        self.apply_action('cycle')
+
+    @property
+    def is_on(self):
+        """Get whether the switch is in on state."""
+        return False
+

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 TAHOMA_COMPONENTS = [
-    'scene', 'sensor', 'cover'
+    'scene', 'sensor', 'cover', 'switch'
 ]
 
 TAHOMA_TYPES = {
@@ -43,6 +43,7 @@ TAHOMA_TYPES = {
     'io:RollerShutterGenericIOComponent': 'cover',
     'io:WindowOpenerVeluxIOComponent': 'cover',
     'io:LightIOSystemSensor': 'sensor',
+    'rts:GarageDoor4TRTSComponent': 'switch',
 }
 
 


### PR DESCRIPTION
Implementing tahoma switches

## Description:
Those are special switches that can only be pushed.
Their state is always OFF, they react to the turn_on action, perform it, but stay OFF
