### PR TITLE
Adds support for switch properties in device_state_attributes

### DIFF
--- a/homeassistant/components/switch/vesync.py
+++ b/homeassistant/components/switch/vesync.py
@@ -91,6 +91,17 @@ class VeSyncSwitchHA(SwitchDevice):
         """Return True if switch is on."""
         return self.smartplug.device_status == "on"
 
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        attr = {}
+        attr['connection_status'] = self.smartplug.connection_status
+        attr['connection_type'] = self.smartplug.connection_type
+        attr['device_type'] = self.smartplug.device_type
+        attr['model'] = self.smartplug.model
+
+        return attr
+
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         self.smartplug.turn_on()


### PR DESCRIPTION
## Description:

- Adds support for returning additional attributes exposed by the pyvesync library via the `device_state_attributes` property

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5151

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
