### PR TITLE
Webostv channel up down only on LiveTV

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -35,6 +35,7 @@ CONF_SOURCES = 'sources'
 CONF_ON_ACTION = 'turn_on_action'
 
 DEFAULT_NAME = 'LG webOS Smart TV'
+LIVETV_APP_ID = 'com.webos.app.livetv'
 
 WEBOSTV_CONFIG_FILE = 'webostv.conf'
 
@@ -357,8 +358,16 @@ class LgWebOSDevice(MediaPlayerDevice):
 
     def media_next_track(self):
         """Send next track command."""
-        self._client.channel_up()
+        current_input = self._client.get_input()
+        if current_input == LIVETV_APP_ID:
+            self._client.channel_up()
+        else:
+            self._client.fast_forward()
 
     def media_previous_track(self):
         """Send the previous track command."""
-        self._client.channel_down()
+        current_input = self._client.get_input()
+        if current_input == LIVETV_APP_ID:
+            self._client.channel_down()
+        else:
+            self._client.rewind()


### PR DESCRIPTION
## Description:
As per comment in related PR, restricts channels up down only when on television

**Related issue (if applicable):** fixes #13624 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
