### PR TITLE
extend platform plant: initialize from history, check max age - WIP

### DIFF
--- a/homeassistant/components/plant.py
+++ b/homeassistant/components/plant.py
@@ -92,11 +92,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# Flag for enabling/disabling the loading of the history from the database.
-# This feature is turned off right now as its tests are not 100% stable.
-ENABLE_LOAD_HISTORY = False
-
-
 @asyncio.coroutine
 def async_setup(hass, config):
     """Set up the Plant component."""
@@ -249,7 +244,7 @@ class Plant(Entity):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """After being added to hass, load from history."""
-        if ENABLE_LOAD_HISTORY and 'recorder' in self.hass.config.components:
+        if 'recorder' in self.hass.config.components:
             # only use the database if it's configured
             self.hass.async_add_job(self._load_history_from_db)
 

--- a/tests/components/test_plant.py
+++ b/tests/components/test_plant.py
@@ -104,10 +104,6 @@ class TestPlant(unittest.TestCase):
         self.assertEqual(STATE_PROBLEM, state.state)
         self.assertEqual(5, state.attributes[plant.READING_MOISTURE])
 
-    @pytest.mark.skipif(plant.ENABLE_LOAD_HISTORY is False,
-                        reason="tests for loading from DB are unstable, thus"
-                               "this feature is turned of until tests become"
-                               "stable")
     def test_load_from_db(self):
         """Test bootstrapping the brightness history from the database.
 

--- a/tests/components/test_plant.py
+++ b/tests/components/test_plant.py
@@ -159,7 +159,7 @@ class TestPlant(unittest.TestCase):
         self.assertEqual(STATE_OK, state.state)
 
     def test_max_age(self):
-        """Test if the max_age is set"""
+        """Test if the max_age is set."""
         config = GOOD_CONFIG.copy()
         config['max_age'] = {'seconds': 0}
         plant_name = 'some_plant'

--- a/tests/components/test_plant.py
+++ b/tests/components/test_plant.py
@@ -1,7 +1,6 @@
 """Unit tests for platform/plant.py."""
 import asyncio
 import unittest
-import pytest
 from datetime import datetime, timedelta
 
 from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN,
@@ -158,6 +157,23 @@ class TestPlant(unittest.TestCase):
         self.hass.block_till_done()
         state = self.hass.states.get('plant.'+plant_name)
         self.assertEqual(STATE_OK, state.state)
+
+    def test_max_age(self):
+        """Test if the max_age is set"""
+        config = GOOD_CONFIG.copy()
+        config['max_age'] = {'seconds': 0}
+        plant_name = 'some_plant'
+        assert setup_component(self.hass, plant.DOMAIN, {
+            plant.DOMAIN: {
+                plant_name: config
+            }
+        })
+        self.hass.states.set(BRIGHTNESS_ENTITY, 100000,
+                             {ATTR_UNIT_OF_MEASUREMENT: 'lux'})
+        self.hass.block_till_done()
+        state = self.hass.states.get('plant.'+plant_name)
+        self.assertEqual(STATE_PROBLEM, state.state)
+        self.assertIn('brightness old', state.attributes['problem'])
 
 
 class TestDailyHistory(unittest.TestCase):


### PR DESCRIPTION
## Description:
1. After Python3.4 was removed, we can now activate the bootstrapping of the brightness values from the history (=database), if the user has the history component enabled. The old code is still working :smile: Benefit: even after restarting HASS you have proper values for you brightness history.
2. Check if the readings are not older than max_age. If they are older: report a problem. This helps to detect broken/stuck sensors.
3. :warning:  breaking change: replaced config parameter `check_days` with `check_interval` and use type `time_period` instead of just an integer. This way `check_interval` behaves the same as `max_age`.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
plant:
  simulated_plant:
      sensors:
        moisture: sensor.mqtt_plant_moisture
        battery: sensor.mqtt_plant_battery
        temperature: sensor.mqtt_plant_temperature
        conductivity: sensor.mqtt_plant_conductivity
        brightness: sensor.mqtt_plant_brightness
      min_moisture: 20
      max_moisture: 60
      min_battery: 17
      min_brightness: 6000
      check_interval: 
        days: 3
      max_age:
        days: 1 # you might want to lower this for testing...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
