### PR TITLE
Fix startca ISP sensor component to work again after changes in the website.

### DIFF
--- a/homeassistant/components/sensor/startca.py
+++ b/homeassistant/components/sensor/startca.py
@@ -145,7 +145,7 @@ class StartcaData(object):
         """Get the Start.ca bandwidth data from the web service."""
         import xmltodict
         _LOGGER.debug("Updating Start.ca usage data")
-        url = 'https://www.start.ca/support/usage/api?key=' + \
+        url = 'https://www.start.ca/account/usage/api?key=' + \
               self.api_key
         with async_timeout.timeout(REQUEST_TIMEOUT, loop=self.loop):
             req = await self.websession.get(url)
@@ -155,7 +155,7 @@ class StartcaData(object):
 
         data = await req.text()
         try:
-            xml_data = xmltodict.parse(data)
+            xml_data = xmltodict.parse(data.lstrip())
         except ExpatError:
             return False
 

--- a/tests/components/sensor/test_startca.py
+++ b/tests/components/sensor/test_startca.py
@@ -132,7 +132,7 @@ def test_unlimited_setup(hass, aioclient_mock):
              '<upload>6480700153</upload>'\
              '</grace>'\
              '</usage>'
-    aioclient_mock.get('https://www.start.ca/support/usage/api?key='
+    aioclient_mock.get('https://www.start.ca/account/usage/api?key='
                        'NOTAKEY',
                        text=result)
 

--- a/tests/components/sensor/test_startca.py
+++ b/tests/components/sensor/test_startca.py
@@ -41,7 +41,7 @@ def test_capped_setup(hass, aioclient_mock):
              '<upload>6480700153</upload>'\
              '</grace>'\
              '</usage>'
-    aioclient_mock.get('https://www.start.ca/support/usage/api?key='
+    aioclient_mock.get('https://www.start.ca/account/usage/api?key='
                        'NOTAKEY',
                        text=result)
 
@@ -190,7 +190,7 @@ def test_unlimited_setup(hass, aioclient_mock):
 @asyncio.coroutine
 def test_bad_return_code(hass, aioclient_mock):
     """Test handling a return code that isn't HTTP OK."""
-    aioclient_mock.get('https://www.start.ca/support/usage/api?key='
+    aioclient_mock.get('https://www.start.ca/account/usage/api?key='
                        'NOTAKEY',
                        status=404)
 
@@ -204,7 +204,7 @@ def test_bad_return_code(hass, aioclient_mock):
 @asyncio.coroutine
 def test_bad_json_decode(hass, aioclient_mock):
     """Test decoding invalid json result."""
-    aioclient_mock.get('https://www.start.ca/support/usage/api?key='
+    aioclient_mock.get('https://www.start.ca/account/usage/api?key='
                        'NOTAKEY',
                        text='this is not xml')
 


### PR DESCRIPTION
## Description:

* Pull request for component https://www.home-assistant.io/components/sensor.startca/

* fixes #13648 by correcting API end-point in the component and the component test script and sanitizing the XML response string

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

No changes are required to the component configuration

## Checklist:
  - [x ] The code change is tested and works locally.
  - [x ] Local tests pass with `tox`. (_Tested with Tox on Raspbian with python3.5: test_startca.py passed along with almost everything else except TestCoinMarketCapSensor.test_setup (missing redis.so) and TestApns.test_disable_when_unregistered which are not related to the component in this PR_)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) [_no documentation changes required_]

If the code communicates with devices, web services, or third-party tools [_No new components_]:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ x] Tests have been *modifed* to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
