### PR TITLE
Add authentication to error log endpoint

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -52,9 +52,8 @@ def setup(hass, config):
     hass.http.register_view(APIComponentsView)
     hass.http.register_view(APITemplateView)
 
-    log_path = hass.data.get(DATA_LOGGING, None)
-    if log_path:
-        hass.http.register_static_path(URL_API_ERROR_LOG, log_path, False)
+    if DATA_LOGGING in hass.data:
+        hass.http.register_view(APIErrorLog)
 
     return True
 
@@ -354,6 +353,17 @@ class APITemplateView(HomeAssistantView):
         except (ValueError, TemplateError) as ex:
             return self.json_message('Error rendering template: {}'.format(ex),
                                      HTTP_BAD_REQUEST)
+
+
+class APIErrorLog(HomeAssistantView):
+    """View to fetch the error log."""
+
+    url = URL_API_ERROR_LOG
+    name = "api:error_log"
+
+    async def get(self, request):
+        """Retrieve API error log."""
+        return await self.file(request, request.app['hass'].data[DATA_LOGGING])
 
 
 @asyncio.coroutine

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -2,12 +2,17 @@
 # pylint: disable=protected-access
 import asyncio
 import json
+from unittest.mock import patch
 
+from aiohttp import web
 import pytest
 
 from homeassistant import const
+from homeassistant.bootstrap import DATA_LOGGING
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
+
+from tests.common import mock_coro
 
 
 @pytest.fixture
@@ -398,3 +403,31 @@ def _stream_next_event(stream):
 def _listen_count(hass):
     """Return number of event listeners."""
     return sum(hass.bus.async_listeners().values())
+
+
+async def test_api_error_log(hass, aiohttp_client):
+    """Test if we can fetch the error log."""
+    hass.data[DATA_LOGGING] = '/some/path'
+    await async_setup_component(hass, 'api', {
+        'http': {
+            'api_password': 'yolo'
+        }
+    })
+    client = await aiohttp_client(hass.http.app)
+
+    resp = await client.get(const.URL_API_ERROR_LOG)
+    # Verufy auth required
+    assert resp.status == 401
+
+    with patch(
+                'homeassistant.components.http.view.HomeAssistantView.file',
+                return_value=mock_coro(web.Response(status=200, text='Hello'))
+            ) as mock_file:
+        resp = await client.get(const.URL_API_ERROR_LOG, headers={
+            'x-ha-access': 'yolo'
+        })
+
+    assert len(mock_file.mock_calls) == 1
+    assert mock_file.mock_calls[0][1][1] == hass.data[DATA_LOGGING]
+    assert resp.status == 200
+    assert await resp.text() == 'Hello'


### PR DESCRIPTION
## Description:
Require authentication when fetching the raw error log.

Does not require a frontend change as frontend already calls API using auth.

**Related issue (if applicable):** Reported by Matt Hamilton.

## Example entry for `configuration.yaml` (if applicable):
```yaml
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
