### PR TITLE
Upgrade pyteleloisirs to 3.4

### DIFF
--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['liveboxplaytv==2.0.2', 'pyteleloisirs==3.3']
+REQUIREMENTS = ['liveboxplaytv==2.0.2', 'pyteleloisirs==3.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -917,7 +917,7 @@ pystride==0.1.7
 pysyncthru==0.3.1
 
 # homeassistant.components.media_player.liveboxplaytv
-pyteleloisirs==3.3
+pyteleloisirs==3.4
 
 # homeassistant.components.sensor.thinkingcleaner
 # homeassistant.components.switch.thinkingcleaner


### PR DESCRIPTION
## Description:
This bumps the pyteleloisirs requirement to 3.4, which uses proper `async`/`await` syntax.

**Related issue (if applicable):** fixes #10175