### PR TITLE
Update AbodePy version to 0.12.3

### DIFF
--- a/homeassistant/components/abode.py
+++ b/homeassistant/components/abode.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['abodepy==0.12.2']
+REQUIREMENTS = ['abodepy==0.12.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -64,7 +64,7 @@ WazeRouteCalculator==0.5
 YesssSMS==0.1.1b3
 
 # homeassistant.components.abode
-abodepy==0.12.2
+abodepy==0.12.3
 
 # homeassistant.components.media_player.frontier_silicon
 afsapi==0.0.3


### PR DESCRIPTION
## Description:

Update AbodePy library to version 0.12.3 to fix login failure due to API changes.

**Related issue (if applicable):** fixes #13687