### PR TITLE
Implemented platform filtering for HomeKit and other components.

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -165,7 +165,10 @@ class HomeKit():
 
     def add_bridge_accessory(self, state):
         """Try adding accessory to bridge if configured beforehand."""
-        if not state or not self._filter(state.entity_id):
+        entity_platform = None
+        if state.entity_id in self._hass.data['entity_registry'].entities.keys():
+            entity_platform = self._hass.data['entity_registry'].entities[state.entity_id].platform
+        if not state or not self._filter(state.entity_id, entity_platform):
             return
         aid = generate_aid(state.entity_id)
         conf = self._config.pop(state.entity_id, {})

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -1,4 +1,4 @@
-"""Helper class to implement include/exclude of entities and domains."""
+"""Helper class to implement include/exclude of entities, domains, and platforms."""
 
 import voluptuous as vol
 
@@ -9,92 +9,137 @@ CONF_INCLUDE_DOMAINS = 'include_domains'
 CONF_INCLUDE_ENTITIES = 'include_entities'
 CONF_EXCLUDE_DOMAINS = 'exclude_domains'
 CONF_EXCLUDE_ENTITIES = 'exclude_entities'
+CONF_INCLUDE_PLATFORMS = 'include_platforms'
+CONF_EXCLUDE_PLATFORMS = 'exclude_platforms'
 
 FILTER_SCHEMA = vol.All(
     vol.Schema({
         vol.Optional(CONF_EXCLUDE_DOMAINS, default=[]):
             vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_EXCLUDE_ENTITIES, default=[]): cv.entity_ids,
+        vol.Optional(CONF_EXCLUDE_PLATFORMS, default=[]):
+            vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_INCLUDE_DOMAINS, default=[]):
             vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_INCLUDE_ENTITIES, default=[]): cv.entity_ids,
+        vol.Optional(CONF_INCLUDE_PLATFORMS, default=[]):
+            vol.All(cv.ensure_list, [cv.string]),
     }),
     lambda config: generate_filter(
         config[CONF_INCLUDE_DOMAINS],
         config[CONF_INCLUDE_ENTITIES],
+        config[CONF_INCLUDE_PLATFORMS],
         config[CONF_EXCLUDE_DOMAINS],
         config[CONF_EXCLUDE_ENTITIES],
+        config[CONF_EXCLUDE_PLATFORMS],
     ))
 
 
-def generate_filter(include_domains, include_entities,
-                    exclude_domains, exclude_entities):
+def generate_filter(include_domains, include_entities, include_platforms,
+                    exclude_domains, exclude_entities, exclude_platforms):
     """Return a function that will filter entities based on the args."""
     include_d = set(include_domains)
     include_e = set(include_entities)
+    include_p = set(include_platforms)
     exclude_d = set(exclude_domains)
     exclude_e = set(exclude_entities)
+    exclude_p = set(exclude_platforms)
 
-    have_exclude = bool(exclude_e or exclude_d)
-    have_include = bool(include_e or include_d)
+    have_exclude = bool(exclude_e or exclude_d or exclude_p)
+    have_include = bool(include_e or include_d or include_p)
 
     # Case 1 - no includes or excludes - pass all entities
     if not have_include and not have_exclude:
-        return lambda entity_id: True
+        return lambda entity_id, entity_platform=None: True
 
-    # Case 2 - includes, no excludes - only include specified entities
+    # Case 2 - includes, no excludes - only include specified entities/domains/platforms
     if have_include and not have_exclude:
-        def entity_filter_2(entity_id):
+        def entity_filter_2(entity_id, entity_platform=None):
             """Return filter function for case 2."""
             domain = split_entity_id(entity_id)[0]
             return (entity_id in include_e or
-                    domain in include_d)
+                    domain in include_d or
+                    entity_platform in include_p)
 
         return entity_filter_2
 
-    # Case 3 - excludes, no includes - only exclude specified entities
+    # Case 3 - excludes, no includes - only exclude specified entities/domains/platforms
     if not have_include and have_exclude:
-        def entity_filter_3(entity_id):
+        def entity_filter_3(entity_id, entity_platform=None):
             """Return filter function for case 3."""
             domain = split_entity_id(entity_id)[0]
             return (entity_id not in exclude_e and
-                    domain not in exclude_d)
+                    domain not in exclude_d and
+                    entity_platform not in exclude_p)
 
         return entity_filter_3
 
     # Case 4 - both includes and excludes specified
-    # Case 4a - include domain specified
+    # Case 4a - include platform specified
+    #  - if platform is included, and domain and entity not excluded, pass
+    #  - if platform is not included, and entity or domain not included, fail
+    # note: if both include and exclude platform specified,
+    #   the exclude platforms are ignored
+    if include_p:
+        def entity_filter_4a(entity_id, entity_platform=None):
+            """Return filter function for case 4a."""
+            domain = split_entity_id(entity_id)[0]
+            if entity_platform in include_p:
+                return (entity_id not in exclude_e and
+                        domain not in exclude_d)
+            return (entity_id not in include_e or
+                    domain not in include_d)
+
+        return entity_filter_4a
+
+    # Case 4b - exclude platform specified
+    #  - if platform is excluded, and entity not included, fail
+    #  - if platform is not excluded:
+    #        and entity is included,
+    #        or the domain is included but the entity is neither, pass
+    if exclude_p:
+        def entity_filter_4b(entity_id, entity_platform=None):
+            """Return filter function for case 4b."""
+            domain = split_entity_id(entity_id)[0]
+            if entity_platform in exclude_p:
+                return entity_id in include_e
+            return (entity_id in include_e or
+                    (entity_id not in exclude_e and domain in include_d))
+
+        return entity_filter_4b
+
+    # Case 4c - include domain specified
     #  - if domain is included, and entity not excluded, pass
     #  - if domain is not included, and entity not included, fail
     # note: if both include and exclude domains specified,
     #   the exclude domains are ignored
     if include_d:
-        def entity_filter_4a(entity_id):
+        def entity_filter_4c(entity_id, entity_platform=None):
             """Return filter function for case 4a."""
             domain = split_entity_id(entity_id)[0]
             if domain in include_d:
                 return entity_id not in exclude_e
             return entity_id in include_e
 
-        return entity_filter_4a
+        return entity_filter_4c
 
-    # Case 4b - exclude domain specified
+    # Case 4d - exclude domain specified
     #  - if domain is excluded, and entity not included, fail
     #  - if domain is not excluded, and entity not excluded, pass
     if exclude_d:
-        def entity_filter_4b(entity_id):
+        def entity_filter_4d(entity_id, entity_platform=None):
             """Return filter function for case 4b."""
             domain = split_entity_id(entity_id)[0]
             if domain in exclude_d:
                 return entity_id in include_e
             return entity_id not in exclude_e
 
-        return entity_filter_4b
+        return entity_filter_4d
 
-    # Case 4c - neither include or exclude domain specified
+    # Case 4e - neither include or exclude platform or domain specified
     #  - Only pass if entity is included.  Ignore entity excludes.
-    def entity_filter_4c(entity_id):
+    def entity_filter_4e(entity_id, entity_platform=None):
         """Return filter function for case 4c."""
         return entity_id in include_e
 
-    return entity_filter_4c
+    return entity_filter_4e

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -129,7 +129,7 @@ class TestHomeKit(unittest.TestCase):
 
     def test_homekit_entity_filter(self):
         """Test the entity filter."""
-        entity_filter = generate_filter(['cover'], ['demo.test'], [], [])
+        entity_filter = generate_filter(['cover'], ['demo.test'], 'hue', [], [], [])
         homekit = HomeKit(self.hass, None, entity_filter, {})
 
         with patch(PATH_HOMEKIT + '.get_accessory') as mock_get_acc:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5113

## Example entry for `configuration.yaml` (if applicable):
```yaml
# HomeKit
homekit:
    auto_start: false
    filter:
        exclude_platforms:
            - hue
        exclude_domains:
            - sensor
        include_entities:
            - sensor.weather_temperature
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools: **N/A**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54