### PR TITLE
Restore edimax type error check for units without energy tracking

### DIFF
--- a/homeassistant/components/switch/edimax.py
+++ b/homeassistant/components/switch/edimax.py
@@ -84,12 +84,12 @@ class SmartPlugSwitch(SwitchDevice):
         """Update edimax switch."""
         try:
             self._now_power = float(self.smartplug.now_power)
-        except ValueError:
+        except (TypeError, ValueError):
             self._now_power = None
 
         try:
             self._now_energy_day = float(self.smartplug.now_energy_day)
-        except ValueError:
+        except (TypeError, ValueError):
             self._now_energy_day = None
 
         self._state = self.smartplug.state == 'ON'


### PR DESCRIPTION
## Description:
Some edimax switch devices don't have energy tracking functionality, so this change adds back the handling of the type error when trying to convert the energy usage values allowing them to be set back to None instead of yielding the following traceback as in the current release:

**Traceback (if applicable):**
```
ERROR (MainThread) [homeassistant.helpers.entity] Update for switch.kitchen1 fails^[[0m
Traceback (most recent call last):
  File "/Users/josh/.pyenv/versions/3.6.2/lib/python3.6/site-packages/homeassistant/helpers/entity.py", line 204, in async_update_ha_state
    yield from self.async_device_update()
  File "/Users/josh/.pyenv/versions/3.6.2/lib/python3.6/site-packages/homeassistant/helpers/entity.py", line 327, in async_device_update
    yield from self.hass.async_add_job(self.update)
  File "/Users/josh/.pyenv/versions/3.6.2/lib/python3.6/asyncio/futures.py", line 332, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/Users/josh/.pyenv/versions/3.6.2/lib/python3.6/asyncio/tasks.py", line 250, in _wakeup
    future.result()
  File "/Users/josh/.pyenv/versions/3.6.2/lib/python3.6/asyncio/futures.py", line 245, in result
    raise self._exception
  File "/Users/josh/.pyenv/versions/3.6.2/lib/python3.6/concurrent/futures/thread.py", line 55, in run 
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/josh/.pyenv/versions/3.6.2/lib/python3.6/site-packages/homeassistant/components/switch/edimax.py", line 86, in update
    self._now_power = float(self.smartplug.now_power)
  File "/Users/josh/.homeassistant/deps/lib/python3.6/site-packages/pyedimax/smartplug.py", line 208, in now_power
    float(res)
TypeError: float() argument must be a string or a number, not 'NoneType'
```

**Related issue (if applicable):** fixes #13619

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: edimax
    name: Kitchen1
    host: 192.168.0.82
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**



[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54