### PR TITLE
Adds SigFox sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -640,6 +640,7 @@ omit =
     homeassistant/components/sensor/serial_pm.py
     homeassistant/components/sensor/serial.py
     homeassistant/components/sensor/shodan.py
+    homeassistant/components/sensor/sigfox.py
     homeassistant/components/sensor/simulated.py
     homeassistant/components/sensor/skybeacon.py
     homeassistant/components/sensor/sma.py

--- a/homeassistant/components/sensor/sigfox.py
+++ b/homeassistant/components/sensor/sigfox.py
@@ -50,10 +50,10 @@ class SigfoxAPI(object):
     """Class for interacting with the SigFox API."""
     def __init__(self, api_login, api_password):
         self._auth = requests.auth.HTTPBasicAuth(api_login, api_password)
-        r = requests.get(API_URL + 'devicetypes', auth=self._auth)
-        if r.status_code != 200:
+        response = requests.get(API_URL + 'devicetypes', auth=self._auth)
+        if response.status_code != 200:
             _LOGGER.warning(
-                "Unable to login to Sigfox API: " + str(r.status_code))
+                "Unable to login to Sigfox API: " + str(response.status_code))
             self._devices = []
             return
         device_types = self.get_device_types()
@@ -62,9 +62,9 @@ class SigfoxAPI(object):
     def get_device_types(self):
         """Get a list of device types."""
         url = API_URL + 'devicetypes'
-        r = requests.get(url, auth=self._auth)
+        response = requests.get(url, auth=self._auth)
         device_types = []
-        for device in json.loads(r.text)['data']:
+        for device in json.loads(response.text)['data']:
             device_types.append(device['id'])
         return device_types
 
@@ -73,8 +73,8 @@ class SigfoxAPI(object):
         devices = []
         for unique_type in device_types:
             url = API_URL + 'devicetypes/' + unique_type + '/devices'
-            r = requests.get(url, auth=self._auth)
-            devices_data = json.loads(r.text)['data']
+            response = requests.get(url, auth=self._auth)
+            devices_data = json.loads(response.text)['data']
             for device in devices_data:
                 devices.append(device['id'])
         return devices
@@ -103,8 +103,8 @@ class SigfoxDevice(Entity):
     def get_last_message(self):
         """Return the last message from a device."""
         url = API_URL + 'devices/' + self._device_id + '/messages?limit=1'
-        r = requests.get(url, auth=self._auth)
-        data = json.loads(r.text)['data'][0]
+        response = requests.get(url, auth=self._auth)
+        data = json.loads(response.text)['data'][0]
         payload = bytes.fromhex(data['data']).decode('utf-8')
         lat = data['rinfos'][0]['lat']
         lng = data['rinfos'][0]['lng']
@@ -114,8 +114,7 @@ class SigfoxDevice(Entity):
                 'lng': lng,
                 'payload': payload,
                 'snr': snr,
-                'time': epoch_to_datetime(epoch_time)
-                }
+                'time': epoch_to_datetime(epoch_time)}
 
     def update(self):
         """Fetch the latest device message."""

--- a/homeassistant/components/sensor/sigfox.py
+++ b/homeassistant/components/sensor/sigfox.py
@@ -48,7 +48,9 @@ def epoch_to_datetime(epoch_time):
 
 class SigfoxAPI(object):
     """Class for interacting with the SigFox API."""
+
     def __init__(self, api_login, api_password):
+        """Initialise the API object."""
         self._auth = requests.auth.HTTPBasicAuth(api_login, api_password)
         response = requests.get(API_URL + 'devicetypes', auth=self._auth)
         if response.status_code != 200:
@@ -92,8 +94,9 @@ class SigfoxAPI(object):
 
 class SigfoxDevice(Entity):
     """Class for single sigfox device."""
-    def __init__(self, device_id, auth):
 
+    def __init__(self, device_id, auth):
+        """Initialise the device object."""
         self._device_id = device_id
         self._auth = auth
         self._message_data = {}

--- a/homeassistant/components/sensor/sigfox.py
+++ b/homeassistant/components/sensor/sigfox.py
@@ -8,8 +8,8 @@ import logging
 import datetime
 import json
 from urllib.parse import urljoin
-import requests
 
+import requests
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/sensor/sigfox.py
+++ b/homeassistant/components/sensor/sigfox.py
@@ -7,9 +7,10 @@ https://home-assistant.io/components/sensor.sigfox/
 import logging
 import datetime
 import json
-import voluptuous as vol
 import requests
 from urllib.parse import urljoin
+
+import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA

--- a/homeassistant/components/sensor/sigfox.py
+++ b/homeassistant/components/sensor/sigfox.py
@@ -7,8 +7,8 @@ https://home-assistant.io/components/sensor.sigfox/
 import logging
 import datetime
 import json
-import requests
 from urllib.parse import urljoin
+import requests
 
 import voluptuous as vol
 

--- a/homeassistant/components/sensor/sigfox.py
+++ b/homeassistant/components/sensor/sigfox.py
@@ -1,0 +1,138 @@
+"""
+Sensor for SigFox devices.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.sigfox/
+"""
+import logging
+import datetime
+import json
+import voluptuous as vol
+import requests
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = datetime.timedelta(seconds=30)
+API_URL = 'https://backend.sigfox.com/api/'
+CONF_API_LOGIN = 'api_login'
+CONF_API_PASSWORD = 'api_password'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_LOGIN): cv.string,
+    vol.Required(CONF_API_PASSWORD): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the sigfox sensor."""
+    api_login = config[CONF_API_LOGIN]
+    api_password = config[CONF_API_PASSWORD]
+    sigfox = SigfoxAPI(api_login, api_password)
+    auth = sigfox.auth
+    devices = sigfox.devices
+
+    sensors = []
+    for device in devices:
+        sensors.append(SigfoxDevice(device, auth))
+    add_devices(sensors, True)
+
+
+def epoch_to_datetime(epoch_time):
+    """Take an ms since epoch and return datetime string."""
+    return datetime.datetime.fromtimestamp(epoch_time).isoformat()
+
+
+class SigfoxAPI(object):
+    """Class for interacting with the SigFox API."""
+    def __init__(self, api_login, api_password):
+        self._auth = requests.auth.HTTPBasicAuth(api_login, api_password)
+        r = requests.get(API_URL + 'devicetypes', auth=self._auth)
+        if r.status_code != 200:
+            _LOGGER.warning(
+                "Unable to login to Sigfox API: " + str(r.status_code))
+            self._devices = []
+            return
+        device_types = self.get_device_types()
+        self._devices = self.get_devices(device_types)
+
+    def get_device_types(self):
+        """Get a list of device types."""
+        url = API_URL + 'devicetypes'
+        r = requests.get(url, auth=self._auth)
+        device_types = []
+        for device in json.loads(r.text)['data']:
+            device_types.append(device['id'])
+        return device_types
+
+    def get_devices(self, device_types):
+        """Get the device_id of each device registered."""
+        devices = []
+        for unique_type in device_types:
+            url = API_URL + 'devicetypes/' + unique_type + '/devices'
+            r = requests.get(url, auth=self._auth)
+            devices_data = json.loads(r.text)['data']
+            for device in devices_data:
+                devices.append(device['id'])
+        return devices
+
+    @property
+    def auth(self):
+        """Return the API authentification."""
+        return self._auth
+
+    @property
+    def devices(self):
+        """Return the list of device_id."""
+        return self._devices
+
+
+class SigfoxDevice(Entity):
+    """Class for single sigfox device."""
+    def __init__(self, device_id, auth):
+
+        self._device_id = device_id
+        self._auth = auth
+        self._message_data = {}
+        self._name = 'sigfox_' + device_id
+        self._state = None
+
+    def get_last_message(self):
+        """Return the last message from a device."""
+        url = API_URL + 'devices/' + self._device_id + '/messages?limit=1'
+        r = requests.get(url, auth=self._auth)
+        data = json.loads(r.text)['data'][0]
+        payload = bytes.fromhex(data['data']).decode('utf-8')
+        lat = data['rinfos'][0]['lat']
+        lng = data['rinfos'][0]['lng']
+        snr = data['snr']
+        epoch_time = data['time']
+        return {'lat': lat,
+                'lng': lng,
+                'payload': payload,
+                'snr': snr,
+                'time': epoch_to_datetime(epoch_time)
+                }
+
+    def update(self):
+        """Fetch the latest device message."""
+        self._message_data = self.get_last_message()
+        self._state = self._message_data['payload']
+
+    @property
+    def name(self):
+        """Return the HA name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the payload of the last message."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return other details about the last message."""
+        return self._message_data

--- a/homeassistant/components/sensor/sigfox.py
+++ b/homeassistant/components/sensor/sigfox.py
@@ -53,7 +53,7 @@ class SigfoxAPI(object):
         response = requests.get(API_URL + 'devicetypes', auth=self._auth)
         if response.status_code != 200:
             _LOGGER.warning(
-                "Unable to login to Sigfox API: " + str(response.status_code))
+                "Unable to login to Sigfox API: %s", str(response.status_code))
             self._devices = []
             return
         device_types = self.get_device_types()

--- a/homeassistant/components/sensor/sigfox.py
+++ b/homeassistant/components/sensor/sigfox.py
@@ -37,8 +37,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config[CONF_NAME]
     try:
         sigfox = SigfoxAPI(api_login, api_password)
-    except:
-        _LOGGER.error("Sigfox component not setup")
+    except ValueError:
         return False
     auth = sigfox.auth
     devices = sigfox.devices
@@ -76,7 +75,7 @@ class SigfoxAPI(object):
                 _LOGGER.error(
                     "Unable to login to Sigfox API, error code %s", str(
                         response.status_code))
-            raise Exception()
+            raise ValueError('Sigfox component not setup')
         return True
 
     def get_device_types(self):

--- a/tests/components/sensor/test_sigfox.py
+++ b/tests/components/sensor/test_sigfox.py
@@ -1,0 +1,68 @@
+"""Tests for the sigfox sensor."""
+import re
+import requests_mock
+import unittest
+
+from homeassistant.components.sensor.sigfox import (
+    API_URL, CONF_API_LOGIN, CONF_API_PASSWORD)
+from homeassistant.setup import setup_component
+from tests.common import get_test_home_assistant
+
+TEST_API_LOGIN = 'foo'
+TEST_API_PASSWORD = 'ebcd1234'
+
+VALID_CONFIG = {
+    'sensor': {
+        'platform': 'sigfox',
+        CONF_API_LOGIN: TEST_API_LOGIN,
+        CONF_API_PASSWORD: TEST_API_PASSWORD}}
+
+VALID_MESSAGE = """
+{"data":[{
+"time":1521879720,
+"data":"7061796c6f6164",
+"rinfos":[{"lat":"0.0","lng":"0.0"}],
+"snr":"50.0"}]}
+"""
+
+
+class TestSigfoxSensor(unittest.TestCase):
+    """Test the sigfox platform."""
+
+    def setUp(self):
+        """Initialize values for this testcase class."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_invalid_credentials(self):
+        """Test for a invalid credentials."""
+        with requests_mock.Mocker() as mock_req:
+            url = re.compile(API_URL + 'devicetypes')
+            mock_req.get(url, text='{}', status_code=401)
+            self.assertTrue(
+                setup_component(self.hass, 'sensor', VALID_CONFIG))
+        assert len(self.hass.states.entity_ids()) == 0
+
+    def test_valid_credentials(self):
+        """Test for a valid credentials."""
+        with requests_mock.Mocker() as mock_req:
+            url1 = re.compile(API_URL + 'devicetypes')
+            mock_req.get(url1, text='{"data":[{"id":"fake_type"}]}',
+                         status_code=200)
+
+            url2 = re.compile(API_URL + 'devicetypes/fake_type/devices')
+            mock_req.get(url2, text='{"data":[{"id":"fake_id"}]}')
+
+            url3 = re.compile(API_URL + 'devices/fake_id/messages*')
+            mock_req.get(url3, text=VALID_MESSAGE)
+
+            self.assertTrue(
+                setup_component(self.hass, 'sensor', VALID_CONFIG))
+
+            assert len(self.hass.states.entity_ids()) == 1
+            state = self.hass.states.get('sensor.sigfox_fake_id')
+            assert state.state == 'payload'
+            assert state.attributes.get('snr') == '50.0'


### PR DESCRIPTION
## Description:
[SigFox](https://www.sigfox.com/en) component adding a sensor for each SigFox device. The state of the sensor is the payload of the last message published by a device, and there are attributes for the lat/long coords of the device, as well as the signal [SNR](https://en.wikipedia.org/wiki/Signal-to-noise_ratio) (snr).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/) with documentation (if applicable):** home-assistant/home-assistant.github.io#5130

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: sigfox
    api_login: your_api_login
    api_password: your_api_password
```

Where `your_api_login` and `your_api_password` are not the same as the credential you use to access Sigfox backend. Required are API access credentials:

1. Log into [Sigfox backend](https://backend.sigfox.com)
2. Go to Groups
3. Select group
4. API ACCESS.
5. Click on 'new' and create new access entry.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New files were added to `.coveragerc`.