### PR TITLE
Initialize queue before filtering (fixes #13363)

### DIFF
--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -341,7 +341,7 @@ class OutlierFilter(Filter):
 
     def _filter_state(self, new_state):
         """Implement the outlier filter."""
-        if (self.states and
+        if (len(self.states) == self.states.maxlen and
                 abs(new_state.state -
                     statistics.median([s.state for s in self.states])) >
                 self._radius):

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -95,15 +95,26 @@ class TestFilterSensor(unittest.TestCase):
                     self.hass.block_till_done()
 
                 state = self.hass.states.get('sensor.test')
-                self.assertEqual('19.25', state.state)
+                self.assertEqual('17.05', state.state)
 
     def test_outlier(self):
         """Test if outlier filter works."""
-        filt = OutlierFilter(window_size=10,
+        filt = OutlierFilter(window_size=3,
                              precision=2,
                              entity=None,
                              radius=4.0)
         for state in self.values:
+            filtered = filt.filter_state(state)
+        self.assertEqual(22, filtered.state)
+
+    def test_initial_outlier(self):
+        """Test issue #13363."""
+        filt = OutlierFilter(window_size=3,
+                             precision=2,
+                             entity=None,
+                             radius=4.0)
+        out = ha.State('sensor.test_monitored', 4000)
+        for state in [out]+self.values:
             filtered = filt.filter_state(state)
         self.assertEqual(22, filtered.state)
 


### PR DESCRIPTION
## Description:

The **outlier filter** would filter out values as soon as _one_ state was available.
This meant that if the first state was an outlier, all new states (normal states) would be filtered out as they would become outliers of the outlier.
This patch waits for the window to be filled before start filtering.

**Related issue (if applicable):** fixes #13363

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: filter
    name: "filtered realistic humidity"
    entity_id: sensor.realistic_humidity
    filters:
      - filter: outlier
        window_size: 4
        radius: 4.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54