### PR TITLE
Add unique_id to MQTT switch

### DIFF
--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -144,6 +144,7 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
         """Return a unique ID."""
         return self._unique_id
 
+    @property
     def icon(self):
         """Return the icon."""
         return self._icon

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/switch.mqtt/
 """
 import asyncio
 import logging
+from typing import Optional
 
 import voluptuous as vol
 
@@ -29,12 +30,14 @@ DEFAULT_NAME = 'MQTT Switch'
 DEFAULT_PAYLOAD_ON = 'ON'
 DEFAULT_PAYLOAD_OFF = 'OFF'
 DEFAULT_OPTIMISTIC = False
+CONF_UNIQUE_ID = 'unique_id'
 
 PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_ICON): cv.icon,
     vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
     vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
+    vol.Optional(CONF_UNIQUE_ID): cv.string,
     vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
@@ -62,6 +65,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_OPTIMISTIC),
         config.get(CONF_PAYLOAD_AVAILABLE),
         config.get(CONF_PAYLOAD_NOT_AVAILABLE),
+        config.get(CONF_UNIQUE_ID),
         value_template,
     )])
 
@@ -72,7 +76,7 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
     def __init__(self, name, icon,
                  state_topic, command_topic, availability_topic,
                  qos, retain, payload_on, payload_off, optimistic,
-                 payload_available, payload_not_available, value_template):
+                 payload_available, payload_not_available, unique_id: Optional[str], value_template):
         """Initialize the MQTT switch."""
         super().__init__(availability_topic, qos, payload_available,
                          payload_not_available)
@@ -87,6 +91,7 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
         self._payload_off = payload_off
         self._optimistic = optimistic
         self._template = value_template
+        self._unique_id = unique_id
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -135,6 +140,10 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
         return self._optimistic
 
     @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
+
     def icon(self):
         """Return the icon."""
         return self._icon

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -76,7 +76,8 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
     def __init__(self, name, icon,
                  state_topic, command_topic, availability_topic,
                  qos, retain, payload_on, payload_off, optimistic,
-                 payload_available, payload_not_available, unique_id: Optional[str], value_template):
+                 payload_available, payload_not_available,
+                 unique_id: Optional[str], value_template):
         """Initialize the MQTT switch."""
         super().__init__(availability_topic, qos, payload_available,
                          payload_not_available)

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -242,3 +242,23 @@ class TestSwitchMQTT(unittest.TestCase):
 
         state = self.hass.states.get('switch.test')
         self.assertEqual(STATE_ON, state.state)
+        
+    def test_unique_id(self):
+        """Test unique id option only creates one switch per unique_id."""
+        assert setup_component(self.hass, switch.DOMAIN, {
+            switch.DOMAIN: [{
+                'platform': 'mqtt',
+                'name': 'Test 1',
+                'state_topic': 'test-topic',
+                'unique_id': 'TOTALLY_UNIQUE'
+            }, {
+                'platform': 'mqtt',
+                'name': 'Test 2',
+                'state_topic': 'test-topic',
+                'unique_id': 'TOTALLY_UNIQUE'
+            }]
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', 'payload')
+        self.hass.block_till_done()
+        assert len(self.hass.states.all()) == 1

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -242,7 +242,7 @@ class TestSwitchMQTT(unittest.TestCase):
 
         state = self.hass.states.get('switch.test')
         self.assertEqual(STATE_ON, state.state)
-        
+
     def test_unique_id(self):
         """Test unique id option only creates one switch per unique_id."""
         assert setup_component(self.hass, switch.DOMAIN, {

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -250,11 +250,13 @@ class TestSwitchMQTT(unittest.TestCase):
                 'platform': 'mqtt',
                 'name': 'Test 1',
                 'state_topic': 'test-topic',
+                'command_topic': 'command-topic',
                 'unique_id': 'TOTALLY_UNIQUE'
             }, {
                 'platform': 'mqtt',
                 'name': 'Test 2',
                 'state_topic': 'test-topic',
+                'command_topic': 'command-topic',
                 'unique_id': 'TOTALLY_UNIQUE'
             }]
         })

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -264,4 +264,4 @@ class TestSwitchMQTT(unittest.TestCase):
         fire_mqtt_message(self.hass, 'test-topic', 'payload')
         self.hass.block_till_done()
         assert len(self.hass.states.async_entity_ids()) == 2
-        #all switches group is 1, unique id created is 1
+        # all switches group is 1, unique id created is 1

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -263,4 +263,5 @@ class TestSwitchMQTT(unittest.TestCase):
 
         fire_mqtt_message(self.hass, 'test-topic', 'payload')
         self.hass.block_till_done()
-        assert len(self.hass.states.async_entity_ids()) == 1
+        assert len(self.hass.states.async_entity_ids()) == 2
+        #all switches group is 1, unique id created is 1

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -263,4 +263,4 @@ class TestSwitchMQTT(unittest.TestCase):
 
         fire_mqtt_message(self.hass, 'test-topic', 'payload')
         self.hass.block_till_done()
-        assert len(self.hass.states.all()) == 1
+        assert len(self.hass.states.async_entity_ids()) == 1


### PR DESCRIPTION
## Description:
Add unique_id to MQTT switch for use with discovery.  This enables easier management of large numbers of devices using discovery.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
This feature is helpful precisely because you don't need to edit configuration.yaml; you can use discovery for almost all devices instead.

Here is an example json discovery topic that works:
`{"state_topic":"homeassistant/relay/fishroom/520E4E","unique_id":"relay_520E4E","command_topic":"homeassistant/fishroom/520E4E","availability_topic":"homeassistant/online/fishroom/520E4E","payload_available": "online","payload_not_available": "offline","payload_on":"on","payload_off":"off","optimistic":"false","assumed_state":"false","qos":"0","retain":"true"}`

On the backend (in the Arduino IDE), the unique_id is generated using switch_type (in this case, 'relay') + `ESP.getChipId();`

As long as each ESP only controls one switch, the id will be truly unique.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
Is there a guideline for what to use for tests?  I'm happy to put something together, but I'm not really sure where to start.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

This should not be necessary in this case.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

Is there a guideline for what to use for tests?  I'm happy to put something together, but I'm not really sure where to start.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
