### PR TITLE
Coveralls & Codeowners

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -159,7 +159,7 @@ omit =
 
     homeassistant/components/maxcube.py
     homeassistant/components/*/maxcube.py
-    
+
     homeassistant/components/mochad.py
     homeassistant/components/*/mochad.py
 
@@ -286,11 +286,9 @@ omit =
     homeassistant/components/*/wink.py
 
     homeassistant/components/xiaomi_aqara.py
-    homeassistant/components/binary_sensor/xiaomi_aqara.py
-    homeassistant/components/cover/xiaomi_aqara.py
-    homeassistant/components/light/xiaomi_aqara.py
-    homeassistant/components/sensor/xiaomi_aqara.py
-    homeassistant/components/switch/xiaomi_aqara.py
+    homeassistant/components/*/xiaomi_aqara.py
+
+    homeassistant/components/*/xiaomi_miio.py
 
     homeassistant/components/zabbix.py
     homeassistant/components/*/zabbix.py
@@ -398,7 +396,6 @@ omit =
     homeassistant/components/emoncms_history.py
     homeassistant/components/emulated_hue/upnp.py
     homeassistant/components/fan/mqtt.py
-    homeassistant/components/fan/xiaomi_miio.py
     homeassistant/components/feedreader.py
     homeassistant/components/folder_watcher.py
     homeassistant/components/foursquare.py
@@ -431,7 +428,6 @@ omit =
     homeassistant/components/light/tplink.py
     homeassistant/components/light/tradfri.py
     homeassistant/components/light/x10.py
-    homeassistant/components/light/xiaomi_miio.py
     homeassistant/components/light/yeelight.py
     homeassistant/components/light/yeelightsunflower.py
     homeassistant/components/light/zengge.py
@@ -440,6 +436,7 @@ omit =
     homeassistant/components/lock/nello.py
     homeassistant/components/lock/nuki.py
     homeassistant/components/lock/sesame.py
+    homeassistant/components/map.py
     homeassistant/components/media_extractor.py
     homeassistant/components/media_player/anthemav.py
     homeassistant/components/media_player/aquostv.py
@@ -538,7 +535,6 @@ omit =
     homeassistant/components/remember_the_milk/__init__.py
     homeassistant/components/remote/harmony.py
     homeassistant/components/remote/itach.py
-    homeassistant/components/remote/xiaomi_miio.py
     homeassistant/components/scene/hunterdouglas_powerview.py
     homeassistant/components/scene/lifx_cloud.py
     homeassistant/components/sensor/airvisual.py
@@ -674,6 +670,7 @@ omit =
     homeassistant/components/sensor/vasttrafik.py
     homeassistant/components/sensor/viaggiatreno.py
     homeassistant/components/sensor/waqi.py
+    homeassistant/components/sensor/waze_travel_time.py
     homeassistant/components/sensor/whois.py
     homeassistant/components/sensor/worldtidesinfo.py
     homeassistant/components/sensor/worxlandroid.py
@@ -707,7 +704,6 @@ omit =
     homeassistant/components/switch/tplink.py
     homeassistant/components/switch/transmission.py
     homeassistant/components/switch/vesync.py
-    homeassistant/components/switch/xiaomi_miio.py
     homeassistant/components/telegram_bot/*
     homeassistant/components/thingspeak.py
     homeassistant/components/tts/amazon_polly.py
@@ -716,7 +712,6 @@ omit =
     homeassistant/components/tts/picotts.py
     homeassistant/components/vacuum/mqtt.py
     homeassistant/components/vacuum/roomba.py
-    homeassistant/components/vacuum/xiaomi_miio.py
     homeassistant/components/weather/bom.py
     homeassistant/components/weather/buienradar.py
     homeassistant/components/weather/darksky.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,8 +68,9 @@ homeassistant/components/sensor/irish_rail_transport.py @ttroy50
 homeassistant/components/sensor/miflora.py @danielhiversen @ChristianKuehnel
 homeassistant/components/sensor/pollen.py @bachya
 homeassistant/components/sensor/qnap.py @colinodell
-homeassistant/components/sensor/sytadin.py @gautric
+homeassistant/components/sensor/sma.py @kellerza
 homeassistant/components/sensor/sql.py @dgomes
+homeassistant/components/sensor/sytadin.py @gautric
 homeassistant/components/sensor/tibber.py @danielhiversen
 homeassistant/components/sensor/waqi.py @andrey-git
 homeassistant/components/switch/rainmachine.py @bachya
@@ -79,17 +80,17 @@ homeassistant/components/xiaomi_aqara.py @danielhiversen @syssi
 homeassistant/components/*/axis.py @kane610
 homeassistant/components/*/bmw_connected_drive.py @ChristianKuehnel
 homeassistant/components/*/broadlink.py @danielhiversen
+homeassistant/components/*/deconz.py @kane610
 homeassistant/components/eight_sleep.py @mezz64
 homeassistant/components/*/eight_sleep.py @mezz64
 homeassistant/components/hive.py @Rendili @KJonline
 homeassistant/components/*/hive.py @Rendili @KJonline
 homeassistant/components/homekit/* @cdce8p
-homeassistant/components/*/deconz.py @kane610
-homeassistant/components/*/rfxtrx.py @danielhiversen
-homeassistant/components/velux.py @Julius2342
-homeassistant/components/*/velux.py @Julius2342
 homeassistant/components/knx.py @Julius2342
 homeassistant/components/*/knx.py @Julius2342
+homeassistant/components/qwikswitch.py @kellerza
+homeassistant/components/*/qwikswitch.py @kellerza
+homeassistant/components/*/rfxtrx.py @danielhiversen
 homeassistant/components/tahoma.py @philklei
 homeassistant/components/*/tahoma.py @philklei
 homeassistant/components/tesla.py @zabuldon
@@ -97,5 +98,9 @@ homeassistant/components/*/tesla.py @zabuldon
 homeassistant/components/tellduslive.py @molobrakos @fredrike
 homeassistant/components/*/tellduslive.py @molobrakos @fredrike
 homeassistant/components/*/tradfri.py @ggravlingen
+homeassistant/components/velux.py @Julius2342
+homeassistant/components/*/velux.py @Julius2342
 homeassistant/components/*/xiaomi_aqara.py @danielhiversen @syssi
 homeassistant/components/*/xiaomi_miio.py @rytilahti @syssi
+
+homeassistant/scripts/check_config.py @kellerza


### PR DESCRIPTION
## Description:
* Fix gaps in coveralls exclusions (xiaomi_miio, sensor.wave_travel_time & map) refer [here](https://coveralls.io/builds/16336528)
* Nominated myself for qwikswitch, sensor.sma and check_config
* Minor cleanups/sort in the two files

Could exclude homeassistant/monkey_patch.py as well, since it is 10% covered in the latest Python 