### PR TITLE
Enable autodiscovery for mqtt cameras

### DIFF
--- a/homeassistant/components/camera/mqtt.py
+++ b/homeassistant/components/camera/mqtt.py
@@ -12,20 +12,20 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 import homeassistant.components.mqtt as mqtt
+from homeassistant.components.mqtt import CONF_STATE_TOPIC
 from homeassistant.const import CONF_NAME
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_TOPIC = 'topic'
 
 DEFAULT_NAME = 'MQTT Camera'
 
 DEPENDENCIES = ['mqtt']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Required(CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
 })
 
@@ -33,9 +33,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the MQTT Camera."""
-    topic = config[CONF_TOPIC]
+    if discovery_info is not None:
+        config = PLATFORM_SCHEMA(discovery_info)
 
-    async_add_devices([MqttCamera(config[CONF_NAME], topic)])
+    async_add_devices([MqttCamera(
+        config.get(CONF_NAME),
+        config.get(CONF_STATE_TOPIC)
+    )])
 
 
 class MqttCamera(Camera):

--- a/homeassistant/components/camera/mqtt.py
+++ b/homeassistant/components/camera/mqtt.py
@@ -12,20 +12,19 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 import homeassistant.components.mqtt as mqtt
-from homeassistant.components.mqtt import CONF_STATE_TOPIC
 from homeassistant.const import CONF_NAME
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-
+CONF_TOPIC = 'topic'
 DEFAULT_NAME = 'MQTT Camera'
 
 DEPENDENCIES = ['mqtt']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Required(CONF_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
 })
 
@@ -38,7 +37,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     async_add_devices([MqttCamera(
         config.get(CONF_NAME),
-        config.get(CONF_STATE_TOPIC)
+        config.get(CONF_TOPIC)
     )])
 
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -20,10 +20,11 @@ TOPIC_MATCHER = re.compile(
     r'(?:(?P<node_id>[a-zA-Z0-9_-]+)/)?(?P<object_id>[a-zA-Z0-9_-]+)/config')
 
 SUPPORTED_COMPONENTS = [
-    'binary_sensor', 'cover', 'fan', 'light', 'sensor', 'switch', 'lock']
+    'binary_sensor', 'camera', 'cover', 'fan', 'light', 'sensor', 'switch', 'lock']
 
 ALLOWED_PLATFORMS = {
     'binary_sensor': ['mqtt'],
+    'camera': ['mqtt'],
     'cover': ['mqtt'],
     'fan': ['mqtt'],
     'light': ['mqtt', 'mqtt_json', 'mqtt_template'],

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -20,7 +20,8 @@ TOPIC_MATCHER = re.compile(
     r'(?:(?P<node_id>[a-zA-Z0-9_-]+)/)?(?P<object_id>[a-zA-Z0-9_-]+)/config')
 
 SUPPORTED_COMPONENTS = [
-    'binary_sensor', 'camera', 'cover', 'fan', 'light', 'sensor', 'switch', 'lock']
+    'binary_sensor', 'camera', 'cover', 'fan',
+    'light', 'sensor', 'switch', 'lock']
 
 ALLOWED_PLATFORMS = {
     'binary_sensor': ['mqtt'],

--- a/tests/components/camera/test_mqtt.py
+++ b/tests/components/camera/test_mqtt.py
@@ -15,7 +15,7 @@ def test_run_camera_setup(hass, aiohttp_client):
     yield from async_setup_component(hass, 'camera', {
         'camera': {
             'platform': 'mqtt',
-            'state_topic': topic,
+            'topic': topic,
             'name': 'Test Camera',
         }})
 

--- a/tests/components/camera/test_mqtt.py
+++ b/tests/components/camera/test_mqtt.py
@@ -15,7 +15,7 @@ def test_run_camera_setup(hass, aiohttp_client):
     yield from async_setup_component(hass, 'camera', {
         'camera': {
             'platform': 'mqtt',
-            'topic': topic,
+            'state_topic': topic,
             'name': 'Test Camera',
         }})
 


### PR DESCRIPTION
This pr enables autodiscovery for mqtt cameras.

## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5120

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
camera:
  - platform: mqtt
    topic: zanzito/shared_locations/my-device
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54