### PR TITLE
Clicksend: Added support for multiple recipients

### DIFF
--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -66,7 +66,6 @@ class ClicksendNotificationService(BaseNotificationService):
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
         data = {"messages": []}
-        
         for recipient in self.recipients:
             data["messages"].append({
                 'source': 'hass.notify',

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -37,7 +37,8 @@ PLATFORM_SCHEMA = vol.Schema(
     vol.All(PLATFORM_SCHEMA.extend({
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_API_KEY): cv.string,
-        vol.Required(CONF_RECIPIENT): cv.string,
+        vol.Required(CONF_RECIPIENT, default=[]):
+            vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_SENDER): cv.string,
     }), validate_sender))
 
@@ -59,21 +60,20 @@ class ClicksendNotificationService(BaseNotificationService):
         """Initialize the service."""
         self.username = config.get(CONF_USERNAME)
         self.api_key = config.get(CONF_API_KEY)
-        self.recipient = config.get(CONF_RECIPIENT)
+        self.recipients = config.get(CONF_RECIPIENT)
         self.sender = config.get(CONF_SENDER, CONF_RECIPIENT)
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        data = ({
-            'messages': [
-                {
-                    'source': 'hass.notify',
-                    'from': self.sender,
-                    'to': self.recipient,
-                    'body': message,
-                }
-            ]
-        })
+        data = {"messages": []}
+        
+        for recipient in self.recipients:
+            data["messages"].append({
+                'source': 'hass.notify',
+                'from': self.sender,
+                'to': recipient,
+                'body': message,
+            })
 
         api_url = "{}/sms/send".format(BASE_API_URL)
 


### PR DESCRIPTION
## Description:
Added support for multiple recipients for platform Clicksend (under component `notify`).
This also provides backward compatibility, so no change to an existing configuration is needed.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5149

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: clicksend
    name: ClickSend
    username: my_username
    api_key: <API KEY>
    recipient: [123456789, 987654321]
    sender: Home Assistant
# OR #
notify:
  - platform: clicksend
    name: ClickSend
    username: my_username
    api_key: <API KEY>
    recipient: 123456789
    sender: Home Assistant
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54