### PR TITLE
Squeezebox: Only flag media position as updated when it really has changed

### DIFF
--- a/homeassistant/components/media_player/squeezebox.py
+++ b/homeassistant/components/media_player/squeezebox.py
@@ -266,6 +266,8 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         if response is False:
             return
 
+        last_media_position = self.media_position
+
         self._status = {}
 
         try:
@@ -278,7 +280,11 @@ class SqueezeBoxDevice(MediaPlayerDevice):
             pass
 
         self._status.update(response)
-        self._last_update = utcnow()
+
+        if self.media_position != last_media_position:
+            _LOGGER.debug('Media position updated for %s: %s',
+                          self, self.media_position)
+            self._last_update = utcnow()
 
     @property
     def volume_level(self):


### PR DESCRIPTION
## Description:
To prevent logs, database, etc to be spammed with state updates, the media_position_updated_at property should only change when the media position has in fact changed.

This is analogous to e.g. https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/media_player/vlc.py#L72

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
