### PR TITLE
Add extra attributes for device scanner, Nmap and Unifi (IP, SSID, etc.)

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -660,6 +660,17 @@ class DeviceScanner(object):
         """
         return self.hass.async_add_job(self.get_device_name, device)
 
+    def get_extra_attributes(self, device: str) -> dict:
+        """Get the extra attributes of a device."""
+        return {}
+
+    def async_get_extra_attributes(self, device: str) -> Any:
+        """Get the extra attributes of a device.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.async_add_job(self.get_extra_attributes, device)
+
 
 def load_config(path: str, hass: HomeAssistantType, consider_home: timedelta):
     """Load devices from YAML configuration file."""
@@ -743,11 +754,17 @@ def async_setup_scanner_platform(hass: HomeAssistantType, config: ConfigType,
             else:
                 host_name = yield from scanner.async_get_device_name(mac)
                 seen.add(mac)
+            
+            extra_attributes = yield from scanner.async_get_extra_attributes(mac)
 
             kwargs = {
                 'mac': mac,
                 'host_name': host_name,
-                'source_type': SOURCE_TYPE_ROUTER
+                'source_type': SOURCE_TYPE_ROUTER,
+                'attributes': {
+                    'scanner': scanner.__class__.__name__,
+                    **extra_attributes
+                }
             }
 
             zone_home = hass.states.get(zone.ENTITY_ID_HOME)

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -662,7 +662,7 @@ class DeviceScanner(object):
 
     def get_extra_attributes(self, device: str) -> dict:
         """Get the extra attributes of a device."""
-        return {}
+        raise NotImplementedError()
 
     def async_get_extra_attributes(self, device: str) -> Any:
         """Get the extra attributes of a device.
@@ -755,8 +755,11 @@ def async_setup_scanner_platform(hass: HomeAssistantType, config: ConfigType,
                 host_name = yield from scanner.async_get_device_name(mac)
                 seen.add(mac)
 
-            extra_attributes = (yield from
-                                scanner.async_get_extra_attributes(mac))
+            try:
+                extra_attributes = (yield from
+                                    scanner.async_get_extra_attributes(mac))
+            except NotImplementedError:
+                extra_attributes = dict()
 
             kwargs = {
                 'mac': mac,

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -754,8 +754,9 @@ def async_setup_scanner_platform(hass: HomeAssistantType, config: ConfigType,
             else:
                 host_name = yield from scanner.async_get_device_name(mac)
                 seen.add(mac)
-            
-            extra_attributes = yield from scanner.async_get_extra_attributes(mac)
+
+            extra_attributes = (yield from
+                                scanner.async_get_extra_attributes(mac))
 
             kwargs = {
                 'mac': mac,

--- a/homeassistant/components/device_tracker/nmap_tracker.py
+++ b/homeassistant/components/device_tracker/nmap_tracker.py
@@ -80,6 +80,8 @@ class NmapDeviceScanner(DeviceScanner):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
 
+        _LOGGER.debug("Nmap last results %s", self.last_results)
+
         return [device.mac for device in self.last_results]
 
     def get_device_name(self, device):
@@ -89,6 +91,15 @@ class NmapDeviceScanner(DeviceScanner):
 
         if filter_named:
             return filter_named[0]
+        return None
+
+    def get_extra_attributes(self, device):
+        """Return the IP pf the given device."""
+        filter_ip = [result.ip for result in self.last_results
+                     if result.mac == device]
+
+        if filter_ip:
+            return {'ip': filter_ip[0]}
         return None
 
     def _update_info(self):

--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -122,3 +122,9 @@ class UnifiScanner(DeviceScanner):
         name = client.get('name') or client.get('hostname')
         _LOGGER.debug("Device mac %s name %s", device, name)
         return name
+
+    def get_extra_attributes(self, device):
+        """Return the extra attributes of the device."""
+        client = self._clients.get(device, {})
+        _LOGGER.debug("Device mac %s attributes %s", device, client)
+        return client


### PR DESCRIPTION
## Description:
Add extra state attributes for device scanner :
 - Common : add device scanner name
 - Nmap : add last detected IP
 - Unifi : add last detected IP, SSID, BSSID, etc.

These attributes allows better control in automation scripts or templating.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
N/A

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
N/A
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
N/A
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
N/A
  - [ ] New files were added to `.coveragerc`.
N/A

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
N/A

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
