### PR TITLE
Style change follow up

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -116,7 +116,7 @@ def get_accessory(hass, state, aid, config):
         return None
 
     _LOGGER.debug('Add "%s" as "%s"', state.entity_id, a_type)
-    return TYPES[a_type](hass, state.name, state.entity_id, config, aid)
+    return TYPES[a_type](hass, state.name, state.entity_id, aid, config=config)
 
 
 def generate_aid(entity_id):

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -77,6 +77,9 @@ def get_accessory(hass, state, aid, config):
                         state.entity_id)
         return None
 
+    a_type = None
+    config = config or {}
+
     if state.domain == 'alarm_control_panel':
         a_type = 'SecuritySystem'
 
@@ -109,11 +112,11 @@ def get_accessory(hass, state, aid, config):
             or state.domain == 'input_boolean' or state.domain == 'script':
         a_type = 'Switch'
 
-    else:
+    if a_type is None:
         return None
 
     _LOGGER.debug('Add "%s" as "%s"', state.entity_id, a_type)
-    return TYPES[a_type](hass, state.name, state.entity_id, config, aid=aid)
+    return TYPES[a_type](hass, state.name, state.entity_id, config, aid)
 
 
 def generate_aid(entity_id):

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.components.climate import (
     SUPPORT_TARGET_TEMPERATURE_HIGH, SUPPORT_TARGET_TEMPERATURE_LOW)
 from homeassistant.components.cover import SUPPORT_SET_POSITION
 from homeassistant.const import (
-    ATTR_CODE, ATTR_SUPPORTED_FEATURES, ATTR_UNIT_OF_MEASUREMENT,
+    ATTR_SUPPORTED_FEATURES, ATTR_UNIT_OF_MEASUREMENT,
     CONF_PORT, TEMP_CELSIUS, TEMP_FAHRENHEIT,
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
@@ -79,12 +79,8 @@ def get_accessory(hass, state, aid, config):
                         state.entity_id)
         return None
 
-    a_type = None
-    a_kwargs = {'aid': aid}
-
     if state.domain == 'alarm_control_panel':
         a_type = 'SecuritySystem'
-        a_kwargs['alarm_code'] = config.get(ATTR_CODE)
 
     elif state.domain == 'binary_sensor' or state.domain == 'device_tracker':
         a_type = 'BinarySensor'
@@ -95,7 +91,7 @@ def get_accessory(hass, state, aid, config):
             SUPPORT_TARGET_TEMPERATURE_HIGH
         # Check if climate device supports auto mode
         a_type = 'Thermostat'
-        a_kwargs['support_auto'] = bool(features & support_temp_range)
+        config['support_auto'] = bool(features & support_temp_range)
 
     elif state.domain == 'cover':
         # Only add covers that support set_cover_position
@@ -120,11 +116,11 @@ def get_accessory(hass, state, aid, config):
             or state.domain == 'input_boolean' or state.domain == 'script':
         a_type = 'Switch'
 
-    if a_type is None:
+    else:
         return None
 
     _LOGGER.debug('Add "%s" as "%s"', state.entity_id, a_type)
-    return TYPES[a_type](hass, state.name, state.entity_id, **a_kwargs)
+    return TYPES[a_type](hass, state.name, state.entity_id, config, aid=aid)
 
 
 def generate_aid(entity_id):

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -77,7 +77,7 @@ def get_accessory(hass, state, aid, config):
         _LOGGER.warning('The entitiy "%s" is not supported, since it '
                         'generates an invalid aid, please change it.',
                         state.entity_id)
-        return
+        return None
 
     a_type = None
     a_kwargs = {'aid': aid}
@@ -121,7 +121,7 @@ def get_accessory(hass, state, aid, config):
         a_type = 'Switch'
 
     if a_type is None:
-        return
+        return None
 
     _LOGGER.debug('Add "%s" as "%s"', state.entity_id, a_type)
     return TYPES[a_type](hass, state.name, state.entity_id, **a_kwargs)
@@ -131,7 +131,7 @@ def generate_aid(entity_id):
     """Generate accessory aid with zlib adler32."""
     aid = adler32(entity_id.encode('utf-8'))
     if aid == 0 or aid == 1:
-        return
+        return None
     return aid
 
 

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -8,8 +8,6 @@ from zlib import adler32
 
 import voluptuous as vol
 
-from homeassistant.components.climate import (
-    SUPPORT_TARGET_TEMPERATURE_HIGH, SUPPORT_TARGET_TEMPERATURE_LOW)
 from homeassistant.components.cover import SUPPORT_SET_POSITION
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_UNIT_OF_MEASUREMENT,
@@ -86,12 +84,7 @@ def get_accessory(hass, state, aid, config):
         a_type = 'BinarySensor'
 
     elif state.domain == 'climate':
-        features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-        support_temp_range = SUPPORT_TARGET_TEMPERATURE_LOW | \
-            SUPPORT_TARGET_TEMPERATURE_HIGH
-        # Check if climate device supports auto mode
         a_type = 'Thermostat'
-        config['support_auto'] = bool(features & support_temp_range)
 
     elif state.domain == 'cover':
         # Only add covers that support set_cover_position

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -85,23 +85,13 @@ def set_accessory_info(acc, name, model, manufacturer=MANUFACTURER,
 class HomeAccessory(Accessory):
     """Adapter class for Accessory."""
 
-    category = 'OTHER'
-
-    def __init__(self, hass, name, entity_id, config, aid):
+    def __init__(self, hass, name, entity_id, aid, category):
         """Initialize a Accessory object."""
         super().__init__(name, aid=aid)
         set_accessory_info(self, name, model=entity_id)
-        self.category = getattr(Category, self.category, Category.OTHER)
+        self.category = getattr(Category, category, Category.OTHER)
         self.entity_id = entity_id
         self.hass = hass
-        self.init_setup(config)
-
-    def init_setup(self, config):
-        """Method called from __init__ at instance creation.
-
-        Overridden by accessory types.
-        """
-        pass
 
     def _set_services(self):
         add_preload_service(self, SERV_ACCESSORY_INFO)

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -7,7 +7,7 @@ import logging
 from pyhap.accessory import Accessory, Bridge, Category
 from pyhap.accessory_driver import AccessoryDriver
 
-from homeassistant.core import callback
+from homeassistant.core import callback as ha_callback
 from homeassistant.helpers.event import (
     async_track_state_change, track_point_in_utc_time)
 from homeassistant.util import dt as dt_util
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def debounce(func):
     """Decorator function. Debounce callbacks form HomeKit."""
-    @callback
+    @ha_callback
     def call_later_listener(*args):
         """Callback listener called from call_later."""
         # pylint: disable=unsubscriptable-object
@@ -70,6 +70,18 @@ def add_preload_service(acc, service, chars=None):
             service.add_characteristic(char)
     acc.add_service(service)
     return service
+
+
+def setup_char(char_name, service, value=None, properties=None, callback=None):
+    """Helper function to return fully configured characteristic."""
+    char = service.get_characteristic(char_name)
+    if value:
+        char.value = value
+    if properties:
+        char.override_properties(properties)
+    if callback:
+        char.setter_callback = callback
+    return char
 
 
 def set_accessory_info(acc, name, model, manufacturer=MANUFACTURER,

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -87,9 +87,9 @@ class HomeAccessory(Accessory):
 
     category = 'OTHER'
 
-    def __init__(self, hass, name, entity_id, config, **kwargs):
+    def __init__(self, hass, name, entity_id, config, aid):
         """Initialize a Accessory object."""
-        super().__init__(name, **kwargs)
+        super().__init__(name, aid=aid)
         set_accessory_info(self, name, model=entity_id)
         self.category = getattr(Category, self.category, Category.OTHER)
         self.entity_id = entity_id
@@ -132,9 +132,9 @@ class HomeAccessory(Accessory):
 class HomeBridge(Bridge):
     """Adapter class for Bridge."""
 
-    def __init__(self, hass, name=BRIDGE_NAME, **kwargs):
+    def __init__(self, hass, name=BRIDGE_NAME):
         """Initialize a Bridge object."""
-        super().__init__(name, **kwargs)
+        super().__init__(name)
         set_accessory_info(self, name, model=BRIDGE_MODEL)
         self.hass = hass
 

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -106,6 +106,7 @@ class HomeAccessory(Accessory):
     def update_state_callback(self, entity_id=None, old_state=None,
                               new_state=None):
         """Callback from state change listener."""
+        _LOGGER.debug('New_state: %s', new_state)
         if new_state is None:
             return
         self.update_state(new_state)

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -85,13 +85,23 @@ def set_accessory_info(acc, name, model, manufacturer=MANUFACTURER,
 class HomeAccessory(Accessory):
     """Adapter class for Accessory."""
 
-    def __init__(self, hass, name, entity_id, category='OTHER', **kwargs):
+    category = 'OTHER'
+
+    def __init__(self, hass, name, entity_id, config, **kwargs):
         """Initialize a Accessory object."""
         super().__init__(name, **kwargs)
         set_accessory_info(self, name, model=entity_id)
-        self.category = getattr(Category, category, Category.OTHER)
+        self.category = getattr(Category, self.category, Category.OTHER)
         self.entity_id = entity_id
         self.hass = hass
+        self.init_setup(config)
+
+    def init_setup(self, config):
+        """Method called from __init__ at instance creation.
+
+        Overridden by accessory types.
+        """
+        pass
 
     def _set_services(self):
         add_preload_service(self, SERV_ACCESSORY_INFO)

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -18,8 +18,6 @@ DEFAULT_PORT = 51827
 SERVICE_HOMEKIT_START = 'start'
 
 # #### STRING CONSTANTS ####
-ACCESSORY_MODEL = 'homekit.accessory'
-ACCESSORY_NAME = 'Home Accessory'
 BRIDGE_MODEL = 'homekit.bridge'
 BRIDGE_NAME = 'Home Assistant'
 MANUFACTURER = 'HomeAssistant'

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -9,7 +9,6 @@ from .const import (
     CATEGORY_WINDOW_COVERING, SERV_WINDOW_COVERING,
     CHAR_CURRENT_POSITION, CHAR_TARGET_POSITION, CHAR_POSITION_STATE)
 
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -20,13 +19,10 @@ class WindowCovering(HomeAccessory):
     The cover entity must support: set_cover_position.
     """
 
-    def __init__(self, hass, entity_id, display_name, **kwargs):
+    def __init__(self, hass, name, entity_id, **kwargs):
         """Initialize a WindowCovering accessory object."""
-        super().__init__(display_name, entity_id,
-                         CATEGORY_WINDOW_COVERING, **kwargs)
-
-        self.hass = hass
-        self.entity_id = entity_id
+        super().__init__(hass, name, entity_id,
+                         category=CATEGORY_WINDOW_COVERING, **kwargs)
 
         self.current_position = None
         self.homekit_target = None
@@ -56,11 +52,8 @@ class WindowCovering(HomeAccessory):
             self.hass.components.cover.set_cover_position(
                 value, self.entity_id)
 
-    def update_state(self, entity_id=None, old_state=None, new_state=None):
+    def update_state(self, new_state):
         """Update cover position after state changed."""
-        if new_state is None:
-            return
-
         current_position = new_state.attributes.get(ATTR_CURRENT_POSITION)
         if isinstance(current_position, int):
             self.current_position = current_position

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant.components.cover import ATTR_CURRENT_POSITION
 
 from . import TYPES
-from .accessories import HomeAccessory, add_preload_service
+from .accessories import HomeAccessory, add_preload_service, setup_char
 from .const import (
     CATEGORY_WINDOW_COVERING, SERV_WINDOW_COVERING,
     CHAR_CURRENT_POSITION, CHAR_TARGET_POSITION, CHAR_POSITION_STATE)
@@ -26,17 +26,13 @@ class WindowCovering(HomeAccessory):
         self.homekit_target = None
 
         serv_cover = add_preload_service(self, SERV_WINDOW_COVERING)
-        self.char_current_position = serv_cover. \
-            get_characteristic(CHAR_CURRENT_POSITION)
-        self.char_target_position = serv_cover. \
-            get_characteristic(CHAR_TARGET_POSITION)
-        self.char_position_state = serv_cover. \
-            get_characteristic(CHAR_POSITION_STATE)
-        self.char_current_position.value = 0
-        self.char_target_position.value = 0
-        self.char_position_state.value = 0
-
-        self.char_target_position.setter_callback = self.move_cover
+        self.char_current_position = setup_char(
+            CHAR_CURRENT_POSITION, serv_cover, value=0)
+        self.char_target_position = setup_char(
+            CHAR_TARGET_POSITION, serv_cover, value=0,
+            callback=self.move_cover)
+        self.char_position_state = setup_char(
+            CHAR_POSITION_STATE, serv_cover, value=0)
 
     def move_cover(self, value):
         """Move cover to value if call came from HomeKit."""

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -1,5 +1,4 @@
 """Class to hold all cover accessories."""
-# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.components.cover import ATTR_CURRENT_POSITION
@@ -20,10 +19,9 @@ class WindowCovering(HomeAccessory):
     The cover entity must support: set_cover_position.
     """
 
-    category = CATEGORY_WINDOW_COVERING
-
-    def init_setup(self, config):
+    def __init__(self, *args, config):
         """Initialize a WindowCovering accessory object."""
+        super().__init__(*args, category=CATEGORY_WINDOW_COVERING)
         self.current_position = None
         self.homekit_target = None
 

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -19,7 +19,7 @@ class WindowCovering(HomeAccessory):
     The cover entity must support: set_cover_position.
     """
 
-    def __init__(self, hass, name, entity_id, **kwargs):
+    def __init__(self, hass, name, entity_id, config, **kwargs):
         """Initialize a WindowCovering accessory object."""
         super().__init__(hass, name, entity_id,
                          category=CATEGORY_WINDOW_COVERING, **kwargs)

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -1,4 +1,5 @@
 """Class to hold all cover accessories."""
+# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.components.cover import ATTR_CURRENT_POSITION
@@ -19,11 +20,10 @@ class WindowCovering(HomeAccessory):
     The cover entity must support: set_cover_position.
     """
 
-    def __init__(self, hass, name, entity_id, config, **kwargs):
-        """Initialize a WindowCovering accessory object."""
-        super().__init__(hass, name, entity_id,
-                         category=CATEGORY_WINDOW_COVERING, **kwargs)
+    category = CATEGORY_WINDOW_COVERING
 
+    def init_setup(self, config):
+        """Initialize a WindowCovering accessory object."""
         self.current_position = None
         self.homekit_target = None
 

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -1,4 +1,5 @@
 """Class to hold all light accessories."""
+# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.components.light import (
@@ -24,11 +25,10 @@ class Light(HomeAccessory):
     Currently supports: state, brightness, color temperature, rgb_color.
     """
 
-    def __init__(self, hass, name, entity_id, config, **kwargs):
-        """Initialize a new Light accessory object."""
-        super().__init__(hass, name, entity_id,
-                         category=CATEGORY_LIGHT, **kwargs)
+    category = CATEGORY_LIGHT
 
+    def init_setup(self, config):
+        """Initialize a new Light accessory object."""
         self._flag = {CHAR_ON: False, CHAR_BRIGHTNESS: False,
                       CHAR_HUE: False, CHAR_SATURATION: False,
                       CHAR_COLOR_TEMPERATURE: False, RGB_COLOR: False}

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -24,12 +24,11 @@ class Light(HomeAccessory):
     Currently supports: state, brightness, color temperature, rgb_color.
     """
 
-    def __init__(self, hass, entity_id, name, **kwargs):
+    def __init__(self, hass, name, entity_id, **kwargs):
         """Initialize a new Light accessory object."""
-        super().__init__(name, entity_id, CATEGORY_LIGHT, **kwargs)
+        super().__init__(hass, name, entity_id,
+                         category=CATEGORY_LIGHT, **kwargs)
 
-        self.hass = hass
-        self.entity_id = entity_id
         self._flag = {CHAR_ON: False, CHAR_BRIGHTNESS: False,
                       CHAR_HUE: False, CHAR_SATURATION: False,
                       CHAR_COLOR_TEMPERATURE: False, RGB_COLOR: False}
@@ -136,11 +135,8 @@ class Light(HomeAccessory):
             self.hass.components.light.turn_on(
                 self.entity_id, hs_color=color)
 
-    def update_state(self, entity_id=None, old_state=None, new_state=None):
+    def update_state(self, new_state):
         """Update light after state change."""
-        if not new_state:
-            return
-
         # Handle State
         state = new_state.state
         if state in (STATE_ON, STATE_OFF):

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -24,7 +24,7 @@ class Light(HomeAccessory):
     Currently supports: state, brightness, color temperature, rgb_color.
     """
 
-    def __init__(self, hass, name, entity_id, **kwargs):
+    def __init__(self, hass, name, entity_id, config, **kwargs):
         """Initialize a new Light accessory object."""
         super().__init__(hass, name, entity_id,
                          category=CATEGORY_LIGHT, **kwargs)

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -1,5 +1,4 @@
 """Class to hold all light accessories."""
-# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.components.light import (
@@ -25,10 +24,9 @@ class Light(HomeAccessory):
     Currently supports: state, brightness, color temperature, rgb_color.
     """
 
-    category = CATEGORY_LIGHT
-
-    def init_setup(self, config):
+    def __init__(self, *args, config):
         """Initialize a new Light accessory object."""
+        super().__init__(*args, category=CATEGORY_LIGHT)
         self._flag = {CHAR_ON: False, CHAR_BRIGHTNESS: False,
                       CHAR_HUE: False, CHAR_SATURATION: False,
                       CHAR_COLOR_TEMPERATURE: False, RGB_COLOR: False}

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -156,7 +156,8 @@ class Light(HomeAccessory):
         if CHAR_COLOR_TEMPERATURE in self.chars:
             color_temperature = new_state.attributes.get(ATTR_COLOR_TEMP)
             if not self._flag[CHAR_COLOR_TEMPERATURE] \
-                    and isinstance(color_temperature, int):
+                and isinstance(color_temperature, int) and \
+                    self.char_color_temperature.value != color_temperature:
                 self.char_color_temperature.set_value(color_temperature)
             self._flag[CHAR_COLOR_TEMPERATURE] = False
 

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -7,7 +7,8 @@ from homeassistant.components.light import (
 from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_ON, STATE_OFF
 
 from . import TYPES
-from .accessories import HomeAccessory, add_preload_service, debounce
+from .accessories import (
+    HomeAccessory, add_preload_service, debounce, setup_char)
 from .const import (
     CATEGORY_LIGHT, SERV_LIGHTBULB, CHAR_COLOR_TEMPERATURE,
     CHAR_BRIGHTNESS, CHAR_HUE, CHAR_ON, CHAR_SATURATION)
@@ -46,36 +47,29 @@ class Light(HomeAccessory):
             self._saturation = None
 
         serv_light = add_preload_service(self, SERV_LIGHTBULB, self.chars)
-        self.char_on = serv_light.get_characteristic(CHAR_ON)
-        self.char_on.setter_callback = self.set_state
-        self.char_on.value = self._state
+        self.char_on = setup_char(
+            CHAR_ON, serv_light, value=self._state, callback=self.set_state)
 
         if CHAR_BRIGHTNESS in self.chars:
-            self.char_brightness = serv_light \
-                .get_characteristic(CHAR_BRIGHTNESS)
-            self.char_brightness.setter_callback = self.set_brightness
-            self.char_brightness.value = 0
+            self.char_brightness = setup_char(
+                CHAR_BRIGHTNESS, serv_light, value=0,
+                callback=self.set_brightness)
         if CHAR_COLOR_TEMPERATURE in self.chars:
-            self.char_color_temperature = serv_light \
-                .get_characteristic(CHAR_COLOR_TEMPERATURE)
-            self.char_color_temperature.setter_callback = \
-                self.set_color_temperature
             min_mireds = self.hass.states.get(self.entity_id) \
                 .attributes.get(ATTR_MIN_MIREDS, 153)
             max_mireds = self.hass.states.get(self.entity_id) \
                 .attributes.get(ATTR_MAX_MIREDS, 500)
-            self.char_color_temperature.override_properties({
-                'minValue': min_mireds, 'maxValue': max_mireds})
-            self.char_color_temperature.value = min_mireds
+            self.char_color_temperature = setup_char(
+                CHAR_COLOR_TEMPERATURE, serv_light, value=min_mireds,
+                properties={'minValue': min_mireds, 'maxValue': max_mireds},
+                callback=self.set_color_temperature)
         if CHAR_HUE in self.chars:
-            self.char_hue = serv_light.get_characteristic(CHAR_HUE)
-            self.char_hue.setter_callback = self.set_hue
-            self.char_hue.value = 0
+            self.char_hue = setup_char(
+                CHAR_HUE, serv_light, value=0, callback=self.set_hue)
         if CHAR_SATURATION in self.chars:
-            self.char_saturation = serv_light \
-                .get_characteristic(CHAR_SATURATION)
-            self.char_saturation.setter_callback = self.set_saturation
-            self.char_saturation.value = 75
+            self.char_saturation = setup_char(
+                CHAR_SATURATION, serv_light, value=75,
+                callback=self.set_saturation)
 
     def set_state(self, value):
         """Set state if call came from HomeKit."""

--- a/homeassistant/components/homekit/type_locks.py
+++ b/homeassistant/components/homekit/type_locks.py
@@ -5,7 +5,7 @@ from homeassistant.components.lock import (
     ATTR_ENTITY_ID, STATE_LOCKED, STATE_UNLOCKED, STATE_UNKNOWN)
 
 from . import TYPES
-from .accessories import HomeAccessory, add_preload_service
+from .accessories import HomeAccessory, add_preload_service, setup_char
 from .const import (
     CATEGORY_LOCK, SERV_LOCK, CHAR_LOCK_CURRENT_STATE, CHAR_LOCK_TARGET_STATE)
 
@@ -33,15 +33,12 @@ class Lock(HomeAccessory):
         self.flag_target_state = False
 
         serv_lock_mechanism = add_preload_service(self, SERV_LOCK)
-        self.char_current_state = serv_lock_mechanism. \
-            get_characteristic(CHAR_LOCK_CURRENT_STATE)
-        self.char_target_state = serv_lock_mechanism. \
-            get_characteristic(CHAR_LOCK_TARGET_STATE)
-
-        self.char_current_state.value = HASS_TO_HOMEKIT[STATE_UNKNOWN]
-        self.char_target_state.value = HASS_TO_HOMEKIT[STATE_LOCKED]
-
-        self.char_target_state.setter_callback = self.set_state
+        self.char_current_state = setup_char(
+            CHAR_LOCK_CURRENT_STATE, serv_lock_mechanism,
+            value=HASS_TO_HOMEKIT[STATE_UNKNOWN])
+        self.char_target_state = setup_char(
+            CHAR_LOCK_TARGET_STATE, serv_lock_mechanism,
+            value=HASS_TO_HOMEKIT[STATE_LOCKED], callback=self.set_state)
 
     def set_state(self, value):
         """Set lock state to value if call came from HomeKit."""

--- a/homeassistant/components/homekit/type_locks.py
+++ b/homeassistant/components/homekit/type_locks.py
@@ -1,5 +1,4 @@
 """Class to hold all lock accessories."""
-# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.components.lock import (
@@ -28,10 +27,9 @@ class Lock(HomeAccessory):
     The lock entity must support: unlock and lock.
     """
 
-    category = CATEGORY_LOCK
-
-    def init_setup(self, config):
+    def __init__(self, *args, config):
         """Initialize a Lock accessory object."""
+        super().__init__(*args, category=CATEGORY_LOCK)
         self.flag_target_state = False
 
         serv_lock_mechanism = add_preload_service(self, SERV_LOCK)

--- a/homeassistant/components/homekit/type_locks.py
+++ b/homeassistant/components/homekit/type_locks.py
@@ -27,7 +27,7 @@ class Lock(HomeAccessory):
     The lock entity must support: unlock and lock.
     """
 
-    def __init__(self, hass, name, entity_id, **kwargs):
+    def __init__(self, hass, name, entity_id, config, **kwargs):
         """Initialize a Lock accessory object."""
         super().__init__(hass, name, entity_id,
                          category=CATEGORY_LOCK, **kwargs)

--- a/homeassistant/components/homekit/type_locks.py
+++ b/homeassistant/components/homekit/type_locks.py
@@ -1,4 +1,5 @@
 """Class to hold all lock accessories."""
+# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.components.lock import (
@@ -27,11 +28,10 @@ class Lock(HomeAccessory):
     The lock entity must support: unlock and lock.
     """
 
-    def __init__(self, hass, name, entity_id, config, **kwargs):
-        """Initialize a Lock accessory object."""
-        super().__init__(hass, name, entity_id,
-                         category=CATEGORY_LOCK, **kwargs)
+    category = CATEGORY_LOCK
 
+    def init_setup(self, config):
+        """Initialize a Lock accessory object."""
         self.flag_target_state = False
 
         serv_lock_mechanism = add_preload_service(self, SERV_LOCK)

--- a/homeassistant/components/homekit/type_locks.py
+++ b/homeassistant/components/homekit/type_locks.py
@@ -27,12 +27,10 @@ class Lock(HomeAccessory):
     The lock entity must support: unlock and lock.
     """
 
-    def __init__(self, hass, entity_id, name, **kwargs):
+    def __init__(self, hass, name, entity_id, **kwargs):
         """Initialize a Lock accessory object."""
-        super().__init__(name, entity_id, CATEGORY_LOCK, **kwargs)
-
-        self.hass = hass
-        self.entity_id = entity_id
+        super().__init__(hass, name, entity_id,
+                         category=CATEGORY_LOCK, **kwargs)
 
         self.flag_target_state = False
 
@@ -58,11 +56,8 @@ class Lock(HomeAccessory):
         params = {ATTR_ENTITY_ID: self.entity_id}
         self.hass.services.call('lock', service, params)
 
-    def update_state(self, entity_id=None, old_state=None, new_state=None):
+    def update_state(self, new_state):
         """Update lock after state changed."""
-        if new_state is None:
-            return
-
         hass_state = new_state.state
         if hass_state in HASS_TO_HOMEKIT:
             current_lock_state = HASS_TO_HOMEKIT[hass_state]

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -27,12 +27,12 @@ STATE_TO_SERVICE = {STATE_ALARM_DISARMED: 'alarm_disarm',
 class SecuritySystem(HomeAccessory):
     """Generate an SecuritySystem accessory for an alarm control panel."""
 
-    def __init__(self, hass, name, entity_id, alarm_code, **kwargs):
+    def __init__(self, hass, name, entity_id, config, **kwargs):
         """Initialize a SecuritySystem accessory object."""
         super().__init__(hass, name, entity_id,
                          category=CATEGORY_ALARM_SYSTEM, **kwargs)
 
-        self._alarm_code = alarm_code
+        self._alarm_code = config[ATTR_CODE]
         self.flag_target_state = False
 
         serv_alarm = add_preload_service(self, SERV_SECURITY_SYSTEM)

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -1,4 +1,5 @@
 """Class to hold all alarm control panel accessories."""
+# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.const import (
@@ -27,11 +28,10 @@ STATE_TO_SERVICE = {STATE_ALARM_DISARMED: 'alarm_disarm',
 class SecuritySystem(HomeAccessory):
     """Generate an SecuritySystem accessory for an alarm control panel."""
 
-    def __init__(self, hass, name, entity_id, config, **kwargs):
-        """Initialize a SecuritySystem accessory object."""
-        super().__init__(hass, name, entity_id,
-                         category=CATEGORY_ALARM_SYSTEM, **kwargs)
+    category = CATEGORY_ALARM_SYSTEM
 
+    def init_setup(self, config):
+        """Initialize a SecuritySystem accessory object."""
         self._alarm_code = config[ATTR_CODE]
         self.flag_target_state = False
 

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -27,15 +27,12 @@ STATE_TO_SERVICE = {STATE_ALARM_DISARMED: 'alarm_disarm',
 class SecuritySystem(HomeAccessory):
     """Generate an SecuritySystem accessory for an alarm control panel."""
 
-    def __init__(self, hass, entity_id, display_name, alarm_code, **kwargs):
+    def __init__(self, hass, name, entity_id, alarm_code, **kwargs):
         """Initialize a SecuritySystem accessory object."""
-        super().__init__(display_name, entity_id,
-                         CATEGORY_ALARM_SYSTEM, **kwargs)
+        super().__init__(hass, name, entity_id,
+                         category=CATEGORY_ALARM_SYSTEM, **kwargs)
 
-        self.hass = hass
-        self.entity_id = entity_id
         self._alarm_code = alarm_code
-
         self.flag_target_state = False
 
         serv_alarm = add_preload_service(self, SERV_SECURITY_SYSTEM)
@@ -61,11 +58,8 @@ class SecuritySystem(HomeAccessory):
             params[ATTR_CODE] = self._alarm_code
         self.hass.services.call('alarm_control_panel', service, params)
 
-    def update_state(self, entity_id=None, old_state=None, new_state=None):
+    def update_state(self, new_state):
         """Update security state after state changed."""
-        if new_state is None:
-            return
-
         hass_state = new_state.state
         if hass_state in HASS_TO_HOMEKIT:
             current_security_state = HASS_TO_HOMEKIT[hass_state]

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -1,5 +1,4 @@
 """Class to hold all alarm control panel accessories."""
-# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.const import (
@@ -28,10 +27,9 @@ STATE_TO_SERVICE = {STATE_ALARM_DISARMED: 'alarm_disarm',
 class SecuritySystem(HomeAccessory):
     """Generate an SecuritySystem accessory for an alarm control panel."""
 
-    category = CATEGORY_ALARM_SYSTEM
-
-    def init_setup(self, config):
+    def __init__(self, *args, config):
         """Initialize a SecuritySystem accessory object."""
+        super().__init__(*args, category=CATEGORY_ALARM_SYSTEM)
         self._alarm_code = config[ATTR_CODE]
         self.flag_target_state = False
 

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -7,7 +7,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_CODE)
 
 from . import TYPES
-from .accessories import HomeAccessory, add_preload_service
+from .accessories import HomeAccessory, add_preload_service, setup_char
 from .const import (
     CATEGORY_ALARM_SYSTEM, SERV_SECURITY_SYSTEM,
     CHAR_CURRENT_SECURITY_STATE, CHAR_TARGET_SECURITY_STATE)
@@ -34,14 +34,11 @@ class SecuritySystem(HomeAccessory):
         self.flag_target_state = False
 
         serv_alarm = add_preload_service(self, SERV_SECURITY_SYSTEM)
-        self.char_current_state = serv_alarm. \
-            get_characteristic(CHAR_CURRENT_SECURITY_STATE)
-        self.char_current_state.value = 3
-        self.char_target_state = serv_alarm. \
-            get_characteristic(CHAR_TARGET_SECURITY_STATE)
-        self.char_target_state.value = 3
-
-        self.char_target_state.setter_callback = self.set_security_state
+        self.char_current_state = setup_char(
+            CHAR_CURRENT_SECURITY_STATE, serv_alarm, value=3)
+        self.char_target_state = setup_char(
+            CHAR_TARGET_SECURITY_STATE, serv_alarm, value=3,
+            callback=self.set_security_state)
 
     def set_security_state(self, value):
         """Move security state to value if call came from HomeKit."""

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -20,9 +20,7 @@ from .const import (
     DEVICE_CLASS_SMOKE, SERV_SMOKE_SENSOR, CHAR_SMOKE_DETECTED)
 from .util import convert_to_float, temperature_to_homekit
 
-
 _LOGGER = logging.getLogger(__name__)
-
 
 BINARY_SENSOR_SERVICE_MAP = {
     DEVICE_CLASS_CO2: (SERV_CARBON_DIOXIDE_SENSOR,
@@ -43,12 +41,10 @@ class TemperatureSensor(HomeAccessory):
     Sensor entity must return temperature in °C, °F.
     """
 
-    def __init__(self, hass, entity_id, name, **kwargs):
+    def __init__(self, hass, name, entity_id, **kwargs):
         """Initialize a TemperatureSensor accessory object."""
-        super().__init__(name, entity_id, CATEGORY_SENSOR, **kwargs)
-
-        self.hass = hass
-        self.entity_id = entity_id
+        super().__init__(hass, name, entity_id,
+                         category=CATEGORY_SENSOR, **kwargs)
 
         serv_temp = add_preload_service(self, SERV_TEMPERATURE_SENSOR)
         self.char_temp = serv_temp.get_characteristic(CHAR_CURRENT_TEMPERATURE)
@@ -56,11 +52,8 @@ class TemperatureSensor(HomeAccessory):
         self.char_temp.value = 0
         self.unit = None
 
-    def update_state(self, entity_id=None, old_state=None, new_state=None):
+    def update_state(self, new_state):
         """Update temperature after state changed."""
-        if new_state is None:
-            return
-
         unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
         temperature = convert_to_float(new_state.state)
         if temperature:
@@ -74,23 +67,18 @@ class TemperatureSensor(HomeAccessory):
 class HumiditySensor(HomeAccessory):
     """Generate a HumiditySensor accessory as humidity sensor."""
 
-    def __init__(self, hass, entity_id, name, *args, **kwargs):
+    def __init__(self, hass, name, entity_id, **kwargs):
         """Initialize a HumiditySensor accessory object."""
-        super().__init__(name, entity_id, CATEGORY_SENSOR, *args, **kwargs)
-
-        self.hass = hass
-        self.entity_id = entity_id
+        super().__init__(hass, name, entity_id,
+                         category=CATEGORY_SENSOR, **kwargs)
 
         serv_humidity = add_preload_service(self, SERV_HUMIDITY_SENSOR)
         self.char_humidity = serv_humidity \
             .get_characteristic(CHAR_CURRENT_HUMIDITY)
         self.char_humidity.value = 0
 
-    def update_state(self, entity_id=None, old_state=None, new_state=None):
+    def update_state(self, new_state):
         """Update accessory after state change."""
-        if new_state is None:
-            return
-
         humidity = convert_to_float(new_state.state)
         if humidity:
             self.char_humidity.set_value(humidity)
@@ -102,14 +90,12 @@ class HumiditySensor(HomeAccessory):
 class BinarySensor(HomeAccessory):
     """Generate a BinarySensor accessory as binary sensor."""
 
-    def __init__(self, hass, entity_id, name, **kwargs):
+    def __init__(self, hass, name, entity_id, **kwargs):
         """Initialize a BinarySensor accessory object."""
-        super().__init__(name, entity_id, CATEGORY_SENSOR, **kwargs)
+        super().__init__(hass, name, entity_id,
+                         category=CATEGORY_SENSOR, **kwargs)
 
-        self.hass = hass
-        self.entity_id = entity_id
-
-        device_class = hass.states.get(entity_id).attributes \
+        device_class = self.hass.states.get(self.entity_id).attributes \
             .get(ATTR_DEVICE_CLASS)
         service_char = BINARY_SENSOR_SERVICE_MAP[device_class] \
             if device_class in BINARY_SENSOR_SERVICE_MAP \
@@ -119,11 +105,8 @@ class BinarySensor(HomeAccessory):
         self.char_detected = service.get_characteristic(service_char[1])
         self.char_detected.value = 0
 
-    def update_state(self, entity_id=None, old_state=None, new_state=None):
+    def update_state(self, new_state):
         """Update accessory after state change."""
-        if new_state is None:
-            return
-
         state = new_state.state
         detected = (state == STATE_ON) or (state == STATE_HOME)
         self.char_detected.set_value(detected)

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -1,5 +1,4 @@
 """Class to hold all sensor accessories."""
-# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.const import (
@@ -42,10 +41,9 @@ class TemperatureSensor(HomeAccessory):
     Sensor entity must return temperature in °C, °F.
     """
 
-    category = CATEGORY_SENSOR
-
-    def init_setup(self, config):
+    def __init__(self, *args, config):
         """Initialize a TemperatureSensor accessory object."""
+        super().__init__(*args, category=CATEGORY_SENSOR)
         serv_temp = add_preload_service(self, SERV_TEMPERATURE_SENSOR)
         self.char_temp = serv_temp.get_characteristic(CHAR_CURRENT_TEMPERATURE)
         self.char_temp.override_properties(properties=PROP_CELSIUS)
@@ -67,10 +65,9 @@ class TemperatureSensor(HomeAccessory):
 class HumiditySensor(HomeAccessory):
     """Generate a HumiditySensor accessory as humidity sensor."""
 
-    category = CATEGORY_SENSOR
-
-    def init_setup(self, config):
+    def __init__(self, *args, config):
         """Initialize a HumiditySensor accessory object."""
+        super().__init__(*args, category=CATEGORY_SENSOR)
         serv_humidity = add_preload_service(self, SERV_HUMIDITY_SENSOR)
         self.char_humidity = serv_humidity \
             .get_characteristic(CHAR_CURRENT_HUMIDITY)
@@ -89,10 +86,9 @@ class HumiditySensor(HomeAccessory):
 class BinarySensor(HomeAccessory):
     """Generate a BinarySensor accessory as binary sensor."""
 
-    category = CATEGORY_SENSOR
-
-    def init_setup(self, config):
+    def __init__(self, *args, config):
         """Initialize a BinarySensor accessory object."""
+        super().__init__(*args, category=CATEGORY_SENSOR)
         device_class = self.hass.states.get(self.entity_id).attributes \
             .get(ATTR_DEVICE_CLASS)
         service_char = BINARY_SENSOR_SERVICE_MAP[device_class] \

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -1,4 +1,5 @@
 """Class to hold all sensor accessories."""
+# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.const import (
@@ -41,11 +42,10 @@ class TemperatureSensor(HomeAccessory):
     Sensor entity must return temperature in °C, °F.
     """
 
-    def __init__(self, hass, name, entity_id, config, **kwargs):
-        """Initialize a TemperatureSensor accessory object."""
-        super().__init__(hass, name, entity_id,
-                         category=CATEGORY_SENSOR, **kwargs)
+    category = CATEGORY_SENSOR
 
+    def init_setup(self, config):
+        """Initialize a TemperatureSensor accessory object."""
         serv_temp = add_preload_service(self, SERV_TEMPERATURE_SENSOR)
         self.char_temp = serv_temp.get_characteristic(CHAR_CURRENT_TEMPERATURE)
         self.char_temp.override_properties(properties=PROP_CELSIUS)
@@ -67,11 +67,10 @@ class TemperatureSensor(HomeAccessory):
 class HumiditySensor(HomeAccessory):
     """Generate a HumiditySensor accessory as humidity sensor."""
 
-    def __init__(self, hass, name, entity_id, config, **kwargs):
-        """Initialize a HumiditySensor accessory object."""
-        super().__init__(hass, name, entity_id,
-                         category=CATEGORY_SENSOR, **kwargs)
+    category = CATEGORY_SENSOR
 
+    def init_setup(self, config):
+        """Initialize a HumiditySensor accessory object."""
         serv_humidity = add_preload_service(self, SERV_HUMIDITY_SENSOR)
         self.char_humidity = serv_humidity \
             .get_characteristic(CHAR_CURRENT_HUMIDITY)
@@ -90,11 +89,10 @@ class HumiditySensor(HomeAccessory):
 class BinarySensor(HomeAccessory):
     """Generate a BinarySensor accessory as binary sensor."""
 
-    def __init__(self, hass, name, entity_id, config, **kwargs):
-        """Initialize a BinarySensor accessory object."""
-        super().__init__(hass, name, entity_id,
-                         category=CATEGORY_SENSOR, **kwargs)
+    category = CATEGORY_SENSOR
 
+    def init_setup(self, config):
+        """Initialize a BinarySensor accessory object."""
         device_class = self.hass.states.get(self.entity_id).attributes \
             .get(ATTR_DEVICE_CLASS)
         service_char = BINARY_SENSOR_SERVICE_MAP[device_class] \

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -6,7 +6,7 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS, STATE_ON, STATE_HOME)
 
 from . import TYPES
-from .accessories import HomeAccessory, add_preload_service
+from .accessories import HomeAccessory, add_preload_service, setup_char
 from .const import (
     CATEGORY_SENSOR, SERV_HUMIDITY_SENSOR, SERV_TEMPERATURE_SENSOR,
     CHAR_CURRENT_HUMIDITY, CHAR_CURRENT_TEMPERATURE, PROP_CELSIUS,
@@ -45,9 +45,9 @@ class TemperatureSensor(HomeAccessory):
         """Initialize a TemperatureSensor accessory object."""
         super().__init__(*args, category=CATEGORY_SENSOR)
         serv_temp = add_preload_service(self, SERV_TEMPERATURE_SENSOR)
-        self.char_temp = serv_temp.get_characteristic(CHAR_CURRENT_TEMPERATURE)
-        self.char_temp.override_properties(properties=PROP_CELSIUS)
-        self.char_temp.value = 0
+        self.char_temp = setup_char(
+            CHAR_CURRENT_TEMPERATURE, serv_temp, value=0,
+            properties=PROP_CELSIUS)
         self.unit = None
 
     def update_state(self, new_state):
@@ -69,9 +69,8 @@ class HumiditySensor(HomeAccessory):
         """Initialize a HumiditySensor accessory object."""
         super().__init__(*args, category=CATEGORY_SENSOR)
         serv_humidity = add_preload_service(self, SERV_HUMIDITY_SENSOR)
-        self.char_humidity = serv_humidity \
-            .get_characteristic(CHAR_CURRENT_HUMIDITY)
-        self.char_humidity.value = 0
+        self.char_humidity = setup_char(
+            CHAR_CURRENT_HUMIDITY, serv_humidity, value=0)
 
     def update_state(self, new_state):
         """Update accessory after state change."""
@@ -96,8 +95,7 @@ class BinarySensor(HomeAccessory):
             else BINARY_SENSOR_SERVICE_MAP[DEVICE_CLASS_OCCUPANCY]
 
         service = add_preload_service(self, service_char[0])
-        self.char_detected = service.get_characteristic(service_char[1])
-        self.char_detected.value = 0
+        self.char_detected = setup_char(service_char[1], service, value=0)
 
     def update_state(self, new_state):
         """Update accessory after state change."""

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -41,7 +41,7 @@ class TemperatureSensor(HomeAccessory):
     Sensor entity must return temperature in °C, °F.
     """
 
-    def __init__(self, hass, name, entity_id, **kwargs):
+    def __init__(self, hass, name, entity_id, config, **kwargs):
         """Initialize a TemperatureSensor accessory object."""
         super().__init__(hass, name, entity_id,
                          category=CATEGORY_SENSOR, **kwargs)
@@ -67,7 +67,7 @@ class TemperatureSensor(HomeAccessory):
 class HumiditySensor(HomeAccessory):
     """Generate a HumiditySensor accessory as humidity sensor."""
 
-    def __init__(self, hass, name, entity_id, **kwargs):
+    def __init__(self, hass, name, entity_id, config, **kwargs):
         """Initialize a HumiditySensor accessory object."""
         super().__init__(hass, name, entity_id,
                          category=CATEGORY_SENSOR, **kwargs)
@@ -90,7 +90,7 @@ class HumiditySensor(HomeAccessory):
 class BinarySensor(HomeAccessory):
     """Generate a BinarySensor accessory as binary sensor."""
 
-    def __init__(self, hass, name, entity_id, **kwargs):
+    def __init__(self, hass, name, entity_id, config, **kwargs):
         """Initialize a BinarySensor accessory object."""
         super().__init__(hass, name, entity_id,
                          category=CATEGORY_SENSOR, **kwargs)

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -1,5 +1,4 @@
 """Class to hold all switch accessories."""
-# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.const import (
@@ -17,10 +16,9 @@ _LOGGER = logging.getLogger(__name__)
 class Switch(HomeAccessory):
     """Generate a Switch accessory."""
 
-    category = CATEGORY_SWITCH
-
-    def init_setup(self, config):
+    def __init__(self, *args, config):
         """Initialize a Switch accessory object to represent a remote."""
+        super().__init__(*args, category=CATEGORY_SWITCH)
         self._domain = split_entity_id(self.entity_id)[0]
         self.flag_target_state = False
 

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -16,14 +16,12 @@ _LOGGER = logging.getLogger(__name__)
 class Switch(HomeAccessory):
     """Generate a Switch accessory."""
 
-    def __init__(self, hass, entity_id, display_name, **kwargs):
+    def __init__(self, hass, name, entity_id, **kwargs):
         """Initialize a Switch accessory object to represent a remote."""
-        super().__init__(display_name, entity_id, CATEGORY_SWITCH, **kwargs)
+        super().__init__(hass, name, entity_id,
+                         category=CATEGORY_SWITCH, **kwargs)
 
-        self.hass = hass
-        self.entity_id = entity_id
-        self._domain = split_entity_id(entity_id)[0]
-
+        self._domain = split_entity_id(self.entity_id)[0]
         self.flag_target_state = False
 
         serv_switch = add_preload_service(self, SERV_SWITCH)
@@ -40,15 +38,11 @@ class Switch(HomeAccessory):
         self.hass.services.call(self._domain, service,
                                 {ATTR_ENTITY_ID: self.entity_id})
 
-    def update_state(self, entity_id=None, old_state=None, new_state=None):
+    def update_state(self, new_state):
         """Update switch state after state changed."""
-        if new_state is None:
-            return
-
         current_state = (new_state.state == STATE_ON)
         if not self.flag_target_state:
             _LOGGER.debug('%s: Set current state to %s',
                           self.entity_id, current_state)
             self.char_on.set_value(current_state)
-
         self.flag_target_state = False

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 class Switch(HomeAccessory):
     """Generate a Switch accessory."""
 
-    def __init__(self, hass, name, entity_id, **kwargs):
+    def __init__(self, hass, name, entity_id, config, **kwargs):
         """Initialize a Switch accessory object to represent a remote."""
         super().__init__(hass, name, entity_id,
                          category=CATEGORY_SWITCH, **kwargs)

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -1,4 +1,5 @@
 """Class to hold all switch accessories."""
+# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.const import (
@@ -16,11 +17,10 @@ _LOGGER = logging.getLogger(__name__)
 class Switch(HomeAccessory):
     """Generate a Switch accessory."""
 
-    def __init__(self, hass, name, entity_id, config, **kwargs):
-        """Initialize a Switch accessory object to represent a remote."""
-        super().__init__(hass, name, entity_id,
-                         category=CATEGORY_SWITCH, **kwargs)
+    category = CATEGORY_SWITCH
 
+    def init_setup(self, config):
+        """Initialize a Switch accessory object to represent a remote."""
         self._domain = split_entity_id(self.entity_id)[0]
         self.flag_target_state = False
 

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -6,7 +6,7 @@ from homeassistant.const import (
 from homeassistant.core import split_entity_id
 
 from . import TYPES
-from .accessories import HomeAccessory, add_preload_service
+from .accessories import HomeAccessory, add_preload_service, setup_char
 from .const import CATEGORY_SWITCH, SERV_SWITCH, CHAR_ON
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,9 +23,8 @@ class Switch(HomeAccessory):
         self.flag_target_state = False
 
         serv_switch = add_preload_service(self, SERV_SWITCH)
-        self.char_on = serv_switch.get_characteristic(CHAR_ON)
-        self.char_on.value = False
-        self.char_on.setter_callback = self.set_state
+        self.char_on = setup_char(
+            CHAR_ON, serv_switch, value=False, callback=self.set_state)
 
     def set_state(self, value):
         """Move switch state to value if call came from HomeKit."""

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -1,5 +1,4 @@
 """Class to hold all thermostat accessories."""
-# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.components.climate import (
@@ -37,10 +36,9 @@ SUPPORT_TEMP_RANGE = SUPPORT_TARGET_TEMPERATURE_LOW | \
 class Thermostat(HomeAccessory):
     """Generate a Thermostat accessory for a climate."""
 
-    category = CATEGORY_THERMOSTAT
-
-    def init_setup(self, config):
+    def __init__(self, *args, config):
         """Initialize a Thermostat accessory object."""
+        super().__init__(*args, category=CATEGORY_THERMOSTAT)
         self._unit = TEMP_CELSIUS
         self.heat_cool_flag_target_state = False
         self.temperature_flag_target_state = False

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -31,12 +31,13 @@ HC_HOMEKIT_TO_HASS = {c: s for s, c in HC_HASS_TO_HOMEKIT.items()}
 class Thermostat(HomeAccessory):
     """Generate a Thermostat accessory for a climate."""
 
-    def __init__(self, hass, name, entity_id, support_auto, **kwargs):
+    def __init__(self, hass, name, entity_id, config, **kwargs):
         """Initialize a Thermostat accessory object."""
         super().__init__(hass, name, entity_id,
                          category=CATEGORY_THERMOSTAT, **kwargs)
 
         self._unit = TEMP_CELSIUS
+        self._support_auto = config['support_auto']
         self.heat_cool_flag_target_state = False
         self.temperature_flag_target_state = False
         self.coolingthresh_flag_target_state = False
@@ -45,7 +46,7 @@ class Thermostat(HomeAccessory):
         # Add additional characteristics if auto mode is supported
         extra_chars = [
             CHAR_COOLING_THRESHOLD_TEMPERATURE,
-            CHAR_HEATING_THRESHOLD_TEMPERATURE] if support_auto else None
+            CHAR_HEATING_THRESHOLD_TEMPERATURE] if self._support_auto else None
 
         # Preload the thermostat service
         serv_thermostat = add_preload_service(self, SERV_THERMOSTAT,
@@ -75,7 +76,7 @@ class Thermostat(HomeAccessory):
         self.char_display_units.value = 0
 
         # If the device supports it: high and low temperature characteristics
-        if support_auto:
+        if self._support_auto:
             self.char_cooling_thresh_temp = serv_thermostat. \
                 get_characteristic(CHAR_COOLING_THRESHOLD_TEMPERATURE)
             self.char_cooling_thresh_temp.value = 23.0

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -47,16 +47,15 @@ class Thermostat(HomeAccessory):
         self.heatingthresh_flag_target_state = False
 
         # Add additional characteristics if auto mode is supported
+        self.chars = []
         features = self.hass.states.get(self.entity_id) \
             .attributes.get(ATTR_SUPPORTED_FEATURES)
-        support_auto = bool(features & SUPPORT_TEMP_RANGE)
-        extra_chars = [
-            CHAR_COOLING_THRESHOLD_TEMPERATURE,
-            CHAR_HEATING_THRESHOLD_TEMPERATURE] if support_auto else None
+        if features & SUPPORT_TEMP_RANGE:
+            self.chars.extend((CHAR_COOLING_THRESHOLD_TEMPERATURE,
+                               CHAR_HEATING_THRESHOLD_TEMPERATURE))
 
-        # Preload the thermostat service
-        serv_thermostat = add_preload_service(self, SERV_THERMOSTAT,
-                                              extra_chars)
+        serv_thermostat = add_preload_service(
+            self, SERV_THERMOSTAT, self.chars)
 
         # Current and target mode characteristics
         self.char_current_heat_cool = setup_char(
@@ -79,11 +78,11 @@ class Thermostat(HomeAccessory):
         # If the device supports it: high and low temperature characteristics
         self.char_cooling_thresh_temp = None
         self.char_heating_thresh_temp = None
-        if support_auto:
+        if CHAR_COOLING_THRESHOLD_TEMPERATURE in self.chars:
             self.char_cooling_thresh_temp = setup_char(
                 CHAR_COOLING_THRESHOLD_TEMPERATURE, serv_thermostat,
                 value=23.0, callback=self.set_cooling_threshold)
-
+        if CHAR_HEATING_THRESHOLD_TEMPERATURE in self.chars:
             self.char_heating_thresh_temp = setup_char(
                 CHAR_HEATING_THRESHOLD_TEMPERATURE, serv_thermostat,
                 value=19.0, callback=self.set_heating_threshold)

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -1,4 +1,5 @@
 """Class to hold all thermostat accessories."""
+# pylint: disable=attribute-defined-outside-init
 import logging
 
 from homeassistant.components.climate import (
@@ -36,11 +37,10 @@ SUPPORT_TEMP_RANGE = SUPPORT_TARGET_TEMPERATURE_LOW | \
 class Thermostat(HomeAccessory):
     """Generate a Thermostat accessory for a climate."""
 
-    def __init__(self, hass, name, entity_id, config, **kwargs):
-        """Initialize a Thermostat accessory object."""
-        super().__init__(hass, name, entity_id,
-                         category=CATEGORY_THERMOSTAT, **kwargs)
+    category = CATEGORY_THERMOSTAT
 
+    def init_setup(self, config):
+        """Initialize a Thermostat accessory object."""
         self._unit = TEMP_CELSIUS
         self.heat_cool_flag_target_state = False
         self.temperature_flag_target_state = False

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -31,16 +31,12 @@ HC_HOMEKIT_TO_HASS = {c: s for s, c in HC_HASS_TO_HOMEKIT.items()}
 class Thermostat(HomeAccessory):
     """Generate a Thermostat accessory for a climate."""
 
-    def __init__(self, hass, entity_id, display_name, support_auto, **kwargs):
+    def __init__(self, hass, name, entity_id, support_auto, **kwargs):
         """Initialize a Thermostat accessory object."""
-        super().__init__(display_name, entity_id,
-                         CATEGORY_THERMOSTAT, **kwargs)
+        super().__init__(hass, name, entity_id,
+                         category=CATEGORY_THERMOSTAT, **kwargs)
 
-        self.hass = hass
-        self.entity_id = entity_id
-        self._call_timer = None
         self._unit = TEMP_CELSIUS
-
         self.heat_cool_flag_target_state = False
         self.temperature_flag_target_state = False
         self.coolingthresh_flag_target_state = False
@@ -141,11 +137,8 @@ class Thermostat(HomeAccessory):
         self.hass.components.climate.set_temperature(
             temperature=value, entity_id=self.entity_id)
 
-    def update_state(self, entity_id=None, old_state=None, new_state=None):
+    def update_state(self, new_state):
         """Update security state after state changed."""
-        if new_state is None:
-            return
-
         self._unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT,
                                               TEMP_CELSIUS)
 

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -33,7 +33,7 @@ def validate_entity_config(values):
     return entities
 
 
-def show_setup_message(bridge, hass):
+def show_setup_message(hass, bridge):
     """Display persistent notification with setup information."""
     pin = bridge.pincode.decode()
     _LOGGER.info('Pincode: %s', pin)

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -91,8 +91,7 @@ class TestAccessories(unittest.TestCase):
     def test_set_accessory_info(self):
         """Test setting the basic accessory information."""
         # Test HomeAccessory
-        acc = HomeAccessory('hass', 'Home Accessory', 'homekit.accessory',
-                            {}, aid=2)
+        acc = HomeAccessory('HA', 'Home Accessory', 'homekit.accessory', 2, '')
         set_accessory_info(acc, 'name', 'model', 'manufacturer', '0000')
 
         serv = acc.get_service(SERV_ACCESSORY_INFO)
@@ -118,8 +117,7 @@ class TestAccessories(unittest.TestCase):
         """Test HomeAccessory class."""
         hass = get_test_home_assistant()
 
-        acc = HomeAccessory(hass, 'Home Accessory', 'homekit.accessory',
-                            {}, aid=2)
+        acc = HomeAccessory(hass, 'Home Accessory', 'homekit.accessory', 2, '')
         self.assertEqual(acc.hass, hass)
         self.assertEqual(acc.display_name, 'Home Accessory')
         self.assertEqual(acc.category, 1)  # Category.OTHER
@@ -134,7 +132,7 @@ class TestAccessories(unittest.TestCase):
         hass.states.set('homekit.accessory', 'off')
         hass.block_till_done()
 
-        acc = HomeAccessory('hass', 'test_name', 'test_model', {}, aid=2)
+        acc = HomeAccessory('hass', 'test_name', 'test_model', 2, '')
         self.assertEqual(acc.display_name, 'test_name')
         self.assertEqual(acc.aid, 2)
         self.assertEqual(len(acc.services), 1)

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -91,7 +91,7 @@ class TestAccessories(unittest.TestCase):
     def test_set_accessory_info(self):
         """Test setting the basic accessory information."""
         # Test HomeAccessory
-        acc = HomeAccessory('hass', 'Home Accessory', 'homekit.accessory')
+        acc = HomeAccessory('hass', 'Home Accessory', 'homekit.accessory', {})
         set_accessory_info(acc, 'name', 'model', 'manufacturer', '0000')
 
         serv = acc.get_service(SERV_ACCESSORY_INFO)
@@ -117,7 +117,7 @@ class TestAccessories(unittest.TestCase):
         """Test HomeAccessory class."""
         hass = get_test_home_assistant()
 
-        acc = HomeAccessory(hass, 'Home Accessory', 'homekit.accessory')
+        acc = HomeAccessory(hass, 'Home Accessory', 'homekit.accessory', {})
         self.assertEqual(acc.hass, hass)
         self.assertEqual(acc.display_name, 'Home Accessory')
         self.assertEqual(acc.category, 1)  # Category.OTHER
@@ -132,9 +132,8 @@ class TestAccessories(unittest.TestCase):
         hass.states.set('homekit.accessory', 'off')
         hass.block_till_done()
 
-        acc = HomeAccessory('hass', 'test_name', 'test_model', 'FAN', aid=2)
+        acc = HomeAccessory('hass', 'test_name', 'test_model', {}, aid=2)
         self.assertEqual(acc.display_name, 'test_name')
-        self.assertEqual(acc.category, 3)  # Category.FAN
         self.assertEqual(acc.aid, 2)
         self.assertEqual(len(acc.services), 1)
         serv = acc.services[0]  # SERV_ACCESSORY_INFO

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -10,9 +10,8 @@ from homeassistant.components.homekit.accessories import (
     add_preload_service, set_accessory_info,
     debounce, HomeAccessory, HomeBridge, HomeDriver)
 from homeassistant.components.homekit.const import (
-    ACCESSORY_MODEL, ACCESSORY_NAME, BRIDGE_MODEL, BRIDGE_NAME,
-    SERV_ACCESSORY_INFO, CHAR_MANUFACTURER, CHAR_MODEL,
-    CHAR_NAME, CHAR_SERIAL_NUMBER)
+    BRIDGE_MODEL, BRIDGE_NAME, SERV_ACCESSORY_INFO,
+    CHAR_MANUFACTURER, CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER)
 from homeassistant.const import ATTR_NOW, EVENT_TIME_CHANGED
 import homeassistant.util.dt as dt_util
 
@@ -92,7 +91,7 @@ class TestAccessories(unittest.TestCase):
     def test_set_accessory_info(self):
         """Test setting the basic accessory information."""
         # Test HomeAccessory
-        acc = HomeAccessory()
+        acc = HomeAccessory('hass', 'Home Accessory', 'homekit.accessory')
         set_accessory_info(acc, 'name', 'model', 'manufacturer', '0000')
 
         serv = acc.get_service(SERV_ACCESSORY_INFO)
@@ -104,7 +103,7 @@ class TestAccessories(unittest.TestCase):
             serv.get_characteristic(CHAR_SERIAL_NUMBER).value, '0000')
 
         # Test HomeBridge
-        acc = HomeBridge(None)
+        acc = HomeBridge('hass')
         set_accessory_info(acc, 'name', 'model', 'manufacturer', '0000')
 
         serv = acc.get_service(SERV_ACCESSORY_INFO)
@@ -116,15 +115,24 @@ class TestAccessories(unittest.TestCase):
 
     def test_home_accessory(self):
         """Test HomeAccessory class."""
-        acc = HomeAccessory()
-        self.assertEqual(acc.display_name, ACCESSORY_NAME)
+        hass = get_test_home_assistant()
+
+        acc = HomeAccessory(hass, 'Home Accessory', 'homekit.accessory')
+        self.assertEqual(acc.hass, hass)
+        self.assertEqual(acc.display_name, 'Home Accessory')
         self.assertEqual(acc.category, 1)  # Category.OTHER
         self.assertEqual(len(acc.services), 1)
         serv = acc.services[0]  # SERV_ACCESSORY_INFO
         self.assertEqual(
-            serv.get_characteristic(CHAR_MODEL).value, ACCESSORY_MODEL)
+            serv.get_characteristic(CHAR_MODEL).value, 'homekit.accessory')
 
-        acc = HomeAccessory('test_name', 'test_model', 'FAN', aid=2)
+        hass.states.set('homekit.accessory', 'on')
+        hass.block_till_done()
+        acc.run()
+        hass.states.set('homekit.accessory', 'off')
+        hass.block_till_done()
+
+        acc = HomeAccessory('hass', 'test_name', 'test_model', 'FAN', aid=2)
         self.assertEqual(acc.display_name, 'test_name')
         self.assertEqual(acc.category, 3)  # Category.FAN
         self.assertEqual(acc.aid, 2)
@@ -133,9 +141,12 @@ class TestAccessories(unittest.TestCase):
         self.assertEqual(
             serv.get_characteristic(CHAR_MODEL).value, 'test_model')
 
+        hass.stop()
+
     def test_home_bridge(self):
         """Test HomeBridge class."""
-        bridge = HomeBridge(None)
+        bridge = HomeBridge('hass')
+        self.assertEqual(bridge.hass, 'hass')
         self.assertEqual(bridge.display_name, BRIDGE_NAME)
         self.assertEqual(bridge.category, 2)  # Category.BRIDGE
         self.assertEqual(len(bridge.services), 1)
@@ -144,12 +155,10 @@ class TestAccessories(unittest.TestCase):
         self.assertEqual(
             serv.get_characteristic(CHAR_MODEL).value, BRIDGE_MODEL)
 
-        bridge = HomeBridge('hass', 'test_name', 'test_model')
+        bridge = HomeBridge('hass', 'test_name')
         self.assertEqual(bridge.display_name, 'test_name')
         self.assertEqual(len(bridge.services), 1)
         serv = bridge.services[0]  # SERV_ACCESSORY_INFO
-        self.assertEqual(
-            serv.get_characteristic(CHAR_MODEL).value, 'test_model')
 
         # setup_message
         bridge.setup_message()
@@ -174,11 +183,11 @@ class TestAccessories(unittest.TestCase):
 
         self.assertEqual(
             mock_remove_paired_client.call_args, call('client_uuid'))
-        self.assertEqual(mock_show_msg.call_args, call(bridge, 'hass'))
+        self.assertEqual(mock_show_msg.call_args, call('hass', bridge))
 
     def test_home_driver(self):
         """Test HomeDriver class."""
-        bridge = HomeBridge(None)
+        bridge = HomeBridge('hass')
         ip_address = '127.0.0.1'
         port = 51826
         path = '.homekit.state'

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -91,7 +91,8 @@ class TestAccessories(unittest.TestCase):
     def test_set_accessory_info(self):
         """Test setting the basic accessory information."""
         # Test HomeAccessory
-        acc = HomeAccessory('hass', 'Home Accessory', 'homekit.accessory', {})
+        acc = HomeAccessory('hass', 'Home Accessory', 'homekit.accessory',
+                            {}, aid=2)
         set_accessory_info(acc, 'name', 'model', 'manufacturer', '0000')
 
         serv = acc.get_service(SERV_ACCESSORY_INFO)
@@ -117,7 +118,8 @@ class TestAccessories(unittest.TestCase):
         """Test HomeAccessory class."""
         hass = get_test_home_assistant()
 
-        acc = HomeAccessory(hass, 'Home Accessory', 'homekit.accessory', {})
+        acc = HomeAccessory(hass, 'Home Accessory', 'homekit.accessory',
+                            {}, aid=2)
         self.assertEqual(acc.hass, hass)
         self.assertEqual(acc.display_name, 'Home Accessory')
         self.assertEqual(acc.category, 1)  # Category.OTHER

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -99,10 +99,6 @@ class TestGetAccessories(unittest.TestCase):
             state = State('climate.test', 'auto')
             get_accessory(None, state, 2, {})
 
-        # pylint: disable=unsubscriptable-object
-        self.assertEqual(
-            self.mock_type.call_args[0][-1]['support_auto'], False)
-
     def test_light(self):
         """Test light devices."""
         with patch.dict(TYPES, {'Light': self.mock_type}):
@@ -117,10 +113,6 @@ class TestGetAccessories(unittest.TestCase):
                     SUPPORT_TARGET_TEMPERATURE_LOW |
                     SUPPORT_TARGET_TEMPERATURE_HIGH})
             get_accessory(None, state, 2, {})
-
-        # pylint: disable=unsubscriptable-object
-        self.assertEqual(
-            self.mock_type.call_args[0][-1]['support_auto'], True)
 
     def test_switch(self):
         """Test switch."""

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -91,7 +91,7 @@ class TestGetAccessories(unittest.TestCase):
 
         # pylint: disable=unsubscriptable-object
         self.assertEqual(
-            self.mock_type.call_args[0][-1][ATTR_CODE], '1234')
+            self.mock_type.call_args[0][3][ATTR_CODE], '1234')
 
     def test_climate(self):
         """Test climate devices."""

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -48,7 +48,6 @@ class TestGetAccessories(unittest.TestCase):
                           {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
             get_accessory(None, state, 2, {})
 
-    # pylint: disable=invalid-name
     def test_sensor_temperature_fahrenheit(self):
         """Test temperature sensor with Fahrenheit as unit."""
         with patch.dict(TYPES, {'TemperatureSensor': self.mock_type}):
@@ -139,4 +138,10 @@ class TestGetAccessories(unittest.TestCase):
         """Test input_boolean."""
         with patch.dict(TYPES, {'Switch': self.mock_type}):
             state = State('input_boolean.test', 'on')
+            get_accessory(None, state, 2, {})
+
+    def test_lock(self):
+        """Test lock."""
+        with patch.dict(TYPES, {'Lock': self.mock_type}):
+            state = State('lock.test', 'locked')
             get_accessory(None, state, 2, {})

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -19,14 +19,14 @@ CONFIG = {}
 def test_get_accessory_invalid_aid(caplog):
     """Test with unsupported component."""
     assert get_accessory(None, State('light.demo', 'on'),
-                         aid=None, config=None) is None
+                         None, config=None) is None
     assert caplog.records[0].levelname == 'WARNING'
     assert 'invalid aid' in caplog.records[0].msg
 
 
 def test_not_supported():
     """Test if none is returned if entity isn't supported."""
-    assert get_accessory(None, State('demo.demo', 'on'), aid=2, config=None) \
+    assert get_accessory(None, State('demo.demo', 'on'), 2, config=None) \
         is None
 
 
@@ -90,8 +90,9 @@ class TestGetAccessories(unittest.TestCase):
             get_accessory(None, state, 2, config)
 
         # pylint: disable=unsubscriptable-object
+        print(self.mock_type.call_args[1])
         self.assertEqual(
-            self.mock_type.call_args[0][3][ATTR_CODE], '1234')
+            self.mock_type.call_args[1]['config'][ATTR_CODE], '1234')
 
     def test_climate(self):
         """Test climate devices."""

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -91,7 +91,7 @@ class TestGetAccessories(unittest.TestCase):
 
         # pylint: disable=unsubscriptable-object
         self.assertEqual(
-            self.mock_type.call_args[1]['alarm_code'], '1234')
+            self.mock_type.call_args[0][-1][ATTR_CODE], '1234')
 
     def test_climate(self):
         """Test climate devices."""
@@ -101,7 +101,7 @@ class TestGetAccessories(unittest.TestCase):
 
         # pylint: disable=unsubscriptable-object
         self.assertEqual(
-            self.mock_type.call_args[1]['support_auto'], False)
+            self.mock_type.call_args[0][-1]['support_auto'], False)
 
     def test_light(self):
         """Test light devices."""
@@ -120,7 +120,7 @@ class TestGetAccessories(unittest.TestCase):
 
         # pylint: disable=unsubscriptable-object
         self.assertEqual(
-            self.mock_type.call_args[1]['support_auto'], True)
+            self.mock_type.call_args[0][-1]['support_auto'], True)
 
     def test_switch(self):
         """Test switch."""

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -91,7 +91,7 @@ class TestGetAccessories(unittest.TestCase):
 
         # pylint: disable=unsubscriptable-object
         self.assertEqual(
-            self.mock_type.call_args[1].get('alarm_code'), '1234')
+            self.mock_type.call_args[1]['alarm_code'], '1234')
 
     def test_climate(self):
         """Test climate devices."""
@@ -101,7 +101,7 @@ class TestGetAccessories(unittest.TestCase):
 
         # pylint: disable=unsubscriptable-object
         self.assertEqual(
-            self.mock_type.call_args[0][-1], False)  # support_auto
+            self.mock_type.call_args[1]['support_auto'], False)
 
     def test_light(self):
         """Test light devices."""
@@ -120,7 +120,7 @@ class TestGetAccessories(unittest.TestCase):
 
         # pylint: disable=unsubscriptable-object
         self.assertEqual(
-            self.mock_type.call_args[0][-1], True)  # support_auto
+            self.mock_type.call_args[1]['support_auto'], True)
 
     def test_switch(self):
         """Test switch."""

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -173,7 +173,7 @@ class TestHomeKit(unittest.TestCase):
 
         self.assertEqual(mock_add_bridge_acc.mock_calls, [call(state)])
         self.assertEqual(mock_show_setup_msg.mock_calls, [
-            call(homekit.bridge, self.hass)])
+            call(self.hass, homekit.bridge)])
         self.assertEqual(homekit.driver.mock_calls, [call.start()])
         self.assertTrue(homekit.started)
 

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -35,7 +35,7 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         window_cover = 'cover.window'
 
-        acc = WindowCovering(self.hass, 'Cover', window_cover, None, aid=2)
+        acc = WindowCovering(self.hass, 'Cover', window_cover, 2, config=None)
         acc.run()
 
         self.assertEqual(acc.aid, 2)

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -35,7 +35,7 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         window_cover = 'cover.window'
 
-        acc = WindowCovering(self.hass, window_cover, 'Cover', aid=2)
+        acc = WindowCovering(self.hass, 'Cover', window_cover, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -35,7 +35,7 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         window_cover = 'cover.window'
 
-        acc = WindowCovering(self.hass, 'Cover', window_cover, aid=2)
+        acc = WindowCovering(self.hass, 'Cover', window_cover, None, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -53,6 +53,7 @@ class TestHomekitLights(unittest.TestCase):
 
         self.hass.states.set(entity_id, STATE_ON,
                              {ATTR_SUPPORTED_FEATURES: 0})
+        self.hass.block_till_done()
         acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
         self.assertEqual(acc.aid, 2)
         self.assertEqual(acc.category, 5)  # Lightbulb
@@ -98,6 +99,7 @@ class TestHomekitLights(unittest.TestCase):
 
         self.hass.states.set(entity_id, STATE_ON, {
             ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS: 255})
+        self.hass.block_till_done()
         acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
         self.assertEqual(acc.char_brightness.value, 0)
 
@@ -141,6 +143,7 @@ class TestHomekitLights(unittest.TestCase):
         self.hass.states.set(entity_id, STATE_ON, {
             ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR_TEMP,
             ATTR_COLOR_TEMP: 190})
+        self.hass.block_till_done()
         acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
         self.assertEqual(acc.char_color_temperature.value, 153)
 
@@ -164,6 +167,7 @@ class TestHomekitLights(unittest.TestCase):
         self.hass.states.set(entity_id, STATE_ON, {
             ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR,
             ATTR_HS_COLOR: (260, 90)})
+        self.hass.block_till_done()
         acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
         self.assertEqual(acc.char_hue.value, 0)
         self.assertEqual(acc.char_saturation.value, 75)

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -50,9 +50,10 @@ class TestHomekitLights(unittest.TestCase):
     def test_light_basic(self):
         """Test light with char state."""
         entity_id = 'light.demo'
+
         self.hass.states.set(entity_id, STATE_ON,
                              {ATTR_SUPPORTED_FEATURES: 0})
-        acc = self.light_cls(self.hass, entity_id, 'Light', aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, aid=2)
         self.assertEqual(acc.aid, 2)
         self.assertEqual(acc.category, 5)  # Lightbulb
         self.assertEqual(acc.char_on.value, 0)
@@ -94,9 +95,10 @@ class TestHomekitLights(unittest.TestCase):
     def test_light_brightness(self):
         """Test light with brightness."""
         entity_id = 'light.demo'
+
         self.hass.states.set(entity_id, STATE_ON, {
             ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS: 255})
-        acc = self.light_cls(self.hass, entity_id, 'Light', aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, aid=2)
         self.assertEqual(acc.char_brightness.value, 0)
 
         acc.run()
@@ -135,10 +137,11 @@ class TestHomekitLights(unittest.TestCase):
     def test_light_color_temperature(self):
         """Test light with color temperature."""
         entity_id = 'light.demo'
+
         self.hass.states.set(entity_id, STATE_ON, {
             ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR_TEMP,
             ATTR_COLOR_TEMP: 190})
-        acc = self.light_cls(self.hass, entity_id, 'Light', aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, aid=2)
         self.assertEqual(acc.char_color_temperature.value, 153)
 
         acc.run()
@@ -157,10 +160,11 @@ class TestHomekitLights(unittest.TestCase):
     def test_light_rgb_color(self):
         """Test light with rgb_color."""
         entity_id = 'light.demo'
+
         self.hass.states.set(entity_id, STATE_ON, {
             ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR,
             ATTR_HS_COLOR: (260, 90)})
-        acc = self.light_cls(self.hass, entity_id, 'Light', aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, aid=2)
         self.assertEqual(acc.char_hue.value, 0)
         self.assertEqual(acc.char_saturation.value, 75)
 

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -54,7 +54,7 @@ class TestHomekitLights(unittest.TestCase):
         self.hass.states.set(entity_id, STATE_ON,
                              {ATTR_SUPPORTED_FEATURES: 0})
         self.hass.block_till_done()
-        acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, 2, config=None)
         self.assertEqual(acc.aid, 2)
         self.assertEqual(acc.category, 5)  # Lightbulb
         self.assertEqual(acc.char_on.value, 0)
@@ -100,7 +100,7 @@ class TestHomekitLights(unittest.TestCase):
         self.hass.states.set(entity_id, STATE_ON, {
             ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS: 255})
         self.hass.block_till_done()
-        acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, 2, config=None)
         self.assertEqual(acc.char_brightness.value, 0)
 
         acc.run()
@@ -144,7 +144,7 @@ class TestHomekitLights(unittest.TestCase):
             ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR_TEMP,
             ATTR_COLOR_TEMP: 190})
         self.hass.block_till_done()
-        acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, 2, config=None)
         self.assertEqual(acc.char_color_temperature.value, 153)
 
         acc.run()
@@ -168,7 +168,7 @@ class TestHomekitLights(unittest.TestCase):
             ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR,
             ATTR_HS_COLOR: (260, 90)})
         self.hass.block_till_done()
-        acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, 2, config=None)
         self.assertEqual(acc.char_hue.value, 0)
         self.assertEqual(acc.char_saturation.value, 75)
 

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -53,7 +53,7 @@ class TestHomekitLights(unittest.TestCase):
 
         self.hass.states.set(entity_id, STATE_ON,
                              {ATTR_SUPPORTED_FEATURES: 0})
-        acc = self.light_cls(self.hass, 'Light', entity_id, aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
         self.assertEqual(acc.aid, 2)
         self.assertEqual(acc.category, 5)  # Lightbulb
         self.assertEqual(acc.char_on.value, 0)
@@ -98,7 +98,7 @@ class TestHomekitLights(unittest.TestCase):
 
         self.hass.states.set(entity_id, STATE_ON, {
             ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS: 255})
-        acc = self.light_cls(self.hass, 'Light', entity_id, aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
         self.assertEqual(acc.char_brightness.value, 0)
 
         acc.run()
@@ -141,7 +141,7 @@ class TestHomekitLights(unittest.TestCase):
         self.hass.states.set(entity_id, STATE_ON, {
             ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR_TEMP,
             ATTR_COLOR_TEMP: 190})
-        acc = self.light_cls(self.hass, 'Light', entity_id, aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
         self.assertEqual(acc.char_color_temperature.value, 153)
 
         acc.run()
@@ -164,7 +164,7 @@ class TestHomekitLights(unittest.TestCase):
         self.hass.states.set(entity_id, STATE_ON, {
             ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR,
             ATTR_HS_COLOR: (260, 90)})
-        acc = self.light_cls(self.hass, 'Light', entity_id, aid=2)
+        acc = self.light_cls(self.hass, 'Light', entity_id, None, aid=2)
         self.assertEqual(acc.char_hue.value, 0)
         self.assertEqual(acc.char_saturation.value, 75)
 

--- a/tests/components/homekit/test_type_locks.py
+++ b/tests/components/homekit/test_type_locks.py
@@ -33,7 +33,7 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         kitchen_lock = 'lock.kitchen_door'
 
-        acc = Lock(self.hass, kitchen_lock, 'Lock', aid=2)
+        acc = Lock(self.hass, 'Lock', kitchen_lock, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)

--- a/tests/components/homekit/test_type_locks.py
+++ b/tests/components/homekit/test_type_locks.py
@@ -33,7 +33,7 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         kitchen_lock = 'lock.kitchen_door'
 
-        acc = Lock(self.hass, 'Lock', kitchen_lock, None, aid=2)
+        acc = Lock(self.hass, 'Lock', kitchen_lock, 2, config=None)
         acc.run()
 
         self.assertEqual(acc.aid, 2)

--- a/tests/components/homekit/test_type_locks.py
+++ b/tests/components/homekit/test_type_locks.py
@@ -33,7 +33,7 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         kitchen_lock = 'lock.kitchen_door'
 
-        acc = Lock(self.hass, 'Lock', kitchen_lock, aid=2)
+        acc = Lock(self.hass, 'Lock', kitchen_lock, None, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)

--- a/tests/components/homekit/test_type_security_systems.py
+++ b/tests/components/homekit/test_type_security_systems.py
@@ -36,7 +36,7 @@ class TestHomekitSecuritySystems(unittest.TestCase):
         acp = 'alarm_control_panel.test'
 
         acc = SecuritySystem(self.hass, 'SecuritySystem', acp,
-                             {ATTR_CODE: '1234'}, aid=2)
+                             2, config={ATTR_CODE: '1234'})
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -108,7 +108,7 @@ class TestHomekitSecuritySystems(unittest.TestCase):
         acp = 'alarm_control_panel.test'
 
         acc = SecuritySystem(self.hass, 'SecuritySystem', acp,
-                             {ATTR_CODE: None}, aid=2)
+                             2, config={ATTR_CODE: None})
         acc.run()
 
         # Set from HomeKit

--- a/tests/components/homekit/test_type_security_systems.py
+++ b/tests/components/homekit/test_type_security_systems.py
@@ -36,7 +36,7 @@ class TestHomekitSecuritySystems(unittest.TestCase):
         acp = 'alarm_control_panel.test'
 
         acc = SecuritySystem(self.hass, 'SecuritySystem', acp,
-                             alarm_code='1234', aid=2)
+                             {ATTR_CODE: '1234'}, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -108,7 +108,7 @@ class TestHomekitSecuritySystems(unittest.TestCase):
         acp = 'alarm_control_panel.test'
 
         acc = SecuritySystem(self.hass, 'SecuritySystem', acp,
-                             alarm_code=None, aid=2)
+                             {ATTR_CODE: None}, aid=2)
         acc.run()
 
         # Set from HomeKit

--- a/tests/components/homekit/test_type_security_systems.py
+++ b/tests/components/homekit/test_type_security_systems.py
@@ -35,7 +35,7 @@ class TestHomekitSecuritySystems(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         acp = 'alarm_control_panel.test'
 
-        acc = SecuritySystem(self.hass, acp, 'SecuritySystem',
+        acc = SecuritySystem(self.hass, 'SecuritySystem', acp,
                              alarm_code='1234', aid=2)
         acc.run()
 
@@ -107,7 +107,7 @@ class TestHomekitSecuritySystems(unittest.TestCase):
         """Test accessory if security_system doesn't require a alarm_code."""
         acp = 'alarm_control_panel.test'
 
-        acc = SecuritySystem(self.hass, acp, 'SecuritySystem',
+        acc = SecuritySystem(self.hass, 'SecuritySystem', acp,
                              alarm_code=None, aid=2)
         acc.run()
 

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -26,7 +26,7 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory is updated after state change."""
         entity_id = 'sensor.temperature'
 
-        acc = TemperatureSensor(self.hass, entity_id, 'Temperature', aid=2)
+        acc = TemperatureSensor(self.hass, 'Temperature', entity_id, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -54,7 +54,7 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory is updated after state change."""
         entity_id = 'sensor.humidity'
 
-        acc = HumiditySensor(self.hass, entity_id, 'Humidity', aid=2)
+        acc = HumiditySensor(self.hass, 'Humidity', entity_id, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -78,7 +78,7 @@ class TestHomekitSensors(unittest.TestCase):
                              {ATTR_DEVICE_CLASS: "opening"})
         self.hass.block_till_done()
 
-        acc = BinarySensor(self.hass, entity_id, 'Window Opening', aid=2)
+        acc = BinarySensor(self.hass, 'Window Opening', entity_id, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -118,6 +118,6 @@ class TestHomekitSensors(unittest.TestCase):
                                  {ATTR_DEVICE_CLASS: device_class})
             self.hass.block_till_done()
 
-            acc = BinarySensor(self.hass, entity_id, 'Binary Sensor', aid=2)
+            acc = BinarySensor(self.hass, 'Binary Sensor', entity_id, aid=2)
             self.assertEqual(acc.get_service(service).display_name, service)
             self.assertEqual(acc.char_detected.display_name, char)

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -26,7 +26,8 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory is updated after state change."""
         entity_id = 'sensor.temperature'
 
-        acc = TemperatureSensor(self.hass, 'Temperature', entity_id, aid=2)
+        acc = TemperatureSensor(self.hass, 'Temperature', entity_id,
+                                None, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -54,7 +55,7 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory is updated after state change."""
         entity_id = 'sensor.humidity'
 
-        acc = HumiditySensor(self.hass, 'Humidity', entity_id, aid=2)
+        acc = HumiditySensor(self.hass, 'Humidity', entity_id, None, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -78,7 +79,7 @@ class TestHomekitSensors(unittest.TestCase):
                              {ATTR_DEVICE_CLASS: "opening"})
         self.hass.block_till_done()
 
-        acc = BinarySensor(self.hass, 'Window Opening', entity_id, aid=2)
+        acc = BinarySensor(self.hass, 'Window Opening', entity_id, None, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -118,6 +119,7 @@ class TestHomekitSensors(unittest.TestCase):
                                  {ATTR_DEVICE_CLASS: device_class})
             self.hass.block_till_done()
 
-            acc = BinarySensor(self.hass, 'Binary Sensor', entity_id, aid=2)
+            acc = BinarySensor(self.hass, 'Binary Sensor', entity_id,
+                               None, aid=2)
             self.assertEqual(acc.get_service(service).display_name, service)
             self.assertEqual(acc.char_detected.display_name, char)

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -27,7 +27,7 @@ class TestHomekitSensors(unittest.TestCase):
         entity_id = 'sensor.temperature'
 
         acc = TemperatureSensor(self.hass, 'Temperature', entity_id,
-                                None, aid=2)
+                                2, config=None)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -55,7 +55,7 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory is updated after state change."""
         entity_id = 'sensor.humidity'
 
-        acc = HumiditySensor(self.hass, 'Humidity', entity_id, None, aid=2)
+        acc = HumiditySensor(self.hass, 'Humidity', entity_id, 2, config=None)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -79,7 +79,8 @@ class TestHomekitSensors(unittest.TestCase):
                              {ATTR_DEVICE_CLASS: "opening"})
         self.hass.block_till_done()
 
-        acc = BinarySensor(self.hass, 'Window Opening', entity_id, None, aid=2)
+        acc = BinarySensor(self.hass, 'Window Opening', entity_id,
+                           2, config=None)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -120,6 +121,6 @@ class TestHomekitSensors(unittest.TestCase):
             self.hass.block_till_done()
 
             acc = BinarySensor(self.hass, 'Binary Sensor', entity_id,
-                               None, aid=2)
+                               2, config=None)
             self.assertEqual(acc.get_service(service).display_name, service)
             self.assertEqual(acc.char_detected.display_name, char)

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -34,7 +34,7 @@ class TestHomekitSwitches(unittest.TestCase):
         entity_id = 'switch.test'
         domain = split_entity_id(entity_id)[0]
 
-        acc = Switch(self.hass, entity_id, 'Switch', aid=2)
+        acc = Switch(self.hass, 'Switch', entity_id, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -70,7 +70,7 @@ class TestHomekitSwitches(unittest.TestCase):
         entity_id = 'remote.test'
         domain = split_entity_id(entity_id)[0]
 
-        acc = Switch(self.hass, entity_id, 'Switch', aid=2)
+        acc = Switch(self.hass, 'Switch', entity_id, aid=2)
         acc.run()
 
         self.assertEqual(acc.char_on.value, False)
@@ -89,7 +89,7 @@ class TestHomekitSwitches(unittest.TestCase):
         entity_id = 'input_boolean.test'
         domain = split_entity_id(entity_id)[0]
 
-        acc = Switch(self.hass, entity_id, 'Switch', aid=2)
+        acc = Switch(self.hass, 'Switch', entity_id, aid=2)
         acc.run()
 
         self.assertEqual(acc.char_on.value, False)

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -34,7 +34,7 @@ class TestHomekitSwitches(unittest.TestCase):
         entity_id = 'switch.test'
         domain = split_entity_id(entity_id)[0]
 
-        acc = Switch(self.hass, 'Switch', entity_id, None, aid=2)
+        acc = Switch(self.hass, 'Switch', entity_id, 2, config=None)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -70,7 +70,7 @@ class TestHomekitSwitches(unittest.TestCase):
         entity_id = 'remote.test'
         domain = split_entity_id(entity_id)[0]
 
-        acc = Switch(self.hass, 'Switch', entity_id, None, aid=2)
+        acc = Switch(self.hass, 'Switch', entity_id, 2, config=None)
         acc.run()
 
         self.assertEqual(acc.char_on.value, False)
@@ -89,7 +89,7 @@ class TestHomekitSwitches(unittest.TestCase):
         entity_id = 'input_boolean.test'
         domain = split_entity_id(entity_id)[0]
 
-        acc = Switch(self.hass, 'Switch', entity_id, None, aid=2)
+        acc = Switch(self.hass, 'Switch', entity_id, 2, config=None)
         acc.run()
 
         self.assertEqual(acc.char_on.value, False)

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -34,7 +34,7 @@ class TestHomekitSwitches(unittest.TestCase):
         entity_id = 'switch.test'
         domain = split_entity_id(entity_id)[0]
 
-        acc = Switch(self.hass, 'Switch', entity_id, aid=2)
+        acc = Switch(self.hass, 'Switch', entity_id, None, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -70,7 +70,7 @@ class TestHomekitSwitches(unittest.TestCase):
         entity_id = 'remote.test'
         domain = split_entity_id(entity_id)[0]
 
-        acc = Switch(self.hass, 'Switch', entity_id, aid=2)
+        acc = Switch(self.hass, 'Switch', entity_id, None, aid=2)
         acc.run()
 
         self.assertEqual(acc.char_on.value, False)
@@ -89,7 +89,7 @@ class TestHomekitSwitches(unittest.TestCase):
         entity_id = 'input_boolean.test'
         domain = split_entity_id(entity_id)[0]
 
-        acc = Switch(self.hass, 'Switch', entity_id, aid=2)
+        acc = Switch(self.hass, 'Switch', entity_id, None, aid=2)
         acc.run()
 
         self.assertEqual(acc.char_on.value, False)

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -7,8 +7,9 @@ from homeassistant.components.climate import (
     ATTR_TARGET_TEMP_LOW, ATTR_TARGET_TEMP_HIGH, ATTR_OPERATION_MODE,
     ATTR_OPERATION_LIST, STATE_COOL, STATE_HEAT, STATE_AUTO)
 from homeassistant.const import (
-    ATTR_SERVICE, EVENT_CALL_SERVICE, ATTR_SERVICE_DATA,
-    ATTR_UNIT_OF_MEASUREMENT, STATE_OFF, TEMP_CELSIUS, TEMP_FAHRENHEIT)
+    ATTR_SERVICE, ATTR_SERVICE_DATA, ATTR_SUPPORTED_FEATURES,
+    ATTR_UNIT_OF_MEASUREMENT, EVENT_CALL_SERVICE,
+    STATE_OFF, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
 from tests.common import get_test_home_assistant
 from tests.components.homekit.test_accessories import patch_debounce
@@ -52,8 +53,9 @@ class TestHomekitThermostats(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         climate = 'climate.test'
 
-        acc = self.thermostat_cls(self.hass, 'Climate', climate,
-                                  {'support_auto': False}, aid=2)
+        self.hass.states.set(climate, STATE_OFF, {ATTR_SUPPORTED_FEATURES: 0})
+        self.hass.block_till_done()
+        acc = self.thermostat_cls(self.hass, 'Climate', climate, None, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -188,8 +190,10 @@ class TestHomekitThermostats(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         climate = 'climate.test'
 
-        acc = self.thermostat_cls(self.hass, 'Climate', climate,
-                                  {'support_auto': True}, aid=2)
+        # support_auto = True
+        self.hass.states.set(climate, STATE_OFF, {ATTR_SUPPORTED_FEATURES: 6})
+        self.hass.block_till_done()
+        acc = self.thermostat_cls(self.hass, 'Climate', climate, None, aid=2)
         acc.run()
 
         self.assertEqual(acc.char_cooling_thresh_temp.value, 23.0)
@@ -259,8 +263,10 @@ class TestHomekitThermostats(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         climate = 'climate.test'
 
-        acc = self.thermostat_cls(self.hass, 'Climate', climate,
-                                  {'support_auto': True}, aid=2)
+        # support_auto = True
+        self.hass.states.set(climate, STATE_OFF, {ATTR_SUPPORTED_FEATURES: 6})
+        self.hass.block_till_done()
+        acc = self.thermostat_cls(self.hass, 'Climate', climate, None, aid=2)
         acc.run()
 
         self.hass.states.set(climate, STATE_AUTO,

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -52,7 +52,7 @@ class TestHomekitThermostats(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         climate = 'climate.test'
 
-        acc = self.thermostat_cls(self.hass, climate, 'Climate', False, aid=2)
+        acc = self.thermostat_cls(self.hass, 'Climate', climate, False, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -187,7 +187,7 @@ class TestHomekitThermostats(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         climate = 'climate.test'
 
-        acc = self.thermostat_cls(self.hass, climate, 'Climate', True)
+        acc = self.thermostat_cls(self.hass, 'Climate', climate, True)
         acc.run()
 
         self.assertEqual(acc.char_cooling_thresh_temp.value, 23.0)
@@ -257,7 +257,7 @@ class TestHomekitThermostats(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         climate = 'climate.test'
 
-        acc = self.thermostat_cls(self.hass, climate, 'Climate', True)
+        acc = self.thermostat_cls(self.hass, 'Climate', climate, True)
         acc.run()
 
         self.hass.states.set(climate, STATE_AUTO,

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -52,7 +52,8 @@ class TestHomekitThermostats(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         climate = 'climate.test'
 
-        acc = self.thermostat_cls(self.hass, 'Climate', climate, False, aid=2)
+        acc = self.thermostat_cls(self.hass, 'Climate', climate,
+                                  {'support_auto': False}, aid=2)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -187,7 +188,8 @@ class TestHomekitThermostats(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         climate = 'climate.test'
 
-        acc = self.thermostat_cls(self.hass, 'Climate', climate, True)
+        acc = self.thermostat_cls(self.hass, 'Climate', climate,
+                                  {'support_auto': True}, aid=2)
         acc.run()
 
         self.assertEqual(acc.char_cooling_thresh_temp.value, 23.0)
@@ -257,7 +259,8 @@ class TestHomekitThermostats(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         climate = 'climate.test'
 
-        acc = self.thermostat_cls(self.hass, 'Climate', climate, True)
+        acc = self.thermostat_cls(self.hass, 'Climate', climate,
+                                  {'support_auto': True}, aid=2)
         acc.run()
 
         self.hass.states.set(climate, STATE_AUTO,

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -55,7 +55,8 @@ class TestHomekitThermostats(unittest.TestCase):
 
         self.hass.states.set(climate, STATE_OFF, {ATTR_SUPPORTED_FEATURES: 0})
         self.hass.block_till_done()
-        acc = self.thermostat_cls(self.hass, 'Climate', climate, None, aid=2)
+        acc = self.thermostat_cls(self.hass, 'Climate', climate,
+                                  2, config=None)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -193,7 +194,8 @@ class TestHomekitThermostats(unittest.TestCase):
         # support_auto = True
         self.hass.states.set(climate, STATE_OFF, {ATTR_SUPPORTED_FEATURES: 6})
         self.hass.block_till_done()
-        acc = self.thermostat_cls(self.hass, 'Climate', climate, None, aid=2)
+        acc = self.thermostat_cls(self.hass, 'Climate', climate,
+                                  2, config=None)
         acc.run()
 
         self.assertEqual(acc.char_cooling_thresh_temp.value, 23.0)
@@ -266,7 +268,8 @@ class TestHomekitThermostats(unittest.TestCase):
         # support_auto = True
         self.hass.states.set(climate, STATE_OFF, {ATTR_SUPPORTED_FEATURES: 6})
         self.hass.block_till_done()
-        acc = self.thermostat_cls(self.hass, 'Climate', climate, None, aid=2)
+        acc = self.thermostat_cls(self.hass, 'Climate', climate,
+                                  2, config=None)
         acc.run()
 
         self.hass.states.set(climate, STATE_AUTO,

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -58,7 +58,7 @@ class TestUtil(unittest.TestCase):
         """Test show setup message as persistence notification."""
         bridge = HomeBridge(self.hass)
 
-        show_setup_message(bridge, self.hass)
+        show_setup_message(self.hass, bridge)
         self.hass.block_till_done()
 
         data = self.events[0].data


### PR DESCRIPTION
**Follow up to:** #13654 

## Description:
During the last style change @kellerza suggested to rework what is passed into the `HomeAccessory` constructor. I think to following changes might make sense:
 - `hass` is now a class variable of `HomeAccessory` and `HomeBridge` and set during the HomeKit setup. That way it doesn't need to be passed to each accessory individually.
 - For the `HomeAccessory` I added the method `update_state_callback` which checks that the new state isn't `None` (previously done in each type) and calls the `update_state` method.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.