### PR TITLE
Broadlink Switch - Use entity_id instead of friendly_name for entity_id

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -14,7 +14,7 @@ import socket
 import voluptuous as vol
 
 from homeassistant.components.switch import (
-    DOMAIN, PLATFORM_SCHEMA, SwitchDevice)
+    DOMAIN, PLATFORM_SCHEMA, SwitchDevice, ENTITY_ID_FORMAT)
 from homeassistant.const import (
     CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_FRIENDLY_NAME, CONF_HOST, CONF_MAC,
     CONF_SWITCHES, CONF_TIMEOUT, CONF_TYPE)
@@ -150,6 +150,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         for object_id, device_config in devices.items():
             switches.append(
                 BroadlinkRMSwitch(
+                    object_id,
                     device_config.get(CONF_FRIENDLY_NAME, object_id),
                     broadlink_device,
                     device_config.get(CONF_COMMAND_ON),
@@ -184,8 +185,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class BroadlinkRMSwitch(SwitchDevice):
     """Representation of an Broadlink switch."""
 
-    def __init__(self, friendly_name, device, command_on, command_off):
+    def __init__(self, name, friendly_name, device, command_on, command_off):
         """Initialize the switch."""
+        self.entity_id = ENTITY_ID_FORMAT.format(name)
         self._name = friendly_name
         self._state = False
         self._command_on = b64decode(command_on) if command_on else None


### PR DESCRIPTION
## Description:
The current version of this component uses the friendly_name instead of the set entity_id as set in the config. This fixes this issue. In the example, the entity_id would be 'tv_phillips' and the friendly_name 'Phillips TV Power'.

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: broadlink
    host: 192.168.1.2
    mac: 'B4:43:0D:CC:0F:58'
    timeout: 15
    switches:
      tv_phillips:
        friendly_name: "Phillips TV Power"
        command_on: 'JgAcAB0dHB44HhweGx4cHR06HB0cHhwdHB8bHhwADQUAAAAAAAAAAAAAAAA='
        command_off: 'JgAaABweOR4bHhwdHB4dHRw6HhsdHR0dOTocAA0FAAAAAAAAAAAAAAAAAAA='
```

## Breaking Change
Users who were using this switch with the entity_id and the friendly_name as different names will need to update their automations/groups to use the entity_id instead of the friendly_name.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**