### PR TITLE
Update Homekit to 1.1.9

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -28,7 +28,7 @@ from .util import (
 TYPES = Registry()
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['HAP-python==1.1.8']
+REQUIREMENTS = ['HAP-python==1.1.9']
 
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -46,7 +46,6 @@ class WindowCovering(HomeAccessory):
 
     def move_cover(self, value):
         """Move cover to value if call came from HomeKit."""
-        self.char_target_position.set_value(value, should_callback=False)
         if value != self.current_position:
             _LOGGER.debug('%s: Set position to %d', self.entity_id, value)
             self.homekit_target = value

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -87,7 +87,6 @@ class Light(HomeAccessory):
 
         _LOGGER.debug('%s: Set state to %d', self.entity_id, value)
         self._flag[CHAR_ON] = True
-        self.char_on.set_value(value, should_callback=False)
 
         if value == 1:
             self.hass.components.light.turn_on(self.entity_id)
@@ -98,7 +97,6 @@ class Light(HomeAccessory):
         """Set brightness if call came from HomeKit."""
         _LOGGER.debug('%s: Set brightness to %d', self.entity_id, value)
         self._flag[CHAR_BRIGHTNESS] = True
-        self.char_brightness.set_value(value, should_callback=False)
         if value != 0:
             self.hass.components.light.turn_on(
                 self.entity_id, brightness_pct=value)
@@ -109,14 +107,12 @@ class Light(HomeAccessory):
         """Set color temperature if call came from HomeKit."""
         _LOGGER.debug('%s: Set color temp to %s', self.entity_id, value)
         self._flag[CHAR_COLOR_TEMPERATURE] = True
-        self.char_color_temperature.set_value(value, should_callback=False)
         self.hass.components.light.turn_on(self.entity_id, color_temp=value)
 
     def set_saturation(self, value):
         """Set saturation if call came from HomeKit."""
         _LOGGER.debug('%s: Set saturation to %d', self.entity_id, value)
         self._flag[CHAR_SATURATION] = True
-        self.char_saturation.set_value(value, should_callback=False)
         self._saturation = value
         self.set_color()
 
@@ -124,7 +120,6 @@ class Light(HomeAccessory):
         """Set hue if call came from HomeKit."""
         _LOGGER.debug('%s: Set hue to %d', self.entity_id, value)
         self._flag[CHAR_HUE] = True
-        self.char_hue.set_value(value, should_callback=False)
         self._hue = value
         self.set_color()
 
@@ -150,7 +145,7 @@ class Light(HomeAccessory):
         if state in (STATE_ON, STATE_OFF):
             self._state = 1 if state == STATE_ON else 0
             if not self._flag[CHAR_ON] and self.char_on.value != self._state:
-                self.char_on.set_value(self._state, should_callback=False)
+                self.char_on.set_value(self._state)
             self._flag[CHAR_ON] = False
 
         # Handle Brightness
@@ -159,8 +154,7 @@ class Light(HomeAccessory):
             if not self._flag[CHAR_BRIGHTNESS] and isinstance(brightness, int):
                 brightness = round(brightness / 255 * 100, 0)
                 if self.char_brightness.value != brightness:
-                    self.char_brightness.set_value(brightness,
-                                                   should_callback=False)
+                    self.char_brightness.set_value(brightness)
             self._flag[CHAR_BRIGHTNESS] = False
 
         # Handle color temperature
@@ -168,8 +162,7 @@ class Light(HomeAccessory):
             color_temperature = new_state.attributes.get(ATTR_COLOR_TEMP)
             if not self._flag[CHAR_COLOR_TEMPERATURE] \
                     and isinstance(color_temperature, int):
-                self.char_color_temperature.set_value(color_temperature,
-                                                      should_callback=False)
+                self.char_color_temperature.set_value(color_temperature)
             self._flag[CHAR_COLOR_TEMPERATURE] = False
 
         # Handle Color
@@ -180,8 +173,7 @@ class Light(HomeAccessory):
                     hue != self._hue or saturation != self._saturation) and \
                     isinstance(hue, (int, float)) and \
                     isinstance(saturation, (int, float)):
-                self.char_hue.set_value(hue, should_callback=False)
-                self.char_saturation.set_value(saturation,
-                                               should_callback=False)
+                self.char_hue.set_value(hue)
+                self.char_saturation.set_value(saturation)
                 self._hue, self._saturation = (hue, saturation)
             self._flag[RGB_COLOR] = False

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -53,7 +53,6 @@ class SecuritySystem(HomeAccessory):
         _LOGGER.debug('%s: Set security state to %d',
                       self.entity_id, value)
         self.flag_target_state = True
-        self.char_target_state.set_value(value, should_callback=False)
         hass_value = HOMEKIT_TO_HASS[value]
         service = STATE_TO_SERVICE[hass_value]
 
@@ -72,13 +71,11 @@ class SecuritySystem(HomeAccessory):
             return
 
         current_security_state = HASS_TO_HOMEKIT[hass_state]
-        self.char_current_state.set_value(current_security_state,
-                                          should_callback=False)
+        self.char_current_state.set_value(current_security_state)
         _LOGGER.debug('%s: Updated current state to %s (%d)',
                       self.entity_id, hass_state, current_security_state)
 
         if not self.flag_target_state:
-            self.char_target_state.set_value(current_security_state,
-                                             should_callback=False)
+            self.char_target_state.set_value(current_security_state)
         if self.char_target_state.value == self.char_current_state.value:
             self.flag_target_state = False

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -44,7 +44,7 @@ class TemperatureSensor(HomeAccessory):
         temperature = convert_to_float(new_state.state)
         if temperature:
             temperature = temperature_to_homekit(temperature, unit)
-            self.char_temp.set_value(temperature, should_callback=False)
+            self.char_temp.set_value(temperature)
             _LOGGER.debug('%s: Current temperature set to %d°C',
                           self.entity_id, temperature)
 
@@ -72,6 +72,6 @@ class HumiditySensor(HomeAccessory):
 
         humidity = convert_to_float(new_state.state)
         if humidity:
-            self.char_humidity.set_value(humidity, should_callback=False)
+            self.char_humidity.set_value(humidity)
             _LOGGER.debug('%s: Percent set to %d%%',
                           self.entity_id, humidity)

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -36,7 +36,6 @@ class Switch(HomeAccessory):
         _LOGGER.debug('%s: Set switch state to %s',
                       self.entity_id, value)
         self.flag_target_state = True
-        self.char_on.set_value(value, should_callback=False)
         service = SERVICE_TURN_ON if value else SERVICE_TURN_OFF
         self.hass.services.call(self._domain, service,
                                 {ATTR_ENTITY_ID: self.entity_id})
@@ -50,6 +49,6 @@ class Switch(HomeAccessory):
         if not self.flag_target_state:
             _LOGGER.debug('%s: Set current state to %s',
                           self.entity_id, current_state)
-            self.char_on.set_value(current_state, should_callback=False)
+            self.char_on.set_value(current_state)
 
         self.flag_target_state = False

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -97,7 +97,6 @@ class Thermostat(HomeAccessory):
 
     def set_heat_cool(self, value):
         """Move operation mode to value if call came from HomeKit."""
-        self.char_target_heat_cool.set_value(value, should_callback=False)
         if value in HC_HOMEKIT_TO_HASS:
             _LOGGER.debug('%s: Set heat-cool to %d', self.entity_id, value)
             self.heat_cool_flag_target_state = True
@@ -110,7 +109,6 @@ class Thermostat(HomeAccessory):
         _LOGGER.debug('%s: Set cooling threshold temperature to %.2f°C',
                       self.entity_id, value)
         self.coolingthresh_flag_target_state = True
-        self.char_cooling_thresh_temp.set_value(value, should_callback=False)
         low = self.char_heating_thresh_temp.value
         low = temperature_to_states(low, self._unit)
         value = temperature_to_states(value, self._unit)
@@ -123,7 +121,6 @@ class Thermostat(HomeAccessory):
         _LOGGER.debug('%s: Set heating threshold temperature to %.2f°C',
                       self.entity_id, value)
         self.heatingthresh_flag_target_state = True
-        self.char_heating_thresh_temp.set_value(value, should_callback=False)
         # Home assistant always wants to set low and high at the same time
         high = self.char_cooling_thresh_temp.value
         high = temperature_to_states(high, self._unit)
@@ -137,7 +134,6 @@ class Thermostat(HomeAccessory):
         _LOGGER.debug('%s: Set target temperature to %.2f°C',
                       self.entity_id, value)
         self.temperature_flag_target_state = True
-        self.char_target_temp.set_value(value, should_callback=False)
         value = temperature_to_states(value, self._unit)
         self.hass.components.climate.set_temperature(
             temperature=value, entity_id=self.entity_id)
@@ -161,8 +157,7 @@ class Thermostat(HomeAccessory):
         if isinstance(target_temp, (int, float)):
             target_temp = temperature_to_homekit(target_temp, self._unit)
             if not self.temperature_flag_target_state:
-                self.char_target_temp.set_value(target_temp,
-                                                should_callback=False)
+                self.char_target_temp.set_value(target_temp)
         self.temperature_flag_target_state = False
 
         # Update cooling threshold temperature if characteristic exists
@@ -172,8 +167,7 @@ class Thermostat(HomeAccessory):
                 cooling_thresh = temperature_to_homekit(cooling_thresh,
                                                         self._unit)
                 if not self.coolingthresh_flag_target_state:
-                    self.char_cooling_thresh_temp.set_value(
-                        cooling_thresh, should_callback=False)
+                    self.char_cooling_thresh_temp.set_value(cooling_thresh)
         self.coolingthresh_flag_target_state = False
 
         # Update heating threshold temperature if characteristic exists
@@ -183,8 +177,7 @@ class Thermostat(HomeAccessory):
                 heating_thresh = temperature_to_homekit(heating_thresh,
                                                         self._unit)
                 if not self.heatingthresh_flag_target_state:
-                    self.char_heating_thresh_temp.set_value(
-                        heating_thresh, should_callback=False)
+                    self.char_heating_thresh_temp.set_value(heating_thresh)
         self.heatingthresh_flag_target_state = False
 
         # Update display units
@@ -197,7 +190,7 @@ class Thermostat(HomeAccessory):
                 and operation_mode in HC_HASS_TO_HOMEKIT:
             if not self.heat_cool_flag_target_state:
                 self.char_target_heat_cool.set_value(
-                    HC_HASS_TO_HOMEKIT[operation_mode], should_callback=False)
+                    HC_HASS_TO_HOMEKIT[operation_mode])
         self.heat_cool_flag_target_state = False
 
         # Set current operation mode based on temperatures and target mode

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -22,7 +22,7 @@ attrs==17.4.0
 DoorBirdPy==0.1.3
 
 # homeassistant.components.homekit
-HAP-python==1.1.8
+HAP-python==1.1.9
 
 # homeassistant.components.notify.mastodon
 Mastodon.py==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -19,7 +19,7 @@ requests_mock==1.4
 
 
 # homeassistant.components.homekit
-HAP-python==1.1.8
+HAP-python==1.1.9
 
 # homeassistant.components.notify.html5
 PyJWT==1.6.0

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -62,7 +62,7 @@ class TestHomekitSensors(unittest.TestCase):
         self.assertEqual(acc.char_position_state.value, 2)
 
         # Set from HomeKit
-        acc.char_target_position.set_value(25)
+        acc.char_target_position.client_update_value(25)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[0].data[ATTR_SERVICE], 'set_cover_position')
@@ -74,7 +74,7 @@ class TestHomekitSensors(unittest.TestCase):
         self.assertEqual(acc.char_position_state.value, 0)
 
         # Set from HomeKit
-        acc.char_target_position.set_value(75)
+        acc.char_target_position.client_update_value(75)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[0].data[ATTR_SERVICE], 'set_cover_position')

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -57,7 +57,7 @@ class TestHomekitLights(unittest.TestCase):
         self.assertEqual(acc.char_on.value, 0)
 
         # Set from HomeKit
-        acc.char_on.set_value(1)
+        acc.char_on.client_update_value(1)
         self.hass.block_till_done()
         self.assertEqual(self.events[0].data[ATTR_DOMAIN], DOMAIN)
         self.assertEqual(self.events[0].data[ATTR_SERVICE], SERVICE_TURN_ON)
@@ -65,7 +65,7 @@ class TestHomekitLights(unittest.TestCase):
         self.hass.states.set(entity_id, STATE_ON)
         self.hass.block_till_done()
 
-        acc.char_on.set_value(0)
+        acc.char_on.client_update_value(0)
         self.hass.block_till_done()
         self.assertEqual(self.events[1].data[ATTR_DOMAIN], DOMAIN)
         self.assertEqual(self.events[1].data[ATTR_SERVICE], SERVICE_TURN_OFF)
@@ -94,8 +94,8 @@ class TestHomekitLights(unittest.TestCase):
         self.assertEqual(acc.char_brightness.value, 40)
 
         # Set from HomeKit
-        acc.char_brightness.set_value(20)
-        acc.char_on.set_value(1)
+        acc.char_brightness.client_update_value(20)
+        acc.char_on.client_update_value(1)
         self.hass.block_till_done()
         self.assertEqual(self.events[0].data[ATTR_DOMAIN], DOMAIN)
         self.assertEqual(self.events[0].data[ATTR_SERVICE], SERVICE_TURN_ON)
@@ -103,8 +103,8 @@ class TestHomekitLights(unittest.TestCase):
             self.events[0].data[ATTR_SERVICE_DATA], {
                 ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS_PCT: 20})
 
-        acc.char_on.set_value(1)
-        acc.char_brightness.set_value(40)
+        acc.char_on.client_update_value(1)
+        acc.char_brightness.client_update_value(40)
         self.hass.block_till_done()
         self.assertEqual(self.events[1].data[ATTR_DOMAIN], DOMAIN)
         self.assertEqual(self.events[1].data[ATTR_SERVICE], SERVICE_TURN_ON)
@@ -112,8 +112,8 @@ class TestHomekitLights(unittest.TestCase):
             self.events[1].data[ATTR_SERVICE_DATA], {
                 ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS_PCT: 40})
 
-        acc.char_on.set_value(1)
-        acc.char_brightness.set_value(0)
+        acc.char_on.client_update_value(1)
+        acc.char_brightness.client_update_value(0)
         self.hass.block_till_done()
         self.assertEqual(self.events[2].data[ATTR_DOMAIN], DOMAIN)
         self.assertEqual(self.events[2].data[ATTR_SERVICE], SERVICE_TURN_OFF)
@@ -132,7 +132,7 @@ class TestHomekitLights(unittest.TestCase):
         self.assertEqual(acc.char_color_temperature.value, 190)
 
         # Set from HomeKit
-        acc.char_color_temperature.set_value(250)
+        acc.char_color_temperature.client_update_value(250)
         self.hass.block_till_done()
         self.assertEqual(self.events[0].data[ATTR_DOMAIN], DOMAIN)
         self.assertEqual(self.events[0].data[ATTR_SERVICE], SERVICE_TURN_ON)
@@ -156,8 +156,8 @@ class TestHomekitLights(unittest.TestCase):
         self.assertEqual(acc.char_saturation.value, 90)
 
         # Set from HomeKit
-        acc.char_hue.set_value(145)
-        acc.char_saturation.set_value(75)
+        acc.char_hue.client_update_value(145)
+        acc.char_saturation.client_update_value(75)
         self.hass.block_till_done()
         self.assertEqual(self.events[0].data[ATTR_DOMAIN], DOMAIN)
         self.assertEqual(self.events[0].data[ATTR_SERVICE], SERVICE_TURN_ON)

--- a/tests/components/homekit/test_type_security_systems.py
+++ b/tests/components/homekit/test_type_security_systems.py
@@ -71,7 +71,7 @@ class TestHomekitSecuritySystems(unittest.TestCase):
         self.assertEqual(acc.char_current_state.value, 3)
 
         # Set from HomeKit
-        acc.char_target_state.set_value(0)
+        acc.char_target_state.client_update_value(0)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[0].data[ATTR_SERVICE], 'alarm_arm_home')
@@ -79,7 +79,7 @@ class TestHomekitSecuritySystems(unittest.TestCase):
             self.events[0].data[ATTR_SERVICE_DATA][ATTR_CODE], '1234')
         self.assertEqual(acc.char_target_state.value, 0)
 
-        acc.char_target_state.set_value(1)
+        acc.char_target_state.client_update_value(1)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[1].data[ATTR_SERVICE], 'alarm_arm_away')
@@ -87,7 +87,7 @@ class TestHomekitSecuritySystems(unittest.TestCase):
             self.events[0].data[ATTR_SERVICE_DATA][ATTR_CODE], '1234')
         self.assertEqual(acc.char_target_state.value, 1)
 
-        acc.char_target_state.set_value(2)
+        acc.char_target_state.client_update_value(2)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[2].data[ATTR_SERVICE], 'alarm_arm_night')
@@ -95,7 +95,7 @@ class TestHomekitSecuritySystems(unittest.TestCase):
             self.events[0].data[ATTR_SERVICE_DATA][ATTR_CODE], '1234')
         self.assertEqual(acc.char_target_state.value, 2)
 
-        acc.char_target_state.set_value(3)
+        acc.char_target_state.client_update_value(3)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[3].data[ATTR_SERVICE], 'alarm_disarm')
@@ -112,7 +112,7 @@ class TestHomekitSecuritySystems(unittest.TestCase):
         acc.run()
 
         # Set from HomeKit
-        acc.char_target_state.set_value(0)
+        acc.char_target_state.client_update_value(0)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[0].data[ATTR_SERVICE], 'alarm_arm_home')

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -51,14 +51,14 @@ class TestHomekitSwitches(unittest.TestCase):
         self.assertEqual(acc.char_on.value, False)
 
         # Set from HomeKit
-        acc.char_on.set_value(True)
+        acc.char_on.client_update_value(True)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[0].data[ATTR_DOMAIN], domain)
         self.assertEqual(
             self.events[0].data[ATTR_SERVICE], SERVICE_TURN_ON)
 
-        acc.char_on.set_value(False)
+        acc.char_on.client_update_value(False)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[1].data[ATTR_DOMAIN], domain)
@@ -76,7 +76,7 @@ class TestHomekitSwitches(unittest.TestCase):
         self.assertEqual(acc.char_on.value, False)
 
         # Set from HomeKit
-        acc.char_on.set_value(True)
+        acc.char_on.client_update_value(True)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[0].data[ATTR_DOMAIN], domain)
@@ -95,7 +95,7 @@ class TestHomekitSwitches(unittest.TestCase):
         self.assertEqual(acc.char_on.value, False)
 
         # Set from HomeKit
-        acc.char_on.set_value(True)
+        acc.char_on.client_update_value(True)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[0].data[ATTR_DOMAIN], domain)

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -151,7 +151,7 @@ class TestHomekitThermostats(unittest.TestCase):
         self.assertEqual(acc.char_display_units.value, 0)
 
         # Set from HomeKit
-        acc.char_target_temp.set_value(19.0)
+        acc.char_target_temp.client_update_value(19.0)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[0].data[ATTR_SERVICE], 'set_temperature')
@@ -159,7 +159,7 @@ class TestHomekitThermostats(unittest.TestCase):
             self.events[0].data[ATTR_SERVICE_DATA][ATTR_TEMPERATURE], 19.0)
         self.assertEqual(acc.char_target_temp.value, 19.0)
 
-        acc.char_target_heat_cool.set_value(1)
+        acc.char_target_heat_cool.client_update_value(1)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[1].data[ATTR_SERVICE], 'set_operation_mode')
@@ -221,7 +221,7 @@ class TestHomekitThermostats(unittest.TestCase):
         self.assertEqual(acc.char_display_units.value, 0)
 
         # Set from HomeKit
-        acc.char_heating_thresh_temp.set_value(20.0)
+        acc.char_heating_thresh_temp.client_update_value(20.0)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[0].data[ATTR_SERVICE], 'set_temperature')
@@ -229,7 +229,7 @@ class TestHomekitThermostats(unittest.TestCase):
             self.events[0].data[ATTR_SERVICE_DATA][ATTR_TARGET_TEMP_LOW], 20.0)
         self.assertEqual(acc.char_heating_thresh_temp.value, 20.0)
 
-        acc.char_cooling_thresh_temp.set_value(25.0)
+        acc.char_cooling_thresh_temp.client_update_value(25.0)
         self.hass.block_till_done()
         self.assertEqual(
             self.events[1].data[ATTR_SERVICE], 'set_temperature')
@@ -260,19 +260,19 @@ class TestHomekitThermostats(unittest.TestCase):
         self.assertEqual(acc.char_display_units.value, 1)
 
         # Set from HomeKit
-        acc.char_cooling_thresh_temp.set_value(23)
+        acc.char_cooling_thresh_temp.client_update_value(23)
         self.hass.block_till_done()
         service_data = self.events[-1].data[ATTR_SERVICE_DATA]
         self.assertEqual(service_data[ATTR_TARGET_TEMP_HIGH], 73.4)
         self.assertEqual(service_data[ATTR_TARGET_TEMP_LOW], 68)
 
-        acc.char_heating_thresh_temp.set_value(22)
+        acc.char_heating_thresh_temp.client_update_value(22)
         self.hass.block_till_done()
         service_data = self.events[-1].data[ATTR_SERVICE_DATA]
         self.assertEqual(service_data[ATTR_TARGET_TEMP_HIGH], 73.4)
         self.assertEqual(service_data[ATTR_TARGET_TEMP_LOW], 71.6)
 
-        acc.char_target_temp.set_value(24.0)
+        acc.char_target_temp.client_update_value(24.0)
         self.hass.block_till_done()
         service_data = self.events[-1].data[ATTR_SERVICE_DATA]
         self.assertEqual(service_data[ATTR_TEMPERATURE], 75.2)


### PR DESCRIPTION
## Changelog:
 - No longer necessary to call `self.char.set_value(value, should_callback=False)` in the `setter_callback` method
 - The parameter `should_callback` has been removed from `set_value`
 - Tests should use `client_update_value` instead of `set_value` to emulate char set by HomeKit

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**