### PR TITLE
Add Konnected component with support for discovery, binary sensor, and switch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -153,6 +153,9 @@ omit =
     homeassistant/components/knx.py
     homeassistant/components/*/knx.py
 
+    homeassistant/components/konnected.py
+    homeassistant/components/*/konnected.py
+
     homeassistant/components/lametric.py
     homeassistant/components/*/lametric.py
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -94,6 +94,8 @@ homeassistant/components/*/hive.py @Rendili @KJonline
 homeassistant/components/homekit/* @cdce8p
 homeassistant/components/knx.py @Julius2342
 homeassistant/components/*/knx.py @Julius2342
+homeassistant/components/konnected.py @heythisisnate
+homeassistant/components/*/konnected.py @heythisisnate
 homeassistant/components/matrix.py @tinloaf
 homeassistant/components/*/matrix.py @tinloaf
 homeassistant/components/qwikswitch.py @kellerza

--- a/homeassistant/components/binary_sensor/konnected.py
+++ b/homeassistant/components/binary_sensor/konnected.py
@@ -17,7 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['konnected']
 
 
-async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
     """Set up binary sensors attached to a Konnected device."""
     if discovery_info is None:
         return

--- a/homeassistant/components/binary_sensor/konnected.py
+++ b/homeassistant/components/binary_sensor/konnected.py
@@ -17,8 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['konnected']
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up binary sensors attached to a Konnected device."""
     if discovery_info is None:
         return

--- a/homeassistant/components/binary_sensor/konnected.py
+++ b/homeassistant/components/binary_sensor/konnected.py
@@ -28,7 +28,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     sensors = [KonnectedBinarySensor(device_id, pin_num, pin_data)
                for pin_num, pin_data in
                data[CONF_DEVICES][device_id][CONF_SENSORS].items()]
-    async_add_devices(sensors, True)
+    async_add_devices(sensors)
 
 
 class KonnectedBinarySensor(BinarySensorDevice):
@@ -40,11 +40,11 @@ class KonnectedBinarySensor(BinarySensorDevice):
         self._device_id = device_id
         self._pin_num = pin_num
         self._state = self._data.get(ATTR_STATE)
-        self._device_class = self._data.get(CONF_TYPE, 'motion')
+        self._device_class = self._data.get(CONF_TYPE)
         self._name = self._data.get(CONF_NAME, 'Konnected {} Zone {}'.format(
             device_id, PIN_TO_ZONE[pin_num]))
         self._data['entity'] = self
-        _LOGGER.info('Created new sensor: %s', self._name)
+        _LOGGER.debug('Created new Konnected sensor: %s', self._name)
 
     @property
     def name(self):
@@ -72,4 +72,3 @@ class KonnectedBinarySensor(BinarySensorDevice):
         self._state = state
         self._data[ATTR_STATE] = state
         self.async_schedule_update_ha_state()
-        _LOGGER.info('Updating state: %s is %s', self.name, state)

--- a/homeassistant/components/binary_sensor/konnected.py
+++ b/homeassistant/components/binary_sensor/konnected.py
@@ -9,6 +9,8 @@ import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.konnected import (DOMAIN, PIN_TO_ZONE)
+from homeassistant.const import (
+    CONF_DEVICES, CONF_TYPE, CONF_NAME, CONF_SENSORS, ATTR_STATE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +27,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     device_id = discovery_info['device_id']
     sensors = [KonnectedBinarySensor(device_id, pin_num, pin_data)
                for pin_num, pin_data in
-               data['devices'][device_id]['sensors'].items()]
+               data[CONF_DEVICES][device_id][CONF_SENSORS].items()]
     async_add_devices(sensors, True)
 
 
@@ -37,9 +39,9 @@ class KonnectedBinarySensor(BinarySensorDevice):
         self._data = data
         self._device_id = device_id
         self._pin_num = pin_num
-        self._state = self._data.get('state')
-        self._device_class = self._data.get('type', 'motion')
-        self._name = self._data.get('name', 'Konnected {} Zone {}'.format(
+        self._state = self._data.get(ATTR_STATE)
+        self._device_class = self._data.get(CONF_TYPE, 'motion')
+        self._name = self._data.get(CONF_NAME, 'Konnected {} Zone {}'.format(
             device_id, PIN_TO_ZONE[pin_num]))
         self._data['entity'] = self
         _LOGGER.info('Created new sensor: %s', self._name)
@@ -68,6 +70,6 @@ class KonnectedBinarySensor(BinarySensorDevice):
     def async_set_state(self, state):
         """Update the sensor's state."""
         self._state = state
-        self._data['state'] = state
+        self._data[ATTR_STATE] = state
         self.async_schedule_update_ha_state()
         _LOGGER.info('Updating state: %s is %s', self.name, state)

--- a/homeassistant/components/binary_sensor/konnected.py
+++ b/homeassistant/components/binary_sensor/konnected.py
@@ -1,0 +1,73 @@
+"""
+Support for wired binary sensors attached to a Konnected device.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.konnected/
+"""
+import asyncio
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.konnected import (DOMAIN, PIN_TO_ZONE)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['konnected']
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up binary sensors attached to a Konnected device."""
+    if discovery_info is None:
+        return
+
+    data = hass.data[DOMAIN]
+    device_id = discovery_info['device_id']
+    sensors = [KonnectedBinarySensor(device_id, pin_num, pin_data)
+               for pin_num, pin_data in
+               data['devices'][device_id]['sensors'].items()]
+    async_add_devices(sensors, True)
+
+
+class KonnectedBinarySensor(BinarySensorDevice):
+    """Representation of a Konnected binary sensor."""
+
+    def __init__(self, device_id, pin_num, data):
+        """Initialize the binary sensor."""
+        self._data = data
+        self._device_id = device_id
+        self._pin_num = pin_num
+        self._state = self._data.get('state')
+        self._device_class = self._data.get('type', 'motion')
+        self._name = self._data.get('name', 'Konnected {} Zone {}'.format(
+            device_id, PIN_TO_ZONE[pin_num]))
+        self._data['entity'] = self
+        _LOGGER.info('Created new sensor: %s', self._name)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return self._device_class
+
+    @asyncio.coroutine
+    def async_set_state(self, state):
+        """Update the sensor's state."""
+        self._state = state
+        self._data['state'] = state
+        self.async_schedule_update_ha_state()
+        _LOGGER.info('Updating state: %s is %s', self.name, state)

--- a/homeassistant/components/binary_sensor/konnected.py
+++ b/homeassistant/components/binary_sensor/konnected.py
@@ -10,7 +10,7 @@ import logging
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.konnected import (DOMAIN, PIN_TO_ZONE)
 from homeassistant.const import (
-    CONF_DEVICES, CONF_TYPE, CONF_NAME, CONF_SENSORS, ATTR_STATE)
+    CONF_DEVICES, CONF_TYPE, CONF_NAME, CONF_BINARY_SENSORS, ATTR_STATE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ async def async_setup_platform(hass, config, async_add_devices,
     device_id = discovery_info['device_id']
     sensors = [KonnectedBinarySensor(device_id, pin_num, pin_data)
                for pin_num, pin_data in
-               data[CONF_DEVICES][device_id][CONF_SENSORS].items()]
+               data[CONF_DEVICES][device_id][CONF_BINARY_SENSORS].items()]
     async_add_devices(sensors)
 
 

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -37,6 +37,7 @@ SERVICE_WINK = 'wink'
 SERVICE_XIAOMI_GW = 'xiaomi_gw'
 SERVICE_TELLDUSLIVE = 'tellstick'
 SERVICE_HUE = 'philips_hue'
+SERVICE_KONNECTED = 'konnected'
 SERVICE_DECONZ = 'deconz'
 SERVICE_DAIKIN = 'daikin'
 SERVICE_SABNZBD = 'sabnzbd'
@@ -62,6 +63,7 @@ SERVICE_HANDLERS = {
     SERVICE_DAIKIN: ('daikin', None),
     SERVICE_SABNZBD: ('sabnzbd', None),
     SERVICE_SAMSUNG_PRINTER: ('sensor', 'syncthru'),
+    SERVICE_KONNECTED: ('konnected', None),
     'google_cast': ('media_player', 'cast'),
     'panasonic_viera': ('media_player', 'panasonic_viera'),
     'plex_mediaserver': ('media_player', 'plex'),
@@ -191,6 +193,7 @@ def _discover(netdisco):
         for disc in netdisco.discover():
             for service in netdisco.get_info(disc):
                 results.append((disc, service))
+
     finally:
         netdisco.stop()
 

--- a/homeassistant/components/konnected.py
+++ b/homeassistant/components/konnected.py
@@ -17,10 +17,11 @@ from homeassistant.components.discovery import SERVICE_KONNECTED
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import (
     HTTP_BAD_REQUEST, HTTP_INTERNAL_SERVER_ERROR, HTTP_UNAUTHORIZED,
-    CONF_DEVICES, CONF_SENSORS, CONF_SWITCHES, CONF_HOST, CONF_PORT,
+    CONF_DEVICES, CONF_BINARY_SENSORS, CONF_SWITCHES, CONF_HOST, CONF_PORT,
     CONF_ID, CONF_NAME, CONF_TYPE, CONF_PIN, CONF_ZONE, ATTR_STATE)
+from homeassistant.core import callback
 from homeassistant.helpers import discovery
-from homeassistant.helpers import config_validation
+from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,33 +32,35 @@ DOMAIN = 'konnected'
 PIN_TO_ZONE = {1: 1, 2: 2, 5: 3, 6: 4, 7: 5, 8: 'out', 9: 6}
 ZONE_TO_PIN = {zone: pin for pin, zone in PIN_TO_ZONE.items()}
 
-_SENSOR_SCHEMA = vol.All(
+_BINARY_SENSOR_SCHEMA = vol.All(
     vol.Schema({
         vol.Exclusive(CONF_PIN, 's_pin'): vol.Any(*PIN_TO_ZONE),
         vol.Exclusive(CONF_ZONE, 's_pin'): vol.Any(*ZONE_TO_PIN),
         vol.Required(CONF_TYPE): DEVICE_CLASSES_SCHEMA,
-        vol.Optional(CONF_NAME): config_validation.string,
-    }), config_validation.has_at_least_one_key(CONF_PIN, CONF_ZONE)
+        vol.Optional(CONF_NAME): cv.string,
+    }), cv.has_at_least_one_key(CONF_PIN, CONF_ZONE)
 )
 
 _SWITCH_SCHEMA = vol.All(
     vol.Schema({
         vol.Exclusive(CONF_PIN, 'a_pin'): vol.Any(*PIN_TO_ZONE),
         vol.Exclusive(CONF_ZONE, 'a_pin'): vol.Any(*ZONE_TO_PIN),
-        vol.Optional(CONF_NAME): config_validation.string,
+        vol.Optional(CONF_NAME): cv.string,
         vol.Optional('activation', default='high'):
             vol.All(vol.Lower, vol.Any('high', 'low'))
-    }), config_validation.has_at_least_one_key(CONF_PIN, CONF_ZONE)
+    }), cv.has_at_least_one_key(CONF_PIN, CONF_ZONE)
 )
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema({
-            vol.Required('auth_token'): config_validation.string,
+            vol.Required('auth_token'): cv.string,
             vol.Required(CONF_DEVICES): [{
-                vol.Required(CONF_ID, default=''): config_validation.string,
-                vol.Optional(CONF_SENSORS): [_SENSOR_SCHEMA],
-                vol.Optional(CONF_SWITCHES): [_SWITCH_SCHEMA],
+                vol.Required(CONF_ID): cv.string,
+                vol.Optional(CONF_BINARY_SENSORS): vol.All(
+                    cv.ensure_list, [_BINARY_SENSOR_SCHEMA]),
+                vol.Optional(CONF_SWITCHES): vol.All(
+                    cv.ensure_list, [_SWITCH_SCHEMA]),
             }],
         }),
     },
@@ -89,7 +92,7 @@ async def async_setup(hass, config):
         port = info.get(CONF_PORT)
 
         device = KonnectedDevice(hass, host, port, cfg)
-        device.setup()
+        hass.async_add_job(device.async_setup)
 
     discovery.async_listen(
         hass,
@@ -116,13 +119,14 @@ class KonnectedDevice(object):
         self.status = self.client.get_status()
         _LOGGER.info('Initialized Konnected device %s', self.device_id)
 
-    def setup(self):
+    @callback
+    def async_setup(self):
         """Set up a newly discovered Konnected device."""
         user_config = self.config()
         if user_config:
             _LOGGER.debug('Configuring Konnected device %s', self.device_id)
             self.save_data()
-            self.hass.async_add_job(self.sync_device)
+            self.hass.async_add_job(self.async_sync_device_config)
             self.hass.async_add_job(
                 discovery.async_load_platform(
                     self.hass, 'binary_sensor',
@@ -153,7 +157,7 @@ class KonnectedDevice(object):
         TODO: This can probably be refactored and tidied up.
         """
         sensors = {}
-        for entity in self.config().get(CONF_SENSORS) or []:
+        for entity in self.config().get(CONF_BINARY_SENSORS) or []:
             if CONF_ZONE in entity:
                 pin = ZONE_TO_PIN[entity[CONF_ZONE]]
             else:
@@ -205,7 +209,7 @@ class KonnectedDevice(object):
 
         device_data = {
             'client': self.client,
-            CONF_SENSORS: sensors,
+            CONF_BINARY_SENSORS: sensors,
             CONF_SWITCHES: actuators,
             CONF_HOST: self.host,
             CONF_PORT: self.port,
@@ -225,7 +229,7 @@ class KonnectedDevice(object):
     def sensor_configuration(self):
         """Return the configuration map for syncing sensors."""
         return [{'pin': p} for p in
-                self.stored_configuration[CONF_SENSORS].keys()]
+                self.stored_configuration[CONF_BINARY_SENSORS].keys()]
 
     def actuator_configuration(self):
         """Return the configuration map for syncing actuators."""
@@ -234,7 +238,8 @@ class KonnectedDevice(object):
                 for p, data in
                 self.stored_configuration[CONF_SWITCHES].items()]
 
-    def sync_device(self):
+    @callback
+    def async_sync_device_config(self):
         """Sync the new pin configuration to the Konnected device."""
         desired_sensor_configuration = self.sensor_configuration()
         current_sensor_configuration = [
@@ -289,7 +294,7 @@ class KonnectedView(HomeAssistantView):
         if device is None:
             return self.json_message('unregistered device',
                                      status_code=HTTP_BAD_REQUEST)
-        pin_data = device[CONF_SENSORS].get(pin_num) or \
+        pin_data = device[CONF_BINARY_SENSORS].get(pin_num) or \
             device[CONF_SWITCHES].get(pin_num)
 
         if pin_data is None:

--- a/homeassistant/components/konnected.py
+++ b/homeassistant/components/konnected.py
@@ -174,8 +174,8 @@ class KonnectedDevice(object):
                 ATTR_STATE: initial_state
             }
             _LOGGER.debug('Set up sensor %s (initial state: %s)',
-                         sensors[pin].get('name'),
-                         sensors[pin].get(ATTR_STATE))
+                          sensors[pin].get('name'),
+                          sensors[pin].get(ATTR_STATE))
 
         actuators = {}
         for entity in self.config().get(CONF_SWITCHES) or []:
@@ -200,8 +200,8 @@ class KonnectedDevice(object):
                 'activation': entity['activation'],
             }
             _LOGGER.debug('Set up actuator %s (initial state: %s)',
-                         actuators[pin].get(CONF_NAME),
-                         actuators[pin].get(ATTR_STATE))
+                          actuators[pin].get(CONF_NAME),
+                          actuators[pin].get(ATTR_STATE))
 
         device_data = {
             'client': self.client,
@@ -240,16 +240,16 @@ class KonnectedDevice(object):
         current_sensor_configuration = [
             {'pin': s[CONF_PIN]} for s in self.status.get('sensors')]
         _LOGGER.debug('%s: desired sensor config: %s', self.device_id,
-                     desired_sensor_configuration)
+                      desired_sensor_configuration)
         _LOGGER.debug('%s: current sensor config: %s', self.device_id,
-                     current_sensor_configuration)
+                      current_sensor_configuration)
 
         desired_actuator_config = self.actuator_configuration()
         current_actuator_config = self.status.get('actuators')
         _LOGGER.debug('%s: desired actuator config: %s', self.device_id,
-                     desired_actuator_config)
+                      desired_actuator_config)
         _LOGGER.debug('%s: current actuator config: %s', self.device_id,
-                     current_actuator_config)
+                      current_actuator_config)
 
         if (desired_sensor_configuration != current_sensor_configuration) or \
                 (current_actuator_config != desired_actuator_config):

--- a/homeassistant/components/konnected.py
+++ b/homeassistant/components/konnected.py
@@ -1,0 +1,293 @@
+"""
+Support for Konnected devices.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/konnected/
+"""
+import asyncio
+import logging
+import voluptuous as vol
+
+from aiohttp.hdrs import AUTHORIZATION
+from aiohttp.web import Request, Response  # NOQA
+
+from homeassistant.components.binary_sensor import DEVICE_CLASSES_SCHEMA
+from homeassistant.components.discovery import SERVICE_KONNECTED
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.const import (
+    HTTP_BAD_REQUEST, HTTP_INTERNAL_SERVER_ERROR, HTTP_UNAUTHORIZED)
+from homeassistant.helpers import discovery
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['konnected==0.1.2']
+
+DOMAIN = 'konnected'
+
+PIN_TO_ZONE = {1: 1, 2: 2, 5: 3, 6: 4, 7: 5, 8: 'out', 9: 6}
+ZONE_TO_PIN = {zone: pin for pin, zone in PIN_TO_ZONE.items()}
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: {
+            'auth_token': str,
+            vol.Optional('home_assistant_url'): str,
+            'devices': [{
+                vol.Required('id', default=''): vol.Coerce(str),
+                'sensors': [{
+                    vol.Exclusive('pin', 's_pin'): vol.Any(*PIN_TO_ZONE),
+                    vol.Exclusive('zone', 's_pin'): vol.Any(*ZONE_TO_PIN),
+                    vol.Required('type', default='motion'):
+                        DEVICE_CLASSES_SCHEMA,
+                    vol.Optional('name'): str,
+                }],
+                'actuators': [{
+                    vol.Exclusive('pin', 'a_pin'): vol.Any(*PIN_TO_ZONE),
+                    vol.Exclusive('zone', 'a_pin'): vol.Any(*ZONE_TO_PIN),
+                    vol.Optional('name'): str,
+                    vol.Required('activation', default='high'):
+                        vol.All(vol.Lower, vol.Any('high', 'low'))
+                }],
+            }],
+        },
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+DEPENDENCIES = ['http']
+
+ENDPOINT_ROOT = '/api/konnected'
+UPDATE_ENDPOINT = (
+    ENDPOINT_ROOT +
+    r'/device/{device_id:[a-zA-Z0-9]+}/{pin_num:[0-9]}/{state:[01]}')
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up the Konnected platform."""
+    cfg = config.get(DOMAIN)
+    if cfg is None:
+        cfg = {}
+
+    auth_token = cfg.get('auth_token') or 'supersecret'
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {'auth_token': auth_token}
+
+    @asyncio.coroutine
+    def async_device_discovered(service, info):
+        """Call when a Konnected device has been discovered."""
+        _LOGGER.info("Discovered a new Konnected device: %s", info)
+        host = info.get('host')
+        port = info.get('port')
+
+        device = KonnectedDevice(hass, host, port, cfg)
+        device.setup()
+
+    discovery.async_listen(
+        hass,
+        SERVICE_KONNECTED,
+        async_device_discovered)
+
+    hass.http.register_view(KonnectedView(auth_token))
+
+    return True
+
+
+class KonnectedDevice(object):
+    """A representation of a single Konnected device."""
+
+    def __init__(self, hass, host, port, config):
+        """Initialize the Konnected device."""
+        self.hass = hass
+        self.host = host
+        self.port = port
+        self.user_config = config
+
+        import konnected
+        self.client = konnected.Client(host, str(port))
+        self.status = self.client.get_status()
+        _LOGGER.info('Initialized Konnected device %s', self.device_id)
+
+    def setup(self):
+        """Set up a newly discovered Konnected device."""
+        user_config = self.config()
+        if user_config:
+            _LOGGER.info('Configuring Konnected device %s', self.device_id)
+            self.save_data()
+            self.sync_device()
+            self.hass.async_add_job(
+                discovery.async_load_platform(
+                    self.hass, 'binary_sensor',
+                    DOMAIN, {'device_id': self.device_id}))
+            self.hass.async_add_job(
+                discovery.async_load_platform(
+                    self.hass, 'switch', DOMAIN,
+                    {'device_id': self.device_id}))
+
+    @property
+    def device_id(self):
+        """Device id is the MAC address as string with punctuation removed."""
+        return self.status['mac'].replace(':', '')
+
+    def config(self):
+        """Return an object representing the user defined configuration."""
+        device_id = self.device_id
+        valid_keys = [device_id, device_id.upper(),
+                      device_id[6:], device_id.upper()[6:]]
+        configured_devices = self.user_config['devices']
+        return next((device for device in
+                     configured_devices if device['id'] in valid_keys), None)
+
+    def save_data(self):
+        """Save the device configuration to `hass.data`.
+
+        TODO: This can probably be refactored and tidied up.
+        """
+        sensors = {}
+        for entity in self.config().get('sensors') or []:
+            if 'zone' in entity:
+                pin = ZONE_TO_PIN[entity['zone']]
+            else:
+                pin = entity['pin']
+
+            sensor_status = next((sensor for sensor in
+                                  self.status.get('sensors') if
+                                  sensor.get('pin') == pin), {})
+            if sensor_status.get('state'):
+                initial_state = bool(int(sensor_status.get('state')))
+            else:
+                initial_state = None
+
+            sensors[pin] = {
+                'type': entity['type'],
+                'name': entity.get('name', 'Konnected {} Zone {}'.format(
+                    self.device_id[6:], PIN_TO_ZONE[pin])),
+                'state': initial_state
+            }
+            _LOGGER.info('Set up sensor %s (initial state: %s)',
+                         sensors[pin].get('name'), sensors[pin].get('state'))
+
+        actuators = {}
+        for entity in self.config().get('actuators') or []:
+            if 'zone' in entity:
+                pin = ZONE_TO_PIN[entity['zone']]
+            else:
+                pin = entity['pin']
+
+            actuator_status = next((actuator for actuator in
+                                    self.status.get('actuators') if
+                                    actuator.get('pin') == pin), {})
+            if actuator_status.get('state'):
+                initial_state = bool(int(actuator_status.get('state')))
+            else:
+                initial_state = None
+
+            actuators[pin] = {
+                'name': entity.get('name', 'Konnected {} Actuator {}'.format(
+                    self.device_id[6:], PIN_TO_ZONE[pin])),
+                'state': initial_state,
+                'activation': entity['activation'],
+            }
+            _LOGGER.info('Set up actuator %s (initial state: %s)',
+                         actuators[pin].get('name'),
+                         actuators[pin].get('state'))
+
+        device_data = {
+            'client': self.client,
+            'sensors': sensors,
+            'actuators': actuators,
+            'host': self.host,
+            'port': self.port,
+        }
+
+        if 'devices' not in self.hass.data[DOMAIN]:
+            self.hass.data[DOMAIN]['devices'] = {}
+
+        _LOGGER.info('Storing data in hass.data[konnected]: %s', device_data)
+        self.hass.data[DOMAIN]['devices'][self.device_id] = device_data
+
+    @property
+    def stored_configuration(self):
+        """Return the configuration stored in `hass.data` for this device."""
+        return self.hass.data[DOMAIN]['devices'][self.device_id]
+
+    def sensor_configuration(self):
+        """Return the configuration map for syncing sensors."""
+        return [{'pin': p} for p in
+                self.stored_configuration['sensors'].keys()]
+
+    def actuator_configuration(self):
+        """Return the configuration map for syncing actuators."""
+        return [{'pin': p,
+                 'trigger': (0 if data.get('activation') in [0, 'low'] else 1)}
+                for p, data in
+                self.stored_configuration['actuators'].items()]
+
+    def sync_device(self):
+        """Sync the new pin configuration to the Konnected device."""
+        desired_sensor_configuration = self.sensor_configuration()
+        current_sensor_configuration = [
+            {'pin': s['pin']} for s in self.status.get('sensors')]
+        _LOGGER.info('%s: desired sensor config: %s', self.device_id,
+                     desired_sensor_configuration)
+        _LOGGER.info('%s: current sensor config: %s', self.device_id,
+                     current_sensor_configuration)
+
+        desired_actuator_config = self.actuator_configuration()
+        current_actuator_config = self.status.get('actuators')
+        _LOGGER.info('%s: desired actuator config: %s', self.device_id,
+                     desired_actuator_config)
+        _LOGGER.info('%s: current actuator config: %s', self.device_id,
+                     current_actuator_config)
+
+        if (desired_sensor_configuration != current_sensor_configuration) or \
+                (current_actuator_config != desired_actuator_config):
+            _LOGGER.info('pushing settings to device %s', self.device_id)
+            self.client.put_settings(
+                desired_sensor_configuration,
+                desired_actuator_config,
+                self.hass.data[DOMAIN].get('auth_token'),
+                self.hass.config.api.base_url + ENDPOINT_ROOT
+            )
+
+
+class KonnectedView(HomeAssistantView):
+    """View creates an endpoint to receive push updates from the device."""
+
+    url = UPDATE_ENDPOINT
+    name = 'api:konnected'
+    requires_auth = False  # Uses access token from configuration
+
+    def __init__(self, auth_token):
+        """Initialize the view."""
+        self.auth_token = auth_token
+
+    @asyncio.coroutine
+    def put(self, request: Request, device_id, pin_num, state) -> Response:
+        """Receive a sensor update via PUT request and async set state."""
+        hass = request.app['hass']
+        data = hass.data[DOMAIN]
+
+        auth = request.headers.get(AUTHORIZATION, None)
+        if 'Bearer {}'.format(self.auth_token) != auth:
+            return self.json_message(
+                "unauthorized", status_code=HTTP_UNAUTHORIZED)
+        pin_num = int(pin_num)
+        state = bool(int(state))
+        device = data['devices'].get(device_id)
+        if device is None:
+            return self.json_message('unregistered device',
+                                     status_code=HTTP_BAD_REQUEST)
+        pin_data = device['sensors'].get(pin_num) or \
+            device['actuators'].get(pin_num)
+
+        if pin_data is None:
+            return self.json_message('unregistered sensor/actuator',
+                                     status_code=HTTP_BAD_REQUEST)
+        entity = pin_data.get('entity')
+        if entity is None:
+            return self.json_message('uninitialized sensor/actuator',
+                                     status_code=HTTP_INTERNAL_SERVER_ERROR)
+
+        yield from entity.async_set_state(state)
+        return self.json_message('ok')

--- a/homeassistant/components/konnected.py
+++ b/homeassistant/components/konnected.py
@@ -151,10 +151,7 @@ class KonnectedDevice(object):
                     None)
 
     def save_data(self):
-        """Save the device configuration to `hass.data`.
-
-        TODO: This can probably be refactored and tidied up.
-        """
+        """Save the device configuration to `hass.data`."""
         sensors = {}
         for entity in self.config().get(CONF_BINARY_SENSORS) or []:
             if CONF_ZONE in entity:

--- a/homeassistant/components/konnected.py
+++ b/homeassistant/components/konnected.py
@@ -72,8 +72,7 @@ UPDATE_ENDPOINT = (
     r'/device/{device_id:[a-zA-Z0-9]+}/{pin_num:[0-9]}/{state:[01]}')
 
 
-@asyncio.coroutine
-def async_setup(hass, config):
+async def async_setup(hass, config):
     """Set up the Konnected platform."""
     cfg = config.get(DOMAIN)
     if cfg is None:
@@ -83,8 +82,7 @@ def async_setup(hass, config):
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {'auth_token': auth_token}
 
-    @asyncio.coroutine
-    def async_device_discovered(service, info):
+    async def async_device_discovered(service, info):
         """Call when a Konnected device has been discovered."""
         _LOGGER.debug("Discovered a new Konnected device: %s", info)
         host = info.get(CONF_HOST)
@@ -124,7 +122,7 @@ class KonnectedDevice(object):
         if user_config:
             _LOGGER.debug('Configuring Konnected device %s', self.device_id)
             self.save_data()
-            self.sync_device()
+            self.hass.async_add_job(self.sync_device)
             self.hass.async_add_job(
                 discovery.async_load_platform(
                     self.hass, 'binary_sensor',

--- a/homeassistant/components/switch/konnected.py
+++ b/homeassistant/components/switch/konnected.py
@@ -47,7 +47,7 @@ class KonnectedSwitch(ToggleEntity):
                 device_id, PIN_TO_ZONE[pin_num]))
         self._data['entity'] = self
         self._client = client
-        _LOGGER.info('Created new switch: %s', self._name)
+        _LOGGER.debug('Created new switch: %s', self._name)
 
     @property
     def name(self):
@@ -73,7 +73,7 @@ class KonnectedSwitch(ToggleEntity):
         self._state = state
         self._data[ATTR_STATE] = state
         self.schedule_update_ha_state()
-        _LOGGER.info('Setting status of %s actuator pin %s to %s',
+        _LOGGER.debug('Setting status of %s actuator pin %s to %s',
                      self._device_id, self.name, state)
 
     @asyncio.coroutine
@@ -82,4 +82,3 @@ class KonnectedSwitch(ToggleEntity):
         self._state = state
         self._data[ATTR_STATE] = state
         self.async_schedule_update_ha_state()
-        _LOGGER.info('Updating state: %s is %s', self.name, state)

--- a/homeassistant/components/switch/konnected.py
+++ b/homeassistant/components/switch/konnected.py
@@ -8,7 +8,8 @@ https://home-assistant.io/components/switch.konnected/
 import asyncio
 import logging
 
-from homeassistant.components.konnected import (DOMAIN, PIN_TO_ZONE)
+from homeassistant.components.konnected import (
+    DOMAIN, PIN_TO_ZONE, CONF_ACTIVATION, STATE_LOW, STATE_HIGH)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.const import (CONF_DEVICES, CONF_SWITCHES, ATTR_STATE)
 
@@ -41,7 +42,7 @@ class KonnectedSwitch(ToggleEntity):
         self._device_id = device_id
         self._pin_num = pin_num
         self._state = self._data.get(ATTR_STATE)
-        self._activation = self._data.get('activation', 'high')
+        self._activation = self._data.get(CONF_ACTIVATION, STATE_HIGH)
         self._name = self._data.get(
             'name', 'Konnected {} Actuator {}'.format(
                 device_id, PIN_TO_ZONE[pin_num]))
@@ -61,12 +62,14 @@ class KonnectedSwitch(ToggleEntity):
 
     def turn_on(self, **kwargs):
         """Send a command to turn on the switch."""
-        self._client.put_device(self._pin_num, int(self._activation == 'high'))
+        self._client.put_device(self._pin_num,
+                                int(self._activation == STATE_HIGH))
         self._set_state(True)
 
     def turn_off(self, **kwargs):
         """Send a command to turn off the switch."""
-        self._client.put_device(self._pin_num, int(self._activation == 'low'))
+        self._client.put_device(self._pin_num,
+                                int(self._activation == STATE_LOW))
         self._set_state(False)
 
     def _set_state(self, state):

--- a/homeassistant/components/switch/konnected.py
+++ b/homeassistant/components/switch/konnected.py
@@ -1,0 +1,83 @@
+"""
+Support for wired switches attached to a Konnected device.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.konnected/
+"""
+
+import asyncio
+import logging
+
+from homeassistant.components.konnected import (DOMAIN, PIN_TO_ZONE)
+from homeassistant.helpers.entity import ToggleEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['konnected']
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set switches attached to a Konnected device."""
+    if discovery_info is None:
+        return
+
+    data = hass.data[DOMAIN]
+    device_id = discovery_info['device_id']
+    client = data['devices'][device_id]['client']
+    actuators = [KonnectedSwitch(device_id, pin_num, pin_data, client)
+                 for pin_num, pin_data in
+                 data['devices'][device_id]['actuators'].items()]
+    async_add_devices(actuators, True)
+
+
+class KonnectedSwitch(ToggleEntity):
+    """Representation of a Konnected switch."""
+
+    def __init__(self, device_id, pin_num, data, client):
+        """Initialize the switch."""
+        self._data = data
+        self._device_id = device_id
+        self._pin_num = pin_num
+        self._state = self._data.get('state')
+        self._name = self._data.get(
+            'name', 'Konnected {} Actuator {}'.format(
+                device_id, PIN_TO_ZONE[pin_num]))
+        self._data['entity'] = self
+        self._client = client
+        _LOGGER.info('Created new switch: %s', self._name)
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return the status of the sensor."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Send a command to turn on the switch."""
+        self._client.put_device(self._pin_num, 1)
+        self._set_state(True)
+
+    def turn_off(self, **kwargs):
+        """Send a command to turn off the switch."""
+        self._client.put_device(self._pin_num, 0)
+        self._set_state(False)
+
+    def _set_state(self, state):
+        self._state = state
+        self._data['state'] = state
+        self.schedule_update_ha_state()
+        _LOGGER.info('Setting status of %s actuator pin %s to %s',
+                     self._device_id, self.name, state)
+
+    @asyncio.coroutine
+    def async_set_state(self, state):
+        """Update the switch's state."""
+        self._state = state
+        self._data['state'] = state
+        self.async_schedule_update_ha_state()
+        _LOGGER.info('Updating state: %s is %s', self.name, state)

--- a/homeassistant/components/switch/konnected.py
+++ b/homeassistant/components/switch/konnected.py
@@ -17,8 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['konnected']
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set switches attached to a Konnected device."""
     if discovery_info is None:
         return
@@ -29,7 +28,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     switches = [KonnectedSwitch(device_id, pin_num, pin_data, client)
                 for pin_num, pin_data in
                 data[CONF_DEVICES][device_id][CONF_SWITCHES].items()]
-    async_add_devices(switches, True)
+    async_add_devices(switches)
 
 
 class KonnectedSwitch(ToggleEntity):

--- a/homeassistant/components/switch/konnected.py
+++ b/homeassistant/components/switch/konnected.py
@@ -10,6 +10,7 @@ import logging
 
 from homeassistant.components.konnected import (DOMAIN, PIN_TO_ZONE)
 from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.const import (CONF_DEVICES, CONF_SWITCHES, ATTR_STATE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,11 +25,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     data = hass.data[DOMAIN]
     device_id = discovery_info['device_id']
-    client = data['devices'][device_id]['client']
-    actuators = [KonnectedSwitch(device_id, pin_num, pin_data, client)
-                 for pin_num, pin_data in
-                 data['devices'][device_id]['actuators'].items()]
-    async_add_devices(actuators, True)
+    client = data[CONF_DEVICES][device_id]['client']
+    switches = [KonnectedSwitch(device_id, pin_num, pin_data, client)
+                for pin_num, pin_data in
+                data[CONF_DEVICES][device_id][CONF_SWITCHES].items()]
+    async_add_devices(switches, True)
 
 
 class KonnectedSwitch(ToggleEntity):
@@ -39,7 +40,7 @@ class KonnectedSwitch(ToggleEntity):
         self._data = data
         self._device_id = device_id
         self._pin_num = pin_num
-        self._state = self._data.get('state')
+        self._state = self._data.get(ATTR_STATE)
         self._name = self._data.get(
             'name', 'Konnected {} Actuator {}'.format(
                 device_id, PIN_TO_ZONE[pin_num]))
@@ -69,7 +70,7 @@ class KonnectedSwitch(ToggleEntity):
 
     def _set_state(self, state):
         self._state = state
-        self._data['state'] = state
+        self._data[ATTR_STATE] = state
         self.schedule_update_ha_state()
         _LOGGER.info('Setting status of %s actuator pin %s to %s',
                      self._device_id, self.name, state)
@@ -78,6 +79,6 @@ class KonnectedSwitch(ToggleEntity):
     def async_set_state(self, state):
         """Update the switch's state."""
         self._state = state
-        self._data['state'] = state
+        self._data[ATTR_STATE] = state
         self.async_schedule_update_ha_state()
         _LOGGER.info('Updating state: %s is %s', self.name, state)

--- a/homeassistant/components/switch/konnected.py
+++ b/homeassistant/components/switch/konnected.py
@@ -41,6 +41,7 @@ class KonnectedSwitch(ToggleEntity):
         self._device_id = device_id
         self._pin_num = pin_num
         self._state = self._data.get(ATTR_STATE)
+        self._activation = self._data.get('activation', 'high')
         self._name = self._data.get(
             'name', 'Konnected {} Actuator {}'.format(
                 device_id, PIN_TO_ZONE[pin_num]))
@@ -60,12 +61,12 @@ class KonnectedSwitch(ToggleEntity):
 
     def turn_on(self, **kwargs):
         """Send a command to turn on the switch."""
-        self._client.put_device(self._pin_num, 1)
+        self._client.put_device(self._pin_num, int(self._activation == 'high'))
         self._set_state(True)
 
     def turn_off(self, **kwargs):
         """Send a command to turn off the switch."""
-        self._client.put_device(self._pin_num, 0)
+        self._client.put_device(self._pin_num, int(self._activation == 'low'))
         self._set_state(False)
 
     def _set_state(self, state):

--- a/homeassistant/components/switch/konnected.py
+++ b/homeassistant/components/switch/konnected.py
@@ -17,7 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['konnected']
 
 
-async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
     """Set switches attached to a Konnected device."""
     if discovery_info is None:
         return
@@ -73,7 +74,7 @@ class KonnectedSwitch(ToggleEntity):
         self._data[ATTR_STATE] = state
         self.schedule_update_ha_state()
         _LOGGER.debug('Setting status of %s actuator pin %s to %s',
-                     self._device_id, self.name, state)
+                      self._device_id, self.name, state)
 
     @asyncio.coroutine
     def async_set_state(self, state):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -464,6 +464,9 @@ keyring==12.2.0
 # homeassistant.scripts.keyring
 keyrings.alt==3.1
 
+# homeassistant.components.konnected
+konnected==0.1.2
+
 # homeassistant.components.eufy
 lakeside==0.5
 


### PR DESCRIPTION
## Description:
Adds a component for [Konnected](https://konnected.io) devices. Konnected is an [open source](https://github.com/konnected-io/konnected-security) application that runs on a NodeMCU ESP8266. Konnected develops hardware designed for connecting traditional wired alarm system sensors and sirens to home automation.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** https://github.com/home-assistant/home-assistant.github.io/pull/5102

## Example entry for `configuration.yaml`:
```yaml
konnected:
  access_token: REPLACE_ME_WITH_A_RANDOM_STRING
  devices:
    - id: 8bcd53
      binary_sensors:
        - zone: 1
          type: door
          name: 'Front Door'
        - zone: 3
          type: motion
          name: 'Test Motion'
      switches:
        - zone: out
          name: siren
    - id: 438a38
      binary_sensors:
        - pin: 1
          type: motion
          name: 'Office Motion'
        - pin: 2
          type: door
          name: 'Office Door'
      switches:
        - pin: 5
          name: 'Garage Door'
          activation: low
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
