### PR TITLE
Allow not only IP address as host parameter

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -32,8 +32,7 @@ CONF_ALLOW_HUE_GROUPS = "allow_hue_groups"
 DEFAULT_ALLOW_HUE_GROUPS = True
 
 BRIDGE_CONFIG_SCHEMA = vol.Schema({
-    # Validate as IP address and then convert back to a string.
-    vol.Required(CONF_HOST): vol.All(ipaddress.ip_address, cv.string),
+    vol.Required(CONF_HOST): cv.string,
     # This is for legacy reasons and is only used for importing auth.
     vol.Optional(CONF_FILENAME, default=PHUE_CONFIG_FILE): cv.string,
     vol.Optional(CONF_ALLOW_UNREACHABLE,


### PR DESCRIPTION
## Description:

Hue configuration has previously allowed specifying FQDN as host parameter, but recent changes has changed that.

This is understandably inconvenient for users which depend on being able to use FQDN and not IP addresses.

This small change allows FQDN for host parameter again.

It would be nice to update the documentation to reflect this, and I'm more than happy to do so if this small change is accepted.

**Related issue (if applicable):** fixes #13575

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:
  bridges:
    host: hue-fqdn.example.com
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
