### PR TITLE
Send XY color for non-osram hue bulbs

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -300,8 +300,13 @@ class HueLight(Light):
             command['transitiontime'] = int(kwargs[ATTR_TRANSITION] * 10)
 
         if ATTR_HS_COLOR in kwargs:
-            command['hue'] = int(kwargs[ATTR_HS_COLOR][0] / 360 * 65535)
-            command['sat'] = int(kwargs[ATTR_HS_COLOR][1] / 100 * 255)
+            if self.is_osram:
+                command['hue'] = int(kwargs[ATTR_HS_COLOR][0] / 360 * 65535)
+                command['sat'] = int(kwargs[ATTR_HS_COLOR][1] / 100 * 254)
+            else:
+                # Philips bulbs seem don't seem to respond correctly to hue/sat
+                # requests, so we're converting to XY color here.
+                command['xy'] = color.color_hs_to_xy(*kwargs[ATTR_HS_COLOR])
         elif ATTR_COLOR_TEMP in kwargs:
             temp = kwargs[ATTR_COLOR_TEMP]
             command['ct'] = max(self.min_mireds, min(temp, self.max_mireds))

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -302,9 +302,9 @@ class HueLight(Light):
         if ATTR_HS_COLOR in kwargs:
             if self.is_osram:
                 command['hue'] = int(kwargs[ATTR_HS_COLOR][0] / 360 * 65535)
-                command['sat'] = int(kwargs[ATTR_HS_COLOR][1] / 100 * 254)
+                command['sat'] = int(kwargs[ATTR_HS_COLOR][1] / 100 * 255)
             else:
-                # Philips bulbs seem don't seem to respond correctly to hue/sat
+                # Philips bulbs don't seem to respond correctly to hue/sat
                 # requests, so we're converting to XY color here.
                 command['xy'] = color.color_hs_to_xy(*kwargs[ATTR_HS_COLOR])
         elif ATTR_COLOR_TEMP in kwargs:

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -304,8 +304,9 @@ class HueLight(Light):
                 command['hue'] = int(kwargs[ATTR_HS_COLOR][0] / 360 * 65535)
                 command['sat'] = int(kwargs[ATTR_HS_COLOR][1] / 100 * 255)
             else:
-                # Philips bulbs don't seem to respond correctly to hue/sat
-                # requests, so we're converting to XY color here.
+                # Philips hue bulb models respond differently to hue/sat
+                # requests, so we convert to XY first to ensure a consistent
+                # color.
                 command['xy'] = color.color_hs_to_xy(*kwargs[ATTR_HS_COLOR])
         elif ATTR_COLOR_TEMP in kwargs:
             temp = kwargs[ATTR_COLOR_TEMP]


### PR DESCRIPTION
## Description:
It seems that Philips bulbs don't display the correct colors when given a hue/sat command. This PR restores the previous behavior of sending an XY color command for non-osram bulbs.

Original behavior for reference:

https://github.com/home-assistant/home-assistant/pull/11288/files#diff-09fd3b3fbdd20cedcad9fcf474b4aeb7L275

**Related issue (if applicable):** fixes #13632 fixes #13614

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
