### PR TITLE
Support color temperature in Homekit

### DIFF
--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -47,6 +47,7 @@ SERV_WINDOW_COVERING = 'WindowCovering'
 
 # #### Characteristics ####
 CHAR_BRIGHTNESS = 'Brightness'  # Int | [0, 100]
+CHAR_COLOR_TEMPERATURE = 'ColorTemperature'
 CHAR_COOLING_THRESHOLD_TEMPERATURE = 'CoolingThresholdTemperature'
 CHAR_CURRENT_HEATING_COOLING = 'CurrentHeatingCoolingState'
 CHAR_CURRENT_POSITION = 'CurrentPosition'

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -2,13 +2,14 @@
 import logging
 
 from homeassistant.components.light import (
-    ATTR_HS_COLOR, ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, SUPPORT_COLOR)
+    ATTR_HS_COLOR, ATTR_COLOR_TEMP, ATTR_BRIGHTNESS,
+    SUPPORT_COLOR, SUPPORT_COLOR_TEMP, SUPPORT_BRIGHTNESS)
 from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_ON, STATE_OFF
 
 from . import TYPES
 from .accessories import HomeAccessory, add_preload_service
 from .const import (
-    CATEGORY_LIGHT, SERV_LIGHTBULB,
+    CATEGORY_LIGHT, SERV_LIGHTBULB, CHAR_COLOR_TEMPERATURE,
     CHAR_BRIGHTNESS, CHAR_HUE, CHAR_ON, CHAR_SATURATION)
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,7 +21,7 @@ RGB_COLOR = 'rgb_color'
 class Light(HomeAccessory):
     """Generate a Light accessory for a light entity.
 
-    Currently supports: state, brightness, rgb_color.
+    Currently supports: state, brightness, color temperature, rgb_color.
     """
 
     def __init__(self, hass, entity_id, name, **kwargs):
@@ -31,7 +32,7 @@ class Light(HomeAccessory):
         self.entity_id = entity_id
         self._flag = {CHAR_ON: False, CHAR_BRIGHTNESS: False,
                       CHAR_HUE: False, CHAR_SATURATION: False,
-                      RGB_COLOR: False}
+                      CHAR_COLOR_TEMPERATURE: False, RGB_COLOR: False}
         self._state = 0
 
         self.chars = []
@@ -39,6 +40,8 @@ class Light(HomeAccessory):
             .attributes.get(ATTR_SUPPORTED_FEATURES)
         if self._features & SUPPORT_BRIGHTNESS:
             self.chars.append(CHAR_BRIGHTNESS)
+        if self._features & SUPPORT_COLOR_TEMP:
+            self.chars.append(CHAR_COLOR_TEMPERATURE)
         if self._features & SUPPORT_COLOR:
             self.chars.append(CHAR_HUE)
             self.chars.append(CHAR_SATURATION)
@@ -55,6 +58,11 @@ class Light(HomeAccessory):
                 .get_characteristic(CHAR_BRIGHTNESS)
             self.char_brightness.setter_callback = self.set_brightness
             self.char_brightness.value = 0
+        if CHAR_COLOR_TEMPERATURE in self.chars:
+            self.char_color_temperature = serv_light \
+                .get_characteristic(CHAR_COLOR_TEMPERATURE)
+            self.char_color_temperature.setter_callback = self.set_color_temperature
+            self.char_color_temperature.value = 140
         if CHAR_HUE in self.chars:
             self.char_hue = serv_light.get_characteristic(CHAR_HUE)
             self.char_hue.setter_callback = self.set_hue
@@ -89,6 +97,14 @@ class Light(HomeAccessory):
                 self.entity_id, brightness_pct=value)
         else:
             self.hass.components.light.turn_off(self.entity_id)
+
+    def set_color_temperature(self, value):
+        """Set color temperature if call came from HomeKit."""
+        _LOGGER.debug('%s: Set color temperature to %s', self._entity_id, value)
+        self._flag[CHAR_COLOR_TEMPERATURE] = True
+        self.char_color_temperature.set_value(value, should_callback=False)
+        self._hass.components.light.turn_on(
+            self._entity_id, color_temp=value)
 
     def set_saturation(self, value):
         """Set saturation if call came from HomeKit."""
@@ -140,6 +156,14 @@ class Light(HomeAccessory):
                     self.char_brightness.set_value(brightness,
                                                    should_callback=False)
             self._flag[CHAR_BRIGHTNESS] = False
+
+        # Handle color temperature
+        if CHAR_COLOR_TEMPERATURE in self.chars:
+            color_temperature = new_state.attributes.get(ATTR_COLOR_TEMP)
+            if not self._flag[CHAR_COLOR_TEMPERATURE] and isinstance(color_temperature, int):
+                self.char_color_temperature.set_value(color_temperature,
+                                                      should_callback=False)
+            self._flag[CHAR_COLOR_TEMPERATURE] = False
 
         # Handle Color
         if CHAR_SATURATION in self.chars and CHAR_HUE in self.chars:

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -63,9 +63,9 @@ class Light(HomeAccessory):
                 .get_characteristic(CHAR_COLOR_TEMPERATURE)
             self.char_color_temperature.setter_callback = \
                 self.set_color_temperature
-            min_mireds = self._hass.states.get(self._entity_id) \
+            min_mireds = self.hass.states.get(self.entity_id) \
                 .attributes.get(ATTR_MIN_MIREDS, 153)
-            max_mireds = self._hass.states.get(self._entity_id) \
+            max_mireds = self.hass.states.get(self.entity_id) \
                 .attributes.get(ATTR_MAX_MIREDS, 500)
             self.char_color_temperature.override_properties({
                 'minValue': min_mireds, 'maxValue': max_mireds})
@@ -107,10 +107,10 @@ class Light(HomeAccessory):
 
     def set_color_temperature(self, value):
         """Set color temperature if call came from HomeKit."""
-        _LOGGER.debug('%s: Set color temp to %s', self._entity_id, value)
+        _LOGGER.debug('%s: Set color temp to %s', self.entity_id, value)
         self._flag[CHAR_COLOR_TEMPERATURE] = True
         self.char_color_temperature.set_value(value, should_callback=False)
-        self._hass.components.light.turn_on(self._entity_id, color_temp=value)
+        self.hass.components.light.turn_on(self.entity_id, color_temp=value)
 
     def set_saturation(self, value):
         """Set saturation if call came from HomeKit."""

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -61,7 +61,8 @@ class Light(HomeAccessory):
         if CHAR_COLOR_TEMPERATURE in self.chars:
             self.char_color_temperature = serv_light \
                 .get_characteristic(CHAR_COLOR_TEMPERATURE)
-            self.char_color_temperature.setter_callback = self.set_color_temperature
+            self.char_color_temperature.setter_callback = \
+                self.set_color_temperature
             self.char_color_temperature.value = 140
         if CHAR_HUE in self.chars:
             self.char_hue = serv_light.get_characteristic(CHAR_HUE)
@@ -100,7 +101,7 @@ class Light(HomeAccessory):
 
     def set_color_temperature(self, value):
         """Set color temperature if call came from HomeKit."""
-        _LOGGER.debug('%s: Set color temperature to %s', self._entity_id, value)
+        _LOGGER.debug('%s: Set color temp to %s', self._entity_id, value)
         self._flag[CHAR_COLOR_TEMPERATURE] = True
         self.char_color_temperature.set_value(value, should_callback=False)
         self._hass.components.light.turn_on(
@@ -160,7 +161,8 @@ class Light(HomeAccessory):
         # Handle color temperature
         if CHAR_COLOR_TEMPERATURE in self.chars:
             color_temperature = new_state.attributes.get(ATTR_COLOR_TEMP)
-            if not self._flag[CHAR_COLOR_TEMPERATURE] and isinstance(color_temperature, int):
+            if not self._flag[CHAR_COLOR_TEMPERATURE] \
+                    and isinstance(color_temperature, int):
                 self.char_color_temperature.set_value(color_temperature,
                                                       should_callback=False)
             self._flag[CHAR_COLOR_TEMPERATURE] = False

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -125,7 +125,7 @@ class TestHomekitLights(unittest.TestCase):
             ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR_TEMP,
             ATTR_COLOR_TEMP: 190})
         acc = Light(self.hass, entity_id, 'Light', aid=2)
-        self.assertEqual(acc.char_color_temperature.value, 140)
+        self.assertEqual(acc.char_color_temperature.value, 153)
 
         acc.run()
         self.hass.block_till_done()

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -4,8 +4,8 @@ import unittest
 from homeassistant.core import callback
 from homeassistant.components.homekit.type_lights import Light
 from homeassistant.components.light import (
-    DOMAIN, ATTR_BRIGHTNESS, ATTR_BRIGHTNESS_PCT, ATTR_HS_COLOR,
-    SUPPORT_BRIGHTNESS, SUPPORT_COLOR)
+    DOMAIN, ATTR_BRIGHTNESS, ATTR_BRIGHTNESS_PCT, ATTR_COLOR_TEMP, ATTR_HS_COLOR,
+    SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_COLOR)
 from homeassistant.const import (
     ATTR_DOMAIN, ATTR_ENTITY_ID, ATTR_SERVICE, ATTR_SERVICE_DATA,
     ATTR_SUPPORTED_FEATURES, EVENT_CALL_SERVICE, SERVICE_TURN_ON,
@@ -117,6 +117,28 @@ class TestHomekitLights(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(self.events[2].data[ATTR_DOMAIN], DOMAIN)
         self.assertEqual(self.events[2].data[ATTR_SERVICE], SERVICE_TURN_OFF)
+
+    def test_light_color_temperature(self):
+        """Test light with color temperature."""
+        entity_id = 'light.demo'
+        self.hass.states.set(entity_id, STATE_ON, {
+            ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR_TEMP,
+            ATTR_COLOR_TEMP: 190})
+        acc = Light(self.hass, entity_id, 'Light', aid=2)
+        self.assertEqual(acc.char_color_temperature.value, 140)
+
+        acc.run()
+        self.hass.block_till_done()
+        self.assertEqual(acc.char_color_temperature.value, 190)
+
+        # Set from HomeKit
+        acc.char_color_temperature.set_value(250)
+        self.hass.block_till_done()
+        self.assertEqual(self.events[0].data[ATTR_DOMAIN], DOMAIN)
+        self.assertEqual(self.events[0].data[ATTR_SERVICE], SERVICE_TURN_ON)
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE_DATA], {
+                ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 250})
 
     def test_light_rgb_color(self):
         """Test light with rgb_color."""

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -4,8 +4,8 @@ import unittest
 from homeassistant.core import callback
 from homeassistant.components.homekit.type_lights import Light
 from homeassistant.components.light import (
-    DOMAIN, ATTR_BRIGHTNESS, ATTR_BRIGHTNESS_PCT, ATTR_COLOR_TEMP, ATTR_HS_COLOR,
-    SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_COLOR)
+    DOMAIN, ATTR_BRIGHTNESS, ATTR_BRIGHTNESS_PCT, ATTR_COLOR_TEMP,
+    ATTR_HS_COLOR, SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_COLOR)
 from homeassistant.const import (
     ATTR_DOMAIN, ATTR_ENTITY_ID, ATTR_SERVICE, ATTR_SERVICE_DATA,
     ATTR_SUPPORTED_FEATURES, EVENT_CALL_SERVICE, SERVICE_TURN_ON,


### PR DESCRIPTION
## Description:
Adds support for setting color temperature on white spectrum lights through HomeKit. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

Ran tests under Python 3.6 only, i.e. `tox -e py36`. Don't have Python 3.5 installed.

  - [x] This PR needs #13563 to be pulled first (those two commit are included here as well since the code won't run without them).

ColorTemperature is supposed to be [between 140 and 500](https://github.com/ikalchev/HAP-python/blob/fc24e2f33a99680acbe476967a08b20e0827be13/pyhap/resources/characteristics.json#L185). I'm not really happy with using a [magic number](https://github.com/home-assistant/home-assistant/compare/dev...morberg:homekit-color-temp?expand=1#diff-aecdf4f7525a354685ea5b096f27f831R65), is there a better way to do this?

I'm also not sure how extensive the [`test_light_color_temperature`](https://github.com/home-assistant/home-assistant/compare/dev...morberg:homekit-color-temp?expand=1#diff-9ce66f0a3210823ecf44c99448a9fd69R121) should be, any input there is welcome.