### PR TITLE
bump python-ecobee-api version to 0.0.18

### DIFF
--- a/homeassistant/components/ecobee.py
+++ b/homeassistant/components/ecobee.py
@@ -16,7 +16,7 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.util import Throttle
 from homeassistant.util.json import save_json
 
-REQUIREMENTS = ['python-ecobee-api==0.0.17']
+REQUIREMENTS = ['python-ecobee-api==0.0.18']
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -942,7 +942,7 @@ python-clementine-remote==1.0.1
 python-digitalocean==1.13.2
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.0.17
+python-ecobee-api==0.0.18
 
 # homeassistant.components.climate.eq3btsmart
 # python-eq3bt==0.1.9


### PR DESCRIPTION
## Description:
Bump python-ecobee-api version to 0.0.18

This resolved an issue caused by a Typo that prevented Ecobee from utilizing nextTransition when setting a hold mode or temperature.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

https://github.com/nkgilley/python-ecobee-api/pull/33

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54