### PR TITLE
Update beacontools to 1.2.3

### DIFF
--- a/homeassistant/components/sensor/eddystone_temperature.py
+++ b/homeassistant/components/sensor/eddystone_temperature.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_NAME, TEMP_CELSIUS, STATE_UNKNOWN, EVENT_HOMEASSISTANT_STOP,
     EVENT_HOMEASSISTANT_START)
 
-REQUIREMENTS = ['beacontools[scan]==1.2.1', 'construct==2.9.41']
+REQUIREMENTS = ['beacontools[scan]==1.2.3', 'construct==2.9.41']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -131,7 +131,7 @@ basicmodem==0.7
 batinfo==0.4.2
 
 # homeassistant.components.sensor.eddystone_temperature
-# beacontools[scan]==1.2.1
+# beacontools[scan]==1.2.3
 
 # homeassistant.components.device_tracker.linksys_ap
 # homeassistant.components.sensor.geizhals


### PR DESCRIPTION
## Description:

The `construct` developers, again, made a breaking change in a minor version update (2.9.41) which breaks my library `beacontools`. This PR updates the version to 1.2.3 to fix this issue.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
