### PR TITLE
Fix too green color conversion

### DIFF
--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -203,7 +203,7 @@ def color_RGB_to_xy_brightness(
 
     # Wide RGB D65 conversion formula
     X = R * 0.664511 + G * 0.154324 + B * 0.162028
-    Y = R * 0.313881 + G * 0.668433 + B * 0.047685
+    Y = R * 0.283881 + G * 0.668433 + B * 0.047685
     Z = R * 0.000088 + G * 0.072310 + B * 0.986039
 
     # Convert XYZ to xy

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -48,7 +48,7 @@ class TestDemoLight(unittest.TestCase):
         self.assertEqual(
             (250, 252, 255), state.attributes.get(light.ATTR_RGB_COLOR))
         self.assertEqual(
-            (0.316, 0.333), state.attributes.get(light.ATTR_XY_COLOR))
+            (0.319, 0.326), state.attributes.get(light.ATTR_XY_COLOR))
         light.turn_on(self.hass, ENTITY_LIGHT, color_temp=400, effect='none')
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_LIGHT)

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -29,15 +29,15 @@ class TestDemoLight(unittest.TestCase):
     def test_state_attributes(self):
         """Test light state attributes."""
         light.turn_on(
-            self.hass, ENTITY_LIGHT, xy_color=(.4, .6), brightness=25)
+            self.hass, ENTITY_LIGHT, xy_color=(.4, .4), brightness=25)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_LIGHT)
         self.assertTrue(light.is_on(self.hass, ENTITY_LIGHT))
-        self.assertEqual((0.378, 0.574), state.attributes.get(
+        self.assertEqual((0.394, 0.408), state.attributes.get(
             light.ATTR_XY_COLOR))
         self.assertEqual(25, state.attributes.get(light.ATTR_BRIGHTNESS))
         self.assertEqual(
-            (207, 255, 0), state.attributes.get(light.ATTR_RGB_COLOR))
+            (255, 234, 164), state.attributes.get(light.ATTR_RGB_COLOR))
         self.assertEqual('rainbow', state.attributes.get(light.ATTR_EFFECT))
         light.turn_on(
             self.hass, ENTITY_LIGHT, rgb_color=(251, 253, 255),

--- a/tests/components/light/test_demo.py
+++ b/tests/components/light/test_demo.py
@@ -33,7 +33,7 @@ class TestDemoLight(unittest.TestCase):
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_LIGHT)
         self.assertTrue(light.is_on(self.hass, ENTITY_LIGHT))
-        self.assertEqual((0.394, 0.408), state.attributes.get(
+        self.assertEqual((0.4, 0.4), state.attributes.get(
             light.ATTR_XY_COLOR))
         self.assertEqual(25, state.attributes.get(light.ATTR_BRIGHTNESS))
         self.assertEqual(

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -255,7 +255,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual(150, state.attributes.get('color_temp'))
         self.assertEqual('none', state.attributes.get('effect'))
         self.assertEqual(255, state.attributes.get('white_value'))
-        self.assertEqual((0.32, 0.336), state.attributes.get('xy_color'))
+        self.assertEqual((0.323, 0.329), state.attributes.get('xy_color'))
 
         fire_mqtt_message(self.hass, 'test_light_rgb/status', '0')
         self.hass.block_till_done()
@@ -311,7 +311,7 @@ class TestLightMQTT(unittest.TestCase):
         self.hass.block_till_done()
 
         light_state = self.hass.states.get('light.test')
-        self.assertEqual((0.652, 0.343),
+        self.assertEqual((0.672, 0.324),
                          light_state.attributes.get('xy_color'))
 
     def test_brightness_controlling_scale(self):
@@ -519,7 +519,7 @@ class TestLightMQTT(unittest.TestCase):
             mock.call('test_light_rgb/rgb/set', '50,50,50', 2, False),
             mock.call('test_light_rgb/brightness/set', 50, 2, False),
             mock.call('test_light_rgb/white_value/set', 80, 2, False),
-            mock.call('test_light_rgb/xy/set', '0.32,0.336', 2, False),
+            mock.call('test_light_rgb/xy/set', '0.323,0.329', 2, False),
         ], any_order=True)
 
         state = self.hass.states.get('light.test')
@@ -527,7 +527,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual((255, 255, 255), state.attributes['rgb_color'])
         self.assertEqual(50, state.attributes['brightness'])
         self.assertEqual(80, state.attributes['white_value'])
-        self.assertEqual((0.32, 0.336), state.attributes['xy_color'])
+        self.assertEqual((0.323, 0.329), state.attributes['xy_color'])
 
     def test_sending_mqtt_rgb_command_with_template(self):
         """Test the sending of RGB command with template."""
@@ -679,7 +679,7 @@ class TestLightMQTT(unittest.TestCase):
 
         state = self.hass.states.get('light.test')
         self.assertEqual(STATE_ON, state.state)
-        self.assertEqual((0.32, 0.336), state.attributes.get('xy_color'))
+        self.assertEqual((0.323, 0.329), state.attributes.get('xy_color'))
 
     def test_on_command_first(self):
         """Test on command being sent before brightness."""

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -206,7 +206,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertEqual(155, state.attributes.get('color_temp'))
         self.assertEqual('colorloop', state.attributes.get('effect'))
         self.assertEqual(150, state.attributes.get('white_value'))
-        self.assertEqual((0.32, 0.336), state.attributes.get('xy_color'))
+        self.assertEqual((0.323, 0.329), state.attributes.get('xy_color'))
 
         # Turn the light off
         fire_mqtt_message(self.hass, 'test_light_rgb', '{"state":"OFF"}')

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -154,8 +154,8 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 119)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.591, 0.395])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 112)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.606, 0.379])
 
     # pylint: disable=invalid-name
     def test_flux_after_sunrise_before_sunset(self):
@@ -201,8 +201,8 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 180)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.431, 0.38])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 173)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.439, 0.37])
 
     # pylint: disable=invalid-name
     def test_flux_after_sunset_before_stop(self):
@@ -249,8 +249,8 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 153)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.496, 0.397])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 146)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.506, 0.385])
 
     # pylint: disable=invalid-name
     def test_flux_after_stop_before_sunrise(self):
@@ -296,8 +296,8 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 119)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.591, 0.395])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 112)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.606, 0.379])
 
     # pylint: disable=invalid-name
     def test_flux_with_custom_start_stop_times(self):
@@ -345,8 +345,8 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 154)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.494, 0.397])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 147)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.504, 0.385])
 
     def test_flux_before_sunrise_stop_next_day(self):
         """Test the flux switch before sunrise.
@@ -395,8 +395,8 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 119)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.591, 0.395])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 112)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.606, 0.379])
 
     # pylint: disable=invalid-name
     def test_flux_after_sunrise_before_sunset_stop_next_day(self):
@@ -447,8 +447,8 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 180)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.431, 0.38])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 173)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.439, 0.37])
 
     # pylint: disable=invalid-name
     def test_flux_after_sunset_before_midnight_stop_next_day(self):
@@ -498,8 +498,8 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 126)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.574, 0.401])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 119)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.588, 0.386])
 
     # pylint: disable=invalid-name
     def test_flux_after_sunset_after_midnight_stop_next_day(self):
@@ -549,8 +549,8 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 122)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.586, 0.397])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 114)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.601, 0.382])
 
     # pylint: disable=invalid-name
     def test_flux_after_stop_before_sunrise_stop_next_day(self):
@@ -600,8 +600,8 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 119)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.591, 0.395])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 112)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.606, 0.379])
 
     # pylint: disable=invalid-name
     def test_flux_with_custom_colortemps(self):
@@ -650,8 +650,8 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 167)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.461, 0.389])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 159)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.469, 0.378])
 
     # pylint: disable=invalid-name
     def test_flux_with_custom_brightness(self):
@@ -700,7 +700,7 @@ class TestSwitchFlux(unittest.TestCase):
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 255)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.496, 0.397])
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.506, 0.385])
 
     def test_flux_with_multiple_lights(self):
         """Test the flux switch with multiple light entities."""
@@ -762,14 +762,14 @@ class TestSwitchFlux(unittest.TestCase):
                 fire_time_changed(self.hass, test_time)
                 self.hass.block_till_done()
         call = turn_on_calls[-1]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 171)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.452, 0.386])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 163)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.46, 0.376])
         call = turn_on_calls[-2]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 171)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.452, 0.386])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 163)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.46, 0.376])
         call = turn_on_calls[-3]
-        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 171)
-        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.452, 0.386])
+        self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 163)
+        self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.46, 0.376])
 
     def test_flux_with_mired(self):
         """Test the flux switch´s mode mired."""

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -14,7 +14,7 @@ class TestColorUtil(unittest.TestCase):
         """Test color_RGB_to_xy_brightness."""
         self.assertEqual((0, 0, 0),
                          color_util.color_RGB_to_xy_brightness(0, 0, 0))
-        self.assertEqual((0.32, 0.336, 255),
+        self.assertEqual((0.323, 0.329, 255),
                          color_util.color_RGB_to_xy_brightness(255, 255, 255))
 
         self.assertEqual((0.136, 0.04, 12),
@@ -23,17 +23,17 @@ class TestColorUtil(unittest.TestCase):
         self.assertEqual((0.172, 0.747, 170),
                          color_util.color_RGB_to_xy_brightness(0, 255, 0))
 
-        self.assertEqual((0.679, 0.321, 80),
+        self.assertEqual((0.701, 0.299, 72),
                          color_util.color_RGB_to_xy_brightness(255, 0, 0))
 
-        self.assertEqual((0.679, 0.321, 17),
+        self.assertEqual((0.701, 0.299, 16),
                          color_util.color_RGB_to_xy_brightness(128, 0, 0))
 
     def test_color_RGB_to_xy(self):
         """Test color_RGB_to_xy."""
         self.assertEqual((0, 0),
                          color_util.color_RGB_to_xy(0, 0, 0))
-        self.assertEqual((0.32, 0.336),
+        self.assertEqual((0.323, 0.329),
                          color_util.color_RGB_to_xy(255, 255, 255))
 
         self.assertEqual((0.136, 0.04),
@@ -42,10 +42,10 @@ class TestColorUtil(unittest.TestCase):
         self.assertEqual((0.172, 0.747),
                          color_util.color_RGB_to_xy(0, 255, 0))
 
-        self.assertEqual((0.679, 0.321),
+        self.assertEqual((0.701, 0.299),
                          color_util.color_RGB_to_xy(255, 0, 0))
 
-        self.assertEqual((0.679, 0.321),
+        self.assertEqual((0.701, 0.299),
                          color_util.color_RGB_to_xy(128, 0, 0))
 
     def test_color_xy_brightness_to_RGB(self):
@@ -155,16 +155,16 @@ class TestColorUtil(unittest.TestCase):
         self.assertEqual((0.151, 0.343),
                          color_util.color_hs_to_xy(180, 100))
 
-        self.assertEqual((0.352, 0.329),
+        self.assertEqual((0.356, 0.321),
                          color_util.color_hs_to_xy(350, 12.5))
 
-        self.assertEqual((0.228, 0.476),
+        self.assertEqual((0.229, 0.474),
                          color_util.color_hs_to_xy(140, 50))
 
-        self.assertEqual((0.465, 0.33),
+        self.assertEqual((0.474, 0.317),
                          color_util.color_hs_to_xy(0, 40))
 
-        self.assertEqual((0.32, 0.336),
+        self.assertEqual((0.323, 0.329),
                          color_util.color_hs_to_xy(360, 0))
 
     def test_rgb_hex_to_rgb_list(self):


### PR DESCRIPTION
## Description:

I checked our RGB-to-xy conversion function against [the Hue docs](https://developers.meethue.com/documentation/color-conversions-rgb-xy) and I found a difference that apparently gives too green colors:

Before:
```text
>>> from homeassistant.util.color import color_xy_brightness_to_RGB, color_RGB_to_xy_brightness
>>> color_xy_brightness_to_RGB(*color_RGB_to_xy_brightness(250, 250, 250))
(248, 255, 248)
>>> color_RGB_to_xy_brightness(*color_xy_brightness_to_RGB(0.4, 0.4, 128))
(0.395, 0.408, 131)
```

After:
```text
>>> from homeassistant.util.color import color_xy_brightness_to_RGB, color_RGB_to_xy_brightness
>>> color_xy_brightness_to_RGB(*color_RGB_to_xy_brightness(250, 250, 250))
(250, 250, 250)
>>> color_RGB_to_xy_brightness(*color_xy_brightness_to_RGB(0.4, 0.4, 128))
(0.401, 0.4, 127)
```

**Related issue (if applicable):** fixes #13686

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
