### PR TITLE
[WIP] Add support for Tahoma consommation sensor

### DIFF
--- a/homeassistant/components/climate/tahoma.py
+++ b/homeassistant/components/climate/tahoma.py
@@ -1,0 +1,73 @@
+"""
+Support for Tahoma heatpump derogation.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/climate.tahoma/
+"""
+
+from homeassistant.components.climate import (
+    ClimateDevice,
+    SUPPORT_AWAY_MODE)
+from homeassistant.components.tahoma import (
+    DOMAIN as TAHOMA_DOMAIN, TahomaDevice)
+from homeassistant.const import TEMP_CELSIUS
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Tahoma controller devices."""
+    controller = hass.data[TAHOMA_DOMAIN]['controller']
+    devices = []
+    for device in hass.data[TAHOMA_DOMAIN]['devices']['climate']:
+        devices.append(TahomaClimate(device, controller))
+    add_devices(devices, True)
+
+
+class TahomaClimate(TahomaDevice, ClimateDevice):
+    """Representation of a Tahoma heat pump derogration device."""
+
+    def __init__(self, tahoma_device, controller):
+        """Initialize the climate device."""
+        super().__init__(tahoma_device, controller)
+        if self.tahoma_device.type == \
+           'io:EnergyConsumptionSensorsHeatPumpComponent':
+            self._name = 'Heat pump derogation ('+self.name+')'
+        self._support_flags = SUPPORT_AWAY_MODE
+        self._away = tahoma_device.active_states['core:DerogationOnOffState'] \
+            == "off"
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return self._support_flags
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the climate device."""
+        return self._name
+
+    @property
+    def temperature_unit(self):
+        """No temperature handled here but this implementation is required."""
+        return TEMP_CELSIUS
+
+    @property
+    def is_away_mode_on(self):
+        """Return if away mode is on."""
+        return self._away
+
+    def turn_away_mode_on(self):
+        """Turn away mode on."""
+        self._away = True
+        self.apply_action('setDerogationOnOffState', 'off')
+        self.schedule_update_ha_state()
+
+    def turn_away_mode_off(self):
+        """Turn away mode off."""
+        self._away = False
+        self.apply_action('setDerogationOnOffState', 'on')
+        self.schedule_update_ha_state()

--- a/homeassistant/components/climate/tahoma.py
+++ b/homeassistant/components/climate/tahoma.py
@@ -30,7 +30,7 @@ class TahomaClimate(TahomaDevice, ClimateDevice):
         super().__init__(tahoma_device, controller)
         if self.tahoma_device.type == \
            'io:EnergyConsumptionSensorsHeatPumpComponent':
-            self._name = 'Heat pump derogation ('+self.name+')'
+            self._name = 'Heat pump derogation - {0}'.format(self.name)
         self._support_flags = SUPPORT_AWAY_MODE
         self._away = tahoma_device.active_states['core:DerogationOnOffState'] \
             == "off"

--- a/homeassistant/components/sensor/tahoma.py
+++ b/homeassistant/components/sensor/tahoma.py
@@ -45,7 +45,7 @@ class TahomaSensor(TahomaDevice, Entity):
         super().__init__(tahoma_device, controller)
         elec_sensor_type = ELECTRICAL_SENSOR_TYPES.get(self.tahoma_device.type)
         if elec_sensor_type is not None:
-            self._name = elec_sensor_type+' ('+self.name+')'
+            self._name = '{0} - {1}'.format(elec_sensor_type, self.name)
 
     @property
     def state(self):

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 TAHOMA_COMPONENTS = [
-    'scene', 'sensor', 'cover', 'switch'
+    'scene', 'sensor', 'cover', 'switch', 'climate'
 ]
 
 TAHOMA_TYPES = {
@@ -43,6 +43,12 @@ TAHOMA_TYPES = {
     'io:RollerShutterGenericIOComponent': 'cover',
     'io:WindowOpenerVeluxIOComponent': 'cover',
     'io:LightIOSystemSensor': 'sensor',
+    'io:TotalElectricalEnergyConsumptionIOSystemSensor': 'sensor',
+    'io:HeatingElectricalEnergyConsumptionSensor': 'sensor',
+    'io:DHWElectricalEnergyConsumptionSensor': 'sensor',
+    'io:PlugsElectricalEnergyConsumptionSensor': 'sensor',
+    'io:OtherElectricalEnergyConsumptionSensor': 'sensor',
+    'io:EnergyConsumptionSensorsHeatPumpComponent': 'climate',
     'rts:GarageDoor4TRTSComponent': 'switch',
 }
 


### PR DESCRIPTION
5 electrical sensors provide the electrical usage
1 climate component allows the user to force the heating off.

## Description:
Implementation of Tahoma electrical module (implemented from a module manufactured by Atlantic)
provide the electrical sensors output
allow to override the heat pump to disable heeating.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
home-assistant/home-assistant.github.io#5150

## Example entry for `configuration.yaml` (if applicable):
nothing

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Changed the  polling time from the server from 10 seconds to 10 minutes. 10 secs seems a very low value for a non-local server.

If the code communicates with devices, web services, or third-party tools:
  - No new dependencies

If the code does not interact with devices:
  - N/A (interracts with devices)
