### PR TITLE
Update netatmo.py

### DIFF
--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -17,7 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
 REQUIREMENTS = [
-    'https://github.com/jabesq/netatmo-api-python/archive/'
+    'https://github.com/jabesq/netatmo-api-python/'
     'v0.9.2.1.zip#lnetatmo==0.9.2.1']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -400,7 +400,7 @@ https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
 https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f86c90aa26b2.zip#spotipy==2.4.4
 
 # homeassistant.components.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/v0.9.2.1.zip#lnetatmo==0.9.2.1
+https://github.com/jabesq/netatmo-api-python/v0.9.2.1.zip#lnetatmo==0.9.2.1
 
 # homeassistant.components.neato
 https://github.com/jabesq/pybotvac/archive/v0.0.5.zip#pybotvac==0.0.5


### PR DESCRIPTION
## Description:
Updated the URL for Netatmo to fix #13680


**Related issue (if applicable):** fixes #13680 as the URL used returned a 404. updating the URL allows Netatmo plugin to be installed.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. -- Not sure what this is? only new to this.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54