### PR TITLE
Alertover notification

### DIFF
--- a/homeassistant/components/notify/alert_over.py
+++ b/homeassistant/components/notify/alert_over.py
@@ -1,0 +1,47 @@
+import requests
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.notify import (ATTR_TARGET, ATTR_TITLE, PLATFORM_SCHEMA, BaseNotificationService)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+CONF_FROM_SOURCE = "from_source"
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_FROM_SOURCE): cv.string,
+})
+
+
+
+def get_service(hass, config, discovery_info=None):
+    return AlertOverNotificationService(config[CONF_FROM_SOURCE])
+
+
+class AlertOverNotificationService(BaseNotificationService):
+    def __init__(self, from_source):
+        self.from_source = from_source
+
+    def send_message(self, message="", **kwargs):
+        receivers = kwargs.get(ATTR_TARGET)
+        title = kwargs.get(ATTR_TITLE)
+        try:
+            for receiver in receivers:
+                _LOGGER.info("已发送")
+
+                data = {
+                    "source": self.from_source,
+                    "receiver": receiver,
+                    "content": message,
+                    "title": title
+                }
+                _LOGGER.info(data)
+                requests.post(
+                    "https://api.alertover.com/v1/alert",
+                    data=data
+                )
+
+        except ConnectionError:
+            _LOGGER.error("连接失败")


### PR DESCRIPTION
Alertover notification

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: my_notify
    platform: alert_over
    from_source: source key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
