### PR TITLE
Add render json_template before resolving attributes in RESTful sensor

### DIFF
--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -92,7 +92,8 @@ class RestSensor(Entity):
     """Implementation of a REST sensor."""
 
     def __init__(self, hass, rest, name, unit_of_measurement,
-                 value_template, json_attrs, force_update, json_template = None):
+                 value_template, json_attrs, force_update,
+                 json_template=None):
         """Initialize the REST sensor."""
         self._hass = hass
         self.rest = rest
@@ -140,8 +141,9 @@ class RestSensor(Entity):
             if value:
                 try:
                     if self._json_template is not None:
-                        attributes = self._json_template.render_with_possible_json_value(
-                            value, {})
+                        attributes = self._json_template \
+                                         .render_with_possible_json_value(
+                                             value, {})
                         json_dict = json.loads(attributes)
                     else:
                         json_dict = json.loads(value)

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -92,7 +92,7 @@ class RestSensor(Entity):
     """Implementation of a REST sensor."""
 
     def __init__(self, hass, rest, name, unit_of_measurement,
-                 value_template, json_attrs, force_update, json_template):
+                 value_template, json_attrs, force_update, json_template = None):
         """Initialize the REST sensor."""
         self._hass = hass
         self.rest = rest

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -83,7 +83,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     rest.update()
 
     add_devices([RestSensor(
-        hass, rest, name, unit, value_template, json_attrs, force_update, json_template
+        hass, rest, name, unit, value_template, json_attrs, force_update,
+        json_template
     )], True)
 
 
@@ -139,8 +140,8 @@ class RestSensor(Entity):
             if value:
                 try:
                     if self._json_template is not None:
-                        _LOGGER.warning("RESPONSE FROM WEB: %s", value)
-                        attributes  = self._json_template.render_with_possible_json_value(value, {})
+                        attributes = self._json_template.render_with_possible_json_value(
+                            value, {})
                         json_dict = json.loads(attributes)
                     else:
                         json_dict = json.loads(value)

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -29,6 +29,7 @@ DEFAULT_VERIFY_SSL = True
 DEFAULT_FORCE_UPDATE = False
 
 CONF_JSON_ATTRS = 'json_attributes'
+CONF_JSON_TEMPLATE = 'json_template'
 METHODS = ['POST', 'GET']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -37,6 +38,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
     vol.Optional(CONF_HEADERS): vol.Schema({cv.string: cv.string}),
     vol.Optional(CONF_JSON_ATTRS, default=[]): cv.ensure_list_csv,
+    vol.Optional(CONF_JSON_TEMPLATE): cv.template,
     vol.Optional(CONF_METHOD, default=DEFAULT_METHOD): vol.In(METHODS),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
@@ -62,10 +64,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
     value_template = config.get(CONF_VALUE_TEMPLATE)
     json_attrs = config.get(CONF_JSON_ATTRS)
+    json_template = config.get(CONF_JSON_TEMPLATE)
     force_update = config.get(CONF_FORCE_UPDATE)
 
     if value_template is not None:
         value_template.hass = hass
+    if json_template is not None:
+        json_template.hass = hass
 
     if username and password:
         if config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
@@ -78,7 +83,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     rest.update()
 
     add_devices([RestSensor(
-        hass, rest, name, unit, value_template, json_attrs, force_update
+        hass, rest, name, unit, value_template, json_attrs, force_update, json_template
     )], True)
 
 
@@ -86,7 +91,7 @@ class RestSensor(Entity):
     """Implementation of a REST sensor."""
 
     def __init__(self, hass, rest, name, unit_of_measurement,
-                 value_template, json_attrs, force_update):
+                 value_template, json_attrs, force_update, json_template):
         """Initialize the REST sensor."""
         self._hass = hass
         self.rest = rest
@@ -95,6 +100,7 @@ class RestSensor(Entity):
         self._unit_of_measurement = unit_of_measurement
         self._value_template = value_template
         self._json_attrs = json_attrs
+        self._json_template = json_template
         self._attributes = None
         self._force_update = force_update
 
@@ -132,7 +138,12 @@ class RestSensor(Entity):
             self._attributes = {}
             if value:
                 try:
-                    json_dict = json.loads(value)
+                    if self._json_template is not None:
+                        _LOGGER.warning("RESPONSE FROM WEB: %s", value)
+                        attributes  = self._json_template.render_with_possible_json_value(value, {})
+                        json_dict = json.loads(attributes)
+                    else:
+                        json_dict = json.loads(value)
                     if isinstance(json_dict, dict):
                         attrs = {k: json_dict[k] for k in self._json_attrs
                                  if k in json_dict}

--- a/tests/components/sensor/test_rest.py
+++ b/tests/components/sensor/test_rest.py
@@ -131,12 +131,13 @@ class TestRestSensor(unittest.TestCase):
         self.name = 'foo'
         self.unit_of_measurement = 'MB'
         self.value_template = template('{{ value_json.key }}')
+        self.json_template = template('{{ value_json[0] }}')
         self.value_template.hass = self.hass
         self.force_update = False
 
         self.sensor = rest.RestSensor(
             self.hass, self.rest, self.name, self.unit_of_measurement,
-            self.value_template, [], self.force_update
+            self.value_template, [], self.force_update, self.json_template
         )
 
     def tearDown(self):
@@ -194,6 +195,19 @@ class TestRestSensor(unittest.TestCase):
         self.sensor.update()
         self.assertEqual('plain_state', self.sensor.state)
         self.assertTrue(self.sensor.available)
+
+    def test_update_with_json_attrs_and_json_template(self):
+        """Test attributes get extracted from a JSON result."""
+        """After being rendered in the json_template."""
+        self.rest.update = Mock('rest.RestData.update',
+                                side_effect=self.update_side_effect(
+                                    '[{ "key": "some_json_value" }]'))
+        self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
+                                      self.unit_of_measurement, None, ['key'],
+                                      self.force_update, self.json_template)
+        self.sensor.update()
+        self.assertEqual('some_json_value',
+                         self.sensor.device_state_attributes['key'])
 
     def test_update_with_json_attrs(self):
         """Test attributes get extracted from a JSON result."""

--- a/tests/components/sensor/test_rest.py
+++ b/tests/components/sensor/test_rest.py
@@ -131,7 +131,8 @@ class TestRestSensor(unittest.TestCase):
         self.name = 'foo'
         self.unit_of_measurement = 'MB'
         self.value_template = template('{{ value_json.key }}')
-        self.json_template = template('{{ value_json[0] }}')
+        self.json_template = template('{{ value_json[0]|tojson }}')
+        self.json_template.hass = self.hass
         self.value_template.hass = self.hass
         self.force_update = False
 


### PR DESCRIPTION
## Description:
Will add ability in RESTful sensor to preprocess response before resolving attributes. 
In the new `json_template` you will be able to create dictionary with attributes from the REST response, later to be picked by `json_attributes` field.

**Related discussions:** 
https://community.home-assistant.io/t/restful-sensor-parsing-json/12246/9
https://community.home-assistant.io/t/restful-sensor-trying-to-extract-multiple-nested-json-values/41159

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5109

## Example entry for `configuration.yaml` (if applicable):
```yaml
json_attributes:
  - left
  - right
json_template: >
    {% set output = {
      'left':value_json|selectattr('FraksjonId', 'eq', 1)|first,
      'right':value_json|selectattr('FraksjonId', 'eq', 2)|first
    } %}
    {{ output|tojson }}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - ~~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  - ~~New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  - ~~New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
  - ~~New files were added to `.coveragerc`.~~

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54