### PR TITLE
Adding 'namespace' for prometheus metrics

### DIFF
--- a/homeassistant/components/prometheus.py
+++ b/homeassistant/components/prometheus.py
@@ -20,7 +20,7 @@ from homeassistant import core as hacore
 from homeassistant.helpers import state as state_helper
 from homeassistant.util.temperature import fahrenheit_to_celsius
 
-REQUIREMENTS = ['prometheus_client==0.1.0']
+REQUIREMENTS = ['prometheus_client==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -660,7 +660,7 @@ postnl_api==1.0.1
 proliphix==0.4.1
 
 # homeassistant.components.prometheus
-prometheus_client==0.1.0
+prometheus_client==0.2.0
 
 # homeassistant.components.sensor.systemmonitor
 psutil==5.4.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -120,7 +120,7 @@ pilight==0.1.1
 pmsensor==0.4
 
 # homeassistant.components.prometheus
-prometheus_client==0.1.0
+prometheus_client==0.2.0
 
 # homeassistant.components.notify.pushbullet
 # homeassistant.components.sensor.pushbullet

--- a/tests/components/test_prometheus.py
+++ b/tests/components/test_prometheus.py
@@ -12,7 +12,7 @@ def prometheus_client(loop, hass, aiohttp_client):
     assert loop.run_until_complete(async_setup_component(
         hass,
         prometheus.DOMAIN,
-        {},
+        {prometheus.DOMAIN: {}},
     ))
     return loop.run_until_complete(aiohttp_client(hass.http.app))
 


### PR DESCRIPTION
## Description:

Add a "namespace" for all the component metrics. This is a breaking change, motivated by "official best practices" [see Prometheus documentation](https://prometheus.io/docs/practices/naming/)

> A metric name [...] should have a (single-word) application prefix relevant to the domain the metric belongs to. The prefix is sometimes referred to as namespace by client libraries. For metrics specific to an application, the prefix is usually the application name itself.

The code could be tweaked to be non-breaking. IMHO, it is more sane and well-organized to force a top-level namespace and share that by all the metrics --instead of starting the metric name by the hass domain-- but it is arguably the best approach. Before adding the documentation I wanted to discuss that and listen to other opinions. If there is consensus in a different solution, I have no problem modifying this PR to follow the guidelines.

## Example entry for `configuration.yaml` (if applicable):
```yaml
prometheus:
  namespace: "hass"  # this happens to be the default namespace name
```

## Result:

Going to http://hass.example.net:8123/api/prometheus shows:

    ...
    # HELP hass_device_tracker_state State of the device tracker (0/1)
    # TYPE hass_device_tracker_state gauge
    hass_device_tracker_state{entity="device_tracker.04xxxxxxxx9d",friendly_name="04xxxxxxxx9d"} 1.0
    hass_device_tracker_state{entity="device_tracker.androidffxxxxxxxxxxxx2f",friendly_name="android-ffxxxxxxxxxxxxxx2f"} 1.0
    ...

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io): home-assistant/home-assistant.github.io#5152