### PR TITLE
add switch.mqtt_template

### DIFF
--- a/homeassistant/components/switch/mqtt_template.py
+++ b/homeassistant/components/switch/mqtt_template.py
@@ -61,11 +61,11 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_PAYLOAD_NOT_AVAILABLE),
         {
             key: config.get(key) for key in (
-            CONF_PAYLOAD_ON_TEMPLATE,
-            CONF_PAYLOAD_OFF_TEMPLATE,
-            CONF_VALUE_TEMPLATE,
-        )
-            },
+                CONF_PAYLOAD_ON_TEMPLATE,
+                CONF_PAYLOAD_OFF_TEMPLATE,
+                CONF_VALUE_TEMPLATE,
+            )
+        },
     )])
 
 
@@ -102,7 +102,10 @@ class MqttTemplateSwitch(MqttAvailability, SwitchDevice):
         def state_message_received(topic, payload, qos):
             """Handle new MQTT state messages."""
             if self._templates[CONF_VALUE_TEMPLATE] is not None:
-                payload = self._templates[CONF_VALUE_TEMPLATE].async_render_with_possible_json_value(payload)
+                payload = \
+                    self._templates[CONF_VALUE_TEMPLATE]\
+                        .async_render_with_possible_json_value(
+                        payload)
             if payload == self._payload_on:
                 self._state = True
             elif payload == self._payload_off:
@@ -150,8 +153,9 @@ class MqttTemplateSwitch(MqttAvailability, SwitchDevice):
         This method is a coroutine.
         """
         mqtt.async_publish(
-            self.hass, self._command_topic, self._templates[CONF_PAYLOAD_ON_TEMPLATE].async_render(), self._qos,
-            self._retain)
+            self.hass, self._command_topic,
+            self._templates[CONF_PAYLOAD_ON_TEMPLATE].async_render(),
+            self._qos, self._retain)
         if self._optimistic:
             # Optimistically assume that switch has changed state.
             self._state = True
@@ -164,8 +168,9 @@ class MqttTemplateSwitch(MqttAvailability, SwitchDevice):
         This method is a coroutine.
         """
         mqtt.async_publish(
-            self.hass, self._command_topic, self._templates[CONF_PAYLOAD_OFF_TEMPLATE].async_render(), self._qos,
-            self._retain)
+            self.hass, self._command_topic,
+            self._templates[CONF_PAYLOAD_OFF_TEMPLATE].async_render(),
+            self._qos, self._retain)
         if self._optimistic:
             # Optimistically assume that switch has changed state.
             self._state = False

--- a/homeassistant/components/switch/mqtt_template.py
+++ b/homeassistant/components/switch/mqtt_template.py
@@ -104,7 +104,7 @@ class MqttTemplateSwitch(MqttAvailability, SwitchDevice):
             if self._templates[CONF_VALUE_TEMPLATE] is not None:
                 payload = \
                     self._templates[CONF_VALUE_TEMPLATE]\
-                        .async_render_with_possible_json_value(
+                    .async_render_with_possible_json_value(
                         payload)
             if payload == self._payload_on:
                 self._state = True

--- a/homeassistant/components/switch/mqtt_template.py
+++ b/homeassistant/components/switch/mqtt_template.py
@@ -106,9 +106,11 @@ class MqttTemplateSwitch(MqttAvailability, SwitchDevice):
                     self._templates[CONF_VALUE_TEMPLATE]\
                     .async_render_with_possible_json_value(
                         payload)
-            if payload == self._payload_on:
+            if payload ==\
+                    self._templates[CONF_PAYLOAD_ON_TEMPLATE].async_render():
                 self._state = True
-            elif payload == self._payload_off:
+            elif payload == \
+                    self._templates[CONF_PAYLOAD_OFF_TEMPLATE].async_render():
                 self._state = False
 
             self.async_schedule_update_ha_state()

--- a/homeassistant/components/switch/mqtt_template.py
+++ b/homeassistant/components/switch/mqtt_template.py
@@ -1,0 +1,172 @@
+"""
+Support for MQTT Template switches.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.mqtt_template/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.components.mqtt import (
+    CONF_STATE_TOPIC, CONF_COMMAND_TOPIC, CONF_AVAILABILITY_TOPIC,
+    CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS, CONF_RETAIN,
+    MqttAvailability)
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.const import (
+    CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE, CONF_ICON)
+import homeassistant.components.mqtt as mqtt
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'mqtt_template'
+
+DEPENDENCIES = ['mqtt']
+
+CONF_PAYLOAD_OFF_TEMPLATE = 'payload_off_template'
+CONF_PAYLOAD_ON_TEMPLATE = 'payload_on_template'
+
+DEFAULT_NAME = 'MQTT Template Switch'
+DEFAULT_OPTIMISTIC = False
+
+PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_ICON): cv.icon,
+    vol.Required(CONF_PAYLOAD_ON_TEMPLATE): cv.template,
+    vol.Required(CONF_PAYLOAD_OFF_TEMPLATE): cv.template,
+    vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
+}).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the MQTT switch."""
+    if discovery_info is not None:
+        config = PLATFORM_SCHEMA(discovery_info)
+
+    async_add_devices([MqttTemplateSwitch(
+        hass,
+        config.get(CONF_NAME),
+        config.get(CONF_ICON),
+        config.get(CONF_STATE_TOPIC),
+        config.get(CONF_COMMAND_TOPIC),
+        config.get(CONF_AVAILABILITY_TOPIC),
+        config.get(CONF_QOS),
+        config.get(CONF_RETAIN),
+        config.get(CONF_OPTIMISTIC),
+        config.get(CONF_PAYLOAD_AVAILABLE),
+        config.get(CONF_PAYLOAD_NOT_AVAILABLE),
+        {
+            key: config.get(key) for key in (
+            CONF_PAYLOAD_ON_TEMPLATE,
+            CONF_PAYLOAD_OFF_TEMPLATE,
+            CONF_VALUE_TEMPLATE,
+        )
+            },
+    )])
+
+
+class MqttTemplateSwitch(MqttAvailability, SwitchDevice):
+    """Representation of a switch that can be toggled using MQTT."""
+
+    def __init__(self, hass, name, icon,
+                 state_topic, command_topic, availability_topic,
+                 qos, retain, optimistic,
+                 payload_available, payload_not_available, templates):
+        """Initialize the MQTT Template switch."""
+        super().__init__(availability_topic, qos, payload_available,
+                         payload_not_available)
+        self._state = False
+        self._name = name
+        self._icon = icon
+        self._state_topic = state_topic
+        self._command_topic = command_topic
+        self._qos = qos
+        self._retain = retain
+        self._optimistic = optimistic
+        self._templates = templates
+
+        for tpl in self._templates.values():
+            if tpl is not None:
+                tpl.hass = hass
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Subscribe to MQTT events."""
+        yield from super().async_added_to_hass()
+
+        @callback
+        def state_message_received(topic, payload, qos):
+            """Handle new MQTT state messages."""
+            if self._templates[CONF_VALUE_TEMPLATE] is not None:
+                payload = self._templates[CONF_VALUE_TEMPLATE].async_render_with_possible_json_value(payload)
+            if payload == self._payload_on:
+                self._state = True
+            elif payload == self._payload_off:
+                self._state = False
+
+            self.async_schedule_update_ha_state()
+
+        if self._state_topic is None:
+            # Force into optimistic mode.
+            self._optimistic = True
+        else:
+            yield from mqtt.async_subscribe(
+                self.hass, self._state_topic, state_message_received,
+                self._qos)
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def assumed_state(self):
+        """Return true if we do optimistic updates."""
+        return self._optimistic
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._icon
+
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """Turn the device on.
+
+        This method is a coroutine.
+        """
+        mqtt.async_publish(
+            self.hass, self._command_topic, self._templates[CONF_PAYLOAD_ON_TEMPLATE].async_render(), self._qos,
+            self._retain)
+        if self._optimistic:
+            # Optimistically assume that switch has changed state.
+            self._state = True
+            self.async_schedule_update_ha_state()
+
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
+        """Turn the device off.
+
+        This method is a coroutine.
+        """
+        mqtt.async_publish(
+            self.hass, self._command_topic, self._templates[CONF_PAYLOAD_OFF_TEMPLATE].async_render(), self._qos,
+            self._retain)
+        if self._optimistic:
+            # Optimistically assume that switch has changed state.
+            self._state = False
+            self.async_schedule_update_ha_state()

--- a/tests/components/switch/test_mqtt_template.py
+++ b/tests/components/switch/test_mqtt_template.py
@@ -1,0 +1,58 @@
+"""The tests for the MQTT template switch platform."""
+import unittest
+
+from homeassistant.setup import setup_component
+from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ASSUMED_STATE
+import homeassistant.components.switch as switch
+from tests.common import (
+    mock_mqtt_component, get_test_home_assistant)
+
+
+class TestSwitchMQTT(unittest.TestCase):
+    """Test the MQTT template switch."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.mock_publish = mock_mqtt_component(self.hass)
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """"Stop everything that was started."""
+        self.hass.stop()
+
+    def test_sending_mqtt_commands_with_templated_payloads(self):
+        """Test the sending MQTT commands in optimistic mode."""
+        assert setup_component(self.hass, switch.DOMAIN, {
+            switch.DOMAIN: {
+                'platform': 'mqtt_template',
+                'name': 'test',
+                'command_topic': 'command-topic',
+                'payload_on_template': "on,{{ states.sensor.duration_1.state }}",
+                'payload_off_template': "off,{{ states.sensor.duration_2.state }}",
+                'qos': '2'
+            }
+        })
+
+        self.hass.states.set('sensor.duration_1', '1234')
+        self.hass.states.set('sensor.duration_2', '5678')
+
+        state = self.hass.states.get('switch.test')
+        self.assertEqual(STATE_OFF, state.state)
+        self.assertTrue(state.attributes.get(ATTR_ASSUMED_STATE))
+
+        switch.turn_on(self.hass, 'switch.test')
+        self.hass.block_till_done()
+
+        self.mock_publish.async_publish.assert_called_once_with(
+            'command-topic', 'on,1234', 2, False)
+        self.mock_publish.async_publish.reset_mock()
+        state = self.hass.states.get('switch.test')
+        self.assertEqual(STATE_ON, state.state)
+
+        switch.turn_off(self.hass, 'switch.test')
+        self.hass.block_till_done()
+
+        self.mock_publish.async_publish.assert_called_once_with(
+            'command-topic', 'off,5678', 2, False)
+        state = self.hass.states.get('switch.test')
+        self.assertEqual(STATE_OFF, state.state)

--- a/tests/components/switch/test_mqtt_template.py
+++ b/tests/components/switch/test_mqtt_template.py
@@ -27,8 +27,10 @@ class TestSwitchMQTT(unittest.TestCase):
                 'platform': 'mqtt_template',
                 'name': 'test',
                 'command_topic': 'command-topic',
-                'payload_on_template': "on,{{ states.sensor.duration_1.state }}",
-                'payload_off_template': "off,{{ states.sensor.duration_2.state }}",
+                'payload_on_template':
+                    "on,{{ states.sensor.duration_1.state }}",
+                'payload_off_template':
+                    "off,{{ states.sensor.duration_2.state }}",
                 'qos': '2'
             }
         })


### PR DESCRIPTION
## Description:
My usecase is simple: I want to be able to send a custom/templated on/off payload to a MQTT switch, based on another sensor.
The `swtich.mqtt_template` platform in this PR, similar to [light.mqtt_template](https://www.home-assistant.io/components/light.mqtt_template/) allows just that.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5139

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: mqtt_template
    command_topic: "home/bedroom/switch1/set"
    payload_on_template: "on,{{ states.sensor.duration_1.state }}"
    payload_off_template: "off"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)#5139

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
