### PR TITLE
Support basic covers with open/close/stop services

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -99,7 +99,8 @@ def get_accessory(hass, state, aid, config):
         if device_class == 'garage' and \
                 features & (SUPPORT_OPEN | SUPPORT_CLOSE):
             a_type = 'GarageDoorOpener'
-        elif features & (SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP):
+        elif features & (SUPPORT_OPEN | SUPPORT_CLOSE):
+            config['supports_stop'] = features & SUPPORT_STOP
             a_type = 'WindowCoveringBasic'
         elif features & SUPPORT_SET_POSITION:
             a_type = 'WindowCovering'

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -9,7 +9,7 @@ from zlib import adler32
 import voluptuous as vol
 
 from homeassistant.components.cover import (
-    SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_SET_POSITION)
+    SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_SET_POSITION, SUPPORT_STOP)
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_UNIT_OF_MEASUREMENT,
     ATTR_DEVICE_CLASS, CONF_PORT, TEMP_CELSIUS, TEMP_FAHRENHEIT,
@@ -99,6 +99,8 @@ def get_accessory(hass, state, aid, config):
         if device_class == 'garage' and \
                 features & (SUPPORT_OPEN | SUPPORT_CLOSE):
             a_type = 'GarageDoorOpener'
+        elif features & (SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP):
+            a_type = 'WindowCoveringBasic'
         elif features & SUPPORT_SET_POSITION:
             a_type = 'WindowCovering'
 

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -100,7 +100,6 @@ def get_accessory(hass, state, aid, config):
                 features & (SUPPORT_OPEN | SUPPORT_CLOSE):
             a_type = 'GarageDoorOpener'
         elif features & (SUPPORT_OPEN | SUPPORT_CLOSE):
-            config['supports_stop'] = features & SUPPORT_STOP
             a_type = 'WindowCoveringBasic'
         elif features & SUPPORT_SET_POSITION:
             a_type = 'WindowCovering'

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -9,7 +9,7 @@ from zlib import adler32
 import voluptuous as vol
 
 from homeassistant.components.cover import (
-    SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_SET_POSITION, SUPPORT_STOP)
+    SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_SET_POSITION)
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_UNIT_OF_MEASUREMENT,
     ATTR_DEVICE_CLASS, CONF_PORT, TEMP_CELSIUS, TEMP_FAHRENHEIT,
@@ -99,10 +99,10 @@ def get_accessory(hass, state, aid, config):
         if device_class == 'garage' and \
                 features & (SUPPORT_OPEN | SUPPORT_CLOSE):
             a_type = 'GarageDoorOpener'
-        elif features & (SUPPORT_OPEN | SUPPORT_CLOSE):
-            a_type = 'WindowCoveringBasic'
         elif features & SUPPORT_SET_POSITION:
             a_type = 'WindowCovering'
+        elif features & (SUPPORT_OPEN | SUPPORT_CLOSE):
+            a_type = 'WindowCoveringBasic'
 
     elif state.domain == 'light':
         a_type = 'Light'

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -94,6 +94,7 @@ CHAR_TARGET_POSITION = 'TargetPosition'  # Int | [0, 100]
 CHAR_TARGET_SECURITY_STATE = 'SecuritySystemTargetState'
 CHAR_TARGET_TEMPERATURE = 'TargetTemperature'
 CHAR_TEMP_DISPLAY_UNITS = 'TemperatureDisplayUnits'
+CHAR_POSITION_STATE = 'PositionState'
 
 # #### Properties ####
 PROP_CELSIUS = {'minValue': -273, 'maxValue': 999}

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -52,7 +52,8 @@ SERV_SMOKE_SENSOR = 'SmokeSensor'
 SERV_SWITCH = 'Switch'
 SERV_TEMPERATURE_SENSOR = 'TemperatureSensor'
 SERV_THERMOSTAT = 'Thermostat'
-SERV_WINDOW_COVERING = 'WindowCovering'  # CurrentPosition, TargetPosition
+SERV_WINDOW_COVERING = 'WindowCovering'
+# CurrentPosition, TargetPosition, PositionState
 
 
 # #### Characteristics ####
@@ -85,6 +86,7 @@ CHAR_MOTION_DETECTED = 'MotionDetected'
 CHAR_NAME = 'Name'
 CHAR_OCCUPANCY_DETECTED = 'OccupancyDetected'
 CHAR_ON = 'On'  # boolean
+CHAR_POSITION_STATE = 'PositionState'
 CHAR_SATURATION = 'Saturation'  # percent
 CHAR_SERIAL_NUMBER = 'SerialNumber'
 CHAR_SMOKE_DETECTED = 'SmokeDetected'
@@ -94,7 +96,6 @@ CHAR_TARGET_POSITION = 'TargetPosition'  # Int | [0, 100]
 CHAR_TARGET_SECURITY_STATE = 'SecuritySystemTargetState'
 CHAR_TARGET_TEMPERATURE = 'TargetTemperature'
 CHAR_TEMP_DISPLAY_UNITS = 'TemperatureDisplayUnits'
-CHAR_POSITION_STATE = 'PositionState'
 
 # #### Properties ####
 PROP_CELSIUS = {'minValue': -273, 'maxValue': 999}

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -128,28 +128,26 @@ class WindowCoveringBasic(HomeAccessory):
         """Move cover to value if call came from HomeKit."""
         _LOGGER.debug('%s: Set position to %d', self.entity_id, value)
 
-        service, position = (None, None)
         if self.supports_stop:
             if value > 70:
                 service, position = (SERVICE_OPEN_COVER, 100)
             elif value < 30:
                 service, position = (SERVICE_CLOSE_COVER, 0)
-            elif self.supports_stop:
+            else:
                 service, position = (SERVICE_STOP_COVER, 50)
         else:
             if value >= 50:
                 service, position = (SERVICE_OPEN_COVER, 100)
-            elif value < 50:
+            else:
                 service, position = (SERVICE_CLOSE_COVER, 0)
 
-        if service is not None:
-            self.hass.services.call(DOMAIN, service, {
-                ATTR_ENTITY_ID: self.entity_id
-            })
+        self.hass.services.call(DOMAIN, service, {
+            ATTR_ENTITY_ID: self.entity_id
+        })
 
-            # Snap the current/target position to the expected final position.
-            self.char_current_position.set_value(position)
-            self.char_target_position.set_value(position)
+        # Snap the current/target position to the expected final position.
+        self.char_current_position.set_value(position)
+        self.char_target_position.set_value(position)
 
     def update_state(self, new_state):
         """Update cover position after state changed."""

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -12,9 +12,9 @@ from . import TYPES
 from .accessories import HomeAccessory, add_preload_service, setup_char
 from .const import (
     CATEGORY_WINDOW_COVERING, SERV_WINDOW_COVERING,
-    CHAR_CURRENT_POSITION, CHAR_TARGET_POSITION,
+    CHAR_CURRENT_POSITION, CHAR_TARGET_POSITION, CHAR_POSITION_STATE,
     CATEGORY_GARAGE_DOOR_OPENER, SERV_GARAGE_DOOR_OPENER,
-    CHAR_CURRENT_DOOR_STATE, CHAR_TARGET_DOOR_STATE, CHAR_POSITION_STATE)
+    CHAR_CURRENT_DOOR_STATE, CHAR_TARGET_DOOR_STATE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ class WindowCoveringBasic(HomeAccessory):
             CHAR_TARGET_POSITION, serv_cover, value=0,
             callback=self.move_cover)
         self.char_position_state = setup_char(
-            CHAR_POSITION_STATE, serv_cover, value=0)
+            CHAR_POSITION_STATE, serv_cover, value=2)
 
     def move_cover(self, value):
         """Move cover to value if call came from HomeKit."""

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -4,8 +4,8 @@ import logging
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION, ATTR_POSITION, DOMAIN)
 from homeassistant.const import (
-    ATTR_ENTITY_ID, SERVICE_SET_COVER_POSITION, STATE_OPEN, STATE_CLOSED, SERVICE_OPEN_COVER, SERVICE_CLOSE_COVER,
-    SERVICE_STOP_COVER)
+    ATTR_ENTITY_ID, SERVICE_SET_COVER_POSITION, STATE_OPEN, STATE_CLOSED,
+    SERVICE_OPEN_COVER, SERVICE_CLOSE_COVER, SERVICE_STOP_COVER)
 
 from . import TYPES
 from .accessories import HomeAccessory, add_preload_service, setup_char

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -154,6 +154,13 @@ class TestGetAccessories(unittest.TestCase):
                           {ATTR_SUPPORTED_FEATURES: 4})
             get_accessory(None, state, 2, {})
 
+    def test_cover_open_close(self):
+        """Test cover with support for open and close."""
+        with patch.dict(TYPES, {'WindowCoveringBasic': self.mock_type}):
+            state = State('cover.open_window', 'open',
+                          {ATTR_SUPPORTED_FEATURES: 3})
+            get_accessory(None, state, 2, {})
+
     def test_alarm_control_panel(self):
         """Test alarm control panel."""
         config = {ATTR_CODE: '1234'}

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -155,24 +155,28 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 0)
         self.assertEqual(acc.char_target_position.value, 0)
+        self.assertEqual(acc.char_position_state.value, 2)
 
         self.hass.states.set(window_cover, STATE_UNKNOWN)
         self.hass.block_till_done()
 
         self.assertEqual(acc.char_current_position.value, 0)
         self.assertEqual(acc.char_target_position.value, 0)
+        self.assertEqual(acc.char_position_state.value, 2)
 
         self.hass.states.set(window_cover, STATE_OPEN)
         self.hass.block_till_done()
 
         self.assertEqual(acc.char_current_position.value, 100)
         self.assertEqual(acc.char_target_position.value, 100)
+        self.assertEqual(acc.char_position_state.value, 2)
 
         self.hass.states.set(window_cover, STATE_CLOSED)
         self.hass.block_till_done()
 
         self.assertEqual(acc.char_current_position.value, 0)
         self.assertEqual(acc.char_target_position.value, 0)
+        self.assertEqual(acc.char_position_state.value, 2)
 
         # Set from HomeKit
         acc.char_target_position.client_update_value(25)
@@ -182,6 +186,7 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 0)
         self.assertEqual(acc.char_target_position.value, 0)
+        self.assertEqual(acc.char_position_state.value, 2)
 
         # Set from HomeKit
         acc.char_target_position.client_update_value(90)
@@ -191,6 +196,7 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 100)
         self.assertEqual(acc.char_target_position.value, 100)
+        self.assertEqual(acc.char_position_state.value, 2)
 
         # Set from HomeKit
         acc.char_target_position.client_update_value(55)
@@ -200,6 +206,7 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 100)
         self.assertEqual(acc.char_target_position.value, 100)
+        self.assertEqual(acc.char_position_state.value, 2)
 
     def test_window_open_close_stop(self):
         """Test if accessory and HA are updated accordingly."""
@@ -219,6 +226,7 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 0)
         self.assertEqual(acc.char_target_position.value, 0)
+        self.assertEqual(acc.char_position_state.value, 2)
 
         # Set from HomeKit
         acc.char_target_position.client_update_value(90)
@@ -228,6 +236,7 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 100)
         self.assertEqual(acc.char_target_position.value, 100)
+        self.assertEqual(acc.char_position_state.value, 2)
 
         # Set from HomeKit
         acc.char_target_position.client_update_value(55)
@@ -237,3 +246,4 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 50)
         self.assertEqual(acc.char_target_position.value, 50)
+        self.assertEqual(acc.char_position_state.value, 2)

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -8,7 +8,8 @@ from homeassistant.components.homekit.type_covers import (
     GarageDoorOpener, WindowCovering, WindowCoveringBasic)
 from homeassistant.const import (
     STATE_CLOSED, STATE_UNAVAILABLE, STATE_UNKNOWN, STATE_OPEN,
-    ATTR_SERVICE, ATTR_SERVICE_DATA, EVENT_CALL_SERVICE, ATTR_SUPPORTED_FEATURES)
+    ATTR_SERVICE, ATTR_SERVICE_DATA, EVENT_CALL_SERVICE,
+    ATTR_SUPPORTED_FEATURES)
 
 from tests.common import get_test_home_assistant
 
@@ -143,8 +144,11 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         window_cover = 'cover.window'
 
-        self.hass.states.set(window_cover, STATE_UNKNOWN, {ATTR_SUPPORTED_FEATURES: SUPPORT_STOP})
-        acc = WindowCoveringBasic(self.hass, 'Cover', window_cover, 2, config=None)
+        self.hass.states.set(window_cover, STATE_UNKNOWN, {
+            ATTR_SUPPORTED_FEATURES: SUPPORT_STOP
+        })
+        acc = WindowCoveringBasic(self.hass, 'Cover', window_cover, 2,
+                                  config=None)
         acc.run()
 
         self.assertEqual(acc.aid, 2)
@@ -202,8 +206,11 @@ class TestHomekitSensors(unittest.TestCase):
         """Test if accessory and HA are updated accordingly."""
         window_cover = 'cover.window'
 
-        self.hass.states.set(window_cover, STATE_UNKNOWN, {ATTR_SUPPORTED_FEATURES: 0})
-        acc = WindowCoveringBasic(self.hass, 'Cover', window_cover, 2, config=None)
+        self.hass.states.set(window_cover, STATE_UNKNOWN, {
+            ATTR_SUPPORTED_FEATURES: 0
+        })
+        acc = WindowCoveringBasic(self.hass, 'Cover', window_cover, 2,
+                                  config=None)
         acc.run()
 
         self.assertEqual(acc.aid, 2)

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -3,12 +3,12 @@ import unittest
 
 from homeassistant.core import callback
 from homeassistant.components.cover import (
-    ATTR_POSITION, ATTR_CURRENT_POSITION)
+    ATTR_POSITION, ATTR_CURRENT_POSITION, SUPPORT_STOP)
 from homeassistant.components.homekit.type_covers import (
-    GarageDoorOpener, WindowCovering)
+    GarageDoorOpener, WindowCovering, WindowCoveringBasic)
 from homeassistant.const import (
     STATE_CLOSED, STATE_UNAVAILABLE, STATE_UNKNOWN, STATE_OPEN,
-    ATTR_SERVICE, ATTR_SERVICE_DATA, EVENT_CALL_SERVICE)
+    ATTR_SERVICE, ATTR_SERVICE_DATA, EVENT_CALL_SERVICE, ATTR_SUPPORTED_FEATURES)
 
 from tests.common import get_test_home_assistant
 
@@ -132,9 +132,127 @@ class TestHomekitSensors(unittest.TestCase):
         acc.char_target_position.client_update_value(75)
         self.hass.block_till_done()
         self.assertEqual(
-            self.events[0].data[ATTR_SERVICE], 'set_cover_position')
+            self.events[1].data[ATTR_SERVICE], 'set_cover_position')
         self.assertEqual(
             self.events[1].data[ATTR_SERVICE_DATA][ATTR_POSITION], 75)
 
         self.assertEqual(acc.char_current_position.value, 50)
         self.assertEqual(acc.char_target_position.value, 75)
+
+    def test_window_open_close_stop(self):
+        """Test if accessory and HA are updated accordingly."""
+        window_cover = 'cover.window'
+
+        self.hass.states.set(window_cover, STATE_UNKNOWN, {ATTR_SUPPORTED_FEATURES: SUPPORT_STOP})
+        acc = WindowCoveringBasic(self.hass, 'Cover', window_cover, 2, config=None)
+        acc.run()
+
+        self.assertEqual(acc.aid, 2)
+        self.assertEqual(acc.category, 14)  # WindowCovering
+
+        self.assertEqual(acc.char_current_position.value, 0)
+        self.assertEqual(acc.char_target_position.value, 0)
+
+        self.hass.states.set(window_cover, STATE_UNKNOWN)
+        self.hass.block_till_done()
+
+        self.assertEqual(acc.char_current_position.value, 0)
+        self.assertEqual(acc.char_target_position.value, 0)
+
+        self.hass.states.set(window_cover, STATE_OPEN)
+        self.hass.block_till_done()
+
+        self.assertEqual(acc.char_current_position.value, 100)
+        self.assertEqual(acc.char_target_position.value, 100)
+
+        self.hass.states.set(window_cover, STATE_CLOSED)
+        self.hass.block_till_done()
+
+        self.assertEqual(acc.char_current_position.value, 0)
+        self.assertEqual(acc.char_target_position.value, 0)
+
+        # Set from HomeKit
+        acc.char_target_position.client_update_value(25)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE], 'close_cover')
+
+        self.assertEqual(acc.char_current_position.value, 0)
+        self.assertEqual(acc.char_target_position.value, 0)
+
+        # Set from HomeKit
+        acc.char_target_position.client_update_value(90)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[1].data[ATTR_SERVICE], 'open_cover')
+
+        self.assertEqual(acc.char_current_position.value, 100)
+        self.assertEqual(acc.char_target_position.value, 100)
+
+        # Set from HomeKit
+        acc.char_target_position.client_update_value(55)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[2].data[ATTR_SERVICE], 'stop_cover')
+
+        self.assertEqual(acc.char_current_position.value, 50)
+        self.assertEqual(acc.char_target_position.value, 50)
+
+    def test_window_open_close(self):
+        """Test if accessory and HA are updated accordingly."""
+        window_cover = 'cover.window'
+
+        self.hass.states.set(window_cover, STATE_UNKNOWN, {ATTR_SUPPORTED_FEATURES: 0})
+        acc = WindowCoveringBasic(self.hass, 'Cover', window_cover, 2, config=None)
+        acc.run()
+
+        self.assertEqual(acc.aid, 2)
+        self.assertEqual(acc.category, 14)  # WindowCovering
+
+        self.assertEqual(acc.char_current_position.value, 0)
+        self.assertEqual(acc.char_target_position.value, 0)
+
+        self.hass.states.set(window_cover, STATE_UNKNOWN)
+        self.hass.block_till_done()
+
+        self.assertEqual(acc.char_current_position.value, 0)
+        self.assertEqual(acc.char_target_position.value, 0)
+
+        self.hass.states.set(window_cover, STATE_OPEN)
+        self.hass.block_till_done()
+
+        self.assertEqual(acc.char_current_position.value, 100)
+        self.assertEqual(acc.char_target_position.value, 100)
+
+        self.hass.states.set(window_cover, STATE_CLOSED)
+        self.hass.block_till_done()
+
+        self.assertEqual(acc.char_current_position.value, 0)
+        self.assertEqual(acc.char_target_position.value, 0)
+
+        # Set from HomeKit
+        acc.char_target_position.client_update_value(25)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE], 'close_cover')
+
+        self.assertEqual(acc.char_current_position.value, 0)
+        self.assertEqual(acc.char_target_position.value, 0)
+
+        # Set from HomeKit
+        acc.char_target_position.client_update_value(90)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[1].data[ATTR_SERVICE], 'open_cover')
+
+        self.assertEqual(acc.char_current_position.value, 100)
+        self.assertEqual(acc.char_target_position.value, 100)
+
+        # Set from HomeKit
+        acc.char_target_position.client_update_value(55)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[2].data[ATTR_SERVICE], 'open_cover')
+
+        self.assertEqual(acc.char_current_position.value, 100)
+        self.assertEqual(acc.char_target_position.value, 100)

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -140,75 +140,12 @@ class TestHomekitSensors(unittest.TestCase):
         self.assertEqual(acc.char_current_position.value, 50)
         self.assertEqual(acc.char_target_position.value, 75)
 
-    def test_window_open_close_stop(self):
-        """Test if accessory and HA are updated accordingly."""
-        window_cover = 'cover.window'
-
-        self.hass.states.set(window_cover, STATE_UNKNOWN, {
-            ATTR_SUPPORTED_FEATURES: SUPPORT_STOP
-        })
-        acc = WindowCoveringBasic(self.hass, 'Cover', window_cover, 2,
-                                  config=None)
-        acc.run()
-
-        self.assertEqual(acc.aid, 2)
-        self.assertEqual(acc.category, 14)  # WindowCovering
-
-        self.assertEqual(acc.char_current_position.value, 0)
-        self.assertEqual(acc.char_target_position.value, 0)
-
-        self.hass.states.set(window_cover, STATE_UNKNOWN)
-        self.hass.block_till_done()
-
-        self.assertEqual(acc.char_current_position.value, 0)
-        self.assertEqual(acc.char_target_position.value, 0)
-
-        self.hass.states.set(window_cover, STATE_OPEN)
-        self.hass.block_till_done()
-
-        self.assertEqual(acc.char_current_position.value, 100)
-        self.assertEqual(acc.char_target_position.value, 100)
-
-        self.hass.states.set(window_cover, STATE_CLOSED)
-        self.hass.block_till_done()
-
-        self.assertEqual(acc.char_current_position.value, 0)
-        self.assertEqual(acc.char_target_position.value, 0)
-
-        # Set from HomeKit
-        acc.char_target_position.client_update_value(25)
-        self.hass.block_till_done()
-        self.assertEqual(
-            self.events[0].data[ATTR_SERVICE], 'close_cover')
-
-        self.assertEqual(acc.char_current_position.value, 0)
-        self.assertEqual(acc.char_target_position.value, 0)
-
-        # Set from HomeKit
-        acc.char_target_position.client_update_value(90)
-        self.hass.block_till_done()
-        self.assertEqual(
-            self.events[1].data[ATTR_SERVICE], 'open_cover')
-
-        self.assertEqual(acc.char_current_position.value, 100)
-        self.assertEqual(acc.char_target_position.value, 100)
-
-        # Set from HomeKit
-        acc.char_target_position.client_update_value(55)
-        self.hass.block_till_done()
-        self.assertEqual(
-            self.events[2].data[ATTR_SERVICE], 'stop_cover')
-
-        self.assertEqual(acc.char_current_position.value, 50)
-        self.assertEqual(acc.char_target_position.value, 50)
-
     def test_window_open_close(self):
         """Test if accessory and HA are updated accordingly."""
         window_cover = 'cover.window'
 
-        self.hass.states.set(window_cover, STATE_UNKNOWN, {
-            ATTR_SUPPORTED_FEATURES: 0
-        })
+        self.hass.states.set(window_cover, STATE_UNKNOWN,
+                             {ATTR_SUPPORTED_FEATURES: 0})
         acc = WindowCoveringBasic(self.hass, 'Cover', window_cover, 2,
                                   config=None)
         acc.run()
@@ -263,3 +200,40 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 100)
         self.assertEqual(acc.char_target_position.value, 100)
+
+    def test_window_open_close_stop(self):
+        """Test if accessory and HA are updated accordingly."""
+        window_cover = 'cover.window'
+
+        self.hass.states.set(window_cover, STATE_UNKNOWN,
+                             {ATTR_SUPPORTED_FEATURES: SUPPORT_STOP})
+        acc = WindowCoveringBasic(self.hass, 'Cover', window_cover, 2,
+                                  config=None)
+        acc.run()
+
+        # Set from HomeKit
+        acc.char_target_position.client_update_value(25)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE], 'close_cover')
+
+        self.assertEqual(acc.char_current_position.value, 0)
+        self.assertEqual(acc.char_target_position.value, 0)
+
+        # Set from HomeKit
+        acc.char_target_position.client_update_value(90)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[1].data[ATTR_SERVICE], 'open_cover')
+
+        self.assertEqual(acc.char_current_position.value, 100)
+        self.assertEqual(acc.char_target_position.value, 100)
+
+        # Set from HomeKit
+        acc.char_target_position.client_update_value(55)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[2].data[ATTR_SERVICE], 'stop_cover')
+
+        self.assertEqual(acc.char_current_position.value, 50)
+        self.assertEqual(acc.char_target_position.value, 50)


### PR DESCRIPTION
## Description:

Support covers which do not support the `set_cover_position` service. This allows covers which only support `open_cover` and `close_cover` (and optionally `stop_cover`) to be used in Homekit.

In the basic home app, when touching a tile this behaves as expected, touching an open cover closes it, and vice versa, however in order to handle setting an exact position, I had to make some assumptions:

- A user sets position > 70: Open cover
- A user sets position < 30: Close cover
- A user sets position anywhere else: Stop cover (provided the cover supports it).


**Related issue:** 

- A potential workaround for #13676

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/5203

## Example entry for `configuration.yaml` (if applicable):
```yaml
homekit:
cover:
  - platform: mqtt
    name: blindkit_nick_front
    command_topic: /things/blindkit/send_code
    availability_topic: /things/blindkit/status
    qos: 1
    payload_open: 100,0,OPEN
    payload_close: 100,0,CLOSE
    payload_stop: 100,0,STOP
```

## TODO
 - [x] Write tests
 - [x] Update documentation

I am raising this as more of a WIP to get thoughts before committing to spending time to write tests against the implementation. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] ~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  - [ ] ~New dependencies are only imported inside functions that use them ([example][ex-import]).~
  - [ ] ~New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  - [ ] ~New files were added to `.coveragerc`.~

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
