### PR TITLE
Add support for Eufy bulbs and switches

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -94,6 +94,9 @@ omit =
     homeassistant/components/envisalink.py
     homeassistant/components/*/envisalink.py
 
+    homeassistant/components/eufy.py
+    homeassistant/components/*/eufy.py
+
     homeassistant/components/gc100.py
     homeassistant/components/*/gc100.py
 

--- a/homeassistant/components/eufy.py
+++ b/homeassistant/components/eufy.py
@@ -31,8 +31,8 @@ DEVICE_SCHEMA = vol.Schema({
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
-        vol.Optional(CONF_USERNAME): cv.string,
-        vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Inclusive(CONF_USERNAME, 'authentication'): cv.string,
+        vol.Inclusive(CONF_PASSWORD, 'authentication'): cv.string,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -61,15 +61,14 @@ def setup(hass, config):
             discovery.load_platform(hass, EUFY_DISPATCH[type], DOMAIN, device,
                                     config)
 
-    for address, access_token, type, name in \
-     config[DOMAIN][CONF_DEVICES].items():
+    for x, device_info in config[DOMAIN][CONF_DEVICES].items():
         if type not in EUFY_DISPATCH:
             continue
         device = {}
-        device['address'] = address
-        device['code'] = access_token
-        device['type'] = type
-        device['name'] = name
+        device['address'] = device_info['address']
+        device['code'] = device_info['access_token']
+        device['type'] = device_info['type']
+        device['name'] = device_info['name']
         discovery.load_platform(hass, EUFY_DISPATCH[type], DOMAIN, device,
                                 config)
 

--- a/homeassistant/components/eufy.py
+++ b/homeassistant/components/eufy.py
@@ -45,6 +45,7 @@ EUFY_DISPATCH = {
     'T1211': 'switch'
 }
 
+
 def setup(hass, config):
     """Set up Eufy devices."""
     # pylint: disable=import-error
@@ -61,7 +62,7 @@ def setup(hass, config):
                                     config)
 
     for address, access_token, type, name in \
-        config[DOMAIN][CONF_DEVICES].items():
+     config[DOMAIN][CONF_DEVICES].items():
         if type not in EUFY_DISPATCH:
             continue
         device = {}

--- a/homeassistant/components/eufy.py
+++ b/homeassistant/components/eufy.py
@@ -30,7 +30,8 @@ DEVICE_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
+        vol.Optional(CONF_DEVICES, default=[]): vol.All(cv.ensure_list,
+                                                        [DEVICE_SCHEMA]),
         vol.Inclusive(CONF_USERNAME, 'authentication'): cv.string,
         vol.Inclusive(CONF_PASSWORD, 'authentication'): cv.string,
     }),
@@ -55,21 +56,22 @@ def setup(hass, config):
         data = lakeside.get_devices(config[DOMAIN][CONF_USERNAME],
                                     config[DOMAIN][CONF_PASSWORD])
         for device in data:
-            type = device['type']
-            if type not in EUFY_DISPATCH:
+            kind = device['type']
+            if kind not in EUFY_DISPATCH:
                 continue
-            discovery.load_platform(hass, EUFY_DISPATCH[type], DOMAIN, device,
+            discovery.load_platform(hass, EUFY_DISPATCH[kind], DOMAIN, device,
                                     config)
 
-    for x, device_info in config[DOMAIN][CONF_DEVICES].items():
-        if type not in EUFY_DISPATCH:
+    for device_info in config[DOMAIN][CONF_DEVICES]:
+        kind = device_info['type']
+        if kind not in EUFY_DISPATCH:
             continue
         device = {}
         device['address'] = device_info['address']
         device['code'] = device_info['access_token']
         device['type'] = device_info['type']
         device['name'] = device_info['name']
-        discovery.load_platform(hass, EUFY_DISPATCH[type], DOMAIN, device,
+        discovery.load_platform(hass, EUFY_DISPATCH[kind], DOMAIN, device,
                                 config)
 
     return True

--- a/homeassistant/components/eufy.py
+++ b/homeassistant/components/eufy.py
@@ -1,0 +1,75 @@
+"""
+Support for Eufy devices.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/eufy/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_ADDRESS, \
+    CONF_DEVICES, CONF_USERNAME, CONF_PASSWORD, CONF_TYPE, CONF_NAME
+from homeassistant.helpers import discovery
+
+import homeassistant.helpers.config_validation as cv
+
+
+REQUIREMENTS = ['lakeside==0.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'eufy'
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Required(CONF_ADDRESS): cv.string,
+    vol.Required(CONF_ACCESS_TOKEN): cv.string,
+    vol.Required(CONF_TYPE): cv.string,
+    vol.Optional(CONF_NAME): cv.string
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
+        vol.Optional(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_PASSWORD): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+EUFY_DISPATCH = {
+    'T1011': 'light',
+    'T1012': 'light',
+    'T1013': 'light',
+    'T1201': 'switch',
+    'T1202': 'switch',
+    'T1211': 'switch'
+}
+
+def setup(hass, config):
+    """Set up Eufy devices."""
+    # pylint: disable=import-error
+    import lakeside
+
+    if CONF_USERNAME in config[DOMAIN] and CONF_PASSWORD in config[DOMAIN]:
+        data = lakeside.get_devices(config[DOMAIN][CONF_USERNAME],
+                                    config[DOMAIN][CONF_PASSWORD])
+        for device in data:
+            type = device['type']
+            if type not in EUFY_DISPATCH:
+                continue
+            discovery.load_platform(hass, EUFY_DISPATCH[type], DOMAIN, device,
+                                    config)
+
+    for address, access_token, type, name in \
+        config[DOMAIN][CONF_DEVICES].items():
+        if type not in EUFY_DISPATCH:
+            continue
+        device = {}
+        device['address'] = address
+        device['code'] = access_token
+        device['type'] = type
+        device['name'] = name
+        discovery.load_platform(hass, EUFY_DISPATCH[type], DOMAIN, device,
+                                config)
+
+    return True

--- a/homeassistant/components/light/eufy.py
+++ b/homeassistant/components/light/eufy.py
@@ -13,8 +13,8 @@ from homeassistant.components.light import (
 import homeassistant.util.color as color_util
 
 from homeassistant.util.color import (
-        color_temperature_mired_to_kelvin as mired_to_kelvin,
-        color_temperature_kelvin_to_mired as kelvin_to_mired)
+    color_temperature_mired_to_kelvin as mired_to_kelvin,
+    color_temperature_kelvin_to_mired as kelvin_to_mired)
 
 REQUIREMENTS = ['lakeside==0.4']
 

--- a/homeassistant/components/light/eufy.py
+++ b/homeassistant/components/light/eufy.py
@@ -1,0 +1,150 @@
+"""
+Support for Eufy lights
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.eufy/
+"""
+import logging
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_HS_COLOR, SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR_TEMP, SUPPORT_COLOR, Light)
+
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util.color as color_util
+
+from homeassistant.util.color import (
+        color_temperature_mired_to_kelvin as mired_to_kelvin,
+        color_temperature_kelvin_to_mired as kelvin_to_mired)
+
+REQUIREMENTS = ['lakeside==0.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+EUFY_MAX_KELVIN = 6500
+EUFY_MIN_KELVIN = 2700
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Eufy bulbs."""
+    add_devices([EufyLight(discovery_info)], True)
+
+
+class EufyLight(Light):
+    """Representation of a Eufy light."""
+
+    def __init__(self, device):
+        """Initialize the light."""
+        # pylint: disable=import-error
+        import lakeside
+
+        self._name = device['name']
+        self._address = device['address']
+        self._code = device['code']
+        self._type = device['type']
+        self._bulb = lakeside.bulb(self._address, self._code, self._type)
+        if self._type == "T1011":
+            self._features = SUPPORT_BRIGHTNESS
+        elif self._type == "T1012":
+            self._features = SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP
+        elif self._type == "T1013":
+            self._features = SUPPORT_BRIGHTNESS | SUPPORT_COLOR
+        self._bulb.connect()
+
+    def update(self):
+        self._bulb.update()
+        self._brightness = self._bulb.brightness
+        self._temp = self._bulb.temperature        
+        if self._bulb.colors:
+            self._hs = color_util.color_RGB_to_hsv(self._bulb.colors)
+        else:
+            self._hs = None
+        self._state = self._bulb.power
+
+    @property
+    def unique_id(self):
+        """Return the ID of this light."""
+        return self._address
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""        
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return int(self._brightness * 255 / 100)
+
+    @property
+    def min_mireds(self):
+        """Return minimum supported color temperature."""
+        return kelvin_to_mired(EUFY_MAX_KELVIN)
+
+    @property
+    def max_mireds(self):
+        """Return maximu supported color temperature."""
+        return kelvin_to_mired(EUFY_MIN_KELVIN)
+
+    @property
+    def color_temp(self):
+        """Return the color temperature of this light."""
+        temp_in_k = int(EUFY_MIN_KELVIN + (self._temp *
+                                           (EUFY_MAX_KELVIN - EUFY_MIN_KELVIN)
+                                           / 100))
+        return kelvin_to_mired(temp_in_k)
+
+    @property
+    def hs_color(self):
+        """Return the color of this light."""
+        return self._hs
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return self._features
+
+    def turn_on(self, **kwargs):
+        """Turn the specified light on."""
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+        colortemp = kwargs.get(ATTR_COLOR_TEMP)
+        hs = kwargs.get(ATTR_HS_COLOR)
+
+        if brightness is not None:            
+            brightness = int(brightness * 100 / 255)
+        else:
+            brightness = max(1, self._brightness)
+
+        if colortemp is not None:
+            temp_in_k = mired_to_kelvin(colortemp)
+            relative_temp = temp_in_k - EUFY_MIN_KELVIN
+            temp = int(relative_temp * 100 /
+                       (EUFY_MAX_KELVIN - EUFY_MIN_KELVIN))
+        else:
+            temp = None
+
+        if hs is not None:
+            rgb = color_util.color_hsv_to_RGB(
+                hs[0], hs[1], brightness / 255 * 100)
+        else:
+            rgb = None
+
+        try:
+            self._bulb.set_state(power=True, brightness=brightness,
+                                 temperature=temp, colors=rgb)
+        except BrokenPipeError:
+            self._bulb.connect()
+            self._bulb.set_state(power=True, brightness=brightness,
+                                 temperature=temp, colors=rgb)
+
+    def turn_off(self, **kwargs):
+        """Turn the specified light off."""
+        try:
+            self._bulb.set_state(power=False)
+        except BrokenPipeError:
+            self._bulb.connect()
+            self._bulb.set_state(power=False)

--- a/homeassistant/components/light/eufy.py
+++ b/homeassistant/components/light/eufy.py
@@ -1,5 +1,5 @@
 """
-Support for Eufy lights
+Support for Eufy lights.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.eufy/
@@ -39,6 +39,10 @@ class EufyLight(Light):
         # pylint: disable=import-error
         import lakeside
 
+        self._temp = None
+        self._brightness = None
+        self._hs = None
+        self._state = None
         self._name = device['name']
         self._address = device['address']
         self._code = device['code']
@@ -53,11 +57,12 @@ class EufyLight(Light):
         self._bulb.connect()
 
     def update(self):
+        """Synchronise state from the bulb."""
         self._bulb.update()
         self._brightness = self._bulb.brightness
         self._temp = self._bulb.temperature
         if self._bulb.colors:
-            self._hs = color_util.color_RGB_to_hsv(self._bulb.colors)
+            self._hs = color_util.color_RGB_to_hsv(*self._bulb.colors)
         else:
             self._hs = None
         self._state = self._bulb.power

--- a/homeassistant/components/light/eufy.py
+++ b/homeassistant/components/light/eufy.py
@@ -119,6 +119,7 @@ class EufyLight(Light):
         """Turn the specified light on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         colortemp = kwargs.get(ATTR_COLOR_TEMP)
+        # pylint: disable=invalid-name
         hs = kwargs.get(ATTR_HS_COLOR)
 
         if brightness is not None:

--- a/homeassistant/components/light/eufy.py
+++ b/homeassistant/components/light/eufy.py
@@ -16,7 +16,7 @@ from homeassistant.util.color import (
     color_temperature_mired_to_kelvin as mired_to_kelvin,
     color_temperature_kelvin_to_mired as kelvin_to_mired)
 
-REQUIREMENTS = ['lakeside==0.4']
+DEPENDENCIES = ['eufy']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,6 +26,8 @@ EUFY_MIN_KELVIN = 2700
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Eufy bulbs."""
+    if discovery_info is None:
+        return
     add_devices([EufyLight(discovery_info)], True)
 
 

--- a/homeassistant/components/light/eufy.py
+++ b/homeassistant/components/light/eufy.py
@@ -10,7 +10,6 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_HS_COLOR, SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR_TEMP, SUPPORT_COLOR, Light)
 
-import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
 from homeassistant.util.color import (
@@ -23,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 EUFY_MAX_KELVIN = 6500
 EUFY_MIN_KELVIN = 2700
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Eufy bulbs."""
@@ -53,7 +53,7 @@ class EufyLight(Light):
     def update(self):
         self._bulb.update()
         self._brightness = self._bulb.brightness
-        self._temp = self._bulb.temperature        
+        self._temp = self._bulb.temperature
         if self._bulb.colors:
             self._hs = color_util.color_RGB_to_hsv(self._bulb.colors)
         else:
@@ -67,7 +67,7 @@ class EufyLight(Light):
 
     @property
     def name(self):
-        """Return the name of the device if any."""        
+        """Return the name of the device if any."""
         return self._name
 
     @property
@@ -114,7 +114,7 @@ class EufyLight(Light):
         colortemp = kwargs.get(ATTR_COLOR_TEMP)
         hs = kwargs.get(ATTR_HS_COLOR)
 
-        if brightness is not None:            
+        if brightness is not None:
             brightness = int(brightness * 100 / 255)
         else:
             brightness = max(1, self._brightness)

--- a/homeassistant/components/switch/eufy.py
+++ b/homeassistant/components/switch/eufy.py
@@ -1,20 +1,22 @@
 """
-Support for Eufy lights
+Support for Eufy switches
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/light.eufy/
+https://home-assistant.io/components/switch.eufy/
 """
 import logging
 
 from homeassistant.components.switch import SwitchDevice
 
-REQUIREMENTS = ['lakeside==0.4']
+DEPENDENCIES = ['eufy']
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Eufy switches."""
+    if discovery_info is None:
+        return
     add_devices([EufySwitch(discovery_info)], True)
 
 

--- a/homeassistant/components/switch/eufy.py
+++ b/homeassistant/components/switch/eufy.py
@@ -1,5 +1,5 @@
 """
-Support for Eufy switches
+Support for Eufy switches.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.eufy/
@@ -28,6 +28,7 @@ class EufySwitch(SwitchDevice):
         # pylint: disable=import-error
         import lakeside
 
+        self._state = None
         self._name = device['name']
         self._address = device['address']
         self._code = device['code']
@@ -36,6 +37,7 @@ class EufySwitch(SwitchDevice):
         self._switch.connect()
 
     def update(self):
+        """Synchronise state from the switch."""
         self._switch.update()
         self._state = self._switch.power
 

--- a/homeassistant/components/switch/eufy.py
+++ b/homeassistant/components/switch/eufy.py
@@ -8,11 +8,10 @@ import logging
 
 from homeassistant.components.switch import SwitchDevice
 
-import homeassistant.helpers.config_validation as cv
-
 REQUIREMENTS = ['lakeside==0.4']
 
 _LOGGER = logging.getLogger(__name__)
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Eufy switches."""
@@ -45,7 +44,7 @@ class EufySwitch(SwitchDevice):
 
     @property
     def name(self):
-        """Return the name of the device if any."""        
+        """Return the name of the device if any."""
         return self._name
 
     @property

--- a/homeassistant/components/switch/eufy.py
+++ b/homeassistant/components/switch/eufy.py
@@ -1,0 +1,70 @@
+"""
+Support for Eufy lights
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.eufy/
+"""
+import logging
+
+from homeassistant.components.switch import SwitchDevice
+
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['lakeside==0.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Eufy switches."""
+    add_devices([EufySwitch(discovery_info)], True)
+
+
+class EufySwitch(SwitchDevice):
+    """Representation of a Eufy switch."""
+
+    def __init__(self, device):
+        """Initialize the light."""
+        # pylint: disable=import-error
+        import lakeside
+
+        self._name = device['name']
+        self._address = device['address']
+        self._code = device['code']
+        self._type = device['type']
+        self._switch = lakeside.switch(self._address, self._code, self._type)
+        self._switch.connect()
+
+    def update(self):
+        self._switch.update()
+        self._state = self._switch.power
+
+    @property
+    def unique_id(self):
+        """Return the ID of this light."""
+        return self._address
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""        
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Turn the specified switch on."""
+        try:
+            self._switch.set_state(True)
+        except BrokenPipeError:
+            self._switch.connect()
+            self._switch.set_state(power=True)
+
+    def turn_off(self, **kwargs):
+        """Turn the specified switch off."""
+        try:
+            self._switch.set_state(False)
+        except BrokenPipeError:
+            self._switch.connect()
+            self._switch.set_state(False)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -454,6 +454,11 @@ keyring==12.0.0
 # homeassistant.scripts.keyring
 keyrings.alt==3.0
 
+# homeassistant.components.eufy
+# homeassistant.components.light.eufy
+# homeassistant.components.switch.eufy
+lakeside==0.4
+
 # homeassistant.components.device_tracker.owntracks
 # homeassistant.components.device_tracker.owntracks_http
 libnacl==1.6.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -455,8 +455,6 @@ keyring==12.0.0
 keyrings.alt==3.0
 
 # homeassistant.components.eufy
-# homeassistant.components.light.eufy
-# homeassistant.components.switch.eufy
 lakeside==0.4
 
 # homeassistant.components.device_tracker.owntracks


### PR DESCRIPTION
Add support for driving bulbs and switches from the Eufy range.

## Description:

This PR adds support for Eufy devices from Anker. It's currently limited to bulbs and switches, I don't have access to any vacuums. Documentation will follow later this evening.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5145

## Example entry for `configuration.yaml` (if applicable):
```yaml
eufy:
  username: testuser@domain
  password: p4ssw0rd
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
