### PR TITLE
Fix type_cover HomeKit

### DIFF
--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -51,6 +51,7 @@ SERV_SWITCH = 'Switch'
 SERV_TEMPERATURE_SENSOR = 'TemperatureSensor'
 SERV_THERMOSTAT = 'Thermostat'
 SERV_WINDOW_COVERING = 'WindowCovering'
+# CurrentPosition, TargetPosition, PositionState
 
 
 # #### Characteristics ####
@@ -61,7 +62,7 @@ CHAR_COLOR_TEMPERATURE = 'ColorTemperature'
 CHAR_CONTACT_SENSOR_STATE = 'ContactSensorState'
 CHAR_COOLING_THRESHOLD_TEMPERATURE = 'CoolingThresholdTemperature'
 CHAR_CURRENT_HEATING_COOLING = 'CurrentHeatingCoolingState'
-CHAR_CURRENT_POSITION = 'CurrentPosition'
+CHAR_CURRENT_POSITION = 'CurrentPosition'  # Int | [0, 100]
 CHAR_CURRENT_HUMIDITY = 'CurrentRelativeHumidity'  # percent
 CHAR_CURRENT_SECURITY_STATE = 'SecuritySystemCurrentState'
 CHAR_CURRENT_TEMPERATURE = 'CurrentTemperature'
@@ -77,12 +78,11 @@ CHAR_MOTION_DETECTED = 'MotionDetected'
 CHAR_NAME = 'Name'
 CHAR_OCCUPANCY_DETECTED = 'OccupancyDetected'
 CHAR_ON = 'On'  # boolean
-CHAR_POSITION_STATE = 'PositionState'
 CHAR_SATURATION = 'Saturation'  # percent
 CHAR_SERIAL_NUMBER = 'SerialNumber'
 CHAR_SMOKE_DETECTED = 'SmokeDetected'
 CHAR_TARGET_HEATING_COOLING = 'TargetHeatingCoolingState'
-CHAR_TARGET_POSITION = 'TargetPosition'
+CHAR_TARGET_POSITION = 'TargetPosition'  # Int | [0, 100]
 CHAR_TARGET_SECURITY_STATE = 'SecuritySystemTargetState'
 CHAR_TARGET_TEMPERATURE = 'TargetTemperature'
 CHAR_TEMP_DISPLAY_UNITS = 'TemperatureDisplayUnits'

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -1,13 +1,15 @@
 """Class to hold all cover accessories."""
 import logging
 
-from homeassistant.components.cover import ATTR_CURRENT_POSITION
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION, ATTR_POSITION, DOMAIN)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_SET_COVER_POSITION
 
 from . import TYPES
 from .accessories import HomeAccessory, add_preload_service, setup_char
 from .const import (
     CATEGORY_WINDOW_COVERING, SERV_WINDOW_COVERING,
-    CHAR_CURRENT_POSITION, CHAR_TARGET_POSITION, CHAR_POSITION_STATE)
+    CHAR_CURRENT_POSITION, CHAR_TARGET_POSITION)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +24,6 @@ class WindowCovering(HomeAccessory):
     def __init__(self, *args, config):
         """Initialize a WindowCovering accessory object."""
         super().__init__(*args, category=CATEGORY_WINDOW_COVERING)
-        self.current_position = None
         self.homekit_target = None
 
         serv_cover = add_preload_service(self, SERV_WINDOW_COVERING)
@@ -31,29 +32,21 @@ class WindowCovering(HomeAccessory):
         self.char_target_position = setup_char(
             CHAR_TARGET_POSITION, serv_cover, value=0,
             callback=self.move_cover)
-        self.char_position_state = setup_char(
-            CHAR_POSITION_STATE, serv_cover, value=0)
 
     def move_cover(self, value):
         """Move cover to value if call came from HomeKit."""
-        if value != self.current_position:
-            _LOGGER.debug('%s: Set position to %d', self.entity_id, value)
-            self.homekit_target = value
-            if value > self.current_position:
-                self.char_position_state.set_value(1)
-            elif value < self.current_position:
-                self.char_position_state.set_value(0)
-            self.hass.components.cover.set_cover_position(
-                value, self.entity_id)
+        _LOGGER.debug('%s: Set position to %d', self.entity_id, value)
+        self.homekit_target = value
+
+        params = {ATTR_ENTITY_ID: self.entity_id, ATTR_POSITION: value}
+        self.hass.services.call(DOMAIN, SERVICE_SET_COVER_POSITION, params)
 
     def update_state(self, new_state):
         """Update cover position after state changed."""
         current_position = new_state.attributes.get(ATTR_CURRENT_POSITION)
         if isinstance(current_position, int):
-            self.current_position = current_position
-            self.char_current_position.set_value(self.current_position)
+            self.char_current_position.set_value(current_position)
             if self.homekit_target is None or \
-                    abs(self.current_position - self.homekit_target) < 6:
-                self.char_target_position.set_value(self.current_position)
-                self.char_position_state.set_value(2)
+                    abs(current_position - self.homekit_target) < 6:
+                self.char_target_position.set_value(current_position)
                 self.homekit_target = None

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -43,7 +43,6 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 0)
         self.assertEqual(acc.char_target_position.value, 0)
-        self.assertEqual(acc.char_position_state.value, 0)
 
         self.hass.states.set(window_cover, STATE_UNKNOWN,
                              {ATTR_CURRENT_POSITION: None})
@@ -51,7 +50,6 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 0)
         self.assertEqual(acc.char_target_position.value, 0)
-        self.assertEqual(acc.char_position_state.value, 0)
 
         self.hass.states.set(window_cover, STATE_OPEN,
                              {ATTR_CURRENT_POSITION: 50})
@@ -59,7 +57,6 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 50)
         self.assertEqual(acc.char_target_position.value, 50)
-        self.assertEqual(acc.char_position_state.value, 2)
 
         # Set from HomeKit
         acc.char_target_position.client_update_value(25)
@@ -71,7 +68,6 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 50)
         self.assertEqual(acc.char_target_position.value, 25)
-        self.assertEqual(acc.char_position_state.value, 0)
 
         # Set from HomeKit
         acc.char_target_position.client_update_value(75)
@@ -83,4 +79,3 @@ class TestHomekitSensors(unittest.TestCase):
 
         self.assertEqual(acc.char_current_position.value, 50)
         self.assertEqual(acc.char_target_position.value, 75)
-        self.assertEqual(acc.char_position_state.value, 1)


### PR DESCRIPTION
## Description:
The characteristic `char_position_state` isn't used by the Home app. Rather it is causing additional errors, due to unnecessary comparisons. Additionally `move_cover` now uses a dedicated service call instead of `self.hass.components.cover.set_cover_position`.


**Related issue (if applicable):** fixes #13676

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.