### PR TITLE
Update pyhomematic to 0.1.41

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['pyhomematic==0.1.40']
+REQUIREMENTS = ['pyhomematic==0.1.41']
 DOMAIN = 'homematic'
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ pyhik==0.1.8
 pyhiveapi==0.2.11
 
 # homeassistant.components.homematic
-pyhomematic==0.1.40
+pyhomematic==0.1.41
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==2.2.1


### PR DESCRIPTION
## Description:
Update pyhomematic to 0.1.41

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
