### PR TITLE
Support for having a schedule as a trigger or as a standalone sensor.

### DIFF
--- a/homeassistant/components/automation/schedule.py
+++ b/homeassistant/components/automation/schedule.py
@@ -1,0 +1,103 @@
+"""
+Offer automation trigger based on a schedule.
+
+For more details about this automation rule, please refer to the documentation
+at https://home-assistant.io/docs/automation/trigger/#schedule-trigger.
+
+
+Example config:
+---------------
+  input_boolean:
+    mock_heating:
+      name: Mock heating
+      initial: off
+
+  automation:
+    - alias: 'Heating control'
+      trigger:
+        platform: schedule
+        schedule:
+          - "Mon-Wed, Fri: 05:00-07:30, 16:00-22:00"
+          - "Thu: 06:00+2h30m, 15:00+7h"
+          - "Sat-Sun: 06:00=on, 22:00=off"
+      action:
+        - service_template: >
+          {% if trigger.schedule_state == 'on' %}
+            homeassistant.turn_on
+          {% else %}
+            homeassistant.turn_off
+          {% endif %}
+            entity_id: input_boolean.mock_heating
+"""
+import asyncio
+import logging
+
+from datetime import datetime, timedelta
+import voluptuous as vol
+
+from homeassistant.core import callback, HomeAssistant
+from homeassistant.const import CONF_PLATFORM
+from homeassistant.helpers.event import async_track_point_in_time
+import homeassistant.util.dt as dt
+
+import homeassistant.components.schedule.scheduleparser as sp
+
+PLATFORM = 'schedule'
+
+CONF_SCHEDULE = 'schedule'
+
+_LOGGER = logging.getLogger(__name__)
+
+TRIGGER_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): PLATFORM,
+    vol.Required(CONF_SCHEDULE): sp.is_valid_schedule
+})
+
+
+@asyncio.coroutine
+def async_trigger(hass: HomeAssistant, config, action):
+    """Listen for events based on configuration."""
+    schedule = config.get(CONF_SCHEDULE)
+
+    def _schedule_callback(handler, callback_time, now):
+        """Schedule a single callback with hass."""
+        if callback_time <= now:
+            _LOGGER.debug("Running %s for %s as already passed", handler,
+                          callback_time)
+            return hass.async_run_job(handler, now)
+        _LOGGER.debug("Scheduling %s for %s", handler, callback_time)
+        return async_track_point_in_time(hass, handler, callback_time)
+
+    def schedule_callbacks(events, now):
+        """Schedule callbacks for the list of events plus next midnight."""
+        for event_time, _ in events:
+            instant = datetime.combine(now.date(), event_time)
+            instant = instant.replace(tzinfo=now.tzinfo)
+            _schedule_callback(event_callback, instant, now)
+        midnight = dt.start_of_local_day(now) + timedelta(days=1)
+        return _schedule_callback(midnight_callback, midnight, now)
+
+    @callback
+    def midnight_callback(now):
+        """Callback at midnight schedules all the events for today."""
+        _LOGGER.debug("Received midnight callback")
+        events = schedule.get_events_today(now)
+        schedule_callbacks(events, now)
+
+    @callback
+    def event_callback(now):
+        """Trigger action at event time."""
+        _LOGGER.debug("Received event callback")
+        hass.async_run_job(action, {
+            'trigger': {
+                'platform': PLATFORM,
+                'now': now,
+                'schedule_state': schedule.get_current_state(now)
+            },
+        })
+
+    # Schedule events for the rest of today (i.e. don't include the past)
+    now = dt.now()
+    events = [event for event in schedule.get_events_today(now)
+              if event[0] > now.time()]
+    return schedule_callbacks(events, now)

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -1,0 +1,6 @@
+"""
+Provide functionality to define a schedule of state changes.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/state_schedule/
+"""

--- a/homeassistant/components/schedule/schedule.py
+++ b/homeassistant/components/schedule/schedule.py
@@ -1,0 +1,86 @@
+"""Class representing a schedule of events."""
+
+from datetime import date, datetime, time, timedelta
+
+from typing import List, Tuple
+
+from .scheduleutil import daily_schedule, events_until, events_after
+from .scheduletypes import ScheduleEntry, ScheduleEvent, State
+
+
+class Schedule:
+    """Represents a schedule of events."""
+
+    def __init__(self, entries: List[ScheduleEntry], text: str) -> None:
+        """Initialize the schedule."""
+        self._day_list = [daily_schedule(
+            entries, d) for d in range(0, 7)]
+        self.text = text
+
+    def __str__(self):
+        """Return a textual description of the Schedule."""
+        return self.text
+
+    def has_event(self, today: date) -> bool:
+        """Return True if the specified date has any events."""
+        return self._day_list[today.weekday()] != []
+
+    def get_latest_event(self, now: datetime, lookback: bool = True) \
+            -> Tuple[datetime, State]:
+        """
+        Return the most recent event before a date/time, or None.
+
+        Keyword arguments:
+        lookback -- if True then previous days will be considered when looking
+        for a latest event.
+        """
+        result = self._get_last_event(now.date(), now.tzinfo, now.time())
+        if result:
+            return result
+        if lookback:
+            for i in range(1, 7):
+                new_now = now - timedelta(days=i)
+                result = self._get_last_event(new_now.date(), now.tzinfo)
+                if result:
+                    return result
+        return None
+
+    def get_current_state(self, now: datetime, lookback: bool = True) -> str:
+        """
+        Return the current state, or None if there is no previous event.
+
+        Keyword arguments:
+        lookback -- if True then previous days will be considered when looking
+        for a latest event.
+        """
+        event = self.get_latest_event(now, lookback)
+        return event[1] if event else None
+
+    def _get_last_event(self, now: date, tzinfo, until: time = None) \
+            -> Tuple[datetime, State]:
+        """Find the last event on the given day up until the given time."""
+        day = now.weekday()
+        if until is not None:
+            daily_events = events_until(self._day_list[day], until)
+        else:
+            daily_events = self._day_list[day]
+        if not daily_events:
+            return None
+        event_time, state = daily_events[-1]   # Just want the last one
+        event_time = event_time.replace(tzinfo=tzinfo)
+        return datetime.combine(now, event_time), state
+
+    def get_events_today(self, now: date) -> List[ScheduleEvent]:
+        """Return all the events on a given day."""
+        return self._day_list[now.weekday()]
+
+    def get_next_event_today(self, now: datetime) -> ScheduleEvent:
+        """
+        Return the next event after the specified datetime.
+
+        This returns the next event on the same day, or None if there are't
+        any.
+        """
+        events = events_after(
+            self._day_list[now.weekday()], now.time())
+        return events[0] if events else None

--- a/homeassistant/components/schedule/scheduleparser.py
+++ b/homeassistant/components/schedule/scheduleparser.py
@@ -1,0 +1,209 @@
+"""Class to parse a textual schedule into a usuable structure."""
+
+from datetime import date, datetime, time, timedelta
+import re
+import voluptuous as vol
+
+from typing import Any, List
+
+from homeassistant.const import STATE_ON, STATE_OFF
+import homeassistant.helpers.config_validation as cv
+
+from .schedule import Schedule
+from .scheduletypes import ScheduleEntry, ScheduleEvent
+
+
+def is_valid_schedule(value: Any) -> Schedule:
+    """Validate that the entry is a valid schedule."""
+    config_list = [cv.string(item) for item in cv.ensure_list(value)]
+    schedule_text = '; '.join(config_list)
+    parser = ScheduleParser()
+    return parser.parse_schedule(schedule_text)
+
+
+class ScheduleParser:
+    """
+    Class providing facilities to parse schedule text.
+
+    The class may be run in one of two modes:
+    - Stateful (the default) allows schedules to specify on-off ranges or even
+      specifically named states (e.g. 'cold', 'warm', 'hot')
+    - Stateless means that the schedule consists purely of events and doesn't
+      allow state transitions.
+    In stateless mode, the schedule returned consists entirely of 'on' events.
+    """
+
+    _day_map = {'Mon': 0, 'Tue': 1, 'Wed': 2,
+                'Thu': 3, 'Fri': 4, 'Sat': 5, 'Sun': 6}
+    _weekday_pattern = re.compile(r'^(?P<start>\w+)\s*\-\s*(?P<finish>\w+)$')
+    _time_pattern = re.compile(r'^\d?\d:\d\d$')
+    _time_seconds_pattern = re.compile(r'^\d?\d:\d\d:\d\d$')
+    _time_delta_pattern = re.compile(
+        r'^((?P<hours>\d+)h)?((?P<mins>\d+)m)?((?P<secs>\d+)s)?$')
+
+    def __init__(self, *, on_state: str = STATE_ON,
+                 off_state: str = STATE_OFF, stateless: bool = False) \
+            -> None:
+        """
+        Initialise the parser.
+
+        Keyword arguments:
+        on_state -- the string to use to represent on (default 'on')
+        off_state -- the string to use to represent off (default 'off')
+        stateless -- if False then do not allow event states
+        """
+        self.on_state = on_state
+        self.off_state = off_state
+        self.stateless = stateless
+
+    def parse_weekdays(self, text: str) -> List[int]:
+        """
+        Parse a string of the form 'Mon-Wed,Fri' into a list of integers.
+
+        Note that the integers correspond to the Python day numbers of those
+        days, not ISO standard day numbers.
+        """
+        parts = [p.strip() for p in text.split(',')]
+        result = []   # type: List[int]
+        for part in parts:
+            match = self._weekday_pattern.match(part)
+            if match:
+                # Range
+                start, finish = self.weekday(match.group(
+                    'start')), self.weekday(match.group('finish'))
+                result += [start]
+                while start != finish:
+                    start = (start + 1) % 7
+                    result += [start]
+            else:
+                # Singleton
+                result += [self.weekday(part)]
+        return result
+
+    def weekday(self, text: str) -> int:
+        """Convert a single day string into a Python day number."""
+        result = self._day_map.get(text)
+        if result is None:
+            raise vol.Invalid('Bad weekday format: "{}"'.format(text))
+        return result
+
+    def parse_time(self, text: str) -> time:
+        """Parse a string of the form H:M or H:M:S into a time object."""
+        text = text.strip()
+        if self._time_pattern.match(text):
+            return datetime.strptime(text, '%H:%M').time()
+        elif self._time_seconds_pattern.match(text):
+            return datetime.strptime(text, '%H:%M:%S').time()
+        else:
+            raise vol.Invalid('Bad time format: "{}"'.format(text))
+
+    def parse_time_delta(self, text: str) -> timedelta:
+        """
+        Parse a string of the form XhYmZx into a timedelta object.
+
+        All of the components of the string are optional, so you can do
+        things like '2h1s' or '1m'.
+        """
+        text = text.strip()
+        match = self._time_delta_pattern.match(text)
+        if match:
+            hours = int(match.group('hours') or 0)
+            mins = int(match.group('mins') or 0)
+            secs = int(match.group('secs') or 0)
+            return timedelta(hours=hours, minutes=mins, seconds=secs)
+        else:
+            raise vol.Invalid('Bad time delta format: "{}"'.format(text))
+
+    def parse_time_schedule_part(self, text: str) -> List[ScheduleEvent]:
+        """
+        Parse a time range string into a list of events.
+
+        The string may be one of:
+        - Simple time: 11:15[:30] (in stateless mode only this is supported)
+        - On/off time range: 11:15-12:30
+        - On/off time range: 11:15+1h15m
+        - Time and state: 11:15=idle
+        """
+        if self.stateless:
+            return [(self.parse_time(text), self.on_state)]
+
+        if '-' in text:
+            bits = text.split('-')
+            if len(bits) != 2:
+                msg = 'Bad time range format: "{}"'.format(text)
+                raise vol.Invalid(msg)
+            start, finish = bits
+            start_time = self.parse_time(start)
+            finish_time = self.parse_time(finish)
+            if finish_time < start_time:
+                msg = 'Finish time cannot be before start: "{}"'.format(text)
+                raise vol.Invalid(msg)
+            return [(start_time, self.on_state),
+                    (finish_time, self.off_state)]
+        elif '+' in text:
+            bits = text.split('+')
+            if len(bits) != 2:
+                msg = 'Bad time range format: "{}"'.format(text)
+                raise vol.Invalid(msg)
+            start, delta = bits
+            start_time = self.parse_time(start)
+            time_delta = self.parse_time_delta(delta)
+            # We can only apply a time delta to a datetime, not a time
+            base_date = date(2000, 1, 1)
+            start_datetime = datetime.combine(base_date, start_time)
+            end_datetime = start_datetime + time_delta
+            if end_datetime.date() != base_date:
+                msg = ('Cannot currently have time range going past end ' +
+                       'of day: "{}"').format(text)
+                raise vol.Invalid(msg)
+            return [(start_time, self.on_state),
+                    (end_datetime.time(), self.off_state)]
+        elif '=' in text:
+            bits = text.split('=')
+            if len(bits) != 2:
+                msg = 'Bad state change format: "{}"'.format(text)
+                raise vol.Invalid(msg)
+            time_str, state = bits
+            return [(self.parse_time(time_str), state.strip())]
+        else:
+            return [(self.parse_time(text), self.on_state)]
+
+    def parse_time_schedule(self, text: str) -> List[ScheduleEvent]:
+        """
+        Parse a string into a list of time events.
+
+        Example: '10:00-11:15, 12:30-14:45'
+        """
+        result = []   # type: List[ScheduleEvent]
+        for part in text.split(','):
+            result += self.parse_time_schedule_part(part)
+        return result
+
+    def parse_schedule_entry(self, text: str) -> ScheduleEntry:
+        """
+        Parse a string into a ScheduleEntry structure.
+
+        Example: 'Mon-Fri: 10:00-11:15, 12:30-14:45'
+        """
+        bits = text.split(':')
+        if len(bits) < 2:
+            raise vol.Invalid('Bad schedule format: "{}"'.format(text))
+        days = bits[0]
+        times = ':'.join(bits[1:])
+        return (self.parse_weekdays(days), self.parse_time_schedule(times))
+
+    def parse_schedule_line(self, text: str) -> List[ScheduleEntry]:
+        """
+        Parse a string separated with ';' into a list of ScheduleEntries.
+
+        Example: 'Mon-Fri: 10:00-11:15; Sat: 09:00-12:15'
+        """
+        return [self.parse_schedule_entry(p) for p in text.split(';')]
+
+    def parse_schedule(self, text: str) -> Schedule:
+        """
+        Parse a string separated with ';' into a Schedule object.
+
+        Example: 'Mon-Fri: 10:00-11:15; Sat: 09:00-12:15'
+        """
+        return Schedule(self.parse_schedule_line(text), text)

--- a/homeassistant/components/schedule/scheduletypes.py
+++ b/homeassistant/components/schedule/scheduletypes.py
@@ -1,0 +1,15 @@
+"""Aliases for types used in schedule parsing."""
+
+from datetime import time
+from typing import List, Tuple
+
+# Pylint currently doesn't understand that type aliases should be treated as
+# classes
+# pylint: disable=C0103
+State = str
+
+# At time t change state to s
+ScheduleEvent = Tuple[time, State]
+
+# On days xyz do state changes abc
+ScheduleEntry = Tuple[List[int], List[ScheduleEvent]]

--- a/homeassistant/components/schedule/scheduleutil.py
+++ b/homeassistant/components/schedule/scheduleutil.py
@@ -1,0 +1,39 @@
+"""Utility methods for schedule parsing."""
+
+from datetime import time
+from typing import List
+
+from .scheduletypes import ScheduleEntry, ScheduleEvent
+
+
+def sort_schedule_events(events: List[ScheduleEvent]) -> List[ScheduleEvent]:
+    """Sort events into time order."""
+    return sorted(events, key=lambda e: e[0])
+
+
+def daily_schedule(schedule: List[ScheduleEntry], day: int) \
+                   -> List[ScheduleEvent]:
+    """Return a single list of events on the given day."""
+    events = [event for entry in schedule if day in entry[0]
+              for event in entry[1]]
+    return sort_schedule_events(events)
+
+
+def events_after(events: List[ScheduleEvent], after: time) \
+                 -> List[ScheduleEvent]:
+    """Return events strictly after the given time."""
+    return [event for event in events if event[0] > after]
+
+
+def events_until(events: List[ScheduleEvent],
+                 until: time, *, after: time = None) \
+                 -> List[ScheduleEvent]:
+    """
+    Return events up to and including the given time.
+
+    Keyword arguments:
+    after -- if specified, only events after this time will be included.
+    """
+    if after is not None:
+        events = events_after(events, after)
+    return [event for event in events if event[0] <= until]

--- a/homeassistant/components/sensor/state_schedule.py
+++ b/homeassistant/components/sensor/state_schedule.py
@@ -1,0 +1,141 @@
+"""
+Sensor providing state changes based on a schedule.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.state_schedule/
+
+Example config
+--------------
+  sensor:
+    platform: state_schedule
+    name: "heating schedule"
+    schedule:
+      - "Mon-Fri: 11:00-17:00"
+      - "Sat, Sun: 12:05+15s"
+
+  input_boolean:
+    mock_heating:
+        name: Mock heating
+        initial: off
+
+  automation:
+    - alias: 'Track heating schedule'
+      trigger:
+        platform: state
+        entity_id: sensor.heating_schedule
+      action:
+        service_template: >
+          {% if is_state('sensor.heating_schedule', 'on') %}
+            homeassistant.turn_on
+          {% else %}
+            homeassistant.turn_off
+          {% endif %}
+        entity_id: input_boolean.mock_heating
+"""
+import asyncio
+from datetime import datetime, timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.components.schedule.scheduleparser as sp
+from homeassistant.const import CONF_NAME
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_point_in_time
+import homeassistant.util.dt as dt
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'State Schedule sensor'
+
+ATTR_SCHEDULE = 'schedule'
+ATTR_LAST_CHANGED = 'last state change'
+ATTR_LAST_UPDATED = 'last updated'
+ATTR_NEXT_UPDATE = 'next update'
+
+CONF_SCHEDULE = 'schedule'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Required(CONF_SCHEDULE): sp.is_valid_schedule
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices,
+                         discovery_info=None):
+    """Set up the Statistics sensor."""
+    name = config.get(CONF_NAME)
+    schedule = config.get(CONF_SCHEDULE)
+
+    sensor = StateScheduleSensor(hass, name, schedule)
+    sensor.add_callback()
+    async_add_devices([sensor], True)
+    return True
+
+
+class StateScheduleSensor(Entity):
+    """Implementation of a sensor which changes state based on a schedule."""
+
+    def __init__(self, hass, name, schedule):
+        """Initialize the sensor."""
+        self._hass = hass
+        self._name = name
+        self._schedule = schedule
+        self._update_internal_state(dt.now())
+
+    def _update_internal_state(self, time_date):
+        """Update the state and calc the next event time."""
+        event = self._schedule.get_latest_event(time_date)
+        self._last_updated = time_date
+        self._last_changed = event[0]
+        self._state = event[1]
+        next_event = self._schedule.get_next_event_today(time_date)
+        if next_event:
+            local_time = next_event[0].replace(tzinfo=time_date.tzinfo)
+            self._next_update = datetime.combine(time_date, local_time)
+        else:
+            self._next_update = dt.start_of_local_day(time_date) + \
+                                timedelta(days=1)
+
+    def add_callback(self):
+        """Set the next callback from Hass."""
+        async_track_point_in_time(self._hass,
+                                  self.point_in_time_listener,
+                                  self._next_update)
+
+    @callback
+    def point_in_time_listener(self, time_date):
+        """Callback from Hass when we hit the next update time."""
+        self._update_internal_state(time_date)
+        self.async_schedule_update_ha_state()
+        self.add_callback()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        state = {
+            ATTR_SCHEDULE: self._schedule.text,
+            ATTR_LAST_CHANGED: self._last_changed.isoformat(),
+            ATTR_LAST_UPDATED: self._last_updated.isoformat(),
+            ATTR_NEXT_UPDATE: self._next_update.isoformat()
+        }
+        return state

--- a/tests/components/automation/test_schedule.py
+++ b/tests/components/automation/test_schedule.py
@@ -1,0 +1,128 @@
+"""The tests for the time automation."""
+import unittest
+from unittest.mock import patch
+
+from homeassistant.core import callback
+from homeassistant.setup import setup_component
+import homeassistant.util.dt as dt_util
+from homeassistant.util.dt import parse_datetime
+import homeassistant.components.automation as automation
+
+from tests.common import (
+    fire_time_changed, get_test_home_assistant, mock_component)
+
+PATCH_DATETIME = parse_datetime('2018-04-01T11:30:00-04:00')
+
+
+# pylint: disable=invalid-name
+class TestAutomationSchedule(unittest.TestCase):
+    """Test the event automation."""
+
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+        # Switch timezone to New York so we make sure things work as expected
+        self.DEFAULT_TIME_ZONE = dt_util.DEFAULT_TIME_ZONE
+        self.new_tz = dt_util.get_time_zone('America/New_York')
+        assert self.new_tz is not None
+        dt_util.set_default_time_zone(self.new_tz)
+
+        mock_component(self.hass, 'group')
+        self.calls = []
+
+        @callback
+        def record_call(service):
+            """Helper to record calls."""
+            self.calls.append(service)
+
+        self.hass.services.register('test', 'automation', record_call)
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        dt_util.set_default_time_zone(self.DEFAULT_TIME_ZONE)
+        self.hass.stop()
+
+    @patch('homeassistant.util.dt.now', return_value=PATCH_DATETIME)
+    def test_schedule_basics(self, _):
+        """Test basic operation."""
+        setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'schedule',
+                    'schedule': 'Mon-Sun: 11:00, 12:00'
+                },
+                'action': {
+                    'service': 'test.automation'
+                }
+            }
+        })
+
+        # Although we set up at 11:30 it shouldn't have fired the 11:00 job
+        self.assertEqual(0, len(self.calls))
+
+        # Moving to 12:30 should trigger the 12:00 job
+        fire_time_changed(self.hass, parse_datetime('2018-04-01T12:30-04:00'))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
+        # Moving to 01:00 the next day shouldn't trigger anything
+        fire_time_changed(self.hass, parse_datetime('2018-04-02T01:00-04:00'))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
+        # Moving to 12:30 then should trigger both jobs
+        fire_time_changed(self.hass, parse_datetime('2018-04-02T12:30-04:00'))
+        self.hass.block_till_done()
+        self.assertEqual(3, len(self.calls))
+
+    @patch('homeassistant.util.dt.now', return_value=PATCH_DATETIME)
+    def test_midnight_edge_case(self, _):
+        """Ensure events at midnight work as we do special things then."""
+        setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'schedule',
+                    'schedule': 'Mon-Sun: 00:00'
+                },
+                'action': {
+                    'service': 'test.automation'
+                }
+            }
+        })
+
+        self.assertEqual(0, len(self.calls))
+
+        # Moving to the next day should fire the job
+        fire_time_changed(self.hass, parse_datetime('2018-04-02T01:00-04:00'))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+
+    @patch('homeassistant.util.dt.now', return_value=PATCH_DATETIME)
+    def test_data_passed_to_action_context(self, _):
+        """Test  the data available for actions."""
+        setup_component(self.hass, automation.DOMAIN, {
+            automation.DOMAIN: {
+                'trigger': {
+                    'platform': 'schedule',
+                    'schedule': 'Mon-Sun: 11:00=a, 12:00=b'
+                },
+                'action': {
+                    'service': 'test.automation',
+                    'data_template': {
+                        'some': '{{ trigger.platform }} - '
+                                '{{ trigger.now }} = '
+                                '{{ trigger.schedule_state }}'
+                    },
+                }
+            }
+        })
+
+        # Although we set up at 11:30 it shouldn't have fired the 11:00 job
+        self.assertEqual(0, len(self.calls))
+
+        fire_time_changed(self.hass, parse_datetime('2018-04-01T12:30-04:00'))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        self.assertEqual('schedule - 2018-04-01 12:30:00-04:00 = b',
+                         self.calls[0].data['some'])

--- a/tests/components/schedule/__init__.py
+++ b/tests/components/schedule/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the State Schedule component."""

--- a/tests/components/schedule/test_schedule.py
+++ b/tests/components/schedule/test_schedule.py
@@ -1,0 +1,88 @@
+"""The tests for the Schedule class."""
+
+from datetime import date, datetime, time
+import unittest
+
+from homeassistant.components.schedule.schedule import Schedule
+from homeassistant.components.schedule.scheduleparser import ScheduleParser
+
+parser = ScheduleParser()
+friday = date(1999, 12, 31)
+saturday = date(2000, 1, 1)
+monday = date(2000, 1, 3)
+SCHEDULE = 'Mon-Fri: 09:00=a, 10:00=b, 11:00=c'
+
+
+def dt(day: date, time: str) -> datetime:
+    """Convenience function to make tests easier to read."""
+    t = parser.parse_time(time)
+    return datetime.combine(day, t)
+
+
+class TestSchedule(unittest.TestCase):
+    """Tests for the Schedule class."""
+
+    def test_has_event(self):
+        """Test has_event works."""
+        schedule = parser.parse_schedule(SCHEDULE)
+        self.assertTrue(schedule.has_event(monday))
+        self.assertFalse(schedule.has_event(saturday))
+
+    def test_preserves_text(self):
+        """Test has_event works."""
+        schedule = Schedule(parser.parse_schedule_line(SCHEDULE), SCHEDULE)
+        self.assertEqual(SCHEDULE, str(schedule))
+
+    def test_get_latest_event(self):
+        """Test get_latest_event works."""
+        schedule = parser.parse_schedule(SCHEDULE)
+        self.assertEqual((dt(monday, '09:00'), "a"),
+                         schedule.get_latest_event(dt(monday, '09:30')))
+        self.assertEqual((dt(monday, '10:00'), "b"),
+                         schedule.get_latest_event(dt(monday, '10:00')))
+        self.assertEqual((dt(monday, '11:00'), "c"),
+                         schedule.get_latest_event(dt(monday, '23:00')))
+
+    def test_looking_back_to_prior_state(self):
+        """Test that when lookback is true that it scans the previous days."""
+        schedule = parser.parse_schedule(SCHEDULE)
+        self.assertIsNone(schedule.get_latest_event(
+            dt(saturday, '09:30'), lookback=False))
+        self.assertEqual((dt(friday, '11:00'), "c"),
+                         schedule.get_latest_event(dt(saturday, '09:30')))
+
+    def test_get_events_today(self):
+        """Test get_event_today works."""
+        schedule = parser.parse_schedule(SCHEDULE)
+        events = schedule.get_events_today(monday)
+        self.assertEqual(3, len(events))
+        self.assertEqual((time(9, 0), 'a'), events[0])
+        self.assertEqual((time(10, 0), 'b'), events[1])
+        self.assertEqual((time(11, 0), 'c'), events[2])
+
+        self.assertEqual([], schedule.get_events_today(saturday))
+
+    def test_get_current_state(self):
+        """Test getting the current state of the schedule."""
+        schedule = parser.parse_schedule(SCHEDULE)
+        self.assertEqual("a", schedule.get_current_state(dt(monday, '09:30')))
+        self.assertEqual("c", schedule.get_current_state(dt(monday, '08:30')))
+        self.assertIsNone(schedule.get_current_state(dt(saturday, '09:30'),
+                                                     lookback=False))
+
+    def test_get_next_event_today(self):
+        """Test get_next_event_today works."""
+        schedule = parser.parse_schedule(SCHEDULE)
+        self.assertEqual((time(9, 0), "a"),
+                         schedule.get_next_event_today(dt(monday, '00:00')))
+        self.assertEqual((time(10, 0), "b"),
+                         schedule.get_next_event_today(dt(monday, '09:00')))
+        self.assertIsNone(schedule.get_next_event_today(dt(monday, '11:00')))
+
+    def test_midnight(self):
+        """Test events set to midnight behave correctly."""
+        schedule_text = 'Mon-Fri: 00:00=a'
+        schedule = parser.parse_schedule(schedule_text)
+        self.assertEqual((dt(monday, '00:00'), "a"),
+                         schedule.get_latest_event(dt(monday, '00:00')))
+        self.assertIsNone(schedule.get_next_event_today(dt(monday, '00:00')))

--- a/tests/components/schedule/test_scheduleparser.py
+++ b/tests/components/schedule/test_scheduleparser.py
@@ -1,0 +1,178 @@
+"""The tests for the ScheduleParser class."""
+
+from datetime import datetime, time, timedelta
+import unittest
+import voluptuous as vol
+
+import homeassistant.components.schedule.scheduleparser as sp
+
+
+class TestScheduleParser(unittest.TestCase):
+    """Test the ScheduleParser class."""
+
+    # pylint: disable=invalid-name
+    def setUp(self):
+        """Set up things needed by all tests."""
+        self.parser = sp.ScheduleParser()
+
+    def test_weekday(self):
+        """Test parsing of weekday strings."""
+        self.assertEqual([5], self.parser.parse_weekdays('Sat'))
+        self.assertEqual([0], self.parser.parse_weekdays('Mon'))
+
+    def test_parse_day_range(self):
+        """Test parsing of day ranges."""
+        self.assertEqual([6, 0, 1], self.parser.parse_weekdays('Sun-Tue'))
+
+    def test_parse_multiple_days(self):
+        """Test parsing of mulitple days."""
+        self.assertEqual([1, 5, 4, 2, 3], self.parser.parse_weekdays(
+            'Tue, Sat, Fri, Wed-Thu'))
+
+    def test_parse_bad_day(self):
+        """Test error handling for unrecognised weekdays."""
+        with self.assertRaisesRegex(vol.Invalid,
+                                    'Bad weekday format: "Blah"'):
+            self.parser.parse_weekdays('Blah')
+
+    def test_parse_simple_time(self):
+        """Test parsing of time strings."""
+        self.assertEqual('01:02:03', self.parser.parse_time(
+            '01:02:03').isoformat())
+        self.assertEqual(
+            '04:05:00', self.parser.parse_time('04:05').isoformat())
+
+    def test_parse_short_time(self):
+        """Test time strings don't have to have two-digit hours."""
+        self.assertEqual(
+            '01:02:03', self.parser.parse_time('1:02:03').isoformat())
+        self.assertEqual(
+            '04:05:00', self.parser.parse_time('4:05').isoformat())
+
+    def test_parse_bad_time(self):
+        """Test error handling for bad time strings."""
+        with self.assertRaisesRegex(vol.Invalid, 'Bad time format: "Blah"'):
+            self.parser.parse_time('Blah')
+
+    def test_parse_time_delta(self):
+        """Test parsing of time delta strings."""
+        self.assertEqual(timedelta(hours=2),
+                         self.parser.parse_time_delta('2h'))
+        self.assertEqual(timedelta(minutes=3),
+                         self.parser.parse_time_delta('3m'))
+        self.assertEqual(timedelta(seconds=4),
+                         self.parser.parse_time_delta('4s'))
+        self.assertEqual(timedelta(hours=11, minutes=12, seconds=13),
+                         self.parser.parse_time_delta('11h12m13s'))
+
+    def test_parse_time_schedule_part(self):
+        """Test parsing of time events or ranges."""
+        parser = self.parser
+        self.assertEqual([(time(9, 5, 6), 'on')],
+                         parser.parse_time_schedule_part('09:05:06'))
+        self.assertEqual([(time(9, 5, 6), 'on'), (time(14, 2), 'off')],
+                         parser.parse_time_schedule_part('09:05:06-14:02'))
+        self.assertEqual([(time(1, 0, 0), 'test')],
+                         parser.parse_time_schedule_part('01:00=test'))
+        self.assertEqual([(time(9, 5, 6), 'on'), (time(10, 7, 9), 'off')],
+                         parser.parse_time_schedule_part('09:05:06+1h2m3s'))
+
+    def test_override_onoff_states(self):
+        """Test overriding the default values for on and off states."""
+        parser = sp.ScheduleParser(on_state='a', off_state='b')
+        self.assertEqual([(time(9, 5, 6), 'a'), (time(14, 2), 'b')],
+                         parser.parse_time_schedule_part('09:05:06-14:02'))
+
+    def test_parse_bad_time_part(self):
+        """Test error handling for bad time ranges."""
+        # Have to put message in a var because of 79-char line length linting
+        msg = 'Bad time range format: "01:00-02:00-03:00"'
+        with self.assertRaisesRegex(vol.Invalid, msg):
+            self.parser.parse_time_schedule_part('01:00-02:00-03:00')
+        msg = 'Bad state change format: "a=b=c"'
+        with self.assertRaisesRegex(Exception, msg):
+            self.parser.parse_time_schedule_part('a=b=c')
+        msg = 'Finish time cannot be before start: "10:00-09:59"'
+        with self.assertRaisesRegex(Exception, msg):
+            self.parser.parse_time_schedule_part('10:00-09:59')
+        msg = 'Cannot currently have time range going ' + \
+              'past end of day: "23:00\+2h"'
+        with self.assertRaisesRegex(Exception, msg):
+            self.parser.parse_time_schedule_part('23:00+2h')
+
+    def test_parse_time_schedule(self):
+        """Test parsing of a schedule of multiple times."""
+        schedule = '01:02, 02:03-04:05, 06:07=wibble'
+        self.assertEqual([(time(1, 2), 'on'),
+                          (time(2, 3), 'on'),
+                          (time(4, 5), 'off'),
+                          (time(6, 7), 'wibble')],
+                         self.parser.parse_time_schedule(schedule))
+
+    def test_parse_schedule_entry(self):
+        """Test parsing of a day list and schedule of multiple times."""
+        days = [1, 2, 4]
+        schedule = 'Tue-Wed, Fri: 01:02, 02:03-04:05, 06:07=wibble'
+        time_schedule = [(time(1, 2), 'on'),
+                         (time(2, 3), 'on'),
+                         (time(4, 5), 'off'),
+                         (time(6, 7), 'wibble')]
+        self.assertEqual((days, time_schedule),
+                         self.parser.parse_schedule_entry(schedule))
+
+    def test_parse_schedule_line(self):
+        """Test parsing of a full schedule."""
+        days_1 = [1, 2, 4]
+        schedule = 'Tue-Wed, Fri: 01:02, 02:03-04:05,' + \
+                   '06:07=wibble; Thu: 14:15:30'
+        time_schedule_1 = [(time(1, 2), 'on'), (time(2, 3), 'on'),
+                           (time(4, 5), 'off'), (time(6, 7), 'wibble')]
+        days_2 = [3]
+        time_schedule_2 = [(time(14, 15, 30), 'on')]
+        self.assertEqual([(days_1, time_schedule_1),
+                          (days_2, time_schedule_2)],
+                         self.parser.parse_schedule_line(schedule))
+
+    def test_parse_schedule_line_ignores_whitespace(self):
+        """Test whitespace doesn't matter."""
+        thin_schedule = 'Tue-Wed,Fri:01:02,02:03-04:05,06:07=wibble,' + \
+                        '09:05+2h3m;Thu:14:15:30'
+        fat_schedule = ' Tue - Wed , Fri : 01:02 , 02:03 - 04:05 ,' +  \
+                       '06:07 = wibble, 09:05 + 2h3m ; Thu : 14:15:30 '
+        self.assertEqual(self.parser.parse_schedule_line(thin_schedule),
+                         self.parser.parse_schedule_line(fat_schedule))
+
+    def test_parse_stateless_schedule(self):
+        """Test parsing a schedule where we're not doing state transitions."""
+        parser = sp.ScheduleParser(stateless=True)
+        schedule = 'Tue-Wed, Fri: 01:02, 02:03, 04:05'
+        days = [1, 2, 4]
+        times = [(time(1, 2), 'on'), (time(2, 3), 'on'), (time(4, 5), 'on')]
+        self.assertEqual([(days, times)], parser.parse_schedule_line(schedule))
+
+    def test_parse_bad_stateless_schedule(self):
+        """Test parsing errors for stateless schedules."""
+        parser = sp.ScheduleParser(stateless=True)
+
+        # Can't do time ranges
+        with self.assertRaisesRegex(vol.Invalid,
+                                    'Bad time format: "01:02-03:04"'):
+            parser.parse_schedule_line('Tue-Wed, Fri: 01:02-03:04')
+
+        # Nor in time delta form
+        with self.assertRaisesRegex(vol.Invalid,
+                                    'Bad time format: "01:02\+3h"'):
+            parser.parse_schedule_line('Tue-Wed, Fri: 01:02+3h')
+
+        # Also can't do specific states
+        with self.assertRaisesRegex(vol.Invalid,
+                                    'Bad time format: "01:02=a"'):
+            parser.parse_schedule_line('Tue-Wed, Fri: 01:02=a')
+
+    def test_parse_schedule(self):
+        """Test parsing into a Schedule object."""
+        test_date = datetime(2018, 4, 6, 7, 7)
+        schedule_text = 'Tue-Wed, Fri: 01:02, 02:03-04:05,' + \
+                        '06:07=wibble; Thu: 14:15:30'
+        schedule = self.parser.parse_schedule(schedule_text)
+        self.assertEqual('wibble', schedule.get_current_state(test_date))

--- a/tests/components/schedule/test_scheduleutil.py
+++ b/tests/components/schedule/test_scheduleutil.py
@@ -1,0 +1,45 @@
+"""The tests for the scheduleutil module."""
+
+from datetime import time
+
+from homeassistant.components.schedule.scheduleparser import ScheduleParser
+from homeassistant.components.schedule.scheduleutil \
+    import sort_schedule_events, daily_schedule, events_until
+
+parser = ScheduleParser()
+
+
+def test_sort_schedule_events():
+    """Test schedule event sorting."""
+    schedule = parser.parse_time_schedule('10:00=b, 9:00=a, 11:00=c')
+    events = sort_schedule_events(schedule)
+    assert time(9, 0) == events[0][0]
+    assert time(10, 0) == events[1][0]
+    assert time(11, 0) == events[2][0]
+
+
+def test_build_daily_schedule():
+    """Test filtering for events on a specific day."""
+    schedule = parser.parse_schedule_line(
+        'Tue-Wed: 14:00=a, 16:00=c; Wed-Thu: 15:00=b, 16:00=d')
+    assert [(time(14, 0), 'a'), (time(16, 0), 'c')
+            ] == daily_schedule(schedule, 1)  # Tue
+    assert [(time(14, 0), 'a'),
+            (time(15, 0), 'b'),
+            (time(16, 0), 'c'),
+            (time(16, 0), 'd')] == daily_schedule(schedule, 2)  # Wed
+    assert [(time(15, 0), 'b'), (time(16, 0), 'd')
+            ] == daily_schedule(schedule, 3)  # Thu
+    assert [] == daily_schedule(schedule, 5)  # Fri
+
+
+def test_events_until():
+    """Test finding events up to a specific time."""
+    events = parser.parse_time_schedule('09:00=a, 10:00=b, 11:00=c')
+    assert [] == events_until(events, time(8, 0))
+    assert [] == events_until(events, time(9, 30), after=time(9, 0))
+    assert [] == events_until(events, time(23, 0), after=time(11, 0))
+    assert [(time(9, 0), 'a')] == events_until(
+        events, time(9, 30), after=time(8, 0))
+    assert [(time(10, 0), 'b')] == events_until(
+        events, time(10, 0), after=time(9, 0))

--- a/tests/components/sensor/test_state_schedule.py
+++ b/tests/components/sensor/test_state_schedule.py
@@ -1,0 +1,116 @@
+"""The test for the state schedule sensor platform."""
+import unittest
+from unittest.mock import patch
+
+from homeassistant.setup import setup_component
+from homeassistant.util import dt
+from tests.common import get_test_home_assistant, fire_time_changed
+
+SINGLE_LINE_CONFIG = {'sensor': {
+    'platform': 'state_schedule',
+    'name': 'test',
+    'schedule': "Mon-Fri: 11:00-17:00"
+}}
+MULTI_LINE_CONFIG = {'sensor': {
+    'platform': 'state_schedule',
+    'name': 'test',
+    'schedule': [
+        "Mon-Fri: 11:00-17:00",
+        "Sat-Sun: 01:00=warm, 03:00=hot, 09:00=off"
+    ]
+}}
+SATURDAY_IN_DST = dt.parse_datetime('2018-03-31T02:47:19-04:00')
+
+
+class TestStateScheduleSensor(unittest.TestCase):
+    """Test the StateSchedule sensor."""
+
+    def setup_method(self, method):
+        """Set things up to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+        # Switch timezone to New York so we make sure things work as expected
+        self.DEFAULT_TIME_ZONE = dt.DEFAULT_TIME_ZONE
+        new_tz = dt.get_time_zone('America/New_York')
+        assert new_tz is not None
+        dt.set_default_time_zone(new_tz)
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        dt.set_default_time_zone(self.DEFAULT_TIME_ZONE)
+        self.hass.stop()
+
+    @patch('homeassistant.util.dt.now', return_value=SATURDAY_IN_DST)
+    def test_platform_setup_single_line(self, _):
+        """Test setting up a StateSchedule."""
+        assert setup_component(self.hass, 'sensor', SINGLE_LINE_CONFIG)
+
+        state = self.hass.states.get('sensor.test')
+        self.assertEqual('off', state.state)
+        self.assertEqual('Mon-Fri: 11:00-17:00',
+                         state.attributes.get('schedule'))
+
+    @patch('homeassistant.util.dt.now', return_value=SATURDAY_IN_DST)
+    def test_platform_setup_multi_line(self, _):
+        """Test setting up a StateSchedule with multiple schedule entries."""
+        assert setup_component(self.hass, 'sensor', MULTI_LINE_CONFIG)
+
+        state = self.hass.states.get('sensor.test')
+        self.assertEqual('warm', state.state)
+        self.assertEqual('Mon-Fri: 11:00-17:00; Sat-Sun: 01:00=warm, ' +
+                         '03:00=hot, 09:00=off',
+                         state.attributes.get('schedule'))
+
+    @patch('homeassistant.util.dt.now', return_value=SATURDAY_IN_DST)
+    def test_state_attributes_set(self, _):
+        """Test state attributes are set correctly on startup."""
+        assert setup_component(self.hass, 'sensor', SINGLE_LINE_CONFIG)
+
+        state = self.hass.states.get('sensor.test')
+        self.assertEqual('off', state.state)
+        self.assertEqual('Mon-Fri: 11:00-17:00',
+                         state.attributes.get('schedule'))
+        self.assertEqual('test', state.attributes.get('friendly_name'))
+        self.assertEqual('2018-03-31T02:47:19-04:00',
+                         state.attributes.get('last updated'))
+        self.assertEqual('2018-04-01T00:00:00-04:00',
+                         state.attributes.get('next update'))
+        self.assertEqual('2018-03-30T17:00:00-04:00',
+                         state.attributes.get('last state change'))
+
+    @patch('homeassistant.util.dt.now', return_value=SATURDAY_IN_DST)
+    def test_state_changes_over_time(self, _):
+        """Test state changes correctly as time moves forward."""
+        assert setup_component(self.hass, 'sensor', MULTI_LINE_CONFIG)
+
+        self.assertEqual('warm', self.hass.states.get('sensor.test').state)
+
+        self._advance_time('2018-03-31T04:00:00-04:00')
+        state = self.hass.states.get('sensor.test')
+        self.assertEqual('hot', state.state)
+        self.assertEqual('2018-03-31T09:00:00-04:00',
+                         state.attributes.get('next update'))
+
+        # After all events in a day, next update should be midnight
+        self._advance_time('2018-03-31T14:00:00-04:00')
+        state = self.hass.states.get('sensor.test')
+        self.assertEqual('off', state.state)
+        self.assertEqual('2018-04-01T00:00:00-04:00',
+                         state.attributes.get('next update'))
+
+        self._advance_time('2018-04-02T01:00:00-04:00')
+        state = self.hass.states.get('sensor.test')
+        self.assertEqual('off', state.state)
+        self.assertEqual('2018-04-02T11:00:00-04:00',
+                         state.attributes.get('next update'))
+
+        self._advance_time('2018-04-02T12:00:00-04:00')
+        state = self.hass.states.get('sensor.test')
+        self.assertEqual('on', state.state)
+        self.assertEqual('2018-04-02T17:00:00-04:00',
+                         state.attributes.get('next update'))
+
+    def _advance_time(self, time_str):
+        """Convenience function."""
+        fire_time_changed(self.hass, dt.parse_datetime(time_str))
+        self.hass.block_till_done()


### PR DESCRIPTION
## Description:

Added a trigger platform that allows weekly schedules of events to be specified much more human-readably than with the current time platform and conditions.  For example "Mon-Fri: 09:00-11:00, 16:00-17:30".  This also supports the concept of "on" vs "off" events which is useful for controlling devices (see example below), which can be further used to support other arbitrary states (e.g. "warm" for heating).  Also added a sensor platform that supports its state changing based on the same schedules, but which would allow multiple bindings.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
  input_boolean:
    mock_heating:
      name: Mock heating
      initial: off

  automation:
    - alias: 'Heating control'
      trigger:
        platform: schedule
        schedule:
          - "Mon-Wed, Fri: 05:00-07:30, 16:00-22:00"
          - "Thu: 06:00+2h30m, 15:00+7h"
          - "Sat-Sun: 06:00=on, 22:00=off"
      action:
        - service_template: >
          {% if trigger.schedule_state == 'on' %}
            homeassistant.turn_on
          {% else %}
            homeassistant.turn_off
          {% endif %}
            entity_id: input_boolean.mock_heating
```

## Checklist:
  - [Y] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
      - couldn't get tox working on Ubuntu/Win10, but tests passes with py.test

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
      - Documentation not done yet as this is a new component.  Will address if this PR is accepted.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
     - No devices or third-party tools

If the code does not interact with devices:
  - [Y] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
