### PR TITLE
Adding configration to disable ip address as a requirement Fixes: #13399

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
-    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_MODE,
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_MODE, 
     CONF_PROTOCOL)
 
 REQUIREMENTS = ['pexpect==4.0.1']
@@ -25,6 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_PUB_KEY = 'pub_key'
 CONF_SSH_KEY = 'ssh_key'
+CONF_REQUIRE_IP = 'require_ip'
 DEFAULT_SSH_PORT = 22
 SECRET_GROUP = 'Password or SSH Key'
 
@@ -36,6 +37,7 @@ PLATFORM_SCHEMA = vol.All(
         vol.Optional(CONF_PROTOCOL, default='ssh'): vol.In(['ssh', 'telnet']),
         vol.Optional(CONF_MODE, default='router'): vol.In(['router', 'ap']),
         vol.Optional(CONF_PORT, default=DEFAULT_SSH_PORT): cv.port,
+        vol.Optional(CONF_REQUIRE_IP, default=True): cv.boolean,
         vol.Exclusive(CONF_PASSWORD, SECRET_GROUP): cv.string,
         vol.Exclusive(CONF_SSH_KEY, SECRET_GROUP): cv.isfile,
         vol.Exclusive(CONF_PUB_KEY, SECRET_GROUP): cv.isfile
@@ -115,6 +117,7 @@ class AsusWrtDeviceScanner(DeviceScanner):
         self.protocol = config[CONF_PROTOCOL]
         self.mode = config[CONF_MODE]
         self.port = config[CONF_PORT]
+        self.require_ip = config[CONF_REQUIRE_IP]
 
         if self.protocol == 'ssh':
             self.connection = SshConnection(
@@ -172,7 +175,7 @@ class AsusWrtDeviceScanner(DeviceScanner):
 
         ret_devices = {}
         for key in devices:
-            if devices[key].ip is not None:
+            if not self.require_ip or devices[key].ip is not None:
                 ret_devices[key] = devices[key]
         return ret_devices
 

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
-    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_MODE, 
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_MODE,
     CONF_PROTOCOL)
 
 REQUIREMENTS = ['pexpect==4.0.1']


### PR DESCRIPTION
## Description:

A change to the asuswrt device tracker requires a device to have an ip address. In AP mode its possible for all of the detection methods to not provide an ip address. The new config option allows for the old (and working) functionality to be restored by no requiring an ip address. This is more specific to devices in ap mode. Default value True.

**Related issue (if applicable):** fixes #13399

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5117

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: asuswrt
    host: YOUR_ROUTER_IP
    username: YOUR_ADMIN_USERNAME
    require_ip: False
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
