### PR TITLE
Bugfixes HomeKit covers and lights

### DIFF
--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -63,14 +63,11 @@ class WindowCovering(HomeAccessory):
             return
 
         current_position = new_state.attributes.get(ATTR_CURRENT_POSITION)
-        if current_position is None:
-            return
-
-        self.current_position = int(current_position)
-        self.char_current_position.set_value(self.current_position)
-
-        if self.homekit_target is None or \
-                abs(self.current_position - self.homekit_target) < 6:
-            self.char_target_position.set_value(self.current_position)
-            self.char_position_state.set_value(2)
-            self.homekit_target = None
+        if isinstance(current_position, int):
+            self.current_position = current_position
+            self.char_current_position.set_value(self.current_position)
+            if self.homekit_target is None or \
+                    abs(self.current_position - self.homekit_target) < 6:
+                self.char_target_position.set_value(self.current_position)
+                self.char_position_state.set_value(2)
+                self.homekit_target = None

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -146,7 +146,9 @@ class Light(HomeAccessory):
             hue, saturation = new_state.attributes.get(
                 ATTR_HS_COLOR, (None, None))
             if not self._flag[RGB_COLOR] and (
-                    hue != self._hue or saturation != self._saturation):
+                    hue != self._hue or saturation != self._saturation) and \
+                    isinstance(hue, (int, float)) and \
+                    isinstance(saturation, (int, float)):
                 self.char_hue.set_value(hue, should_callback=False)
                 self.char_saturation.set_value(saturation,
                                                should_callback=False)


### PR DESCRIPTION
## Description:
Added additional input validation to catch some errors.
* covers -> current_position attribute
* lights -> hue and saturation attribute


**Related issue:** fixes #13656
**Related issue:** fixes #13676
**Issue reported by:** `daemontomato` (on discord)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
