### PR TITLE
Added headers configuration variable to notify.rest component

### DIFF
--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -12,7 +12,8 @@ import voluptuous as vol
 from homeassistant.components.notify import (
     ATTR_TARGET, ATTR_TITLE, ATTR_TITLE_DEFAULT, BaseNotificationService,
     PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_RESOURCE, CONF_METHOD, CONF_NAME, CONF_HEADERS)
+from homeassistant.const import (CONF_RESOURCE, CONF_METHOD, CONF_NAME,
+                                 CONF_HEADERS)
 import homeassistant.helpers.config_validation as cv
 
 CONF_DATA = 'data'
@@ -102,11 +103,14 @@ class RestNotificationService(BaseNotificationService):
             data.update(_data_template_creator(self._data_template))
 
         if self._method == 'POST':
-            response = requests.post(self._resource, headers=self._headers, data=data, timeout=10)
+            response = requests.post(self._resource, headers=self._headers,
+                                     data=data, timeout=10)
         elif self._method == 'POST_JSON':
-            response = requests.post(self._resource, headers=self._headers, json=data, timeout=10)
+            response = requests.post(self._resource, headers=self._headers,
+                                     json=data, timeout=10)
         else:   # default GET
-            response = requests.get(self._resource, headers=self._headers, params=data, timeout=10)
+            response = requests.get(self._resource, headers=self._headers,
+                                    params=data, timeout=10)
 
         if response.status_code not in (200, 201):
             _LOGGER.exception(

--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant.components.notify import (
     ATTR_TARGET, ATTR_TITLE, ATTR_TITLE_DEFAULT, BaseNotificationService,
     PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_RESOURCE, CONF_METHOD, CONF_NAME)
+from homeassistant.const import (CONF_RESOURCE, CONF_METHOD, CONF_NAME, CONF_HEADERS)
 import homeassistant.helpers.config_validation as cv
 
 CONF_DATA = 'data'
@@ -29,6 +29,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                  default=DEFAULT_MESSAGE_PARAM_NAME): cv.string,
     vol.Optional(CONF_METHOD, default=DEFAULT_METHOD):
         vol.In(['POST', 'GET', 'POST_JSON']),
+    vol.Optional(CONF_HEADERS): vol.Schema({cv.string: cv.string}),
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_TARGET_PARAMETER_NAME): cv.string,
     vol.Optional(CONF_TITLE_PARAMETER_NAME): cv.string,
@@ -43,6 +44,7 @@ def get_service(hass, config, discovery_info=None):
     """Get the RESTful notification service."""
     resource = config.get(CONF_RESOURCE)
     method = config.get(CONF_METHOD)
+    headers = config.get(CONF_HEADERS)
     message_param_name = config.get(CONF_MESSAGE_PARAMETER_NAME)
     title_param_name = config.get(CONF_TITLE_PARAMETER_NAME)
     target_param_name = config.get(CONF_TARGET_PARAMETER_NAME)
@@ -50,19 +52,20 @@ def get_service(hass, config, discovery_info=None):
     data_template = config.get(CONF_DATA_TEMPLATE)
 
     return RestNotificationService(
-        hass, resource, method, message_param_name,
+        hass, resource, method, headers, message_param_name,
         title_param_name, target_param_name, data, data_template)
 
 
 class RestNotificationService(BaseNotificationService):
     """Implementation of a notification service for REST."""
 
-    def __init__(self, hass, resource, method, message_param_name,
+    def __init__(self, hass, resource, method, headers, message_param_name,
                  title_param_name, target_param_name, data, data_template):
         """Initialize the service."""
         self._resource = resource
         self._hass = hass
         self._method = method.upper()
+        self._headers = headers
         self._message_param_name = message_param_name
         self._title_param_name = title_param_name
         self._target_param_name = target_param_name
@@ -99,11 +102,11 @@ class RestNotificationService(BaseNotificationService):
             data.update(_data_template_creator(self._data_template))
 
         if self._method == 'POST':
-            response = requests.post(self._resource, data=data, timeout=10)
+            response = requests.post(self._resource, headers=self._headers, data=data, timeout=10)
         elif self._method == 'POST_JSON':
-            response = requests.post(self._resource, json=data, timeout=10)
+            response = requests.post(self._resource, headers=self._headers, json=data, timeout=10)
         else:   # default GET
-            response = requests.get(self._resource, params=data, timeout=10)
+            response = requests.get(self._resource, headers=self._headers, params=data, timeout=10)
 
         if response.status_code not in (200, 201):
             _LOGGER.exception(


### PR DESCRIPTION
## Description:
Added configuration variable `headers` to `notify.rest` component.
This is provide possibility to send requests with headers.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
home-assistant/home-assistant.github.io#5103

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: NOTIFIER_NAME
    platform: rest
    resource: http://IP_ADDRESS/ENDPOINT
    headers:
      Authorization: Token AUTH_TOKEN
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
