### PR TITLE
Support fan/vacuum/media_player as Switch in HomeKit

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -130,8 +130,8 @@ def get_accessory(hass, state, aid, config):
     elif state.domain == 'lock':
         return TYPES['Lock'](hass, state.entity_id, state.name, aid=aid)
 
-    elif state.domain == 'switch' or state.domain == 'remote' \
-            or state.domain == 'input_boolean' or state.domain == 'script':
+    elif state.domain in ['switch', 'remote', 'input_boolean', 'script',
+                          'fan', 'vacuum', 'media_player']:
         _LOGGER.debug('Add "%s" as "%s"', state.entity_id, 'Switch')
         return TYPES['Switch'](hass, state.entity_id, state.name, aid=aid)
 

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -140,3 +140,21 @@ class TestGetAccessories(unittest.TestCase):
         with patch.dict(TYPES, {'Switch': self.mock_type}):
             state = State('input_boolean.test', 'on')
             get_accessory(None, state, 2, {})
+
+    def test_fan(self):
+        """Test fan."""
+        with patch.dict(TYPES, {'Switch': self.mock_type}):
+            state = State('fan.test', 'on')
+            get_accessory(None, state, 2, {})
+
+    def test_vacuum(self):
+        """Test vacuum."""
+        with patch.dict(TYPES, {'Switch': self.mock_type}):
+            state = State('vacuum.test', 'on')
+            get_accessory(None, state, 2, {})
+
+    def test_media_player(self):
+        """Test media_player."""
+        with patch.dict(TYPES, {'Switch': self.mock_type}):
+            state = State('media_player.test', 'on')
+            get_accessory(None, state, 2, {})

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -85,8 +85,65 @@ class TestHomekitSwitches(unittest.TestCase):
         self.assertEqual(acc.char_on.value, True)
 
     def test_input_boolean_set_state(self):
-        """Test service call for remote as domain."""
+        """Test service call for input_boolean as domain."""
         entity_id = 'input_boolean.test'
+        domain = split_entity_id(entity_id)[0]
+
+        acc = Switch(self.hass, entity_id, 'Switch', aid=2)
+        acc.run()
+
+        self.assertEqual(acc.char_on.value, False)
+
+        # Set from HomeKit
+        acc.char_on.client_update_value(True)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[0].data[ATTR_DOMAIN], domain)
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE], SERVICE_TURN_ON)
+        self.assertEqual(acc.char_on.value, True)
+
+    def test_fan_set_state(self):
+        """Test service call for fan as domain."""
+        entity_id = 'fan.test'
+        domain = split_entity_id(entity_id)[0]
+
+        acc = Switch(self.hass, entity_id, 'Switch', aid=2)
+        acc.run()
+
+        self.assertEqual(acc.char_on.value, False)
+
+        # Set from HomeKit
+        acc.char_on.client_update_value(True)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[0].data[ATTR_DOMAIN], domain)
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE], SERVICE_TURN_ON)
+        self.assertEqual(acc.char_on.value, True)
+
+    def test_vacuum_set_state(self):
+        """Test service call for vacuum as domain."""
+        entity_id = 'vacuum.test'
+        domain = split_entity_id(entity_id)[0]
+
+        acc = Switch(self.hass, entity_id, 'Switch', aid=2)
+        acc.run()
+
+        self.assertEqual(acc.char_on.value, False)
+
+        # Set from HomeKit
+        acc.char_on.client_update_value(True)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[0].data[ATTR_DOMAIN], domain)
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE], SERVICE_TURN_ON)
+        self.assertEqual(acc.char_on.value, True)
+
+    def test_media_player_set_state(self):
+        """Test service call for media_player as domain."""
+        entity_id = 'media_player.test'
         domain = split_entity_id(entity_id)[0]
 
         acc = Switch(self.hass, entity_id, 'Switch', aid=2)


### PR DESCRIPTION
## Description:

Support fan/vacuum/media_player as Switch in HomeKit.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#NA *If @cdce8p consider this PR is acceptable, I'll update the document in home-assistant.github.io*


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
