### PR TITLE
Brightness conversion for Abode dimmers

### DIFF
--- a/homeassistant/components/light/abode.py
+++ b/homeassistant/components/light/abode.py
@@ -51,7 +51,12 @@ class AbodeLight(AbodeDevice, Light):
                 *kwargs[ATTR_HS_COLOR]))
 
         if ATTR_BRIGHTNESS in kwargs and self._device.is_dimmable:
-            self._device.set_level(kwargs[ATTR_BRIGHTNESS])
+            # Convert HASS brightness (0-255) to Abode brightness (0-100)
+            brightness = int(kwargs[ATTR_BRIGHTNESS] * 100 / 255)
+            # If 100 is sent to Abode, 99 is returned causing an error
+            if brightness == 100:
+                brightness = 99
+            self._device.set_level(brightness)
         else:
             self._device.switch_on()
 
@@ -68,7 +73,8 @@ class AbodeLight(AbodeDevice, Light):
     def brightness(self):
         """Return the brightness of the light."""
         if self._device.is_dimmable and self._device.has_brightness:
-            return self._device.brightness
+            # Convert Abode brightness (0-100) to HASS brightness (0-255)
+            return int(self._device.brightness) * 255 / 100
 
     @property
     def hs_color(self):

--- a/homeassistant/components/light/abode.py
+++ b/homeassistant/components/light/abode.py
@@ -52,7 +52,7 @@ class AbodeLight(AbodeDevice, Light):
 
         if ATTR_BRIGHTNESS in kwargs and self._device.is_dimmable:
             # Convert HASS brightness (0-255) to Abode brightness (0-99)
-            # If 100 is sent to Abode, 99 is returned causing an error
+            # If 100 is sent to Abode, response is 99 causing an error
             self._device.set_level(ceil(kwargs[ATTR_BRIGHTNESS] * 99 / 255))
         else:
             self._device.switch_on()
@@ -70,9 +70,13 @@ class AbodeLight(AbodeDevice, Light):
     def brightness(self):
         """Return the brightness of the light."""
         if self._device.is_dimmable and self._device.has_brightness:
-            # Convert Abode brightness (0-100) to HASS brightness (0-255)
-            # Abode will return 100 during initialization of Abode
-            return ceil(int(self._device.brightness) * 255 / 100)
+            brightness = int(self._device.brightness)
+            # Abode returns 100 during device initialization and device refresh
+            if brightness == 100:
+                return 255
+            else:
+                # Convert Abode brightness (0-99) to HASS brightness (0-255)
+                return ceil(brightness * 255 / 99)
 
     @property
     def hs_color(self):

--- a/homeassistant/components/light/abode.py
+++ b/homeassistant/components/light/abode.py
@@ -5,13 +5,12 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.abode/
 """
 import logging
-
+from math import ceil
 from homeassistant.components.abode import AbodeDevice, DOMAIN as ABODE_DOMAIN
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_HS_COLOR,
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR, Light)
 import homeassistant.util.color as color_util
-from math import ceil
 
 
 DEPENDENCIES = ['abode']
@@ -52,7 +51,7 @@ class AbodeLight(AbodeDevice, Light):
                 *kwargs[ATTR_HS_COLOR]))
 
         if ATTR_BRIGHTNESS in kwargs and self._device.is_dimmable:
-            # Convert HASS brightness (0-255) to Abode brightness (0-100)
+            # Convert HASS brightness (0-255) to Abode brightness (0-99)
             # If 100 is sent to Abode, 99 is returned causing an error
             self._device.set_level(ceil(kwargs[ATTR_BRIGHTNESS] * 99 / 255))
         else:

--- a/homeassistant/components/light/abode.py
+++ b/homeassistant/components/light/abode.py
@@ -53,7 +53,7 @@ class AbodeLight(AbodeDevice, Light):
         if ATTR_BRIGHTNESS in kwargs and self._device.is_dimmable:
             # Convert HASS brightness (0-255) to Abode brightness (0-99)
             # If 100 is sent to Abode, response is 99 causing an error
-            self._device.set_level(ceil(kwargs[ATTR_BRIGHTNESS] * 99 / 255))
+            self._device.set_level(ceil(kwargs[ATTR_BRIGHTNESS] * 99 / 255.0))
         else:
             self._device.switch_on()
 
@@ -74,9 +74,8 @@ class AbodeLight(AbodeDevice, Light):
             # Abode returns 100 during device initialization and device refresh
             if brightness == 100:
                 return 255
-            else:
-                # Convert Abode brightness (0-99) to HASS brightness (0-255)
-                return ceil(brightness * 255 / 99)
+            # Convert Abode brightness (0-99) to HASS brightness (0-255)
+            return ceil(brightness * 255 / 99.0)
 
     @property
     def hs_color(self):

--- a/homeassistant/components/light/abode.py
+++ b/homeassistant/components/light/abode.py
@@ -11,6 +11,7 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_HS_COLOR,
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR, Light)
 import homeassistant.util.color as color_util
+from math import ceil
 
 
 DEPENDENCIES = ['abode']
@@ -52,11 +53,8 @@ class AbodeLight(AbodeDevice, Light):
 
         if ATTR_BRIGHTNESS in kwargs and self._device.is_dimmable:
             # Convert HASS brightness (0-255) to Abode brightness (0-100)
-            brightness = int(kwargs[ATTR_BRIGHTNESS] * 100 / 255)
             # If 100 is sent to Abode, 99 is returned causing an error
-            if brightness == 100:
-                brightness = 99
-            self._device.set_level(brightness)
+            self._device.set_level(ceil(kwargs[ATTR_BRIGHTNESS] * 99 / 255))
         else:
             self._device.switch_on()
 
@@ -74,7 +72,8 @@ class AbodeLight(AbodeDevice, Light):
         """Return the brightness of the light."""
         if self._device.is_dimmable and self._device.has_brightness:
             # Convert Abode brightness (0-100) to HASS brightness (0-255)
-            return int(self._device.brightness) * 255 / 100
+            # Abode will return 100 during initialization of Abode
+            return ceil(int(self._device.brightness) * 255 / 100)
 
     @property
     def hs_color(self):


### PR DESCRIPTION
With AbodePy 0.12.3, dimmers will now work but a conversion of the brightness is required. Additionally, when a brightness value of 100 is sent to Abode, 99 is returned causing AbodePy to throw an error so this component will send 99 instead of 100.

## Description:


**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable #13709 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
