### PR TITLE
Fix so it is possible to ignore discovered config entry handlers

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -85,7 +85,7 @@ CONFIG_SCHEMA = vol.Schema({
     vol.Required(DOMAIN): vol.Schema({
         vol.Optional(CONF_IGNORE, default=[]):
             vol.All(cv.ensure_list, [
-                vol.In({**CONFIG_ENTRY_HANDLERS, **SERVICE_HANDLERS})])
+                vol.In(list(CONFIG_ENTRY_HANDLERS) + list(SERVICE_HANDLERS))])
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -84,7 +84,8 @@ CONF_IGNORE = 'ignore'
 CONFIG_SCHEMA = vol.Schema({
     vol.Required(DOMAIN): vol.Schema({
         vol.Optional(CONF_IGNORE, default=[]):
-            vol.All(cv.ensure_list, [vol.In(SERVICE_HANDLERS)])
+            vol.All(cv.ensure_list, [
+                vol.In({**CONFIG_ENTRY_HANDLERS, **SERVICE_HANDLERS})])
     }),
 }, extra=vol.ALLOW_EXTRA)
 


### PR DESCRIPTION
## Description:


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**