### PR TITLE
Add niko-home-control support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -422,6 +422,7 @@ omit =
     homeassistant/components/light/lifx.py
     homeassistant/components/light/limitlessled.py
     homeassistant/components/light/mystrom.py
+    homeassistant/components/light/niko_home_control.py
     homeassistant/components/light/osramlightify.py
     homeassistant/components/light/piglow.py
     homeassistant/components/light/rpi_gpio_pwm.py

--- a/homeassistant/components/light/niko_home_control.py
+++ b/homeassistant/components/light/niko_home_control.py
@@ -1,0 +1,99 @@
+"""
+Support for Niko Home Control.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/light.niko_home_control/
+"""
+import logging
+
+import voluptuous as vol
+
+# Import the device class from the component that you want to support
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, Light, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
+
+# Home Assistant depends on 3rd party packages for API specific code.
+REQUIREMENTS = ['niko-home-control==0.1.8']
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the NikoHomeControl platform."""
+    import nikohomecontrol
+
+    host = config.get(CONF_HOST)
+
+    hub = nikohomecontrol.Hub({
+        'ip': host,
+        'port': 8000,
+        'timeout': 20000,
+        'events': True
+    })
+
+    add_devices(
+        [NikoHomeControlLight(light, hub) for light in hub.list_actions()],
+        True
+    )
+
+    return True
+
+
+class NikoHomeControlLight(Light):
+    """Representation of an Niko Light."""
+
+    def __init__(self, light, nhc):
+        """Set up the Niko Home Control platform."""
+        self._nhc = nhc
+        self._light = light
+        self._name = light.name
+        self._state = None
+        self._brightness = None
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """Return the brightness of the light.
+
+        This method is optional. Removing it indicates to Home Assistant
+        that brightness is not supported for this light.
+        """
+        return self._brightness
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Instruct the light to turn on.
+
+        You can skip the brightness part if your light does not support
+        brightness control.
+        """
+        self._light.brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        self._light.turn_on()
+        self._state = True
+
+    def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        self._light.turn_off()
+        self._state = False
+
+    def update(self):
+        """Fetch new state data for this light.
+
+        This is the only method that should fetch new data for Home Assistant.
+        """
+        self._light.update()
+        self._state = self._light.is_on

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -545,6 +545,9 @@ netdisco==1.3.1
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1
 
+# homeassistant.components.light.niko_home_control
+niko-home-control==0.1.8
+
 # homeassistant.components.sensor.nederlandse_spoorwegen
 nsapi==2.7.4
 


### PR DESCRIPTION
## Description:

Add support for niko-home-control

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5137

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: niko_home_control
    host: 192.168.1.123
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
