### PR TITLE
Fix bad metrics format for short metrics.

### DIFF
--- a/homeassistant/components/prometheus.py
+++ b/homeassistant/components/prometheus.py
@@ -185,6 +185,9 @@ class Metrics(object):
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         metric = state.entity_id.split(".")[1]
 
+        if '_' not in str(metric):
+            metric = state.entity_id.replace('.', '_')
+
         try:
             int(metric.split("_")[-1])
             metric = "_".join(metric.split("_")[:-1])


### PR DESCRIPTION
## Description:

Fix metrics for mfi component which generates `sensor.2` which raises

```
    raise ValueError('Invalid metric name: ' + full_name)
ValueError: Invalid metric name: sensor.2
```
or

```
  File "/Users/michaelkuty/projects/home-assistant-dev/src/hass/homeassistant/components/prometheus.py", line 94, in _metric
    return self._metrics[metric]
KeyError: 'sensor.2'
```

this PR fix errors and generate 

```
sensor{entity="sensor.3",friendly_name="3"} 0.0
sensor{entity="sensor.1",friendly_name="1"} 15.0
sensor{entity="sensor.4",friendly_name="4"} 13.0
sensor{entity="sensor.2",friendly_name="2"} 0.0
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
