### PR TITLE
Throw an error when invalid device_mode is given

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -187,6 +187,9 @@ class NestThermostat(ClimateDevice):
             device_mode = operation_mode
         elif operation_mode == STATE_AUTO:
             device_mode = NEST_MODE_HEAT_COOL
+        else:
+            device_mode = STATE_OFF
+            _LOGGER.error("An error occured while setting device mode. Invalid value '%s' is given." % device_mode)
         self.device.mode = device_mode
 
     @property

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -191,7 +191,7 @@ class NestThermostat(ClimateDevice):
             device_mode = STATE_OFF
             _LOGGER.error(
                 "An error occurred while setting device mode. "
-                "Invalid operation mode: %s" % operation_mode)
+                "Invalid operation mode: %s", operation_mode)
         self.device.mode = device_mode
 
     @property

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -189,7 +189,9 @@ class NestThermostat(ClimateDevice):
             device_mode = NEST_MODE_HEAT_COOL
         else:
             device_mode = STATE_OFF
-            _LOGGER.error("An error occured while setting device mode. Invalid value '%s' is given." % device_mode)
+            _LOGGER.error(
+                "An error occurred while setting device mode. "
+                "Invalid operation mode: %s" % operation_mode)
         self.device.mode = device_mode
 
     @property


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #13724

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
nest:
  client_id: f13c70e4-Xxxxxxxxxxxxxxx
  client_secret: jqXm Xxxxxxxxxxxxxxx
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
