### PR TITLE
Broadlink Sensor - switch to connection-less mode

### DIFF
--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -125,9 +125,6 @@ class BroadlinkData(object):
 
     def _update(self, retry=3):
         try:
-            self._connect()
-            if not self._auth():
-                _LOGGER.warning("Failed to connect to device")
             data = self._device.check_sensors_raw()
             if data is not None:
                 self.data = self._schema(data)
@@ -143,6 +140,7 @@ class BroadlinkData(object):
 
     def _auth(self, retry=3):
         try:
+            self._connect()
             auth = self._device.auth()
         except socket.timeout:
             auth = False

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -94,7 +94,7 @@ class BroadlinkSensor(Entity):
         if self._broadlink_data.data is None:
             return
         self._state = self._broadlink_data.data[self._type]
-        
+       
 class BroadlinkData(object):
     """Representation of a Broadlink data object."""
 

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -104,10 +104,15 @@ class BroadlinkData(object):
 
     def __init__(self, interval, ip_addr, mac_addr, timeout):
         """Initialize the data object."""
-        import broadlink
         self.data = None
-        self._device = broadlink.a1((ip_addr, 80), mac_addr, None)
-        self._device.timeout = timeout
+
+        self.interval=interval
+        self.ip_addr=ip_addr
+        self.mac_addr=mac_addr
+        self.timeout=timeout
+
+        self._connect()
+
         self._schema = vol.Schema({
             vol.Optional('temperature'): vol.Range(min=-50, max=150),
             vol.Optional('humidity'): vol.Range(min=0, max=100),
@@ -119,8 +124,20 @@ class BroadlinkData(object):
         if not self._auth():
             _LOGGER.warning("Failed to connect to device")
 
+    def _connect(self):
+        import broadlink
+        self._device = broadlink.a1((self.ip_addr, 80), self.mac_addr, None)
+        self._device.timeout = self.timeout
+
+
     def _update(self, retry=3):
         try:
+
+            self._connect()
+            if not self._auth():
+                _LOGGER.warning("Failed to connect to device")
+
+
             data = self._device.check_sensors_raw()
             if data is not None:
                 self.data = self._schema(data)

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -56,14 +56,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     timeout = config.get(CONF_TIMEOUT)
     update_interval = config.get(CONF_UPDATE_INTERVAL)
-
     broadlink_data = BroadlinkData(update_interval, host, mac_addr, timeout)
-
     dev = []
     for variable in config[CONF_MONITORED_CONDITIONS]:
         dev.append(BroadlinkSensor(name, broadlink_data, variable))
     add_devices(dev, True)
-
 
 class BroadlinkSensor(Entity):
     """Representation of a Broadlink device sensor."""
@@ -97,22 +94,18 @@ class BroadlinkSensor(Entity):
         if self._broadlink_data.data is None:
             return
         self._state = self._broadlink_data.data[self._type]
-
-
+        
 class BroadlinkData(object):
     """Representation of a Broadlink data object."""
 
     def __init__(self, interval, ip_addr, mac_addr, timeout):
         """Initialize the data object."""
         self.data = None
-
         self.interval = interval
         self.ip_addr = ip_addr
         self.mac_addr = mac_addr
         self.timeout = timeout
-
         self._connect()
-
         self._schema = vol.Schema({
             vol.Optional('temperature'): vol.Range(min=-50, max=150),
             vol.Optional('humidity'): vol.Range(min=0, max=100),
@@ -129,15 +122,11 @@ class BroadlinkData(object):
         self._device = broadlink.a1((self.ip_addr, 80), self.mac_addr, None)
         self._device.timeout = self.timeout
 
-
     def _update(self, retry=3):
         try:
-
             self._connect()
             if not self._auth():
                 _LOGGER.warning("Failed to connect to device")
-
-
             data = self._device.check_sensors_raw()
             if data is not None:
                 self.data = self._schema(data)

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -106,10 +106,10 @@ class BroadlinkData(object):
         """Initialize the data object."""
         self.data = None
 
-        self.interval=interval
-        self.ip_addr=ip_addr
-        self.mac_addr=mac_addr
-        self.timeout=timeout
+        self.interval = interval
+        self.ip_addr = ip_addr
+        self.mac_addr = mac_addr
+        self.timeout = timeout
 
         self._connect()
 

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -62,6 +62,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         dev.append(BroadlinkSensor(name, broadlink_data, variable))
     add_devices(dev, True)
 
+
 class BroadlinkSensor(Entity):
     """Representation of a Broadlink device sensor."""
 
@@ -94,7 +95,8 @@ class BroadlinkSensor(Entity):
         if self._broadlink_data.data is None:
             return
         self._state = self._broadlink_data.data[self._type]
-       
+
+
 class BroadlinkData(object):
     """Representation of a Broadlink data object."""
 

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -103,7 +103,6 @@ class BroadlinkData(object):
     def __init__(self, interval, ip_addr, mac_addr, timeout):
         """Initialize the data object."""
         self.data = None
-        self.interval = interval
         self.ip_addr = ip_addr
         self.mac_addr = mac_addr
         self.timeout = timeout

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -140,10 +140,10 @@ class BroadlinkData(object):
 
     def _auth(self, retry=3):
         try:
-            self._connect()
             auth = self._device.auth()
         except socket.timeout:
             auth = False
         if not auth and retry > 0:
+            self._connect()
             return self._auth(retry-1)
         return auth


### PR DESCRIPTION
Solved the issue with broadlink sensor that occurs when short connection loss with RM2/3 is present on poor WiFi networks.

## Description:


**Related issue (if applicable):** fixes #11795

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
