### PR TITLE
Fix asuswrt ap mode failure

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -174,9 +174,8 @@ class AsusWrtDeviceScanner(DeviceScanner):
         for key in devices:
             if self.mode == 'ap':
                 ret_devices[key] = devices[key]
-            else:
-                if devices[key].ip is not None:
-                    ret_devices[key] = devices[key]
+            elif devices[key].ip is not None:
+                ret_devices[key] = devices[key]
         return ret_devices
 
     def _get_wl(self):

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -172,8 +172,11 @@ class AsusWrtDeviceScanner(DeviceScanner):
 
         ret_devices = {}
         for key in devices:
-            if devices[key].ip is not None:
+            if self.mode == 'ap':
                 ret_devices[key] = devices[key]
+            else:
+                if devices[key].ip is not None:
+                    ret_devices[key] = devices[key]
         return ret_devices
 
     def _get_wl(self):

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -172,7 +172,7 @@ class AsusWrtDeviceScanner(DeviceScanner):
 
         ret_devices = {}
         for key in devices:
-            if self.mode == 'ap' or devices[key].ip is not None::
+            if self.mode == 'ap' or devices[key].ip is not None:
                 ret_devices[key] = devices[key]
         return ret_devices
 

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -172,9 +172,7 @@ class AsusWrtDeviceScanner(DeviceScanner):
 
         ret_devices = {}
         for key in devices:
-            if self.mode == 'ap':
-                ret_devices[key] = devices[key]
-            elif devices[key].ip is not None:
+            if self.mode == 'ap' or devices[key].ip is not None::
                 ret_devices[key] = devices[key]
         return ret_devices
 


### PR DESCRIPTION
When using ap mode, asuswrt device_tracker does not work properly as ip can not be retrieved from wl command. This version fixed the issue.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
